### PR TITLE
docs(planning): conversation topics / omnichannel continuity design spec

### DIFF
--- a/.squad/decisions/inbox/leela-conversation-model-review.md
+++ b/.squad/decisions/inbox/leela-conversation-model-review.md
@@ -1,0 +1,136 @@
+# Decision: Conversation Model Final Design Review
+
+**Date:** 2026-04-27  
+**Author:** Leela (Lead/Architect)  
+**Status:** Approved with implementation clarifications  
+**Spec:** `docs/planning/feature-conversation-topics/design-spec.md`
+
+## Summary
+
+The Conversation Model feature is approved to move into implementation. The product direction is correct: BotNexus needs a durable user-facing `Conversation` above runtime `Session` to support omnichannel continuity, default per-agent conversations, and conversation-first portal UX.
+
+The review found **no blockers**, but did identify several critical clarifications that must shape implementation:
+
+1. `ConversationId` already exists in `BotNexus.Domain.Primitives` and must be reused.
+2. `IConversationStore` belongs in `BotNexus.Gateway.Contracts`; implementations belong in `BotNexus.Gateway.Sessions`.
+3. Conversation persistence should ship with `InMemory`, `File`, and `Sqlite` implementations.
+4. `GatewayHub.ResolveOrCreateSessionAsync()` must be replaced with conversation-first routing.
+5. `Session.ConversationId` should remain nullable; existing sessions are legacy-compatible and do not require eager migration.
+6. `ISessionWarmupService` should remain session-scoped; conversations need a separate catalog/warmup concern.
+7. Assistant reply fan-out must be centralized in a gateway-level `IConversationRouter`, not pushed into each channel adapter.
+
+## Key Architectural Decisions
+
+### D1. Conversation is the user-visible identity; Session remains the runtime/history segment
+
+This feature should not weaken the current session model. Session still owns:
+- runtime execution
+- compaction/reset boundary
+- replay buffer scope
+- live streaming scope
+- persisted message history segment
+
+Conversation owns:
+- stable omnichannel identity
+- default conversation per agent
+- channel bindings
+- active session pointer
+- title/archive metadata
+
+### D2. Reuse existing `ConversationId`
+
+Do not create a new primitive. The existing type at `src/domain/BotNexus.Domain/Primitives/ConversationId.cs` is the correct home.
+
+### D3. Put persistence beside session persistence
+
+Conversation store implementations should live in `BotNexus.Gateway.Sessions`, not a new project. The storage/configuration problem is the same as session persistence.
+
+### D4. Routing must become conversation-first
+
+Current hub logic resolves a session from `(agentId, channelType)`. That is the main architectural mismatch.
+
+New rule:
+- inbound resolves conversation first
+- conversation resolves/creates active session
+- dispatch remains session-level after that
+
+### D5. Keep `Session.ConversationId` nullable
+
+Legacy sessions without a conversation link are valid old data, not corruption. Populate the field opportunistically when a session becomes conversation-managed.
+
+### D6. Do not overload `ISessionWarmupService`
+
+Conversation discovery/default creation needs its own service (`IConversationCatalogService` or similar). Session warmup should stay focused on sessions.
+
+### D7. Fan-out belongs in a conversation router
+
+Adapters should send transport-specific messages. They should not own binding lookup or cross-channel fan-out policy.
+
+## Contracts to Implement
+
+### Domain
+- `Conversation` → `BotNexus.Domain.Conversations`
+- `ChannelBinding` → `BotNexus.Domain.Conversations`
+- `ConversationStatus`, `BindingMode`, `ThreadingMode` → same namespace
+- `Session.ConversationId` additive change
+
+### Gateway Contracts
+- `IConversationStore`
+- `ConversationSummary`
+- `IConversationRouter`
+- `IConversationHistoryService`
+- conversation history DTOs/cursor types
+
+### Gateway/Runtime
+- `DefaultConversationRouter`
+- `ConversationHistoryService`
+- `InMemoryConversationStore`
+- `FileConversationStore`
+- `SqliteConversationStore`
+- conversation-first `GatewayHub` methods
+- conversation REST controller
+
+## Wave Plan
+
+### Wave 1 — Foundation (Farnsworth)
+**Scope:** domain model, contracts, storage, DI wiring  
+**Tests:** ~18-24
+
+### Wave 2 — Routing (Bender)
+**Scope:** inbound resolution, active session management, outbound fan-out  
+**Tests:** ~16-22
+
+### Wave 3 — API + History (Fry)
+**Scope:** conversation REST/hub APIs, history assembly with session boundaries  
+**Tests:** ~12-18
+
+### Wave 4 — Portal UX (Amy)
+**Scope:** conversation-first sidebar and merged transcript rendering  
+**Tests:** ~10-14
+
+### Wave 5 — Compatibility + Docs (Hermes/Kif)
+**Scope:** regression, migration coverage, architecture/training docs  
+**Tests:** ~20-28
+
+## Top Risks
+
+1. **Routing duality** — old session routing and new conversation routing both try to send messages  
+   **Mitigation:** centralize fan-out in `IConversationRouter`
+
+2. **Legacy session ambiguity** — historical sessions have no conversation linkage  
+   **Mitigation:** keep them readable but exclude from conversation assembly until linked
+
+3. **Portal/session stream mismatch** — portal is conversation-first but live stream is session-first  
+   **Mitigation:** maintain conversation → active session mapping and refresh subscription on active-session change
+
+4. **Storage divergence** — conversation store grows a different persistence/config model than session store  
+   **Mitigation:** implement in `BotNexus.Gateway.Sessions` and mirror session store configuration patterns
+
+5. **Channel fan-out surprises** — duplicate outbound or wrong binding behavior  
+   **Mitigation:** adapters render/send only; router owns policy
+
+## Outcome
+
+The feature is **approved for implementation**. Start with storage/contracts/routing. Do not lead with UI work.
+
+The high-risk seam is not the portal — it is replacing session-first routing with conversation-first routing without duplicating or regressing delivery behavior.

--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -19,6 +19,7 @@
 ## ✨ Features
 
 ### 🟠 High
+- [Conversation Topics for Omnichannel Continuity](feature-conversation-topics/design-spec.md) — `draft` 📄
 - [ask_user Tool](feature-ask-user-tool/design-spec.md) — `design`
 
 ### 🟡 Medium

--- a/docs/planning/INDEX.md
+++ b/docs/planning/INDEX.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 ### 🟠 High
-- [Conversation Topics for Omnichannel Continuity](feature-conversation-topics/design-spec.md) — `draft` 📄
+- [Conversation Model for Omnichannel Continuity](feature-conversation-topics/design-spec.md) — `ready` 📄
 - [ask_user Tool](feature-ask-user-tool/design-spec.md) — `design`
 
 ### 🟡 Medium

