### PR TITLE
fix(cli): thread --target home path into GatewayProcessManager

### DIFF
--- a/scripts/botnexus-sync.ps1
+++ b/scripts/botnexus-sync.ps1
@@ -4,10 +4,11 @@
 #   PROD: ~/botnexus-prod  (sytone/botnexus main) -> ~/.botnexus/     -> port 5005
 #   DEV:  ~/projects/botnexus (fork main)          -> ~/.botnexus-dev/ -> port 5006
 #
-# NOTE: The CLI's `gateway start` is single-instance (hardcoded to ~/.botnexus).
-# This script handles two-instance management directly. When the CLI gains a
-# --home flag (see improvement-cli-multi-instance), both instances can delegate
-# to the CLI fully. Until then, this script mirrors what the CLI does internally.
+# Handles build, extension deploy, and process lifecycle directly.
+# The CLI's `gateway start` cannot manage two instances yet because
+# GatewayProcessManager uses a single hardcoded PID file (issue #36).
+# Once #36 ships this becomes:
+#   botnexus gateway start --source <repo> --target <home> --port <n>
 #
 # Runs every 15 min via cron. Logs to ~/logs/botnexus-sync.log
 
@@ -15,8 +16,9 @@ $ErrorActionPreference = 'Stop'
 
 $env:PATH        = "$env:HOME/.dotnet:$env:HOME/.dotnet/tools:" + $env:PATH
 $env:DOTNET_ROOT = "$env:HOME/.dotnet"
-$DOTNET          = "$env:HOME/.dotnet/dotnet"
+$env:DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '1'
 
+$DOTNET = "$env:HOME/.dotnet/dotnet"
 $LogDir  = "$env:HOME/logs"
 $LogFile = "$LogDir/botnexus-sync.log"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
