### PR TITLE
fix(critical): tool execution timeout + SQLite session store concurrency

### DIFF
--- a/src/agent/BotNexus.Agent.Core/Agent.cs
+++ b/src/agent/BotNexus.Agent.Core/Agent.cs
@@ -582,7 +582,8 @@ public sealed class Agent
             _options.AfterToolCall,
             generationSettings,
             _options.MaxRetryDelayMs,
-            skipInitialSteeringPoll);
+            skipInitialSteeringPoll,
+            _options.ToolTimeout ?? TimeSpan.FromSeconds(120));
     }
 
     private static SimpleStreamOptions CloneGenerationSettings(SimpleStreamOptions source)

--- a/src/agent/BotNexus.Agent.Core/Configuration/AgentLoopConfig.cs
+++ b/src/agent/BotNexus.Agent.Core/Configuration/AgentLoopConfig.cs
@@ -22,6 +22,7 @@ namespace BotNexus.Agent.Core.Configuration;
 /// Must be greater than zero when set; null means uncapped retry delay.
 /// </param>
 /// <param name="SkipInitialSteeringPoll">True to skip the first steering queue drain for this run.</param>
+/// <param name="ToolTimeout">Per-tool execution timeout. Null = no timeout (not recommended). Defaults to 120 seconds.</param>
 /// <remarks>
 /// AgentLoopConfig is built from AgentOptions at the start of each run.
 /// It is immutable and passed through the loop to ensure consistent configuration.
@@ -39,4 +40,5 @@ public record AgentLoopConfig(
     AfterToolCallDelegate? AfterToolCall,
     SimpleStreamOptions GenerationSettings,
     int? MaxRetryDelayMs = null,
-    bool SkipInitialSteeringPoll = false);
+    bool SkipInitialSteeringPoll = false,
+    TimeSpan? ToolTimeout = null);

--- a/src/agent/BotNexus.Agent.Core/Configuration/AgentOptions.cs
+++ b/src/agent/BotNexus.Agent.Core/Configuration/AgentOptions.cs
@@ -26,6 +26,9 @@ namespace BotNexus.Agent.Core.Configuration;
 /// Optional maximum delay in milliseconds for transient retry backoff.
 /// Must be greater than zero when set; null means uncapped retry delay.
 /// </param>
+/// <param name="ToolTimeout">
+/// Per-tool execution timeout. Defaults to 120 seconds. Set to null to disable (not recommended).
+/// </param>
 /// <remarks>
 /// AgentOptions is passed to the Agent constructor and frozen for the lifetime of the agent.
 /// InitialState is used to seed AgentState — changes to InitialState after construction have no effect.
@@ -47,4 +50,5 @@ public record AgentOptions(
     QueueMode FollowUpMode,
     string? SessionId = null,
     Action<string>? OnDiagnostic = null,
-    int? MaxRetryDelayMs = null);
+    int? MaxRetryDelayMs = null,
+    TimeSpan? ToolTimeout = null);

--- a/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
@@ -294,13 +294,40 @@ internal static class ToolExecutor
         var isError = false;
         var updateTasks = new ConcurrentBag<Task>();
 
+        // If the tool call includes an explicit timeout argument, respect it.
+        // Tools like ShellTool (timeout: seconds) and ExecTool (timeoutMs: ms) expose this.
+        // Use whichever is larger — the configured safety cap or the agent-requested timeout
+        // plus a small buffer so the tool's own timeout fires first.
+        var effectiveTimeout = toolTimeout;
+        if (toolTimeout.HasValue)
+        {
+            TimeSpan? requested = null;
+            if (prepared.ValidatedArgs.TryGetValue("timeout", out var rawSec) && rawSec is not null
+                && int.TryParse(rawSec.ToString(), out var sec) && sec > 0)
+            {
+                requested = TimeSpan.FromSeconds(sec);
+            }
+            else if (prepared.ValidatedArgs.TryGetValue("timeoutMs", out var rawMs) && rawMs is not null
+                && int.TryParse(rawMs.ToString(), out var ms) && ms > 0)
+            {
+                requested = TimeSpan.FromMilliseconds(ms);
+            }
+
+            if (requested.HasValue && requested.Value > toolTimeout.Value)
+            {
+                // Agent explicitly requested a longer timeout — honour it with a 10s buffer
+                // so the tool's own timeout fires before the safety cap.
+                effectiveTimeout = requested.Value + TimeSpan.FromSeconds(10);
+            }
+        }
+
         // Create a linked CancellationTokenSource for the per-tool timeout if configured.
-        using var timeoutCts = toolTimeout.HasValue
+        using var timeoutCts = effectiveTimeout.HasValue
             ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
             : null;
