### PR TITLE
refactor(domain): rename agent-to-agent exchange types for clarity

### DIFF
--- a/src/domain/BotNexus.Domain/AgentExchange/AgentExchangeRequest.cs
+++ b/src/domain/BotNexus.Domain/AgentExchange/AgentExchangeRequest.cs
@@ -1,11 +1,11 @@
 using BotNexus.Domain.Primitives;
 
-namespace BotNexus.Domain.Conversations;
+namespace BotNexus.Domain.AgentExchange;
 
 /// <summary>
 /// Represents a request for one agent to converse with another registered agent.
 /// </summary>
-public sealed record ConversationRequest
+public sealed record AgentExchangeRequest
 {
     /// <summary>
     /// The initiating agent.

--- a/src/domain/BotNexus.Domain/AgentExchange/CrossWorldAgentReference.cs
+++ b/src/domain/BotNexus.Domain/AgentExchange/CrossWorldAgentReference.cs
@@ -1,6 +1,6 @@
 using BotNexus.Domain.Primitives;
 
-namespace BotNexus.Domain.Conversations;
+namespace BotNexus.Domain.AgentExchange;
 
 /// <summary>
 /// Represents cross world agent reference.

--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentConversationResult.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentConversationResult.cs
@@ -5,7 +5,7 @@ namespace BotNexus.Gateway.Abstractions.Models;
 /// <summary>
 /// Result payload for an agent-to-agent conversation.
 /// </summary>
-public sealed record AgentConversationResult
+public sealed record AgentExchangeResult
 {
     /// <summary>
     /// Conversation session identifier.
@@ -30,7 +30,7 @@ public sealed record AgentConversationResult
     /// <summary>
     /// Full conversation transcript.
     /// </summary>
-    public IReadOnlyList<AgentConversationTranscriptEntry> Transcript { get; init; } = [];
+    public IReadOnlyList<AgentExchangeTranscriptEntry> Transcript { get; init; } = [];
 }
 
 /// <summary>
@@ -38,4 +38,4 @@ public sealed record AgentConversationResult
 /// </summary>
 /// <param name="Role">Message role.</param>
 /// <param name="Content">Message content.</param>
-public sealed record AgentConversationTranscriptEntry(string Role, string Content);
+public sealed record AgentExchangeTranscriptEntry(string Role, string Content);

--- a/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 
-[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentConversationResult))]
-[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentConversationTranscriptEntry))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentExchangeResult))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentExchangeTranscriptEntry))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentDescriptor))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentExecutionContext))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentResponse))]
@@ -48,7 +48,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentCommunicator))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentConfigurationSource))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentConfigurationWriter))]
-[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentConversationService))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentExchangeService))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentHandle))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentHandleInspector))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentRegistry))]

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentExchangeService.cs
@@ -1,4 +1,4 @@
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Gateway.Abstractions.Models;
 
 namespace BotNexus.Gateway.Abstractions.Agents;
@@ -6,10 +6,10 @@ namespace BotNexus.Gateway.Abstractions.Agents;
 /// <summary>
 /// Executes synchronous conversations between registered peer agents.
 /// </summary>