--- a/docs/planning/feature-conversation-topics/design-review.md
+++ b/docs/planning/feature-conversation-topics/design-review.md
@@ -1,0 +1,809 @@
+# Design Review: Conversation Model
+
+**Date:** 2026-04-27  
+**Author:** Leela (Lead/Architect)  
+**Status:** Approved with clarifications before implementation starts  
+**Spec reviewed:** `docs/planning/feature-conversation-topics/design-spec.md`  
+**Research reviewed:** `docs/planning/feature-conversation-topics/research.md`
+
+## Executive Summary
+
+The feature is directionally correct and buildable on the current BotNexus codebase. The core architectural move — introducing a durable `Conversation` above runtime `Session` — is the right correction for omnichannel continuity.
+
+The spec is **not blocked**, but it is **underspecified in seven implementation-critical seams**:
+
+1. `ConversationId` is **already present** in `BotNexus.Domain.Primitives`; the spec should build on that instead of re-inventing it.
+2. `IConversationStore` needs a concrete home and default persistence strategy.
+3. DI registration must be explicit in `GatewayServiceCollectionExtensions` and platform config wiring.
+4. `GatewayHub.ResolveOrCreateSessionAsync()` must become conversation-first instead of channel/session-first.
+5. `Session.ConversationId` needs nullable backfill semantics for existing sessions.
+6. `ISessionWarmupService` should stay session-scoped; conversation warmup needs a separate concern.
+7. Fan-out cannot live in channel adapters alone; it needs a gateway-level conversation routing service.
+
+## Overall Assessment
+
+### What is strong
+
+- The product model is correct: **conversation = user-visible continuity**, **session = runtime/history segment**.
+- The additive migration strategy is correct.
+- Keeping session history as the source of truth and assembling conversation history on demand is correct.
+- The portal becoming conversation-first while live transport stays session-level is the right compatibility balance.
+
+### What must be clarified before implementation
+
+The spec currently mixes three different layers:
+- domain model (`Conversation`, `ChannelBinding`)
+- routing behavior (inbound resolution, outbound fan-out)
+- UI/API terminology (`Topic*` method names in some examples, `Conversation*` elsewhere)
+
+Implementation should standardize on **Conversation** everywhere in C# contracts and REST routes.
+
+---
+
+## Final Architecture Review
+
+## 1. Missing primitives
+
+### Finding
+`ConversationId` is **not missing**. It already exists at:
+- `src/domain/BotNexus.Domain/Primitives/ConversationId.cs`
+
+That is the correct location, alongside `SessionId`, `AgentId`, and `ChannelKey`.
+
+### Decision
+- **Use the existing `ConversationId` value object.**
+- Do **not** create a second `ConversationId` in Gateway projects.
+- Add generation helper parity later if needed (for example `Create()`), but do not fork the primitive.
+
+### Implication
+The spec's Phase 1 item "Add `ConversationId` primitive" is already complete from a type-placement perspective. Implementation only needs to adopt it.
+
+---
+
+## 2. Storage: where `IConversationStore` lives and who implements it
+
+### Finding
+The current codebase pattern is:
+- contracts/interfaces in `src/gateway/BotNexus.Gateway.Contracts/`
+- runtime orchestration in `src/gateway/BotNexus.Gateway/`
+- persistence implementations in `src/gateway/BotNexus.Gateway.Sessions/`
+- domain/value types in `src/domain/BotNexus.Domain/`
+
+Session persistence already has three implementations:
+- `InMemorySessionStore`
+- `FileSessionStore`
+- `SqliteSessionStore`
+
+### Decision
+- `IConversationStore` should live in **`BotNexus.Gateway.Contracts/Conversations`**.
+- The initial implementations should live in **`BotNexus.Gateway.Sessions`**, not a new assembly.
+- Required implementations for v1:
+  - `InMemoryConversationStore`
+  - `FileConversationStore`
+  - `SqliteConversationStore`
+
+### Rationale
+Conversation persistence is the same class of problem as session persistence: gateway-owned durable state. Reusing `BotNexus.Gateway.Sessions` avoids unnecessary project sprawl and allows the same config path / storage mode decisions to apply.
+
+### Backing store shape
+- **InMemory**: for tests/dev parity.
+- **File**: one JSON file per conversation plus binding metadata embedded in the same document.
+- **Sqlite**: preferred durable implementation for single-node production.
+
+### Sqlite schema recommendation
+Use two tables, not one:
+
+#### `conversations`
+- `id TEXT PRIMARY KEY`
+- `agent_id TEXT NOT NULL`
+- `title TEXT NOT NULL`
+- `is_default INTEGER NOT NULL`
+- `status TEXT NOT NULL`
+- `active_session_id TEXT NULL`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+- `metadata_json TEXT NOT NULL`
+
+#### `conversation_bindings`
+- `binding_id TEXT PRIMARY KEY`
+- `conversation_id TEXT NOT NULL`
+- `channel_type TEXT NOT NULL`
+- `external_address TEXT NOT NULL`
+- `mode TEXT NOT NULL`
+- `threading_mode TEXT NOT NULL`
+- `thread_id TEXT NULL`
+- `display_prefix TEXT NULL`
+- `bound_at TEXT NOT NULL`
+- `last_inbound_at TEXT NULL`
+- `last_outbound_at TEXT NULL`
+
+Unique index:
+- `(agent_id, channel_type, external_address)` is conceptually required, but because `agent_id` lives on `conversations`, the effective uniqueness should be enforced in store logic or via join-aware insert/update logic.
+
+### Why not store conversation state in session metadata?
+Because conversation is a first-class durable object with its own lifecycle, bindings, active session pointer, title, and archive state. Session metadata would become a fragmented secondary source of truth.
+
+---
+
+## 3. DI registration
+
+### Finding
+Current gateway registration happens in:
+- `src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs`
+
+Session store selection is already driven from platform config in `ConfigureSessionStore(...)`.
+
+### Decision
+Add a parallel `ConfigureConversationStore(...)` path in the same extension file.
+
+### Required DI registrations
+At minimum:
+- `IConversationStore`
+- `IConversationRouter` (new)
+- `IConversationHistoryService` (new)
+- `IConversationLifecycleService` (optional if reset/compact orchestration is separated)
+
+### Default registrations
+- `TryAddSingleton<IConversationStore, InMemoryConversationStore>()`
+- Platform config override to `FileConversationStore` or `SqliteConversationStore`
+- `AddSingleton<IConversationRouter, DefaultConversationRouter>()`
+- `AddSingleton<IConversationHistoryService, ConversationHistoryService>()`
+
+### Config recommendation
+Mirror session store config rather than inventing a separate top-level model:
+
+```json
+"gateway": {
+  "conversationStore": {
+    "type": "Sqlite",
+    "connectionString": "Data Source=..."
+  }
+}
+```
+
+If omitted:
+- follow the same mode as `sessionStore` where practical
+- default to in-memory in tests/dev
+
+---
+
+## 4. Channel routing: `GatewayHub.ResolveOrCreateSessionAsync()`
+
+### Finding
+Today `GatewayHub.SendMessage(...)` is session-centric:
+1. find a recent session by `(agentId, channelType)`
+2. create or reuse session
+3. dispatch inbound message with `ConversationId = session.SessionId.Value`
+
+This is the biggest architectural mismatch with the new spec.
+
+### Decision
+`GatewayHub` must stop resolving sessions directly for user-facing chat entrypoints.
+
+### Required replacement flow
+Replace `ResolveOrCreateSessionAsync(...)` with conversation-first resolution:
+
+1. resolve or create the target `Conversation`
+   - portal message with explicit conversation ID -> use it
+   - external channel message -> resolve by binding
+   - no binding -> bind to default conversation
+2. resolve or create the conversation's active session
+3. ensure `Session.ConversationId = conversation.ConversationId`
+4. dispatch inbound message to that session
+5. keep live stream semantics session-based
+
+### Concrete change to hub surface
+Current:
+- `SendMessage(AgentId agentId, ChannelKey channelType, string content)`
+
+Needed additions:
+- `SendConversationMessage(ConversationId conversationId, string content)` for portal
+- legacy `SendMessage(...)` can remain as a shim that resolves default/bound conversation first
+
+### Important nuance
+The portal is **not** a persisted `ChannelBinding`. Jon already resolved that: the portal is an implicit observer/control surface.
+
+So the router must distinguish:
+- **interactive external channel bindings** -> persisted in store
+- **portal traffic** -> explicit conversation id from UI, no stored binding
+
+---
+
+## 5. `Session.ConversationId` and existing sessions
+
+### Finding
+Adding nullable `Session.ConversationId` is the correct compatibility move.
+
+### Risk
+Existing sessions in file/sqlite stores will have no `ConversationId`. The spec does not define what that means at read time.
+
+### Decision
+Treat null `ConversationId` as **legacy ungrouped session**, not as corrupted data.
+
+### Migration/backfill rules
+- Existing sessions remain readable with `ConversationId = null`.
+- They do **not** need eager data migration.
+- When a legacy session becomes the active session of a conversation, save it back with `ConversationId` populated.
+- When listing conversation history, only sessions explicitly linked by `ConversationId` are included.
+- A compatibility shim may expose "legacy sessions" separately in diagnostics, but they are not auto-stitched into conversations without explicit adoption.
+
+### Why not auto-backfill all existing sessions into a default conversation?
+Because channel identity and user intent are ambiguous for historical session data. Silent mass migration would create false conversation groupings.
+
+---
+
+## 6. `ISessionWarmupService`
+
+### Finding
+`ISessionWarmupService` currently caches and returns available session summaries for the portal/session subscription model.
+
+### Decision
+Do **not** overload `ISessionWarmupService` to warm conversations.
+
+### Rationale
+Its responsibility is session availability cache. Conversations are a different abstraction and will need:
+- default conversation eager creation
+- conversation summaries per agent
+- possibly binding hydration
+
+That is not a session warmup concern.
+
+### Required addition
+Introduce a separate service:
+
+```csharp
+public interface IConversationCatalogService
+{
+    Task<IReadOnlyList<ConversationSummary>> GetAvailableConversationsAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ConversationSummary>> GetAvailableConversationsAsync(AgentId agentId, CancellationToken cancellationToken = default);
+    Task<ConversationSummary> EnsureDefaultConversationAsync(AgentId agentId, CancellationToken cancellationToken = default);
+}
+```
+
+### Warmup behavior recommendation
+- Keep `SessionWarmupService` unchanged except for ignoring conversation concerns.
+- Add `ConversationCatalogService : IHostedService` or an eager-create startup pass for default conversations.
+- On gateway startup, ensure each visible agent has exactly one default conversation.
+
+This aligns with Jon's explicit decision: **default conversation eager creation**.
+
+---
+
+## 7. Fan-out and outbound routing
+
+### Finding
+The spec correctly says assistant replies fan out to all bound channels.
+
+But the proposed implementation direction is underspecified. The current architecture routes outbound delivery via channel adapters keyed off the session's original channel context. That is not sufficient for conversation fan-out.
+
+### Decision
+Fan-out must be coordinated in a gateway-level service, not embedded inside each channel adapter.
+
+### Required new service
+```csharp
+public interface IConversationRouter
+{
+    Task<Conversation> ResolveForInboundAsync(
+        AgentId agentId,
+        ChannelKey channelType,
+        string externalAddress,
+        CancellationToken cancellationToken = default);
+
+    Task<GatewaySession> ResolveActiveSessionAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
+
+    Task FanOutAssistantMessageAsync(
+        ConversationId conversationId,
+        SessionId sessionId,
+        OutboundConversationMessage message,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Rationale
+The router owns three policies that adapters should not each re-implement:
+- binding lookup
+- active-session resolution
+- binding-mode/threading fan-out
+
+### Adapter role after change
+Adapters become transport-specific render/send executors:
+- apply `ThreadingMode`
+- apply `DisplayPrefix`
+- send to external address
+
+They should not decide *which* bindings receive a message.
+
+### SignalR-specific implication
+`SignalRChannelAdapter` and any other adapters should receive outbound sends from the conversation router with already-resolved binding targets. The portal still receives live session events through SignalR groups, but explicit external outbound fan-out is conversation-driven.
+
+---
+
+## Interface Contracts
+
+## 1. `ConversationId`
+
+**Placement:** `src/domain/BotNexus.Domain/Primitives/ConversationId.cs`  
+**Namespace:** `BotNexus.Domain.Primitives`
+
+### Decision
+Reuse the existing type.
+
+### Optional improvement
+Add `Create()` for parity with `SessionId.Create()` if missing:
+
+```csharp
+public static ConversationId Create() => From($"c_{Guid.NewGuid():N}");
+```
+
+This is optional but recommended for consistency.
+
+---
+
+## 2. `Conversation`
+
+**Placement:** `src/domain/BotNexus.Domain/Conversations/Conversation.cs`  
+**Namespace:** `BotNexus.Domain.Conversations`
+
+```csharp
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.Conversations;
+
+public sealed record Conversation
+{
+    public ConversationId ConversationId { get; set; }
+    public AgentId AgentId { get; set; }
+    public string Title { get; set; } = "New conversation";
+    public bool IsDefault { get; set; }
+    public ConversationStatus Status { get; set; } = ConversationStatus.Active;
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public SessionId? ActiveSessionId { get; set; }
+    public List<ChannelBinding> ChannelBindings { get; set; } = [];
+    public Dictionary<string, object?> Metadata { get; set; } = [];
+}
+```
+
+### Notes
+- Keep it in Domain, not Gateway.Contracts.
+- `ActiveSessionId` is the durable pointer used by routing.
+- `Metadata` is appropriate for future title suggestions, archive reason, summary hints.
+
+---
+
+## 3. `ChannelBinding` and `ThreadingMode`
+
+**Placement:** `src/domain/BotNexus.Domain/Conversations/ChannelBinding.cs`  
+**Namespace:** `BotNexus.Domain.Conversations`
+
+```csharp
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.Conversations;
+
+public sealed record ChannelBinding
+{
+    public string BindingId { get; set; } = Guid.NewGuid().ToString("N");
+    public ChannelKey ChannelType { get; set; }
+    public string ExternalAddress { get; set; } = string.Empty;
+    public BindingMode Mode { get; set; } = BindingMode.Interactive;
+    public ThreadingMode ThreadingMode { get; set; } = ThreadingMode.Single;
+    public string? ThreadId { get; set; }
+    public string? DisplayPrefix { get; set; }
+    public DateTimeOffset BoundAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? LastInboundAt { get; set; }
+    public DateTimeOffset? LastOutboundAt { get; set; }
+}
+
+public enum BindingMode
+{
+    Interactive,
+    NotifyOnly,
+    Muted
+}
+
+public enum ThreadingMode
+{
+    Single,
+    NativeThread,
+    Prefix
+}
+```
+
+### Notes
+- This belongs in Domain with `Conversation`, not hidden in an infrastructure project.
+- `ExternalAddress` stays string-based for v1; channel-specific parsing stays in adapters/router.
+
+---
+
+## 4. `IConversationStore`
+
+**Placement:** `src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs`  
+**Namespace:** `BotNexus.Gateway.Abstractions.Conversations`
+
+```csharp
+using BotNexus.Domain.Conversations;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Conversations;
+
+public interface IConversationStore
+{
+    Task<Conversation?> GetAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Conversation>> ListAsync(
+        AgentId? agentId = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Conversation> GetOrCreateDefaultAsync(
+        AgentId agentId,
+        CancellationToken cancellationToken = default);
+
+    Task<Conversation> CreateAsync(
+        Conversation conversation,
+        CancellationToken cancellationToken = default);
+
+    Task SaveAsync(
+        Conversation conversation,
+        CancellationToken cancellationToken = default);
+
+    Task ArchiveAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
+
+    Task<Conversation?> ResolveByBindingAsync(
+        AgentId agentId,
+        ChannelKey channelType,
+        string externalAddress,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Additional recommendation
+Do not add reset/compact methods here. Those are orchestration operations over conversation + session, not raw persistence operations.
+
+---
+
+## 5. `ConversationSummary`
+
+**Placement:** `src/gateway/BotNexus.Gateway.Contracts/Conversations/ConversationSummary.cs`  
+**Namespace:** `BotNexus.Gateway.Abstractions.Conversations`
+
+```csharp
+namespace BotNexus.Gateway.Abstractions.Conversations;
+
+public sealed record ConversationSummary(
+    string ConversationId,
+    string AgentId,
+    string Title,
+    bool IsDefault,
+    string Status,
+    string? ActiveSessionId,
+    int SessionCount,
+    int BindingCount,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);
+```
+
+### Notes
+- Keep as transport/API DTO, not domain entity.
+- `SessionCount` should be derived from `ISessionStore` by `ConversationId`.
+
+---
+
+## 6. `Session` changes
+
+**Placement:** `src/domain/BotNexus.Domain/Gateway/Models/Session.cs`  
+**Namespace:** existing `BotNexus.Gateway.Abstractions.Models`
+
+### Required additive change
+```csharp
+public ConversationId? ConversationId { get; set; }
+```
+
+### Recommended placement in record
+Immediately after `AgentId` so identity fields stay grouped:
+
+```csharp
+public SessionId SessionId { get; set; }
+public AgentId AgentId { get; set; }
+public ConversationId? ConversationId { get; set; }
+public ChannelKey? ChannelType { get; set; }
+```
+
+### Migration rule
+Nullable, no eager backfill, populate on first conversation-aware save.
+
+---
+
+## 7. `GatewayHub` changes
+
+### Required contract changes
+
+#### Keep for compatibility
+- `SendMessage(AgentId agentId, ChannelKey channelType, string content)`
+
+#### Add conversation-first hub methods
+**Placement:** existing `GatewayHub.cs`
+
+```csharp
+public Task<IReadOnlyList<ConversationSummary>> GetConversations(string agentId);
+public Task<ConversationSummary> CreateConversation(string agentId, string? title = null);
+public Task OpenConversation(string conversationId);
+public Task<SendMessageResult> SendConversationMessage(string conversationId, string content);
+public Task ResetConversation(string conversationId);
+public Task<CompactSessionResult> CompactConversation(string conversationId);
+```
+
+### Behavioral changes in hub internals
+- Replace `ResolveOrCreateSessionAsync(AgentId, ChannelKey)` with conversation routing.
+- `SendConversationMessage` should:
+  1. load conversation
+  2. resolve/create active session
+  3. subscribe caller to that active session group
+  4. dispatch using that session id and conversation id
+
+### Naming decision
+Use `Conversation*` methods, not `Topic*`, to match resolved product language.
+
+---
+
+## Additional contracts required by implementation
+
+## 1. `IConversationRouter`
+
+**Placement:** `src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs`
+
+```csharp
+using BotNexus.Domain.Conversations;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Abstractions.Conversations;
+
+public interface IConversationRouter
+{
+    Task<Conversation> ResolveForInboundAsync(
+        AgentId agentId,
+        ChannelKey channelType,
+        string externalAddress,
+        CancellationToken cancellationToken = default);
+
+    Task<GatewaySession> ResolveActiveSessionAsync(
+        ConversationId conversationId,
+        CancellationToken cancellationToken = default);
+
+    Task BindChannelAsync(
+        ConversationId conversationId,
+        ChannelBinding binding,
+        CancellationToken cancellationToken = default);
+
+    Task FanOutAssistantMessageAsync(
+        ConversationId conversationId,
+        SessionId sessionId,
+        string content,
+        CancellationToken cancellationToken = default);
+}
+```
+
+---
+
+## 2. `IConversationHistoryService`
+
+**Placement:** `src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationHistoryService.cs`
+
+```csharp
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Conversations;
+
+public interface IConversationHistoryService
+{
+    Task<ConversationHistoryResponse> GetHistoryAsync(
+        ConversationId conversationId,
+        ConversationHistoryCursor? cursor = null,
+        int pageSize = 100,
+        CancellationToken cancellationToken = default);
+}
+```
+
+With DTOs:
+- `ConversationHistoryResponse`
+- `ConversationHistoryEntryDto`
+- `ConversationBoundaryEntryDto`
+- `ConversationHistoryCursor`
+
+This keeps history assembly out of the store.
+
+---
+
+## Implementation Wave Breakdown
+
+## Wave 1 — Domain + Contracts + Storage Foundation
+
+**Agent:** Farnsworth  
+**Dependencies:** none  
+**Estimated tests:** 18-24
+
+### Tasks
+- Create `Conversation`, `ChannelBinding`, `ConversationStatus`, `BindingMode`, `ThreadingMode`
+- Reuse/adjust `ConversationId` primitive as needed
+- Add `Session.ConversationId`
+- Add `IConversationStore`
+- Add `ConversationSummary`
+- Add file/in-memory/sqlite conversation store implementations
+- Add conversation store config wiring in `GatewayServiceCollectionExtensions`
+
+### Files
+- `src/domain/BotNexus.Domain/Conversations/Conversation.cs`
+- `src/domain/BotNexus.Domain/Conversations/ChannelBinding.cs`
+- `src/domain/BotNexus.Domain/Gateway/Models/Session.cs`
+- `src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs`
+- `src/gateway/BotNexus.Gateway.Contracts/Conversations/ConversationSummary.cs`
+- `src/gateway/BotNexus.Gateway.Sessions/InMemoryConversationStore.cs`
+- `src/gateway/BotNexus.Gateway.Sessions/FileConversationStore.cs`
+- `src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs`
+- `src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs`
+
+### Done when
+- Conversations can be created, listed, archived, and resolved by binding
+- Default conversation creation is idempotent
+- Session model compiles with nullable `ConversationId`
+- Storage mode selection works the same way as session store selection
+
+---
+
+## Wave 2 — Routing + Active Session Resolution + Fan-out Core
+
+**Agent:** Bender  
+**Dependencies:** Wave 1  
+**Estimated tests:** 16-22
+
+### Tasks
+- Add `IConversationRouter` contract and `DefaultConversationRouter`
+- Move inbound resolution from raw session selection to conversation resolution
+- Ensure default conversation eager-create path exists
+- Resolve/create active session per conversation
+- Persist `Session.ConversationId` when session adopted by conversation
+- Add assistant outbound fan-out orchestration for external bindings
+
+### Files
+- `src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs`
+- `src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs`
+- `src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs`
+- `src/gateway/BotNexus.Gateway/GatewayHost.cs`
+- `src/gateway/BotNexus.Gateway/Channels/InternalChannelAdapter.cs`
+- possibly channel adapters that currently assume one-session-one-channel delivery
+
+### Done when
+- inbound Telegram/SignalR-style traffic resolves conversation first
+- a conversation always has or can create an active session
+- assistant output can be delivered to all eligible bindings on that conversation
+- user inbound is not mirrored cross-channel
+
+---
+
+## Wave 3 — History Assembly + Conversation APIs
+
+**Agent:** Fry  
+**Dependencies:** Wave 1, partial Wave 2  
+**Estimated tests:** 12-18
+
+### Tasks
+- Add `IConversationHistoryService`
+- Assemble merged history from sessions linked by `ConversationId`
+- Emit explicit session boundary entries
+- Add REST endpoints:
+  - list conversations
+  - create conversation
+  - get conversation
+  - get conversation history
+  - bind channel
+- Add hub methods for conversation-first portal usage
+
+### Files
+- `src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationHistoryService.cs`
+- `src/gateway/BotNexus.Gateway/Conversations/ConversationHistoryService.cs`
+- `src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs`
+- `src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs`
+- DTO files under Contracts/Conversations
+
+### Done when
+- conversation history returns merged session history with boundary entries
+- conversation list endpoint returns summaries with counts
+- portal can call conversation-first APIs without relying on raw session ids
+
+---
+
+## Wave 4 — Portal/UI Conversation-First Flip
+
+**Agent:** Amy  
+**Dependencies:** Wave 3  
+**Estimated tests:** 10-14 UI/component/E2E
+
+### Tasks
+- flip sidebar from session-first to conversation-first
+- show default conversation immediately per agent
+- add new conversation affordance
+- render merged history with session divider rows
+- move raw session list into advanced/details panel
+
+### Files
+- Blazor or SignalR client conversation list/view components
+- any existing session-first sidebar/view-model code
+- UI tests/E2E coverage
+
+### Done when
+- user can open an agent and immediately see its default conversation
+- new conversation creates a second visible conversation
+- merged transcript renders boundaries correctly
+- reset/compact actions target active session within the current conversation context
+
+---
+
+## Wave 5 — QA, Compatibility, and Documentation
+
+**Agent:** Hermes + Kif  
+**Dependencies:** Waves 1-4  
+**Estimated tests:** 20-28
+
+### Tasks
+- regression coverage for legacy session APIs
+- compatibility tests for old clients using session shims
+- docs for conversation vs session responsibility split
+- update training and architecture docs
+
+### Done when
+- old session APIs still function
+- conversation-aware behavior is documented clearly
+- no ambiguity remains in naming or ownership boundaries
+
+---
+
+## Risk Register
+
+## 1. Two sources of truth for routing
+
+**Risk:** conversation bindings and session channel fields diverge, causing delivery bugs.  
+**Mitigation:** declare conversation binding as the sole routing source for external outbound; keep `Session.ChannelType` as runtime provenance only.
+
+## 2. Legacy sessions remain ungrouped and confuse history
+
+**Risk:** existing persisted sessions without `ConversationId` produce fragmented UX.  
+**Mitigation:** treat them as legacy-only diagnostics; only explicitly linked sessions participate in conversation history.
+
+## 3. Fan-out duplicates or loops through existing adapter logic
+
+**Risk:** assistant messages may be sent once via old session path and again via new conversation path.  
+**Mitigation:** centralize outbound fan-out in `IConversationRouter`; audit/remove any direct adapter-side rebroadcast assumptions.
+
+## 4. Portal/session live stream mismatch
+
+**Risk:** portal is conversation-first while live streaming remains session-first, creating state mismatch when active session rolls over.  
+**Mitigation:** portal tracks conversation -> activeSessionId mapping and re-subscribes on `ConversationSessionChanged` or equivalent response path.
+
+## 5. SQLite/file schema drift between session and conversation persistence
+
+**Risk:** implementing conversation store in a separate pattern from session store increases maintenance burden.  
+**Mitigation:** keep conversation persistence in `BotNexus.Gateway.Sessions` and mirror session store configuration and serialization conventions.
+
+---
+
+## Final Decisions
+
+1. **Conversation is approved as the top-level user-visible container.**
+2. **`ConversationId` already exists and must be reused.**
+3. **`IConversationStore` belongs in `BotNexus.Gateway.Contracts`; implementations belong in `BotNexus.Gateway.Sessions`.**
+4. **`GatewayHub.ResolveOrCreateSessionAsync()` must be replaced by conversation-first routing.**
+5. **`Session.ConversationId` remains nullable for compatibility; no eager historical backfill.**
+6. **`ISessionWarmupService` remains session-scoped; conversation warmup/catalog is a separate service.**
+7. **Fan-out belongs in a gateway conversation router, not scattered through channel adapters.**
+8. **Portal uses conversation-first APIs; live streaming remains session-level transport.**
+
+## Recommendation
+
+Proceed with implementation, but do it in the wave order above. Do **not** start with the UI flip. The highest-risk seam is routing. Get domain/contracts/storage/routing correct first, then layer history and UI on top.

--- a/docs/planning/feature-conversation-topics/design-spec.md
+++ b/docs/planning/feature-conversation-topics/design-spec.md
@@ -1,0 +1,486 @@
+---
+id: feature-conversation-topics
+title: "Feature: Conversation Topics for Omnichannel Continuity"
+type: feature
+priority: high
+status: draft
+created: 2026-04-27
+author: rusty
+tags: [sessions, channels, signalr, portal, omnichannel, architecture]
+related:
+  - archived/feature-multi-session-connection/architecture-proposal.md
+  - archived/feature-session-visibility/design-spec.md
+  - bug-blazor-session-history-loss/design-spec.md
+---
+
+# Design Spec: Conversation Topics for Omnichannel Continuity
+
+**Type**: Feature  
+**Priority**: High  
+**Status**: Draft  
+**Author**: Rusty (via Jon)
+
+## Overview
+
+Introduce a new user-facing container above `Session` called **ConversationTopic** (working name: *topic*). A topic represents the conversation a user has with an agent, regardless of channel. Sessions remain the runtime/history segments within that topic.
+
+This allows BotNexus to support the intended interaction model:
+- each agent has a default conversation when it comes online,
+- the portal shows that default conversation immediately,
+- the portal can deliberately create second/third/fourth independent conversations with the same agent,
+- external channels like Telegram and iMessage bind to a topic rather than directly to a session,
+- the same conversation can continue across channels,
+- agent replies can be delivered to all subscribed channels on the topic,
+- session operations like compact/reset happen inside the topic without collapsing the topic itself.
+
+## Problem
+
+Today, `Session` is overloaded. It acts as:
+- runtime unit,
+- persistence unit,
+- history segment,
+- user-visible conversation,
+- channel routing target.
+
+That leads to several product problems:
+
+1. **No true omnichannel continuity**  
+   A conversation started in Telegram cannot naturally continue in iMessage and then in the portal as the same conversation.
+
+2. **Portal usability is weak by default**  
+   When an agent appears in the portal, there is no durable default conversation object that the user can immediately open and use.
+
+3. **Multi-conversation UX is built on the wrong primitive**  
+   The portal can show multiple sessions, but the user really wants multiple conversations, not multiple raw runtime segments.
+
+4. **Channel routing semantics are wrong**  
+   External channels should attach to a durable conversation, not whichever active session happens to exist.
+
+5. **Session lifecycle operations are mixed with conversation identity**  
+   Compaction, reset, sealing, and rollover are runtime concerns, but today they implicitly redefine the visible conversation.
+
+## Goals
+
+### Must Have
+
+- Add a new durable parent container above session: `ConversationTopic`
+- Each agent has one default topic available for the user by default
+- A topic can contain one or more sessions over time
+- Portal UI becomes topic-first
+- Portal allows deliberate creation of additional topics per agent
+- External channels bind to a topic
+- Inbound channel messages route to the topic's active session
+- Topic can survive session compaction/reset/sealing/rollover
+- Topic history can be reconstructed from topic sessions
+- Existing session-based infrastructure remains usable during migration
+
+### Should Have
+
+- Agent replies fan out to all active channel bindings on the topic
+- User replies from one external channel are **not** mirrored into other external channels as if sent by the user
+- Topic metadata supports title, created/updated timestamps, and a default flag
+- Portal can switch between topics cleanly
+- Session list becomes a detail view inside a topic rather than the main sidebar abstraction
+
+### Nice to Have
+
+- Per-binding notification modes (`interactive`, `notify-only`, `muted`)
+- Topic rename/archive support
+- Topic search/filter in the portal
+- Topic-level analytics and summaries
+- Explicit "move channel to another topic" workflows in UI
+
+## Non-Goals
+
+- Full multi-user permissions model
+- Cross-agent shared topics
+- Automatic semantic splitting of one conversation into multiple topics
+- Cross-topic search/analytics in this first iteration
+- Immediate parity across every channel UI from day one
+
+## Proposed Domain Model
+
+### New Entity: ConversationTopic
+
+```csharp
+public sealed record ConversationTopic
+{
+    public TopicId TopicId { get; set; }
+    public AgentId AgentId { get; set; }
+    public string Title { get; set; } = "New conversation";
+    public bool IsDefault { get; set; }
+    public TopicStatus Status { get; set; } = TopicStatus.Active;
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public SessionId? ActiveSessionId { get; set; }
+    public List<TopicChannelBinding> ChannelBindings { get; set; } = [];
+    public Dictionary<string, object?> Metadata { get; set; } = [];
+}
+```
+
+### New Value/Object Model: TopicChannelBinding
+
+```csharp
+public sealed record TopicChannelBinding
+{
+    public string BindingId { get; set; } = Guid.NewGuid().ToString("N");
+    public ChannelKey ChannelType { get; set; }
+    public string ExternalAddress { get; set; } = string.Empty; // e.g. telegram:5067802539
+    public BindingMode Mode { get; set; } = BindingMode.Interactive;
+    public DateTimeOffset BoundAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? LastInboundAt { get; set; }
+    public DateTimeOffset? LastOutboundAt { get; set; }
+}
+```
+
+### New Enum: TopicStatus
+
+```csharp
+public enum TopicStatus
+{
+    Active,
+    Archived
+}
+```
+
+### New Enum: BindingMode
+
+```csharp
+public enum BindingMode
+{
+    Interactive, // inbound + outbound
+    NotifyOnly,  // outbound only
+    Muted        // retained binding, no outbound fan-out
+}
+```
+
+## Relationship to Existing Session Model
+
+`Session` remains and continues to represent:
+- agent runtime,
+- stored history segment,
+- compaction/reset boundary,
+- replay buffer scope,
+- execution lifetime.
+
+New relationship:
+
+```text
+Agent
+  -> ConversationTopic
+      -> Session (1..n over time)
+      -> TopicChannelBinding (0..n)
+```
+
+### Required Session Changes
+
+Minimal additive change:
+
+```csharp
+public sealed record Session
+{
+    ...
+    public TopicId? TopicId { get; set; }
+}
+```
+
+This preserves backward compatibility while letting sessions be grouped under a topic.
+
+## Conceptual Behavior
+
+### 1. Default Topic per Agent
+
+When an agent becomes visible/available to the system, BotNexus ensures a default topic exists.
+
+Rules:
+- one default topic per `AgentId`
+- portal shows this topic as the main conversation for that agent
+- if no topic exists yet, create it lazily on first contact or eagerly during warmup (configurable)
+
+### 2. Additional Topics Created Deliberately
+
+The portal exposes **New Conversation** for an agent.
+
+That creates a new topic:
+- `IsDefault = false`
+- no channel bindings initially (or optionally binds the portal view implicitly)
+- title can start as `Conversation 2`, `New conversation`, or first-user-message derived
+
+### 3. Channel Binding Rules
+
+External channels bind to a topic, not directly to a session.
+
+For v1:
+- Telegram/iMessage default to the agent's default topic
+- later, user may explicitly rebind a channel to another topic
+- multiple channels may bind to the same topic
+
+### 4. Inbound Routing
+
+When an inbound message arrives:
+1. resolve `(AgentId, ChannelType, ExternalAddress)` to a topic binding
+2. if none exists, bind the channel to the default topic for that agent
+3. resolve or create the topic's active session
+4. dispatch message into that session
+
+### 5. Outbound Routing
+
+When the agent emits an assistant/user-visible response in the topic's active session:
+- deliver to all channel bindings on the topic where mode allows outbound delivery
+- portal subscribers viewing that topic always receive the update
+
+Important rule:
+- **Do not mirror a human user's inbound message from Telegram into iMessage/portal as if that user sent it there.**
+- Only assistant/system outputs are fanned out cross-channel.
+
+### 6. Session Lifecycle Under a Topic
+
+A topic may accumulate multiple sessions over time.
+
+Examples:
+- topic starts with session A
+- user compacts session A -> same topic continues on compacted A or new session B depending implementation
+- user resets conversation -> session A sealed, session B created, topic unchanged
+- agent crash/restart -> runtime session replaced, topic unchanged
+
+The visible conversation identity is stable even if the runtime segment changes.
+
+## Portal UX Model
+
+### Primary Sidebar
+
+Portal sidebar should show **topics**, not raw sessions.
+
+Per agent:
+- show default topic immediately
+- show any additional user-created topics
+- each topic appears as a separate chat/conversation
+
+### Topic Detail View
+
+Inside a topic:
+- current conversation transcript is shown as the merged history of the topic's sessions
+- session boundaries can optionally appear as dividers (`Compacted`, `Restarted`, `New runtime`) 
+- controls for compact/reset operate on the active session in the topic context
+- advanced panel may show session history/segments for diagnostics
+
+### Session Detail
+
+Raw session list remains valuable, but as a secondary/diagnostic UI:
+- active session id
+- prior sealed sessions in the topic
+- channel bindings attached to the topic
+
+## API and Storage Impact
+
+### New Store Contract
+
+Add `ITopicStore`:
+
+```csharp
+public interface ITopicStore
+{
+    Task<ConversationTopic?> GetAsync(TopicId topicId, CancellationToken ct = default);
+    Task<IReadOnlyList<ConversationTopic>> ListAsync(AgentId? agentId = null, CancellationToken ct = default);
+    Task<ConversationTopic> GetOrCreateDefaultAsync(AgentId agentId, CancellationToken ct = default);
+    Task<ConversationTopic> CreateAsync(ConversationTopic topic, CancellationToken ct = default);
+    Task SaveAsync(ConversationTopic topic, CancellationToken ct = default);
+    Task ArchiveAsync(TopicId topicId, CancellationToken ct = default);
+    Task<ConversationTopic?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, string externalAddress, CancellationToken ct = default);
+}
+```
+
+### New Summary DTOs
+
+```csharp
+public sealed record TopicSummary(
+    string TopicId,
+    string AgentId,
+    string Title,
+    bool IsDefault,
+    string Status,
+    string? ActiveSessionId,
+    int SessionCount,
+    int BindingCount,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);
+```
+
+### New Gateway/REST Endpoints
+
+Potential endpoints:
+- `GET /api/topics?agentId=assistant`
+- `POST /api/topics`
+- `GET /api/topics/{topicId}`
+- `GET /api/topics/{topicId}/history`
+- `POST /api/topics/{topicId}/bind-channel`
+- `POST /api/topics/{topicId}/sessions/reset`
+- `POST /api/topics/{topicId}/sessions/compact`
+
+### SignalR Additions
+
+Potential hub methods:
+- `GetTopics(agentId)`
+- `CreateTopic(agentId, title?)`
+- `OpenTopic(topicId)`
+- `SendTopicMessage(topicId, content)`
+- `ResetTopic(topicId)`
+- `CompactTopic(topicId)`
+
+New events:
+- `TopicCreated`
+- `TopicUpdated`
+- `TopicBindingsChanged`
+- `TopicSessionChanged`
+
+## History Model
+
+### Topic History Endpoint
+
+`GET /api/topics/{topicId}/history`
+
+Behavior:
+- returns merged chronological entries across all sessions linked to the topic
+- includes boundary markers between sessions
+- supports pagination
+
+Example response concept:
+
+```json
+{
+  "topicId": "t_123",
+  "entries": [
+    { "kind": "message", "sessionId": "s1", "role": "user", "content": "hey" },
+    { "kind": "message", "sessionId": "s1", "role": "assistant", "content": "hi" },
+    { "kind": "boundary", "reason": "compacted", "sessionId": "s1" },
+    { "kind": "message", "sessionId": "s2", "role": "user", "content": "continue" }
+  ]
+}
+```
+
+This lets the portal show one continuous conversation while preserving runtime segmentation.
+
+## Migration Strategy
+
+### Phase 1 — Planning + additive model
+
+- Add `TopicId` primitive
+- Add `ConversationTopic` + `TopicChannelBinding`
+- Add `ITopicStore`
+- Add optional `Session.TopicId`
+- Introduce default topic creation for agents
+- No UI change yet
+
+### Phase 2 — routing layer
+
+- Change inbound channel routing to resolve topic first
+- Add topic binding persistence
+- Route inbound messages to topic active session
+- Fan out assistant replies to topic bindings
+- Preserve current session APIs for compatibility
+
+### Phase 3 — portal topic-first UX
+
+- Portal sidebar lists topics instead of raw sessions
+- Default topic visible immediately
+- New conversation creates a new topic
+- Topic history endpoint used by portal
+- Session list moved into advanced/details panel
+
+### Phase 4 — lifecycle polish
+
+- reset/compact operate in topic context
+- explicit rebind/move channel workflows
+- archive topic
+- optional topic rename and summaries
+
+## Compatibility Notes
+
+- Existing session store remains valid.
+- Existing channel adapters can keep writing to sessions during transition if routing shims resolve topic -> active session.
+- Existing Blazor history/session code can be adapted gradually by swapping session list endpoints for topic list endpoints.
+- Existing `SubscribeAll` session model may remain as a lower-level transport while the portal becomes topic-oriented.
+
+## Risks
+
+### 1. Conceptual duplication
+
+Having both topics and sessions may confuse contributors unless responsibilities are documented clearly.
+
+**Mitigation:** make topic user-facing, session runtime-facing in all docs/API naming.
+
+### 2. History reconstruction complexity
+
+Merged topic history across sessions may complicate pagination and scrollback.
+
+**Mitigation:** introduce explicit boundary entries and keep session-scoped history endpoints intact.
+
+### 3. Channel fan-out surprises
+
+Cross-channel outbound delivery could annoy users if too aggressive.
+
+**Mitigation:** binding modes and conservative default behavior.
+
+### 4. Migration churn in UI and tests
+
+The Blazor client recently moved toward session-first logic.
+
+**Mitigation:** additive rollout; first add topics alongside sessions, then flip UI abstraction later.
+
+### 5. Future multi-user scope
+
+Current design assumes a single effective user per agent/channel context.
+
+**Mitigation:** keep `Topic` model extensible for future owner/participant metadata.
+
+## Testing Plan
+
+### Domain / Store Tests
+
+- creating default topic for an agent is idempotent
+- creating additional topics does not affect default topic
+- resolving channel binding returns the correct topic
+- archived topics are excluded from active lists
+- topic summaries include active session and binding counts
+
+### Routing Tests
+
+- first Telegram message binds to default topic
+- subsequent Telegram message routes to same topic even if session rolled over
+- iMessage can bind to same topic and continue context
+- assistant message fans out to all interactive/notify bindings
+- inbound user message on one channel is not replayed as user input to other channels
+
+### Portal Tests
+
+- default topic is visible when agent loads
+- new conversation creates second topic
+- switching topics changes visible merged history
+- compact/reset inside topic preserves topic identity
+- topic history shows session boundaries correctly
+
+### Compatibility Tests
+
+- existing session APIs still work when topic support is enabled
+- session history endpoint remains correct for a topic's active session
+- old clients can still send messages through session routing shim
+
+## Open Questions
+
+1. Final name: `Topic`, `Conversation`, or `Thread`?
+2. Should default topic creation be eager (agent startup) or lazy (first contact)?
+3. Should the portal itself create an explicit channel binding, or be treated as an implicit subscriber?
+4. Are channel bindings scoped to exact external address only, or can one provider/channel family bind broadly?
+5. When resetting a topic, should a new session always be created immediately?
+6. Should topic title come from user input, auto-summary, or both?
+7. Do we need a distinct topic event stream, or is session stream + lookup enough initially?
+
+## Recommendation
+
+Proceed with a **topic-first architectural iteration**.
+
+The key product correction is:
+- **sessions are runtime segments**,
+- **topics are the user-visible omnichannel conversations**.
+
+That matches the mental model Jon described and gives BotNexus a cleaner long-term foundation for portal UX, channel routing, and agent continuity across transports.

--- a/docs/planning/feature-conversation-topics/design-spec.md
+++ b/docs/planning/feature-conversation-topics/design-spec.md
@@ -3,7 +3,7 @@ id: feature-conversation-model
 title: "Feature: Conversation Model — for Omnichannel Continuity"
 type: feature
 priority: high
-status: draft
+status: ready
 created: 2026-04-27
 author: rusty
 tags: [sessions, channels, signalr, portal, omnichannel, architecture]
@@ -17,7 +17,7 @@ related:
 
 **Type**: Feature  
 **Priority**: High  
-**Status**: Draft  
+**Status**: Ready for implementation  
 **Author**: Rusty (via Jon)
 
 ## Overview
@@ -503,18 +503,15 @@ The following were decided by Jon Bullen on 2026-04-27:
 
 ## Remaining Open Questions
 
-1. Do we need a distinct conversation event stream (`ConversationCreated`, `BindingAdded`, etc.) or is session stream + REST lookup sufficient initially?
-
-   - **Option A: Session stream + lookup** — portal gets a session event with a `conversationId`, calls `GET /api/conversations/{id}` to refresh conversation state. No new SignalR events needed. Simpler upfront.
-   - **Option B: Distinct conversation events** — new hub events (`ConversationCreated`, `ConversationUpdated`, `BindingAdded`, `BindingRemoved`). Portal updates in real-time without polling. Cleaner long-term, more work to implement.
-
-   Recommendation: **Option A** for initial implementation, migrate to Option B as conversation event surface grows.
+None — all decisions resolved.
 
 ## Resolved Decisions
 
 1. **Reset timing** — resetting a conversation creates a new session. The first inbound message starts the session. Any pre-session hooks (e.g. soul/memory injection) should fire eagerly on reset to reduce response latency on the first message.
 
 2. **Conversation title** — user can set or rename a conversation title at any time. If no title is set, the agent auto-generates one based on conversation content. Both can coexist: agent suggestion, user override.
+
+3. **Event stream** — **Option A: session stream + lookup.** Conversations are metadata — a stable identity container. All live events happen at session level. The portal observes session events and looks up conversation context via REST when needed. No dedicated conversation event stream required. Conversation is just a lookup.
 
 ## Recommendation
 

--- a/docs/planning/feature-conversation-topics/design-spec.md
+++ b/docs/planning/feature-conversation-topics/design-spec.md
@@ -274,7 +274,7 @@ Per agent:
 
 Inside a conversation:
 - current conversation transcript is shown as the merged history of the conversation's sessions
-- session boundaries can optionally appear as dividers (`Compacted`, `Restarted`, `New runtime`) 
+- session boundaries **always** appear as explicit dividers in the portal — a horizontal rule showing the date/time and session ID 
 - controls for compact/reset operate on the active session in the conversation context
 - advanced panel may show session history/segments for diagnostics
 
@@ -355,19 +355,20 @@ New events:
 
 Behavior:
 - returns merged chronological entries across all sessions linked to the conversation
-- includes boundary markers between sessions
+- includes explicit `boundary` entries between sessions carrying `sessionId`, `timestamp`, and `reason`
+- the portal renders each boundary as a full-width horizontal rule: `────── Session s_abc123 · Apr 27 2026 14:32 UTC ──────`
 - supports pagination
 
 Example response concept:
 
 ```json
 {
-  "topicId": "t_123",
+  "conversationId": "c_123",
   "entries": [
-    { "kind": "message", "sessionId": "s1", "role": "user", "content": "hey" },
-    { "kind": "message", "sessionId": "s1", "role": "assistant", "content": "hi" },
-    { "kind": "boundary", "reason": "compacted", "sessionId": "s1" },
-    { "kind": "message", "sessionId": "s2", "role": "user", "content": "continue" }
+    { "kind": "message", "sessionId": "s1", "role": "user", "content": "hey", "timestamp": "2026-04-27T10:00:00Z" },
+    { "kind": "message", "sessionId": "s1", "role": "assistant", "content": "hi", "timestamp": "2026-04-27T10:00:05Z" },
+    { "kind": "boundary", "sessionId": "s1", "timestamp": "2026-04-27T10:05:00Z", "reason": "compacted" },
+    { "kind": "message", "sessionId": "s2", "role": "user", "content": "continue", "timestamp": "2026-04-27T10:05:10Z" }
   ]
 }
 ```
@@ -498,7 +499,7 @@ The following were decided by Jon Bullen on 2026-04-27:
    - **Portal:** full native multi-conversation UI — sidebar shows each conversation as a distinct chat, no prefixing needed.
    - `ChannelBinding` should carry a `ThreadingMode` hint: `NativeThread`, `Prefix`, or `Single`, so each channel adapter can apply the right display strategy.
 
-5. **History: assembled from session segments** — No separate materialized conversation history store. Full history is assembled on demand from the ordered sessions linked to the conversation. Segment boundaries appear as dividers (e.g. `Compacted Apr 27`). Sessions remain the single source of truth.
+5. **History: assembled from session segments** — No separate materialized conversation history store. Full history is assembled on demand from the ordered sessions linked to the conversation. The portal renders an explicit **session boundary divider** between segments — a horizontal rule with the date/time and session ID — so the user can see exactly where one session ended and the next began. Sessions remain the single source of truth.
 
 ## Remaining Open Questions
 

--- a/docs/planning/feature-conversation-topics/design-spec.md
+++ b/docs/planning/feature-conversation-topics/design-spec.md
@@ -1,6 +1,6 @@
 ---
-id: feature-conversation-topics
-title: "Feature: Conversation Topics for Omnichannel Continuity"
+id: feature-conversation-model
+title: "Feature: Conversation Model — for Omnichannel Continuity"
 type: feature
 priority: high
 status: draft
@@ -13,7 +13,7 @@ related:
   - bug-blazor-session-history-loss/design-spec.md
 ---
 
-# Design Spec: Conversation Topics for Omnichannel Continuity
+# Design Spec: Conversation Model for Omnichannel Continuity
 
 **Type**: Feature  
 **Priority**: High  
@@ -22,16 +22,16 @@ related:
 
 ## Overview
 
-Introduce a new user-facing container above `Session` called **ConversationTopic** (working name: *topic*). A topic represents the conversation a user has with an agent, regardless of channel. Sessions remain the runtime/history segments within that topic.
+Introduce a new user-facing container above `Session` called **Conversation**. A conversation represents the discussion a user has with an agent, regardless of which channel or device they are using. Sessions remain the runtime/history segments within that conversation.
 
 This allows BotNexus to support the intended interaction model:
 - each agent has a default conversation when it comes online,
 - the portal shows that default conversation immediately,
 - the portal can deliberately create second/third/fourth independent conversations with the same agent,
-- external channels like Telegram and iMessage bind to a topic rather than directly to a session,
+- external channels like Telegram and iMessage bind to a conversation rather than directly to a session,
 - the same conversation can continue across channels,
-- agent replies can be delivered to all subscribed channels on the topic,
-- session operations like compact/reset happen inside the topic without collapsing the topic itself.
+- agent replies can be delivered to all subscribed channels on the conversation,
+- session operations like compact/reset happen inside the conversation without collapsing the conversation itself.
 
 ## Problem
 
@@ -63,80 +63,83 @@ That leads to several product problems:
 
 ### Must Have
 
-- Add a new durable parent container above session: `ConversationTopic`
-- Each agent has one default topic available for the user by default
-- A topic can contain one or more sessions over time
-- Portal UI becomes topic-first
-- Portal allows deliberate creation of additional topics per agent
-- External channels bind to a topic
-- Inbound channel messages route to the topic's active session
-- Topic can survive session compaction/reset/sealing/rollover
-- Topic history can be reconstructed from topic sessions
+- Add a new durable parent container above session: `Conversation`
+- Each agent has one default conversation available for the user by default
+- A conversation can contain one or more sessions over time
+- Portal UI becomes conversation-first
+- Portal allows deliberate creation of additional conversations per agent
+- External channels bind to a conversation
+- Inbound channel messages route to the conversation's active session
+- Conversation can survive session compaction/reset/sealing/rollover
+- Conversation history can be reconstructed from conversation sessions
 - Existing session-based infrastructure remains usable during migration
 
 ### Should Have
 
-- Agent replies fan out to all active channel bindings on the topic
+- Agent replies fan out to all active channel bindings on the conversation
 - User replies from one external channel are **not** mirrored into other external channels as if sent by the user
-- Topic metadata supports title, created/updated timestamps, and a default flag
-- Portal can switch between topics cleanly
-- Session list becomes a detail view inside a topic rather than the main sidebar abstraction
+- Conversation metadata supports title, created/updated timestamps, and a default flag
+- Portal can switch between conversations cleanly
+- Session list becomes a detail view inside a conversation rather than the main sidebar abstraction
 
 ### Nice to Have
 
 - Per-binding notification modes (`interactive`, `notify-only`, `muted`)
-- Topic rename/archive support
-- Topic search/filter in the portal
-- Topic-level analytics and summaries
-- Explicit "move channel to another topic" workflows in UI
+- Conversation rename/archive support
+- Conversation search/filter in the portal
+- Conversation-level analytics and summaries
+- Explicit "move channel to another conversation" workflows in UI
 
 ## Non-Goals
 
 - Full multi-user permissions model
-- Cross-agent shared topics
-- Automatic semantic splitting of one conversation into multiple topics
-- Cross-topic search/analytics in this first iteration
+- Cross-agent shared conversations
+- Automatic semantic splitting of one conversation into multiple conversations
+- Cross-conversation search/analytics in this first iteration
 - Immediate parity across every channel UI from day one
 
 ## Proposed Domain Model
 
-### New Entity: ConversationTopic
+### New Entity: Conversation
 
 ```csharp
-public sealed record ConversationTopic
+public sealed record Conversation
 {
-    public TopicId TopicId { get; set; }
+    public ConversationId ConversationId { get; set; }
     public AgentId AgentId { get; set; }
     public string Title { get; set; } = "New conversation";
     public bool IsDefault { get; set; }
-    public TopicStatus Status { get; set; } = TopicStatus.Active;
+    public ConversationStatus Status { get; set; } = ConversationStatus.Active;
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
     public SessionId? ActiveSessionId { get; set; }
-    public List<TopicChannelBinding> ChannelBindings { get; set; } = [];
+    public List<ChannelBinding> ChannelBindings { get; set; } = [];
     public Dictionary<string, object?> Metadata { get; set; } = [];
 }
 ```
 
-### New Value/Object Model: TopicChannelBinding
+### New Value/Object Model: ChannelBinding
 
 ```csharp
-public sealed record TopicChannelBinding
+public sealed record ChannelBinding
 {
     public string BindingId { get; set; } = Guid.NewGuid().ToString("N");
     public ChannelKey ChannelType { get; set; }
     public string ExternalAddress { get; set; } = string.Empty; // e.g. telegram:5067802539
     public BindingMode Mode { get; set; } = BindingMode.Interactive;
+    public ThreadingMode ThreadingMode { get; set; } = ThreadingMode.Single;
+    public string? ThreadId { get; set; } // native thread/topic id when ThreadingMode = NativeThread
+    public string? DisplayPrefix { get; set; } // short name for prefix mode, e.g. "Project Alpha"
     public DateTimeOffset BoundAt { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset? LastInboundAt { get; set; }
     public DateTimeOffset? LastOutboundAt { get; set; }
 }
 ```
 
-### New Enum: TopicStatus
+### New Enum: ConversationStatus
 
 ```csharp
-public enum TopicStatus
+public enum ConversationStatus
 {
     Active,
     Archived
@@ -154,6 +157,17 @@ public enum BindingMode
 }
 ```
 
+### New Enum: ThreadingMode
+
+```csharp
+public enum ThreadingMode
+{
+    Single,       // channel maps to one conversation only (default; Telegram, iMessage)
+    NativeThread, // conversation maps to a native thread/topic (Teams, Slack)
+    Prefix        // conversation name prefixed on all outbound messages (iMessage fallback, SMS)
+}
+```
+
 ## Relationship to Existing Session Model
 
 `Session` remains and continues to represent:
@@ -167,9 +181,9 @@ New relationship:
 
 ```text
 Agent
-  -> ConversationTopic
+  -> Conversation
       -> Session (1..n over time)
-      -> TopicChannelBinding (0..n)
+      -> ChannelBinding (0..n)
 ```
 
 ### Required Session Changes
@@ -180,68 +194,68 @@ Minimal additive change:
 public sealed record Session
 {
     ...
-    public TopicId? TopicId { get; set; }
+    public ConversationId? ConversationId { get; set; }
 }
 ```
 
-This preserves backward compatibility while letting sessions be grouped under a topic.
+This preserves backward compatibility while letting sessions be grouped under a conversation.
 
 ## Conceptual Behavior
 
-### 1. Default Topic per Agent
+### 1. Default Conversation per Agent
 
-When an agent becomes visible/available to the system, BotNexus ensures a default topic exists.
+When an agent becomes visible/available to the system, BotNexus ensures a default conversation exists.
 
 Rules:
-- one default topic per `AgentId`
-- portal shows this topic as the main conversation for that agent
-- if no topic exists yet, create it lazily on first contact or eagerly during warmup (configurable)
+- one default conversation per `AgentId`
+- portal shows this conversation as the main conversation for that agent
+- if no conversation exists yet, create it lazily on first contact or eagerly during warmup (configurable)
 
-### 2. Additional Topics Created Deliberately
+### 2. Additional Conversations Created Deliberately
 
 The portal exposes **New Conversation** for an agent.
 
-That creates a new topic:
+That creates a new conversation:
 - `IsDefault = false`
 - no channel bindings initially (or optionally binds the portal view implicitly)
 - title can start as `Conversation 2`, `New conversation`, or first-user-message derived
 
 ### 3. Channel Binding Rules
 
-External channels bind to a topic, not directly to a session.
+External channels bind to a conversation, not directly to a session.
 
 For v1:
-- Telegram/iMessage default to the agent's default topic
-- later, user may explicitly rebind a channel to another topic
-- multiple channels may bind to the same topic
+- Telegram/iMessage default to the agent's default conversation
+- later, user may explicitly rebind a channel to another conversation
+- multiple channels may bind to the same conversation
 
 ### 4. Inbound Routing
 
 When an inbound message arrives:
-1. resolve `(AgentId, ChannelType, ExternalAddress)` to a topic binding
-2. if none exists, bind the channel to the default topic for that agent
-3. resolve or create the topic's active session
+1. resolve `(AgentId, ChannelType, ExternalAddress)` to a conversation binding
+2. if none exists, bind the channel to the default conversation for that agent
+3. resolve or create the conversation's active session
 4. dispatch message into that session
 
 ### 5. Outbound Routing
 
-When the agent emits an assistant/user-visible response in the topic's active session:
-- deliver to all channel bindings on the topic where mode allows outbound delivery
-- portal subscribers viewing that topic always receive the update
+When the agent emits an assistant/user-visible response in the conversation's active session:
+- deliver to all channel bindings on the conversation where mode allows outbound delivery
+- portal subscribers viewing that conversation always receive the update
 
 Important rule:
 - **Do not mirror a human user's inbound message from Telegram into iMessage/portal as if that user sent it there.**
 - Only assistant/system outputs are fanned out cross-channel.
 
-### 6. Session Lifecycle Under a Topic
+### 6. Session Lifecycle Under a Conversation
 
-A topic may accumulate multiple sessions over time.
+A conversation may accumulate multiple sessions over time.
 
 Examples:
-- topic starts with session A
-- user compacts session A -> same topic continues on compacted A or new session B depending implementation
-- user resets conversation -> session A sealed, session B created, topic unchanged
-- agent crash/restart -> runtime session replaced, topic unchanged
+- conversation starts with session A
+- user compacts session A -> same conversation continues on compacted A or new session B depending implementation
+- user resets conversation -> session A sealed, session B created, conversation unchanged
+- agent crash/restart -> runtime session replaced, conversation unchanged
 
 The visible conversation identity is stable even if the runtime segment changes.
 
@@ -249,52 +263,52 @@ The visible conversation identity is stable even if the runtime segment changes.
 
 ### Primary Sidebar
 
-Portal sidebar should show **topics**, not raw sessions.
+Portal sidebar should show **conversations**, not raw sessions.
 
 Per agent:
-- show default topic immediately
-- show any additional user-created topics
-- each topic appears as a separate chat/conversation
+- show default conversation immediately
+- show any additional user-created conversations
+- each conversation appears as a separate chat/conversation
 
-### Topic Detail View
+### Conversation Detail View
 
-Inside a topic:
-- current conversation transcript is shown as the merged history of the topic's sessions
+Inside a conversation:
+- current conversation transcript is shown as the merged history of the conversation's sessions
 - session boundaries can optionally appear as dividers (`Compacted`, `Restarted`, `New runtime`) 
-- controls for compact/reset operate on the active session in the topic context
+- controls for compact/reset operate on the active session in the conversation context
 - advanced panel may show session history/segments for diagnostics
 
 ### Session Detail
 
 Raw session list remains valuable, but as a secondary/diagnostic UI:
 - active session id
-- prior sealed sessions in the topic
-- channel bindings attached to the topic
+- prior sealed sessions in the conversation
+- channel bindings attached to the conversation
 
 ## API and Storage Impact
 
 ### New Store Contract
 
-Add `ITopicStore`:
+Add `IConversationStore`:
 
 ```csharp
-public interface ITopicStore
+public interface IConversationStore
 {
-    Task<ConversationTopic?> GetAsync(TopicId topicId, CancellationToken ct = default);
-    Task<IReadOnlyList<ConversationTopic>> ListAsync(AgentId? agentId = null, CancellationToken ct = default);
-    Task<ConversationTopic> GetOrCreateDefaultAsync(AgentId agentId, CancellationToken ct = default);
-    Task<ConversationTopic> CreateAsync(ConversationTopic topic, CancellationToken ct = default);
-    Task SaveAsync(ConversationTopic topic, CancellationToken ct = default);
-    Task ArchiveAsync(TopicId topicId, CancellationToken ct = default);
-    Task<ConversationTopic?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, string externalAddress, CancellationToken ct = default);
+    Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default);
+    Task<IReadOnlyList<Conversation>> ListAsync(AgentId? agentId = null, CancellationToken ct = default);
+    Task<Conversation> GetOrCreateDefaultAsync(AgentId agentId, CancellationToken ct = default);
+    Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default);
+    Task SaveAsync(Conversation conversation, CancellationToken ct = default);
+    Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default);
+    Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, string externalAddress, CancellationToken ct = default);
 }
 ```
 
 ### New Summary DTOs
 
 ```csharp
