### PR TITLE
fix(cli): embed git commit SHA into gateway build via SourceRevisionId

### DIFF
--- a/.squad/skills/botnexus-issue-workflow/references/open-issues.md
+++ b/.squad/skills/botnexus-issue-workflow/references/open-issues.md
@@ -11,16 +11,25 @@ Last updated: 2026-04-28
 | #27 | Gateway | Message queue injection timing | bug | open |
 | #28 | Agents | ask_user tool — interactive mid-turn user input | enhancement | open |
 | #29 | Agents | Prompt templates — named parameterised prompt library | enhancement | open |
-| #31 | Config | Dynamic configuration reload — hot-reload without gateway restart | enhancement | open |
+| #31 | Config | Dynamic configuration reload without gateway restart | enhancement | open |
 | #32 | Memory | Memory persistence lifecycle | enhancement | open |
-| #34 | Portal | Dynamic agent list in portal sidebar | enhancement | open |
-| #36 | CLI | CLI multi-instance support — global --target for all commands | enhancement | open |
-| #37 | Portal | Portal: conversation-first sidebar and chat UI | enhancement | in progress (wt-37) |
+| #34 | Portal | Dynamic agent list in sidebar | enhancement | open |
+| #36 | CLI | Global --target option for all commands | enhancement | closed (merged #42) |
+| #37 | Portal | Conversation-first sidebar and chat UI | enhancement | in progress (wt-37) |
+| #41 | Portal | Show gateway build info — restart time and commit SHA | enhancement | PR #43 open |
 
-## Worktrees active
+## Active PRs
+
+| PR | Issue | Description | Status |
+|---|---|---|---|
+| #43 | #41 | Portal gateway build info | Open — CI green |
+| #3 | — | Audio transcription test coverage | Open |
+
+## Active Worktrees
 
 | Path | Branch | Issue |
 |---|---|---|
+| ~/projects/botnexus | main | — |
+| ~/projects/botnexus-wt-36 | improvement/36-cli-global-target | #36 (merged, cleanup pending) |
 | ~/projects/botnexus-wt-37 | feat/37-portal-conversation-ui | #37 |
