### PR TITLE
[Portal] Conversation-first sidebar and chat UI

### DIFF
--- a/.squad/decisions/inbox/leela-portal-conversation-ui.md
+++ b/.squad/decisions/inbox/leela-portal-conversation-ui.md
@@ -1,0 +1,99 @@
+# Decision: Portal conversation-first UI contracts
+
+**Author:** Leela (Lead/Architect)  
+**Date:** 2026-04-28  
+**Issue:** #37  
+**Status:** Delivered
+
+## Decision
+
+The Blazor portal will move to a **conversation-first UI** while keeping the existing `AgentSessionManager` / `AgentSessionState` architecture.
+
+### Core call
+
+- **Do not** introduce a separate top-level `ConversationState` object graph for v1.
+- **Do** make `AgentSessionState` conversation-aware.
+- **Do** load conversations and conversation history from REST.
+- **Do** keep SignalR session routing unchanged for live streaming.
+- **Do** render session boundaries inline inside the chat timeline.
+
+## Why
+
+1. `ChatPanel.razor` already depends on `AgentSessionState` for streaming state, tool calls, connection state, and sub-agent metadata.
+2. Live updates still arrive by `sessionId`; the existing manager already owns that routing problem.
+3. A new parallel conversation state model would duplicate selection, unread, and history state and force reconciliation between two trees.
+4. Conversation-first UX is a sidebar/history concern, not a reason to replace the current panel contract.
+
+## Contracts finalized
+
+### Services
+`AgentSessionState` grows:
+- `Conversations`
+- `ActiveConversationId`
+- `ConversationsLoaded`
+- `IsLoadingConversations`
+- `ActiveConversationTitle`
+
+`AgentSessionManager` grows:
+- `LoadConversationsAsync(agentId)`
+- `SelectConversationAsync(agentId, conversationId)`
+- `CreateConversationAsync(agentId, title, select)`
+- `RefreshConversationsAsync(agentId)`
+- `MarkConversationRead(agentId, conversationId)`
+
+### DTOs
+Create new client REST DTO file:
+- `Services/ConversationContracts.cs`
+
+Do not add conversation REST DTOs to `HubContracts.cs`.
+
+### Sidebar
+Replace the current per-agent session list with a conversation list under the selected agent.
+Required UI elements:
+- conversation row
+- active highlight
+- default badge
+- unread dot
+- `+ New` button
+
+### Chat panel
+`ChatPanel.razor` keeps taking `AgentSessionState`.
+The panel renders one timeline list containing:
+- normal messages
+- inline session boundary rows
+
+### Session divider
+Exact label format:
+- `Session · Apr 27 14:32 · s_abc123`
+
+Exact root class:
+- `.session-boundary`
+
+## Wave split
+
+### Fry
+- DTOs
+- state/service changes
+- sidebar markup
+- history mapping
+- boundary rendering
+- conversation unread plumbing
+
+### Amy
+- sidebar visuals
+- active/default/unread visuals
+- `+ New` button styling
+- session divider styling
+- responsive polish
+
+## Jon input needed
+
+One confirmation only:
+- whether the first send into a selected conversation guarantees immediate conversation→active-session linkage from the current backend flow
+
+If not, Fry can refresh conversations after first send. Not a blocker.
+
+## Deliverable
+
+Full design review written to:
+- `docs/planning/feature-conversation-topics/portal-design-review.md`

