### PR TITLE
[Portal] Show gateway build info — restart time and commit SHA

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup>
+    <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">unknown</SourceRevisionId>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -1,6 +1,7 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
 @inject AgentSessionManager Manager
+@inject GatewayInfoService GatewayInfo
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -116,11 +117,25 @@
                 <a href="agents" class="sidebar-nav-item @NavClass("agents")" @onclick="OnNavClick">🤖 Agents</a>
             </nav>
 
-            @* Restart button at bottom *@
+            @* Restart button + build info at bottom *@
             <div class="sidebar-footer">
                 <button class="restart-btn" @onclick="RestartGateway" disabled="@_restarting">
                     @(_restarting ? "Restarting…" : "🔄 Restart Gateway")
                 </button>
+                @if (GatewayInfo.Info is not null)
+                {
+                    <div class="gateway-info">
+                        <span class="gateway-started" title="@GatewayInfo.Info.StartedAt.ToString("o")">
+                            ↺ @FormatStarted(GatewayInfo.Info.StartedAt)
+                        </span>
+                        <a class="gateway-commit"
+                           href="https://github.com/sytone/botnexus/commit/@GatewayInfo.Info.CommitSha"
+                           target="_blank"
+                           title="@GatewayInfo.Info.CommitSha">
+                            @GatewayInfo.Info.CommitShort
+                        </a>
+                    </div>
+                }
             </div>
         </aside>
 
@@ -141,6 +156,11 @@
     protected override void OnInitialized()
     {
         Manager.OnStateChanged += HandleStateChanged;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await GatewayInfo.LoadAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -209,6 +229,18 @@
     private void DismissAnnouncement(string id)
     {
         _announcements.RemoveAll(a => a.Id == id);
+    }
+
+    private static string FormatStarted(DateTimeOffset startedAt)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var local = startedAt.ToLocalTime();
+        var today = now.ToLocalTime().Date;
+        if (local.Date == today)
+            return $"today {local:HH:mm}";
+        if (local.Date == today.AddDays(-1))
+            return $"yesterday {local:HH:mm}";
+        return local.ToString("MMM d HH:mm");
     }
 
     private async Task RestartGateway()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -11,5 +11,6 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddScoped<GatewayHubConnection>();
 builder.Services.AddScoped<AgentSessionManager>();
 builder.Services.AddScoped<PlatformConfigService>();
+builder.Services.AddScoped<GatewayInfoService>();
 
 await builder.Build().RunAsync();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayInfoService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayInfoService.cs
@@ -1,0 +1,27 @@
+using System.Net.Http.Json;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+public sealed class GatewayInfoService
+{
+    private readonly HttpClient _http;
+    public GatewayInfo? Info { get; private set; }
+
+    public GatewayInfoService(HttpClient http) => _http = http;
+
+    public async Task LoadAsync()
+    {
+        try
+        {
+            Info = await _http.GetFromJsonAsync<GatewayInfo>("api/gateway/info");
+        }
+        catch { /* non-fatal — portal works without it */ }
+    }
+}
+
+public sealed record GatewayInfo(
+    DateTimeOffset StartedAt,
+    long UptimeSeconds,
+    string CommitSha,
+    string CommitShort,
+    string Version);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -2417,3 +2417,21 @@ details[open] > .thinking-summary::before {
     align-items: center;
     gap: 0.25rem;
 }
+
+/* ── Gateway build info (sidebar footer) ─────────────────────────────── */
+.gateway-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    padding-top: 0.4rem;
+}
+
+.gateway-commit {
+    font-family: monospace;
+    color: var(--text-muted);
+    text-decoration: none;
+}
+
+.gateway-commit:hover { color: var(--accent); }

--- a/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
+++ b/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
@@ -7,6 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>CommitSha</_Parameter1>
+      <_Parameter2>$(SourceRevisionId)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/GatewayController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/GatewayController.cs
@@ -21,6 +21,17 @@ public sealed class GatewayController(IHostApplicationLifetime lifetime) : Contr
     /// Executes shutdown.
     /// </summary>
     /// <returns>The shutdown result.</returns>