-| ~/projects/botnexus-wt-rename-exchange | refactor/rename-agent-exchange | — (pre-issue era, PR #21 pending) |
-| ~/projects/botnexus-wt-cli-source | refactor/cli-source-target-params | — (pre-issue era, PR #22 pending) |
+| ~/projects/botnexus-wt-41 | feat/41-gateway-build-info | #41 |

--- a/scripts/botnexus-sync.ps1
+++ b/scripts/botnexus-sync.ps1
@@ -1,14 +1,8 @@
 #!/usr/bin/env pwsh
 # botnexus-sync.ps1
-# Manages two BotNexus instances:
+# Manages two BotNexus instances via the BotNexus CLI:
 #   PROD: ~/botnexus-prod  (sytone/botnexus main) -> ~/.botnexus/     -> port 5005
 #   DEV:  ~/projects/botnexus (fork main)          -> ~/.botnexus-dev/ -> port 5006
-#
-# Handles build, extension deploy, and process lifecycle directly.
-# The CLI's `gateway start` cannot manage two instances yet because
-# GatewayProcessManager uses a single hardcoded PID file (issue #36).
-# Once #36 ships this becomes:
-#   botnexus gateway start --source <repo> --target <home> --port <n>
 #
 # Runs every 15 min via cron. Logs to ~/logs/botnexus-sync.log
 
@@ -18,7 +12,7 @@ $env:PATH        = "$env:HOME/.dotnet:$env:HOME/.dotnet/tools:" + $env:PATH
 $env:DOTNET_ROOT = "$env:HOME/.dotnet"
 $env:DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '1'
 
-$DOTNET = "$env:HOME/.dotnet/dotnet"
+$DOTNET  = "$env:HOME/.dotnet/dotnet"
 $LogDir  = "$env:HOME/logs"
 $LogFile = "$LogDir/botnexus-sync.log"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
@@ -40,86 +34,16 @@ try {
     exit 0
 }
 
-function Test-GatewayRunning {
-    param([string]$BnHome)
-    $PidFile = "$BnHome/gateway.pid"
-    if (-not (Test-Path $PidFile)) { return $false }
-    $GwPid = [int](Get-Content $PidFile -Raw).Trim()
-    try { return $null -ne (Get-Process -Id $GwPid -ErrorAction Stop) }
-    catch { return $false }
-}
-
-function Stop-Gateway {
-    param([string]$BnHome, [string]$Label)
-    $PidFile = "$BnHome/gateway.pid"
-    if (-not (Test-Path $PidFile)) { return }
-    $GwPid = [int](Get-Content $PidFile -Raw).Trim()
-    Write-Log "[$Label] Stopping gateway (pid $GwPid)..."
-    Stop-Process -Id $GwPid -Force -ErrorAction SilentlyContinue
-    Start-Sleep -Seconds 2
-    Stop-Process -Id $GwPid -Force -ErrorAction SilentlyContinue
-    Remove-Item $PidFile -Force -ErrorAction SilentlyContinue
-}
-
-function Start-Gateway {
-    param([string]$Dll, [string]$BnHome, [int]$Port, [string]$Label)
-    $PidFile = "$BnHome/gateway.pid"
-    $GwLog   = "$LogDir/botnexus-gateway-$Label.log"
-    Write-Log "[$Label] Starting gateway (port $Port)..."
-    $env:BOTNEXUS_HOME = $BnHome
-    # stdout and stderr go to separate files — Start-Process on Linux cannot
-    # redirect both to the same path
-    $proc = Start-Process -FilePath $DOTNET `
-        -ArgumentList "$Dll --urls http://0.0.0.0:$Port" `
-        -RedirectStandardOutput $GwLog `
-        -RedirectStandardError  "$GwLog.err" `
-        -NoNewWindow -PassThru
-    $proc.Id | Set-Content $PidFile
-    Start-Sleep -Seconds 4
-    if (Test-GatewayRunning $BnHome) {
-        Write-Log "[$Label] Started (pid $($proc.Id))"
-    } else {
-        Write-Log "[$Label] ERROR: Exited immediately — check $GwLog"
-        Remove-Item $PidFile -Force -ErrorAction SilentlyContinue
-        throw "Gateway failed to start for $Label"
-    }
-}
-
-function Deploy-Extensions {
-    # Mirrors what the CLI's ServeCommand.DeployExtensions does:
-    # publish extensions, publish Blazor client, copy to BnHome/extensions/
-    param([string]$Repo, [string]$BnHome, [string]$Label)
-    Write-Log "[$Label] Deploying extensions..."
-
-    # Publish Blazor client (wwwroot static assets)
-    & $DOTNET publish "$Repo/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient" `
-        -c Release --nologo 2>&1 | Add-Content $LogFile
-
-    $BlazorPublish = "$Repo/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/bin/Release/net10.0/publish/wwwroot"
-    if (Test-Path $BlazorPublish) {
-        Remove-Item "$BnHome/extensions/botnexus-signalr/blazor" -Recurse -Force -ErrorAction SilentlyContinue
-        Copy-Item $BlazorPublish "$BnHome/extensions/botnexus-signalr/blazor" -Recurse -Force
-    }
-
-    # Copy extension DLLs — published alongside the gateway build
-    $ExtSrc = "$Repo/src/extensions"
-    foreach ($extDir in (Get-ChildItem $ExtSrc -Directory)) {
-        $publishDir = "$($extDir.FullName)/bin/Release/net10.0/publish"
-        if (-not (Test-Path $publishDir)) { continue }
-        $extName = $extDir.Name.ToLower() -replace 'botnexus\.', 'botnexus-'
-        $extDest = "$BnHome/extensions/$extName"
-        New-Item -ItemType Directory -Force -Path $extDest | Out-Null
-        Copy-Item "$publishDir/*" $extDest -Recurse -Force -ErrorAction SilentlyContinue
-    }
-
-    Write-Log "[$Label] Extensions deployed."
+function Invoke-Cli {
+    param([string]$Repo, [string[]]$CliArgs)
+    $CliDll = "$Repo/src/gateway/BotNexus.Cli/bin/Release/net10.0/BotNexus.Cli.dll"
+    & $DOTNET $CliDll $CliArgs 2>&1 | Add-Content $LogFile
+    return $LASTEXITCODE
 }
 
 function Sync-Instance {
-    param([string]$Repo, [string]$Remote, [string]$BnHome, [int]$Port, [string]$Label)
+    param([string]$Repo, [string]$Remote, [string]$Target, [int]$Port, [string]$Label)
 
-    # Release build — same as CLI gateway start
-    $Dll = "$Repo/src/gateway/BotNexus.Gateway.Api/bin/Release/net10.0/BotNexus.Gateway.Api.dll"
     Set-Location $Repo
 
     & git fetch $Remote main 2>&1 | Add-Content $LogFile
@@ -128,10 +52,11 @@ function Sync-Instance {
 
     if ($LocalSha -eq $RemoteSha) {
         Write-Log "[$Label] Up to date ($LocalSha)."
-        if (-not (Test-GatewayRunning $BnHome)) {
+        $statusCode = Invoke-Cli $Repo @("gateway", "status", "--target", $Target)
+        if ($statusCode -ne 0) {
             Write-Log "[$Label] Gateway not running — starting..."
-            Deploy-Extensions $Repo $BnHome $Label
-            Start-Gateway $Dll $BnHome $Port $Label
+            $startCode = Invoke-Cli $Repo @("gateway", "start", "--source", $Repo, "--target", $Target, "--port", "$Port")
+            if ($startCode -ne 0) { Write-Log "[$Label] ERROR: gateway start failed." }
         }
         return
     }
@@ -148,19 +73,20 @@ function Sync-Instance {
     if ($LASTEXITCODE -ne 0) { Write-Log "[$Label] ERROR: Tests failed — aborting restart."; return }
     Write-Log "[$Label] Tests passed."
 
-    Deploy-Extensions $Repo $BnHome $Label
-
-    if (Test-GatewayRunning $BnHome) { Stop-Gateway $BnHome $Label }
-    Start-Gateway $Dll $BnHome $Port $Label
+    Write-Log "[$Label] Restarting gateway via CLI..."
+    Invoke-Cli $Repo @("gateway", "stop", "--target", $Target) | Out-Null
+    $startCode = Invoke-Cli $Repo @("gateway", "start", "--source", $Repo, "--target", $Target, "--port", "$Port")
+    if ($startCode -ne 0) { Write-Log "[$Label] ERROR: gateway start failed." }
+    else { Write-Log "[$Label] Gateway restarted." }
 }
 
 try {
     Write-Log "=== BotNexus sync started ==="
 
-    # PROD: sytone/botnexus (--source) -> ~/.botnexus (--target) -> port 5005
+    # PROD: sytone/botnexus -> ~/.botnexus -> port 5005
     Sync-Instance "$env:HOME/botnexus-prod" "origin" "$env:HOME/.botnexus" 5005 "prod"
 
-    # DEV: fork (--source) -> ~/.botnexus-dev (--target) -> port 5006
+    # DEV: fork -> ~/.botnexus-dev -> port 5006
     Sync-Instance "$env:HOME/projects/botnexus" "fork" "$env:HOME/.botnexus-dev" 5006 "dev"
 
     Write-Log "=== Done ==="

--- a/scripts/botnexus-sync.ps1
+++ b/scripts/botnexus-sync.ps1
@@ -65,7 +65,8 @@ function Sync-Instance {
     & git pull $Remote main 2>&1 | Add-Content $LogFile
 
     Write-Log "[$Label] Building (Release)..."
-    & $DOTNET build "$Repo/BotNexus.slnx" -c Release --nologo --tl:off 2>&1 | Add-Content $LogFile
+    $CommitSha = (git -C $Repo rev-parse HEAD).Trim()
+    & $DOTNET build "$Repo/BotNexus.slnx" -c Release --nologo --tl:off -p:SourceRevisionId=$CommitSha 2>&1 | Add-Content $LogFile
     if ($LASTEXITCODE -ne 0) { Write-Log "[$Label] ERROR: Build failed — aborting."; return }
 
     Write-Log "[$Label] Running tests..."

--- a/src/gateway/BotNexus.Cli/Commands/BuildCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/BuildCommand.cs
@@ -43,9 +43,42 @@ internal sealed class BuildCommand
             return 1;
         }
 
+        // Resolve git commit SHA from the repo so it gets embedded in the gateway binary.
+        // Falls back to "unknown" if git is unavailable or the directory is not a repo.
+        var commitSha = ResolveCommitSha(repoRoot);
+
         AnsiConsole.MarkupLine("[blue][[build]][/] Building solution (Release, skipping test projects)...");
 
-        return await BuildOutputStreamer.RunAsync(solution, repoRoot, verbose, cancellationToken);
+        return await BuildOutputStreamer.RunAsync(solution, repoRoot, commitSha, verbose, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves the current git commit SHA from the repo at <paramref name="repoRoot"/>.
+    /// Returns <c>"unknown"</c> if git is not available or the directory is not a git repo.
+    /// </summary>
+    internal static string ResolveCommitSha(string repoRoot)
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "-C \"" + repoRoot + "\" rev-parse HEAD",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            using var proc = System.Diagnostics.Process.Start(psi);
+            if (proc is null) return "unknown";
+            var sha = proc.StandardOutput.ReadLine()?.Trim();
+            proc.WaitForExit();
+            return string.IsNullOrWhiteSpace(sha) ? "unknown" : sha;
+        }
+        catch
+        {
+            return "unknown";
+        }
     }
 
     internal static string ResolveRepoRoot(string? explicitPath, bool dev)

--- a/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
+++ b/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
@@ -17,13 +17,14 @@ internal static partial class BuildOutputStreamer
     internal static async Task<int> RunAsync(
         string solution,
         string workingDirectory,
+        string commitSha,
         bool verbose,
         CancellationToken cancellationToken)
     {
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"build \"{solution}\" -c Release --nologo --tl:off /p:SkipTests=true",
+            Arguments = $"build \"{solution}\" -c Release --nologo --tl:off /p:SkipTests=true /p:SourceRevisionId={commitSha}",
             WorkingDirectory = workingDirectory,
             UseShellExecute = false,
             RedirectStandardOutput = true,


### PR DESCRIPTION
BuildCommand now resolves the git SHA from the repo root and passes it as `/p:SourceRevisionId` to `dotnet build`, so the gateway binary correctly reports its commit in `GET /api/gateway/info` instead of showing `unknown`.