--- a/docs/planning/feature-conversation-topics/portal-design-review.md
+++ b/docs/planning/feature-conversation-topics/portal-design-review.md
@@ -1,0 +1,652 @@
+# Portal Conversation-First UI — Design Review
+
+**Author:** Leela (Lead/Architect)  
+**Date:** 2026-04-28  
+**Issue:** #37  
+**Branch:** `feat/37-portal-conversation-ui`
+
+## Summary
+
+The portal should switch from **session-first** to **conversation-first** without introducing a parallel state model.
+
+**Decision:** keep `AgentSessionManager` and `AgentSessionState` as the primary client-side state types, but make them **conversation-aware**. Do **not** create a separate top-level `ConversationManager` + `ConversationState` tree for v1.
+
+Why:
+- `ChatPanel.razor` already binds to one per-agent state object and should stay that way.
+- SignalR streaming is still session-scoped; the existing manager already routes by `sessionId`.
+- Conversations are loaded via REST, but live streaming still lands in the active session inside the active conversation.
+- A second parallel state model would force Fry to reconcile session events into conversation state twice.
+
+So the contract is:
+- **Sidebar unit:** conversation
+- **Live stream routing unit:** session
+- **Chat panel binding unit:** `AgentSessionState`
+- **History payload:** conversation history entries with boundary markers between sessions
+
+---
+
+## 1. Service changes
+
+## 1.1 `AgentSessionState` grows conversation-awareness
+
+Keep one `AgentSessionState` per agent. Add conversation collections + active selection to it.
+
+### New types
+
+```csharp
+public sealed class ConversationListItemState
+{
+    public required string ConversationId { get; init; }
+    public string Title { get; set; } = "New conversation";
+    public bool IsDefault { get; set; }
+    public string Status { get; set; } = "Active";
+    public string? ActiveSessionId { get; set; }
+    public int UnreadCount { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    // UI-only state
+    public bool HistoryLoaded { get; set; }
+    public bool IsLoadingHistory { get; set; }
+}
+
+public sealed record ConversationHistoryItem(
+    string Kind,
+    string SessionId,
+    DateTimeOffset Timestamp)
+{
+    public string? Role { get; init; }
+    public string? Content { get; init; }
+    public string? ToolName { get; init; }
+    public string? ToolCallId { get; init; }
+    public string? Reason { get; init; }
+
+    public bool IsBoundary => Kind == "boundary";
+}
+```
+
+### Add these properties to `AgentSessionState`
+
+```csharp
+public Dictionary<string, ConversationListItemState> Conversations { get; } = new();
+public string? ActiveConversationId { get; set; }
+public bool ConversationsLoaded { get; set; }
+public bool IsLoadingConversations { get; set; }
+public string? ActiveConversationTitle =>
+    ActiveConversationId is not null && Conversations.TryGetValue(ActiveConversationId, out var c)
+        ? c.Title
+        : null;
+```
+
+### Existing properties that stay
+
+These remain and keep their current meaning:
+- `SessionId`
+- `SessionType`
+- `Messages`
+- `IsStreaming`
+- `CurrentStreamBuffer`
+- `ThinkingBuffer`
+- `ActiveToolCalls`
+- `UnreadCount`
+- `SubAgents`
+
+### Meaning changes
+
+- `SessionId` becomes **the currently active live session for the selected conversation**, not “the one session for this agent”.
+- `Messages` becomes **the rendered timeline for the selected conversation**, including session-boundary markers.
+- `UnreadCount` stays agent-level for the dropdown badge.
+- Conversation unread state lives on `ConversationListItemState.UnreadCount`.
+
+## 1.2 `ChatMessage` must support boundary entries
+
+Do not invent a second list just for dividers. Let the message timeline render both normal messages and session boundaries.
+
+Add to `ChatMessage`:
+
+```csharp
+public string Kind { get; init; } = "message"; // "message" | "boundary"
+public string? BoundaryLabel { get; init; }
+public string? BoundarySessionId { get; init; }
+```
+
+Helper:
+
+```csharp
+public bool IsBoundary => Kind == "boundary";
+```
+
+This keeps `ChatPanel` simple: one ordered list, one renderer.
+
+## 1.3 `AgentSessionManager` new responsibilities
+
+### New public methods
+
+```csharp
+public Task LoadConversationsAsync(string agentId);
+public Task SelectConversationAsync(string agentId, string conversationId);
+public Task<string?> CreateConversationAsync(string agentId, string? title = null, bool select = true);
+public Task RefreshConversationsAsync(string agentId);
+public void MarkConversationRead(string agentId, string conversationId);
+```
+
+### Exact behavior
+
+#### `LoadConversationsAsync(agentId)`
+- `GET /api/conversations?agentId={agentId}`
+- Populate `state.Conversations`
+- If `state.ActiveConversationId` is null:
+  - select default conversation if present
+  - otherwise select most recently updated conversation
+- Set `ConversationsLoaded = true`
+- Do **not** load history yet unless this is the active/visible agent
+
+#### `SelectConversationAsync(agentId, conversationId)`
+- Set `state.ActiveConversationId = conversationId`
+- Copy selected conversation’s `ActiveSessionId` into `state.SessionId`
+- Clear conversation unread count
+- Call `LoadConversationHistoryAsync(agentId, conversationId)` if not loaded
+- Fire `OnStateChanged`
+
+#### `CreateConversationAsync(agentId, title, select)`
+- `POST /api/conversations`
+- Request body:
+  ```json
+  { "agentId": "...", "title": "..." }
+  ```
+- Add returned conversation into `state.Conversations`
+- If `select == true`, call `SelectConversationAsync(...)`
+- Return created `conversationId`
+
+#### `RefreshConversationsAsync(agentId)`
+- Re-fetch list from REST
+- Preserve `UnreadCount`, `HistoryLoaded`, `IsLoadingHistory` for any existing matching conversation ids
+- Preserve `ActiveConversationId` if still present
+
+#### `LoadConversationHistoryAsync(agentId, conversationId)`
+Private helper. Calls:
+- `GET /api/conversations/{conversationId}/history?limit=200`
+
+Maps response entries into `state.Messages`:
+- `kind == "message"` → normal `ChatMessage`
+- `kind == "boundary"` → `ChatMessage` with `Kind = "boundary"` and label text
+
+Also:
+- set selected conversation `HistoryLoaded = true`
+- set `state.SessionId = selectedConversation.ActiveSessionId` after load
+
+## 1.4 Unread rules
+
+### Conversation unread
+When a streamed assistant message ends:
+- resolve `state` by `sessionId` as today
+- find the conversation whose `ActiveSessionId == evt.SessionId`
+- if that conversation is **not** `state.ActiveConversationId`, increment `ConversationListItemState.UnreadCount`
+
+### Agent unread
+Keep existing behavior:
+- if `state.AgentId != ActiveAgentId`, increment `state.UnreadCount`
+
+### Mark read
+When a conversation becomes active:
+- set conversation unread to 0
+- if that agent is the active agent, recompute `state.UnreadCount` as sum of conversation unread counts
+
+## 1.5 No new top-level `ConversationState`
+
+**Explicit decision:** `ChatPanel.razor` continues to take `AgentSessionState`.
+
+Reason:
+- the panel already needs streaming buffers, tool calls, connection status, and sub-agent info
+- all of that already lives on `AgentSessionState`
+- adding a second wrapper would only re-expose the same data through another object
+
+---
+
+## 2. DTOs
+
+## 2.1 File location
+
+Create a new file:
+
+`src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs`
+
+Do **not** add these to `HubContracts.cs`.
+
+Reason: these are REST DTOs, not hub DTOs.
+
+## 2.2 Client DTO contract
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+public sealed record ConversationSummaryDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("isDefault")] bool IsDefault,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("activeSessionId")] string? ActiveSessionId,
+    [property: JsonPropertyName("bindingCount")] int BindingCount,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt);
+
+public sealed record CreateConversationRequestDto(
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("title")] string? Title);
+
+public sealed record ConversationResponseDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("isDefault")] bool IsDefault,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("activeSessionId")] string? ActiveSessionId,
+    [property: JsonPropertyName("bindings")] IReadOnlyList<ConversationBindingDto> Bindings,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt);
+
+public sealed record ConversationBindingDto(
+    [property: JsonPropertyName("bindingId")] string BindingId,
+    [property: JsonPropertyName("channelType")] string ChannelType,
+    [property: JsonPropertyName("channelAddress")] string ChannelAddress,
+    [property: JsonPropertyName("threadId")] string? ThreadId,
+    [property: JsonPropertyName("mode")] string Mode,
+    [property: JsonPropertyName("threadingMode")] string ThreadingMode,
+    [property: JsonPropertyName("displayPrefix")] string? DisplayPrefix,
+    [property: JsonPropertyName("boundAt")] DateTimeOffset BoundAt);
+
+public sealed record ConversationHistoryResponseDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("totalCount")] int TotalCount,
+    [property: JsonPropertyName("offset")] int Offset,
+    [property: JsonPropertyName("limit")] int Limit,
+    [property: JsonPropertyName("entries")] IReadOnlyList<ConversationHistoryEntryDto> Entries);
+
+public sealed class ConversationHistoryEntryDto
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("sessionId")]
+    public required string SessionId { get; init; }
+
+    [JsonPropertyName("timestamp")]
+    public required DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("role")]
+    public string? Role { get; init; }
+
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
+
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; init; }
+
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; init; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+}
+```
+
+## 2.3 DTO notes
+
+Portal only needs:
+- conversation list summaries
+- create response
+- full history entries
+
+It does **not** need binding mutation DTOs for issue #37 implementation.
+
+---
+
+## 3. Sidebar contract
+
+## 3.1 Structure decision
+
+The existing sidebar uses:
+- agent dropdown
+- per-agent session list under selected agent
+
+For v1, keep the **agent dropdown**. Replace the **session list** under the selected agent with a **conversation list**.
+
+Do not redesign agent selection in this issue.
+
+## 3.2 Razor pseudocode contract
+
+```razor
+@if (Manager.ActiveAgentId is not null &&
+     Manager.Sessions.TryGetValue(Manager.ActiveAgentId, out var activeState))
+{
+    <div class="agent-conversation-list">
+        <div class="agent-conversation-list-header">
+            <span class="agent-conversation-list-title">Conversations</span>
+            <button class="conversation-new-btn"
+                    @onclick="() => CreateConversationAndClose(activeState.AgentId)"
+                    title="Start a new conversation">
+                <span class="conversation-new-btn-icon">+</span>
+                <span class="conversation-new-btn-label">New</span>
+            </button>
+        </div>
+
+        @if (activeState.IsLoadingConversations)
+        {
+            <div class="conversation-list-loading">Loading conversations…</div>
+        }
+        else if (activeState.Conversations.Count == 0)
+        {
+            <div class="conversation-list-empty">No conversations yet.</div>
+        }
+        else
+        {
+            @foreach (var conversation in activeState.Conversations.Values
+                .OrderByDescending(c => c.IsDefault)
+                .ThenByDescending(c => c.UpdatedAt))
+            {
+                <button class="conversation-list-item @(conversation.ConversationId == activeState.ActiveConversationId ? "active" : "")"
+                        @onclick="() => SelectConversationAndClose(activeState.AgentId, conversation.ConversationId)">
+                    <span class="conversation-list-item-main">
+                        <span class="conversation-list-item-title">@conversation.Title</span>
+
+                        @if (conversation.IsDefault)
+                        {
+                            <span class="conversation-default-badge">Default</span>
+                        }
+                    </span>
+
+                    <span class="conversation-list-item-meta">
+                        @if (conversation.UnreadCount > 0)
+                        {
+                            <span class="conversation-unread-dot"
+                                  aria-label="Unread messages"></span>
+                        }
+
+                        <span class="conversation-updated-at">
+                            @FormatConversationTimestamp(conversation.UpdatedAt)
+                        </span>
+                    </span>
+                </button>
+            }
+        }
+    </div>
+}
+```
+
+## 3.3 Required CSS hooks
+
+- `.agent-conversation-list`
+- `.agent-conversation-list-header`
+- `.agent-conversation-list-title`
+- `.conversation-new-btn`
+- `.conversation-list-loading`
+- `.conversation-list-empty`
+- `.conversation-list-item`
+- `.conversation-list-item.active`
+- `.conversation-list-item-main`
+- `.conversation-list-item-title`
+- `.conversation-default-badge`
+- `.conversation-list-item-meta`
+- `.conversation-unread-dot`
+- `.conversation-updated-at`
+
+## 3.4 UI rules
+
+- **Active highlight:** entire row gets `.active`
+- **Default badge:** text badge to right of title
+- **Unread dot:** small dot, not a numeric pill, for v1
+- **New button:** always visible in header
+- **Ordering:** default first, then most recently updated
+
+---
+
+## 4. Chat panel contract
+
+## 4.1 Binding decision
+
+`ChatPanel.razor` continues to accept:
+
+```csharp
+[Parameter, EditorRequired]
+public AgentSessionState State { get; set; } = default!;
+```
+
+Do **not** replace this with `ConversationState`.
+
+## 4.2 Header changes
+
+Current header shows agent name. Update it to show agent + conversation.
+
+### Header contract
+
+```razor
+<header class="chat-header">
+    <div class="chat-header-left">
+        <div class="chat-title-stack">
+            <h3>@State.DisplayName</h3>
+            @if (State.ActiveConversationId is not null)
+            {
+                <div class="conversation-title-row">
+                    <span class="conversation-title">@State.ActiveConversationTitle</span>
+                    @if (State.Conversations.TryGetValue(State.ActiveConversationId, out var activeConversation) && activeConversation.IsDefault)
+                    {
+                        <span class="conversation-default-badge">Default</span>
+                    }
+                </div>
+            }
+            <span class="agent-id-label">@State.AgentId</span>
+        </div>
+
+        @if (State.IsStreaming)
+        {
+            <span class="streaming-badge">Streaming…</span>
+        }
+    </div>
+
+    ...existing actions...
+</header>
+```
+
+## 4.3 Rendering history
+
+`State.Messages` becomes the single ordered timeline for the selected conversation.
+
+### New rendering branch
+
+Inside the `foreach (var msg in State.Messages)` loop, add this branch first:
+
+```razor
+@if (msg.IsBoundary)
+{
+    <div class="session-boundary" role="separator" aria-label="Session boundary">
+        <span class="session-boundary-line"></span>
+        <span class="session-boundary-label">@msg.BoundaryLabel</span>
+        <span class="session-boundary-line"></span>
+    </div>
+}
+else if (msg.Role == "System")
+{
+    ...
+}
+```
+
+## 4.4 Sending messages
+
+No behavioral change in panel event handlers. They still call:
+- `Manager.SendMessageAsync(State.AgentId, text)`
+- `Manager.SteerAsync(...)`
+- `Manager.FollowUpAsync(...)`
+
+But `AgentSessionManager.SendMessageAsync` must send against the selected conversation context:
+- if selected conversation has `ActiveSessionId`, continue into it if hub API allows
+- otherwise first send creates a new session and the manager updates the selected conversation’s `ActiveSessionId` after refresh
+
+If conversation/session linking is not returned by SignalR send result, Fry should refresh conversations after first send for that agent.
+
+## 4.5 Empty-state text
+
+When no conversation is selected:
+
+```razor
+<div class="chat-empty-state">
+    Select a conversation or start a new one.
+</div>
+```
+
+Do not auto-create a new conversation on panel render.
+
+---
+
+## 5. Session boundary divider contract
+
+## 5.1 Exact markup
+
+```razor
+<div class="session-boundary" role="separator" aria-label="Session boundary">
+    <span class="session-boundary-line"></span>
+    <span class="session-boundary-label">
+        Session · @FormatBoundaryTimestamp(msg.Timestamp) · @msg.BoundarySessionId
+    </span>
+    <span class="session-boundary-line"></span>
+</div>
+```
+
+## 5.2 Exact label format
+
+```text
+Session · Apr 27 14:32 · s_abc123
+```
+
+Formatting rule:
+- `MMM d HH:mm` in local time
+- use raw session id as returned by API
+
+## 5.3 Mapping rule
+
+When mapping `ConversationHistoryEntryDto` with `kind == "boundary"`:
+
+```csharp
+var label = $"Session · {entry.Timestamp.ToLocalTime():MMM d HH:mm} · {entry.SessionId}";
+```
+
+Then create:
+
+```csharp
+new ChatMessage("System", string.Empty, entry.Timestamp)
+{
+    Kind = "boundary",
+    BoundaryLabel = label,
+    BoundarySessionId = entry.SessionId
+}
+```
+
+## 5.4 CSS class contract
+
+Required selectors:
+- `.session-boundary`
+- `.session-boundary-line`
+- `.session-boundary-label`
+
+Behavior:
+- horizontal rule effect using flex lines on both sides
+- centered label
+- muted text style
+- enough vertical margin to visually separate sessions
+
+---
+
+## 6. Wave breakdown
+
+## Wave 1 — Fry (Blazor/C#)
+
+### Scope
+1. Add `ConversationContracts.cs`
+2. Extend `AgentSessionState` with conversation list + active conversation fields
+3. Extend `ChatMessage` with boundary support
+4. Add `AgentSessionManager` methods:
+   - `LoadConversationsAsync`
+   - `SelectConversationAsync`
+   - `CreateConversationAsync`
+   - `RefreshConversationsAsync`
+5. Replace sidebar session list with conversation list markup
+6. Update `ChatPanel.razor` header to show active conversation title
+7. Update `ChatPanel.razor` message loop to render session boundaries
+8. Wire unread counts per conversation
+9. Load conversations when agent becomes active
+
+### Out of scope for Fry
+- final visual polish
+- spacing/color tuning
+- animation/micro-interaction choices
+
+## Wave 2 — Amy (CSS/visual)
+
+### Scope
+1. Style conversation list rows
+2. Style active highlight
+3. Style default badge
+4. Style unread dot
+5. Style "+ New" button
+6. Style session boundary divider
+7. Refine header conversation title row
+8. Responsive/mobile layout cleanup in sidebar
+
+### Constraints for Amy
+- Amy should not rename Fry’s CSS hooks
+- Amy should not change data flow or markup shape unless a11y requires a minimal adjustment
+
+---
+
+## 7. Risks and guidance
+
+## Risk 1 — first send may not immediately bind conversation → session
+If the send pipeline does not return conversation linkage, Fry should refresh `/api/conversations?agentId=` after first message send.
+
+## Risk 2 — conversation unread resolution from session id
+Unread mapping assumes the active live session belongs to one conversation. That matches current gateway contract and is acceptable for v1.
+
+## Risk 3 — active conversation removed or archived
+If refresh no longer contains the selected conversation:
+- fall back to default conversation
+- otherwise first available conversation
+- otherwise clear `ActiveConversationId` and empty the panel
+
+---
+
+## 8. Explicit decisions for implementation
+
+1. **Use `AgentSessionState` as the panel state.** No separate `ConversationState` wrapper.
+2. **Create `ConversationContracts.cs`.** Do not mix REST DTOs into `HubContracts.cs`.
+3. **Replace the sidebar session list with a conversation list under the selected agent.**
+4. **Render boundary markers as `ChatMessage` entries in the same timeline list.**
+5. **Keep SignalR session routing as-is.** REST provides list/history; SignalR continues to stream by session.
+
+---
+
+## 9. Jon input needed
+
+Only one thing needs Jon’s confirmation before implementation starts:
+
+### Should first-message conversation linking be explicit in the live send flow?
+Current API surface clearly supports conversation history/listing, but the Blazor client contract is easiest if the first send into a selected conversation reliably updates that conversation’s `ActiveSessionId` immediately.
+
+If the current gateway already guarantees that via existing routing, no change needed.
+If not, Fry can still ship v1 by refreshing the conversation list after first send.
+
+That is not a blocker, just the only place where server behavior needs a quick confirmation.
+
+---
+
+## Final recommendation
+
+Proceed with Fry + Amy split exactly as above.
+
+This keeps the change bounded:
+- no duplicated client state model
+- no panel rewrite
+- no hub contract churn
+- conversation-first UX in the sidebar and timeline
+- session detail preserved where it matters: inside conversation history

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -3,8 +3,21 @@
 <div class="chat-panel">
     <header class="chat-header">
         <div class="chat-header-left">
-            <h3>@State.DisplayName</h3>
-            <span class="agent-id-label">@State.AgentId</span>
+            <div class="chat-title-stack">
+                <h3>@State.DisplayName</h3>
+                @if (State.ActiveConversationId is not null)
+                {
+                    <div class="conversation-title-row">
+                        <span class="conversation-title">@State.ActiveConversationTitle</span>
+                        @if (State.Conversations.TryGetValue(State.ActiveConversationId, out var activeConversation) && activeConversation.IsDefault)
+                        {
+                            <span class="conversation-default-badge">Default</span>
+                        }
+                    </div>
+                }
+                <span class="agent-id-label">@State.AgentId</span>
+            </div>
+
             @if (State.IsStreaming)
             {
                 <span class="streaming-badge">Streaming…</span>
@@ -56,9 +69,24 @@
             </div>
         }
 
+        @if (State.ActiveConversationId is null && !State.IsLoadingConversations)
+        {
+            <div class="chat-empty-state">
+                Select a conversation or start a new one.
+            </div>
+        }
+
         @foreach (var msg in State.Messages)
         {
-            @if (msg.Role == "System")
+            @if (msg.IsBoundary)
+            {
+                <div class="session-boundary" role="separator" aria-label="Session boundary">
+                    <span class="session-boundary-line"></span>
+                    <span class="session-boundary-label">@msg.BoundaryLabel</span>
+                    <span class="session-boundary-line"></span>
+                </div>
+            }
+            else if (msg.Role == "System")
             {
                 <div class="system-message">@msg.Content</div>
             }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -73,14 +73,58 @@
                     @if (Manager.ActiveAgentId is not null &&
                          Manager.Sessions.TryGetValue(Manager.ActiveAgentId, out var activeState))
                     {
-                        <div class="agent-session-list">
-                            @if (activeState.SessionId is not null)
+                        <div class="agent-conversation-list">
+                            <div class="agent-conversation-list-header">
+                                <span class="agent-conversation-list-title">Conversations</span>
+                                <button class="conversation-new-btn"
+                                        @onclick="() => CreateConversationAndClose(activeState.AgentId)"
+                                        title="Start a new conversation">
+                                    <span class="conversation-new-btn-icon">+</span>
+                                    <span class="conversation-new-btn-label">New</span>
+                                </button>
+                            </div>
+
+                            @if (activeState.IsLoadingConversations)
                             {
-                                <div class="agent-session-item active">
-                                    <span>💬</span>
-                                    <span>@(activeState.ChannelType ?? "signalr")</span>
-                                </div>
+                                <div class="conversation-list-loading">Loading conversations…</div>
                             }
+                            else if (activeState.Conversations.Count == 0)
+                            {
+                                <div class="conversation-list-empty">No conversations yet.</div>
+                            }
+                            else
+                            {
+                                @foreach (var conversation in activeState.Conversations.Values
+                                    .OrderByDescending(c => c.IsDefault)
+                                    .ThenByDescending(c => c.UpdatedAt))
+                                {
+                                    <button class="conversation-list-item @(conversation.ConversationId == activeState.ActiveConversationId ? "active" : "")"
+                                            @onclick="() => SelectConversationAndClose(activeState.AgentId, conversation.ConversationId)">
+                                        <span class="conversation-list-item-main">
+                                            <span class="conversation-list-item-title">@conversation.Title</span>
+
+                                            @if (conversation.IsDefault)
+                                            {
+                                                <span class="conversation-default-badge">Default</span>
+                                            }
+                                        </span>
+
+                                        <span class="conversation-list-item-meta">
+                                            @if (conversation.UnreadCount > 0)
+                                            {
+                                                <span class="conversation-unread-dot"
+                                                      aria-label="Unread messages"></span>
+                                            }
+
+                                            <span class="conversation-updated-at">
+                                                @FormatConversationTimestamp(conversation.UpdatedAt)
+                                            </span>
+                                        </span>
+                                    </button>
+                                }
+                            }
+
+                            @* Sub-agent sessions *@
                             @foreach (var sub in activeState.SubAgents.Values
                                 .Where(s => s.Status is "Running" or "Completed"))
                             {
@@ -224,6 +268,27 @@
     private bool IsSubAgentActive(SubAgentInfo sub)
     {
         return Manager.ActiveAgentId == sub.SubAgentId;
+    }
+
+    private async Task SelectConversationAndClose(string agentId, string conversationId)
+    {
+        await Manager.SelectConversationAsync(agentId, conversationId);
+        _sidebarOpen = false;
+    }
+
+    private async Task CreateConversationAndClose(string agentId)
+    {
+        await Manager.CreateConversationAsync(agentId);
+        _sidebarOpen = false;
+    }
+
+    private static string FormatConversationTimestamp(DateTimeOffset ts)
+    {
+        var local = ts.ToLocalTime();
+        var now = DateTimeOffset.Now;
+        return local.Date == now.Date
+            ? local.ToString("h:mm tt")
+            : local.ToString("MMM d");
     }
 
     private void DismissAnnouncement(string id)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -204,7 +204,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        await GatewayInfo.LoadAsync();
+        // GatewayInfo.LoadAsync() is called from HandleStateChanged once
+        // ApiBaseUrl is available (set after SignalR connects)
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -217,7 +218,21 @@
         }
     }
 
-    private void HandleStateChanged() => InvokeAsync(StateHasChanged);
+    private bool _gatewayInfoLoaded;
+    private void HandleStateChanged()
+    {
+        // Load gateway info once ApiBaseUrl is available (after SignalR connects)
+        if (!_gatewayInfoLoaded && Manager.ApiBaseUrl is not null)
+        {
+            _gatewayInfoLoaded = true;
+            _ = InvokeAsync(async () =>
+            {
+                await GatewayInfo.LoadAsync();
+                StateHasChanged();
+            });
+        }
+        InvokeAsync(StateHasChanged);
+    }
 
     private async Task ToggleSidebar()
     {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -74,7 +74,7 @@ public sealed class AgentSessionManager : IDisposable
         }
     }
 
-    /// <summary>Set the active agent tab, clear its unread count, and load history if needed.</summary>
+    /// <summary>Set the active agent tab, clear its unread count, and load conversations if needed.</summary>
     public async Task SetActiveAgentAsync(string? agentId)
     {
         ActiveAgentId = agentId;
@@ -82,13 +82,16 @@ public sealed class AgentSessionManager : IDisposable
         {
             state.UnreadCount = 0;
 
-            // Load history on first visit when a session exists but we have no local messages
-            if (!state.HistoryLoaded && !state.IsLoadingHistory)
+            // Load conversations on first visit
+            if (!state.ConversationsLoaded && !state.IsLoadingConversations)
             {
-                if (state.SessionId is not null && state.Messages.Count == 0)
-                    await LoadHistoryAsync(agentId);
-                else
-                    state.HistoryLoaded = true;
+                await LoadConversationsAsync(agentId);
+            }
+            else if (state.ActiveConversationId is not null
+                && state.Conversations.TryGetValue(state.ActiveConversationId, out var conv)
+                && !conv.HistoryLoaded && !conv.IsLoadingHistory)
+            {
+                await LoadConversationHistoryAsync(agentId, state.ActiveConversationId);
             }
         }
 
@@ -288,6 +291,294 @@ public sealed class AgentSessionManager : IDisposable
         finally
         {
             state.IsLoadingHistory = false;
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    // ── Conversation methods ─────────────────────────────────────────────────
+
+    /// <summary>Load the conversation list for the given agent from the REST API.</summary>
+    public async Task LoadConversationsAsync(string agentId)
+    {
+        if (!_sessions.TryGetValue(agentId, out var state))
+            return;
+        if (state.ConversationsLoaded || state.IsLoadingConversations)
+            return;
+
+        state.IsLoadingConversations = true;
+        OnStateChanged?.Invoke();
+
+        try
+        {
+            var url = $"{_apiBaseUrl}conversations?agentId={Uri.EscapeDataString(agentId)}";
+            var list = await _http.GetFromJsonAsync<List<ConversationSummaryDto>>(url);
+
+            if (list is not null)
+            {
+                state.Conversations.Clear();
+                foreach (var dto in list)
+                {
+                    state.Conversations[dto.ConversationId] = new ConversationListItemState
+                    {
+                        ConversationId = dto.ConversationId,
+                        Title = dto.Title,
+                        IsDefault = dto.IsDefault,
+                        Status = dto.Status,
+                        ActiveSessionId = dto.ActiveSessionId,
+                        CreatedAt = dto.CreatedAt,
+                        UpdatedAt = dto.UpdatedAt
+                    };
+                }
+            }
+
+            // Auto-select a conversation if none is selected
+            if (state.ActiveConversationId is null && state.Conversations.Count > 0)
+            {
+                var defaultConv = state.Conversations.Values.FirstOrDefault(c => c.IsDefault)
+                    ?? state.Conversations.Values.OrderByDescending(c => c.UpdatedAt).First();
+                state.ActiveConversationId = defaultConv.ConversationId;
+
+                // Sync SessionId to the active conversation's session
+                if (defaultConv.ActiveSessionId is not null)
+                    state.SessionId = defaultConv.ActiveSessionId;
+            }
+
+            state.ConversationsLoaded = true;
+
+            // If this is the currently visible agent, load history now
+            if (agentId == ActiveAgentId && state.ActiveConversationId is not null)
+            {
+                var conv = state.Conversations.GetValueOrDefault(state.ActiveConversationId);
+                if (conv is not null && !conv.HistoryLoaded && !conv.IsLoadingHistory)
+                    await LoadConversationHistoryAsync(agentId, state.ActiveConversationId);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to load conversations for {agentId}: {ex.Message}");
+            state.ConversationsLoaded = true; // Don't retry on failure
+        }
+        finally
+        {
+            state.IsLoadingConversations = false;
+            OnStateChanged?.Invoke();
+        }
+    }
+
+    /// <summary>Select a conversation for the given agent and load its history if needed.</summary>
+    public async Task SelectConversationAsync(string agentId, string conversationId)
+    {
+        if (!_sessions.TryGetValue(agentId, out var state))
+            return;
+        if (!state.Conversations.TryGetValue(conversationId, out var conv))
+            return;
+
+        state.ActiveConversationId = conversationId;
+
+        // Sync active session to the selected conversation's live session
+        if (conv.ActiveSessionId is not null)
+            state.SessionId = conv.ActiveSessionId;
+
+        // Clear conversation unread count
+        conv.UnreadCount = 0;
+
+        OnStateChanged?.Invoke();
+
+        if (!conv.HistoryLoaded && !conv.IsLoadingHistory)
+            await LoadConversationHistoryAsync(agentId, conversationId);
+    }
+
+    /// <summary>Create a new conversation for the given agent.</summary>
+    public async Task<string?> CreateConversationAsync(string agentId, string? title = null, bool select = true)
+    {
+        if (!_sessions.TryGetValue(agentId, out var state))
+            return null;
+
+        try
+        {
+            var request = new CreateConversationRequestDto(agentId, title);
+            var response = await _http.PostAsJsonAsync($"{_apiBaseUrl}conversations", request);
+            response.EnsureSuccessStatusCode();
+
+            var dto = await response.Content.ReadFromJsonAsync<ConversationResponseDto>();
+            if (dto is null)
+                return null;
+
+            state.Conversations[dto.ConversationId] = new ConversationListItemState
+            {
+                ConversationId = dto.ConversationId,
+                Title = dto.Title,
+                IsDefault = dto.IsDefault,
+                Status = dto.Status,
+                ActiveSessionId = dto.ActiveSessionId,
+                CreatedAt = dto.CreatedAt,
+                UpdatedAt = dto.UpdatedAt
+            };
+
+            if (select)
+                await SelectConversationAsync(agentId, dto.ConversationId);
+            else
+                OnStateChanged?.Invoke();
+
+            return dto.ConversationId;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to create conversation for {agentId}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Re-fetch the conversation list, preserving local UI state for existing conversations.</summary>
+    public async Task RefreshConversationsAsync(string agentId)
+    {
+        if (!_sessions.TryGetValue(agentId, out var state))
+            return;
+
+        try
+        {
+            var url = $"{_apiBaseUrl}conversations?agentId={Uri.EscapeDataString(agentId)}";
+            var list = await _http.GetFromJsonAsync<List<ConversationSummaryDto>>(url);
+
+            if (list is null)
+                return;
+
+            var incoming = list.ToDictionary(d => d.ConversationId);
+
+            // Add or update, preserving local UI state for existing entries
+            foreach (var dto in list)
+            {
+                if (state.Conversations.TryGetValue(dto.ConversationId, out var existing))
+                {
+                    // Preserve local-only fields
+                    existing.Title = dto.Title;
+                    existing.IsDefault = dto.IsDefault;
+                    existing.Status = dto.Status;
+                    existing.ActiveSessionId = dto.ActiveSessionId;
+                    existing.CreatedAt = dto.CreatedAt;
+                    existing.UpdatedAt = dto.UpdatedAt;
+                }
+                else
+                {
+                    state.Conversations[dto.ConversationId] = new ConversationListItemState
+                    {
+                        ConversationId = dto.ConversationId,
+                        Title = dto.Title,
+                        IsDefault = dto.IsDefault,
+                        Status = dto.Status,
+                        ActiveSessionId = dto.ActiveSessionId,
+                        CreatedAt = dto.CreatedAt,
+                        UpdatedAt = dto.UpdatedAt
+                    };
+                }
+            }
+
+            // Remove any conversations no longer in the list
+            var toRemove = state.Conversations.Keys.Where(id => !incoming.ContainsKey(id)).ToList();
+            foreach (var id in toRemove)
+                state.Conversations.Remove(id);
+
+            // If active conversation was removed, fall back
+            if (state.ActiveConversationId is not null && !state.Conversations.ContainsKey(state.ActiveConversationId))
+            {
+                var fallback = state.Conversations.Values.FirstOrDefault(c => c.IsDefault)
+                    ?? state.Conversations.Values.OrderByDescending(c => c.UpdatedAt).FirstOrDefault();
+                state.ActiveConversationId = fallback?.ConversationId;
+                if (state.ActiveConversationId is null)
+                    state.Messages.Clear();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to refresh conversations for {agentId}: {ex.Message}");
+        }
+
+        OnStateChanged?.Invoke();
+    }
+
+    /// <summary>Mark all messages in a conversation as read.</summary>
+    public void MarkConversationRead(string agentId, string conversationId)
+    {
+        if (!_sessions.TryGetValue(agentId, out var state))
+            return;
+        if (!state.Conversations.TryGetValue(conversationId, out var conv))
+            return;
+
+        conv.UnreadCount = 0;
+
+        // If this is the active agent, recompute agent-level unread as sum of conversations
+        if (agentId == ActiveAgentId)
+            state.UnreadCount = state.Conversations.Values.Sum(c => c.UnreadCount);
+
+        OnStateChanged?.Invoke();
+    }
+
+    /// <summary>Load conversation history from the REST API and populate the message timeline.</summary>
+    private async Task LoadConversationHistoryAsync(string agentId, string conversationId)
+    {
+        if (!_sessions.TryGetValue(agentId, out var state))
+            return;
+        if (!state.Conversations.TryGetValue(conversationId, out var conv))
+            return;
+        if (conv.HistoryLoaded || conv.IsLoadingHistory)
+            return;
+
+        conv.IsLoadingHistory = true;
+        OnStateChanged?.Invoke();
+
+        try
+        {
+            var url = $"{_apiBaseUrl}conversations/{Uri.EscapeDataString(conversationId)}/history?limit=200";
+            var response = await _http.GetFromJsonAsync<ConversationHistoryResponseDto>(url);
+
+            if (response?.Entries is { Count: > 0 })
+            {
+                // Only replace messages if this conversation is still active
+                if (state.ActiveConversationId == conversationId)
+                {
+                    state.Messages.Clear();
+                    foreach (var entry in response.Entries)
+                    {
+                        if (entry.Kind == "boundary")
+                        {
+                            var label = $"Session \u00b7 {entry.Timestamp.ToLocalTime():MMM d HH:mm} \u00b7 {entry.SessionId}";
+                            state.Messages.Add(new ChatMessage("System", string.Empty, entry.Timestamp)
+                            {
+                                Kind = "boundary",
+                                BoundaryLabel = label,
+                                BoundarySessionId = entry.SessionId
+                            });
+                        }
+                        else
+                        {
+                            state.Messages.Add(new ChatMessage(
+                                MapRole(entry.Role ?? "system"),
+                                entry.Content ?? string.Empty,
+                                entry.Timestamp)
+                            {
+                                ToolName = entry.ToolName,
+                                ToolCallId = entry.ToolCallId,
+                                IsToolCall = entry.ToolName is not null
+                            });
+                        }
+                    }
+                }
+            }
+
+            conv.HistoryLoaded = true;
+
+            // Sync SessionId from the conversation after loading
+            if (state.ActiveConversationId == conversationId && conv.ActiveSessionId is not null)
+                state.SessionId = conv.ActiveSessionId;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to load history for conversation {conversationId}: {ex.Message}");
+            conv.HistoryLoaded = true; // Don't retry on failure
+        }
+        finally
+        {
+            conv.IsLoadingHistory = false;
             OnStateChanged?.Invoke();
         }
     }
@@ -558,10 +849,18 @@ public sealed class AgentSessionManager : IDisposable
         state.IsStreaming = false;
         state.ProcessingStage = null;
 
-        // Track unread for non-active agents
+        // Track unread for non-active agents, and per-conversation for non-active conversations
         if (state.AgentId != ActiveAgentId)
         {
             state.UnreadCount++;
+        }
+
+        // Increment conversation unread count for the conversation whose live session fired this event
+        var activeConv = state.Conversations.Values
+            .FirstOrDefault(c => c.ActiveSessionId == evt.SessionId);
+        if (activeConv is not null && activeConv.ConversationId != state.ActiveConversationId)
+        {
+            activeConv.UnreadCount++;
         }
 
         OnStateChanged?.Invoke();
@@ -726,8 +1025,8 @@ public sealed class AgentSessionManager : IDisposable
                     state.CurrentStreamBuffer = "";
                     state.ThinkingBuffer = "";
                     state.ProcessingStage = null;
-                    state.HistoryLoaded = false; // Force reload to pick up missed messages
-                    await LoadHistoryAsync(agentId);
+                    state.ConversationsLoaded = false; // Force reload to pick up missed messages
+                    await LoadConversationsAsync(agentId);
                 }
             }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionState.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionState.cs
@@ -65,6 +65,62 @@ public sealed class AgentSessionState
 
     /// <summary>Whether thinking blocks are visible in the chat panel.</summary>
     public bool ShowThinking { get; set; } = true;
+
+    // ── Conversation-awareness ─────────────────────────────────────────────
+
+    /// <summary>All conversations for this agent, keyed by conversation ID.</summary>
+    public Dictionary<string, ConversationListItemState> Conversations { get; } = new();
+
+    /// <summary>The currently selected conversation ID.</summary>
+    public string? ActiveConversationId { get; set; }
+
+    /// <summary>Whether the conversation list has been loaded from the REST API.</summary>
+    public bool ConversationsLoaded { get; set; }
+
+    /// <summary>Whether a conversation list fetch is currently in-flight.</summary>
+    public bool IsLoadingConversations { get; set; }
+
+    /// <summary>Display title of the active conversation, or null if none selected.</summary>
+    public string? ActiveConversationTitle =>
+        ActiveConversationId is not null && Conversations.TryGetValue(ActiveConversationId, out var c)
+            ? c.Title
+            : null;
+}
+
+/// <summary>
+/// Client-side view-model for one conversation in the sidebar list.
+/// </summary>
+public sealed class ConversationListItemState
+{
+    public required string ConversationId { get; init; }
+    public string Title { get; set; } = "New conversation";
+    public bool IsDefault { get; set; }
+    public string Status { get; set; } = "Active";
+    public string? ActiveSessionId { get; set; }
+    public int UnreadCount { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    // UI-only state
+    public bool HistoryLoaded { get; set; }
+    public bool IsLoadingHistory { get; set; }
+}
+
+/// <summary>
+/// A conversation history entry, used when mapping REST responses into the message timeline.
+/// </summary>
+public sealed record ConversationHistoryItem(
+    string Kind,
+    string SessionId,
+    DateTimeOffset Timestamp)
+{
+    public string? Role { get; init; }
+    public string? Content { get; init; }
+    public string? ToolName { get; init; }
+    public string? ToolCallId { get; init; }
+    public string? Reason { get; init; }
+
+    public bool IsBoundary => Kind == "boundary";
 }
 
 /// <summary>
@@ -149,6 +205,18 @@ public sealed record ChatMessage(string Role, string Content, DateTimeOffset Tim
 
     /// <summary>Thinking content attached to this assistant message (from ThinkingDelta events).</summary>
     public string? ThinkingContent { get; init; }
+
+    /// <summary>Message kind: "message" (default) or "boundary" (session divider).</summary>
+    public string Kind { get; init; } = "message";
+
+    /// <summary>Human-readable label for session boundary entries.</summary>
+    public string? BoundaryLabel { get; init; }
+
+    /// <summary>Session ID encoded in the boundary entry.</summary>
+    public string? BoundarySessionId { get; init; }
+
+    /// <summary>Whether this entry is a session boundary divider.</summary>
+    public bool IsBoundary => Kind == "boundary";
 
     /// <summary>CSS class derived from the message role.</summary>
     public string CssClass => Role.ToLowerInvariant();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+#pragma warning disable CS1591 // REST DTOs — public API via JSON deserialization
+
+public sealed record ConversationSummaryDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("isDefault")] bool IsDefault,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("activeSessionId")] string? ActiveSessionId,
+    [property: JsonPropertyName("bindingCount")] int BindingCount,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt);
+
+public sealed record CreateConversationRequestDto(
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("title")] string? Title);
+
+public sealed record ConversationResponseDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("isDefault")] bool IsDefault,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("activeSessionId")] string? ActiveSessionId,
+    [property: JsonPropertyName("bindings")] IReadOnlyList<ConversationBindingDto> Bindings,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt);
+
+public sealed record ConversationBindingDto(
+    [property: JsonPropertyName("bindingId")] string BindingId,
+    [property: JsonPropertyName("channelType")] string ChannelType,
+    [property: JsonPropertyName("channelAddress")] string ChannelAddress,
+    [property: JsonPropertyName("threadId")] string? ThreadId,
+    [property: JsonPropertyName("mode")] string Mode,
+    [property: JsonPropertyName("threadingMode")] string ThreadingMode,
+    [property: JsonPropertyName("displayPrefix")] string? DisplayPrefix,
+    [property: JsonPropertyName("boundAt")] DateTimeOffset BoundAt);
+
+public sealed record ConversationHistoryResponseDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("totalCount")] int TotalCount,
+    [property: JsonPropertyName("offset")] int Offset,
+    [property: JsonPropertyName("limit")] int Limit,
+    [property: JsonPropertyName("entries")] IReadOnlyList<ConversationHistoryEntryDto> Entries);
+
+public sealed class ConversationHistoryEntryDto
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("sessionId")]
+    public required string SessionId { get; init; }
+
+    [JsonPropertyName("timestamp")]
+    public required DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("role")]
+    public string? Role { get; init; }
+
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
+
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; init; }
+
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; init; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayInfoService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayInfoService.cs
@@ -2,18 +2,33 @@ using System.Net.Http.Json;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
+/// <summary>
+/// Fetches build and runtime info from the gateway's /api/gateway/info endpoint.
+/// Uses the hub-derived API base URL so it works correctly behind reverse proxies.
+/// </summary>
 public sealed class GatewayInfoService
 {
     private readonly HttpClient _http;
+    private readonly AgentSessionManager _manager;
     public GatewayInfo? Info { get; private set; }
 
-    public GatewayInfoService(HttpClient http) => _http = http;
+    public GatewayInfoService(HttpClient http, AgentSessionManager manager)
+    {
+        _http = http;
+        _manager = manager;
+    }
 
     public async Task LoadAsync()
     {
         try
         {
-            Info = await _http.GetFromJsonAsync<GatewayInfo>("api/gateway/info");
+            // Use the hub-derived API base URL — resolves correctly even behind
+            // reverse proxies like NetBird where HostEnvironment.BaseAddress differs
+            // from the actual gateway address.
+            var baseUrl = _manager.ApiBaseUrl;
+            if (string.IsNullOrEmpty(baseUrl)) return;
+
+            Info = await _http.GetFromJsonAsync<GatewayInfo>($"{baseUrl}gateway/info");
         }
         catch { /* non-fatal — portal works without it */ }
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -2435,3 +2435,194 @@ details[open] > .thinking-summary::before {
 }
 
 .gateway-commit:hover { color: var(--accent); }
+
+/* ── Conversation UI — Wave 2 ─────────────────────────────────────────────── */
+
+/* Sidebar container */
+.agent-conversation-list {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.agent-conversation-list-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.4rem 0.6rem;
+}
+
+.agent-conversation-list-title {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+
+/* New conversation button */
+.conversation-new-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.5rem;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) / 2);
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.conversation-new-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: rgba(0, 180, 216, 0.08);
+}
+
+.conversation-new-btn-icon {
+    font-size: 1rem;
+    line-height: 1;
+    font-weight: 400;
+}
+
+.conversation-new-btn-label {
+    line-height: 1;
+}
+
+/* Loading / empty states */
+.conversation-list-loading,
+.conversation-list-empty {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8rem;
+    font-style: italic;
+    color: var(--text-muted);
+}
+
+/* Individual conversation item */
+.conversation-list-item {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 0.45rem 0.75rem;
+    background: transparent;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0;
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+    gap: 0.2rem;
+}
+
+.conversation-list-item:hover {
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+}
+
+.conversation-list-item.active {
+    border-left-color: var(--accent);
+    background: rgba(0, 180, 216, 0.07);
+    color: var(--text-primary);
+}
+
+/* Item main row: title + badge */
+.conversation-list-item-main {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.conversation-list-item-title {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+/* "Default" pill badge */
+.conversation-default-badge {
+    flex-shrink: 0;
+    font-size: 0.65rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0 4px;
+    white-space: nowrap;
+    line-height: 1.4;
+}
+
+/* Item meta row: unread dot + timestamp */
+.conversation-list-item-meta {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.35rem;
+    margin-left: auto;
+}
+
+.conversation-unread-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+    flex-shrink: 0;
+}
+
+.conversation-updated-at {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+/* ── Session Boundary Divider ─────────────────────────────────────────────── */
+
+.session-boundary {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+    width: 100%;
+    margin: 0.5rem 0;
+}
+
+.session-boundary-line {
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+}
+
+.session-boundary-label {
+    padding: 0 0.5rem;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+}
+
+/* ── Chat Header — Conversation Title Row ─────────────────────────────────── */
+
+.conversation-title-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.1rem;
+}
+
+.conversation-title {
+    font-size: 0.8rem;
+    font-weight: 400;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -27,7 +27,7 @@ public sealed class MainLayoutTests : IDisposable
         _ctx.Services.AddSingleton(_manager);
         _ctx.Services.AddSingleton(_manager.Hub);
         _ctx.Services.AddSingleton(new HttpClient());
-        _ctx.Services.AddScoped<GatewayInfoService>();
+        _ctx.Services.AddScoped(sp => new GatewayInfoService(sp.GetRequiredService<HttpClient>(), _manager));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 


### PR DESCRIPTION
Closes #37

## What changed

Switches the portal from session-first to conversation-first UX.

### Sidebar
- Agent dropdown stays; session list replaced by **conversation list**
- Each conversation shows: title, Default badge, unread dot, relative timestamp
- Active conversation highlighted with left accent border
- `+ New` button to create a conversation per agent
- Conversations loaded on agent select via `GET /api/conversations?agentId=`

### Chat panel
- Header now shows agent name + active conversation title
- Message timeline includes **session boundary dividers**: `────── Session · Apr 27 14:32 · s_abc123 ──────`
- History loaded from `GET /api/conversations/{id}/history` — spans all sessions in the conversation
- Empty state when no conversation selected

### State model
- `AgentSessionState` extended with conversation collections — no separate wrapper class
- `ChatMessage` extended with `Kind/BoundaryLabel/BoundarySessionId` for timeline boundaries
- New `AgentSessionManager` methods: `LoadConversationsAsync`, `SelectConversationAsync`, `CreateConversationAsync`, `RefreshConversationsAsync`
- Per-conversation unread counts

### CSS
- 17 new class hooks styled matching existing dark theme
- Active conversation: left accent border + subtle tint
- Session boundary: mono font label, flex lines either side
- Mobile/responsive sidebar unchanged

## Test results
2,594 passing, 0 failing