-public interface IAgentConversationService
+public interface IAgentExchangeService
 {
     /// <summary>
     /// Starts a peer agent conversation and returns the completed transcript/result.
     /// </summary>
-    Task<AgentConversationResult> ConverseAsync(ConversationRequest request, CancellationToken cancellationToken = default);
+    Task<AgentExchangeResult> ConverseAsync(AgentExchangeRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -1,4 +1,4 @@
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Channels;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -16,23 +16,23 @@ namespace BotNexus.Gateway.Agents;
 /// <summary>
 /// Default implementation for synchronous peer agent conversations.
 /// </summary>
-public sealed class AgentConversationService : IAgentConversationService
+public sealed class AgentExchangeService : IAgentExchangeService
 {
     private readonly IAgentRegistry _registry;
     private readonly IAgentSupervisor _supervisor;
     private readonly ISessionStore _sessionStore;
     private readonly IOptions<Gateway.Configuration.GatewayOptions> _options;
-    private readonly ILogger<AgentConversationService> _logger;
+    private readonly ILogger<AgentExchangeService> _logger;
     private readonly PlatformConfig _platformConfig;
     private readonly CrossWorldChannelAdapter _crossWorldChannelAdapter;
     private readonly string _sourceWorldId;
 
-    public AgentConversationService(
+    public AgentExchangeService(
         IAgentRegistry registry,
         IAgentSupervisor supervisor,
         ISessionStore sessionStore,
         IOptions<Gateway.Configuration.GatewayOptions> options,
-        ILogger<AgentConversationService> logger,
+        ILogger<AgentExchangeService> logger,
         PlatformConfig? platformConfig = null,
         CrossWorldChannelAdapter? crossWorldChannelAdapter = null)
     {
@@ -49,7 +49,7 @@ public sealed class AgentConversationService : IAgentConversationService
     }
 
     /// <inheritdoc />
-    public async Task<AgentConversationResult> ConverseAsync(ConversationRequest request, CancellationToken cancellationToken = default)
+    public async Task<AgentExchangeResult> ConverseAsync(AgentExchangeRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (string.IsNullOrWhiteSpace(request.Message))
@@ -101,7 +101,7 @@ public sealed class AgentConversationService : IAgentConversationService
         session.Metadata["objective"] = request.Objective;
         session.Metadata["maxTurns"] = request.MaxTurns;
 
-        var transcript = new List<AgentConversationTranscriptEntry>();
+        var transcript = new List<AgentExchangeTranscriptEntry>();
         var targetHandle = await _supervisor.GetOrCreateAsync(request.TargetId, sessionId, cancellationToken).ConfigureAwait(false);
 
         var message = request.Message;
@@ -139,7 +139,7 @@ public sealed class AgentConversationService : IAgentConversationService
             throw;
         }
 
-        return new AgentConversationResult
+        return new AgentExchangeResult
         {
             SessionId = sessionId,
             Status = "sealed",
@@ -149,8 +149,8 @@ public sealed class AgentConversationService : IAgentConversationService
         };
     }
 
-    private async Task<AgentConversationResult> ConverseCrossWorldAsync(
-        ConversationRequest request,
+    private async Task<AgentExchangeResult> ConverseCrossWorldAsync(
+        AgentExchangeRequest request,
         CrossWorldAgentReference parsedTarget,
         IReadOnlyList<AgentId> normalizedChain,
         CancellationToken cancellationToken)
@@ -197,7 +197,7 @@ public sealed class AgentConversationService : IAgentConversationService
         session.Metadata["targetWorldId"] = resolvedTarget.WorldId;
         session.Metadata["conversationId"] = conversationId;
 
-        var transcript = new List<AgentConversationTranscriptEntry>();
+        var transcript = new List<AgentExchangeTranscriptEntry>();
         var message = request.Message;
         var finalResponse = string.Empty;
         string? remoteSessionId = null;
@@ -257,7 +257,7 @@ public sealed class AgentConversationService : IAgentConversationService
             throw;
         }
 
-        return new AgentConversationResult
+        return new AgentExchangeResult
         {
             SessionId = sessionId,
             Status = "sealed",
@@ -270,10 +270,10 @@ public sealed class AgentConversationService : IAgentConversationService
     private static void AddTurn(
         MessageRole role,
         string content,
-        List<AgentConversationTranscriptEntry> transcript,
+        List<AgentExchangeTranscriptEntry> transcript,
         GatewaySession session)
     {
-        transcript.Add(new AgentConversationTranscriptEntry(role.Value, content));
+        transcript.Add(new AgentExchangeTranscriptEntry(role.Value, content));
         session.AddEntry(new SessionEntry
         {
             Role = role,

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -109,7 +109,7 @@ public static class GatewayServiceCollectionExtensions
          services.TryAddSingleton<IAgentConfigurationWriter, NoOpAgentConfigurationWriter>();
         services.AddSingleton<IAgentSupervisor, DefaultAgentSupervisor>();
         services.AddSingleton<IAgentCommunicator, DefaultAgentCommunicator>();
-        services.AddSingleton<IAgentConversationService, AgentConversationService>();
+        services.AddSingleton<IAgentExchangeService, AgentExchangeService>();
         services.AddSingleton<CrossWorldInboundAuthService>();
         services.TryAddSingleton<CrossWorldChannelOptions>();
         services.AddSingleton<CrossWorldChannelAdapter>(serviceProvider =>

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -178,7 +178,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 tools.Add(new SubAgentManageTool(subAgentManager, context.SessionId));
         }
 
-        var conversationService = _serviceProvider.GetService<IAgentConversationService>();
+        var conversationService = _serviceProvider.GetService<IAgentExchangeService>();
         if (conversationService is not null && sessionStore is not null)
         {
             var includeConverse = descriptor.ToolIds.Count == 0

--- a/src/gateway/BotNexus.Gateway/Tools/AgentConverseTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/AgentConverseTool.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -10,7 +10,7 @@ using BotNexus.Agent.Providers.Core.Models;
 namespace BotNexus.Gateway.Tools;
 
 public sealed class AgentConverseTool(
-    IAgentConversationService conversationService,
+    IAgentExchangeService conversationService,
     ISessionStore sessionStore,
     AgentId initiatorAgentId,
     SessionId sessionId) : IAgentTool
@@ -63,7 +63,7 @@ public sealed class AgentConverseTool(
             ?? throw new ArgumentException("Missing required argument: message.");
 
         var result = await conversationService.ConverseAsync(
-            new ConversationRequest
+            new AgentExchangeRequest
             {
                 InitiatorId = initiatorAgentId,
                 TargetId = AgentId.From(targetAgentId),

--- a/tests/BotNexus.Domain.Tests/AgentExchangeRequestTests.cs
+++ b/tests/BotNexus.Domain.Tests/AgentExchangeRequestTests.cs
@@ -1,14 +1,14 @@
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 
 namespace BotNexus.Domain.Tests;
 
-public sealed class ConversationRequestTests
+public sealed class AgentExchangeRequestTests
 {
     [Fact]
-    public void ConversationRequest_Defaults_MaxTurnsAndCallChainAreSafe()
+    public void AgentExchangeRequest_Defaults_MaxTurnsAndCallChainAreSafe()
     {
-        var request = new ConversationRequest
+        var request = new AgentExchangeRequest
         {
             InitiatorId = AgentId.From("agent-a"),
             TargetId = AgentId.From("agent-b"),
@@ -21,9 +21,9 @@ public sealed class ConversationRequestTests
     }
 
     [Fact]
-    public void ConversationRequest_AllowsExplicitCallChainAndTurnLimit()
+    public void AgentExchangeRequest_AllowsExplicitCallChainAndTurnLimit()
     {
-        var request = new ConversationRequest
+        var request = new AgentExchangeRequest
         {
             InitiatorId = AgentId.From("agent-a"),
             TargetId = AgentId.From("agent-b"),

--- a/tests/BotNexus.Domain.Tests/CrossWorldAgentReferenceTests.cs
+++ b/tests/BotNexus.Domain.Tests/CrossWorldAgentReferenceTests.cs
@@ -1,4 +1,4 @@
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 
 namespace BotNexus.Domain.Tests;

--- a/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -1,4 +1,4 @@
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Channels;
 using System.Net;
@@ -16,7 +16,7 @@ using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
 namespace BotNexus.Gateway.Tests.Agents;
 
-public sealed class AgentConversationServiceTests
+public sealed class AgentExchangeServiceTests
 {
     [Fact]
     public async Task ConverseAsync_SingleTurn_CreatesSealedAgentAgentSessionVisibleToBothAgents()
@@ -33,14 +33,14 @@ public sealed class AgentConversationServiceTests
         supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
 
-        var service = new AgentConversationService(
+        var service = new AgentExchangeService(
             registry.Object,
             supervisor.Object,
             sessionStore,
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentConversationService>.Instance);
+            NullLogger<AgentExchangeService>.Instance);
 
-        var result = await service.ConverseAsync(new ConversationRequest
+        var result = await service.ConverseAsync(new AgentExchangeRequest
         {
             InitiatorId = initiator,
             TargetId = target,
@@ -72,14 +72,14 @@ public sealed class AgentConversationServiceTests
         var initiator = AgentId.From("nova");
         var target = AgentId.From("leela");
         var registry = CreateRegistry(initiator, target, []);
-        var service = new AgentConversationService(
+        var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             new InMemorySessionStore(),
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentConversationService>.Instance);
+            NullLogger<AgentExchangeService>.Instance);
 
-        Func<Task> action = () => service.ConverseAsync(new ConversationRequest
+        Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {
             InitiatorId = initiator,
             TargetId = target,
@@ -95,14 +95,14 @@ public sealed class AgentConversationServiceTests
         var initiator = AgentId.From("nova");
         var target = AgentId.From("leela");
         var registry = CreateRegistry(initiator, target, ["leela"]);
-        var service = new AgentConversationService(
+        var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             new InMemorySessionStore(),
             Options.Create(new GatewayOptions { AgentConversationMaxDepth = 4 }),
-            NullLogger<AgentConversationService>.Instance);
+            NullLogger<AgentExchangeService>.Instance);
 
-        Func<Task> action = () => service.ConverseAsync(new ConversationRequest
+        Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {
             InitiatorId = initiator,
             TargetId = target,
@@ -120,14 +120,14 @@ public sealed class AgentConversationServiceTests
         var initiator = AgentId.From("nova");
         var target = AgentId.From("leela");
         var registry = CreateRegistry(initiator, target, ["leela"]);
-        var service = new AgentConversationService(
+        var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             new InMemorySessionStore(),
             Options.Create(new GatewayOptions { AgentConversationMaxDepth = 2 }),
-            NullLogger<AgentConversationService>.Instance);
+            NullLogger<AgentExchangeService>.Instance);
 
-        Func<Task> action = () => service.ConverseAsync(new ConversationRequest
+        Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {
             InitiatorId = initiator,
             TargetId = target,
@@ -167,12 +167,12 @@ public sealed class AgentConversationServiceTests
             NullLogger<CrossWorldChannelAdapter>.Instance,
             new HttpClient(handler));
 
-        var service = new AgentConversationService(
+        var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             sessionStore,
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentConversationService>.Instance,
+            NullLogger<AgentExchangeService>.Instance,
             new PlatformConfig
             {
                 Gateway = new GatewaySettingsConfig
@@ -203,7 +203,7 @@ public sealed class AgentConversationServiceTests
             },
             adapter);
 
-        var result = await service.ConverseAsync(new ConversationRequest
+        var result = await service.ConverseAsync(new AgentExchangeRequest
         {
             InitiatorId = initiator,
             TargetId = target,
@@ -232,12 +232,12 @@ public sealed class AgentConversationServiceTests
         var registry = CreateRegistry(initiator, AgentId.From("leela"), ["world-b:leela"]);
         registry.Setup(r => r.Contains(target)).Returns(false);
 
-        var service = new AgentConversationService(
+        var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             new InMemorySessionStore(),
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentConversationService>.Instance,
+            NullLogger<AgentExchangeService>.Instance,
             new PlatformConfig
             {
                 Gateway = new GatewaySettingsConfig
@@ -266,7 +266,7 @@ public sealed class AgentConversationServiceTests
                 }
             });
 
-        Func<Task> action = () => service.ConverseAsync(new ConversationRequest
+        Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {
             InitiatorId = initiator,
             TargetId = target,

--- a/tests/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
@@ -1,6 +1,6 @@
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
-using BotNexus.Domain.Conversations;
+using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
@@ -15,7 +15,7 @@ public sealed class AgentConverseToolTests
     [Fact]
     public void Tool_HasExpectedNameAndLabel()
     {
-        var tool = new AgentConverseTool(Mock.Of<IAgentConversationService>(), new InMemorySessionStore(), "nova", "session-1");
+        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), "nova", "session-1");
         tool.Name.ShouldBe("agent_converse");
         tool.Label.ShouldBe("Agent Converse");
     }
@@ -23,7 +23,7 @@ public sealed class AgentConverseToolTests
     [Fact]
     public async Task PrepareArgumentsAsync_WhenRequiredArgsMissing_Throws()
     {
-        var tool = new AgentConverseTool(Mock.Of<IAgentConversationService>(), new InMemorySessionStore(), "nova", "session-1");
+        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), "nova", "session-1");
 
         Func<Task> action = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?>());
 
@@ -31,13 +31,13 @@ public sealed class AgentConverseToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenSessionHasCallChain_ForwardsChainToConversationRequest()
+    public async Task ExecuteAsync_WhenSessionHasCallChain_ForwardsChainToAgentExchangeRequest()
     {
-        ConversationRequest? captured = null;
-        var service = new Mock<IAgentConversationService>();
-        service.Setup(s => s.ConverseAsync(It.IsAny<ConversationRequest>(), It.IsAny<CancellationToken>()))
-            .Callback<ConversationRequest, CancellationToken>((request, _) => captured = request)
-            .ReturnsAsync(new AgentConversationResult
+        AgentExchangeRequest? captured = null;
+        var service = new Mock<IAgentExchangeService>();
+        service.Setup(s => s.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentExchangeRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new AgentExchangeResult
             {
                 SessionId = "nova::agent-agent::leela::abc123",
                 Status = "sealed",
@@ -65,11 +65,11 @@ public sealed class AgentConverseToolTests
     [Fact]
     public async Task ExecuteAsync_WhenNoCallChain_UsesInitiatorAsDefaultChain()
     {
-        ConversationRequest? captured = null;
-        var service = new Mock<IAgentConversationService>();
-        service.Setup(s => s.ConverseAsync(It.IsAny<ConversationRequest>(), It.IsAny<CancellationToken>()))
-            .Callback<ConversationRequest, CancellationToken>((request, _) => captured = request)
-            .ReturnsAsync(new AgentConversationResult
+        AgentExchangeRequest? captured = null;
+        var service = new Mock<IAgentExchangeService>();
+        service.Setup(s => s.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentExchangeRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new AgentExchangeResult
             {
                 SessionId = "nova::agent-agent::leela::abc123",
                 Status = "sealed",


### PR DESCRIPTION
ConversationRequest/AgentConversationService clashed with the new user-facing Conversation entity (feature-conversation-model).

## Renames

| Old name | New name |
|---|---|
| \`ConversationRequest\` | \`AgentExchangeRequest\` |
| \`AgentConversationResult\` | \`AgentExchangeResult\` |
| \`AgentConversationTranscriptEntry\` | \`AgentExchangeTranscriptEntry\` |
| \`AgentConversationService\` | \`AgentExchangeService\` |
| \`IAgentConversationService\` | \`IAgentExchangeService\` |
| namespace \`BotNexus.Domain.Conversations\` | \`BotNexus.Domain.AgentExchange\` |
| folder \`src/domain/BotNexus.Domain/Conversations/\` | \`src/domain/BotNexus.Domain/AgentExchange/\` |

No behaviour change — rename only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>