### PR TITLE
refactor(domain): rename InboundMessage/OutboundMessage.ConversationId to ChannelAddress

### DIFF
--- a/.squad/.ralph-state.json
+++ b/.squad/.ralph-state.json
@@ -1,0 +1,5 @@
+{
+  "lastHealthCheck": "2026-04-24T15:07:59.913Z",
+  "agents": [],
+  "observations": []
+}

--- a/scripts/botnexus-sync.sh
+++ b/scripts/botnexus-sync.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# botnexus-sync.sh
+# Manages two BotNexus instances:
+#   PROD: ~/botnexus-prod  (sytone/botnexus main) → ~/.botnexus/     → port 5005
+#   DEV:  ~/projects/botnexus (fork main)          → ~/.botnexus-dev/ → port 5006
+#
+# Runs every 15 min via cron. Logs to ~/logs/botnexus-sync.log
+
+set -euo pipefail
+
+export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+export DOTNET_ROOT="$HOME/.dotnet"
+
+DOTNET="$HOME/.dotnet/dotnet"
+LOG_DIR="$HOME/logs"
+LOG_FILE="$LOG_DIR/botnexus-sync.log"
+mkdir -p "$LOG_DIR"
+
+# Lock file — prevent concurrent runs
+LOCK="/tmp/botnexus-sync.lock"
+exec 9>"$LOCK"
+flock -n 9 || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] Already running — skipping" >> "$LOG_FILE"; exit 0; }
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+
+gateway_is_running() {
+    local pidfile="$1"
+    [[ -f "$pidfile" ]] && kill -0 "$(cat "$pidfile")" 2>/dev/null
+}
+
+gateway_stop() {
+    local pidfile="$1" label="$2"
+    if [[ -f "$pidfile" ]]; then
+        local pid; pid=$(cat "$pidfile")
+        log "[$label] Stopping gateway (pid $pid)..."
+        kill "$pid" 2>/dev/null || true
+        sleep 2; kill -9 "$pid" 2>/dev/null || true
+        rm -f "$pidfile"
+    fi
+}
+
+gateway_start() {
+    local dll="$1" home="$2" port="$3" pidfile="$4" logfile="$5" label="$6"
+    log "[$label] Starting gateway (port $port)..."
+    # setsid fully detaches from the terminal session — nohup alone isn't sufficient
+    # DOTNET_SYSTEM_GLOBALIZATION_INVARIANT avoids CultureNotFoundException on Linux
+    BOTNEXUS_HOME="$home" DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 setsid "$DOTNET" "$dll" --urls "http://0.0.0.0:$port" \
+        >> "$logfile" 2>&1 </dev/null &
+    local pid=$!
+    echo "$pid" > "$pidfile"
+    disown
+    sleep 4
+    if kill -0 "$pid" 2>/dev/null; then
+        log "[$label] Started (pid $pid)"
+    else
+        log "[$label] ERROR: Exited immediately — check $logfile"
+        rm -f "$pidfile"; return 1
+    fi
+}
+
+sync_instance() {
+    local repo="$1" remote="$2" home="$3" port="$4" label="$5"
+    local pidfile="$home/gateway.pid"
+    local dll="$repo/src/gateway/BotNexus.Gateway.Api/bin/Debug/net10.0/BotNexus.Gateway.Api.dll"
+    local gwlog="$LOG_DIR/botnexus-gateway-${label}.log"
+
+    cd "$repo"
+    git fetch "$remote" main >> "$LOG_FILE" 2>&1
+    local local_sha remote_sha
+    local_sha=$(git rev-parse HEAD)
+    remote_sha=$(git rev-parse "$remote/main")
+
+    if [[ "$local_sha" == "$remote_sha" ]]; then
+        log "[$label] Up to date ($local_sha)."
+        if ! gateway_is_running "$pidfile"; then
+            log "[$label] Gateway not running — starting..."
+            gateway_start "$dll" "$home" "$port" "$pidfile" "$gwlog" "$label"
+        fi
+        return
+    fi
+
+    log "[$label] New commits: $local_sha → $remote_sha — pulling..."
+    git pull "$remote" main >> "$LOG_FILE" 2>&1
+
+    log "[$label] Building..."
+    if ! "$DOTNET" build BotNexus.slnx --nologo --tl:off >> "$LOG_FILE" 2>&1; then
+        log "[$label] ERROR: Build failed — aborting."
+        return 1
+    fi
+
+    log "[$label] Running tests..."
+    if ! "$DOTNET" test BotNexus.slnx --nologo --tl:off >> "$LOG_FILE" 2>&1; then
+        log "[$label] ERROR: Tests failed — aborting restart."
+        return 1
+    fi
+    log "[$label] Tests passed."
+
+    # Deploy extensions — run CLI deploy then copy to the correct home
+    log "[$label] Deploying extensions..."
+    BOTNEXUS_HOME="$home" "$DOTNET" "$repo/src/gateway/BotNexus.Cli/bin/Debug/net10.0/BotNexus.Cli.dll" \
+        gateway start --path "$repo" --dev >> "$LOG_FILE" 2>&1 || true
+    # CLI always deploys to ~/.botnexus — copy to the right home if different
+    if [[ "$home" != "$HOME/.botnexus" ]] && [[ -d "$HOME/.botnexus/extensions" ]]; then
+        mkdir -p "$home/extensions"
+        cp -r "$HOME/.botnexus/extensions/"* "$home/extensions/"
+    fi
+    # Publish Blazor client to get fresh static assets (index.html + _framework)
+    "$DOTNET" publish "$repo/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient" \
+        -c Release --nologo >> "$LOG_FILE" 2>&1 || true
+    BLAZOR_PUBLISH="$repo/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/bin/Release/net10.0/publish/wwwroot"
+    if [[ -d "$BLAZOR_PUBLISH" ]]; then
+        rm -rf "$home/extensions/botnexus-signalr/blazor"
+        cp -r "$BLAZOR_PUBLISH" "$home/extensions/botnexus-signalr/blazor"
+    fi
+    log "[$label] Extensions deployed."
+
+    if gateway_is_running "$pidfile"; then
+        gateway_stop "$pidfile" "$label"
+    fi
+    gateway_start "$dll" "$home" "$port" "$pidfile" "$gwlog" "$label"
+}
+
+log "=== BotNexus sync started ==="
+
+# PROD: sytone/botnexus → ~/.botnexus → port 5005
+sync_instance "$HOME/botnexus-prod" "origin" "$HOME/.botnexus" "5005" "prod"
+
+# DEV: fork → ~/.botnexus-dev → port 5006
+sync_instance "$HOME/projects/botnexus" "fork" "$HOME/.botnexus-dev" "5006" "dev"
+
+log "=== Done ==="

