### PR TITLE
refactor(cli): replace --path/--dev with --source and --target

### DIFF
--- a/src/gateway/BotNexus.Cli/CliPaths.cs
+++ b/src/gateway/BotNexus.Cli/CliPaths.cs
@@ -1,0 +1,31 @@
+namespace BotNexus.Cli;
+
+/// <summary>
+/// Canonical path resolution for CLI source and target directories.
+/// </summary>
+internal static class CliPaths
+{
+    /// <summary>
+    /// Default source (repo) location: ~/botnexus
+    /// </summary>
+    public static string DefaultSource => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "botnexus");
+
+    /// <summary>
+    /// Default target (runtime home) location: ~/.botnexus
+    /// </summary>
+    public static string DefaultTarget => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".botnexus");
+
+    /// <summary>
+    /// Resolve the source directory. Explicit path wins; otherwise DefaultSource.
+    /// </summary>
+    public static string ResolveSource(string? explicitSource) =>
+        string.IsNullOrWhiteSpace(explicitSource) ? DefaultSource : explicitSource;
+
+    /// <summary>
+    /// Resolve the target (BotNexus home) directory. Explicit path wins; otherwise DefaultTarget.
+    /// </summary>
+    public static string ResolveTarget(string? explicitTarget) =>
+        string.IsNullOrWhiteSpace(explicitTarget) ? DefaultTarget : explicitTarget;
+}

