### PR TITLE
fix: suppress NO_REPLY in SignalR adapter; expose skill path on load

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -15,6 +15,9 @@ namespace BotNexus.Extensions.Channels.SignalR;
 public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger, IHubContext<GatewayHub, IGatewayHubClient> hubContext)
     : ChannelAdapterBase(logger), IStreamEventChannelAdapter
 {
+    /// <summary>Sentinel value agents use to suppress user-visible replies.</summary>
+    private const string NoReplySentinel = "NO_REPLY";
+
     private readonly IHubContext<GatewayHub, IGatewayHubClient> _hubContext = hubContext;
 
     public override ChannelKey ChannelType => ChannelKey.From("signalr");
@@ -39,6 +42,12 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
     /// <returns>The send async result.</returns>
     public override Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
     {
+        if (string.Equals(message.Content?.Trim(), NoReplySentinel, StringComparison.Ordinal))
+        {
+            logger.LogDebug("Suppressed NO_REPLY message for session {SessionId}", message.SessionId ?? message.ConversationId);
+            return Task.CompletedTask;
+        }
+
         var normalizedSessionId = NormalizeSessionId(message.SessionId ?? message.ConversationId);
         return _hubContext.Clients.Group(GetSessionGroup(normalizedSessionId))
             .ContentDelta(new ContentDeltaPayload(normalizedSessionId, message.Content));

--- a/src/extensions/BotNexus.Extensions.Skills/SkillTool.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillTool.cs
@@ -106,7 +106,10 @@ public sealed class SkillTool(
         {
             lines.Add("## Loaded Skills");
             foreach (var s in resolution.Loaded)
+            {
                 lines.Add($"- **{s.Name}**: {s.Description}");
+                lines.Add($"  Path: {s.SourcePath}");
+            }
             lines.Add("");
         }
 
@@ -155,7 +158,8 @@ public sealed class SkillTool(
 
         return TextResult($"""
             ## Skill: {skill.Name}
-            
+            **Path:** {skill.SourcePath}
+
             {skill.Content}
             """);
     }


### PR DESCRIPTION
Closes two small high-value fixes.

## fix: NO_REPLY sentinel suppressed in SignalR channel

`SignalRChannelAdapter.SendAsync` now checks for the `NO_REPLY` sentinel before forwarding to UI clients. Cron heartbeats, sub-agent housekeeping, and any other no-op turns no longer produce broken-looking message bubbles in the Blazor UI.

- Trims and compares with `StringComparison.Ordinal` — only exact sentinel suppressed, not messages containing the word
- Logs at Debug level for diagnostics
- No change to other channels (they already handle this independently)

## fix: skill SourcePath exposed in tool response

`SkillTool.LoadSkill` now includes `**Path:** {skill.SourcePath}` in the response. Agents can immediately resolve relative file references from skill content (`scripts/`, `references/`, `assets/`) without guessing or searching.

`SkillTool.ListSkills` also shows paths for loaded skills.

`SkillDefinition.SourcePath` was already populated — this is purely a formatting change.

## Tests
2,024 passing, 0 failures.