-public sealed record TopicSummary(
-    string TopicId,
+public sealed record ConversationSummary(
+    string ConversationId,
     string AgentId,
     string Title,
     bool IsDefault,
@@ -309,13 +323,13 @@ public sealed record TopicSummary(
 ### New Gateway/REST Endpoints
 
 Potential endpoints:
-- `GET /api/topics?agentId=assistant`
-- `POST /api/topics`
-- `GET /api/topics/{topicId}`
-- `GET /api/topics/{topicId}/history`
-- `POST /api/topics/{topicId}/bind-channel`
-- `POST /api/topics/{topicId}/sessions/reset`
-- `POST /api/topics/{topicId}/sessions/compact`
+- `GET /api/conversations?agentId=assistant`
+- `POST /api/conversations`
+- `GET /api/conversations/{topicId}`
+- `GET /api/conversations/{topicId}/history`
+- `POST /api/conversations/{topicId}/bind-channel`
+- `POST /api/conversations/{topicId}/sessions/reset`
+- `POST /api/conversations/{topicId}/sessions/compact`
 
 ### SignalR Additions
 
@@ -335,12 +349,12 @@ New events:
 
 ## History Model
 
-### Topic History Endpoint
+### Conversation History Endpoint
 
-`GET /api/topics/{topicId}/history`
+`GET /api/conversations/{topicId}/history`
 
 Behavior:
-- returns merged chronological entries across all sessions linked to the topic
+- returns merged chronological entries across all sessions linked to the conversation
 - includes boundary markers between sessions
 - supports pagination
 
@@ -364,54 +378,54 @@ This lets the portal show one continuous conversation while preserving runtime s
 
 ### Phase 1 — Planning + additive model
 
-- Add `TopicId` primitive
-- Add `ConversationTopic` + `TopicChannelBinding`
-- Add `ITopicStore`
-- Add optional `Session.TopicId`
-- Introduce default topic creation for agents
+- Add `ConversationId` primitive
+- Add `Conversation` + `ChannelBinding`
+- Add `IConversationStore`
+- Add optional `Session.ConversationId`
+- Introduce default conversation creation for agents
 - No UI change yet
 
 ### Phase 2 — routing layer
 
-- Change inbound channel routing to resolve topic first
-- Add topic binding persistence
-- Route inbound messages to topic active session
-- Fan out assistant replies to topic bindings
+- Change inbound channel routing to resolve conversation first
+- Add conversation binding persistence
+- Route inbound messages to conversation active session
+- Fan out assistant replies to conversation bindings
 - Preserve current session APIs for compatibility
 
-### Phase 3 — portal topic-first UX
+### Phase 3 — portal conversation-first UX
 
-- Portal sidebar lists topics instead of raw sessions
-- Default topic visible immediately
-- New conversation creates a new topic
-- Topic history endpoint used by portal
+- Portal sidebar lists conversations instead of raw sessions
+- Default conversation visible immediately
+- New conversation creates a new conversation
+- Conversation history endpoint used by portal
 - Session list moved into advanced/details panel
 
 ### Phase 4 — lifecycle polish
 
-- reset/compact operate in topic context
+- reset/compact operate in conversation context
 - explicit rebind/move channel workflows
-- archive topic
-- optional topic rename and summaries
+- archive conversation
+- optional conversation rename and summaries
 
 ## Compatibility Notes
 
 - Existing session store remains valid.
-- Existing channel adapters can keep writing to sessions during transition if routing shims resolve topic -> active session.
-- Existing Blazor history/session code can be adapted gradually by swapping session list endpoints for topic list endpoints.
-- Existing `SubscribeAll` session model may remain as a lower-level transport while the portal becomes topic-oriented.
+- Existing channel adapters can keep writing to sessions during transition if routing shims resolve conversation -> active session.
+- Existing Blazor history/session code can be adapted gradually by swapping session list endpoints for conversation list endpoints.
+- Existing `SubscribeAll` session model may remain as a lower-level transport while the portal becomes conversation-oriented.
 
 ## Risks
 
 ### 1. Conceptual duplication
 
-Having both topics and sessions may confuse contributors unless responsibilities are documented clearly.
+Having both conversations and sessions may confuse contributors unless responsibilities are documented clearly.
 
-**Mitigation:** make topic user-facing, session runtime-facing in all docs/API naming.
+**Mitigation:** make conversation user-facing, session runtime-facing in all docs/API naming.
 
 ### 2. History reconstruction complexity
 
-Merged topic history across sessions may complicate pagination and scrollback.
+Merged conversation history across sessions may complicate pagination and scrollback.
 
 **Mitigation:** introduce explicit boundary entries and keep session-scoped history endpoints intact.
 
@@ -425,62 +439,79 @@ Cross-channel outbound delivery could annoy users if too aggressive.
 
 The Blazor client recently moved toward session-first logic.
 
-**Mitigation:** additive rollout; first add topics alongside sessions, then flip UI abstraction later.
+**Mitigation:** additive rollout; first add conversations alongside sessions, then flip UI abstraction later.
 
 ### 5. Future multi-user scope
 
 Current design assumes a single effective user per agent/channel context.
 
-**Mitigation:** keep `Topic` model extensible for future owner/participant metadata.
+**Mitigation:** keep `Conversation` model extensible for future owner/participant metadata.
 
 ## Testing Plan
 
 ### Domain / Store Tests
 
-- creating default topic for an agent is idempotent
-- creating additional topics does not affect default topic
-- resolving channel binding returns the correct topic
-- archived topics are excluded from active lists
-- topic summaries include active session and binding counts
+- creating default conversation for an agent is idempotent
+- creating additional conversations does not affect default conversation
+- resolving channel binding returns the correct conversation
+- archived conversations are excluded from active lists
+- conversation summaries include active session and binding counts
 
 ### Routing Tests
 
-- first Telegram message binds to default topic
-- subsequent Telegram message routes to same topic even if session rolled over
-- iMessage can bind to same topic and continue context
+- first Telegram message binds to default conversation
+- subsequent Telegram message routes to same conversation even if session rolled over
+- iMessage can bind to same conversation and continue context
 - assistant message fans out to all interactive/notify bindings
 - inbound user message on one channel is not replayed as user input to other channels
 
 ### Portal Tests
 
-- default topic is visible when agent loads
-- new conversation creates second topic
-- switching topics changes visible merged history
-- compact/reset inside topic preserves topic identity
-- topic history shows session boundaries correctly
+- default conversation is visible when agent loads
+- new conversation creates second conversation
+- switching conversations changes visible merged history
+- compact/reset inside conversation preserves conversation identity
+- conversation history shows session boundaries correctly
 
 ### Compatibility Tests
 
-- existing session APIs still work when topic support is enabled
-- session history endpoint remains correct for a topic's active session
+- existing session APIs still work when conversation support is enabled
+- session history endpoint remains correct for a conversation's active session
 - old clients can still send messages through session routing shim
 
-## Open Questions
+## Design Decisions
 
-1. Final name: `Topic`, `Conversation`, or `Thread`?
-2. Should default topic creation be eager (agent startup) or lazy (first contact)?
-3. Should the portal itself create an explicit channel binding, or be treated as an implicit subscriber?
-4. Are channel bindings scoped to exact external address only, or can one provider/channel family bind broadly?
-5. When resetting a topic, should a new session always be created immediately?
-6. Should topic title come from user input, auto-summary, or both?
-7. Do we need a distinct topic event stream, or is session stream + lookup enough initially?
+The following were decided by Jon Bullen on 2026-04-27:
+
+1. **Name: `Conversation`** — More natural. Humans have conversations across any channel — in person, on the phone, via text.
+
+2. **Default conversation: eager creation** — When an agent comes online, BotNexus immediately ensures a default conversation exists. The agent is always ready; no waiting for a first contact.
+
+3. **Portal: implicit subscriber to all active conversations** — The portal does not create an explicit channel binding. It is always subscribed to all active conversations and sees everything. It is the control surface, not just another channel.
+
+4. **Fan-out: all surfaces receive all agent replies by default** — Agent replies go to every surface with an active binding. This may be refined later with `BindingMode`, but the starting position is full fan-out so every channel stays in sync.
+
+   **Channel threading strategies** — Channels vary in their ability to represent multiple conversations:
+   - **Teams / Slack:** a dedicated agent channel where each new post starts a thread that maps to one conversation. Replies stay inside that thread. Native, idiomatic.
+   - **iMessage / SMS:** no thread model. Prefix messages with the short conversation name so the user can visually group them. e.g. `[Project Alpha] Here is the plan...`
+   - **Telegram:** may support topics/threads in groups; otherwise fall back to the prefix approach.
+   - **Portal:** full native multi-conversation UI — sidebar shows each conversation as a distinct chat, no prefixing needed.
+   - `ChannelBinding` should carry a `ThreadingMode` hint: `NativeThread`, `Prefix`, or `Single`, so each channel adapter can apply the right display strategy.
+
+5. **History: assembled from session segments** — No separate materialized conversation history store. Full history is assembled on demand from the ordered sessions linked to the conversation. Segment boundaries appear as dividers (e.g. `Compacted Apr 27`). Sessions remain the single source of truth.
+
+## Remaining Open Questions
+
+1. When resetting a conversation, should a new session start immediately or only on the next inbound message?
+2. Should conversation title come from user input, auto-summary, or both?
+3. Do we need a distinct conversation event stream, or is session stream + lookup sufficient initially?
 
 ## Recommendation
 
-Proceed with a **topic-first architectural iteration**.
+Proceed with a **conversation-first architectural iteration**.
 
 The key product correction is:
 - **sessions are runtime segments**,
-- **topics are the user-visible omnichannel conversations**.
+- **conversations are the user-visible omnichannel conversations**.
 
 That matches the mental model Jon described and gives BotNexus a cleaner long-term foundation for portal UX, channel routing, and agent continuity across transports.

--- a/docs/planning/feature-conversation-topics/design-spec.md
+++ b/docs/planning/feature-conversation-topics/design-spec.md
@@ -503,9 +503,18 @@ The following were decided by Jon Bullen on 2026-04-27:
 
 ## Remaining Open Questions
 
-1. When resetting a conversation, should a new session start immediately or only on the next inbound message?
-2. Should conversation title come from user input, auto-summary, or both?
-3. Do we need a distinct conversation event stream, or is session stream + lookup sufficient initially?
+1. Do we need a distinct conversation event stream (`ConversationCreated`, `BindingAdded`, etc.) or is session stream + REST lookup sufficient initially?
+
+   - **Option A: Session stream + lookup** — portal gets a session event with a `conversationId`, calls `GET /api/conversations/{id}` to refresh conversation state. No new SignalR events needed. Simpler upfront.
+   - **Option B: Distinct conversation events** — new hub events (`ConversationCreated`, `ConversationUpdated`, `BindingAdded`, `BindingRemoved`). Portal updates in real-time without polling. Cleaner long-term, more work to implement.
+
+   Recommendation: **Option A** for initial implementation, migrate to Option B as conversation event surface grows.
+
+## Resolved Decisions
+
+1. **Reset timing** — resetting a conversation creates a new session. The first inbound message starts the session. Any pre-session hooks (e.g. soul/memory injection) should fire eagerly on reset to reduce response latency on the first message.
+
+2. **Conversation title** — user can set or rename a conversation title at any time. If no title is set, the agent auto-generates one based on conversation content. Both can coexist: agent suggestion, user override.
 
 ## Recommendation
 

--- a/docs/planning/feature-conversation-topics/research.md
+++ b/docs/planning/feature-conversation-topics/research.md
@@ -137,28 +137,28 @@ A new domain object is needed above session. Working name from Jon: **topic**.
 
 Alternative names:
 - `Conversation`
-- `Thread`
-- `Topic`
+- `Thread` (not chosen)
+- `Conversation`
 - `WorkspaceConversation`
 - `Dialogue`
 
-Initial recommendation: **ConversationTopic** in specs/code until naming is finalized.
+Initial recommendation: **Conversation** in specs/code until naming is finalized.
 
 Reason:
 - `Session` is already overloaded.
 - `Conversation` alone may collide with existing transport/runtime vocabulary.
-- `Topic` suggests user intent grouping and supports multiple runtime sessions beneath it.
+- `Conversation` suggests user intent grouping and supports multiple runtime sessions beneath it.
 
 ## Proposed Conceptual Model
 
 ```text
 Agent
-  -> ConversationTopic (user-visible)
+  -> Conversation (user-visible)
       -> ChannelBinding(s)
       -> Session(s) (runtime/history segments)
 ```
 
-### ConversationTopic responsibilities
+### Conversation responsibilities
 
 - User-facing conversation container
 - Stable identity across channels
@@ -195,7 +195,7 @@ Agent
 
 ## Open Questions
 
-1. **Naming** — should the new container be `Topic`, `Conversation`, or `Thread`?
+1. **Naming** — should the new container be `Conversation`, `Conversation`, or `Thread` (not chosen)?
 2. **Binding granularity** — is channel binding per provider (`telegram`) or per channel identity (`telegram chat 5067802539`)?
 3. **Fan-out policy** — should all agent replies go to all bound channels by default, or should bindings support notification-only vs interactive modes?
 4. **Topic creation policy** — should every agent always have exactly one default topic at first boot, or only once first contacted?

--- a/docs/planning/feature-conversation-topics/research.md
+++ b/docs/planning/feature-conversation-topics/research.md
@@ -1,0 +1,221 @@
+---
+id: feature-conversation-topics
+title: "Research: Conversation Topics / Omnichannel Continuity"
+type: feature
+priority: high
+status: draft
+created: 2026-04-27
+author: rusty
+related:
+  - archived/feature-multi-session-connection/architecture-proposal.md
+  - archived/feature-session-visibility/design-spec.md
+---
+
+# Research: Conversation Topics / Omnichannel Continuity
+
+## Problem Statement
+
+BotNexus currently treats the session as both:
+1. the runtime unit of agent execution, and
+2. the user-facing conversation container.
+
+That coupling breaks omnichannel continuity.
+
+Today, a user can talk to the same agent from Telegram, iMessage, and the web portal, but those interactions are represented as separate sessions rather than a shared conversation. That means:
+- context continuity across channels is weak or absent,
+- the portal cannot cleanly show "the conversation" an agent is currently in,
+- channels cannot be attached to a durable user-facing conversation concept,
+- session operations like compact/reset are applied to the only visible unit, even though they are really runtime operations.
+
+The desired model is closer to how a human works:
+- one agent can have one or more user-visible conversations,
+- a conversation can continue across channels without losing context,
+- the portal can deliberately create multiple independent conversations,
+- only the portal needs explicit multi-conversation UX,
+- external channels like Telegram/iMessage usually map to one active conversation unless deliberately re-bound.
+
+## Current State
+
+### Existing BotNexus model
+
+The current domain `Session` contains:
+- `SessionId`
+- `AgentId`
+- `ChannelType`
+- `SessionType`
+- `Status`
+- `Participants`
+- `Metadata`
+- `History`
+
+This makes the session carry both runtime lifecycle and user-visible history.
+
+The SignalR hub already supports a multi-session subscription model (`SubscribeAll`) so the portal can see multiple sessions at once, but the visible unit is still the session.
+
+Relevant existing concepts:
+- **Session** = execution + persistence + history unit
+- **ChannelType / ChannelKey** = source transport (`signalr`, `telegram`, etc.)
+- **Session visibility rules** = decide which sessions appear in the portal
+- **Channel-scoped history** = combine multiple sessions for a channel/agent pair
+
+### What works today
+
+- Agents have memory and workspace files.
+- Skills can be loaded on demand.
+- Sessions persist history.
+- The portal can list multiple sessions.
+- Channels can send messages into an agent.
+
+### What does not work
+
+- A Telegram conversation cannot naturally continue in iMessage or the portal as the *same* user conversation.
+- Portal multi-session support is based on raw sessions, not a higher-level conversation object.
+- Channel routing is session-centric, not conversation-centric.
+- There is no durable default conversation per agent.
+- There is no clear concept for "this set of channels is attached to this conversation."
+
+## Industry Research
+
+### Omnichannel support systems
+
+Mainstream support platforms distinguish between:
+- **channel** (transport),
+- **conversation/case/thread** (user-facing unit), and
+- **internal processing state** (agent assignment, handoff, work item state).
+
+Salesforce describes omnichannel service as continuity across channels rather than isolated channel silos. Their framing is that a customer can start in one channel and continue in another without losing context because conversation history is unified across channels.
+
+Microsoft Dynamics 365 Omnichannel similarly uses the conversation as an analyzable top-level unit, with channels acting as facets of the customer interaction rather than the primary container.
+
+### Key pattern from industry
+
+A stable user-facing container sits **above** transport and below account/customer identity:
+
+```text
+User / Customer
+  -> Conversation / Thread / Case
+      -> Channel bindings / touchpoints
+      -> Runtime work items / sessions / assignments
+```
+
+BotNexus currently jumps from:
+
+```text
+User
+  -> Session
+      -> Channel
+```
+
+That is too flat for omnichannel continuity.
+
+## BotNexus-Specific Findings
+
+### Prior platform direction already points this way
+
+The archived multi-session work introduced:
+- subscription to multiple sessions,
+- client-side switching between sessions,
+- visibility filtering.
+
+That solved UI switching problems, but it did **not** solve the core modeling problem: session is still the wrong top-level user concept.
+
+### Sessions are still valuable
+
+The current session model should not be removed. It is still the right place for:
+- execution lifetime,
+- compaction,
+- abort/reset,
+- replay buffering,
+- message history segments,
+- sub-agent and system lifecycle integration.
+
+What is missing is a parent container.
+
+### A new container is needed
+
+A new domain object is needed above session. Working name from Jon: **topic**.
+
+Alternative names:
+- `Conversation`
+- `Thread`
+- `Topic`
+- `WorkspaceConversation`
+- `Dialogue`
+
+Initial recommendation: **ConversationTopic** in specs/code until naming is finalized.
+
+Reason:
+- `Session` is already overloaded.
+- `Conversation` alone may collide with existing transport/runtime vocabulary.
+- `Topic` suggests user intent grouping and supports multiple runtime sessions beneath it.
+
+## Proposed Conceptual Model
+
+```text
+Agent
+  -> ConversationTopic (user-visible)
+      -> ChannelBinding(s)
+      -> Session(s) (runtime/history segments)
+```
+
+### ConversationTopic responsibilities
+
+- User-facing conversation container
+- Stable identity across channels
+- Default conversation for an agent
+- Holds display name/title/created metadata
+- Owns channel bindings
+- Owns one or more sessions over time
+- Defines which session is currently active for message continuation
+
+### Session responsibilities
+
+- Execution/runtime unit
+- History segment within a topic
+- Can be compacted/reset/archived
+- Can roll over without losing topic continuity
+
+### ChannelBinding responsibilities
+
+- Maps an external channel identity to a topic
+- Defines how inbound user messages are routed
+- Defines which outbound agent messages are fanned out to which channels
+
+## Design Principles Emerging from Research
+
+1. **Portal shows conversations, not raw sessions, by default.**
+2. **Every agent should have a default topic available when it comes online.**
+3. **Portal can deliberately create additional topics for the same agent.**
+4. **External channels should bind to a topic, not directly to whichever session happens to exist.**
+5. **Agent responses can fan out to all subscribed/bound channels for a topic.**
+6. **User messages should not be mirrored to other channels automatically.**
+7. **Sessions remain internal/runtime segments under a topic.**
+8. **Compaction/reset applies to a session, but is initiated from a topic context.**
+9. **Only the portal needs rich multi-topic UX at first.**
+
+## Open Questions
+
+1. **Naming** — should the new container be `Topic`, `Conversation`, or `Thread`?
+2. **Binding granularity** — is channel binding per provider (`telegram`) or per channel identity (`telegram chat 5067802539`)?
+3. **Fan-out policy** — should all agent replies go to all bound channels by default, or should bindings support notification-only vs interactive modes?
+4. **Topic creation policy** — should every agent always have exactly one default topic at first boot, or only once first contacted?
+5. **Portal semantics** — when the user clicks "new conversation", does that create a new topic immediately or lazily on first message?
+6. **History model** — should topic history be materialized, or assembled from ordered session segments?
+7. **Permissions** — if BotNexus grows to multi-user access, are topics scoped by agent+user or globally per agent?
+
+## Recommendation
+
+Create a new feature spec for **Conversation Topics** that:
+- introduces a parent container above session,
+- routes channels to topics,
+- makes the portal topic-first,
+- preserves sessions as runtime/history segments,
+- provides an incremental migration path so existing session infrastructure keeps working.
+
+## Sources
+
+- Salesforce: *Omnichannel Customer Service: Benefits, How It Works & Examples* — continuity across channels, unified conversation history
+- Microsoft Learn: *Conversation dashboard in Omnichannel historical analytics* — conversations as top-level analyzable units across channels
+- BotNexus archived planning:
+  - `docs/planning/archived/feature-multi-session-connection/architecture-proposal.md`
+  - `docs/planning/archived/feature-session-visibility/design-spec.md`


### PR DESCRIPTION
## Conversation Model for Omnichannel Continuity

Planning docs only — no code changes.

---

### The Problem

`Session` is overloaded. It acts as runtime unit, history segment, and user-visible conversation simultaneously. That coupling breaks omnichannel continuity: a Telegram conversation cannot continue in iMessage or the portal as the same conversation.

### The Direction

Introduce **Conversation** as a new parent container above sessions:

```
Agent
  -> Conversation (user-visible)
      -> ChannelBinding(s)   (Telegram, iMessage, Teams, portal...)
      -> Session(s)          (runtime/history segments)
```

---

### Decisions Made

1. **Name: `Conversation`** — Natural. Humans have conversations across any channel.

2. **Default: eager creation** — When an agent comes online, a default conversation is created immediately. Always ready.

3. **Portal: implicit, always-subscribed** — Portal is the control surface, not a channel. It sees all active conversations without needing an explicit binding.

4. **Fan-out: all surfaces by default** — Agent replies go to every active binding. Refined later via `BindingMode`.  
   Channel threading strategies:
   - **Teams/Slack:** each thread = one conversation (native)
   - **iMessage/SMS:** prefix messages with conversation short name e.g. `[Project Alpha] ...`
   - **Telegram:** native topics if available, otherwise prefix
   - **Portal:** full sidebar multi-conversation UI
   - `ChannelBinding.ThreadingMode` carries the hint: `NativeThread`, `Prefix`, `Single`

5. **History: assembled from session segments** — No separate history store. Full conversation history assembled on demand from ordered sessions. Sessions remain the single source of truth.

---

### Remaining Open Questions

1. When resetting a conversation, should a new session start immediately or only on the next inbound message?
2. Should conversation title come from user input, auto-summary, or both?
3. Distinct conversation event stream, or session stream + lookup initially?