--- a/src/domain/BotNexus.Domain/Gateway/Models/CrossWorldRelayModels.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/CrossWorldRelayModels.cs
@@ -24,7 +24,7 @@ public sealed record CrossWorldRelayRequest
     /// <summary>
     /// Gets or sets the conversation id.
     /// </summary>
-    public required string ConversationId { get; init; }
+    public required string ChannelAddress { get; init; }
     /// <summary>
     /// Gets or sets the source session id.
     /// </summary>

--- a/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
@@ -17,7 +17,7 @@ public sealed record InboundMessage
     /// Conversation identifier within the channel (e.g., chat ID, thread ID).
     /// Combined with <see cref="ChannelType"/> to derive a session key.
     /// </summary>
-    public required string ConversationId { get; init; }
+    public required string ChannelAddress { get; init; }
 
     /// <summary>The message text content.</summary>
     public required string Content { get; init; }
@@ -55,7 +55,7 @@ public sealed record OutboundMessage
     public required ChannelKey ChannelType { get; init; }
 
     /// <summary>Target conversation identifier within the channel.</summary>
-    public required string ConversationId { get; init; }
+    public required string ChannelAddress { get; init; }
 
     /// <summary>The message content.</summary>
     public required string Content { get; init; }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -221,7 +221,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
-                    ConversationId = session.SessionId.Value,
+                    ChannelAddress = session.SessionId.Value,
                     SessionId = session.SessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
