### PR TITLE
fix: cross-platform test compatibility wave 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,15 +78,20 @@ Common properties and package versions are centralized — **do not duplicate th
 
 **All file paths must be constructed using `Path.Combine()` and platform APIs.** BotNexus runs on Windows, Linux, and macOS — hardcoded paths break portability.
 
+The project uses **`System.IO.Abstractions`** (`TestableIO.System.IO.Abstractions`) for filesystem operations. Production code should inject `IFileSystem` and use its path APIs (`fileSystem.Path.Combine()`, `fileSystem.Path.GetTempPath()`, etc.) rather than calling `System.IO.Path` directly. This enables testability via `MockFileSystem` and ensures consistent cross-platform behaviour.
+
 **Rules:**
-- Use `Path.Combine()` to build all file paths — never concatenate strings with `/` or `\`
+- Use `IFileSystem.Path.Combine()` in production code (or `Path.Combine()` in tests and static helpers)
 - Use `Path.GetTempPath()` for temporary directories — never hardcode `/tmp/` or `C:\Temp\`
 - Use `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` for the user home directory, with a fallback to `Environment.GetEnvironmentVariable("HOME")` on Linux/macOS
 - Use `Path.DirectorySeparatorChar` or `Path.AltDirectorySeparatorChar` when separator-aware logic is needed
 - In test assertions, normalise paths before comparing (e.g., `Path.GetFullPath()`) rather than asserting exact separator characters
 
 ```csharp
-// GOOD — works on all platforms
+// GOOD — production code with IFileSystem
+var configDir = _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), "botnexus", "config");
+
+// GOOD — test setup
 var configDir = Path.Combine(Path.GetTempPath(), "botnexus-tests", Guid.NewGuid().ToString("N"));
 var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
     is { Length: > 0 } home ? home : Environment.GetEnvironmentVariable("HOME") ?? "/tmp";

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,36 @@ Common properties and package versions are centralized — **do not duplicate th
 
 ## Code Practices
 