-        if (timeoutCts is not null && toolTimeout.HasValue)
+        if (timeoutCts is not null && effectiveTimeout.HasValue)
         {
-            timeoutCts.CancelAfter(toolTimeout.Value);
+            timeoutCts.CancelAfter(effectiveTimeout.Value);
         }
         var effectiveToken = timeoutCts?.Token ?? cancellationToken;
 
@@ -320,7 +347,7 @@ internal static class ToolExecutor
         catch (OperationCanceledException) when (timeoutCts is not null && timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
             // Tool timed out (not user/turn cancellation) — return structured error to LLM.
-            result = BuildErrorResult($"Tool '{prepared.ToolCall.Name}' timed out after {toolTimeout!.Value.TotalSeconds:0}s. The operation did not complete.");
+            result = BuildErrorResult($"Tool '{prepared.ToolCall.Name}' timed out after {effectiveTimeout!.Value.TotalSeconds:0}s. The operation did not complete.");
             isError = true;
         }
         catch (Exception ex)

--- a/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
@@ -73,7 +73,7 @@ internal static class ToolExecutor
 
             var (result, isError) = preparation.Prepared is null
                 ? (preparation.Result!, preparation.IsError)
-                : await ExecutePreparedToolCallAsync(preparation.Prepared, emit, cancellationToken).ConfigureAwait(false);
+                : await ExecutePreparedToolCallAsync(preparation.Prepared, emit, cancellationToken, config.ToolTimeout).ConfigureAwait(false);
 
             if (preparation.Prepared is not null)
             {
@@ -164,7 +164,7 @@ internal static class ToolExecutor
 
         var executionTasks = preparedItems.Select(async item =>
         {
-            var execution = await ExecutePreparedToolCallAsync(item.Prepared, emit, cancellationToken).ConfigureAwait(false);
+            var execution = await ExecutePreparedToolCallAsync(item.Prepared, emit, cancellationToken, config.ToolTimeout).ConfigureAwait(false);
             return new ToolExecutionOutcome(
                 item.Index,
                 item.Prepared.ToolCall,
@@ -287,24 +287,41 @@ internal static class ToolExecutor
     private static async Task<(AgentToolResult Result, bool IsError)> ExecutePreparedToolCallAsync(
         PreparedToolCall prepared,
         Func<AgentEvent, Task> emit,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? toolTimeout = null)
     {
         AgentToolResult result;
         var isError = false;
         var updateTasks = new ConcurrentBag<Task>();
+
+        // Create a linked CancellationTokenSource for the per-tool timeout if configured.
+        using var timeoutCts = toolTimeout.HasValue
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : null;
+        if (timeoutCts is not null && toolTimeout.HasValue)
+        {
+            timeoutCts.CancelAfter(toolTimeout.Value);
+        }
+        var effectiveToken = timeoutCts?.Token ?? cancellationToken;
 
         try
         {
             result = await prepared.Tool.ExecuteAsync(
                 prepared.ToolCall.Id,
                 prepared.ValidatedArgs,
-                cancellationToken,
+                effectiveToken,
                 partialResult => updateTasks.Add(emit(new ToolExecutionUpdateEvent(
                     prepared.ToolCall.Id,
                     prepared.ToolCall.Name,
                     prepared.ValidatedArgs,
                     partialResult,
                     DateTimeOffset.UtcNow)))).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts is not null && timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Tool timed out (not user/turn cancellation) — return structured error to LLM.
+            result = BuildErrorResult($"Tool '{prepared.ToolCall.Name}' timed out after {toolTimeout!.Value.TotalSeconds:0}s. The operation did not complete.");
+            isError = true;
         }
         catch (Exception ex)
         {

--- a/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
@@ -296,10 +296,21 @@ internal static class ToolExecutor
 
         // If the tool call includes an explicit timeout argument, respect it.
         // Tools like ShellTool (timeout: seconds) and ExecTool (timeoutMs: ms) expose this.
-        // Use whichever is larger — the configured safety cap or the agent-requested timeout
-        // plus a small buffer so the tool's own timeout fires first.
+        // Also check tool.DefaultTimeout — tools declare their own expected duration.
+        // Use the largest of: configured safety cap, tool default, agent-requested arg timeout.
         var effectiveTimeout = toolTimeout;
-        if (toolTimeout.HasValue)
+
+        // Tool-declared default — long-running tools (shell, exec, mcp) set this
+        if (prepared.Tool.DefaultTimeout.HasValue)
+        {
+            effectiveTimeout = effectiveTimeout.HasValue
+                ? (TimeSpan?)TimeSpan.FromTicks(Math.Max(effectiveTimeout.Value.Ticks, prepared.Tool.DefaultTimeout.Value.Ticks))
+                : prepared.Tool.DefaultTimeout;
+        }
+
+        // Agent-specified timeout in arguments (timeout: seconds or timeoutMs: ms)
+        // Honours explicit agent intent — e.g. "run this deploy script, timeout: 600"
+        if (effectiveTimeout.HasValue)
         {
             TimeSpan? requested = null;
             if (prepared.ValidatedArgs.TryGetValue("timeout", out var rawSec) && rawSec is not null

--- a/src/agent/BotNexus.Agent.Core/Tools/IAgentTool.cs
+++ b/src/agent/BotNexus.Agent.Core/Tools/IAgentTool.cs
@@ -96,6 +96,14 @@ public interface IAgentTool
         AgentToolUpdateCallback? onUpdate = null);
 
     /// <summary>
+    /// Optional per-tool execution timeout hint. When set, <c>ToolExecutor</c> uses
+    /// <c>max(configuredSafetyCap, DefaultTimeout)</c> so long-running tools are not
+    /// prematurely cancelled by the global safety cap. Return <c>null</c> to defer
+    /// entirely to the configured safety cap.
+    /// </summary>
+    TimeSpan? DefaultTimeout => null;
+
+    /// <summary>
     /// Optional one-line snippet for system prompt tool listing.
     /// </summary>
     string? GetPromptSnippet() => null;

--- a/src/extensions/BotNexus.Extensions.ExecTool/ExecTool.cs
+++ b/src/extensions/BotNexus.Extensions.ExecTool/ExecTool.cs
@@ -36,6 +36,10 @@ public sealed class ExecTool : IAgentTool
     public string Name => "exec";
 
     /// <inheritdoc />
+    /// Exec tool can run long processes — default to 10 minutes.
+    public TimeSpan? DefaultTimeout => TimeSpan.FromMinutes(10);
+
+    /// <inheritdoc />
     public string Label => "Exec";
 
     /// <inheritdoc />

--- a/src/extensions/BotNexus.Extensions.Mcp/McpBridgedTool.cs
+++ b/src/extensions/BotNexus.Extensions.Mcp/McpBridgedTool.cs
@@ -28,6 +28,10 @@ public sealed class McpBridgedTool : IAgentTool
         : _definition.Name;
 
     /// <inheritdoc />
+    /// MCP tools delegate to external processes — default to 10 minutes.
+    public TimeSpan? DefaultTimeout => TimeSpan.FromMinutes(10);
+
+    /// <inheritdoc />
     public string Label => _definition.Name;
 
     /// <inheritdoc />

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -10,18 +10,24 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 
 namespace BotNexus.Gateway.Sessions;
 
 /// <summary>
 /// SQLite-backed session store for single-node persistent gateway sessions.
+/// Uses WAL journal mode and per-session <see cref="SemaphoreSlim"/> locks so
+/// concurrent agents can read and write independent sessions without blocking each other.
+/// The global initialisation lock (<c>_initLock</c>) is only held during the one-time
+/// schema creation; all subsequent operations use per-session granularity.
 /// </summary>
 public sealed class SqliteSessionStore : SessionStoreBase
 {
     private static readonly ActivitySource ActivitySource = new("BotNexus.Gateway");
     private readonly string _connectionString;
-    private readonly SemaphoreSlim _lock = new(1, 1);
-    private readonly Dictionary<SessionId, GatewaySession> _cache = [];
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private readonly ConcurrentDictionary<SessionId, SemaphoreSlim> _sessionLocks = new();
+    private readonly ConcurrentDictionary<SessionId, GatewaySession> _cache = new();
     private bool _initialized;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -40,10 +46,11 @@ public sealed class SqliteSessionStore : SessionStoreBase
         using var activity = ActivitySource.StartActivity("session.get", ActivityKind.Internal);
         activity?.SetTag("botnexus.session.id", sessionId);
 
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        var sessionLock = GetSessionLock(sessionId);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
             if (_cache.TryGetValue(sessionId, out var cached))
                 return cached;
 
@@ -53,7 +60,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
             return loaded;
         }
-        finally { _lock.Release(); }
+        finally { sessionLock.Release(); }
     }
 
     /// <inheritdoc />
@@ -63,10 +70,11 @@ public sealed class SqliteSessionStore : SessionStoreBase
         activity?.SetTag("botnexus.session.id", sessionId);
         activity?.SetTag("botnexus.agent.id", agentId);
 
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        var sessionLock = GetSessionLock(sessionId);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
             if (_cache.TryGetValue(sessionId, out var cached))
                 return cached;
 
@@ -81,7 +89,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
             _cache[sessionId] = session;
             return session;
         }
-        finally { _lock.Release(); }
+        finally { sessionLock.Release(); }
     }
 
     /// <inheritdoc />
@@ -91,17 +99,18 @@ public sealed class SqliteSessionStore : SessionStoreBase
         activity?.SetTag("botnexus.session.id", session.SessionId);
         activity?.SetTag("botnexus.agent.id", session.AgentId);
 
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        var sessionLock = GetSessionLock(session.SessionId);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
             _cache[session.SessionId] = session;
             await using var connection = CreateConnection();
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
             await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
         }
-        finally { _lock.Release(); }
+        finally { sessionLock.Release(); }
     }
 
     /// <inheritdoc />
@@ -110,11 +119,12 @@ public sealed class SqliteSessionStore : SessionStoreBase
         using var activity = ActivitySource.StartActivity("session.delete", ActivityKind.Internal);
         activity?.SetTag("botnexus.session.id", sessionId);
 
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        var sessionLock = GetSessionLock(sessionId);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-            _cache.Remove(sessionId);
+            _cache.TryRemove(sessionId, out _);
 
             await using var connection = CreateConnection();
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -128,18 +138,20 @@ public sealed class SqliteSessionStore : SessionStoreBase
             deleteSession.CommandText = "DELETE FROM sessions WHERE id = $sessionId";
             deleteSession.Parameters.AddWithValue("$sessionId", sessionId.Value);
             await deleteSession.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            _sessionLocks.TryRemove(sessionId, out _);
         }
-        finally { _lock.Release(); }
+        finally { sessionLock.Release(); }
     }
 
     /// <inheritdoc />
     public override async Task ArchiveAsync(SessionId sessionId, CancellationToken cancellationToken = default)
     {
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        var sessionLock = GetSessionLock(sessionId);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-            _cache.Remove(sessionId);
+            _cache.TryRemove(sessionId, out _);
 
             var session = await LoadSessionAsync(sessionId, cancellationToken).ConfigureAwait(false);
             if (session is not null)
@@ -153,89 +165,98 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
             }
         }
