### PR TITLE
feat(config): world-level agent defaults with field-level inheritance (#12)

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -15740,3 +15740,97 @@ Adopt the simpler and deterministic wake strategy: **always dispatch sub-agent c
 
 The test scaffold `InterfaceBackedSubAgentManager` in `DefaultSubAgentManagerTests.cs` still uses `FollowUpAsync` for completion delivery. Consider updating it to use `IChannelDispatcher.DispatchAsync` in a future cleanup to keep test scaffolds aligned with production behavior.
 
+
+---
+
+# Issue #12 — World Settings and Defaults (2026-04-22)
+
+## Jon Bullen (Owner) — Config Design Decisions
+
+**Decided By:** Jon Bullen | **Date:** 2026-04-22 | **Status:** Active
+
+### 1. Field-level merge (not block replacement)
+Agent config inherits world defaults field-by-field. Setting one field on an agent does not wipe the rest of the inherited block.
+
+### 2. `agents.defaults` JSON shape
+World-level defaults live under `agents.defaults`. Makes clear these are agent-specific defaults; `defaults` is not a real agent.
+
+### 3. Extensions are world-level
+Extensions are configured at world level — not part of `agents.defaults`.
+
+### 4. Cron is world-level, enabled by default
+`CronConfig.Enabled = true` is canonical. Scaffold emits `cron.enabled: true` explicitly.
+
+### 5. Memory enabled by default via `agents.defaults`
+`agents.defaults.memory.enabled = true` in new-world scaffold supports per-agent memory management on cron.
+
+---
+
+## Leela (Architect) — Issue #12 World Settings and Defaults
+
+**Date:** 2026-04-22 | **Status:** Approved
+
+### `AgentDefaultsConfig` allowed fields
+`ToolIds`, `Memory`, `Heartbeat`, `FileAccess`. Provider/model/identity/extensions/soul/topology/security-governance excluded from this wave.
+
+### Merge semantics
+- `memory` → deep field merge
+- `heartbeat` → deep field merge
+- `fileAccess` → field-level merge; each list replaces when explicitly set
+- `toolIds` → replacement, not union
+- `extensions` → unchanged; merges at world level via `ExtensionConfigMerger`
+
+### Effective-config endpoint required
+`GET /api/config/agents/{agentId}/effective` — returns resolved values + provenance/source metadata per field.
+
+### Presence-aware scalars
+Do not fake presence with `default(T)` heuristics. Use raw `JsonElement` presence detection.
+
+---
+
+## Bender — Effective-Config API Endpoint
+
+**Date:** 2026-04-22 | **Commit:** `7aa9cfd8`
+
+### Provenance values
+`"agent"` — property key exists in agent's raw JSON  
+`"inherited"` — absent on agent, present in `AgentDefaults`  
+`"implicit-default"` — absent on both; value comes from C# type default  
+
+`"world-default"` reserved for future multi-level hierarchy; currently equivalent to `"inherited"`.
+
+### List fields use replacement semantics
+For `toolIds` and file-access lists: if agent JSON has the key, source is `"agent"` regardless of value.
+
+### Reserved key: `defaults`
+`GET /api/config/agents/defaults/effective` returns 404.
+
+---
+
+## Hermes — Wave 5 Integration Tests
+
+**Date:** 2026-04-22
+
+### Integration over unit for effective-config endpoint
+`WebApplicationFactory` tests the real stack end-to-end. Mocking `PlatformConfigLoader` I/O adds fragility.
+
+### Inline DTO in Razor
+`EffectiveAgentConfigResponse` added as private nested record in `AgentConfigPanel.razor`. Avoids circular/cross-layer project reference.
+
+### IConfiguration injection in controller
+`GetEffectiveAgentConfig` now respects `BotNexus:ConfigPath`. Required for testability, consistent with other controllers.
+
+### Graceful badge fallback
+If effective-config endpoint is unavailable, badges silently disappear. No regression on error path.
+
+---
+
+## Fry — UI World-Default Inheritance Badges
+
+**Date:** 2026-04-22 | **Commit:** `502ec16c`
+
+### Badge approach: endpoint-driven (after Hermes wave 5)
+Initially implemented client-side (Option B — full config fetch + manual diff). Hermes wave 5 replaced this with direct `GET /api/config/agents/{agentId}/effective` call; `Sources` dict drives `_inheritedFields`.
+
+### Badge styling
+`.world-default-badge` — subtle, muted purple-ish tint, small text. Informational only; not visually dominant.

--- a/.squad/decisions/inbox/hermes-issue-12-tests.md
+++ b/.squad/decisions/inbox/hermes-issue-12-tests.md
@@ -1,0 +1,68 @@
+# Hermes — Issue #12 agents.defaults test coverage
+
+**Date:** 2026-04-22
+**Status:** Complete
+**Branch:** `test/issue-12-agent-defaults-hermes`
+
+## What I added
+
+### 1. `tests/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs`
+Comprehensive merge-contract coverage for `agents.defaults`:
+- memory full inherit
+- memory partial override
+- memory explicit `false`
+- heartbeat partial override
+- fileAccess list replacement
+- fileAccess partial inheritance
+- toolIds inherit when omitted
+- toolIds full replacement when set
+- explicit empty toolIds list replaces defaults
+- null-default passthrough behavior
+- direct presence-aware merge helper coverage for memory/heartbeat
+
+### 2. `tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs`
+Integration coverage for descriptor loading:
+- backward compatibility when no `agents.defaults` exists
+- reserved `defaults` key is not emitted as an `AgentDescriptor`
+- memory inheritance flows into loaded `AgentDescriptor`
+- toolIds inheritance flows into loaded `AgentDescriptor`
+
+### 3. `tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs`
+Loader/validation coverage:
+- invalid `agents.defaults.memory.indexing` reports exact field path
+- invalid `agents.defaults.heartbeat.intervalMinutes` reports exact field path
+- invalid `agents.defaults.fileAccess.allowedReadPaths[1]` reports exact field path/index
+- valid `agents.defaults` returns no validation errors
+- `CronConfig` default remains `Enabled = true`
+- `ExtractAgentDefaults` extracts defaults block and strips reserved key
+- `ExtractAgentDefaults` no-op behavior when no defaults block exists
+
+### 4. `tests/BotNexus.Gateway.Tests/Cli/InitCommandTests.cs`
+Scaffold coverage:
+- init scaffold emits `cron.enabled = true`
+- init scaffold emits `agents.defaults.memory.enabled = true`
+
+## Test result
+
+Ran:
+
+```bash
+dotnet test tests/BotNexus.Gateway.Tests --nologo --tl:off
+```
+
+Result:
+- **Passed:** 987
+- **Failed:** 0
+- **Skipped:** 0
+
+## Gaps / findings
+
+- Farnsworth’s merge implementation appears present enough for the contract tests to pass.
+- I hit one compile issue in `PlatformConfigAgentSource` around nullable `JsonElement` handling for raw agent elements; corrected it so tests could run.
+- I did **not** add effective-config API coverage here; that is Bender’s/API-side contract and can land with endpoint implementation.
+- I did **not** add a direct “config file without cron block resolves to enabled=true after full load” integration case because the current model-level default is already covered and scaffold emission is now covered separately.
+
+## Notes for merge
+
+- Keep `scripts/botnexus-sync.sh` out of this test commit; unrelated local file.
+- Branch is safe to cherry-pick or merge on top of Farnsworth’s feature branch.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,15 +1,16 @@
 ---
-updated_at: 2026-04-20T23:30:00Z
-focus_area: Sub-Agent Completion Wakeup Bug Fix Delivered
-active_issues: []
-status: subagent_wake_fix_delivered
+updated_at: 2026-04-22T01:13:00Z
+focus_area: Issue #12 World Defaults — PR #13 open for review
+active_issues: [12]
+status: pr_open
 ---
 
 # What We're Focused On
 
-**Sub-Agent Completion Wakeup Bug Fix delivered (2026-04-20 23:30Z).** Fixed two root causes preventing sub-agent completion signals from waking parent session: (1) InternalChannelAdapter stream event delivery via `SendStreamEventAsync`, (2) IsRunning race condition in `DefaultSubAgentManager.OnCompletedAsync` eliminated by removing timing-dependent branching and always dispatching via gateway queue. 5-wave delivery: Design Review (Leela) → Tests (Hermes) → Adapter Integration (Farnsworth) → Race Fix (Bender) → Consistency Review (Nibbler). 6 files changed, 309 insertions, 46 deletions. 3 new reproducing tests + 5 existing tests updated. 2,584 total tests passing, zero failures.
+**Issue #12 — World Settings and Defaults — PR #13 open for review (2026-04-22).**
+5-wave delivery: Leela (triage + design review) → Farnsworth (config schema + `AgentConfigMerger`) → Hermes (tests wave 1) → Bender (effective-config API) → Fry (UI badges) → Hermes (API integration tests + UI wiring). 2024 tests passing, 0 failures. `agents.defaults` block, field-level merge, nullable presence tracking, `toolIds` replacement, cron world-level default, `GET /api/config/agents/{agentId}/effective` with provenance.
 
-**Previous:** Read-Only Sub-Agent Session View delivered (2026-04-20 19:06Z). Users can click sub-agent sessions in sidebar to view full conversation history, tool calls, and streaming output in read-only mode. 92 BlazorClient tests passing (+22 new), 0 code issues.
+**Previous:** Sub-Agent Completion Wakeup Bug Fix delivered (2026-04-20 23:30Z). Fixed two root causes preventing sub-agent completion signals from waking parent session. 2,584 total tests passing, zero failures.
 
 ## Deferred
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentConfigPanel.razor
@@ -1,7 +1,6 @@
 @inject HttpClient Http
 @inject IJSRuntime JS
 @using System.Text.Json
-@using System.Text.Json.Nodes
 
 @if (_showPanel)
 {
@@ -254,61 +253,36 @@
     }
 
     /// <summary>
-    /// Computes which fields are inherited from world defaults by fetching the full config
-    /// and comparing the agent's raw JSON against agents.defaults.
-    /// Option B: client-side inheritance computation until Bender's effective-config endpoint ships.
+    /// Populates inheritance badges by calling Bender's effective-config endpoint
+    /// (GET /api/config/agents/{agentId}/effective). The <c>Sources</c> dict drives
+    /// which fields show the "World default" badge.
     /// </summary>
     private async Task ComputeInheritanceBadgesAsync(string apiBase)
     {
         _inheritedFields.Clear();
         try
         {
-            // Fetch the full platform config to get the agents section
-            var fullConfig = await Http.GetFromJsonAsync<JsonObject>($"{apiBase}config");
-            if (fullConfig is null) return;
+            var effective = await Http.GetFromJsonAsync<EffectiveAgentConfigResponse>(
+                $"{apiBase}config/agents/{State.AgentId}/effective");
+            if (effective?.Sources is null) return;
 
-            // Extract agents.defaults and the agent-specific raw config
-            var agentsNode = fullConfig["agents"] as JsonObject;
-            if (agentsNode is null) return;
-
-            var defaultsNode = agentsNode["defaults"] as JsonObject;
-            var agentNode = agentsNode[State.AgentId] as JsonObject;
-
-            // toolIds — inherited if agent doesn't set it but defaults has it
-            if (defaultsNode?["toolIds"] is not null)
-            {
-                var agentSetsToolIds = agentNode?.ContainsKey("toolIds") == true;
-                _inheritedFields["toolIds"] = !agentSetsToolIds;
-            }
-
-            // memory.enabled
-            if (defaultsNode?["memory"] is JsonObject defaultsMem && defaultsMem.ContainsKey("enabled"))
-            {
-                var agentMem = agentNode?["memory"] as JsonObject;
-                _inheritedFields["memory.enabled"] = agentMem?.ContainsKey("enabled") != true;
-            }
-
-            // heartbeat.enabled and heartbeat.intervalMinutes
-            if (defaultsNode?["heartbeat"] is JsonObject defaultsHb)
-            {
-                var agentHb = agentNode?["heartbeat"] as JsonObject;
-                if (defaultsHb.ContainsKey("enabled"))
-                    _inheritedFields["heartbeat.enabled"] = agentHb?.ContainsKey("enabled") != true;
-                if (defaultsHb.ContainsKey("intervalMinutes"))
-                    _inheritedFields["heartbeat.intervalMinutes"] = agentHb?.ContainsKey("intervalMinutes") != true;
-            }
-
-            // fileAccess — inherited if agent doesn't set it but defaults has it
-            if (defaultsNode?["fileAccess"] is not null)
-            {
-                _inheritedFields["fileAccess"] = agentNode?.ContainsKey("fileAccess") != true;
-            }
+            // Map endpoint sources to _inheritedFields — true when value is "inherited"
+            foreach (var (field, source) in effective.Sources)
+                _inheritedFields[field] = string.Equals(source, "inherited", StringComparison.OrdinalIgnoreCase);
         }
         catch
         {
-            // Inheritance badges are optional — silently ignore if config fetch fails
+            // Inheritance badges are optional — silently ignore if endpoint is unavailable
             _inheritedFields.Clear();
         }
+    }
+
+    // DTO for the effective-config endpoint response (mirrors BotNexus.Gateway.Api.Models.EffectiveAgentConfigResponse)
+    private sealed class EffectiveAgentConfigResponse
+    {
+        public string? AgentId { get; init; }
+        public bool DefaultsApplied { get; init; }
+        public Dictionary<string, string>? Sources { get; init; }
     }
 
     private void Close()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentConfigPanel.razor
@@ -1,5 +1,7 @@
 @inject HttpClient Http
 @inject IJSRuntime JS
+@using System.Text.Json
+@using System.Text.Json.Nodes
 
 @if (_showPanel)
 {
@@ -66,8 +68,70 @@
 
                         <div class="config-field">
                             <label>Tool Count</label>
-                            <span class="config-value">@_agentConfig.ToolCount</span>
+                            <div class="config-field-with-badge">
+                                <span class="config-value">@_agentConfig.ToolCount</span>
+                                @if (IsInherited("toolIds"))
+                                {
+                                    <span class="world-default-badge" title="Inherited from agents.defaults">World default</span>
+                                }
+                            </div>
                         </div>
+
+                        @if (_agentConfig.MemoryEnabled.HasValue)
+                        {
+                            <div class="config-field">
+                                <label>Memory</label>
+                                <div class="config-field-with-badge">
+                                    <span class="config-value">@(_agentConfig.MemoryEnabled.Value ? "Enabled" : "Disabled")</span>
+                                    @if (IsInherited("memory.enabled"))
+                                    {
+                                        <span class="world-default-badge" title="Inherited from agents.defaults">World default</span>
+                                    }
+                                </div>
+                            </div>
+                        }
+
+                        @if (_agentConfig.HeartbeatEnabled.HasValue)
+                        {
+                            <div class="config-field">
+                                <label>Heartbeat</label>
+                                <div class="config-field-with-badge">
+                                    <span class="config-value">@(_agentConfig.HeartbeatEnabled.Value ? "Enabled" : "Disabled")</span>
+                                    @if (IsInherited("heartbeat.enabled"))
+                                    {
+                                        <span class="world-default-badge" title="Inherited from agents.defaults">World default</span>
+                                    }
+                                </div>
+                            </div>
+                        }
+
+                        @if (_agentConfig.HeartbeatIntervalMinutes.HasValue)
+                        {
+                            <div class="config-field">
+                                <label>Heartbeat Interval</label>
+                                <div class="config-field-with-badge">
+                                    <span class="config-value">@_agentConfig.HeartbeatIntervalMinutes.Value min</span>
+                                    @if (IsInherited("heartbeat.intervalMinutes"))
+                                    {
+                                        <span class="world-default-badge" title="Inherited from agents.defaults">World default</span>
+                                    }
+                                </div>
+                            </div>
+                        }
+
+                        @if (_agentConfig.HasFileAccess)
+                        {
+                            <div class="config-field">
+                                <label>File Access</label>
+                                <div class="config-field-with-badge">
+                                    <span class="config-value">Configured</span>
+                                    @if (IsInherited("fileAccess"))
+                                    {
+                                        <span class="world-default-badge" title="Inherited from agents.defaults">World default</span>
+                                    }
+                                </div>
+                            </div>
+                        }
 
                         <div class="config-field">
                             <label>System Prompt Size</label>
@@ -111,6 +175,14 @@
     private string _selectedModel = "";
     private string? _contextSize;
 
+    // Tracks which fields are inherited from world defaults vs explicitly set.
+    // Key: field path (e.g. "toolIds", "memory.enabled"). Value: true = inherited.
+    private Dictionary<string, bool> _inheritedFields = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Returns true if the field value is inherited from world defaults.</summary>
+    private bool IsInherited(string fieldPath) =>
+        _inheritedFields.TryGetValue(fieldPath, out var inherited) && inherited;
+
     public async Task Open()
     {
         _showPanel = true;
@@ -145,6 +217,10 @@
                 _availableModels = [];
             }
 
+            // Compute inheritance badges using Option B (client-side merge).
+            // Wire to GET /api/config/agents/{agentId}/effective when Bender's endpoint is ready.
+            await ComputeInheritanceBadgesAsync(apiBase);
+
             // Fetch context/system prompt size
             if (State.SessionId is not null)
             {
@@ -174,6 +250,64 @@
         {
             _loading = false;
             StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Computes which fields are inherited from world defaults by fetching the full config
+    /// and comparing the agent's raw JSON against agents.defaults.
+    /// Option B: client-side inheritance computation until Bender's effective-config endpoint ships.
+    /// </summary>
+    private async Task ComputeInheritanceBadgesAsync(string apiBase)
+    {
+        _inheritedFields.Clear();
+        try
+        {
+            // Fetch the full platform config to get the agents section
+            var fullConfig = await Http.GetFromJsonAsync<JsonObject>($"{apiBase}config");
+            if (fullConfig is null) return;
+
+            // Extract agents.defaults and the agent-specific raw config
+            var agentsNode = fullConfig["agents"] as JsonObject;
+            if (agentsNode is null) return;
+
+            var defaultsNode = agentsNode["defaults"] as JsonObject;
+            var agentNode = agentsNode[State.AgentId] as JsonObject;
+
+            // toolIds — inherited if agent doesn't set it but defaults has it
+            if (defaultsNode?["toolIds"] is not null)
+            {
+                var agentSetsToolIds = agentNode?.ContainsKey("toolIds") == true;
+                _inheritedFields["toolIds"] = !agentSetsToolIds;
+            }
+
+            // memory.enabled
+            if (defaultsNode?["memory"] is JsonObject defaultsMem && defaultsMem.ContainsKey("enabled"))
+            {
+                var agentMem = agentNode?["memory"] as JsonObject;
+                _inheritedFields["memory.enabled"] = agentMem?.ContainsKey("enabled") != true;
+            }
+
+            // heartbeat.enabled and heartbeat.intervalMinutes
+            if (defaultsNode?["heartbeat"] is JsonObject defaultsHb)
+            {
+                var agentHb = agentNode?["heartbeat"] as JsonObject;
+                if (defaultsHb.ContainsKey("enabled"))
+                    _inheritedFields["heartbeat.enabled"] = agentHb?.ContainsKey("enabled") != true;
+                if (defaultsHb.ContainsKey("intervalMinutes"))
+                    _inheritedFields["heartbeat.intervalMinutes"] = agentHb?.ContainsKey("intervalMinutes") != true;
+            }
+
+            // fileAccess — inherited if agent doesn't set it but defaults has it
+            if (defaultsNode?["fileAccess"] is not null)
+            {
+                _inheritedFields["fileAccess"] = agentNode?.ContainsKey("fileAccess") != true;
+            }
+        }
+        catch
+        {
+            // Inheritance badges are optional — silently ignore if config fetch fails
+            _inheritedFields.Clear();
         }
     }
 
@@ -222,6 +356,10 @@
         public string? Model { get; init; }
         public string? Provider { get; init; }
         public int ToolCount { get; init; }
+        public bool? MemoryEnabled { get; init; }
+        public bool? HeartbeatEnabled { get; init; }
+        public int? HeartbeatIntervalMinutes { get; init; }
+        public bool HasFileAccess { get; init; }
     }
 
     private sealed record ContextInfoDto

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
@@ -162,6 +162,34 @@
                 </DictionarySection>
             </ConfigSection>
 
+            @* ── Agent World Defaults ────────────────────────────── *@
+            <ConfigSection Id="cfg-agent-defaults" Title="🌍 World Settings" Description="World-level agent defaults — inherited by all agents unless explicitly overridden.">
+                @{
+                    var agentsSection = GetObject("agents");
+                    var agentDef = GetObject(agentsSection, "defaults");
+                }
+
+                @* Memory defaults *@
+                <NestedSection Title="Agent Memory Defaults">
+                    @{ var memDef = GetObject(agentDef, "memory"); }
+                    <BoolField Label="Memory Enabled (default)" Value="@GetBool(memDef, "enabled")" ValueChanged="@(v => SetAgentDefaultBool("memory", "enabled", v))" />
+                    <SelectField Label="Indexing (default)" Value="@GetStr(memDef, "indexing")" ValueChanged="@(v => SetAgentDefaultStr("memory", "indexing", v))"
+                                 Options="@(new[] { "auto", "manual", "off" })" />
+                </NestedSection>
+
+                @* Heartbeat defaults *@
+                <NestedSection Title="Agent Heartbeat Defaults">
+                    @{ var hbDef = GetObject(agentDef, "heartbeat"); }
+                    <BoolField Label="Heartbeat Enabled (default)" Value="@GetBool(hbDef, "enabled")" ValueChanged="@(v => SetAgentDefaultBool("heartbeat", "enabled", v))" />
+                    <NumberField Label="Interval Minutes (default)" Value="@GetNullableInt(hbDef, "intervalMinutes")" ValueChanged="@(v => SetAgentDefaultNum("heartbeat", "intervalMinutes", v))" />
+                </NestedSection>
+
+                @* Default tool IDs *@
+                <NestedSection Title="Default Tool IDs">
+                    <ListField Label="Tool IDs" Items="@GetList(agentDef, "toolIds")" ItemsChanged="@(v => SetAgentDefaultList("toolIds", v))" />
+                </NestedSection>
+            </ConfigSection>
+
             @* ── Cron ────────────────────────────────────────────── *@
             <ConfigSection Id="cfg-cron" Title="⏰ Cron" Description="Scheduled job configuration — enable cron, set tick interval, and manage jobs.">
                 @{ var cron = GetObject("cron"); }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor.cs
@@ -438,6 +438,65 @@ public partial class Configuration : IDisposable
             parent[key] = new JsonObject();
     }
 
+    // ── Agent Defaults helpers (agents.defaults) ─────────────────
+
+    /// <summary>Sets a bool field on agents.defaults.{section}.{key}.</summary>
+    private void SetAgentDefaultBool(string section, string key, bool value)
+    {
+        if (_config is null) return;
+        EnsureObject("agents");
+        var agents = (_config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        EnsureChildObject(defaults, section);
+        var sectionObj = (defaults[section] as JsonObject)!;
+        sectionObj[key] = value;
+        MarkDirty();
+    }
+
+    /// <summary>Sets a string field on agents.defaults.{section}.{key}.</summary>
+    private void SetAgentDefaultStr(string section, string key, string? value)
+    {
+        if (_config is null) return;
+        EnsureObject("agents");
+        var agents = (_config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        EnsureChildObject(defaults, section);
+        var sectionObj = (defaults[section] as JsonObject)!;
+        sectionObj[key] = value;
+        MarkDirty();
+    }
+
+    /// <summary>Sets an int field on agents.defaults.{section}.{key}.</summary>
+    private void SetAgentDefaultNum(string section, string key, int? value)
+    {
+        if (_config is null) return;
+        EnsureObject("agents");
+        var agents = (_config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        EnsureChildObject(defaults, section);
+        var sectionObj = (defaults[section] as JsonObject)!;
+        if (value.HasValue) sectionObj[key] = value.Value;
+        else sectionObj.Remove(key);
+        MarkDirty();
+    }
+
+    /// <summary>Sets a top-level list field on agents.defaults.{key}.</summary>
+    private void SetAgentDefaultList(string key, List<string> value)
+    {
+        if (_config is null) return;
+        EnsureObject("agents");
+        var agents = (_config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        var arr = new JsonArray();
+        foreach (var item in value) arr.Add(item);
+        defaults[key] = arr;
+        MarkDirty();
+    }
+
     public void Dispose()
     {
         _statusTimer?.Stop();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -2312,3 +2312,25 @@ details[open] > .thinking-summary::before {
     color: var(--text-secondary); /* Better contrast than text-muted */
     font-size: 0.8rem;
 }
+
+/* ── World Default Inheritance Badge ─────────────────────────────────────── */
+
+.world-default-badge {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: 9999px;
+    font-size: 0.68rem;
+    font-weight: 500;
+    background: rgba(120, 120, 180, 0.12);
+    color: var(--text-secondary);
+    border: 1px solid rgba(120, 120, 180, 0.2);
+    margin-left: 0.4rem;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+.config-field-with-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}

--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -47,6 +47,11 @@ internal sealed class InitCommand
                 ListenUrl = "http://localhost:5005",
                 DefaultAgentId = "assistant"
             },
+            Cron = new CronConfig
+            {
+                Enabled = true,
+                TickIntervalSeconds = 60
+            },
             Agents = new Dictionary<string, AgentDefinitionConfig>(StringComparer.OrdinalIgnoreCase)
             {
                 ["assistant"] = new()
@@ -75,7 +80,43 @@ internal sealed class InitCommand
     private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
         PlatformConfigLoader.EnsureConfigDirectory(PlatformConfigLoader.DefaultHomePath);
-        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(config, CreateWriteJsonOptions()), cancellationToken);
+        var json = SerializeWithAgentDefaults(config);
+        await File.WriteAllTextAsync(configPath, json, cancellationToken);
+    }
+
+    /// <summary>
+    /// Serializes the config to JSON and injects the <c>agents.defaults</c> block
+    /// into the agents dictionary, since <see cref="PlatformConfig.AgentDefaults" /> is
+    /// a computed/non-serialized property.
+    /// </summary>
+    private static string SerializeWithAgentDefaults(PlatformConfig config)
+    {
+        var opts = CreateWriteJsonOptions();
+        var json = JsonSerializer.Serialize(config, opts);
+
+        using var document = System.Text.Json.JsonDocument.Parse(json);
+        var root = System.Text.Json.Nodes.JsonNode.Parse(json)!.AsObject();
+
+        // Inject agents.defaults block if agents object exists
+        var agentsNode = root["agents"] as System.Text.Json.Nodes.JsonObject;
+        if (agentsNode is not null)
+        {
+            var defaultsBlock = new System.Text.Json.Nodes.JsonObject
+            {
+                ["memory"] = new System.Text.Json.Nodes.JsonObject
+                {
+                    ["enabled"] = true,
+                    ["indexing"] = "auto"
+                }
+            };
+            // Insert defaults as the first key
+            var newAgents = new System.Text.Json.Nodes.JsonObject { ["defaults"] = defaultsBlock };
+            foreach (var kv in agentsNode)
+                newAgents[kv.Key] = kv.Value?.DeepClone();
+            root["agents"] = newAgents;
+        }
+
+        return root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
     }
 
     private static JsonSerializerOptions CreateWriteJsonOptions() => new()

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
@@ -103,9 +103,13 @@ public sealed class ConfigController : ControllerBase
     [HttpGet("agents/{agentId}/effective")]
     public async Task<ActionResult<EffectiveAgentConfigResponse>> GetEffectiveAgentConfig(
         string agentId,
+        [FromServices] IConfiguration configuration,
         CancellationToken ct)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
+        var configuredPath = configuration["BotNexus:ConfigPath"];
+        var configPath = string.IsNullOrWhiteSpace(configuredPath)
+            ? PlatformConfigLoader.DefaultConfigPath
+            : configuredPath;
         if (!System.IO.File.Exists(configPath))
             return NotFound($"Config file not found at '{configPath}'.");
 

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
@@ -1,6 +1,8 @@
+using BotNexus.Gateway.Api.Models;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace BotNexus.Gateway.Api.Controllers;
@@ -93,6 +95,145 @@ public sealed class ConfigController : ControllerBase
     {
         await writer.RemoveSectionEntryAsync(section, key, ct);
         return Ok(new { message = $"Entry '{key}' removed from section '{section}'." });
+    }
+
+    /// <summary>
+    /// Returns the effective (merged) configuration for a specific agent, with provenance per field.
+    /// </summary>
+    [HttpGet("agents/{agentId}/effective")]
+    public async Task<ActionResult<EffectiveAgentConfigResponse>> GetEffectiveAgentConfig(
+        string agentId,
+        CancellationToken ct)
+    {
+        var configPath = PlatformConfigLoader.DefaultConfigPath;
+        if (!System.IO.File.Exists(configPath))
+            return NotFound($"Config file not found at '{configPath}'.");
+
+        PlatformConfig config;
+        try
+        {
+            config = await PlatformConfigLoader.LoadAsync(configPath, ct, validateOnLoad: false);
+        }
+        catch
+        {
+            return StatusCode(500, "Failed to load platform config.");
+        }
+
+        // Normalise lookup — defaults is a reserved key, never a real agent
+        if (string.Equals(agentId, "defaults", StringComparison.OrdinalIgnoreCase))
+            return NotFound($"Agent '{agentId}' not found.");
+
+        if (config.Agents is null || !config.Agents.TryGetValue(agentId, out var agentConfig))
+            return NotFound($"Agent '{agentId}' not found.");
+
+        var defaults = config.AgentDefaults;
+        var rawElementNullable = config.AgentRawElements is not null && config.AgentRawElements.TryGetValue(agentId, out var re)
+            ? re
+            : (JsonElement?)null;
+
+        var effective = AgentConfigMerger.Merge(defaults, agentConfig, rawElementNullable);
+
+        var sources = BuildSources(defaults, agentConfig, rawElementNullable);
+
+        return Ok(new EffectiveAgentConfigResponse
+        {
+            AgentId = agentId,
+            DefaultsApplied = defaults is not null,
+            Config = new EffectiveAgentConfigDto
+            {
+                ToolIds = effective.ToolIds,
+                Memory = effective.Memory,
+                Heartbeat = effective.Heartbeat,
+                FileAccess = effective.FileAccess,
+            },
+            Sources = sources,
+        });
+    }
+
+    private static Dictionary<string, string> BuildSources(
+        AgentDefaultsConfig? defaults,
+        AgentDefinitionConfig agent,
+        JsonElement? rawElement)
+    {
+        var sources = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        // toolIds
+        sources["toolIds"] = ResolveListSource("toolIds", defaults?.ToolIds, agent.ToolIds, rawElement);
+
+        // memory.*
+        var agentMemObj = GetNestedObject(rawElement, "memory");
+        sources["memory.enabled"] = ResolveBoolSource("enabled", defaults?.Memory?.Enabled, agent.Memory?.Enabled, agentMemObj, agent.Memory is null);
+        sources["memory.indexing"] = ResolveStringSource("indexing", defaults?.Memory?.Indexing, agent.Memory?.Indexing, agentMemObj, agent.Memory is null);
+
+        // heartbeat.*
+        var agentHbObj = GetNestedObject(rawElement, "heartbeat");
+        sources["heartbeat.enabled"] = ResolveBoolSource("enabled", defaults?.Heartbeat?.Enabled, agent.Heartbeat?.Enabled, agentHbObj, agent.Heartbeat is null);
+        sources["heartbeat.intervalMinutes"] = ResolveIntSource("intervalMinutes", defaults?.Heartbeat?.IntervalMinutes, agent.Heartbeat?.IntervalMinutes, agentHbObj, agent.Heartbeat is null);
+
+        // fileAccess.*
+        var agentFaObj = GetNestedObject(rawElement, "fileAccess");
+        sources["fileAccess.allowedReadPaths"] = ResolveListSource("allowedReadPaths", defaults?.FileAccess?.AllowedReadPaths, agent.FileAccess?.AllowedReadPaths, agentFaObj);
+        sources["fileAccess.allowedWritePaths"] = ResolveListSource("allowedWritePaths", defaults?.FileAccess?.AllowedWritePaths, agent.FileAccess?.AllowedWritePaths, agentFaObj);
+        sources["fileAccess.deniedPaths"] = ResolveListSource("deniedPaths", defaults?.FileAccess?.DeniedPaths, agent.FileAccess?.DeniedPaths, agentFaObj);
+
+        return sources;
+    }
+
+    private static JsonElement? GetNestedObject(JsonElement? parent, string key)
+    {
+        if (parent is null) return null;
+        if (!parent.Value.TryGetProperty(key, out var prop)) return null;
+        return prop.ValueKind == JsonValueKind.Object ? prop : null;
+    }
+
+    private static bool HasKey(JsonElement? obj, string key)
+        => obj is not null && obj.Value.TryGetProperty(key, out _);
+
+    /// <summary>
+    /// Source for a list field (replacement semantics).
+    /// </summary>
+    private static string ResolveListSource(string key, System.Collections.IEnumerable? defaultVal, System.Collections.IEnumerable? agentVal, JsonElement? agentObj)
+    {
+        if (HasKey(agentObj, key))
+            return "agent";
+        if (agentObj is null && agentVal is not null)
+            return "agent"; // inferred from value presence without raw JSON
+        if (defaultVal is not null)
+            return "inherited";
+        return "implicit-default";
+    }
+
+    private static string ResolveBoolSource(string key, bool? defaultVal, bool? agentVal, JsonElement? agentObj, bool agentSectionAbsent)
+    {
+        if (!agentSectionAbsent && HasKey(agentObj, key))
+            return "agent";
+        if (!agentSectionAbsent && agentObj is null && agentVal.HasValue)
+            return "agent";
+        if (defaultVal.HasValue)
+            return "inherited";
+        return "implicit-default";
+    }
+
+    private static string ResolveStringSource(string key, string? defaultVal, string? agentVal, JsonElement? agentObj, bool agentSectionAbsent)
+    {
+        if (!agentSectionAbsent && HasKey(agentObj, key))
+            return "agent";
+        if (!agentSectionAbsent && agentObj is null && agentVal is not null)
+            return "agent";
+        if (defaultVal is not null)
+            return "inherited";
+        return "implicit-default";
+    }
+
+    private static string ResolveIntSource(string key, int? defaultVal, int? agentVal, JsonElement? agentObj, bool agentSectionAbsent)
+    {
+        if (!agentSectionAbsent && HasKey(agentObj, key))
+            return "agent";
+        if (!agentSectionAbsent && agentObj is null && agentVal.HasValue)
+            return "agent";
+        if (defaultVal.HasValue)
+            return "inherited";
+        return "implicit-default";
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway.Api/Models/EffectiveAgentConfigResponse.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Models/EffectiveAgentConfigResponse.cs
@@ -1,0 +1,44 @@
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+
+namespace BotNexus.Gateway.Api.Models;
+
+/// <summary>
+/// Response for the effective agent config endpoint. Contains the resolved
+/// configuration with provenance metadata per field.
+/// </summary>
+public sealed class EffectiveAgentConfigResponse
+{
+    /// <summary>The agent identifier.</summary>
+    public string AgentId { get; set; } = string.Empty;
+
+    /// <summary>Whether world-level defaults were applied to produce this config.</summary>
+    public bool DefaultsApplied { get; set; }
+
+    /// <summary>The resolved (effective) agent configuration.</summary>
+    public EffectiveAgentConfigDto Config { get; set; } = new();
+
+    /// <summary>
+    /// Provenance per field. Keys are field paths (e.g. <c>"toolIds"</c>, <c>"memory.enabled"</c>).
+    /// Values are one of: <c>"agent"</c>, <c>"inherited"</c>, <c>"world-default"</c>, <c>"implicit-default"</c>.
+    /// </summary>
+    public Dictionary<string, string> Sources { get; set; } = [];
+}
+
+/// <summary>
+/// The effective resolved fields from an agent's merged configuration.
+/// </summary>
+public sealed class EffectiveAgentConfigDto
+{
+    /// <summary>Resolved tool IDs available to the agent.</summary>
+    public List<string>? ToolIds { get; set; }
+
+    /// <summary>Resolved memory configuration.</summary>
+    public MemoryAgentConfig? Memory { get; set; }
+
+    /// <summary>Resolved heartbeat configuration.</summary>
+    public HeartbeatAgentConfig? Heartbeat { get; set; }
+
+    /// <summary>Resolved file-access policy.</summary>
+    public FileAccessPolicyConfig? FileAccess { get; set; }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -8,7 +8,7 @@ namespace BotNexus.Gateway.Configuration;
 /// Agent-explicitly-set fields win; absent fields inherit from defaults.
 /// Presence is detected via the optional raw JSON element for the agent config.
 /// </summary>
-internal static class AgentConfigMerger
+public static class AgentConfigMerger
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Merges <see cref="AgentDefaultsConfig" /> into an <see cref="AgentDefinitionConfig" /> field-by-field.
+/// Agent-explicitly-set fields win; absent fields inherit from defaults.
+/// Presence is detected via the optional raw JSON element for the agent config.
+/// </summary>
+internal static class AgentConfigMerger
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Produces a new <see cref="AgentDefinitionConfig" /> with defaults merged in.
+    /// </summary>
+    /// <param name="defaults">World-level agent defaults (may be null).</param>
+    /// <param name="agent">Agent-specific config.</param>
+    /// <param name="agentRawElement">
+    /// Raw JSON element for the agent definition used for presence detection.
+    /// When null, any null field on the agent is assumed to mean "inherit from defaults".
+    /// </param>
+    public static AgentDefinitionConfig Merge(
+        AgentDefaultsConfig? defaults,
+        AgentDefinitionConfig agent,
+        JsonElement? agentRawElement = null)
+    {
+        ArgumentNullException.ThrowIfNull(agent);
+
+        if (defaults is null)
+            return agent;
+
+        // Determine presence of agent-level fields via raw JSON
+        var agentObj = agentRawElement is { ValueKind: JsonValueKind.Object } el ? el : (JsonElement?)null;
+
+        return new AgentDefinitionConfig
+        {
+            // Identity / provider fields — never inherited from defaults
+            Provider = agent.Provider,
+            DisplayName = agent.DisplayName,
+            Description = agent.Description,
+            Model = agent.Model,
+            AllowedModels = agent.AllowedModels,
+            SystemPromptFile = agent.SystemPromptFile,
+            SystemPromptFiles = agent.SystemPromptFiles,
+            SubAgents = agent.SubAgents,
+            IsolationStrategy = agent.IsolationStrategy,
+            MaxConcurrentSessions = agent.MaxConcurrentSessions,
+            Metadata = agent.Metadata,
+            IsolationOptions = agent.IsolationOptions,
+            Enabled = agent.Enabled,
+            Soul = agent.Soul,
+            SessionAccess = agent.SessionAccess,
+            ToolPolicy = agent.ToolPolicy,
+            Extensions = agent.Extensions,
+
+            // Inherited / merged fields
+            ToolIds = MergeToolIds(defaults.ToolIds, agent.ToolIds, agentObj),
+            Memory = MergeMemory(defaults.Memory, agent.Memory, agentObj),
+            Heartbeat = MergeHeartbeat(defaults.Heartbeat, agent.Heartbeat, agentObj),
+            FileAccess = MergeFileAccess(defaults.FileAccess, agent.FileAccess, agentObj),
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // ToolIds: replacement when agent explicitly sets them
+    // -------------------------------------------------------------------------
+
+    private static List<string>? MergeToolIds(
+        List<string>? defaults,
+        List<string>? agent,
+        JsonElement? agentObj)
+    {
+        // If agent JSON explicitly contained "toolIds", use it (even if empty list)
+        if (agentObj is not null && agentObj.Value.TryGetProperty("toolIds", out _))
+            return agent;
+
+        // No agent override — inherit defaults
+        return agent ?? defaults;
+    }
+
+    // -------------------------------------------------------------------------
+    // Memory
+    // -------------------------------------------------------------------------
+
+    internal static MemoryAgentConfig? MergeMemory(
+        MemoryAgentConfig? defaults,
+        MemoryAgentConfig? agent,
+        JsonElement? agentObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneMemory(agent);
+        if (agent is null)
+        {
+            // Did agent JSON explicitly set "memory" to null? Only if the key existed.
+            if (agentObj is not null && agentObj.Value.TryGetProperty("memory", out var memProp) && memProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneMemory(defaults);
+        }
+
+        // Both exist — deep merge
+        var agentMemObj = agentObj is not null && agentObj.Value.TryGetProperty("memory", out var mProp) && mProp.ValueKind == JsonValueKind.Object
+            ? mProp : (JsonElement?)null;
+
+        return new MemoryAgentConfig
+        {
+            Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentMemObj),
+            Indexing = PickString("indexing", defaults.Indexing, agent.Indexing, agentMemObj),
+            Search = MergeMemorySearch(defaults.Search, agent.Search, agentMemObj),
+        };
+    }
+
+    private static MemorySearchAgentConfig? MergeMemorySearch(
+        MemorySearchAgentConfig? defaults,
+        MemorySearchAgentConfig? agent,
+        JsonElement? agentMemObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneMemorySearch(agent);
+        if (agent is null)
+        {
+            if (agentMemObj is not null && agentMemObj.Value.TryGetProperty("search", out var sProp) && sProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneMemorySearch(defaults);
+        }
+
+        var agentSearchObj = agentMemObj is not null && agentMemObj.Value.TryGetProperty("search", out var searchProp) && searchProp.ValueKind == JsonValueKind.Object
+            ? searchProp : (JsonElement?)null;
+
+        return new MemorySearchAgentConfig
+        {
+            DefaultTopK = PickInt("defaultTopK", defaults.DefaultTopK, agent.DefaultTopK, agentSearchObj),
+            TemporalDecay = MergeTemporalDecay(defaults.TemporalDecay, agent.TemporalDecay, agentSearchObj),
+        };
+    }
+
+    private static TemporalDecayAgentConfig? MergeTemporalDecay(
+        TemporalDecayAgentConfig? defaults,
+        TemporalDecayAgentConfig? agent,
+        JsonElement? agentSearchObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneTemporalDecay(agent);
+        if (agent is null)
+        {
+            if (agentSearchObj is not null && agentSearchObj.Value.TryGetProperty("temporalDecay", out var tdProp) && tdProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneTemporalDecay(defaults);
+        }
+
+        var agentTdObj = agentSearchObj is not null && agentSearchObj.Value.TryGetProperty("temporalDecay", out var tProp) && tProp.ValueKind == JsonValueKind.Object
+            ? tProp : (JsonElement?)null;
+
+        return new TemporalDecayAgentConfig
+        {
+            Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentTdObj),
+            HalfLifeDays = PickInt("halfLifeDays", defaults.HalfLifeDays, agent.HalfLifeDays, agentTdObj),
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Heartbeat
+    // -------------------------------------------------------------------------
+
+    internal static HeartbeatAgentConfig? MergeHeartbeat(
+        HeartbeatAgentConfig? defaults,
+        HeartbeatAgentConfig? agent,
+        JsonElement? agentObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneHeartbeat(agent);
+        if (agent is null)
+        {
+            if (agentObj is not null && agentObj.Value.TryGetProperty("heartbeat", out var hProp) && hProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneHeartbeat(defaults);
+        }
+
+        var agentHbObj = agentObj is not null && agentObj.Value.TryGetProperty("heartbeat", out var hbProp) && hbProp.ValueKind == JsonValueKind.Object
+            ? hbProp : (JsonElement?)null;
+
+        return new HeartbeatAgentConfig
+        {
+            Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentHbObj),
+            IntervalMinutes = PickInt("intervalMinutes", defaults.IntervalMinutes, agent.IntervalMinutes, agentHbObj),
+            Prompt = PickNullableString("prompt", defaults.Prompt, agent.Prompt, agentHbObj),
+            QuietHours = MergeQuietHours(defaults.QuietHours, agent.QuietHours, agentHbObj),
+        };
+    }
+
+    private static QuietHoursConfig? MergeQuietHours(
+        QuietHoursConfig? defaults,
+        QuietHoursConfig? agent,
+        JsonElement? agentHbObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneQuietHours(agent);
+        if (agent is null)
+        {
+            if (agentHbObj is not null && agentHbObj.Value.TryGetProperty("quietHours", out var qhProp) && qhProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneQuietHours(defaults);
+        }
+
+        var agentQhObj = agentHbObj is not null && agentHbObj.Value.TryGetProperty("quietHours", out var qProp) && qProp.ValueKind == JsonValueKind.Object
+            ? qProp : (JsonElement?)null;
+
+        return new QuietHoursConfig
+        {
+            Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentQhObj),
+            Start = PickString("start", defaults.Start, agent.Start, agentQhObj),
+            End = PickString("end", defaults.End, agent.End, agentQhObj),
+            Timezone = PickNullableString("timezone", defaults.Timezone, agent.Timezone, agentQhObj),
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // FileAccess
+    // -------------------------------------------------------------------------
+
+    internal static FileAccessPolicyConfig? MergeFileAccess(
+        FileAccessPolicyConfig? defaults,
+        FileAccessPolicyConfig? agent,
+        JsonElement? agentObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneFileAccess(agent);
+        if (agent is null)
+        {
+            if (agentObj is not null && agentObj.Value.TryGetProperty("fileAccess", out var faProp) && faProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneFileAccess(defaults);
+        }
+
+        var agentFaObj = agentObj is not null && agentObj.Value.TryGetProperty("fileAccess", out var fProp) && fProp.ValueKind == JsonValueKind.Object
+            ? fProp : (JsonElement?)null;
+
+        return new FileAccessPolicyConfig
+        {
+            AllowedReadPaths = PickList("allowedReadPaths", defaults.AllowedReadPaths, agent.AllowedReadPaths, agentFaObj),
+            AllowedWritePaths = PickList("allowedWritePaths", defaults.AllowedWritePaths, agent.AllowedWritePaths, agentFaObj),
+            DeniedPaths = PickList("deniedPaths", defaults.DeniedPaths, agent.DeniedPaths, agentFaObj),
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Presence-aware scalar pickers
+    // -------------------------------------------------------------------------
+
+    private static bool PickBool(string propName, bool defaultVal, bool agentVal, JsonElement? agentObj)
+    {
+        if (agentObj is null)
+            // No raw JSON — if agent value differs from its type default, treat as explicit
+            return agentObj is null && agentVal != default ? agentVal : defaultVal;
+
+        return agentObj.Value.TryGetProperty(propName, out _) ? agentVal : defaultVal;
+    }
+
+    private static int PickInt(string propName, int defaultVal, int agentVal, JsonElement? agentObj)
+    {
+        if (agentObj is null)
+            return agentVal != default ? agentVal : defaultVal;
+
+        return agentObj.Value.TryGetProperty(propName, out _) ? agentVal : defaultVal;
+    }
+
+    private static string PickString(string propName, string defaultVal, string agentVal, JsonElement? agentObj)
+    {
+        if (agentObj is null)
+            return !string.IsNullOrEmpty(agentVal) ? agentVal : defaultVal;
+
+        return agentObj.Value.TryGetProperty(propName, out _) ? agentVal : defaultVal;
+    }
+
+    private static string? PickNullableString(string propName, string? defaultVal, string? agentVal, JsonElement? agentObj)
+    {
+        if (agentObj is null)
+            return agentVal ?? defaultVal;
+
+        return agentObj.Value.TryGetProperty(propName, out _) ? agentVal : defaultVal;
+    }
+
+    private static List<string>? PickList(string propName, List<string>? defaultVal, List<string>? agentVal, JsonElement? agentObj)
+    {
+        if (agentObj is null)
+            return agentVal ?? defaultVal;
+
+        return agentObj.Value.TryGetProperty(propName, out _) ? agentVal : defaultVal;
+    }
+
+    // -------------------------------------------------------------------------
+    // Clone helpers
+    // -------------------------------------------------------------------------
+
+    private static MemoryAgentConfig CloneMemory(MemoryAgentConfig src) => new()
+    {
+        Enabled = src.Enabled,
+        Indexing = src.Indexing,
+        Search = src.Search is null ? null : CloneMemorySearch(src.Search),
+    };
+
+    private static MemorySearchAgentConfig CloneMemorySearch(MemorySearchAgentConfig src) => new()
+    {
+        DefaultTopK = src.DefaultTopK,
+        TemporalDecay = src.TemporalDecay is null ? null : CloneTemporalDecay(src.TemporalDecay),
+    };
+
+    private static TemporalDecayAgentConfig CloneTemporalDecay(TemporalDecayAgentConfig src) => new()
+    {
+        Enabled = src.Enabled,
+        HalfLifeDays = src.HalfLifeDays,
+    };
+
+    private static HeartbeatAgentConfig CloneHeartbeat(HeartbeatAgentConfig src) => new()
+    {
+        Enabled = src.Enabled,
+        IntervalMinutes = src.IntervalMinutes,
+        Prompt = src.Prompt,
+        QuietHours = src.QuietHours is null ? null : CloneQuietHours(src.QuietHours),
+    };
+
+    private static QuietHoursConfig CloneQuietHours(QuietHoursConfig src) => new()
+    {
+        Enabled = src.Enabled,
+        Start = src.Start,
+        End = src.End,
+        Timezone = src.Timezone,
+    };
+
+    private static FileAccessPolicyConfig CloneFileAccess(FileAccessPolicyConfig src) => new()
+    {
+        AllowedReadPaths = src.AllowedReadPaths is null ? null : new List<string>(src.AllowedReadPaths),
+        AllowedWritePaths = src.AllowedWritePaths is null ? null : new List<string>(src.AllowedWritePaths),
+        DeniedPaths = src.DeniedPaths is null ? null : new List<string>(src.DeniedPaths),
+    };
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentDefaultsConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentDefaultsConfig.cs
@@ -1,0 +1,22 @@
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// World-level defaults that are field-merged into each agent's effective config.
+/// Exposed in JSON as <c>agents.defaults</c>.
+/// </summary>
+public sealed class AgentDefaultsConfig
+{
+    /// <summary>Default tool IDs inherited by agents that do not explicitly set their own toolIds.</summary>
+    public List<string>? ToolIds { get; set; }
+
+    /// <summary>Default memory configuration inherited by agents.</summary>
+    public MemoryAgentConfig? Memory { get; set; }
+
+    /// <summary>Default heartbeat configuration inherited by agents.</summary>
+    public HeartbeatAgentConfig? Heartbeat { get; set; }
+
+    /// <summary>Default file access policy inherited by agents.</summary>
+    public FileAccessPolicyConfig? FileAccess { get; set; }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -36,6 +36,20 @@ public sealed class PlatformConfig
     /// <summary>Cron scheduler settings and optional seed jobs.</summary>
     public CronConfig? Cron { get; set; }
 
+    /// <summary>
+    /// World-level agent defaults. Populated at load time from the <c>agents.defaults</c> reserved key.
+    /// Not directly serialized — extracted separately from the agents dictionary.
+    /// </summary>
+    [JsonIgnore]
+    public AgentDefaultsConfig? AgentDefaults { get; set; }
+
+    /// <summary>
+    /// Raw JSON elements for each agent, keyed by agent ID. Used for presence-aware field-level merge.
+    /// Populated at load time alongside <see cref="AgentDefaults" />.
+    /// </summary>
+    [JsonIgnore]
+    internal Dictionary<string, System.Text.Json.JsonElement>? AgentRawElements { get; set; }
+
 }
 
 /// <summary>Provider-specific configuration.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -48,7 +48,7 @@ public sealed class PlatformConfig
     /// Populated at load time alongside <see cref="AgentDefaults" />.
     /// </summary>
     [JsonIgnore]
-    internal Dictionary<string, System.Text.Json.JsonElement>? AgentRawElements { get; set; }
+    public Dictionary<string, System.Text.Json.JsonElement>? AgentRawElements { get; set; }
 
 }
 

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -62,40 +62,53 @@ public sealed class PlatformConfigAgentSource(
         if (agents is null || agents.Count == 0)
             return descriptors;
 
+        var agentDefaults = platformConfig.AgentDefaults;
+        var agentRawElements = platformConfig.AgentRawElements;
+
         foreach (var (agentId, agentConfig) in agents)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Skip the reserved defaults pseudo-agent (safety guard in case it wasn't stripped on load)
+            if (string.Equals(agentId, "defaults", StringComparison.OrdinalIgnoreCase))
+                continue;
+
             if (!agentConfig.Enabled)
                 continue;
+
+            // Merge world-level agent defaults into this agent's config
+            JsonElement? rawElement = null;
+            if (agentRawElements is not null && agentRawElements.TryGetValue(agentId, out var rawEl))
+                rawElement = rawEl;
+            var effectiveConfig = AgentConfigMerger.Merge(agentDefaults, agentConfig, rawElement);
 
             var descriptor = new AgentDescriptor
             {
                 AgentId = AgentId.From(agentId),
-                DisplayName = agentConfig.DisplayName ?? agentId,
-                Description = agentConfig.Description,
-                ModelId = agentConfig.Model ?? string.Empty,
-                ApiProvider = agentConfig.Provider ?? string.Empty,
-                SystemPromptFile = agentConfig.SystemPromptFile,
-                SystemPromptFiles = ResolveSystemPromptFiles(agentConfig),
-                ToolIds = agentConfig.ToolIds?.ToArray() ?? [],
-                AllowedModelIds = agentConfig.AllowedModels?.ToArray() ?? [],
-                SubAgentIds = agentConfig.SubAgents?.ToArray() ?? [],
-                IsolationStrategy = string.IsNullOrWhiteSpace(agentConfig.IsolationStrategy)
+                DisplayName = effectiveConfig.DisplayName ?? agentId,
+                Description = effectiveConfig.Description,
+                ModelId = effectiveConfig.Model ?? string.Empty,
+                ApiProvider = effectiveConfig.Provider ?? string.Empty,
+                SystemPromptFile = effectiveConfig.SystemPromptFile,
+                SystemPromptFiles = ResolveSystemPromptFiles(effectiveConfig),
+                ToolIds = effectiveConfig.ToolIds?.ToArray() ?? [],
+                AllowedModelIds = effectiveConfig.AllowedModels?.ToArray() ?? [],
+                SubAgentIds = effectiveConfig.SubAgents?.ToArray() ?? [],
+                IsolationStrategy = string.IsNullOrWhiteSpace(effectiveConfig.IsolationStrategy)
                     ? "in-process"
-                    : agentConfig.IsolationStrategy,
-                MaxConcurrentSessions = agentConfig.MaxConcurrentSessions ?? 0,
-                Metadata = ConvertObject(agentConfig.Metadata),
-                IsolationOptions = ConvertObject(agentConfig.IsolationOptions),
-                Memory = CloneMemoryConfig(agentConfig.Memory),
-                Soul = CloneSoulConfig(agentConfig.Soul),
-                Heartbeat = CloneHeartbeatConfig(agentConfig.Heartbeat),
-                SessionAccessLevel = agentConfig.SessionAccess?.Level ?? "own",
-                SessionAllowedAgents = agentConfig.SessionAccess?.AllowedAgents?.ToArray() ?? [],
-                FileAccess = MapFileAccessPolicy(agentConfig.FileAccess, platformConfig.Gateway?.FileAccess),
+                    : effectiveConfig.IsolationStrategy,
+                MaxConcurrentSessions = effectiveConfig.MaxConcurrentSessions ?? 0,
+                Metadata = ConvertObject(effectiveConfig.Metadata),
+                IsolationOptions = ConvertObject(effectiveConfig.IsolationOptions),
+                Memory = CloneMemoryConfig(effectiveConfig.Memory),
+                Soul = CloneSoulConfig(effectiveConfig.Soul),
+                Heartbeat = CloneHeartbeatConfig(effectiveConfig.Heartbeat),
+                SessionAccessLevel = effectiveConfig.SessionAccess?.Level ?? "own",
+                SessionAllowedAgents = effectiveConfig.SessionAccess?.AllowedAgents?.ToArray() ?? [],
+                FileAccess = MapFileAccessPolicy(effectiveConfig.FileAccess, platformConfig.Gateway?.FileAccess),
                 ExtensionConfig = ExtensionConfigMerger.Merge(
                     platformConfig.Gateway?.Extensions?.Defaults,
-                    agentConfig.Extensions)
+                    effectiveConfig.Extensions)
             };
 
             var validationErrors = AgentDescriptorValidator.Validate(descriptor);
@@ -189,8 +202,8 @@ public sealed class PlatformConfigAgentSource(
 
     private FileAccessPolicy? MapFileAccessPolicy(FileAccessPolicyConfig? agentLevel, FileAccessPolicyConfig? worldLevel)
     {
-        // Agent-level policy takes full precedence if set
-        var effective = agentLevel ?? worldLevel;
+        // Field-level merge: agent-level fields win over world-level where explicitly set
+        var effective = AgentConfigMerger.MergeFileAccess(worldLevel, agentLevel, null);
         if (effective is null)
             return null;
 

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
@@ -60,6 +60,7 @@ public static class PlatformConfigLoader
             config = JsonSerializer.Deserialize<PlatformConfig>(rawJson, JsonOptions)
                 ?? new PlatformConfig();
             config = MigrateLegacyGatewaySettings(config, rawJson);
+            ExtractAgentDefaults(config, rawJson);
         }
         catch (JsonException ex)
         {
@@ -106,6 +107,7 @@ public static class PlatformConfigLoader
             config = JsonSerializer.Deserialize<PlatformConfig>(rawJson, JsonOptions)
                 ?? new PlatformConfig();
             config = MigrateLegacyGatewaySettings(config, rawJson);
+            ExtractAgentDefaults(config, rawJson);
         }
         catch (JsonException ex)
         {
@@ -184,6 +186,7 @@ public static class PlatformConfigLoader
         ValidateProviders(config.Providers, errors);
         ValidateChannels(config.Channels, errors);
         ValidateAgents(config.Agents, errors);
+        ValidateAgentDefaults(config.AgentDefaults, errors);
         ValidateApiKeys(config.Gateway?.ApiKeys, errors);
         ValidateCron(config.Cron, errors);
 
@@ -271,6 +274,61 @@ public static class PlatformConfigLoader
             {
                 errors.Add($"providers.{providerKey}.baseUrl must be a valid http or https absolute URL.");
             }
+        }
+    }
+
+
+    /// <summary>
+    /// Extracts <c>agents.defaults</c> from the raw JSON and populates
+    /// <see cref="PlatformConfig.AgentDefaults" /> and <see cref="PlatformConfig.AgentRawElements" />,
+    /// then removes the reserved <c>defaults</c> key from <see cref="PlatformConfig.Agents" />.
+    /// </summary>
+    internal static void ExtractAgentDefaults(PlatformConfig config, string rawJson)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (string.IsNullOrWhiteSpace(rawJson))
+            return;
+
+        using var document = JsonDocument.Parse(rawJson);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (!document.RootElement.TryGetProperty("agents", out var agentsElement) ||
+            agentsElement.ValueKind != JsonValueKind.Object)
+            return;
+
+        // Extract agents.defaults
+        if (agentsElement.TryGetProperty("defaults", out var defaultsElement) &&
+            defaultsElement.ValueKind == JsonValueKind.Object)
+        {
+            config.AgentDefaults = JsonSerializer.Deserialize<AgentDefaultsConfig>(
+                defaultsElement.GetRawText(), JsonOptions);
+        }
+
+        // Remove reserved key from the Agents dictionary
+        if (config.Agents is not null)
+        {
+            var keysToRemove = config.Agents.Keys
+                .Where(k => string.Equals(k, "defaults", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            foreach (var key in keysToRemove)
+                config.Agents.Remove(key);
+        }
+
+        // Capture raw JSON elements for each agent for presence-aware merging
+        if (config.Agents is not null && config.Agents.Count > 0)
+        {
+            var rawElements = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in agentsElement.EnumerateObject())
+            {
+                if (string.Equals(property.Name, "defaults", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (property.Value.ValueKind == JsonValueKind.Object)
+                    rawElements[property.Name] = property.Value.Clone();
+            }
+
+            config.AgentRawElements = rawElements;
         }
     }
 
@@ -445,10 +503,67 @@ public static class PlatformConfigLoader
                 continue;
             }
 
+            // Reserved key — handled separately
+            if (string.Equals(agentId, "defaults", StringComparison.OrdinalIgnoreCase))
+                continue;
+
             if (string.IsNullOrWhiteSpace(agentConfig.Provider))
                 errors.Add($"agents.{agentId}.provider is required (example: 'copilot').");
             if (string.IsNullOrWhiteSpace(agentConfig.Model))
                 errors.Add($"agents.{agentId}.model is required (example: 'gpt-4.1').");
+        }
+    }
+
+    private static void ValidateAgentDefaults(AgentDefaultsConfig? defaults, List<string> errors)
+    {
+        if (defaults is null)
+            return;
+
+        const string prefix = "agents.defaults";
+
+        // toolIds
+        if (defaults.ToolIds is not null)
+        {
+            for (var i = 0; i < defaults.ToolIds.Count; i++)
+            {
+                if (string.IsNullOrWhiteSpace(defaults.ToolIds[i]))
+                    errors.Add($"{prefix}.toolIds[{i}] must be a non-empty string.");
+            }
+        }
+
+        // memory
+        if (defaults.Memory is not null)
+        {
+            // indexing must be non-empty if explicitly set to something other than default
+            if (defaults.Memory.Indexing is not null && string.IsNullOrWhiteSpace(defaults.Memory.Indexing))
+                errors.Add($"{prefix}.memory.indexing must be a non-empty string if specified.");
+        }
+
+        // heartbeat
+        if (defaults.Heartbeat is not null)
+        {
+            if (defaults.Heartbeat.IntervalMinutes <= 0)
+                errors.Add($"{prefix}.heartbeat.intervalMinutes must be greater than zero.");
+        }
+
+        // fileAccess
+        if (defaults.FileAccess is not null)
+        {
+            ValidateFileAccessPaths(defaults.FileAccess.AllowedReadPaths, $"{prefix}.fileAccess.allowedReadPaths", errors);
+            ValidateFileAccessPaths(defaults.FileAccess.AllowedWritePaths, $"{prefix}.fileAccess.allowedWritePaths", errors);
+            ValidateFileAccessPaths(defaults.FileAccess.DeniedPaths, $"{prefix}.fileAccess.deniedPaths", errors);
+        }
+    }
+
+    private static void ValidateFileAccessPaths(List<string>? paths, string fieldPath, List<string> errors)
+    {
+        if (paths is null)
+            return;
+
+        for (var i = 0; i < paths.Count; i++)
+        {
+            if (string.IsNullOrWhiteSpace(paths[i]))
+                errors.Add($"{fieldPath}[{i}] must be a non-empty string.");
         }
     }
 

--- a/tests/BotNexus.Gateway.Tests/Cli/InitCommandTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Cli/InitCommandTests.cs
@@ -1,4 +1,6 @@
 
+using System.Text.Json;
+
 namespace BotNexus.Gateway.Tests.Cli;
 
 public sealed class InitCommandTests
@@ -47,6 +49,44 @@ public sealed class InitCommandTests
         result.ExitCode.ShouldBe(0);
         config.Gateway?.ListenUrl.ShouldBe("http://localhost:5005");
         config.Agents.ShouldContainKey("assistant");
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #12: InitCommand scaffold — agents.defaults and cron (scenario 11)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Init_ScaffoldEmitsCronEnabledTrue()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync();
+
+        var result = await fixture.RunCliAsync("init");
+        var rawJson = await File.ReadAllTextAsync(fixture.ConfigPath);
+
+        result.ExitCode.ShouldBe(0);
+        // cron.enabled defaults to true in the C# model; init scaffold should emit it
+        using var doc = JsonDocument.Parse(rawJson);
+        doc.RootElement.TryGetProperty("cron", out var cronEl).ShouldBeTrue();
+        cronEl.TryGetProperty("enabled", out var cronEnabledEl).ShouldBeTrue();
+        cronEnabledEl.GetBoolean().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Init_ScaffoldEmitsAgentsDefaultsMemoryEnabledTrue()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync();
+
+        var result = await fixture.RunCliAsync("init");
+        var rawJson = await File.ReadAllTextAsync(fixture.ConfigPath);
+
+        result.ExitCode.ShouldBe(0);
+        // agents.defaults block with memory.enabled = true must be present
+        using var doc = JsonDocument.Parse(rawJson);
+        doc.RootElement.TryGetProperty("agents", out var agentsEl).ShouldBeTrue();
+        agentsEl.TryGetProperty("defaults", out var defaultsEl).ShouldBeTrue();
+        defaultsEl.TryGetProperty("memory", out var memoryEl).ShouldBeTrue();
+        memoryEl.TryGetProperty("enabled", out var enabledEl).ShouldBeTrue();
+        enabledEl.GetBoolean().ShouldBeTrue();
     }
 }
 

--- a/tests/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs
@@ -1,0 +1,358 @@
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+/// <summary>
+/// Tests for <see cref="AgentConfigMerger"/> — field-level inheritance merge semantics.
+/// All scenarios derived from Leela's design review (Issue #12).
+/// </summary>
+public sealed class AgentConfigMergerTests
+{
+    // -------------------------------------------------------------------------
+    // Memory merge — full inherit (scenario 3)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentOmitsMemory_InheritsFullDefaultMemoryBlock()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            Memory = new MemoryAgentConfig
+            {
+                Enabled = true,
+                Indexing = "auto",
+                Search = new MemorySearchAgentConfig { DefaultTopK = 5 }
+            }
+        };
+        var agent = new AgentDefinitionConfig { Provider = "copilot", Model = "gpt-4.1" };
+        // No memory on agent, no raw JSON — treat all nulls as "inherit"
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, agentRawElement: null);
+
+        // Assert
+        result.Memory.ShouldNotBeNull();
+        result.Memory!.Enabled.ShouldBeTrue();
+        result.Memory.Indexing.ShouldBe("auto");
+        result.Memory.Search.ShouldNotBeNull();
+        result.Memory.Search!.DefaultTopK.ShouldBe(5);
+    }
+
+    [Fact]
+    public void Merge_AgentOmitsMemory_WithRawJson_InheritsFullDefaultMemoryBlock()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            Memory = new MemoryAgentConfig { Enabled = true, Indexing = "semantic" }
+        };
+        var agent = new AgentDefinitionConfig { Provider = "copilot", Model = "gpt-4.1" };
+        // Raw JSON that does NOT contain "memory" key
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","enabled":true}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.Memory.ShouldNotBeNull();
+        result.Memory!.Enabled.ShouldBeTrue();
+        result.Memory.Indexing.ShouldBe("semantic");
+    }
+
+    // -------------------------------------------------------------------------
+    // Memory merge — partial override (scenario 4)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentOverridesOneMemoryField_OtherFieldsInheritedFromDefaults()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            Memory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" }
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            Memory = new MemoryAgentConfig { Indexing = "manual" }
+        };
+        // Raw JSON explicitly includes "memory" with only "indexing"
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","memory":{"indexing":"manual"}}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.Memory.ShouldNotBeNull();
+        result.Memory!.Indexing.ShouldBe("manual");        // agent override wins
+        result.Memory.Enabled.ShouldBeTrue();              // inherited from defaults
+    }
+
+    // -------------------------------------------------------------------------
+    // Memory merge — explicit false (scenario 5)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentSetsMemoryEnabledFalse_OverridesInheritedTrue()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            Memory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" }
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            Memory = new MemoryAgentConfig { Enabled = false, Indexing = "auto" }
+        };
+        // Raw JSON explicitly sets memory.enabled = false
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","memory":{"enabled":false}}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.Memory.ShouldNotBeNull();
+        result.Memory!.Enabled.ShouldBeFalse();   // explicit false wins over inherited true
+        result.Memory.Indexing.ShouldBe("auto");  // inherits when not in raw
+    }
+
+    // -------------------------------------------------------------------------
+    // Heartbeat merge — partial override (scenario 6)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentOverridesHeartbeatIntervalOnly_InheritedEnabledRemains()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            Heartbeat = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 30 }
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            Heartbeat = new HeartbeatAgentConfig { IntervalMinutes = 60 }
+        };
+        // Raw JSON: agent only sets intervalMinutes
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","heartbeat":{"intervalMinutes":60}}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.Heartbeat.ShouldNotBeNull();
+        result.Heartbeat!.IntervalMinutes.ShouldBe(60);   // agent override
+        result.Heartbeat.Enabled.ShouldBeTrue();          // inherited from defaults
+    }
+
+    // -------------------------------------------------------------------------
+    // FileAccess merge — list replacement (scenario 7)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentSuppliesAllowedReadPaths_ReplacesDefaultListNotUnion()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            FileAccess = new FileAccessPolicyConfig
+            {
+                AllowedReadPaths = ["/defaults/read1", "/defaults/read2"]
+            }
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            FileAccess = new FileAccessPolicyConfig
+            {
+                AllowedReadPaths = ["/agent/read"]
+            }
+        };
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","fileAccess":{"allowedReadPaths":["/agent/read"]}}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.FileAccess.ShouldNotBeNull();
+        result.FileAccess!.AllowedReadPaths.ShouldBe(["/agent/read"]);  // replaced, not union
+        result.FileAccess.AllowedReadPaths.ShouldNotContain("/defaults/read1");
+    }
+
+    // -------------------------------------------------------------------------
+    // FileAccess merge — partial (scenario 8)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentOverridesOneFileAccessList_OtherListsRemainInherited()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            FileAccess = new FileAccessPolicyConfig
+            {
+                AllowedReadPaths = ["/defaults/read"],
+                AllowedWritePaths = ["/defaults/write"],
+                DeniedPaths = ["/defaults/denied"]
+            }
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            FileAccess = new FileAccessPolicyConfig
+            {
+                AllowedWritePaths = ["/agent/write"]
+            }
+        };
+        // Agent only sets allowedWritePaths
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","fileAccess":{"allowedWritePaths":["/agent/write"]}}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.FileAccess.ShouldNotBeNull();
+        result.FileAccess!.AllowedWritePaths.ShouldBe(["/agent/write"]);   // overridden
+        result.FileAccess.AllowedReadPaths.ShouldBe(["/defaults/read"]);   // inherited
+        result.FileAccess.DeniedPaths.ShouldBe(["/defaults/denied"]);      // inherited
+    }
+
+    // -------------------------------------------------------------------------
+    // ToolIds replacement (scenario 9)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_AgentOmitsToolIds_InheritsDefaultList()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            ToolIds = ["tool-a", "tool-b"]
+        };
+        var agent = new AgentDefinitionConfig { Provider = "copilot", Model = "gpt-4.1" };
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1"}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.ToolIds.ShouldBe(["tool-a", "tool-b"]);
+    }
+
+    [Fact]
+    public void Merge_AgentSetsToolIds_ReplacesDefaultListEntirely()
+    {
+        // Arrange
+        var defaults = new AgentDefaultsConfig
+        {
+            ToolIds = ["tool-a", "tool-b"]
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            ToolIds = ["tool-c"]
+        };
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","toolIds":["tool-c"]}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.ToolIds.ShouldBe(["tool-c"]);      // replaced entirely
+        result.ToolIds.ShouldNotContain("tool-a");
+    }
+
+    [Fact]
+    public void Merge_AgentSetsEmptyToolIds_ReplacesDefaultListWithEmpty()
+    {
+        // Arrange — agent explicitly sets empty list (replacement semantics)
+        var defaults = new AgentDefaultsConfig { ToolIds = ["tool-a"] };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            ToolIds = []
+        };
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","toolIds":[]}""").RootElement;
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        // Assert
+        result.ToolIds.ShouldNotBeNull();
+        result.ToolIds!.ShouldBeEmpty();  // empty list replacement wins
+    }
+
+    // -------------------------------------------------------------------------
+    // No defaults — passthrough (scenario 1 — merger side)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Merge_NullDefaults_ReturnsOriginalAgentConfigUnchanged()
+    {
+        // Arrange
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            ToolIds = ["tool-x"],
+            Memory = new MemoryAgentConfig { Enabled = true }
+        };
+
+        // Act
+        var result = AgentConfigMerger.Merge(defaults: null, agent: agent, agentRawElement: null);
+
+        // Assert — exact same instance returned
+        result.ShouldBeSameAs(agent);
+        result.ToolIds.ShouldBe(["tool-x"]);
+        result.Memory!.Enabled.ShouldBeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // MergeMemory internal — direct tests for presence-aware logic
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MergeMemory_BothNull_ReturnsNull()
+    {
+        var result = AgentConfigMerger.MergeMemory(null, null, null);
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MergeMemory_DefaultsOnlyNoAgentKey_ReturnsCloneOfDefaults()
+    {
+        var defaults = new MemoryAgentConfig { Enabled = true, Indexing = "auto" };
+        var agentObj = JsonDocument.Parse("""{"provider":"copilot"}""").RootElement;
+
+        var result = AgentConfigMerger.MergeMemory(defaults, null, agentObj);
+
+        result.ShouldNotBeNull();
+        result!.Enabled.ShouldBeTrue();
+        result.Indexing.ShouldBe("auto");
+        result.ShouldNotBeSameAs(defaults);  // must be a clone
+    }
+
+    [Fact]
+    public void MergeHeartbeat_AgentOmitsBlock_InheritsDefaults()
+    {
+        var defaults = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 15 };
+        var agentObj = JsonDocument.Parse("""{"provider":"copilot"}""").RootElement;
+
+        var result = AgentConfigMerger.MergeHeartbeat(defaults, null, agentObj);
+
+        result.ShouldNotBeNull();
+        result!.Enabled.ShouldBeTrue();
+        result.IntervalMinutes.ShouldBe(15);
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/Integration/EffectiveAgentConfigEndpointTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/EffectiveAgentConfigEndpointTests.cs
@@ -1,0 +1,298 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BotNexus.Gateway.Api.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace BotNexus.Gateway.Tests.Integration;
+
+/// <summary>
+/// Integration tests for GET /api/config/agents/{agentId}/effective (Bender's endpoint).
+/// Tests run against a real WebApplicationFactory with a temp config file.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("IntegrationTests")]
+public sealed class EffectiveAgentConfigEndpointTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public EffectiveAgentConfigEndpointTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "botnexus-effective-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private string WriteConfig(string json)
+    {
+        var path = Path.Combine(_tempDir, Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(string configPath)
+        => new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.UseUrls("http://127.0.0.1:0");
+                builder.ConfigureAppConfiguration((_, cfg) =>
+                    cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["BotNexus:ConfigPath"] = configPath
+                    }));
+                builder.ConfigureServices(services =>
+                {
+                    // Remove background hosted services so tests don't need full infra
+                    var toRemove = services
+                        .Where(d => d.ServiceType == typeof(IHostedService))
+                        .ToList();
+                    foreach (var d in toRemove) services.Remove(d);
+                });
+            });
+
+    private static async Task<EffectiveAgentConfigResponse> GetEffective(HttpClient client, string agentId)
+    {
+        var response = await client.GetAsync($"/api/config/agents/{agentId}/effective");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<EffectiveAgentConfigResponse>();
+        return payload.ShouldNotBeNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 1 — Known agent, no defaults → DefaultsApplied = false
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_KnownAgentNoDefaults_ReturnsFalseDefaultsApplied()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "bot-alpha": {
+              "displayName": "Alpha",
+              "model": "gpt-4o",
+              "toolIds": ["tool-a"]
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-alpha");
+
+        payload.AgentId.ShouldBe("bot-alpha");
+        payload.DefaultsApplied.ShouldBeFalse();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 2 — Known agent with defaults → DefaultsApplied = true, Sources populated
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_KnownAgentWithDefaults_ReturnsTrueDefaultsAppliedAndSourcesPopulated()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "toolIds": ["default-tool"],
+              "memory": { "enabled": true }
+            },
+            "bot-beta": {
+              "displayName": "Beta",
+              "model": "gpt-4o"
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-beta");
+
+        payload.DefaultsApplied.ShouldBeTrue();
+        payload.Sources.ShouldNotBeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 3 — Agent inherits memory → sources["memory.enabled"] = "inherited"
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_AgentInheritsMemory_MemoryEnabledSourceIsInherited()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "memory": { "enabled": true }
+            },
+            "bot-inherits-mem": {
+              "displayName": "Inheritor",
+              "model": "gpt-4o"
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-inherits-mem");
+
+        payload.Sources.ShouldContainKeyAndValue("memory.enabled", "inherited");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 4 — Agent overrides memory → sources["memory.enabled"] = "agent"
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_AgentOverridesMemory_MemoryEnabledSourceIsAgent()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "memory": { "enabled": true }
+            },
+            "bot-overrides-mem": {
+              "displayName": "Overrider",
+              "model": "gpt-4o",
+              "memory": { "enabled": false }
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-overrides-mem");
+
+        payload.Sources.ShouldContainKeyAndValue("memory.enabled", "agent");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 5 — Unknown agentId → 404
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_UnknownAgentId_Returns404()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "bot-known": { "displayName": "Known", "model": "gpt-4o" }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/config/agents/bot-unknown/effective");
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 6 — "defaults" as agentId → 404 (reserved key)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_DefaultsAsAgentId_Returns404()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "toolIds": ["default-tool"]
+            },
+            "bot-real": { "displayName": "Real", "model": "gpt-4o" }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/config/agents/defaults/effective");
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 7 — toolIds inherited → sources["toolIds"] = "inherited"
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_ToolIdsInherited_SourceIsInherited()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "toolIds": ["default-tool-1", "default-tool-2"]
+            },
+            "bot-no-tools": {
+              "displayName": "NoTools",
+              "model": "gpt-4o"
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-no-tools");
+
+        payload.Sources.ShouldContainKeyAndValue("toolIds", "inherited");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Scenario 8 — toolIds overridden → sources["toolIds"] = "agent"
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_ToolIdsOverridden_SourceIsAgent()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "toolIds": ["default-tool"]
+            },
+            "bot-own-tools": {
+              "displayName": "OwnTools",
+              "model": "gpt-4o",
+              "toolIds": ["custom-tool"]
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-own-tools");
+
+        payload.Sources.ShouldContainKeyAndValue("toolIds", "agent");
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -630,6 +630,151 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
+    // -------------------------------------------------------------------------
+    // Issue #12: agents.defaults integration tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_WithoutAgentsDefaults_LoadsAgentsUnchanged_BackwardCompatibility()
+    {
+        // Arrange — config without any agents.defaults key
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["assistant"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    ToolIds = ["tool-a"],
+                    Memory = new MemoryAgentConfig { Enabled = true, Indexing = "manual" }
+                }
+            }
+        };
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        // Act
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        // Assert — original values preserved; no inheritance side effects
+        descriptor.AgentId.Value.ShouldBe("assistant");
+        descriptor.ToolIds.ShouldBe(["tool-a"]);
+        descriptor.Memory.ShouldNotBeNull();
+        descriptor.Memory!.Enabled.ShouldBeTrue();
+        descriptor.Memory.Indexing.ShouldBe("manual");
+    }
+
+    [Fact]
+    public async Task LoadAsync_AgentsDefaultsIsReservedKey_NotRegisteredAsAgentDescriptor()
+    {
+        // Arrange — simulate ExtractAgentDefaults having been called; defaults key should not appear
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                Memory = new MemoryAgentConfig { Enabled = true }
+            },
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                // Safety guard: even if "defaults" leaked into the dictionary, it must be skipped
+                ["defaults"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    Enabled = true
+                },
+                ["assistant"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    Enabled = true
+                }
+            }
+        };
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        // Act
+        var descriptors = await source.LoadAsync();
+
+        // Assert — only "assistant" is registered; "defaults" is excluded
+        descriptors.ShouldHaveSingleItem();
+        descriptors[0].AgentId.Value.ShouldBe("assistant");
+        descriptors.ShouldNotContain(d => d.AgentId.Value.Equals("defaults", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithAgentsDefaults_MemoryInheritedIntoAgentDescriptor()
+    {
+        // Arrange — agent omits memory; defaults provide it
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                Memory = new MemoryAgentConfig { Enabled = true, Indexing = "semantic" }
+            },
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["assistant"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    Enabled = true
+                }
+            }
+        };
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        // Act
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        // Assert
+        descriptor.Memory.ShouldNotBeNull();
+        descriptor.Memory!.Enabled.ShouldBeTrue();
+        descriptor.Memory.Indexing.ShouldBe("semantic");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithAgentsDefaults_ToolIdsInheritedWhenAgentOmitsThem()
+    {
+        // Arrange
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                ToolIds = ["read", "write"]
+            },
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["assistant"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    Enabled = true
+                    // No toolIds
+                }
+            }
+        };
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        // Act
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        // Assert — inherited from defaults since no AgentRawElements present (no raw JSON path)
+        descriptor.ToolIds.ShouldBe(["read", "write"]);
+    }
+
     private sealed class StubLocationResolver(IReadOnlyDictionary<string, string> paths) : ILocationResolver
     {
         private readonly IReadOnlyDictionary<string, string> _paths = paths;

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Configuration;
+using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Extensions;
@@ -793,6 +794,191 @@ public sealed class PlatformConfigurationTests
             string? format,
             params object?[]? args)
             => Write(args is { Length: > 0 } ? string.Format(format ?? string.Empty, args) : format);
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #12: agents.defaults validation (scenario 12)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void PlatformConfigLoader_Validate_WithInvalidAgentsDefaultsMemoryIndexing_ReportsExactFieldPath()
+    {
+        // Arrange — agents.defaults.memory.indexing is empty string (invalid)
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                Memory = new MemoryAgentConfig
+                {
+                    Enabled = true,
+                    Indexing = ""  // invalid: non-empty required
+                }
+            }
+        };
+
+        // Act
+        var errors = PlatformConfigLoader.Validate(config);
+
+        // Assert — error references exact field path
+        errors.ShouldContain(e => e.Contains("agents.defaults.memory.indexing", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PlatformConfigLoader_Validate_WithInvalidAgentsDefaultsHeartbeatInterval_ReportsExactFieldPath()
+    {
+        // Arrange — intervalMinutes <= 0 is invalid
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                Heartbeat = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 0 }
+            }
+        };
+
+        // Act
+        var errors = PlatformConfigLoader.Validate(config);
+
+        // Assert
+        errors.ShouldContain(e => e.Contains("agents.defaults.heartbeat.intervalMinutes", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PlatformConfigLoader_Validate_WithInvalidAgentsDefaultsFileAccessBlankPath_ReportsExactFieldPath()
+    {
+        // Arrange — blank entry in allowedReadPaths is invalid
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                FileAccess = new FileAccessPolicyConfig
+                {
+                    AllowedReadPaths = ["/valid/path", ""]
+                }
+            }
+        };
+
+        // Act
+        var errors = PlatformConfigLoader.Validate(config);
+
+        // Assert — error must name the exact field path including array index
+        errors.ShouldContain(e =>
+            e.Contains("agents.defaults.fileAccess.allowedReadPaths", StringComparison.Ordinal) &&
+            e.Contains("[1]", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PlatformConfigLoader_Validate_WithValidAgentsDefaults_ReturnsNoErrors()
+    {
+        // Arrange — valid defaults config
+        var config = new PlatformConfig
+        {
+            AgentDefaults = new AgentDefaultsConfig
+            {
+                ToolIds = ["read", "write"],
+                Memory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" },
+                Heartbeat = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 30 },
+                FileAccess = new FileAccessPolicyConfig
+                {
+                    AllowedReadPaths = ["/home/user/docs"]
+                }
+            }
+        };
+
+        // Act
+        var errors = PlatformConfigLoader.Validate(config);
+
+        // Assert
+        errors.ShouldBeEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #12: cron default — enabled = true (scenario 10)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CronConfig_WhenCreatedWithDefaults_HasEnabledTrue()
+    {
+        // Arrange & Act
+        var cron = new CronConfig();
+
+        // Assert — default must be enabled per design spec
+        cron.Enabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CronConfig_WhenEnabledSetFalse_ReturnsDisabled()
+    {
+        // Arrange & Act
+        var cron = new CronConfig { Enabled = false };
+
+        // Assert
+        cron.Enabled.ShouldBeFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #12: ExtractAgentDefaults (scenario 2 — loader side)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ExtractAgentDefaults_WithDefaultsInJson_PopulatesAgentDefaultsAndStripsKey()
+    {
+        // Arrange
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["defaults"] = new() { Provider = "copilot", Model = "gpt-4.1" }, // would be present after deserialization
+                ["assistant"] = new() { Provider = "copilot", Model = "gpt-4.1" }
+            }
+        };
+        var rawJson = """
+            {
+              "agents": {
+                "defaults": { "memory": { "enabled": true, "indexing": "auto" } },
+                "assistant": { "provider": "copilot", "model": "gpt-4.1", "enabled": true }
+              }
+            }
+            """;
+
+        // Act
+        PlatformConfigLoader.ExtractAgentDefaults(config, rawJson);
+
+        // Assert — defaults extracted
+        config.AgentDefaults.ShouldNotBeNull();
+        config.AgentDefaults!.Memory.ShouldNotBeNull();
+        config.AgentDefaults.Memory!.Enabled.ShouldBeTrue();
+        config.AgentDefaults.Memory.Indexing.ShouldBe("auto");
+
+        // Assert — reserved key stripped from Agents dictionary
+        config.Agents.ShouldNotContainKey("defaults");
+        config.Agents!.ShouldContainKey("assistant");
+    }
+
+    [Fact]
+    public void ExtractAgentDefaults_WithNoDefaultsInJson_LeavesConfigUnchanged()
+    {
+        // Arrange
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["assistant"] = new() { Provider = "copilot", Model = "gpt-4.1" }
+            }
+        };
+        var rawJson = """
+            {
+              "agents": {
+                "assistant": { "provider": "copilot", "model": "gpt-4.1", "enabled": true }
+              }
+            }
+            """;
+
+        // Act
+        PlatformConfigLoader.ExtractAgentDefaults(config, rawJson);
+
+        // Assert — no defaults extracted; agents unchanged
+        config.AgentDefaults.ShouldBeNull();
+        config.Agents!.ShouldContainKey("assistant");
     }
 
     private sealed class StubLocationResolver : ILocationResolver


### PR DESCRIPTION
Closes #12

## Summary
Implements world-level agent configuration defaults via an `agents.defaults` block with field-level deep merge inheritance. Agents inherit any field not explicitly set; setting one field does not clobber the rest of the inherited block.

## Changes

### Config schema (Farnsworth)
- New `AgentDefaultsConfig` type — `ToolIds`, `Memory`, `Heartbeat`, `FileAccess`
- `agents.defaults` reserved key — extracted before agent iteration, never becomes an AgentDescriptor
- New `AgentConfigMerger` — presence-aware field-level deep merge (raw JSON element check, not `default(T)` heuristics)
- `PlatformConfigAgentSource` merges defaults before building each AgentDescriptor
- `InitCommand` scaffold now emits `cron.enabled: true` + `agents.defaults.memory.enabled: true`

### Merge semantics
- Objects (`memory`, `heartbeat`, `fileAccess`, nested): deep field-by-field merge
- Lists (`toolIds`, file-access path lists): full replacement when agent explicitly sets them
- Scalars (bool/int): presence-aware via raw JSON — agent wins only when the JSON key exists
- Extensions: unchanged, still routed through existing `ExtensionConfigMerger`

### Effective-config API (Bender)
- `GET /api/config/agents/{agentId}/effective` — returns merged config + per-field provenance
- Source values: `agent` / `inherited` / `implicit-default`
- 404 for unknown agents and the reserved `defaults` key
- Respects `BotNexus:ConfigPath` env var (consistent with other controllers)

### UI (Fry + Hermes)
- Agent config panel shows "World default" badges on inherited fields
- New "World Settings" config section for editing `agents.defaults` and `cron.enabled`
- Badges driven by `/effective` endpoint provenance sources

## Example config
```jsonc
{
  "cron": { "enabled": true },
  "agents": {
    "defaults": {
      "memory": { "enabled": true },
      "heartbeat": { "enabled": false }
    },
    "assistant": {
      "provider": "github-copilot",
      "model": "gpt-4.1"
    },
    "reviewer": {
      "provider": "github-copilot",
      "model": "claude-sonnet-4.6",
      "memory": { "enabled": false }
    }
  }
}
```

## Test results
- **2,024 tests passing, 0 failures**
- +37 new tests: AgentConfigMerger unit tests, PlatformConfigAgentSource inheritance tests, effective-config API integration tests

## Squad
Design Review (Leela) → Config+Merge (Farnsworth) → Tests (Hermes) → Effective-config API (Bender) → UI badges (Fry) → Verification (Hermes)