--- a/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
@@ -21,62 +21,77 @@ internal sealed class GatewayCommand
     {
         var command = new Command("gateway", "Manage the BotNexus Gateway lifecycle");
 
-        // Common options
+        // Common options for start/restart
         var portOption = new Option<int>("--port", () => 5005, "Port to listen on.");
-        var pathOption = new Option<string?>("--path", () => null, "Path to the repository root. Defaults to the current directory.");
-        var devOption = new Option<bool>("--dev", "Serve from a development repo clone instead of the install location.");
+        var sourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         // Start command
         var attachedOption = new Option<bool>("--attached", "Run in foreground instead of detached mode.");
         var startCommand = new Command("start", "Start the gateway process")
         {
             portOption,
-            pathOption,
-            devOption,
+            sourceOption,
+            targetOption,
             attachedOption
         };
         startCommand.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(portOption);
-            var path = context.ParseResult.GetValueForOption(pathOption);
-            var dev = context.ParseResult.GetValueForOption(devOption);
+            var source = context.ParseResult.GetValueForOption(sourceOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var attached = context.ParseResult.GetValueForOption(attachedOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var repoRoot = BuildCommand.ResolveRepoRoot(path, dev);
-            context.ExitCode = await StartAsync(repoRoot, port, attached, verbose, context.GetCancellationToken());
+            var repoRoot = CliPaths.ResolveSource(source);
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = await StartAsync(repoRoot, home, port, attached, verbose, context.GetCancellationToken());
         });
 
         // Stop command
-        var stopCommand = new Command("stop", "Stop the gateway process");
+        var stopTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
+        var stopCommand = new Command("stop", "Stop the gateway process")
+        {
+            stopTargetOption
+        };
         stopCommand.SetHandler(async context =>
         {
+            var target = context.ParseResult.GetValueForOption(stopTargetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await StopAsync(verbose, context.GetCancellationToken());
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = await StopAsync(home, verbose, context.GetCancellationToken());
         });
 
         // Status command
-        var statusCommand = new Command("status", "Check gateway process status");
+        var statusTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
+        var statusCommand = new Command("status", "Check gateway process status")
+        {
+            statusTargetOption
+        };
         statusCommand.SetHandler(async context =>
         {
+            var target = context.ParseResult.GetValueForOption(statusTargetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await StatusAsync(verbose, context.GetCancellationToken());
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = await StatusAsync(home, verbose, context.GetCancellationToken());
         });
 
         // Restart command
+        var restartTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
         var restartCommand = new Command("restart", "Restart the gateway process")
         {
             portOption,
-            pathOption,
-            devOption
+            sourceOption,
+            restartTargetOption
         };
         restartCommand.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(portOption);
-            var path = context.ParseResult.GetValueForOption(pathOption);
-            var dev = context.ParseResult.GetValueForOption(devOption);
+            var source = context.ParseResult.GetValueForOption(sourceOption);
+            var target = context.ParseResult.GetValueForOption(restartTargetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var repoRoot = BuildCommand.ResolveRepoRoot(path, dev);
-            context.ExitCode = await RestartAsync(repoRoot, port, verbose, context.GetCancellationToken());
+            var repoRoot = CliPaths.ResolveSource(source);
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = await RestartAsync(repoRoot, home, port, verbose, context.GetCancellationToken());
         });
 
         command.AddCommand(startCommand);
@@ -87,15 +102,13 @@ internal sealed class GatewayCommand
         return command;
     }
 
-    private async Task<int> StartAsync(string repoRoot, int port, bool attached, bool verbose, CancellationToken cancellationToken)
+    private async Task<int> StartAsync(string repoRoot, string home, int port, bool attached, bool verbose, CancellationToken cancellationToken)
     {
-        // If attached mode, delegate to the old foreground behavior
         if (attached)
         {
-            return await StartAttachedAsync(repoRoot, port, verbose, cancellationToken);
+            return await StartAttachedAsync(repoRoot, home, port, verbose, cancellationToken);
         }
 
-        // Build the solution first
         var buildResult = await BuildCommand.BuildSolutionAsync(repoRoot, verbose, cancellationToken);
         if (buildResult != 0)
             return buildResult;
@@ -108,11 +121,10 @@ internal sealed class GatewayCommand
             return 1;
         }
 
-        // Auto-initialize ~/.botnexus/ with a default config if none exists
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
+        var configPath = Path.Combine(home, "config.json");
         if (!File.Exists(configPath))
         {
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found — creating default config...");
+            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found \u2014 creating default config...");
             var init = new InitCommand();
             var initResult = await init.ExecuteAsync(force: false, verbose, cancellationToken);
             if (initResult != 0)
@@ -121,10 +133,8 @@ internal sealed class GatewayCommand
             AnsiConsole.WriteLine();
         }
 
-        // Deploy extensions
-        ServeCommand.DeployExtensions(repoRoot, verbose);
+        ServeCommand.DeployExtensions(repoRoot, home, verbose);
 
-        // Start the gateway using the process manager
         var gatewayUrl = $"http://localhost:{port}";
         var options = new GatewayStartOptions(
             ExecutablePath: gatewayDll,
@@ -136,12 +146,10 @@ internal sealed class GatewayCommand
 
         if (result.Success && result.Pid.HasValue)
         {
-            var logsPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                ".botnexus", "logs", "gateway.log");
+            var logsPath = Path.Combine(home, "logs", "gateway.log");
 
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[green]✓[/] Gateway started (PID [yellow]{result.Pid.Value}[/])");
+            AnsiConsole.MarkupLine($"[green]\u2713[/] Gateway started (PID [yellow]{result.Pid.Value}[/])");
             AnsiConsole.MarkupLine($"  URL:  [green]{Markup.Escape(gatewayUrl)}[/]");
             AnsiConsole.MarkupLine($"  Logs: [dim]{Markup.Escape(logsPath)}[/]");
             AnsiConsole.MarkupLine($"  Stop: [dim]botnexus gateway stop[/]");
@@ -150,14 +158,13 @@ internal sealed class GatewayCommand
         }
         else
         {
-            AnsiConsole.MarkupLine($"[red]✗[/] Failed to start gateway: {Markup.Escape(result.Message ?? "Unknown error")}");
+            AnsiConsole.MarkupLine($"[red]\u2717[/] Failed to start gateway: {Markup.Escape(result.Message ?? "Unknown error")}");
             return 1;
         }
     }
 
-    private async Task<int> StartAttachedAsync(string repoRoot, int port, bool verbose, CancellationToken cancellationToken)
+    private async Task<int> StartAttachedAsync(string repoRoot, string home, int port, bool verbose, CancellationToken cancellationToken)
     {
-        // This is the original foreground behavior from ServeCommand
         var buildResult = await BuildCommand.BuildSolutionAsync(repoRoot, verbose, cancellationToken);
         if (buildResult != 0)
             return buildResult;
@@ -170,11 +177,10 @@ internal sealed class GatewayCommand
             return 1;
         }
 
-        // Auto-initialize ~/.botnexus/ with a default config if none exists
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
+        var configPath = Path.Combine(home, "config.json");
         if (!File.Exists(configPath))
         {
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found — creating default config...");
+            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found \u2014 creating default config...");
             var init = new InitCommand();
             var initResult = await init.ExecuteAsync(force: false, verbose, cancellationToken);
             if (initResult != 0)
@@ -189,7 +195,7 @@ internal sealed class GatewayCommand
             return 1;
         }
 