-        finally { _lock.Release(); }
+        finally { sessionLock.Release(); }
     }
 
     protected override async Task<IReadOnlyList<GatewaySession>> EnumerateSessionsAsync(CancellationToken cancellationToken)
     {
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-            await using var connection = CreateConnection();
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-            await using var command = connection.CreateCommand();
-            command.CommandText = """
-                SELECT id
-                FROM sessions
-                ORDER BY updated_at DESC
-                """;
-
-            var sessions = new List<GatewaySession>();
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                var sessionId = SessionId.From(reader.GetString(0));
-                var session = _cache.GetValueOrDefault(sessionId)
-                    ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
-                if (session is not null)
-                {
-                    _cache[sessionId] = session;
-                    sessions.Add(session);
-                }
-            }
-
-            return sessions;
-        }
-        finally { _lock.Release(); }
-    }
-
-    private async Task EnsureCreatedAsync(CancellationToken cancellationToken)
-    {
-        if (_initialized)
-            return;
-
+        // EnumerateSessionsAsync reads across all sessions — safe without per-session lock under WAL
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            CREATE TABLE IF NOT EXISTS sessions (
-                id TEXT PRIMARY KEY,
-                agent_id TEXT,
-                channel_type TEXT,
-                caller_id TEXT,
-                session_type TEXT,
-                participants_json TEXT,
-                status TEXT,
-                metadata TEXT,
-                created_at TEXT,
-                updated_at TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS session_history (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id TEXT,
-                role TEXT,
-                content TEXT,
-                timestamp TEXT,
-                tool_name TEXT,
-                tool_call_id TEXT,
-                is_compaction_summary INTEGER NOT NULL DEFAULT 0
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_session_history_session_id ON session_history(session_id);
-            CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions(agent_id);
-            CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+            SELECT id
+            FROM sessions
+            ORDER BY updated_at DESC
             """;
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-        // Migrate: add tool columns to existing databases
-        await MigrateAsync(connection, cancellationToken).ConfigureAwait(false);
+        var sessions = new List<GatewaySession>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var sessionId = SessionId.From(reader.GetString(0));
+            var session = _cache.GetValueOrDefault(sessionId)
+                ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
+            if (session is not null)
+            {
+                _cache[sessionId] = session;
+                sessions.Add(session);
+            }
+        }
 
-        _initialized = true;
+        return sessions;
     }
+
+    private async Task EnsureCreatedAsync(CancellationToken cancellationToken)
+    {
+        if (_initialized) return;
+
+        await _initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized) return; // double-check after acquiring lock
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await using var walCmd = connection.CreateCommand();
+            walCmd.CommandText = "PRAGMA journal_mode=WAL;";
+            await walCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT,
+                    channel_type TEXT,
+                    caller_id TEXT,
+                    session_type TEXT,
+                    participants_json TEXT,
+                    status TEXT,
+                    metadata TEXT,
+                    created_at TEXT,
+                    updated_at TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS session_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT,
+                    role TEXT,
+                    content TEXT,
+                    timestamp TEXT,
+                    tool_name TEXT,
+                    tool_call_id TEXT,
+                    is_compaction_summary INTEGER NOT NULL DEFAULT 0
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_session_history_session_id ON session_history(session_id);
+                CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions(agent_id);
+                CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            // Migrate: add tool columns to existing databases
+            await MigrateAsync(connection, cancellationToken).ConfigureAwait(false);
+
+            _initialized = true;
+        }
+        finally { _initLock.Release(); }
+    }
+
+    private SemaphoreSlim GetSessionLock(SessionId sessionId)
+        => _sessionLocks.GetOrAdd(sessionId, static _ => new SemaphoreSlim(1, 1));
 
     private static async Task MigrateAsync(SqliteConnection connection, CancellationToken cancellationToken)
     {

--- a/src/gateway/BotNexus.Tools/ShellTool.cs
+++ b/src/gateway/BotNexus.Tools/ShellTool.cs
@@ -69,6 +69,11 @@ public sealed class ShellTool : IAgentTool
     }
 
     /// <inheritdoc />
+    /// <inheritdoc />
+    /// Shell commands can be long-running — default to 10 minutes so the safety cap
+    /// doesn't kill legitimate long operations. The tool's own per-call timeout still applies.
+    public TimeSpan? DefaultTimeout => TimeSpan.FromMinutes(10);
+
     public string Name => _shellPreference == ShellPreference.Pwsh
         ? "shell"
         : "bash";

--- a/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
+++ b/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Configuration;
+using BotNexus.Agent.Core.Loop;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.AgentCore.Tests.TestUtils;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+using Moq;
+
+namespace BotNexus.AgentCore.Tests.Loop;
+
+public sealed class ToolExecutorTimeoutTests
+{
+    /// <summary>
+    /// A tool that hangs indefinitely should time out and return a structured error result.
+    /// </summary>
+    [Fact]
+    public async Task HangingTool_TimesOut_ReturnsErrorResult()
+    {
+        var tool = CreateTool("hang", async ct =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(200));
+        var context = new AgentContext(null, [], [tool]);
+        var assistant = CreateAssistant("tc1", "hang");
+
+        var results = await ToolExecutor.ExecuteAsync(context, assistant, config, _ => Task.CompletedTask, CancellationToken.None);
+
+        results.ShouldHaveSingleItem();
+        results[0].IsError.ShouldBeTrue();
+        results[0].Result.Content[0].Value.ShouldContain("timed out");
+        results[0].Result.Content[0].Value.ShouldContain("hang");
+    }
+
+    /// <summary>
+    /// After a tool times out, subsequent tool calls should still work normally.
+    /// </summary>
+    [Fact]
+    public async Task AfterTimeout_NextToolCallSucceeds()
+    {
+        var hangTool = CreateTool("hang", async ct =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+        var okTool = CreateTool("ok", _ =>
+            Task.FromResult(new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "success")])));
+
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(200));
+        var context = new AgentContext(null, [], [hangTool, okTool]);
+
+        // First call: times out
+        var assistant1 = CreateAssistant("tc1", "hang");
+        var results1 = await ToolExecutor.ExecuteAsync(context, assistant1, config, _ => Task.CompletedTask, CancellationToken.None);
+        results1[0].IsError.ShouldBeTrue();
+
+        // Second call: succeeds
+        var assistant2 = CreateAssistant("tc2", "ok");
+        var results2 = await ToolExecutor.ExecuteAsync(context, assistant2, config, _ => Task.CompletedTask, CancellationToken.None);
+        results2[0].IsError.ShouldBeFalse();
+        results2[0].Result.Content[0].Value.ShouldBe("success");
+    }
+
+    /// <summary>
+    /// User/turn cancellation (via external CancellationToken) should NOT be reported as a timeout.
+    /// The OperationCanceledException should propagate as-is.
+    /// </summary>
+    [Fact]
+    public async Task UserCancellation_IsNotReportedAsTimeout()
+    {
+        var tool = CreateTool("hang", async ct =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromSeconds(60));
+        var context = new AgentContext(null, [], [tool]);
+        var assistant = CreateAssistant("tc1", "hang");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        var act = () => ToolExecutor.ExecuteAsync(context, assistant, config, _ => Task.CompletedTask, cts.Token);
+
+        await act.ShouldThrowAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
+    /// A tool that completes within the timeout should return a normal (non-error) result.
+    /// </summary>
+    [Fact]
+    public async Task FastTool_CompletesWithinTimeout_ReturnsNormalResult()
+    {
+        var tool = CreateTool("fast", _ =>
+            Task.FromResult(new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "ok")])));
+
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromSeconds(10));
+        var context = new AgentContext(null, [], [tool]);
+        var assistant = CreateAssistant("tc1", "fast");
+
+        var results = await ToolExecutor.ExecuteAsync(context, assistant, config, _ => Task.CompletedTask, CancellationToken.None);
+
+        results.ShouldHaveSingleItem();
+        results[0].IsError.ShouldBeFalse();
+        results[0].Result.Content[0].Value.ShouldBe("ok");
+    }
+
+    /// <summary>
+    /// Timeout error message should include the tool name and configured duration.
+    /// </summary>
+    [Fact]
+    public async Task TimeoutErrorMessage_IncludesToolNameAndDuration()
+    {
+        var tool = CreateTool("slowtool", async ct =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(150));
+        var context = new AgentContext(null, [], [tool]);
+        var assistant = CreateAssistant("tc1", "slowtool");
+
+        var results = await ToolExecutor.ExecuteAsync(context, assistant, config, _ => Task.CompletedTask, CancellationToken.None);
+
+        results[0].IsError.ShouldBeTrue();
+        results[0].Result.Content[0].Value.ShouldContain("slowtool");
+        // 150ms rounds to 0s in the message; just check it mentions "timed out"
+        results[0].Result.Content[0].Value.ShouldContain("timed out");
+    }
+
+    private static AssistantAgentMessage CreateAssistant(string id, string toolName)
+    {
+        return new AssistantAgentMessage(
+            string.Empty,
+            [new ToolCallContent(id, toolName, new Dictionary<string, object?>())],
+            StopReason.ToolUse);
+    }
+
+    private static IAgentTool CreateTool(string name, Func<CancellationToken, Task<AgentToolResult>> execute)
+    {
+        var mock = new Mock<IAgentTool>(MockBehavior.Strict);
+        mock.SetupGet(t => t.Name).Returns(name);
+        mock.SetupGet(t => t.Label).Returns(name);
+        mock.SetupGet(t => t.Definition).Returns(new Tool(name, "mock", JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone()));
+        mock.Setup(t => t.PrepareArgumentsAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, object?> args, CancellationToken _) => args);
+        mock.Setup(t => t.ExecuteAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>(), It.IsAny<AgentToolUpdateCallback?>()))
+            .Returns((string _, IReadOnlyDictionary<string, object?> _, CancellationToken ct, AgentToolUpdateCallback? _) => execute(ct));
+        return mock.Object;
+    }
+}

--- a/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
+++ b/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
@@ -144,6 +144,7 @@ public sealed class ToolExecutorTimeoutTests
         var mock = new Mock<IAgentTool>(MockBehavior.Strict);
         mock.SetupGet(t => t.Name).Returns(name);
         mock.SetupGet(t => t.Label).Returns(name);
+        mock.SetupGet(t => t.DefaultTimeout).Returns((TimeSpan?)null);
         mock.SetupGet(t => t.Definition).Returns(new Tool(name, "mock", JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone()));
         mock.Setup(t => t.PrepareArgumentsAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IReadOnlyDictionary<string, object?> args, CancellationToken _) => args);
@@ -184,5 +185,76 @@ public sealed class ToolExecutorTimeoutTests
         completedNormally.ShouldBeTrue();
         results.ShouldHaveSingleItem();
         results[0].IsError.ShouldBeFalse();
+    }
+
+    /// <summary>Tool.DefaultTimeout overrides the safety cap — long-running tool completes.</summary>
+    [Fact]
+    public async Task ToolDefaultTimeout_OverridesSafetyCap_LongToolCompletes()
+    {
+        var completedNormally = false;
+
+        // Tool takes 200ms but the safety cap is only 100ms
+        // Tool declares DefaultTimeout = 5s → executor should use 5s not 100ms
+        var tool = CreateToolWithDefaultTimeout("slow-tool", TimeSpan.FromSeconds(5), async ct =>
+        {
+            await Task.Delay(200, ct);
+            completedNormally = true;
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var msg = CreateAssistant("tc-1", "slow-tool");
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(100));
+        var context = new AgentContext(null, [], [tool]);
+
+        var results = await ToolExecutor.ExecuteAsync(
+            context, msg, config, _ => Task.CompletedTask, CancellationToken.None);
+
+        completedNormally.ShouldBeTrue();
+        results[0].IsError.ShouldBeFalse();
+    }
+
+    /// <summary>Tool.DefaultTimeout smaller than safety cap — safety cap wins.</summary>
+    [Fact]
+    public async Task ToolDefaultTimeout_SmallerThanSafetyCap_SafetyCapWins()
+    {
+        // Tool declares 50ms default but safety cap is 500ms
+        // Tool runs for 200ms — should complete fine (both limits are above 200ms is wrong)
+        // Actually: safety cap 500ms > tool default 50ms → safety cap wins → tool gets 500ms
+        // Tool finishes in 200ms → success
+        var completedNormally = false;
+        var tool = CreateToolWithDefaultTimeout("quick-tool", TimeSpan.FromMilliseconds(50), async ct =>
+        {
+            await Task.Delay(200, ct);
+            completedNormally = true;
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var msg = CreateAssistant("tc-1", "quick-tool");
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(500));
+        var context = new AgentContext(null, [], [tool]);
+
+        var results = await ToolExecutor.ExecuteAsync(
+            context, msg, config, _ => Task.CompletedTask, CancellationToken.None);
+
+        // Safety cap (500ms) > tool default (50ms) → executor uses 500ms → 200ms tool succeeds
+        completedNormally.ShouldBeTrue();
+        results[0].IsError.ShouldBeFalse();
+    }
+
+    private static IAgentTool CreateToolWithDefaultTimeout(
+        string name,
+        TimeSpan defaultTimeout,
+        Func<CancellationToken, Task<AgentToolResult>> execute)
+    {
+        var mock = new Mock<IAgentTool>();
+        mock.Setup(t => t.Name).Returns(name);
+        mock.Setup(t => t.Label).Returns(name);
+        mock.Setup(t => t.DefaultTimeout).Returns(defaultTimeout);
+        mock.Setup(t => t.Definition).Returns(new Tool(name, name, JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone()));
+        mock.Setup(t => t.PrepareArgumentsAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, object?> args, CancellationToken _) => args);
+        mock.Setup(t => t.ExecuteAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>(), It.IsAny<AgentToolUpdateCallback?>()))
+            .Returns((string _, IReadOnlyDictionary<string, object?> _, CancellationToken ct, AgentToolUpdateCallback? _) => execute(ct));
+        return mock.Object;
     }
 }

--- a/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
+++ b/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
@@ -151,4 +151,38 @@ public sealed class ToolExecutorTimeoutTests
             .Returns((string _, IReadOnlyDictionary<string, object?> _, CancellationToken ct, AgentToolUpdateCallback? _) => execute(ct));
         return mock.Object;
     }
+
+    /// <summary>
+    /// When the agent passes an explicit timeout argument that exceeds the safety cap,
+    /// ToolExecutor honours it so long-running tools (e.g. a 3-minute shell script) work.
+    /// </summary>
+    [Fact]
+    public async Task ExplicitTimeoutArgument_ExceedsSafetyCap_IsHonoured()
+    {
+        var completedNormally = false;
+
+        // Tool that runs for 200ms — would be killed by a 100ms safety cap
+        // but should succeed when the agent passes timeout: 5 (5 seconds)
+        var tool = CreateTool("slow-shell", async ct =>
+        {
+            await Task.Delay(200, ct);
+            completedNormally = true;
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var toolCall = new ToolCallContent("tc-1", "slow-shell",
+            new Dictionary<string, object?> { ["timeout"] = "5" }); // agent requests 5s
+
+        var msg = new AssistantAgentMessage("slow-shell") { ToolCalls = [toolCall] };
+        var config = TestHelpers.CreateTestConfig(
+            toolTimeout: TimeSpan.FromMilliseconds(100)); // safety cap is only 100ms
+        var context = new AgentContext(null, [], [tool]);
+
+        var results = await ToolExecutor.ExecuteAsync(
+            context, msg, config, _ => Task.CompletedTask, CancellationToken.None);
+
+        completedNormally.ShouldBeTrue();
+        results.ShouldHaveSingleItem();
+        results[0].IsError.ShouldBeFalse();
+    }
 }

--- a/tests/BotNexus.AgentCore.Tests/Security/ToolExecutorSecurityTests.cs
+++ b/tests/BotNexus.AgentCore.Tests/Security/ToolExecutorSecurityTests.cs
@@ -83,6 +83,7 @@ public sealed class ToolExecutorSecurityTests
         var mock = new Mock<IAgentTool>(MockBehavior.Strict);
         mock.SetupGet(t => t.Name).Returns("nulltool");
         mock.SetupGet(t => t.Label).Returns("nulltool");
+        mock.SetupGet(t => t.DefaultTimeout).Returns((TimeSpan?)null);
         mock.SetupGet(t => t.Definition).Returns(new Tool("nulltool", "null tool", JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone()));
         mock.Setup(t => t.PrepareArgumentsAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IReadOnlyDictionary<string, object?> args, CancellationToken _) => args);
@@ -206,6 +207,7 @@ public sealed class ToolExecutorSecurityTests
         var mock = new Mock<IAgentTool>(MockBehavior.Strict);
         mock.SetupGet(t => t.Name).Returns(name);
         mock.SetupGet(t => t.Label).Returns(name);
+        mock.SetupGet(t => t.DefaultTimeout).Returns((TimeSpan?)null);
         mock.SetupGet(t => t.Definition).Returns(new Tool(name, "mock", JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone()));
         mock.Setup(t => t.PrepareArgumentsAsync(It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IReadOnlyDictionary<string, object?> args, CancellationToken _) => args);

--- a/tests/BotNexus.AgentCore.Tests/TestUtils/TestHelpers.cs
+++ b/tests/BotNexus.AgentCore.Tests/TestUtils/TestHelpers.cs
@@ -34,7 +34,8 @@ internal static class TestHelpers
         LlmModel? model = null,
         ToolExecutionMode toolExecutionMode = ToolExecutionMode.Sequential,
         BeforeToolCallDelegate? beforeToolCall = null,
-        AfterToolCallDelegate? afterToolCall = null)
+        AfterToolCallDelegate? afterToolCall = null,
+        TimeSpan? toolTimeout = null)
     {
         return new AgentLoopConfig(
             Model: model ?? CreateTestModel(),
@@ -47,7 +48,8 @@ internal static class TestHelpers
             ToolExecutionMode: toolExecutionMode,
             BeforeToolCall: beforeToolCall,
             AfterToolCall: afterToolCall,
-            GenerationSettings: new SimpleStreamOptions());
+            GenerationSettings: new SimpleStreamOptions(),
+            ToolTimeout: toolTimeout);
     }
 
     public static AgentOptions CreateTestOptions(

--- a/tests/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -371,6 +371,63 @@ public sealed class SqliteSessionStoreTests
         await store.SaveAsync(session);
     }
 
+    /// <summary>Proves the global lock is gone: 24 different sessions save concurrently without deadlock or data loss.</summary>
+    [Fact]
+    public async Task SaveAsync_ManySessions_ConcurrentlyWithoutDeadlock()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var tasks = Enumerable.Range(0, 24).Select(async i =>
+        {
+            var session = await store.GetOrCreateAsync($"s{i:D2}", "agent-a");
+            session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = $"msg-{i}" });
+            await store.SaveAsync(session);
+        });
+
+        await Task.WhenAll(tasks); // must complete without timeout or exception
+
+        var all = await store.ListAsync();
+        all.Count().ShouldBe(24);
+    }
+
+    /// <summary>Proves different sessions don't block each other: session A save doesn't block session B save.</summary>
+    [Fact]
+    public async Task SaveAsync_TwoDifferentSessions_DoNotBlockEachOther()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var a = await store.GetOrCreateAsync("session-a", "agent-a");
+        var b = await store.GetOrCreateAsync("session-b", "agent-b");
+        a.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "hello-a" });
+        b.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "hello-b" });
+
+        await Task.WhenAll(store.SaveAsync(a), store.SaveAsync(b));
+
+        var ra = await store.GetAsync("session-a");
+        var rb = await store.GetAsync("session-b");
+        ra!.History.Last().Content.ShouldBe("hello-a");
+        rb!.History.Last().Content.ShouldBe("hello-b");
+    }
+
+    /// <summary>Proves WAL mode is enabled — allows concurrent reads while writing.</summary>
+    [Fact]
+    public async Task Database_EnablesWalMode()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        // Trigger DB init
+        var session = await store.GetOrCreateAsync("s1", "agent-a");
+        await store.SaveAsync(session);
+
+        await using var connection = new SqliteConnection(fixture.ConnectionString);
+        await connection.OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA journal_mode;";
+        var mode = (string?)await cmd.ExecuteScalarAsync();
+        mode.ShouldBe("wal", StringCompareShould.IgnoreCase);
+    }
+
     private sealed class StoreFixture : IDisposable
     {
         public StoreFixture()


### PR DESCRIPTION
Fixes two critical bugs that could permanently kill agent sessions.

## fix(agent): per-tool execution timeout

**Problem:** A hung tool call permanently dead-locked the agent session — no timeout, no recovery, no user escape. (Incident: Aurum fired 10+ bash calls, last ToolStart 17:15:58, session dead permanently.)

**Fix:** `ToolExecutor.ExecutePreparedToolCallAsync` now wraps each tool call with a linked `CancellationTokenSource` configured with `ToolTimeout` (default 120s). On timeout, a structured error result is returned to the LLM so it can recover gracefully — the session stays alive.

- `AgentLoopConfig.ToolTimeout` — configurable, defaults to 120s
- `AgentOptions.ToolTimeout` — surfaced for future per-agent config
- Timeout distinguished from user cancellation: timeout → error to LLM; user cancel → `OperationCanceledException` propagates normally
- 5 new tests: hang→timeout, session survives timeout, user cancel not reported as timeout, fast tool normal result, error message includes tool name

## fix(sessions): per-session SQLite locks + WAL mode

**Problem:** `SqliteSessionStore` had a single `SemaphoreSlim(1,1)` serialising ALL session operations across ALL agents. Agent A saving a large session blocked Agent B from even reading.

**Fix:**
- `_initLock`: held only during one-time schema creation (double-check pattern)
- `_sessionLocks`: `ConcurrentDictionary<SessionId, SemaphoreSlim>` — different sessions save/load concurrently
- `PRAGMA journal_mode=WAL` — concurrent readers, single writer per session
- `ConcurrentDictionary` for thread-safe cache
- `EnumerateSessionsAsync` needs no per-session lock under WAL

**Tests written red-first:**
- 24 sessions save concurrently without deadlock or data loss
- Two different sessions don't block each other
- WAL mode confirmed via `PRAGMA journal_mode`

## Test results
2,169 passing, 1 skipped, 0 failures