@@ -244,7 +244,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
-                ConversationId = typedSessionId.Value,
+                ChannelAddress = typedSessionId.Value,
                 SessionId = typedSessionId.Value,
                 TargetAgentId = typedAgentId.Value,
                 Content = content,
@@ -324,7 +324,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
-                    ConversationId = typedSessionId.Value,
+                    ChannelAddress = typedSessionId.Value,
                     SessionId = typedSessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -44,11 +44,11 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
     {
         if (string.Equals(message.Content?.Trim(), NoReplySentinel, StringComparison.Ordinal))
         {
-            logger.LogDebug("Suppressed NO_REPLY message for session {SessionId}", message.SessionId ?? message.ConversationId);
+            logger.LogDebug("Suppressed NO_REPLY message for session {SessionId}", message.SessionId ?? message.ChannelAddress);
             return Task.CompletedTask;
         }
 
-        var normalizedSessionId = NormalizeSessionId(message.SessionId ?? message.ConversationId);
+        var normalizedSessionId = NormalizeSessionId(message.SessionId ?? message.ChannelAddress);
         return _hubContext.Clients.Group(GetSessionGroup(normalizedSessionId))
             .ContentDelta(new ContentDeltaPayload(normalizedSessionId, message.Content));
     }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -116,12 +116,12 @@ public sealed class TelegramChannelAdapter(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryParseChatId(message.ConversationId, out var chatId))
+        if (!TryParseChatId(message.ChannelAddress, out var chatId))
         {
             _logger.LogWarning(
                 "{DisplayName} send requested with invalid conversation id '{ConversationId}'",
                 DisplayName,
-                message.ConversationId);
+                message.ChannelAddress);
             return;
         }
 
@@ -284,7 +284,7 @@ public sealed class TelegramChannelAdapter(
         {
             ChannelType = ChannelType,
             SenderId = senderId,
-            ConversationId = chatIdText,
+            ChannelAddress = chatIdText,
             Content = message.Text,
             Metadata = new Dictionary<string, object?>
             {

--- a/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
@@ -90,7 +90,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
             _logger.LogDebug("{DisplayName} send requested while adapter is not running", DisplayName);
         }
 
-        return Console.Out.WriteLineAsync($"[{DisplayName}:{message.ConversationId}] {message.Content}");
+        return Console.Out.WriteLineAsync($"[{DisplayName}:{message.ChannelAddress}] {message.Content}");
     }
 
     /// <summary>
@@ -193,7 +193,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
                 {
                     ChannelType = ChannelType,
                     SenderId = Environment.UserName,
-                    ConversationId = "console",
+                    ChannelAddress = "console",
                     SessionId = "tui-console",
                     Content = steerContent,
                     Metadata = new Dictionary<string, object?>
@@ -208,7 +208,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
             {
                 ChannelType = ChannelType,
                 SenderId = Environment.UserName,
-                ConversationId = "console",
+                ChannelAddress = "console",
                 SessionId = "tui-console",
                 Content = line
             }, cancellationToken);

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -82,7 +82,7 @@ public sealed class CrossWorldFederationController(
             WorldId = _localWorldId,
             Role = "target"
         });
-        session.Metadata["conversationId"] = request.ConversationId;
+        session.Metadata["conversationId"] = request.ChannelAddress;
         session.Metadata["sourceWorldId"] = request.SourceWorldId;
         session.Metadata["sourceSessionId"] = request.SourceSessionId;
         session.Status = GatewaySessionStatus.Active;

--- a/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
@@ -65,7 +65,7 @@ public sealed class CrossWorldChannelAdapter(
                 SourceAgentId = sourceAgentId,
                 TargetAgentId = targetAgentId,
                 Message = message.Content,
-                ConversationId = conversationId,
+                ChannelAddress = conversationId,
                 SourceSessionId = sourceSessionId,
                 RemoteSessionId = remoteSessionId
             }, options: JsonOptions)