-        ServeCommand.DeployExtensions(repoRoot, verbose);
+        ServeCommand.DeployExtensions(repoRoot, home, verbose);
 
         var gatewayUrl = $"http://localhost:{port}";
         var lastExitCode = 0;
@@ -211,6 +217,7 @@ internal sealed class GatewayCommand
             };
             psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
             psi.Environment["ASPNETCORE_URLS"] = gatewayUrl;
+            psi.Environment["BOTNEXUS_HOME"] = home;
 
             using var process = System.Diagnostics.Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start Gateway process.");
@@ -231,30 +238,30 @@ internal sealed class GatewayCommand
         return lastExitCode;
     }
 
-    private async Task<int> StopAsync(bool verbose, CancellationToken cancellationToken)
+    private async Task<int> StopAsync(string home, bool verbose, CancellationToken cancellationToken)
     {
         var result = await _processManager.StopAsync(cancellationToken);
 
         if (result.Success)
         {
-            AnsiConsole.MarkupLine($"[green]✓[/] {Markup.Escape(result.Message ?? "Gateway stopped")}");
+            AnsiConsole.MarkupLine($"[green]\u2713[/] {Markup.Escape(result.Message ?? "Gateway stopped")}");
             return 0;
         }
         else
         {
-            AnsiConsole.MarkupLine($"[red]✗[/] {Markup.Escape(result.Message ?? "Failed to stop gateway")}");
+            AnsiConsole.MarkupLine($"[red]\u2717[/] {Markup.Escape(result.Message ?? "Failed to stop gateway")}");
             return 1;
         }
     }
 