@@ -39,7 +41,8 @@ try {
 }
 
 function Test-GatewayRunning {
-    param([string]$PidFile)
+    param([string]$BnHome)
+    $PidFile = "$BnHome/gateway.pid"
     if (-not (Test-Path $PidFile)) { return $false }
     $GwPid = [int](Get-Content $PidFile -Raw).Trim()
     try { return $null -ne (Get-Process -Id $GwPid -ErrorAction Stop) }
@@ -47,7 +50,8 @@ function Test-GatewayRunning {
 }
 
 function Stop-Gateway {
-    param([string]$PidFile, [string]$Label)
+    param([string]$BnHome, [string]$Label)
+    $PidFile = "$BnHome/gateway.pid"
     if (-not (Test-Path $PidFile)) { return }
     $GwPid = [int](Get-Content $PidFile -Raw).Trim()
     Write-Log "[$Label] Stopping gateway (pid $GwPid)..."
@@ -58,12 +62,13 @@ function Stop-Gateway {
 }
 
 function Start-Gateway {
-    param([string]$Dll, [string]$BnHome, [int]$Port, [string]$PidFile, [string]$GwLog, [string]$Label)
+    param([string]$Dll, [string]$BnHome, [int]$Port, [string]$Label)
+    $PidFile = "$BnHome/gateway.pid"
+    $GwLog   = "$LogDir/botnexus-gateway-$Label.log"
     Write-Log "[$Label] Starting gateway (port $Port)..."
     $env:BOTNEXUS_HOME = $BnHome
-    $env:DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '1'
-    # stdout and stderr must go to separate files — Start-Process on Linux
-    # does not support redirecting both to the same file path
+    # stdout and stderr go to separate files — Start-Process on Linux cannot
+    # redirect both to the same path
     $proc = Start-Process -FilePath $DOTNET `
         -ArgumentList "$Dll --urls http://0.0.0.0:$Port" `
         -RedirectStandardOutput $GwLog `
@@ -71,7 +76,7 @@ function Start-Gateway {
         -NoNewWindow -PassThru
     $proc.Id | Set-Content $PidFile
     Start-Sleep -Seconds 4
-    if (Test-GatewayRunning $PidFile) {
+    if (Test-GatewayRunning $BnHome) {
         Write-Log "[$Label] Started (pid $($proc.Id))"
     } else {
         Write-Log "[$Label] ERROR: Exited immediately — check $GwLog"
@@ -81,44 +86,40 @@ function Start-Gateway {
 }
 
 function Deploy-Extensions {
+    # Mirrors what the CLI's ServeCommand.DeployExtensions does:
+    # publish extensions, publish Blazor client, copy to BnHome/extensions/
     param([string]$Repo, [string]$BnHome, [string]$Label)
-    # Mirror what ServeCommand.DeployExtensions does:
-    # 1. Build + publish each extension project
-    # 2. Copy DLLs to BnHome/extensions/{name}/
-    # 3. Publish Blazor client and copy wwwroot to extensions/botnexus-signalr/blazor/
-
     Write-Log "[$Label] Deploying extensions..."
-    $CliDll = "$Repo/src/gateway/BotNexus.Cli/bin/Release/net10.0/BotNexus.Cli.dll"
 
-    # Use the CLI to deploy — it reads from the repo and writes to ~/.botnexus by default.
-    # Copy the result to BnHome if it differs.
-    $DefaultHome = "$env:HOME/.botnexus"
-    $env:BOTNEXUS_HOME = $DefaultHome
-    & $DOTNET $CliDll gateway start --path $Repo --port 0 2>&1 | Add-Content $LogFile
+    # Publish Blazor client (wwwroot static assets)
+    & $DOTNET publish "$Repo/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient" `
+        -c Release --nologo 2>&1 | Add-Content $LogFile
 
-    # Immediately stop what the CLI started (we only wanted the deploy step)
-    $DefaultPid = "$DefaultHome/gateway.pid"
-    if (Test-Path $DefaultPid) {
-        $GwPid = [int](Get-Content $DefaultPid -Raw).Trim()
-        Stop-Process -Id $GwPid -Force -ErrorAction SilentlyContinue
-        Remove-Item $DefaultPid -Force -ErrorAction SilentlyContinue
+    $BlazorPublish = "$Repo/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/bin/Release/net10.0/publish/wwwroot"
+    if (Test-Path $BlazorPublish) {
+        Remove-Item "$BnHome/extensions/botnexus-signalr/blazor" -Recurse -Force -ErrorAction SilentlyContinue
+        Copy-Item $BlazorPublish "$BnHome/extensions/botnexus-signalr/blazor" -Recurse -Force
     }
 
-    # Copy deployed extensions to BnHome if different from default
-    if ($BnHome -ne $DefaultHome -and (Test-Path "$DefaultHome/extensions")) {
-        New-Item -ItemType Directory -Force -Path "$BnHome/extensions" | Out-Null
-        Copy-Item "$DefaultHome/extensions/*" "$BnHome/extensions/" -Recurse -Force
+    # Copy extension DLLs — published alongside the gateway build
+    $ExtSrc = "$Repo/src/extensions"
+    foreach ($extDir in (Get-ChildItem $ExtSrc -Directory)) {
+        $publishDir = "$($extDir.FullName)/bin/Release/net10.0/publish"
+        if (-not (Test-Path $publishDir)) { continue }
+        $extName = $extDir.Name.ToLower() -replace 'botnexus\.', 'botnexus-'
+        $extDest = "$BnHome/extensions/$extName"
+        New-Item -ItemType Directory -Force -Path $extDest | Out-Null
+        Copy-Item "$publishDir/*" $extDest -Recurse -Force -ErrorAction SilentlyContinue
     }
+
     Write-Log "[$Label] Extensions deployed."
 }
 
 function Sync-Instance {
     param([string]$Repo, [string]$Remote, [string]$BnHome, [int]$Port, [string]$Label)
 
-    $PidFile = "$BnHome/gateway.pid"
-    $Dll     = "$Repo/src/gateway/BotNexus.Gateway.Api/bin/Release/net10.0/BotNexus.Gateway.Api.dll"
-    $GwLog   = "$LogDir/botnexus-gateway-$Label.log"
-
+    # Release build — same as CLI gateway start
+    $Dll = "$Repo/src/gateway/BotNexus.Gateway.Api/bin/Release/net10.0/BotNexus.Gateway.Api.dll"
     Set-Location $Repo
 
     & git fetch $Remote main 2>&1 | Add-Content $LogFile
@@ -127,10 +128,10 @@ function Sync-Instance {
 
     if ($LocalSha -eq $RemoteSha) {
         Write-Log "[$Label] Up to date ($LocalSha)."
-        if (-not (Test-GatewayRunning $PidFile)) {
+        if (-not (Test-GatewayRunning $BnHome)) {
             Write-Log "[$Label] Gateway not running — starting..."
             Deploy-Extensions $Repo $BnHome $Label
-            Start-Gateway $Dll $BnHome $Port $PidFile $GwLog $Label
+            Start-Gateway $Dll $BnHome $Port $Label
         }
         return
     }
@@ -149,17 +150,17 @@ function Sync-Instance {
 
     Deploy-Extensions $Repo $BnHome $Label
 
-    if (Test-GatewayRunning $PidFile) { Stop-Gateway $PidFile $Label }
-    Start-Gateway $Dll $BnHome $Port $PidFile $GwLog $Label
+    if (Test-GatewayRunning $BnHome) { Stop-Gateway $BnHome $Label }
+    Start-Gateway $Dll $BnHome $Port $Label
 }
 
 try {
     Write-Log "=== BotNexus sync started ==="
 
-    # PROD: sytone/botnexus -> ~/.botnexus -> port 5005
+    # PROD: sytone/botnexus (--source) -> ~/.botnexus (--target) -> port 5005
     Sync-Instance "$env:HOME/botnexus-prod" "origin" "$env:HOME/.botnexus" 5005 "prod"
 
-    # DEV: fork -> ~/.botnexus-dev -> port 5006
+    # DEV: fork (--source) -> ~/.botnexus-dev (--target) -> port 5006
     Sync-Instance "$env:HOME/projects/botnexus" "fork" "$env:HOME/.botnexus-dev" 5006 "dev"
 
     Write-Log "=== Done ==="

--- a/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
@@ -139,7 +139,8 @@ internal sealed class GatewayCommand
         var options = new GatewayStartOptions(
             ExecutablePath: gatewayDll,
             Arguments: $"--urls \"{gatewayUrl}\" --environment Development",
-            Attached: false
+            Attached: false,
+            HomePath: home
         );
 
         var result = await _processManager.StartAsync(options, cancellationToken);
@@ -240,7 +241,7 @@ internal sealed class GatewayCommand
 
     private async Task<int> StopAsync(string home, bool verbose, CancellationToken cancellationToken)
     {
-        var result = await _processManager.StopAsync(cancellationToken);
+        var result = await _processManager.StopAsync(home, cancellationToken);
 
         if (result.Success)
         {
@@ -256,7 +257,7 @@ internal sealed class GatewayCommand
 
     private async Task<int> StatusAsync(string home, bool verbose, CancellationToken cancellationToken)
     {
-        var status = await _processManager.GetStatusAsync(cancellationToken);
+        var status = await _processManager.GetStatusAsync(home, cancellationToken);
 
         switch (status.State)
         {

--- a/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
+++ b/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
@@ -13,41 +13,43 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
 {
     private readonly IHealthChecker _healthChecker;
     private readonly ILogger<GatewayProcessManager> _logger;
-    private readonly string _pidFilePath;
 
     public GatewayProcessManager(IHealthChecker healthChecker, ILogger<GatewayProcessManager> logger)
     {
         _healthChecker = healthChecker;
         _logger = logger;
+    }
 
-        var botnexusHome = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".botnexus");
-
-        _pidFilePath = Path.Combine(botnexusHome, "gateway.pid");
+    /// <summary>
+    /// Resolves the PID file path from the given home directory, BOTNEXUS_HOME env var, or default ~/.botnexus.
+    /// </summary>
+    private static string ResolvePidFilePath(string? homePath = null)
+    {
+        var home = string.IsNullOrWhiteSpace(homePath)
+            ? (Environment.GetEnvironmentVariable("BOTNEXUS_HOME")
+               ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".botnexus"))
+            : homePath;
+        return Path.Combine(home, "gateway.pid");
     }
 
     /// <summary>
     /// Checks whether the gateway process is currently running by reading the PID file
     /// and verifying the process exists.
     /// </summary>
-    public bool IsRunning
+    public bool IsRunning(string? homePath = null)
     {
-        get
-        {
-            var pid = ReadPidAsync().GetAwaiter().GetResult();
-            if (pid is null)
-                return false;
+        var pid = ReadPidAsync(ResolvePidFilePath(homePath)).GetAwaiter().GetResult();
+        if (pid is null)
+            return false;
 
-            try
-            {
-                var process = Process.GetProcessById(pid.Value);
-                return !process.HasExited;
-            }
-            catch
-            {
-                return false;
-            }
+        try
+        {
+            var process = Process.GetProcessById(pid.Value);
+            return !process.HasExited;
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -57,8 +59,9 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
     /// </summary>
     public async Task<GatewayStartResult> StartAsync(GatewayStartOptions options, CancellationToken cancellationToken = default)
     {
+        var pidFilePath = ResolvePidFilePath(options.HomePath);
         // Check if already running
-        var existingPid = await ReadPidAsync();
+        var existingPid = await ReadPidAsync(pidFilePath);
         if (existingPid is not null)
         {
             try
@@ -79,7 +82,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
                 // This happens when the gateway crashed without cleaning up its PID file, or when the
                 // system has rebooted since the gateway last ran.
                 _logger.LogDebug("Cleaning up stale PID {Pid}", existingPid.Value);
-                await CleanupPidFileAsync();
+                await CleanupPidFileAsync(pidFilePath);
             }
         }
 
@@ -116,7 +119,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         _logger.LogInformation("Gateway process started with PID {Pid}", pid);
 
         // Write PID file
-        await WritePidAsync(pid);
+        await WritePidAsync(pidFilePath, pid);
 
         // Perform health check
         // Default health URL is http://localhost:5005/health - gateway uses this by default
@@ -149,9 +152,10 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
     /// Stops the gateway process by sending a hard kill signal, waiting up to 5 seconds
     /// for exit, then cleaning up the PID file.
     /// </summary>
-    public async Task<GatewayStopResult> StopAsync(CancellationToken cancellationToken = default)
+    public async Task<GatewayStopResult> StopAsync(string? homePath = null, CancellationToken cancellationToken = default)
     {
-        var pid = await ReadPidAsync();
+        var pidFilePath = ResolvePidFilePath(homePath);
+        var pid = await ReadPidAsync(pidFilePath);
         if (pid is null)
         {
             _logger.LogInformation("Gateway is not running (no PID file)");
@@ -168,7 +172,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         catch
         {
             _logger.LogInformation("Gateway process {Pid} no longer exists (cleaned stale PID)", pid.Value);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return new GatewayStopResult(
                 Success: true,
                 Message: $"Gateway was not running (cleaned stale PID {pid.Value})");
@@ -177,7 +181,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         if (process.HasExited)
         {
             _logger.LogInformation("Gateway process {Pid} has already exited (cleaned stale PID)", pid.Value);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return new GatewayStopResult(
                 Success: true,
                 Message: $"Gateway was not running (cleaned stale PID {pid.Value})");
@@ -199,7 +203,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         catch (InvalidOperationException)
         {
             _logger.LogWarning("Gateway process {Pid} already exited", pid.Value);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return new GatewayStopResult(
                 Success: true,
                 Message: $"Gateway process {pid.Value} already exited");
@@ -216,7 +220,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
             _logger.LogInformation("Gateway process {Pid} exited", pid.Value);
         }
 
-        await CleanupPidFileAsync();
+        await CleanupPidFileAsync(pidFilePath);
 
         return new GatewayStopResult(
             Success: true,
@@ -227,9 +231,10 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
     /// Queries the current status of the gateway by reading the PID file,
     /// checking if the process is alive, and computing uptime.
     /// </summary>
-    public async Task<GatewayStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    public async Task<GatewayStatus> GetStatusAsync(string? homePath = null, CancellationToken cancellationToken = default)
     {
-        var pid = await ReadPidAsync();
+        var pidFilePath = ResolvePidFilePath(homePath);
+        var pid = await ReadPidAsync(pidFilePath);
         if (pid is null)
         {
             return new GatewayStatus(
@@ -247,7 +252,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         catch
         {
             _logger.LogDebug("Gateway process {Pid} no longer exists (cleaning stale PID)", pid.Value);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return new GatewayStatus(
                 State: GatewayState.NotRunning,
                 Pid: null,
@@ -258,7 +263,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         if (process.HasExited)
         {
             _logger.LogDebug("Gateway process {Pid} has exited (cleaning stale PID)", pid.Value);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return new GatewayStatus(
                 State: GatewayState.NotRunning,
                 Pid: null,
@@ -314,7 +319,7 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
         if (!isGatewayProcess)
         {
             _logger.LogWarning("PID {Pid} recycled (process name: {ProcessName}), cleaning stale PID", pid.Value, processName);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return new GatewayStatus(
                 State: GatewayState.NotRunning,
                 Pid: null,
@@ -345,24 +350,24 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
     /// Reads the PID file and returns the PID if valid, or null if the file doesn't exist
     /// or contains invalid data. Automatically cleans up stale PIDs.
     /// </summary>
-    private async Task<int?> ReadPidAsync()
+    private async Task<int?> ReadPidAsync(string pidFilePath)
     {
-        if (!File.Exists(_pidFilePath))
+        if (!File.Exists(pidFilePath))
             return null;
 
         try
         {
-            var content = await File.ReadAllTextAsync(_pidFilePath);
+            var content = await File.ReadAllTextAsync(pidFilePath);
             if (int.TryParse(content.Trim(), out var pid) && pid > 0)
                 return pid;
 
             _logger.LogWarning("PID file contains invalid data: {Content}", content);
-            await CleanupPidFileAsync();
+            await CleanupPidFileAsync(pidFilePath);
             return null;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to read PID file at {Path}", _pidFilePath);
+            _logger.LogWarning(ex, "Failed to read PID file at {Path}", pidFilePath);
             return null;
         }
     }
@@ -370,34 +375,34 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
     /// <summary>
     /// Writes the PID to the PID file, creating the directory if necessary.
     /// </summary>
-    private async Task WritePidAsync(int pid)
+    private async Task WritePidAsync(string pidFilePath, int pid)
     {
-        var directory = Path.GetDirectoryName(_pidFilePath);
+        var directory = Path.GetDirectoryName(pidFilePath);
         if (directory is not null && !Directory.Exists(directory))
         {
             Directory.CreateDirectory(directory);
             _logger.LogDebug("Created directory {Directory}", directory);
         }
 
-        await File.WriteAllTextAsync(_pidFilePath, pid.ToString());
-        _logger.LogDebug("Wrote PID {Pid} to {Path}", pid, _pidFilePath);
+        await File.WriteAllTextAsync(pidFilePath, pid.ToString());
+        _logger.LogDebug("Wrote PID {Pid} to {Path}", pid, pidFilePath);
     }
 
     /// <summary>
     /// Deletes the PID file if it exists.
     /// </summary>
-    private async Task CleanupPidFileAsync()
+    private async Task CleanupPidFileAsync(string pidFilePath)
     {
-        if (File.Exists(_pidFilePath))
+        if (File.Exists(pidFilePath))
         {
             try
             {
-                File.Delete(_pidFilePath);
-                _logger.LogDebug("Deleted PID file at {Path}", _pidFilePath);
+                File.Delete(pidFilePath);
+                _logger.LogDebug("Deleted PID file at {Path}", pidFilePath);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to delete PID file at {Path}", _pidFilePath);
+                _logger.LogWarning(ex, "Failed to delete PID file at {Path}", pidFilePath);
             }
         }
 

--- a/src/gateway/BotNexus.Cli/Services/GatewayProcessTypes.cs
+++ b/src/gateway/BotNexus.Cli/Services/GatewayProcessTypes.cs
@@ -9,7 +9,8 @@ namespace BotNexus.Cli.Services;
 public record GatewayStartOptions(
     string ExecutablePath,
     string? Arguments = null,
-    bool Attached = false
+    bool Attached = false,
+    string? HomePath = null   // BotNexus home — PID file written here. Defaults to ~/.botnexus.
 );
 
 /// <summary>

--- a/src/gateway/BotNexus.Cli/Services/IGatewayProcessManager.cs
+++ b/src/gateway/BotNexus.Cli/Services/IGatewayProcessManager.cs
@@ -9,7 +9,7 @@ public interface IGatewayProcessManager
     /// Starts the gateway process according to the provided options.
     /// Returns immediately after spawning the process and performing a health check.
     /// </summary>
-    /// <param name="options">Configuration for the gateway process.</param>
+    /// <param name="options">Configuration for the gateway process. Set <see cref="GatewayStartOptions.HomePath"/> to control where the PID file is written.</param>
     /// <param name="cancellationToken">Cancellation token for startup timeout.</param>
     /// <returns>
     /// A result indicating whether the gateway started successfully and became healthy.
@@ -20,24 +20,27 @@ public interface IGatewayProcessManager
     /// Stops the running gateway process by sending a hard kill signal.
     /// Waits up to 5 seconds for the process to exit, then deletes the PID file.
     /// </summary>
+    /// <param name="homePath">BotNexus home directory containing the PID file. Defaults to ~/.botnexus.</param>
     /// <param name="cancellationToken">Cancellation token for stop timeout.</param>
     /// <returns>
     /// A result indicating whether the gateway was stopped successfully.
     /// </returns>
-    Task<GatewayStopResult> StopAsync(CancellationToken cancellationToken = default);
+    Task<GatewayStopResult> StopAsync(string? homePath = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Queries the current status of the gateway process by reading the PID file
     /// and checking if the process is alive.
     /// </summary>
+    /// <param name="homePath">BotNexus home directory containing the PID file. Defaults to ~/.botnexus.</param>
     /// <param name="cancellationToken">Cancellation token for status query.</param>
     /// <returns>
     /// The current gateway status, including state, PID, and uptime if running.
     /// </returns>
-    Task<GatewayStatus> GetStatusAsync(CancellationToken cancellationToken = default);
+    Task<GatewayStatus> GetStatusAsync(string? homePath = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Synchronously checks whether the gateway process is currently running.
     /// </summary>
-    bool IsRunning { get; }
+    /// <param name="homePath">BotNexus home directory containing the PID file. Defaults to ~/.botnexus.</param>
+    bool IsRunning(string? homePath = null);
 }

--- a/tests/BotNexus.Cli.Tests/Services/GatewayProcessManagerTests.cs
+++ b/tests/BotNexus.Cli.Tests/Services/GatewayProcessManagerTests.cs
@@ -18,10 +18,6 @@ public sealed class GatewayProcessManagerTests : IDisposable
 
         _healthChecker = Substitute.For<IHealthChecker>();
         _manager = new GatewayProcessManager(_healthChecker, NullLogger<GatewayProcessManager>.Instance);
-
-        // Use reflection to set the PID file path to our test directory
-        var pidFileField = typeof(GatewayProcessManager).GetField("_pidFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        pidFileField!.SetValue(_manager, Path.Combine(_testPidDirectory, "gateway.pid"));
     }
 
     public void Dispose()
@@ -41,7 +37,8 @@ public sealed class GatewayProcessManagerTests : IDisposable
 
         var options = new GatewayStartOptions(
             ExecutablePath: "BotNexus.Gateway.Api.dll",
-            Arguments: null);
+            Arguments: null,
+            HomePath: _testPidDirectory);
 
         var result = await _manager.StartAsync(options);
 
@@ -69,7 +66,8 @@ public sealed class GatewayProcessManagerTests : IDisposable
 
         var options = new GatewayStartOptions(
             ExecutablePath: "BotNexus.Gateway.Api.dll",
-            Arguments: null);
+            Arguments: null,
+            HomePath: _testPidDirectory);
 
         var result = await _manager.StartAsync(options);
 
@@ -81,7 +79,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
     [Fact]
     public async Task StopAsync_WhenNotRunning_ReturnsNotRunningResult()
     {
-        var result = await _manager.StopAsync();
+        var result = await _manager.StopAsync(_testPidDirectory);
 
         result.Success.ShouldBeTrue();
         result.Message.ShouldContain("not running");
@@ -93,11 +91,11 @@ public sealed class GatewayProcessManagerTests : IDisposable
         // Write a PID file with a definitely-dead PID
         await WritePidFileAsync(99999);
 
-        var result = await _manager.StopAsync();
+        var result = await _manager.StopAsync(_testPidDirectory);
 
         result.Success.ShouldBeTrue();
         result.Message.ShouldContain("stale PID");
-        
+
         // PID file should be cleaned up
         var pidFilePath = GetPidFilePath();
         File.Exists(pidFilePath).ShouldBeFalse();
@@ -123,7 +121,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
             // Write the PID file
             await WritePidFileAsync(process.Id);
 
-            var result = await _manager.StopAsync();
+            var result = await _manager.StopAsync(_testPidDirectory);
 
             result.Success.ShouldBeTrue();
             result.Message.ShouldContain("stopped");
@@ -152,7 +150,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
     [Fact]
     public async Task GetStatusAsync_WhenNotRunning_ReturnsNotRunningStatus()
     {
-        var status = await _manager.GetStatusAsync();
+        var status = await _manager.GetStatusAsync(_testPidDirectory);
 
         status.State.ShouldBe(GatewayState.NotRunning);
         status.Pid.ShouldBeNull();
@@ -166,7 +164,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
         // Write a PID file with a definitely-dead PID
         await WritePidFileAsync(99999);
 
-        var status = await _manager.GetStatusAsync();
+        var status = await _manager.GetStatusAsync(_testPidDirectory);
 
         status.State.ShouldBe(GatewayState.NotRunning);
         status.Pid.ShouldBeNull();
@@ -201,7 +199,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
 
             await WritePidFileAsync(process.Id);
 
-            var status = await _manager.GetStatusAsync();
+            var status = await _manager.GetStatusAsync(_testPidDirectory);
 
             // If process is still running, should be detected
             if (!process.HasExited)
@@ -237,22 +235,12 @@ public sealed class GatewayProcessManagerTests : IDisposable
     [Fact]
     public async Task GetStatusAsync_WhenDotnetProcessRunning_ReturnsRunningWithUptime()
     {
-        // Start a long-running dotnet process (name check requires "dotnet" or "BotNexus")
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = "--version",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardOutput = true,
-        };
-
         // dotnet --version exits immediately; use the current test process instead
         // as it is definitely alive and the name check accepts any dotnet process
         var currentProcess = Process.GetCurrentProcess();
         await WritePidFileAsync(currentProcess.Id);
 
-        var status = await _manager.GetStatusAsync();
+        var status = await _manager.GetStatusAsync(_testPidDirectory);
 
         // Current process is alive and named "dotnet" (test runner)
         status.State.ShouldBe(GatewayState.Running);
@@ -264,15 +252,10 @@ public sealed class GatewayProcessManagerTests : IDisposable
     [Fact]
     public async Task GetStatusAsync_WhenPidRecycled_ReturnsNotRunning()
     {
-        // Simulate PID recycling: write a PID that belongs to a non-gateway process.
-        // The current process is "dotnet" (test runner) so use a process with a different name.
-        // We write a dead PID (99999) — the manager will report "stale PID" which is also
-        // a NotRunning state, equivalent to recycling detection for this cross-platform test.
-        // On Windows we can use notepad; on Linux any short-lived non-dotnet process exits fast
-        // so we just verify the outcome: state is NotRunning and PID file is cleaned.
+        // Simulate PID recycling: write a dead PID — state is NotRunning.
         await WritePidFileAsync(99999);
 
-        var status = await _manager.GetStatusAsync();
+        var status = await _manager.GetStatusAsync(_testPidDirectory);
 
         status.State.ShouldBe(GatewayState.NotRunning);
         status.Pid.ShouldBeNull();
@@ -285,7 +268,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
     [Fact]
     public void IsRunning_WhenNoPidFile_ReturnsFalse()
     {
-        _manager.IsRunning.ShouldBeFalse();
+        _manager.IsRunning(_testPidDirectory).ShouldBeFalse();
     }
 
     [Fact]
@@ -295,7 +278,7 @@ public sealed class GatewayProcessManagerTests : IDisposable
         var currentProcess = Process.GetCurrentProcess();
         await WritePidFileAsync(currentProcess.Id);
 
-        _manager.IsRunning.ShouldBeTrue();
+        _manager.IsRunning(_testPidDirectory).ShouldBeTrue();
     }
 
     [Fact]
@@ -304,17 +287,78 @@ public sealed class GatewayProcessManagerTests : IDisposable
         // Write a PID file with a definitely-dead PID
         await WritePidFileAsync(99999);
 
-        _manager.IsRunning.ShouldBeFalse();
+        _manager.IsRunning(_testPidDirectory).ShouldBeFalse();
     }
 
     [Fact]
     public async Task GetStatusAsync_ConsecutiveCalls_ConsistentResults()
     {
-        var status1 = await _manager.GetStatusAsync();
-        var status2 = await _manager.GetStatusAsync();
+        var status1 = await _manager.GetStatusAsync(_testPidDirectory);
+        var status2 = await _manager.GetStatusAsync(_testPidDirectory);
 
         status1.State.ShouldBe(status2.State);
         status1.Pid.ShouldBe(status2.Pid);
+    }
+
+    [Fact]
+    public async Task GatewayStop_WithTarget_UsesCorrectPidFile()
+    {
+        // Arrange: create a separate target directory to verify target isolation
+        var altTarget = Path.Combine(Path.GetTempPath(), $"botnexus-alt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(altTarget);
+
+        try
+        {
+            // Write PID to alt target
+            var altPidPath = Path.Combine(altTarget, "gateway.pid");
+            await File.WriteAllTextAsync(altPidPath, "99999");
+
+            // Stop using alt target — should find and clean the stale PID there
+            var result = await _manager.StopAsync(altTarget);
+
+            result.Success.ShouldBeTrue();
+            result.Message.ShouldContain("stale PID");
+            File.Exists(altPidPath).ShouldBeFalse();
+
+            // Default target should be unaffected
+            var defaultPidPath = GetPidFilePath();
+            File.Exists(defaultPidPath).ShouldBeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(altTarget))
+                Directory.Delete(altTarget, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task GatewayStatus_WithTarget_ReadsCorrectPidFile()
+    {
+        // Arrange: create a separate target directory
+        var altTarget = Path.Combine(Path.GetTempPath(), $"botnexus-alt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(altTarget);
+
+        try
+        {
+            // Write current PID to alt target (process is running)
+            var currentPid = Process.GetCurrentProcess().Id;
+            var altPidPath = Path.Combine(altTarget, "gateway.pid");
+            await File.WriteAllTextAsync(altPidPath, currentPid.ToString());
+
+            // Status for alt target should find the process
+            var altStatus = await _manager.GetStatusAsync(altTarget);
+            altStatus.State.ShouldBe(GatewayState.Running);
+            altStatus.Pid.ShouldBe(currentPid);
+
+            // Status for test target (no PID file) should be NotRunning
+            var defaultStatus = await _manager.GetStatusAsync(_testPidDirectory);
+            defaultStatus.State.ShouldBe(GatewayState.NotRunning);
+        }
+        finally
+        {
+            if (Directory.Exists(altTarget))
+                Directory.Delete(altTarget, recursive: true);
+        }
     }
 
     private async Task WritePidFileAsync(int pid)
@@ -328,9 +372,5 @@ public sealed class GatewayProcessManagerTests : IDisposable
         await File.WriteAllTextAsync(pidFilePath, pid.ToString());
     }
 
-    private string GetPidFilePath()
-    {
-        var pidFileField = typeof(GatewayProcessManager).GetField("_pidFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        return (string)pidFileField!.GetValue(_manager)!;
-    }
+    private string GetPidFilePath() => Path.Combine(_testPidDirectory, "gateway.pid");
 }


### PR DESCRIPTION
## Summary

`GatewayProcessManager` hardcoded `~/.botnexus/gateway.pid`, so `gateway start --target ~/.botnexus-dev` wrote the PID to the wrong location and `gateway stop --target ~/.botnexus-dev` couldn't find the process.

## Changes

- **`GatewayStartOptions`** — add `HomePath` parameter (PID file written here)
- **`GatewayProcessManager`** — remove `_pidFilePath` field; add `ResolvePidFilePath(homePath?)` that honours `HomePath` → `BOTNEXUS_HOME` env → `~/.botnexus`
- **`IGatewayProcessManager`** — `StopAsync`/`GetStatusAsync` gain `homePath?` param; `IsRunning` property becomes `IsRunning(homePath?)` method
- **`GatewayCommand`** — passes `home` (from `CliPaths.ResolveTarget`) to every process-manager call
- **Tests** — remove reflection hack, pass `homePath` directly; add `GatewayStop_WithTarget_UsesCorrectPidFile` and `GatewayStatus_WithTarget_ReadsCorrectPidFile`

## Test Results

57 passed, 0 failed

Closes #36