--- a/src/gateway/BotNexus.Gateway/Agents/AgentConversationService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentConversationService.cs
@@ -212,7 +212,7 @@ public sealed class AgentConversationService : IAgentConversationService
                     new OutboundMessage
                     {
                         ChannelType = ChannelKey.From("cross-world"),
-                        ConversationId = conversationId,
+                        ChannelAddress = conversationId,
                         Content = message,
                         SessionId = sessionId.Value,
                         Metadata = new Dictionary<string, object?>

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -306,7 +306,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             {
                 ChannelType = ChannelKey.From("internal"),
                 SenderId = $"subagent:{subAgentId}",
-                ConversationId = updated.ParentSessionId,
+                ChannelAddress = updated.ParentSessionId,
                 SessionId = updated.ParentSessionId,
                 TargetAgentId = parentAgentId,
                 Content = followUp,

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -223,7 +223,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
 
         foreach (var agentId in targetAgents)
         {
-            var sessionId = message.SessionId ?? $"{message.ChannelType}:{message.ConversationId}:{agentId}";
+            var sessionId = message.SessionId ?? $"{message.ChannelType}:{message.ChannelAddress}:{agentId}";
             using var agentActivity = GatewayDiagnostics.Source.StartActivity("gateway.agent_process", ActivityKind.Internal);
             agentActivity?.SetTag("botnexus.agent.id", agentId);
             agentActivity?.SetTag("botnexus.session.id", sessionId);
@@ -372,10 +372,10 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                                     : evt;
 
                                 if (channel is IStreamEventChannelAdapter streamEventChannel)
-                                    return new ValueTask(streamEventChannel.SendStreamEventAsync(message.ConversationId, enriched, ct));
+                                    return new ValueTask(streamEventChannel.SendStreamEventAsync(message.ChannelAddress, enriched, ct));
 
                                 if (evt.Type == AgentStreamEventType.ContentDelta && evt.ContentDelta is not null)
-                                    return new ValueTask(channel.SendStreamDeltaAsync(message.ConversationId, evt.ContentDelta, ct));
+                                    return new ValueTask(channel.SendStreamDeltaAsync(message.ChannelAddress, evt.ContentDelta, ct));
 
                                 return ValueTask.CompletedTask;
                             }),
@@ -395,7 +395,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         await ch.SendAsync(new OutboundMessage
                         {
                             ChannelType = message.ChannelType,
-                            ConversationId = message.ConversationId,
+                            ChannelAddress = message.ChannelAddress,
                             Content = response.Content,
                             SessionId = sessionId
                         }, cancellationToken);
@@ -459,7 +459,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         await errorChannel.SendAsync(new OutboundMessage
                         {
                             ChannelType = message.ChannelType,
-                            ConversationId = message.ConversationId,
+                            ChannelAddress = message.ChannelAddress,
                             Content = $"Error: {ex.Message}",
                             SessionId = sessionId
                         }, CancellationToken.None);
@@ -497,7 +497,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             await channel.SendAsync(new OutboundMessage
             {
                 ChannelType = message.ChannelType,
-                ConversationId = message.ConversationId,
+                ChannelAddress = message.ChannelAddress,
                 Content = statusMessage,
                 SessionId = sessionId
             }, cancellationToken);
@@ -589,7 +589,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             await channel.SendAsync(new OutboundMessage
             {
                 ChannelType = message.ChannelType,
-                ConversationId = message.ConversationId,
+                ChannelAddress = message.ChannelAddress,
                 Content = feedback,
                 SessionId = sessionId
             }, cancellationToken);
@@ -632,7 +632,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private static string GetQueueKey(InboundMessage message)
         => !string.IsNullOrWhiteSpace(message.SessionId)
             ? message.SessionId
-            : $"{message.ChannelType}:{message.ConversationId}";
+            : $"{message.ChannelType}:{message.ChannelAddress}";
 
     private async Task SendBusyAsync(InboundMessage message, CancellationToken cancellationToken)
     {
@@ -642,7 +642,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         await channel.SendAsync(new OutboundMessage
         {
             ChannelType = message.ChannelType,
-            ConversationId = message.ConversationId,
+            ChannelAddress = message.ChannelAddress,
             Content = BusyMessage,
             SessionId = message.SessionId
         }, cancellationToken);

--- a/tests/BotNexus.Domain.Tests/InboundMessageContentPartsTests.cs
+++ b/tests/BotNexus.Domain.Tests/InboundMessageContentPartsTests.cs
@@ -64,7 +64,7 @@ public sealed class InboundMessageContentPartsTests
     {
         ChannelType = ChannelKey.From("signalr"),
         SenderId = "sender-1",
-        ConversationId = "conversation-1",
+        ChannelAddress = "conversation-1",
         Content = "hello"
     };
 }

--- a/tests/BotNexus.Gateway.Tests/Channels/InternalChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/InternalChannelAdapterTests.cs
@@ -34,7 +34,7 @@ public sealed class InternalChannelAdapterTests
         var outbound = new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ConversationId = "conversation-1",
+            ChannelAddress = "conversation-1",
             SessionId = "session-1",
             Content = "hello"
         };