-    private async Task<int> StatusAsync(bool verbose, CancellationToken cancellationToken)
+    private async Task<int> StatusAsync(string home, bool verbose, CancellationToken cancellationToken)
     {
         var status = await _processManager.GetStatusAsync(cancellationToken);
 
         switch (status.State)
         {
             case GatewayState.Running when status.Pid.HasValue:
-                AnsiConsole.MarkupLine($"[green]●[/] Gateway is running");
+                AnsiConsole.MarkupLine($"[green]\u25cf[/] Gateway is running");
                 AnsiConsole.MarkupLine($"  PID:    [yellow]{status.Pid.Value}[/]");
                 if (status.Uptime.HasValue)
                 {
@@ -263,7 +270,7 @@ internal sealed class GatewayCommand
                 return 0;
 
             case GatewayState.NotRunning:
-                AnsiConsole.MarkupLine("[dim]●[/] Gateway is not running");
+                AnsiConsole.MarkupLine("[dim]\u25cf[/] Gateway is not running");
                 if (verbose && !string.IsNullOrWhiteSpace(status.Message))
                 {
                     AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(status.Message)}[/]");
@@ -271,7 +278,7 @@ internal sealed class GatewayCommand
                 return 0;
 
             case GatewayState.Unknown:
-                AnsiConsole.MarkupLine($"[yellow]●[/] Gateway state is unknown");
+                AnsiConsole.MarkupLine($"[yellow]\u25cf[/] Gateway state is unknown");
                 if (!string.IsNullOrWhiteSpace(status.Message))
                 {
                     AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(status.Message)}[/]");
@@ -279,22 +286,21 @@ internal sealed class GatewayCommand
                 return 1;
 
             default:
-                AnsiConsole.MarkupLine("[yellow]●[/] Gateway state is unknown");
+                AnsiConsole.MarkupLine("[yellow]\u25cf[/] Gateway state is unknown");
                 return 1;
         }
     }
 
-    private async Task<int> RestartAsync(string repoRoot, int port, bool verbose, CancellationToken cancellationToken)
+    private async Task<int> RestartAsync(string repoRoot, string home, int port, bool verbose, CancellationToken cancellationToken)
     {
         AnsiConsole.MarkupLine("[blue][[gateway]][/] Stopping gateway...");
-        var stopResult = await StopAsync(verbose, cancellationToken);
+        await StopAsync(home, verbose, cancellationToken);
 
-        // Wait a moment for cleanup
         await Task.Delay(1000, cancellationToken);
 
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[blue][[gateway]][/] Starting gateway...");
-        return await StartAsync(repoRoot, port, attached: false, verbose, cancellationToken);
+        return await StartAsync(repoRoot, home, port, attached: false, verbose, cancellationToken);
     }
 
     private static string FormatUptime(TimeSpan uptime)

--- a/src/gateway/BotNexus.Cli/Commands/InstallCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InstallCommand.cs
@@ -10,10 +10,10 @@ internal sealed class InstallCommand
 
     public Command Build(Option<bool> verboseOption)
     {
-        var pathOption = new Option<string?>(
-            "--path",
+        var sourceOption = new Option<string?>(
+            "--source",
             () => null,
-            "Target directory for the clone. Defaults to USERPROFILE/botnexus.");
+            "Directory to clone into. Defaults to ~/botnexus.");
 
         var repoOption = new Option<string>(
             "--repo",
@@ -26,28 +26,26 @@ internal sealed class InstallCommand
 
         var command = new Command("install", "Clone the BotNexus repository and optionally build it.")
         {
-            pathOption,
+            sourceOption,
             repoOption,
             buildOption
         };
 
         command.SetHandler(async context =>
         {
-            var path = context.ParseResult.GetValueForOption(pathOption);
+            var source = context.ParseResult.GetValueForOption(sourceOption);
             var repo = context.ParseResult.GetValueForOption(repoOption)!;
             var build = context.ParseResult.GetValueForOption(buildOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteAsync(path, repo, build, verbose, context.GetCancellationToken());
+            context.ExitCode = await ExecuteAsync(source, repo, build, verbose, context.GetCancellationToken());
         });
 
         return command;
     }
 
-    private static async Task<int> ExecuteAsync(string? path, string repo, bool build, bool verbose, CancellationToken cancellationToken)
+    private static async Task<int> ExecuteAsync(string? source, string repo, bool build, bool verbose, CancellationToken cancellationToken)
     {
-        var targetPath = path ?? Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            "botnexus");
+        var targetPath = CliPaths.ResolveSource(source);
 
         if (Directory.Exists(Path.Combine(targetPath, ".git")))
         {

--- a/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
@@ -2,7 +2,6 @@ using System.CommandLine;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Text.Json;
-using BotNexus.Gateway.Configuration;
 using Spectre.Console;
 
 namespace BotNexus.Cli.Commands;
@@ -22,48 +21,46 @@ internal sealed class ServeCommand
         var gatewayCommand = _gatewayCommand.Build(verboseOption);
 
         var probePortOption = new Option<int>("--port", () => 5050, "Port for the Probe web UI.");
-        var probeRepoOption = new Option<string?>("--path", () => null, "Path to the repository root. Defaults to the current directory.");
-        var probeDevOption = new Option<bool>("--dev", "Serve from a development repo clone instead of the install location.");
+        var probeSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
         var gatewayUrlOption = new Option<string>("--gateway-url", () => "http://localhost:5005", "URL of a running BotNexus Gateway.");
 
         var probeCommand = new Command("probe", "Start the BotNexus Probe diagnostic tool.")
         {
             probePortOption,
-            probeRepoOption,
-            probeDevOption,
+            probeSourceOption,
             gatewayUrlOption
         };
         probeCommand.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(probePortOption);
-            var path = context.ParseResult.GetValueForOption(probeRepoOption);
-            var dev = context.ParseResult.GetValueForOption(probeDevOption);
+            var source = context.ParseResult.GetValueForOption(probeSourceOption);
             var gatewayUrl = context.ParseResult.GetValueForOption(gatewayUrlOption)!;
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var repoRoot = BuildCommand.ResolveRepoRoot(path, dev);
+            var repoRoot = CliPaths.ResolveSource(source);
             context.ExitCode = await ServeProbeAsync(repoRoot, port, gatewayUrl, verbose, context.GetCancellationToken());
         });
 
         // serve (default = gateway)
         var servePortOption = new Option<int>("--port", () => 5005, "Port to listen on.");
-        var serveRepoOption = new Option<string?>("--path", () => null, "Path to the repository root. Defaults to the current directory.");
-        var serveDevOption = new Option<bool>("--dev", "Serve from a development repo clone instead of the install location.");
+        var serveSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
+        var serveTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         var command = new Command("serve", "Start a BotNexus service. Defaults to the gateway.")
         {
             servePortOption,
-            serveRepoOption,
-            serveDevOption
+            serveSourceOption,
+            serveTargetOption
         };
 
         command.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(servePortOption);
-            var path = context.ParseResult.GetValueForOption(serveRepoOption);
-            var dev = context.ParseResult.GetValueForOption(serveDevOption);
+            var source = context.ParseResult.GetValueForOption(serveSourceOption);
+            var target = context.ParseResult.GetValueForOption(serveTargetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var repoRoot = BuildCommand.ResolveRepoRoot(path, dev);
-            context.ExitCode = await ServeGatewayAsync(repoRoot, port, verbose, context.GetCancellationToken());
+            var repoRoot = CliPaths.ResolveSource(source);
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = await ServeGatewayAsync(repoRoot, home, port, verbose, context.GetCancellationToken());
         });
 
         command.AddCommand(gatewayCommand);
@@ -72,7 +69,7 @@ internal sealed class ServeCommand
         return command;
     }
 