+### Cross-Platform Path Handling
+
+**All file paths must be constructed using `Path.Combine()` and platform APIs.** BotNexus runs on Windows, Linux, and macOS — hardcoded paths break portability.
+
+**Rules:**
+- Use `Path.Combine()` to build all file paths — never concatenate strings with `/` or `\`
+- Use `Path.GetTempPath()` for temporary directories — never hardcode `/tmp/` or `C:\Temp\`
+- Use `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` for the user home directory, with a fallback to `Environment.GetEnvironmentVariable("HOME")` on Linux/macOS
+- Use `Path.DirectorySeparatorChar` or `Path.AltDirectorySeparatorChar` when separator-aware logic is needed
+- In test assertions, normalise paths before comparing (e.g., `Path.GetFullPath()`) rather than asserting exact separator characters
+
+```csharp
+// GOOD — works on all platforms
+var configDir = Path.Combine(Path.GetTempPath(), "botnexus-tests", Guid.NewGuid().ToString("N"));
+var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+    is { Length: > 0 } home ? home : Environment.GetEnvironmentVariable("HOME") ?? "/tmp";
+
+// BAD — breaks on Linux
+var configDir = "C:\\Users\\test\\.botnexus";
+var tempDir = "/tmp/botnexus-tests";
+var path = workspace + "\\" + filename;
+```
+
+### Shell Command Tests
+
+When testing shell execution, ensure commands work on both `bash` and `pwsh`:
+- Use `RuntimeInformation.IsOSPlatform()` for platform-specific test branches if unavoidable
+- Prefer cross-platform commands (pwsh `Write-Output` works everywhere pwsh is installed)
+- Never hardcode `cmd.exe` or `/bin/bash` paths in tests — use the ShellTool abstraction
+
 ### Never Guess Time
 
 **Never assume or calculate the current time.** Always run `Get-Date` to get the local user time. Do not convert UTC timestamps to local time manually — you will get it wrong.

--- a/src/gateway/BotNexus.Tools/ShellTool.cs
+++ b/src/gateway/BotNexus.Tools/ShellTool.cs
@@ -149,13 +149,25 @@ public sealed class ShellTool : IAgentTool
         var startInfo = new ProcessStartInfo
         {
             FileName = invocation.FileName,
-            Arguments = invocation.Args,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
             WorkingDirectory = _workingDirectory ?? string.Empty
         };
+
+        // Handle different argument passing methods
+        if (!string.IsNullOrEmpty(invocation.Args))
+        {
+            startInfo.Arguments = invocation.Args;
+        }
+        else if (!string.IsNullOrEmpty(invocation.Command))
+        {
+            // For Unix bash with commands, use ArgumentList to avoid escaping issues
+            startInfo.ArgumentList.Add("-l");
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(invocation.Command);
+        }
 
         using var process = new Process { StartInfo = startInfo };
         if (!process.Start())
@@ -263,7 +275,7 @@ public sealed class ShellTool : IAgentTool
                 if (!string.IsNullOrWhiteSpace(bashPath))
                 {
                     var bashEscaped = command.Replace("'", "'\"'\"'", StringComparison.Ordinal);
-                    return new ShellInvocation(bashPath, $"-lc '{bashEscaped}'", null);
+                    return new ShellInvocation(bashPath, $"-lc '{bashEscaped}'", null, null);
                 }
 
                 // Bash explicitly requested but not found — fall back to pwsh with warning.
@@ -276,15 +288,16 @@ public sealed class ShellTool : IAgentTool
             if (!string.IsNullOrWhiteSpace(autoBashPath))
             {
                 var bashEscaped = command.Replace("'", "'\"'\"'", StringComparison.Ordinal);
-                return new ShellInvocation(autoBashPath, $"-lc '{bashEscaped}'", null);
+                return new ShellInvocation(autoBashPath, $"-lc '{bashEscaped}'", null, null);
             }
 
             return BuildPwshInvocation(command,
                 "[warning: bash not found, using PowerShell — install Git for Windows for best compatibility]\n");
         }
 
-        var unixBashEscaped = command.Replace("'", "'\"'\"'", StringComparison.Ordinal);
-        return new ShellInvocation("/bin/bash", $"-lc '{unixBashEscaped}'", null);
+        // For Unix, use ArgumentList to avoid shell escaping issues with single quotes
+        // The command will be passed as separate arguments: ["-l", "-c", command]
+        return new ShellInvocation("/bin/bash", null, command, null);
     }
 
     private static ShellInvocation BuildPwshInvocation(string command, string? warningPrefix)
@@ -295,6 +308,7 @@ public sealed class ShellTool : IAgentTool
         return new ShellInvocation(
             pwshPath,
             $"-NoLogo -NoProfile -NonInteractive -Command \"{escaped}\"",
+            null,
             warningPrefix);
     }
 
@@ -515,5 +529,5 @@ public sealed class ShellTool : IAgentTool
     /// </summary>
     public sealed record ShellToolDetails(int ExitCode, bool TimedOut, bool IsError);
 
-    private sealed record ShellInvocation(string FileName, string Args, string? WarningPrefix);
+    private sealed record ShellInvocation(string FileName, string? Args, string? Command, string? WarningPrefix);
 }

--- a/src/gateway/BotNexus.Tools/ShellTool.cs
+++ b/src/gateway/BotNexus.Tools/ShellTool.cs
@@ -9,8 +9,9 @@ using BotNexus.Agent.Providers.Core.Models;
 namespace BotNexus.Tools;
 
 /// <summary>
-/// Controls which shell is used for command execution on Windows.
-/// On non-Windows platforms, bash is always used regardless of this setting.
+/// Controls which shell is used for command execution.
+/// On all platforms, <see cref="ShellPreference.Pwsh"/> uses PowerShell Core (pwsh).
+/// <see cref="ShellPreference.Auto"/> and <see cref="ShellPreference.Bash"/> use bash.
 /// </summary>
 public enum ShellPreference
 {
@@ -33,8 +34,8 @@ public enum ShellPreference
 /// <list type="bullet">
 ///   <item><see cref="ShellPreference.Auto"/> (default) — Windows prefers bash when available,
 ///         falling back to PowerShell; non-Windows uses bash.</item>
-///   <item><see cref="ShellPreference.Pwsh"/> — Windows uses pwsh/powershell directly;
-///         non-Windows still uses bash.</item>
+///   <item><see cref="ShellPreference.Pwsh"/> — Uses pwsh on all platforms.
+///         Requires pwsh to be installed.</item>
 ///   <item><see cref="ShellPreference.Bash"/> — Always uses bash on all platforms.</item>
 /// </list>
 /// </para>
@@ -68,19 +69,19 @@ public sealed class ShellTool : IAgentTool
     }
 
     /// <inheritdoc />
-    public string Name => _shellPreference == ShellPreference.Pwsh && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+    public string Name => _shellPreference == ShellPreference.Pwsh
         ? "shell"
         : "bash";
 
     /// <inheritdoc />
-    public string Label => _shellPreference == ShellPreference.Pwsh && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+    public string Label => _shellPreference == ShellPreference.Pwsh
         ? "Shell (PowerShell)"
         : "Bash";
 
     /// <inheritdoc />
     public Tool Definition => new(
         Name,
-        _shellPreference == ShellPreference.Pwsh && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        _shellPreference == ShellPreference.Pwsh
             ? "Execute a PowerShell command in the current working directory and return stdout/stderr."
             : "Execute a bash command in the current working directory and return stdout/stderr.",
         JsonDocument.Parse("""
@@ -262,13 +263,14 @@ public sealed class ShellTool : IAgentTool
 
     private static ShellInvocation BuildShellInvocation(string command, ShellPreference preference)
     {
+        // Pwsh preference works on all platforms
+        if (preference == ShellPreference.Pwsh)
+        {
+            return BuildPwshInvocation(command, warningPrefix: null);
+        }
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            if (preference == ShellPreference.Pwsh)
-            {
-                return BuildPwshInvocation(command, warningPrefix: null);
-            }
-
             if (preference == ShellPreference.Bash)
             {
                 var bashPath = WindowsBashPath.Value;
@@ -295,8 +297,7 @@ public sealed class ShellTool : IAgentTool
                 "[warning: bash not found, using PowerShell — install Git for Windows for best compatibility]\n");
         }
 
-        // For Unix, use ArgumentList to avoid shell escaping issues with single quotes
-        // The command will be passed as separate arguments: ["-l", "-c", command]
+        // Unix with Auto or Bash preference: use bash with ArgumentList
         return new ShellInvocation("/bin/bash", null, command, null);
     }
 

--- a/test-env.cs
+++ b/test-env.cs
@@ -1,1 +1,0 @@
-using System; class Program { static void Main() { Console.WriteLine($"UserProfile: \"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\""); Console.WriteLine($"HOME env var: \"{Environment.GetEnvironmentVariable("HOME")}\""); Console.WriteLine($"USERPROFILE env var: \"{Environment.GetEnvironmentVariable("USERPROFILE")}\""); } }

--- a/tests/BotNexus.CodingAgent.Tests/Security/FileToolSecurityTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Security/FileToolSecurityTests.cs
@@ -24,7 +24,7 @@ public sealed class FileToolSecurityTests : IDisposable
     [Trait("Category", "Security")]
     public async Task ReadTool_PathTraversal_IsBlocked()
     {
-        var act = () => _readTool.ExecuteAsync("t1", new Dictionary<string, object?> { ["path"] = "..\\..\\etc\\passwd" });
+        var act = () => _readTool.ExecuteAsync("t1", new Dictionary<string, object?> { ["path"] = "../../etc/passwd" });
         await act.ShouldThrowAsync<InvalidOperationException>();
     }
 
@@ -32,7 +32,7 @@ public sealed class FileToolSecurityTests : IDisposable
     [Trait("Category", "Security")]
     public async Task WriteTool_PathTraversal_IsBlocked()
     {
-        var act = () => _writeTool.ExecuteAsync("t1", new Dictionary<string, object?> { ["path"] = "..\\outside\\malicious.txt", ["content"] = "x" });
+        var act = () => _writeTool.ExecuteAsync("t1", new Dictionary<string, object?> { ["path"] = "../outside/malicious.txt", ["content"] = "x" });
         await act.ShouldThrowAsync<InvalidOperationException>();
     }
 

--- a/tests/BotNexus.CodingAgent.Tests/Snapshots/coding-agent-main.prompt.txt
+++ b/tests/BotNexus.CodingAgent.Tests/Snapshots/coding-agent-main.prompt.txt
@@ -1,8 +1,8 @@
 ﻿You are a coding assistant with access to tools for reading, writing, and editing files, and executing shell commands.
 
 ## Environment
-- OS: Microsoft Windows 10.0.26200
-- Working directory: C://repo
+- OS: Ubuntu 24.04.4 LTS
+- Working directory: /tmp/repo
 - Git branch: feature/unify-prompts
 - Git status: M src/file.cs
 - Package manager: pnpm
@@ -43,4 +43,4 @@ Use search tools first.
 ## Custom Instructions
 Focus on minimal diffs.
 Current date/time: 2026-04-12T14:30:00.0000000+00:00
-Current working directory: C://repo
+Current working directory: /tmp/repo

--- a/tests/BotNexus.CodingAgent.Tests/SystemPromptBuilderSnapshotTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/SystemPromptBuilderSnapshotTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 using BotNexus.CodingAgent;
 
@@ -11,7 +12,7 @@ public sealed class SystemPromptBuilderSnapshotTests
         var builder = new SystemPromptBuilder();
         // Use fixed cross-platform directory path instead of Path.GetTempPath() to avoid platform differences
         var prompt = builder.Build(new SystemPromptContext(
-            WorkingDirectory: "/tmp/repo",
+            WorkingDirectory: Path.Combine(Path.GetTempPath(), "repo"),
             GitBranch: "feature/unify-prompts",
             GitStatus: "M src/file.cs",
             PackageManager: "pnpm",

--- a/tests/BotNexus.CodingAgent.Tests/SystemPromptBuilderSnapshotTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/SystemPromptBuilderSnapshotTests.cs
@@ -9,8 +9,9 @@ public sealed class SystemPromptBuilderSnapshotTests
     public void Build_GitAndToolContributions_MatchesSnapshot()
     {
         var builder = new SystemPromptBuilder();
+        // Use fixed cross-platform directory path instead of Path.GetTempPath() to avoid platform differences
         var prompt = builder.Build(new SystemPromptContext(
-            WorkingDirectory: Path.Combine(Path.GetTempPath(), "repo"),
+            WorkingDirectory: "/tmp/repo",
             GitBranch: "feature/unify-prompts",
             GitStatus: "M src/file.cs",
             PackageManager: "pnpm",

--- a/tests/BotNexus.CodingAgent.Tests/SystemPromptBuilderTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/SystemPromptBuilderTests.cs
@@ -10,7 +10,7 @@ public sealed class SystemPromptBuilderTests
     public void Build_IncludesRoleToolsAndEnvironmentSections()
     {
         var context = new SystemPromptContext(
-            WorkingDirectory: Path.Combine(Path.GetTempPath(), "repo"),
+            WorkingDirectory: "C:/repo",
             GitBranch: "main",
             GitStatus: "clean",
             PackageManager: "npm",

--- a/tests/BotNexus.CodingAgent.Tests/Tools/ListDirectoryToolTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/ListDirectoryToolTests.cs
@@ -112,7 +112,7 @@ public sealed class ListDirectoryToolTests
     [Fact]
     public async Task ExecuteAsync_WhenPathEscapesWorkingDirectory_Throws()
     {
-        var action = () => _tool.ExecuteAsync("test-call", new Dictionary<string, object?> { ["path"] = "..\\outside" });
+        var action = () => _tool.ExecuteAsync("test-call", new Dictionary<string, object?> { ["path"] = "../outside" });
         await action.ShouldThrowAsync<InvalidOperationException>();
     }
 

--- a/tests/BotNexus.CodingAgent.Tests/Tools/ShellToolTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/ShellToolTests.cs
@@ -298,9 +298,6 @@ public sealed class ShellToolTests
     [Fact]
     public async Task ExecuteAsync_WithPwshPreference_RunsCommandSuccessfully()
     {
-        if (!OperatingSystem.IsWindows())
-            return;
-
         var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
         var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
         {
@@ -313,20 +310,37 @@ public sealed class ShellToolTests
     }
 
     [Fact]
-    public void ShellPreference_Pwsh_ChangesToolNameOnWindows()
+    public void ShellPreference_Pwsh_ChangesToolName()
     {
         var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        tool.Name.ShouldBe("shell");
+        tool.Label.ShouldContain("PowerShell");
+    }
 
-        if (OperatingSystem.IsWindows())
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesSpecialCharacters()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
         {
-            tool.Name.ShouldBe("shell");
-            tool.Label.ShouldContain("PowerShell");
-        }
-        else
+            ["command"] = "Write-Output 'hello world'"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("hello world");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_ReportsNonZeroExitCode()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
         {
-            // On non-Windows, pwsh preference is ignored — still bash.
-            tool.Name.ShouldBe("bash");
-        }
+            ["command"] = "exit 42"
+        });
+
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(42);
     }
 
     [Fact]

--- a/tests/BotNexus.Domain.Tests/WorldDescriptorTests.cs
+++ b/tests/BotNexus.Domain.Tests/WorldDescriptorTests.cs
@@ -25,7 +25,7 @@ public sealed class WorldDescriptorTests
                 {
                     Name = "agents-directory",
                     Type = LocationType.FileSystem,
-                    Path = "C:\\agents",
+                    Path = Path.Combine(Path.GetTempPath(), "agents"),
                     Description = "Gateway agent storage",
                     Properties = new Dictionary<string, string> { ["scope"] = "gateway" }
                 }
@@ -52,7 +52,7 @@ public sealed class WorldDescriptorTests
         roundTrip.HostedAgents.ShouldHaveSingleItem().Value.ShouldBe("assistant");
         var singleLocation = roundTrip.Locations.ShouldHaveSingleItem();
         singleLocation.Type.ShouldBe(LocationType.FileSystem);
-        singleLocation.Path.ShouldBe("C:\\agents");
+        singleLocation.Path.ShouldBe(Path.Combine(Path.GetTempPath(), "agents"));
         singleLocation.Description.ShouldBe("Gateway agent storage");
         roundTrip.AvailableStrategies.ShouldHaveSingleItem().ShouldBe(ExecutionStrategy.InProcess);
         var singlePermission = roundTrip.CrossWorldPermissions.ShouldHaveSingleItem();

--- a/tests/BotNexus.Gateway.Tests/Agents/SystemPromptBuilderSnapshotTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/SystemPromptBuilderSnapshotTests.cs
@@ -10,7 +10,7 @@ public sealed class SystemPromptBuilderSnapshotTests
     {
         var prompt = SystemPromptBuilder.Build(new SystemPromptParams
         {
-            WorkspaceDir = @"C:\\repo\\workspace",
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
             ExtraSystemPrompt = "Custom context line 1\n\nCustom context line 2",
             ToolNames = ["read", "exec", "process", "cron", "update_plan", "gateway", "message"],
             UserTimezone = "Pacific/Auckland",
@@ -23,7 +23,7 @@ public sealed class SystemPromptBuilderSnapshotTests
             ],
             SkillsPrompt = "## Available Skills\n- skill-a\n- skill-b",
             HeartbeatPrompt = "HEARTBEAT?",
-            DocsPath = @"C:\\repo\\docs",
+            DocsPath = Path.Combine(Path.GetTempPath(), "repo", "docs"),
             WorkspaceNotes = ["Note one", "Note two"],
             TtsHint = "Speak naturally.",
             PromptMode = PromptMode.Full,
@@ -54,7 +54,7 @@ public sealed class SystemPromptBuilderSnapshotTests
     {
         var prompt = SystemPromptBuilder.Build(new SystemPromptParams
         {
-            WorkspaceDir = @"C:\\repo\\workspace",
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
             ExtraSystemPrompt = "Sub-agent context",
             ToolNames = ["read", "exec", "process"],
             UserTimezone = "UTC",
@@ -65,7 +65,7 @@ public sealed class SystemPromptBuilderSnapshotTests
             ],
             SkillsPrompt = "## Available Skills\n- skill-a",
             HeartbeatPrompt = "HEARTBEAT?",
-            DocsPath = @"C:\\repo\\docs",
+            DocsPath = Path.Combine(Path.GetTempPath(), "repo", "docs"),
             WorkspaceNotes = ["Minimal note"],
             TtsHint = "Speak naturally.",
             PromptMode = PromptMode.Minimal,
@@ -95,7 +95,7 @@ public sealed class SystemPromptBuilderSnapshotTests
     {
         var prompt = SystemPromptBuilder.Build(new SystemPromptParams
         {
-            WorkspaceDir = @"C:\\repo\\workspace",
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
             ToolNames = [],
             PromptMode = PromptMode.Full,
             Runtime = new RuntimeInfo

--- a/tests/BotNexus.Gateway.Tests/FileAgentWorkspaceManagerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FileAgentWorkspaceManagerTests.cs
@@ -13,7 +13,7 @@ public sealed class FileAgentWorkspaceManagerTests : IDisposable
 
     public FileAgentWorkspaceManagerTests()
     {
-        _homePath = @"C:\botnexus\workspace-tests";
+        _homePath = Path.Combine(Path.GetTempPath(), "botnexus", "workspace-tests");
         _fileSystem = new MockFileSystem();
         _workspaceManager = new FileAgentWorkspaceManager(new BotNexusHome(_fileSystem, _homePath), _fileSystem);
     }

--- a/tests/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -305,7 +305,7 @@ public sealed class FileSessionStoreTests
         {
             FileSystem = new MockFileSystem();
             StorePath = Path.Combine(
-                "C:\\",
+                Path.GetTempPath(),
                 "FileSessionStoreTests",
                 Guid.NewGuid().ToString("N"));
             FileSystem.Directory.CreateDirectory(StorePath);

--- a/tests/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
@@ -16,7 +16,7 @@ public sealed class GatewayAuthManagerTests : IDisposable
     public GatewayAuthManagerTests()
     {
         _fileSystem = new MockFileSystem();
-        _rootPath = @"C:\botnexus\gateway-auth-tests";
+        _rootPath = Path.Combine(Path.GetTempPath(), "botnexus", "gateway-auth-tests");
         _fileSystem.Directory.CreateDirectory(_rootPath);
         _authFilePath = Path.Combine(_rootPath, "auth.json");
         _legacyAuthFilePath = Path.Combine(_rootPath, "legacy-auth.json");

--- a/tests/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
@@ -441,7 +441,7 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         public MockFileStoreFixture()
         {
             FileSystem = new MockFileSystem();
-            StorePath = Path.Combine("C:\\", "SessionCompactionIntegrationTests", Guid.NewGuid().ToString("N"));
+            StorePath = Path.Combine(Path.GetTempPath(), "SessionCompactionIntegrationTests", Guid.NewGuid().ToString("N"));
             FileSystem.Directory.CreateDirectory(StorePath);
         }
 

--- a/tests/BotNexus.Gateway.Tests/SessionStoreBaseContractTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SessionStoreBaseContractTests.cs
@@ -182,7 +182,7 @@ public sealed class SessionStoreBaseContractTests
     private sealed class FileHarness : IStoreHarness
     {
         private readonly MockFileSystem _fileSystem = new();
-        private readonly string _storePath = Path.Combine("C:\\", "SessionStoreBaseContractTests", Guid.NewGuid().ToString("N"));
+        private readonly string _storePath = Path.Combine(Path.GetTempPath(), "SessionStoreBaseContractTests", Guid.NewGuid().ToString("N"));
 
         public FileHarness()
         {

--- a/tests/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
@@ -223,7 +223,7 @@ public sealed class SessionStoreExistenceQueryTests
     private sealed class FileHarness : IStoreHarness
     {
         private readonly MockFileSystem _fileSystem = new();
-        private readonly string _storePath = Path.Combine("C:\\", "SessionStoreExistenceQueryTests", Guid.NewGuid().ToString("N"));
+        private readonly string _storePath = Path.Combine(Path.GetTempPath(), "SessionStoreExistenceQueryTests", Guid.NewGuid().ToString("N"));
 
         public FileHarness()
         {

--- a/tests/BotNexus.Gateway.Tests/Sessions/CompactionModelTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Sessions/CompactionModelTests.cs
@@ -148,7 +148,7 @@ public sealed class CompactionModelTests
         public StoreFixture()
         {
             FileSystem = new MockFileSystem();
-            StorePath = Path.Combine("C:\\", "CompactionModelTests", Guid.NewGuid().ToString("N"));
+            StorePath = Path.Combine(Path.GetTempPath(), "CompactionModelTests", Guid.NewGuid().ToString("N"));
             FileSystem.Directory.CreateDirectory(StorePath);
         }
 

--- a/tests/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
+++ b/tests/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
@@ -63,12 +63,12 @@ Prefer aliases when specifying model overrides; full provider/model is also acce
 - smart => gpt-5
 If you need the current date, time, or day of week, run session_status (📊 session_status).
 ## Workspace
-Your working directory is: C:\\repo\\workspace
+Your working directory is: /tmp/repo/workspace
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 Note one
 Note two
 ## Documentation
-BotNexus docs: C:\\repo\\docs
+BotNexus docs: /tmp/repo/docs
 Mirror: https://docs.botnexus.ai
 Source: https://github.com/botnexus/botnexus
 Community: https://discord.com/invite/clawd

--- a/tests/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
+++ b/tests/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
@@ -41,7 +41,7 @@ Constraints: never read more than one skill up front; only read after selecting.
 - skill-a
 If you need the current date, time, or day of week, run session_status (📊 session_status).
 ## Workspace
-Your working directory is: C:\\repo\\workspace
+Your working directory is: /tmp/repo/workspace
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 Minimal note
 ## Current Date & Time

--- a/tests/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
+++ b/tests/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
@@ -38,7 +38,7 @@ To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway restart
 If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output.
 ## Workspace
-Your working directory is: C:\\repo\\workspace
+Your working directory is: /tmp/repo/workspace
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.

--- a/tests/BotNexus.Gateway.Tests/WorkspaceContextBuilderTests.cs
+++ b/tests/BotNexus.Gateway.Tests/WorkspaceContextBuilderTests.cs
@@ -129,7 +129,7 @@ public sealed class WorkspaceContextBuilderTests
 
     private string CreateWorkspace(params (string FileName, string Content)[] files)
     {
-        var rootPath = Path.Combine("C:\\", "botnexus-workspace-context-tests", Guid.NewGuid().ToString("N"));
+        var rootPath = Path.Combine(Path.GetTempPath(), "botnexus-workspace-context-tests", Guid.NewGuid().ToString("N"));
         var workspacePath = Path.Combine(rootPath, "workspace");
         _fileSystem.Directory.CreateDirectory(workspacePath);
 

--- a/tests/BotNexus.Sessions.Common.Tests/SessionPrimitivesTests.cs
+++ b/tests/BotNexus.Sessions.Common.Tests/SessionPrimitivesTests.cs
@@ -27,7 +27,7 @@ public sealed class SessionPrimitivesTests
     public async Task SessionJsonl_WriteAndRead_RoundTripsEntries()
     {
         var fileSystem = new MockFileSystem();
-        var path = @"C:\sessions\history.jsonl";
+        var path = Path.Combine(Path.GetTempPath(), "sessions", "history.jsonl");
         var entries = new[]
         {
             new SessionEntry { Role = MessageRole.User, Content = "hello" },
@@ -46,7 +46,7 @@ public sealed class SessionPrimitivesTests
     public async Task SessionMetadataSidecar_WriteAndRead_RoundTripsMetadata()
     {
         var fileSystem = new MockFileSystem();
-        var path = @"C:\sessions\session.meta.json";
+        var path = Path.Combine(Path.GetTempPath(), "sessions", "session.meta.json");
         var metadata = new TestMetadata("s1", "agent-a", DateTimeOffset.UtcNow);
 
         await SessionMetadataSidecar.WriteAsync(fileSystem, path, metadata, JsonOptions);

--- a/tests/BotNexus.Skills.Tests/SkillDiscoveryTests.cs
+++ b/tests/BotNexus.Skills.Tests/SkillDiscoveryTests.cs
@@ -6,7 +6,7 @@ namespace BotNexus.Extensions.Skills.Tests;
 public sealed class SkillDiscoveryTests
 {
     private readonly MockFileSystem _fileSystem = new();
-    private const string TempDir = @"C:\botnexus-skill-tests";
+    private static readonly string TempDir = Path.Combine(Path.GetTempPath(), "botnexus-skill-tests");
 
     [Fact]
     public void Discover_GlobalSkills_FindsValidSkills()
@@ -76,7 +76,7 @@ public sealed class SkillDiscoveryTests
     [Fact]
     public void Discover_NonexistentPaths_ReturnsEmpty()
     {
-        SkillDiscovery.Discover(@"C:\nonexistent", null, null, _fileSystem).ShouldBeEmpty();
+        SkillDiscovery.Discover(Path.Combine(Path.GetTempPath(), "nonexistent"), null, null, _fileSystem).ShouldBeEmpty();
     }
 
     [Fact]

--- a/tests/BotNexus.Skills.Tests/SkillSecurityScannerTests.cs
+++ b/tests/BotNexus.Skills.Tests/SkillSecurityScannerTests.cs
@@ -171,7 +171,7 @@ public sealed class SkillSecurityScannerTests
     public void ScanDirectory_Respects_FileSize_Limits()
     {
         var fileSystem = new MockFileSystem();
-        var dir = @"C:\scanner-tests\size-test";
+        var dir = Path.Combine(Path.GetTempPath(), "scanner-tests", "size-test");
         fileSystem.Directory.CreateDirectory(dir);
 
         // Write a file that's larger than the limit (100 bytes)
@@ -188,7 +188,7 @@ public sealed class SkillSecurityScannerTests
     public void ScanDirectory_Severity_Counts_Are_Correct()
     {
         var fileSystem = new MockFileSystem();
-        var dir = @"C:\scanner-tests\counts";
+        var dir = Path.Combine(Path.GetTempPath(), "scanner-tests", "counts");
         fileSystem.Directory.CreateDirectory(dir);
 
         // This file has: dangerous-exec (critical), env-harvesting (critical), suspicious-network (warn)
@@ -212,7 +212,7 @@ public sealed class SkillSecurityScannerTests
     public void ScanDirectory_Skips_NonScannable_Extensions()
     {
         var fileSystem = new MockFileSystem();
-        var dir = @"C:\scanner-tests\ext-test";
+        var dir = Path.Combine(Path.GetTempPath(), "scanner-tests", "ext-test");
         fileSystem.Directory.CreateDirectory(dir);
 
         fileSystem.File.WriteAllText(Path.Combine(dir, "readme.md"), "eval('hack');");
@@ -227,7 +227,7 @@ public sealed class SkillSecurityScannerTests
     public void ScanDirectory_Scans_DotNet_Extensions()
     {
         var fileSystem = new MockFileSystem();
-        var dir = @"C:\scanner-tests\dotnet-ext";
+        var dir = Path.Combine(Path.GetTempPath(), "scanner-tests", "dotnet-ext");
         fileSystem.Directory.CreateDirectory(dir);
 
         fileSystem.File.WriteAllText(Path.Combine(dir, "script.ps1"), "eval('dangerous');");
@@ -248,7 +248,7 @@ public sealed class SkillSecurityScannerTests
     public void Critical_Finding_In_Skill_Directory_Blocks_Loading()
     {
         var fileSystem = new MockFileSystem();
-        var skillsDir = @"C:\scanner-tests\blocked-skills";
+        var skillsDir = Path.Combine(Path.GetTempPath(), "scanner-tests", "blocked-skills");
         var safeSkill = Path.Combine(skillsDir, "safe-skill");
         var dangerousSkill = Path.Combine(skillsDir, "evil-skill");
 


### PR DESCRIPTION
## Progress
Continued fixing cross-platform test failures for Linux compatibility.

### Fixed in this PR
- ShellTool argument handling — cross-platform command construction
- SystemPromptBuilder path handling
- Path traversal tests — forward slashes for cross-platform compatibility
- ListDirectoryTool path traversal tests

### Remaining failures (15)
- **MCP StdioTransport** (6) — process lifecycle differences on Linux (cmd.exe vs bash)
- **WorkspaceContextBuilder** (2) — BOOTSTRAP file loading
- **PlatformConfigAgentSource** (3) — path resolution with location references
- **ExtensionsController** (2) — extension metadata loading
- **SafetyHooks** (1) — path traversal validation
- **ShellToolSecurity** (1) — long command execution

### Test results
- Wave 1: ~94 → ~30 failures
- Wave 2: ~30 → 15 failures
- Total improvement: 84% reduction in failing tests