@@ -45,7 +45,7 @@ public sealed class InternalChannelAdapterTests
             a => a.SendAsync(
                 It.Is<OutboundMessage>(m =>
                     m.ChannelType.Equals(ChannelKey.From("signalr")) &&
-                    m.ConversationId == "conversation-1" &&
+                    m.ChannelAddress == "conversation-1" &&
                     m.SessionId == "session-1" &&
                     m.Content == "hello"),
                 CancellationToken.None),
@@ -72,7 +72,7 @@ public sealed class InternalChannelAdapterTests
         await sut.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ConversationId = "conversation-1",
+            ChannelAddress = "conversation-1",
             SessionId = "session-1",
             Content = "hello"
         }, CancellationToken.None);
@@ -99,7 +99,7 @@ public sealed class InternalChannelAdapterTests
         Func<Task> act = () => sut.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ConversationId = "conversation-1",
+            ChannelAddress = "conversation-1",
             SessionId = "session-1",
             Content = "hello"
         }, CancellationToken.None);
@@ -145,7 +145,7 @@ public sealed class InternalChannelAdapterTests
         await sut.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ConversationId = "conversation-1",
+            ChannelAddress = "conversation-1",
             SessionId = "session-1",
             Content = "hello"
         }, CancellationToken.None);

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -74,7 +74,7 @@ public sealed class TelegramChannelAdapterTests
         dispatcher.Invocations
             .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
             .Select(i => (InboundMessage)i.Arguments[0])
-            .Where(m => m.ConversationId == "42" && m.Content == "hello")
+            .Where(m => m.ChannelAddress == "42" && m.Content == "hello")
             .ShouldHaveSingleItem();
     }
 
@@ -99,7 +99,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ConversationId = "42",
+            ChannelAddress = "42",
             Content = new string('a', 5000)
         });
 
@@ -130,7 +130,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ConversationId = "42",
+            ChannelAddress = "42",
             Content = "_*[]()~`>#+-=|{}.!\\"
         });
 
@@ -371,7 +371,7 @@ public sealed class TelegramChannelAdapterTests
         Func<Task> act = () => adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ConversationId = "99",
+            ChannelAddress = "99",
             Content = "blocked"
         });
 

--- a/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -73,7 +73,7 @@ public sealed class CrossWorldFederationControllerTests
                 SourceAgentId = "nova",
                 TargetAgentId = "leela",
                 Message = "Hello from world-a",
-                ConversationId = "nova::cross::leela::abc123"
+                ChannelAddress = "nova::cross::leela::abc123"
             },
             CancellationToken.None);
 
@@ -140,7 +140,7 @@ public sealed class CrossWorldFederationControllerTests
                 SourceAgentId = "nova",
                 TargetAgentId = "leela",
                 Message = "hello",
-                ConversationId = "c-1"
+                ChannelAddress = "c-1"
             },
             CancellationToken.None);
 

