### PR TITLE
fix: Ollama support, mobile UI improvements, session history, Linux fixes

### DIFF
--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -12,7 +12,7 @@
 - [NO_REPLY Sentinel Visible as Literal Text in Blazor UI](bug-noreply-visible-in-ui/design-spec.md) — `draft`
 
 ### 🟡 Medium
-- [Blazor UI Loses Session History for Agent/Channel Combo](bug-blazor-session-history-loss/design-spec.md) — `draft`
+- [Blazor UI Loses Session History for Agent/Channel Combo](bug-blazor-session-history-loss/design-spec.md) — `done`
 - [Message Queue Injection Timing](message-queue-injection-timing/design-spec.md) — `planning`
 - [Steering Messages Not Visible in Conversation Flow](bug-steering-message-visibility/design-spec.md) — `draft` 📄
 

--- a/docs/planning/bug-blazor-session-history-loss/design-spec.md
+++ b/docs/planning/bug-blazor-session-history-loss/design-spec.md
@@ -3,7 +3,7 @@ id: bug-blazor-session-history-loss
 title: "Blazor UI Loses Session History for Agent/Channel Combo"
 type: bug
 priority: medium
-status: draft
+status: done
 created: 2026-07-17
 updated: 2026-07-17
 author: nova

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -12,7 +12,9 @@ This guide helps you diagnose and resolve common issues with BotNexus.
 6. [Tool Execution Failures](#tool-execution-failures)
 7. [Extension Loading Errors](#extension-loading-errors)
 8. [Performance Issues](#performance-issues)
-9. [Logs and Diagnostics](#logs-and-diagnostics)
+9. [Linux-Specific Issues](#linux-specific-issues)
+10. [Ollama / Local Model Issues](#ollama--local-model-issues)
+11. [Logs and Diagnostics](#logs-and-diagnostics)
 
 ---
 
@@ -764,6 +766,118 @@ tail -f ~/.botnexus/logs/gateway.log | grep -i mcp
   "providers": {
     "anthropic": {
       "enablePromptCaching": true
+    }
+  }
+}
+```
+
+---
+
+## Linux-Specific Issues
+
+### WebUI Connects But Immediately Disconnects (CultureNotFoundException)
+
+**Symptom:** The BotNexus web UI loads in the browser but the SignalR hub connection fails immediately. The browser console shows:
+```text
+Hub connection failed: The 'InvokeCoreAsync' method cannot be called if the connection is not active
+```
+Gateway logs show:
+```text
+System.Globalization.CultureNotFoundException: Culture is not supported. (Parameter 'name')
+`1 is an invalid culture identifier.
+   at System.Globalization.CultureInfo.GetCultureInfo(String name)
+   at System.Reflection.RuntimeAssembly.GetLocale()
+   at Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher`1.OnConnectedAsync
+```
+
+**Cause:** .NET 10 on Linux attempts to resolve the locale from assembly metadata when SignalR enumerates hub methods. Generic type names (containing `` `1 ``) produce invalid culture identifiers, crashing `OnConnectedAsync` before the client can handshake.
+
+**Fix:** Run the gateway with globalization invariant mode:
+```bash
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+dotnet BotNexus.Gateway.Api.dll --urls "http://0.0.0.0:5005"
+```
+
+Or set it permanently in your launch script / systemd service:
+```ini
+# systemd service example
+[Service]
+Environment="DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1"
+ExecStart=/home/user/.dotnet/dotnet /path/to/BotNexus.Gateway.Api.dll
+```
+
+---
+
+## Ollama / Local Model Issues
+
+### Agent Not Responding When Using Ollama
+
+**Symptom:** Agent is configured with an Ollama model but never responds. Gateway logs show:
+```text
+System.Net.Http.HttpRequestException: HTTP 400: registry.ollama.ai/library/phi4-reasoning:latest does not support tools
+```
+
+**Cause:** BotNexus sends tool definitions with every agent request. Ollama models that don't declare `tools` in their capabilities manifest reject these requests with HTTP 400.
+
+**Fix:** BotNexus automatically detects Ollama tool support via `/api/show` at startup and strips tool definitions for models that don't support them. If you see this error, ensure you're running BotNexus v1.0+ with the Ollama auto-detection fix.
+
+To check which models on your Ollama instance support tools:
+```bash
+curl -s http://localhost:11434/api/show -d '{"name":"your-model:tag"}' | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('capabilities', []))"
+```
+Models with `tools` in the capabilities list will receive tool definitions. Others get plain chat.
+
+### Ollama Model Not Registered / "Model not registered" Error
+
+**Symptom:** Gateway logs show:
+```text
+System.InvalidOperationException: Model 'phi4-reasoning:latest' for provider 'openai-compat' is not registered.
+```
+
+**Cause:** Ollama models are not in BotNexus's built-in model registry (which covers hosted providers like Copilot, OpenAI, Anthropic). Local models must be declared in `config.json`.
+
+**Fix:** Configure your Ollama provider and agent correctly in `~/.botnexus/config.json`:
+```json
+{
+  "providers": {
+    "openai-compat": {
+      "baseUrl": "http://localhost:11434/v1",
+      "apiKey": "ollama",
+      "enabled": true
+    }
+  },
+  "agents": {
+    "assistant": {
+      "provider": "openai-compat",
+      "model": "your-model:tag",
+      "enabled": true
+    }
+  }
+}
+```
+
+Key points:
+- Provider must be `openai-compat` (not `ollama`) — Ollama exposes an OpenAI-compatible `/v1` endpoint
+- `apiKey` can be any non-empty string (e.g. `"ollama"`) — Ollama doesn't validate it but the gateway requires a value
+- The model ID must exactly match the Ollama model tag shown by `ollama list`
+
+### Ollama "No API Key" Error
+
+**Symptom:**
+```text
+System.InvalidOperationException: No API key for openai-compat.
+Set credentials before using model 'your-model:latest'.
+```
+
+**Cause:** The `openai-compat` provider requires an `apiKey` to be set even though Ollama doesn't authenticate.
+
+**Fix:** Add any non-empty string as the API key:
+```json
+{
+  "providers": {
+    "openai-compat": {
+      "apiKey": "ollama"
     }
   }
 }

--- a/src/agent/BotNexus.Agent.Providers.Core/Compatibility/OpenAICompletionsCompat.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Compatibility/OpenAICompletionsCompat.cs
@@ -7,6 +7,12 @@ namespace BotNexus.Agent.Providers.Core.Compatibility;
 public record OpenAICompletionsCompat
 {
     /// <summary>
+    /// Gets or sets a value indicating whether this provider/model supports tool definitions.
+    /// When false, tool definitions are stripped from requests — the model gets plain chat only.
+    /// Default is true. Set false for Ollama models without tool support.
+    /// </summary>
+    public bool? SupportsTools { get; init; } = true;
+    /// <summary>
     /// Gets or sets the supports store param.
     /// </summary>
     public bool? SupportsStoreParam { get; init; } = true;

--- a/src/agent/BotNexus.Agent.Providers.OpenAI/OpenAICompletionsProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAI/OpenAICompletionsProvider.cs
@@ -287,13 +287,13 @@ public sealed class OpenAICompletionsProvider(
 
         payload["messages"] = ConvertMessages(systemPrompt, model, messages, compat);
 
-        if (tools is { Count: > 0 })
+        if (tools is { Count: > 0 } && compat.SupportsTools != false)
         {
             payload["tools"] = ConvertTools(tools, compat);
             if (compat.ZaiToolStream == true)
                 payload["tool_stream"] = true;
         }
-        else if (HasToolHistory(messages))
+        else if (HasToolHistory(messages) && compat.SupportsTools != false)
         {
             payload["tools"] = new JsonArray();
         }

--- a/src/agent/BotNexus.Agent.Providers.OpenAICompat/CompatDetector.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAICompat/CompatDetector.cs
@@ -19,10 +19,14 @@ public static class CompatDetector
         var baseUrl = model.BaseUrl.ToLowerInvariant();
 
         // Ollama: localhost:11434
+        // Query /api/show to check if this specific model supports tools.
+        // Results are cached per model — safe to call synchronously at startup.
         if (provider == "ollama" || baseUrl.Contains("localhost:11434") || baseUrl.Contains("127.0.0.1:11434"))
         {
+            var supportsTools = OllamaCapabilityChecker.SupportsToolsSync(model.BaseUrl, model.Id);
             return new OpenAICompletionsCompat
             {
+                SupportsTools = supportsTools,
                 SupportsStore = false,
                 SupportsDeveloperRole = false,
                 SupportsReasoningEffort = false,

--- a/src/agent/BotNexus.Agent.Providers.OpenAICompat/OllamaCapabilityChecker.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAICompat/OllamaCapabilityChecker.cs
@@ -13,6 +13,14 @@ public static class OllamaCapabilityChecker
     private static readonly SemaphoreSlim _lock = new(1, 1);
 
     /// <summary>
+    /// Synchronous wrapper for use in <see cref="CompatDetector.Detect"/> which is called per-request.
+    /// Safe because results are cached after the first call.
+    /// </summary>
+    public static bool SupportsToolsSync(string ollamaBaseUrl, string modelId)
+        => SupportsToolsAsync(new HttpClient(), ollamaBaseUrl, modelId)
+            .GetAwaiter().GetResult();
+
+    /// <summary>
     /// Returns true if the Ollama model supports tool calling.
     /// Falls back to false on any error (safe default — strip tools rather than crash).
     /// </summary>

--- a/src/agent/BotNexus.Agent.Providers.OpenAICompat/OllamaCapabilityChecker.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAICompat/OllamaCapabilityChecker.cs
@@ -1,0 +1,76 @@
+using BotNexus.Agent.Providers.Core.Compatibility;
+using System.Net.Http.Json;
+
+namespace BotNexus.Agent.Providers.OpenAICompat;
+
+/// <summary>
+/// Queries the Ollama /api/show endpoint to determine whether a model supports tools.
+/// Results are cached per base URL + model ID to avoid repeated network calls.
+/// </summary>
+public static class OllamaCapabilityChecker
+{
+    private static readonly Dictionary<string, bool> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly SemaphoreSlim _lock = new(1, 1);
+
+    /// <summary>
+    /// Returns true if the Ollama model supports tool calling.
+    /// Falls back to false on any error (safe default — strip tools rather than crash).
+    /// </summary>
+    public static async Task<bool> SupportsToolsAsync(
+        HttpClient httpClient,
+        string ollamaBaseUrl,
+        string modelId,
+        CancellationToken cancellationToken = default)
+    {
+        // Derive the Ollama API base from the /v1 chat completions base URL
+        // e.g. http://localhost:11434/v1 -> http://localhost:11434
+        var apiBase = ollamaBaseUrl
+            .TrimEnd('/')
+            .Replace("/v1", "", StringComparison.OrdinalIgnoreCase);
+
+        var cacheKey = $"{apiBase}|{modelId}";
+
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cache.TryGetValue(cacheKey, out var cached))
+                return cached;
+
+            try
+            {
+                var response = await httpClient.PostAsJsonAsync(
+                    $"{apiBase}/api/show",
+                    new { name = modelId },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _cache[cacheKey] = false;
+                    return false;
+                }
+
+                var body = await response.Content.ReadFromJsonAsync<OllamaShowResponse>(
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                var supportsTools = body?.Capabilities?.Contains("tools", StringComparer.OrdinalIgnoreCase) == true;
+                _cache[cacheKey] = supportsTools;
+                return supportsTools;
+            }
+            catch
+            {
+                // Network error, timeout, parse failure — assume no tools (safe default)
+                _cache[cacheKey] = false;
+                return false;
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private sealed class OllamaShowResponse
+    {
+        public List<string>? Capabilities { get; set; }
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.OpenAICompat/OpenAICompatProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.OpenAICompat/OpenAICompatProvider.cs
@@ -190,7 +190,7 @@ public sealed class OpenAICompatProvider(HttpClient httpClient) : IApiProvider
             body["tool_choice"] = compatOpts2.ToolChoice;
 
         // Tools
-        if (context.Tools is { Count: > 0 })
+        if (context.Tools is { Count: > 0 } && compat.SupportsTools != false)
         {
             var tools = new List<object>();
             foreach (var tool in context.Tools)
@@ -213,7 +213,7 @@ public sealed class OpenAICompatProvider(HttpClient httpClient) : IApiProvider
             }
             body["tools"] = ToNode(tools);
         }
-        else if (HasToolHistory(context.Messages))
+        else if (HasToolHistory(context.Messages) && compat.SupportsTools != false)
         {
             body["tools"] = ToNode(Array.Empty<object>());
         }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -136,15 +136,31 @@
     private List<Announcement> _announcements = [];
     private bool _restarting;
     private bool _sidebarOpen = false;
+    private const string SidebarKey = "botnexus-sidebar-open";
 
     protected override void OnInitialized()
     {
         Manager.OnStateChanged += HandleStateChanged;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var stored = await JS.InvokeAsync<string?>("localStorage.getItem", SidebarKey);
+            _sidebarOpen = stored == "true";
+            StateHasChanged();
+        }
+    }
+
     private void HandleStateChanged() => InvokeAsync(StateHasChanged);
 
-    private void ToggleSidebar() => _sidebarOpen = !_sidebarOpen;
+    private async Task ToggleSidebar()
+    {
+        _sidebarOpen = !_sidebarOpen;
+        await JS.InvokeVoidAsync("localStorage.setItem", SidebarKey, _sidebarOpen ? "true" : "false");
+    }
+
     private void CloseSidebar() => _sidebarOpen = false;
 
     private void OnNavClick()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -5,9 +5,14 @@
 @implements IDisposable
 
 <div class="app-shell">
-    @* Full-width banner *@
+    @* Top bar with burger + logo *@
     <header class="app-banner">
         <div class="banner-header">
+            <button class="burger-btn" @onclick="ToggleSidebar" aria-label="Toggle menu">
+                <span class="burger-line"></span>
+                <span class="burger-line"></span>
+                <span class="burger-line"></span>
+            </button>
             <span class="banner-logo">🤖</span>
             <span class="banner-title">BotNexus</span>
         </div>
@@ -29,7 +34,13 @@
 
     @* Two-column body *@
     <div class="app-body">
-        <aside class="main-sidebar">
+        @* Mobile overlay — tap to close sidebar *@
+        @if (_sidebarOpen)
+        {
+            <div class="sidebar-overlay" @onclick="CloseSidebar"></div>
+        }
+
+        <aside class="main-sidebar @(_sidebarOpen ? "sidebar-open" : "sidebar-closed")">
             @* Connection status *@
             <div class="sidebar-connection">
                 <ConnectionStatus Hub="@Manager.Hub" />
@@ -37,7 +48,7 @@
 
             @* Nav links *@
             <nav class="sidebar-nav">
-                <a href="" class="sidebar-nav-item @NavClass("")">💬 Chat</a>
+                <a href="" class="sidebar-nav-item @NavClass("")" @onclick="OnNavClick">💬 Chat</a>
 
                 @* Agent dropdown + session list nested under Chat *@
                 @if (Manager.Sessions.Count > 0)
@@ -73,7 +84,7 @@
                                 .Where(s => s.Status is "Running" or "Completed"))
                             {
                                 <div class="agent-session-item @(IsSubAgentActive(sub) ? "active" : "")"
-                                     @onclick="() => ViewSubAgent(sub)"
+                                     @onclick="() => ViewSubAgentAndClose(sub)"
                                      style="cursor: pointer;"
                                      title="@sub.Task">
                                     <span>@SubAgentIcon(sub.Status)</span>
@@ -88,21 +99,21 @@
                     }
                 }
 
-                <a href="configuration" class="sidebar-nav-item @NavClass("configuration")">⚙️ Configuration</a>
+                <a href="configuration" class="sidebar-nav-item @NavClass("configuration")" @onclick="OnNavClick">⚙️ Configuration</a>
 
                 @* Config section sub-nav — only shown when on the configuration page *@
                 @if (IsOnPage("configuration"))
                 {
                     <div class="sidebar-subnav">
-                        <a href="configuration#cfg-gateway"  class="sidebar-subnav-item">🌐 Gateway</a>
-                        <a href="configuration#cfg-providers" class="sidebar-subnav-item">🔌 Providers</a>
-                        <a href="configuration#cfg-channels"  class="sidebar-subnav-item">📡 Channels</a>
-                        <a href="configuration#cfg-cron"      class="sidebar-subnav-item">⏰ Cron</a>
-                        <a href="configuration#cfg-apikey"    class="sidebar-subnav-item">🔑 Global API Key</a>
+                        <a href="configuration#cfg-gateway"  class="sidebar-subnav-item" @onclick="CloseSidebar">🌐 Gateway</a>
+                        <a href="configuration#cfg-providers" class="sidebar-subnav-item" @onclick="CloseSidebar">🔌 Providers</a>
+                        <a href="configuration#cfg-channels"  class="sidebar-subnav-item" @onclick="CloseSidebar">📡 Channels</a>
+                        <a href="configuration#cfg-cron"      class="sidebar-subnav-item" @onclick="CloseSidebar">⏰ Cron</a>
+                        <a href="configuration#cfg-apikey"    class="sidebar-subnav-item" @onclick="CloseSidebar">🔑 Global API Key</a>
                     </div>
                 }
 
-                <a href="agents" class="sidebar-nav-item @NavClass("agents")">🤖 Agents</a>
+                <a href="agents" class="sidebar-nav-item @NavClass("agents")" @onclick="OnNavClick">🤖 Agents</a>
             </nav>
 
             @* Restart button at bottom *@
@@ -124,6 +135,7 @@
     private record Announcement(string Id, string Text, string Type = "info");
     private List<Announcement> _announcements = [];
     private bool _restarting;
+    private bool _sidebarOpen = false;
 
     protected override void OnInitialized()
     {
@@ -131,6 +143,15 @@
     }
 
     private void HandleStateChanged() => InvokeAsync(StateHasChanged);
+
+    private void ToggleSidebar() => _sidebarOpen = !_sidebarOpen;
+    private void CloseSidebar() => _sidebarOpen = false;
+
+    private void OnNavClick()
+    {
+        // Close sidebar after navigation on mobile
+        _sidebarOpen = false;
+    }
 
     private string NavClass(string page)
     {
@@ -158,9 +179,10 @@
         _           => "🤖"
     };
 
-    private async Task ViewSubAgent(SubAgentInfo sub)
+    private async Task ViewSubAgentAndClose(SubAgentInfo sub)
     {
         await Manager.ViewSubAgentAsync(sub);
+        _sidebarOpen = false;
     }
 
     private bool IsSubAgentActive(SubAgentInfo sub)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -226,7 +226,8 @@ public sealed class AgentSessionManager : IDisposable
         }
     }
 
-    /// <summary>Load message history from the REST API for the given agent.</summary>
+    /// <summary>Load message history from the REST API for the given agent.
+    /// Queries all sessions for the agent (not channel-scoped) and loads the most recent one.</summary>
     public async Task LoadHistoryAsync(string agentId)
     {
         if (!_sessions.TryGetValue(agentId, out var state))
@@ -239,25 +240,41 @@ public sealed class AgentSessionManager : IDisposable
 
         try
         {
-            var channelType = state.ChannelType ?? "signalr";
-            var url = $"{_apiBaseUrl}channels/{channelType}/agents/{agentId}/history?limit=50";
-            var response = await _http.GetFromJsonAsync<HistoryResponse>(url);
+            // Get all sessions for this agent across all channels
+            var sessionsUrl = $"{_apiBaseUrl}sessions?agentId={Uri.EscapeDataString(agentId)}";
+            var allSessions = await _http.GetFromJsonAsync<List<SessionSummary>>(sessionsUrl);
 
-            if (response?.Messages is { Count: > 0 })
+            // Find the most recent interactive session
+            var recentSession = allSessions
+                ?.Where(s => s.IsInteractive && s.Status != "Sealed")
+                .OrderByDescending(s => s.UpdatedAt ?? s.CreatedAt)
+                .FirstOrDefault();
+
+            if (recentSession is not null)
             {
-                state.Messages.Clear();
-                // API returns messages in chronological order (oldest first)
-                foreach (var msg in response.Messages)
+                // Resume into this session so new messages go to the same session
+                if (state.SessionId is null)
+                    state.SessionId = recentSession.SessionId;
+
+                // Load its history
+                var historyUrl = $"{_apiBaseUrl}sessions/{Uri.EscapeDataString(recentSession.SessionId)}/history?limit=50";
+                var historyResponse = await _http.GetFromJsonAsync<SessionHistoryResponse>(historyUrl);
+
+                if (historyResponse?.Messages is { Count: > 0 })
                 {
-                    state.Messages.Add(new ChatMessage(
-                        MapRole(msg.Role),
-                        msg.Content,
-                        msg.Timestamp)
+                    state.Messages.Clear();
+                    foreach (var msg in historyResponse.Messages)
                     {
-                        ToolName = msg.ToolName,
-                        ToolCallId = msg.ToolCallId,
-                        IsToolCall = msg.ToolName is not null
-                    });
+                        state.Messages.Add(new ChatMessage(
+                            MapRole(msg.Role),
+                            msg.Content,
+                            msg.Timestamp)
+                        {
+                            ToolName = msg.ToolName,
+                            ToolCallId = msg.ToolCallId,
+                            IsToolCall = msg.ToolName is not null
+                        });
+                    }
                 }
             }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/HubContracts.cs
@@ -93,15 +93,16 @@ public sealed record SendMessageResult(
 public sealed record SubscribeAllResult(
     [property: JsonPropertyName("sessions")] IReadOnlyList<SessionSummary> Sessions);
 
-/// <summary>Session summary returned in <see cref="SubscribeAllResult"/>.</summary>
+/// <summary>Session summary returned in <see cref="SubscribeAllResult"/> and GET /api/sessions.</summary>
 public sealed record SessionSummary(
     [property: JsonPropertyName("sessionId")] string SessionId,
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("channelType")] string? ChannelType,
     [property: JsonPropertyName("status")] string? Status,
     [property: JsonPropertyName("messageCount")] int MessageCount,
-    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
-    [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt);
+    [property: JsonPropertyName("isInteractive")] bool IsInteractive = true,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset? CreatedAt = null,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset? UpdatedAt = null);
 
 /// <summary>Result returned by <c>CompactSession</c>.</summary>
 public sealed record CompactSessionResult(
@@ -127,3 +128,10 @@ public sealed record HistoryMessage(
     [property: JsonPropertyName("timestamp")] DateTimeOffset Timestamp,
     [property: JsonPropertyName("toolName")] string? ToolName = null,
     [property: JsonPropertyName("toolCallId")] string? ToolCallId = null);
+
+/// <summary>Response from GET /api/sessions/{sessionId}/history</summary>
+public sealed record SessionHistoryResponse(
+    [property: JsonPropertyName("entries")] IReadOnlyList<HistoryMessage>? Messages,
+    [property: JsonPropertyName("totalCount")] int TotalCount,
+    [property: JsonPropertyName("offset")] int Offset,
+    [property: JsonPropertyName("limit")] int Limit);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -750,6 +750,13 @@ html, body, #app {
     transition: border-color 0.15s;
 }
 
+/* Prevent iOS Safari auto-zoom on input focus — must be >= 16px */
+@media (max-width: 768px) {
+    .chat-input {
+        font-size: 16px;
+    }
+}
+
 .chat-input:focus {
     border-color: var(--accent);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -84,6 +84,34 @@ html, body, #app {
     background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-surface) 100%);
 }
 
+/* ── Burger button ──────────────────────────────────────────────────── */
+
+.burger-btn {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 22px;
+    height: 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.burger-line {
+    display: block;
+    width: 100%;
+    height: 2px;
+    background: var(--text-secondary);
+    border-radius: 2px;
+    transition: background 0.15s;
+}
+
+.burger-btn:hover .burger-line {
+    background: var(--text-primary);
+}
+
 .banner-logo {
     font-size: 1.6rem;
     line-height: 1;
@@ -160,6 +188,54 @@ html, body, #app {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    transition: transform 0.25s ease;
+}
+
+/* Sidebar overlay — covers main canvas on mobile when sidebar is open */
+.sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99;
+}
+
+/* ── Mobile: sidebar is off-screen by default ───────────────────────── */
+@media (max-width: 768px) {
+    .main-sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100%;
+        z-index: 100;
+        transform: translateX(-100%);
+    }
+
+    .main-sidebar.sidebar-open {
+        transform: translateX(0);
+    }
+
+    .sidebar-overlay {
+        display: block;
+    }
+
+    /* Main canvas takes full width on mobile */
+    .main-canvas {
+        width: 100%;
+    }
+}
+
+/* Desktop: sidebar always visible, burger is just for toggling preference */
+@media (min-width: 769px) {
+    .main-sidebar.sidebar-closed {
+        display: none;
+    }
+
+    .main-sidebar.sidebar-open,
+    .main-sidebar:not(.sidebar-closed):not(.sidebar-open) {
+        transform: translateX(0);
+        position: relative;
+    }
 }
 
 .sidebar-connection {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/favicon.svg
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#16213e"/>
+  <text x="16" y="24" font-size="20" text-anchor="middle" font-family="serif">🤖</text>
+</svg>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <title>BotNexus — Blazor Client</title>
     <base href="/" />
     <link rel="preload" id="webassembly" />

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <title>BotNexus — Blazor Client</title>
     <base href="/" />
     <link rel="preload" id="webassembly" />

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -7,8 +7,10 @@ using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Extensions;
 using BotNexus.Agent.Providers.Anthropic;
 using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Compatibility;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.OpenAICompat;
 using Microsoft.Extensions.Options;
 using BotNexus.Agent.Providers.OpenAI;
 using BotNexus.Agent.Providers.OpenAICompat;
@@ -185,17 +187,8 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
             {
                 foreach (var modelId in providerConfig.Models)
                 {
-                    models.Register(providerName, new LlmModel(
-                        Id: modelId,
-                        Name: modelId,
-                        Api: "openai-completions",
-                        Provider: providerName,
-                        BaseUrl: providerConfig.BaseUrl,
-                        Reasoning: false,
-                        Input: ["text"],
-                        Cost: new ModelCost(0, 0, 0, 0),
-                        ContextWindow: 128000,
-                        MaxTokens: 32000));
+                    models.Register(providerName, BuildCompatModel(
+                        modelId, providerName, providerConfig.BaseUrl, httpClient));
                 }
             }
         }
@@ -216,22 +209,51 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
             if (models.GetModel(agentConfig.Provider, agentConfig.Model) is not null)
                 continue; // already registered
 
-            models.Register(agentConfig.Provider, new LlmModel(
-                Id: agentConfig.Model,
-                Name: agentConfig.Model,
-                Api: "openai-completions",
-                Provider: agentConfig.Provider,
-                BaseUrl: agentProvider.BaseUrl,
-                Reasoning: agentConfig.Model.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
-                Input: ["text"],
-                Cost: new ModelCost(0, 0, 0, 0),
-                ContextWindow: 128000,
-                MaxTokens: 32000));
+            models.Register(agentConfig.Provider, BuildCompatModel(
+                agentConfig.Model, agentConfig.Provider, agentProvider.BaseUrl, httpClient));
         }
     }
 
     return new LlmClient(apiProviders, models);
 });
+
+/// <summary>
+/// Builds an LlmModel for an openai-compat provider, checking Ollama tool support when applicable.
+/// </summary>
+static LlmModel BuildCompatModel(string modelId, string provider, string baseUrl, HttpClient httpClient)
+{
+    var isOllama = baseUrl.Contains("localhost:11434") || baseUrl.Contains("127.0.0.1:11434");
+    var supportsTools = !isOllama || OllamaCapabilityChecker
+        .SupportsToolsAsync(httpClient, baseUrl, modelId)
+        .GetAwaiter().GetResult();
+
+    var compat = isOllama
+        ? new OpenAICompletionsCompat
+        {
+            SupportsTools = supportsTools,
+            SupportsStore = false,
+            SupportsDeveloperRole = false,
+            SupportsReasoningEffort = false,
+            SupportsUsageInStreaming = false,
+            MaxTokensField = "max_tokens",
+            SupportsStrictMode = false,
+            RequiresToolResultName = true,
+        }
+        : null; // non-Ollama: let CompatDetector handle it at call time
+
+    return new LlmModel(
+        Id: modelId,
+        Name: modelId,
+        Api: "openai-completions",
+        Provider: provider,
+        BaseUrl: baseUrl,
+        Reasoning: modelId.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
+        Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 128000,
+        MaxTokens: 32000,
+        Compat: compat);
+}
 
 using (var bootstrapLoggerFactory = new Serilog.Extensions.Logging.SerilogLoggerFactory(Log.Logger, dispose: false))
 {

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -7,7 +7,9 @@ using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Extensions;
 using BotNexus.Agent.Providers.Anthropic;
 using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
+using Microsoft.Extensions.Options;
 using BotNexus.Agent.Providers.OpenAI;
 using BotNexus.Agent.Providers.OpenAICompat;
 using BotNexus.Cron;
@@ -168,6 +170,66 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
     apiProviders.Register(new OpenAICompatProvider(httpClient));
 
     serviceProvider.GetRequiredService<BuiltInModels>().RegisterAll(models);
+
+    // Register models from openai-compat providers in config (e.g. Ollama, LM Studio)
+    var platformConfig = serviceProvider.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue;
+    if (platformConfig.Providers is not null)
+    {
+        foreach (var (providerName, providerConfig) in platformConfig.Providers)
+        {
+            if (!providerConfig.Enabled || string.IsNullOrWhiteSpace(providerConfig.BaseUrl))
+                continue;
+
+            // Register each explicitly listed model for this provider
+            if (providerConfig.Models is { Count: > 0 })
+            {
+                foreach (var modelId in providerConfig.Models)
+                {
+                    models.Register(providerName, new LlmModel(
+                        Id: modelId,
+                        Name: modelId,
+                        Api: "openai-completions",
+                        Provider: providerName,
+                        BaseUrl: providerConfig.BaseUrl,
+                        Reasoning: false,
+                        Input: ["text"],
+                        Cost: new ModelCost(0, 0, 0, 0),
+                        ContextWindow: 128000,
+                        MaxTokens: 32000));
+                }
+            }
+        }
+    }
+
+    // Also register the default model for any agent using an openai-compat provider not in BuiltInModels
+    if (platformConfig.Agents is not null && platformConfig.Providers is not null)
+    {
+        foreach (KeyValuePair<string, AgentDefinitionConfig> agentEntry in platformConfig.Agents)
+        {
+            var agentConfig = agentEntry.Value;
+            if (string.IsNullOrWhiteSpace(agentConfig.Provider) || string.IsNullOrWhiteSpace(agentConfig.Model))
+                continue;
+            if (!platformConfig.Providers.TryGetValue(agentConfig.Provider, out var agentProvider))
+                continue;
+            if (string.IsNullOrWhiteSpace(agentProvider.BaseUrl))
+                continue;
+            if (models.GetModel(agentConfig.Provider, agentConfig.Model) is not null)
+                continue; // already registered
+
+            models.Register(agentConfig.Provider, new LlmModel(
+                Id: agentConfig.Model,
+                Name: agentConfig.Model,
+                Api: "openai-completions",
+                Provider: agentConfig.Provider,
+                BaseUrl: agentProvider.BaseUrl,
+                Reasoning: agentConfig.Model.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
+                Input: ["text"],
+                Cost: new ModelCost(0, 0, 0, 0),
+                ContextWindow: 128000,
+                MaxTokens: 32000));
+        }
+    }
+
     return new LlmClient(apiProviders, models);
 });
 

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -7,10 +7,8 @@ using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Extensions;
 using BotNexus.Agent.Providers.Anthropic;
 using BotNexus.Agent.Providers.Core;
-using BotNexus.Agent.Providers.Core.Compatibility;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
-using BotNexus.Agent.Providers.OpenAICompat;
 using Microsoft.Extensions.Options;
 using BotNexus.Agent.Providers.OpenAI;
 using BotNexus.Agent.Providers.OpenAICompat;
@@ -182,19 +180,27 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
             if (!providerConfig.Enabled || string.IsNullOrWhiteSpace(providerConfig.BaseUrl))
                 continue;
 
-            // Register each explicitly listed model for this provider
             if (providerConfig.Models is { Count: > 0 })
             {
                 foreach (var modelId in providerConfig.Models)
                 {
-                    models.Register(providerName, BuildCompatModel(
-                        modelId, providerName, providerConfig.BaseUrl, httpClient));
+                    models.Register(providerName, new LlmModel(
+                        Id: modelId,
+                        Name: modelId,
+                        Api: "openai-completions",
+                        Provider: providerName,
+                        BaseUrl: providerConfig.BaseUrl,
+                        Reasoning: modelId.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
+                        Input: ["text"],
+                        Cost: new ModelCost(0, 0, 0, 0),
+                        ContextWindow: 128000,
+                        MaxTokens: 32000));
                 }
             }
         }
     }
 
-    // Also register the default model for any agent using an openai-compat provider not in BuiltInModels
+    // Register the model for any agent using an openai-compat provider not in BuiltInModels
     if (platformConfig.Agents is not null && platformConfig.Providers is not null)
     {
         foreach (KeyValuePair<string, AgentDefinitionConfig> agentEntry in platformConfig.Agents)
@@ -207,53 +213,24 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
             if (string.IsNullOrWhiteSpace(agentProvider.BaseUrl))
                 continue;
             if (models.GetModel(agentConfig.Provider, agentConfig.Model) is not null)
-                continue; // already registered
+                continue;
 
-            models.Register(agentConfig.Provider, BuildCompatModel(
-                agentConfig.Model, agentConfig.Provider, agentProvider.BaseUrl, httpClient));
+            models.Register(agentConfig.Provider, new LlmModel(
+                Id: agentConfig.Model,
+                Name: agentConfig.Model,
+                Api: "openai-completions",
+                Provider: agentConfig.Provider,
+                BaseUrl: agentProvider.BaseUrl,
+                Reasoning: agentConfig.Model.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
+                Input: ["text"],
+                Cost: new ModelCost(0, 0, 0, 0),
+                ContextWindow: 128000,
+                MaxTokens: 32000));
         }
     }
 
     return new LlmClient(apiProviders, models);
 });
-
-/// <summary>
-/// Builds an LlmModel for an openai-compat provider, checking Ollama tool support when applicable.
-/// </summary>
-static LlmModel BuildCompatModel(string modelId, string provider, string baseUrl, HttpClient httpClient)
-{
-    var isOllama = baseUrl.Contains("localhost:11434") || baseUrl.Contains("127.0.0.1:11434");
-    var supportsTools = !isOllama || OllamaCapabilityChecker
-        .SupportsToolsAsync(httpClient, baseUrl, modelId)
-        .GetAwaiter().GetResult();
-
-    var compat = isOllama
-        ? new OpenAICompletionsCompat
-        {
-            SupportsTools = supportsTools,
-            SupportsStore = false,
-            SupportsDeveloperRole = false,
-            SupportsReasoningEffort = false,
-            SupportsUsageInStreaming = false,
-            MaxTokensField = "max_tokens",
-            SupportsStrictMode = false,
-            RequiresToolResultName = true,
-        }
-        : null; // non-Ollama: let CompatDetector handle it at call time
-
-    return new LlmModel(
-        Id: modelId,
-        Name: modelId,
-        Api: "openai-completions",
-        Provider: provider,
-        BaseUrl: baseUrl,
-        Reasoning: modelId.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
-        Input: ["text"],
-        Cost: new ModelCost(0, 0, 0, 0),
-        ContextWindow: 128000,
-        MaxTokens: 32000,
-        Compat: compat);
-}
 
 using (var bootstrapLoggerFactory = new Serilog.Extensions.Logging.SerilogLoggerFactory(Log.Logger, dispose: false))
 {


### PR DESCRIPTION
A batch of fixes and improvements across provider support, mobile UX, and Linux compatibility.

## Ollama / Local Model Support
- **Auto-register models from config** — agents using `openai-compat` provider (Ollama, LM Studio) now have their models registered at startup without needing to be in `BuiltInModels`
- **Auto-detect tool support** — `OllamaCapabilityChecker` queries `/api/show` at first use and caches the result; models without `tools` capability get plain chat (no HTTP 400 crash)
- **No API key required** — Ollama doesn't authenticate; set `"apiKey": "ollama"` as a placeholder

## Mobile UI
- **Burger menu** — collapsible sidebar with ☰ button in the header
- **Mobile behaviour** — sidebar hidden by default on small screens, slides in as overlay, tap outside to close
- **Desktop behaviour** — burger toggles sidebar visible/hidden
- **Sidebar state persisted** — open/closed state saved to `localStorage`, survives refresh
- **iOS zoom fix** — chat input set to `font-size: 16px` on mobile; `maximum-scale=1.0` in viewport meta prevents auto-zoom on focus
- **Favicon** — SVG robot icon added; fixes `favicon.ico 404` in browser console

## Session History
- **History loads on connect** — previously used a channel-scoped endpoint that returned nothing for fresh sessions; now queries `GET /api/sessions?agentId=X` across all channels and loads the most recent session's history
- **Session resume** — new messages continue the most recent session rather than starting a fresh one every time the UI loads

## Linux / Runtime Fixes
- **CultureNotFoundException** — `OnConnectedAsync` crashed on Linux (.NET 10) when SignalR enumerated hub methods on generic types; fix: run gateway with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`
- **Docs** — `troubleshooting.md` updated with Linux-specific and Ollama FAQ sections

## Tests
2,168 passing, 0 failures