### PR TITLE
fix: remove redundant DeployExtension target from SignalR csproj

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
@@ -39,7 +39,8 @@
        ContinueOnError prevents build failures when the gateway has DLLs locked. -->
   <Target Name="DeployExtension" AfterTargets="CopyBlazorClient">
     <PropertyGroup>
-      <ExtensionDeployDir>$(USERPROFILE)\.botnexus\extensions\signalr\</ExtensionDeployDir>
+      <ExtensionDeployDir Condition="'$(USERPROFILE)' != ''">$(USERPROFILE)\.botnexus\extensions\signalr\</ExtensionDeployDir>
+      <ExtensionDeployDir Condition="'$(USERPROFILE)' == ''">$(HOME)/.botnexus/extensions/signalr/</ExtensionDeployDir>
     </PropertyGroup>
     <ItemGroup>
       <ExtensionFiles Include="$(OutputPath)**\*.*" Exclude="$(OutputPath)ref\**;$(OutputPath)blazor-publish\**" />

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
@@ -35,6 +35,4 @@
     <Copy SourceFiles="@(BlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- Deploy extension to ~/.botnexus/extensions/signalr/ so the gateway discovers it.
-       ContinueOnError prevents build failures when the gateway has DLLs locked. -->
   </Project>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
@@ -37,17 +37,4 @@
 
   <!-- Deploy extension to ~/.botnexus/extensions/signalr/ so the gateway discovers it.
        ContinueOnError prevents build failures when the gateway has DLLs locked. -->
-  <Target Name="DeployExtension" AfterTargets="CopyBlazorClient">
-    <PropertyGroup>
-      <ExtensionDeployDir Condition="'$(USERPROFILE)' != ''">$(USERPROFILE)\.botnexus\extensions\signalr\</ExtensionDeployDir>
-      <ExtensionDeployDir Condition="'$(USERPROFILE)' == ''">$(HOME)/.botnexus/extensions/signalr/</ExtensionDeployDir>
-    </PropertyGroup>
-    <ItemGroup>
-      <ExtensionFiles Include="$(OutputPath)**\*.*" Exclude="$(OutputPath)ref\**;$(OutputPath)blazor-publish\**" />
-    </ItemGroup>
-    <MakeDir Directories="$(ExtensionDeployDir)" />
-    <Copy SourceFiles="@(ExtensionFiles)" DestinationFolder="$(ExtensionDeployDir)%(RecursiveDir)" SkipUnchangedFiles="true" ContinueOnError="true" />
-    <Message Importance="high" Text="Deployed SignalR extension to $(ExtensionDeployDir)" />
-  </Target>
-
-</Project>
+  </Project>


### PR DESCRIPTION
## Problem
The SignalR extension csproj contained a `DeployExtension` MSBuild target that copied built files to `~/.botnexus/extensions/signalr/`. This duplicated work already handled by the CLI and used $(USERPROFILE), a Windows-only variable that breaks on Linux.

## Fix
Removed the entire `DeployExtension` target and its associated comment. The CLI handles extension deployment.