--- a/tests/BotNexus.Gateway.Tests/DefaultMessageRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/DefaultMessageRouterTests.cs
@@ -100,7 +100,7 @@ public sealed class DefaultMessageRouterTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "sender-1",
-            ConversationId = "conv-1",
+            ChannelAddress = "conv-1",
             Content = "hello",
             TargetAgentId = targetAgentId,
             SessionId = sessionId

--- a/tests/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -830,7 +830,7 @@ public sealed class GatewayHostTests
         {
             ChannelType = channelType,
             SenderId = "sender-1",
-            ConversationId = conversationId,
+            ChannelAddress = conversationId,
             Content = content,
             SessionId = sessionId,
             Metadata = metadata ?? new Dictionary<string, object?>()

--- a/tests/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
@@ -213,7 +213,7 @@ public sealed class CopilotIntegrationTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "integration-user",
-            ConversationId = "copilot-integration-conversation",
+            ChannelAddress = "copilot-integration-conversation",
             Content = content,
             SessionId = BotNexus.Domain.Primitives.SessionId.From("integration-session")
         };

--- a/tests/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
@@ -176,7 +176,7 @@ public sealed class Phase5IntegrationTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "phase5-tester",
-            ConversationId = "phase5-live-conv",
+            ChannelAddress = "phase5-live-conv",
             SessionId = BotNexus.Domain.Primitives.SessionId.From("phase5-live"),
             Content = "Reply with a short greeting."
         });

--- a/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -175,7 +175,7 @@ public sealed class SignalRHubTests
                 It.Is<InboundMessage>(m =>
                     m.ChannelType == ChannelKey.From("signalr") &&
                     m.SenderId == "conn-1" &&
-                    m.ConversationId == "session-1" &&
+                    m.ChannelAddress == "session-1" &&
                     m.SessionId == "session-1" &&
                     m.TargetAgentId == "agent-a" &&
                     m.Content == "hello"),
@@ -294,7 +294,7 @@ public sealed class SignalRHubTests
         dispatcher.Verify(value => value.DispatchAsync(
                 It.Is<InboundMessage>(m =>
                     m.ChannelType == ChannelKey.From("signalr") &&
-                    m.ConversationId == "session-1" &&
+                    m.ChannelAddress == "session-1" &&
                     m.SessionId == "session-1" &&
                     m.TargetAgentId == "agent-a"),
                 CancellationToken.None),

--- a/tests/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
+++ b/tests/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
@@ -181,7 +181,7 @@ public sealed class StreamingPipelineTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "sender-1",
-            ConversationId = "conv-1",
+            ChannelAddress = "conv-1",
             Content = content,
             SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1")
         };


### PR DESCRIPTION
## Summary

Renames `ConversationId` → `ChannelAddress` on `InboundMessage`, `OutboundMessage`, and `CrossWorldRelayMessage`.

### Context

`ConversationId` on message models meant *the address of this conversation on its originating channel* (e.g. Telegram chat ID, SignalR session ID, `"console"` for TUI). That is a **channel address**, not a conversation container identity. Renaming clarifies the semantic.

The `ConversationId` value object in `BotNexus.Domain.Primitives` is **retained** — it will be used by a new `Conversation` entity in a future phase (`feature-conversation-model`).

### Changes

- `Messages.cs` — renamed property on `InboundMessage` and `OutboundMessage`
- `CrossWorldRelayModels.cs` — renamed property on `CrossWorldRelayMessage`
- All call sites updated (22 files total)

### No-touch zones respected

- `Primitives/ConversationId.cs` — untouched
- `Serialization/ConversationIdJsonConverter.cs` — untouched
- `docs/` — untouched
- Metadata key `"conversationId"` in `CrossWorldFederationController` — untouched (string key, not property)

### Verification

- `grep` check passes — no stray `.ConversationId` outside primitives/serialization
- `dotnet build` — 0 errors
- `dotnet test` — 0 failures (998 gateway tests + domain/CLI/memory/etc.)

No behaviour change — rename only.