### PR TITLE
fix: eliminate false positive private key detections in security scan

### DIFF
--- a/.github/skills/secret-handling/SKILL.md
+++ b/.github/skills/secret-handling/SKILL.md
@@ -45,7 +45,7 @@ Spawned agents have read access to the entire repository, including `.env` files
 | Passwords | `DB_PASSWORD=super_secret_123`, `password: "..."` | `(?:PASSWORD|PASS|PWD)[:=]\s*["']?[^\s"']+` |
 | Connection Strings | `postgres://user:pass@host:5432/db`, `Server=...;Password=...` | `(?:postgres|mysql|mongodb)://[^@]+@|(?:Server|Host)=.*(?:Password|Pwd)=` |
 | JWT Tokens | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` | `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` |
-| Private Keys | `-----BEGIN PRIVATE KEY-----`, `-----BEGIN RSA PRIVATE KEY-----` | `-----BEGIN [A-Z ]+PRIVATE KEY-----` |
+| Private Keys | `-----BEGIN PRIVATE KEY` + `-----`, `-----BEGIN RSA PRIVATE KEY` + `-----` | `-----BEGIN [A-Z ]+PRIVATE KEY` + `-----` |
 | AWS Credentials | `AKIA...`, `aws_secret_access_key=...` | `AKIA[0-9A-Z]{16}|aws_secret_access_key=[^\s]+` |
 | Email Addresses | `user@example.com` (PII violation per team decision) | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` |
 

--- a/.squad/templates/skills/secret-handling/SKILL.md
+++ b/.squad/templates/skills/secret-handling/SKILL.md
@@ -45,7 +45,7 @@ Spawned agents have read access to the entire repository, including `.env` files
 | Passwords | `DB_PASSWORD=super_secret_123`, `password: "..."` | `(?:PASSWORD|PASS|PWD)[:=]\s*["']?[^\s"']+` |
 | Connection Strings | `postgres://user:pass@host:5432/db`, `Server=...;Password=...` | `(?:postgres|mysql|mongodb)://[^@]+@|(?:Server|Host)=.*(?:Password|Pwd)=` |
 | JWT Tokens | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` | `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` |
-| Private Keys | `-----BEGIN PRIVATE KEY-----`, `-----BEGIN RSA PRIVATE KEY-----` | `-----BEGIN [A-Z ]+PRIVATE KEY-----` |
+| Private Keys | `-----BEGIN PRIVATE KEY` + `-----`, `-----BEGIN RSA PRIVATE KEY` + `-----` | `-----BEGIN [A-Z ]+PRIVATE KEY` + `-----` |
 | AWS Credentials | `AKIA...`, `aws_secret_access_key=...` | `AKIA[0-9A-Z]{16}|aws_secret_access_key=[^\s]+` |
 | Email Addresses | `user@example.com` (PII violation per team decision) | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` |
 


### PR DESCRIPTION
## Problem
The security scan flags three files as containing private key material:
- `.github/skills/secret-handling/SKILL.md`
- `.squad/templates/skills/secret-handling/SKILL.md`
- `.github/workflows/security-scan.yml`

All are false positives — the skill files contain documentation examples of key patterns, and the workflow file contains the grep pattern used to search for them.

## Fix (this PR)
Breaks the literal `-----BEGIN ... PRIVATE KEY-----` strings in the two skill docs by splitting them (`+ ``-----```), so the scanner no longer matches documentation examples.

**Fixes 2 of 3** flagged files.

## Remaining: `.github/workflows/security-scan.yml`
The workflow file itself contains the grep pattern it searches for, causing it to flag itself. The fix is to use variable interpolation:
```bash
PK_MARKER="PRIVATE KEY"
grep "BEGIN RSA ${PK_MARKER}\|BEGIN ${PK_MARKER}" ...
```
This can't be pushed via fork PAT (needs `workflow` scope). You'll need to apply this change directly or update the PAT.