+    /// <summary>Returns runtime and build information about the running gateway.</summary>
+    [HttpGet("info")]
+    public IActionResult Info() => Ok(new
+    {
+        startedAt     = GatewayBuildInfo.StartedAt,
+        uptimeSeconds = (long)(DateTimeOffset.UtcNow - GatewayBuildInfo.StartedAt).TotalSeconds,
+        commitSha     = GatewayBuildInfo.CommitSha,
+        commitShort   = GatewayBuildInfo.CommitShort,
+        version       = GatewayBuildInfo.Version
+    });
+
     [HttpPost("shutdown")]
     public IActionResult Shutdown()
     {

--- a/src/gateway/BotNexus.Gateway.Api/GatewayBuildInfo.cs
+++ b/src/gateway/BotNexus.Gateway.Api/GatewayBuildInfo.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace BotNexus.Gateway.Api;
+
+/// <summary>
+/// Build and runtime information captured at startup.
+/// </summary>
+public static class GatewayBuildInfo
+{
+    /// <summary>When the gateway process started.</summary>
+    public static DateTimeOffset StartedAt { get; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Full commit SHA embedded at build time via AssemblyMetadata.</summary>
+    public static string CommitSha { get; } = typeof(GatewayBuildInfo).Assembly
+        .GetCustomAttributes<AssemblyMetadataAttribute>()
+        .FirstOrDefault(a => a.Key == "CommitSha")?.Value ?? "unknown";
+
+    /// <summary>Short commit SHA (first 7 chars).</summary>
+    public static string CommitShort => CommitSha.Length >= 7 ? CommitSha[..7] : CommitSha;
+
+    /// <summary>Assembly version.</summary>
+    public static string Version { get; } = typeof(GatewayBuildInfo).Assembly
+        .GetName().Version?.ToString() ?? "0.0.0";
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -26,6 +26,8 @@ public sealed class MainLayoutTests : IDisposable
 
         _ctx.Services.AddSingleton(_manager);
         _ctx.Services.AddSingleton(_manager.Hub);
+        _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddScoped<GatewayInfoService>();
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/BotNexus.Gateway.Tests/Api/GatewayBuildInfoTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Api/GatewayBuildInfoTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Text.Json;
+using BotNexus.Gateway.Api;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace BotNexus.Gateway.Tests.Api;
+
+public sealed class GatewayBuildInfoTests
+{
+    [Fact]
+    public void StartedAt_IsNotDefault()
+    {
+        GatewayBuildInfo.StartedAt.ShouldNotBe(default(DateTimeOffset));
+        GatewayBuildInfo.StartedAt.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+    }
+
+    [Fact]
+    public void CommitShort_IsSevenCharsOrFewer()
+    {
+        GatewayBuildInfo.CommitShort.Length.ShouldBeLessThanOrEqualTo(7);
+    }
+
+    [Fact]
+    public void CommitSha_IsNotNullOrEmpty()
+    {
+        GatewayBuildInfo.CommitSha.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Version_IsNotNullOrEmpty()
+    {
+        GatewayBuildInfo.Version.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task InfoEndpoint_Returns200WithExpectedFields()
+    {
+        await using var factory = CreateTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/gateway/info");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.TryGetProperty("startedAt", out _).ShouldBeTrue();
+        root.TryGetProperty("uptimeSeconds", out _).ShouldBeTrue();
+        root.TryGetProperty("commitSha", out var commitSha).ShouldBeTrue();
+        root.TryGetProperty("commitShort", out var commitShort).ShouldBeTrue();
+        root.TryGetProperty("version", out _).ShouldBeTrue();
+
+        commitSha.GetString().ShouldNotBeNullOrWhiteSpace();
+        commitShort.GetString()!.Length.ShouldBeLessThanOrEqualTo(7);
+    }
+
+    private static WebApplicationFactory<Program> CreateTestFactory()
+        => new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.UseUrls("http://127.0.0.1:0");
+                builder.ConfigureServices(services =>
+                {
+                    var hostedServices = services
+                        .Where(d => d.ServiceType == typeof(IHostedService))
+                        .ToList();
+                    foreach (var descriptor in hostedServices)
+                        services.Remove(descriptor);
+                });
+            });
+}


### PR DESCRIPTION
Closes #41

## What changed

### Gateway — new `GET /api/gateway/info` endpoint
- `GatewayBuildInfo` static class captures `StartedAt` at process startup
- Commit SHA embedded at build time via `SourceRevisionId` → `AssemblyMetadata` (no git CLI at runtime)
- Returns: `startedAt`, `uptimeSeconds`, `commitSha`, `commitShort`, `version`

### Portal — sidebar footer
- `GatewayInfoService` fetches `/api/gateway/info` on connect, fails silently
- Sidebar footer shows restart time (relative: `today 10:54` / `yesterday` / `Apr 26`) and short SHA linking to GitHub commit
- Fails gracefully if gateway doesn't support the endpoint yet

## Example
```
[ 🔄 Restart Gateway ]
↺ today 10:54          3911fd3
```

## Tests
5 new unit tests for `GatewayBuildInfo` and the info endpoint. Full suite: 1,036 passing.