-    private static async Task<int> ServeGatewayAsync(string repoRoot, int port, bool verbose, CancellationToken cancellationToken)
+    private static async Task<int> ServeGatewayAsync(string repoRoot, string home, int port, bool verbose, CancellationToken cancellationToken)
     {
         var buildResult = await BuildCommand.BuildSolutionAsync(repoRoot, verbose, cancellationToken);
         if (buildResult != 0)
@@ -86,11 +83,11 @@ internal sealed class ServeCommand
             return 1;
         }
 
-        // Auto-initialize ~/.botnexus/ with a default config if none exists
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
+        // Auto-initialize home with a default config if none exists
+        var configPath = Path.Combine(home, "config.json");
         if (!File.Exists(configPath))
         {
-            AnsiConsole.MarkupLine("[blue][[serve]][/] No configuration found — creating default config...");
+            AnsiConsole.MarkupLine("[blue][[serve]][/] No configuration found \u2014 creating default config...");
             var init = new InitCommand();
             var initResult = await init.ExecuteAsync(force: false, verbose, cancellationToken);
             if (initResult != 0)
@@ -105,7 +102,7 @@ internal sealed class ServeCommand
             return 1;
         }
 
-        DeployExtensions(repoRoot, verbose);
+        DeployExtensions(repoRoot, home, verbose);
 
         var gatewayUrl = $"http://localhost:{port}";
         var lastExitCode = 0;
@@ -127,6 +124,7 @@ internal sealed class ServeCommand
             };
             psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
             psi.Environment["ASPNETCORE_URLS"] = gatewayUrl;
+            psi.Environment["BOTNEXUS_HOME"] = home;
 
             using var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start Gateway process.");
@@ -193,10 +191,10 @@ internal sealed class ServeCommand
     }
 
     /// <summary>
-    /// Deploys built extensions from the repository to ~/.botnexus/extensions.
+    /// Deploys built extensions from the repository to {home}/extensions.
     /// Public to allow GatewayCommand to use it.
     /// </summary>
-    public static void DeployExtensions(string repoRoot, bool verbose)
+    public static void DeployExtensions(string repoRoot, string home, bool verbose)
     {
         var extensionsRoot = Path.Combine(repoRoot, "src", "extensions");
         if (!Directory.Exists(extensionsRoot))
@@ -206,9 +204,7 @@ internal sealed class ServeCommand
             return;
         }
 
-        var destRoot = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".botnexus", "extensions");
+        var destRoot = Path.Combine(home, "extensions");
 
         var projects = Directory.GetFiles(extensionsRoot, "*.csproj", SearchOption.AllDirectories);
         var deployed = 0;


### PR DESCRIPTION
## Summary

`--path` meant different things on different commands (repo root vs clone destination). `--dev` was opaque. Neither allowed specifying where BotNexus runs from.

## New options

| Option | Where | Default | Replaces |
|--------|-------|---------|---------|
| `--source` | `build`, `serve`, `gateway start/restart`, `install` | `~/botnexus` | `--path` + `--dev` |
| `--target` | `gateway start/stop/status/restart`, `serve` | `~/.botnexus` | hardcoded paths |

## Changes

- New `CliPaths` helper with `DefaultSource`, `DefaultTarget`, `ResolveSource`, `ResolveTarget`
- `BuildCommand`: `--source` replaces `--path`/`--dev`; removed `ResolveRepoRoot` and `DefaultInstallPath`
- `GatewayCommand`: `--source` on start/restart; `--target` on all subcommands; passes `BOTNEXUS_HOME` env var
- `ServeCommand`: `--source`/`--target` replace `--path`/`--dev`; `DeployExtensions` takes `home` param
- `InstallCommand`: `--path` → `--source` (clone destination)
- `GatewayProcessManager`: accepts optional `homePath` ctor param, falls back to `BOTNEXUS_HOME` env var

## Tests

- `dotnet build BotNexus.slnx` — 0 errors
- `dotnet test BotNexus.slnx` — 0 failures (full suite)