### PR TITLE
fix(blazor-client): fix conversation UI bugs — sidebar, title rename, agent refresh, conversation history

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -8,10 +8,23 @@
                 @if (State.ActiveConversationId is not null)
                 {
                     <div class="conversation-title-row">
-                        <span class="conversation-title">@State.ActiveConversationTitle</span>
-                        @if (State.Conversations.TryGetValue(State.ActiveConversationId, out var activeConversation) && activeConversation.IsDefault)
+                        @if (_editingTitle)
                         {
-                            <span class="conversation-default-badge">Default</span>
+                            <input class="conversation-title-input"
+                                   @bind="_titleDraft"
+                                   @bind:event="oninput"
+                                   @onblur="SaveTitle"
+                                   @onkeydown="TitleKeyDown"
+                                   @ref="_titleInput"
+                                   maxlength="200" />
+                        }
+                        else
+                        {
+                            <span class="conversation-title editable" @onclick="StartEditTitle" title="Click to rename">@State.ActiveConversationTitle</span>
+                            @if (State.Conversations.TryGetValue(State.ActiveConversationId, out var activeConversation) && activeConversation.IsDefault)
+                            {
+                                <span class="conversation-default-badge">Default</span>
+                            }
                         }
                     </div>
                 }
@@ -258,8 +271,48 @@
     private string _inputText = "";
     private ElementReference _messagesContainer;
     private ElementReference _inputElement;
+    private ElementReference _titleInput;
     private bool _enterPreventionBound;
     private AgentConfigPanel? _configPanel;
+
+    // ── Inline title editing ──────────────────────────────────────────────
+
+    private bool _editingTitle;
+    private string _titleDraft = "";
+
+    private void StartEditTitle()
+    {
+        _titleDraft = State.ActiveConversationTitle ?? "";
+        _editingTitle = true;
+        _ = InvokeAsync(async () =>
+        {
+            StateHasChanged();
+            await Task.Delay(50);
+            try { await JS.InvokeVoidAsync("eval", "document.querySelector('.conversation-title-input')?.focus()"); }
+            catch { /* JS interop may fail during disposal */ }
+        });
+    }
+
+    private async Task SaveTitle()
+    {
+        _editingTitle = false;
+        var draft = _titleDraft.Trim();
+        if (!string.IsNullOrWhiteSpace(draft) && draft != State.ActiveConversationTitle)
+            await Manager.RenameConversationAsync(State.AgentId, State.ActiveConversationId, draft);
+        else
+            StateHasChanged();
+    }
+
+    private async Task TitleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+            await SaveTitle();
+        else if (e.Key == "Escape")
+        {
+            _editingTitle = false;
+            StateHasChanged();
+        }
+    }
 
     // ── Markdown rendering cache ──────────────────────────────────────────
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 @inject GatewayInfoService GatewayInfo
 @inject IJSRuntime JS
 @implements IDisposable
+@implements IAsyncDisposable
 
 <div class="app-shell">
     @* Top bar with burger + logo *@
@@ -77,7 +78,7 @@
                             <div class="agent-conversation-list-header">
                                 <span class="agent-conversation-list-title">Conversations</span>
                                 <button class="conversation-new-btn"
-                                        @onclick="() => CreateConversationAndClose(activeState.AgentId)"
+                                        @onclick="() => CreateConversationAsync(activeState.AgentId)"
                                         title="Start a new conversation">
                                     <span class="conversation-new-btn-icon">+</span>
                                     <span class="conversation-new-btn-label">New</span>
@@ -99,7 +100,7 @@
                                     .ThenByDescending(c => c.UpdatedAt))
                                 {
                                     <button class="conversation-list-item @(conversation.ConversationId == activeState.ActiveConversationId ? "active" : "")"
-                                            @onclick="() => SelectConversationAndClose(activeState.AgentId, conversation.ConversationId)">
+                                            @onclick="() => SelectConversationAsync(activeState.AgentId, conversation.ConversationId)">
                                         <span class="conversation-list-item-main">
                                             <span class="conversation-list-item-title">@conversation.Title</span>
 
@@ -129,7 +130,7 @@
                                 .Where(s => s.Status is "Running" or "Completed"))
                             {
                                 <div class="agent-session-item @(IsSubAgentActive(sub) ? "active" : "")"
-                                     @onclick="() => ViewSubAgentAndClose(sub)"
+                                     @onclick="() => ViewSubAgentAsync(sub)"
                                      style="cursor: pointer;"
                                      title="@sub.Task">
                                     <span>@SubAgentIcon(sub.Status)</span>
@@ -195,11 +196,13 @@
     private List<Announcement> _announcements = [];
     private bool _restarting;
     private bool _sidebarOpen = false;
+    private bool _isMobile = false;
     private const string SidebarKey = "botnexus-sidebar-open";
 
     protected override void OnInitialized()
     {
         Manager.OnStateChanged += HandleStateChanged;
+        Nav.LocationChanged += OnLocationChanged;
     }
 
     protected override async Task OnInitializedAsync()
@@ -214,6 +217,7 @@
         {
             var stored = await JS.InvokeAsync<string?>("localStorage.getItem", SidebarKey);
             _sidebarOpen = stored == "true";
+            _isMobile = await JS.InvokeAsync<bool>("chatScroll.isMobileView");
             StateHasChanged();
         }
     }
@@ -240,12 +244,31 @@
         await JS.InvokeVoidAsync("localStorage.setItem", SidebarKey, _sidebarOpen ? "true" : "false");
     }
 
-    private void CloseSidebar() => _sidebarOpen = false;
+    private void CloseSidebar()
+    {
+        if (_isMobile)
+            _sidebarOpen = false;
+    }
 
     private void OnNavClick()
     {
-        // Close sidebar after navigation on mobile
-        _sidebarOpen = false;
+        // Close sidebar after navigation on mobile only
+        if (_isMobile)
+            _sidebarOpen = false;
+    }
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        // When navigating back to chat from configuration/agents, refresh agent list
+        var relative = Nav.ToBaseRelativePath(e.Location).TrimEnd('/');
+        if (relative == "")
+        {
+            _ = InvokeAsync(async () =>
+            {
+                await Manager.RefreshAgentsAsync();
+                StateHasChanged();
+            });
+        }
     }
 
     private string NavClass(string page)
@@ -264,7 +287,11 @@
     {
         var agentId = e.Value?.ToString();
         if (!string.IsNullOrEmpty(agentId))
+        {
             await Manager.SetActiveAgentAsync(agentId);
+            if (_isMobile)
+                _sidebarOpen = false;
+        }
     }
 
     private static string SubAgentIcon(string status) => status switch
@@ -274,10 +301,11 @@
         _           => "🤖"
     };
 
-    private async Task ViewSubAgentAndClose(SubAgentInfo sub)
+    private async Task ViewSubAgentAsync(SubAgentInfo sub)
     {
         await Manager.ViewSubAgentAsync(sub);
-        _sidebarOpen = false;
+        if (_isMobile)
+            _sidebarOpen = false;
     }
 
     private bool IsSubAgentActive(SubAgentInfo sub)
@@ -285,16 +313,18 @@
         return Manager.ActiveAgentId == sub.SubAgentId;
     }
 
-    private async Task SelectConversationAndClose(string agentId, string conversationId)
+    private async Task SelectConversationAsync(string agentId, string conversationId)
     {
         await Manager.SelectConversationAsync(agentId, conversationId);
-        _sidebarOpen = false;
+        if (_isMobile)
+            _sidebarOpen = false;
     }
 
-    private async Task CreateConversationAndClose(string agentId)
+    private async Task CreateConversationAsync(string agentId)
     {
         await Manager.CreateConversationAsync(agentId);
-        _sidebarOpen = false;
+        if (_isMobile)
+            _sidebarOpen = false;
     }
 
     private static string FormatConversationTimestamp(DateTimeOffset ts)
@@ -338,5 +368,8 @@
     public void Dispose()
     {
         Manager.OnStateChanged -= HandleStateChanged;
+        Nav.LocationChanged -= OnLocationChanged;
     }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -103,6 +103,23 @@ public sealed class AgentSessionManager : IDisposable
         if (!_sessions.TryGetValue(agentId, out var state))
             return;
 
+        // Ensure we have an active conversation before sending — creates a default one if absent.
+        // This also guarantees convId is non-null in all downstream event handlers,
+        // preventing the IsStreaming-stuck and message-loss bugs.
+        if (state.ActiveConversationId is null)
+        {
+            var convId = await CreateConversationAsync(agentId, title: null, select: true);
+            if (convId is null)
+            {
+                // Couldn't create conversation — surface error and bail
+                GetOrCreateMessageStore(state, state.ActiveConversationId)
+                    .Add(new ChatMessage("Error", "Failed to create conversation before sending.", DateTimeOffset.UtcNow));
+                OnStateChanged?.Invoke();
+                return;
+            }
+        }
+
+        // Route user message via the conversation store (never into the temp []).
         GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));
         OnStateChanged?.Invoke();
 
@@ -110,6 +127,10 @@ public sealed class AgentSessionManager : IDisposable
         {
             var result = await _hub.SendMessageAsync(agentId, state.ChannelType ?? "signalr", content);
             RegisterSession(agentId, result.SessionId, result.ChannelType);
+
+            // Refresh conversation list so the server-assigned ActiveSessionId is picked up.
+            // This lets FindConversationIdForSession resolve correctly for subsequent events.
+            await RefreshConversationsAsync(agentId);
         }
         catch (Exception ex)
         {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -305,6 +305,10 @@ public sealed class AgentSessionManager : IDisposable
         if (state.ConversationsLoaded || state.IsLoadingConversations)
             return;
 
+        // If API URL not yet available, return early without marking loaded — allows retry
+        if (_apiBaseUrl is null)
+            return;
+
         state.IsLoadingConversations = true;
         OnStateChanged?.Invoke();
 
@@ -373,6 +377,21 @@ public sealed class AgentSessionManager : IDisposable
         if (!state.Conversations.TryGetValue(conversationId, out var conv))
             return;
 
+        // Clear messages when switching conversations so we don't show stale history
+        if (state.ActiveConversationId != conversationId)
+        {
+            state.Messages.Clear();
+            // Reset history flags so the new conversation's history will be loaded
+            foreach (var c in state.Conversations.Values)
+            {
+                if (c.ConversationId == conversationId)
+                {
+                    c.HistoryLoaded = false;
+                    c.IsLoadingHistory = false;
+                }
+            }
+        }
+
         state.ActiveConversationId = conversationId;
 
         // Sync active session to the selected conversation's live session
@@ -416,7 +435,12 @@ public sealed class AgentSessionManager : IDisposable
             };
 
             if (select)
+            {
+                // New conversation — clear messages so we don't inherit previous history
+                if (_sessions.TryGetValue(agentId, out var st))
+                    st.Messages.Clear();
                 await SelectConversationAsync(agentId, dto.ConversationId);
+            }
             else
                 OnStateChanged?.Invoke();
 
@@ -429,7 +453,69 @@ public sealed class AgentSessionManager : IDisposable
         }
     }
 
-    /// <summary>Re-fetch the conversation list, preserving local UI state for existing conversations.</summary>
+    /// <summary>Refresh the agent list from the REST API, adding any new agents.</summary>
+    public async Task RefreshAgentsAsync()
+    {
+        if (_apiBaseUrl is null)
+            return;
+
+        try
+        {
+            var url = $"{_apiBaseUrl}agents";
+            var agents = await _http.GetFromJsonAsync<List<AgentSummary>>(url);
+            if (agents is null)
+                return;
+
+            foreach (var agent in agents)
+            {
+                if (!_sessions.ContainsKey(agent.AgentId))
+                {
+                    _sessions[agent.AgentId] = new AgentSessionState
+                    {
+                        AgentId = agent.AgentId,
+                        DisplayName = agent.DisplayName,
+                        IsConnected = true
+                    };
+                }
+                else
+                {
+                    _sessions[agent.AgentId].DisplayName = agent.DisplayName;
+                }
+            }
+
+            OnStateChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to refresh agents: {ex.Message}");
+        }
+    }
+
+    /// <summary>Rename a conversation via PATCH /api/conversations/{id}.</summary>
+    public async Task RenameConversationAsync(string agentId, string? conversationId, string newTitle)
+    {
+        if (conversationId is null || !_sessions.TryGetValue(agentId, out var state))
+            return;
+        if (!state.Conversations.TryGetValue(conversationId, out var conv))
+            return;
+        if (string.IsNullOrWhiteSpace(newTitle))
+            return;
+
+        try
+        {
+            var url = $"{_apiBaseUrl}conversations/{Uri.EscapeDataString(conversationId)}";
+            var request = new PatchConversationRequestDto(newTitle);
+            var response = await _http.PatchAsJsonAsync(url, request);
+            response.EnsureSuccessStatusCode();
+
+            conv.Title = newTitle;
+            OnStateChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to rename conversation {conversationId}: {ex.Message}");
+        }
+    }
     public async Task RefreshConversationsAsync(string agentId)
     {
         if (!_sessions.TryGetValue(agentId, out var state))
@@ -695,6 +781,15 @@ public sealed class AgentSessionManager : IDisposable
                 DisplayName = agent.DisplayName,
                 IsConnected = true
             };
+        }
+
+        // Retry loading conversations for the active agent if not yet loaded
+        // (handles race where SetActiveAgentAsync was called before _apiBaseUrl was set)
+        if (ActiveAgentId is not null
+            && _sessions.TryGetValue(ActiveAgentId, out var activeState)
+            && !activeState.ConversationsLoaded)
+        {
+            _ = Task.Run(() => LoadConversationsAsync(ActiveAgentId));
         }
 
         OnStateChanged?.Invoke();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -88,8 +88,7 @@ public sealed class AgentSessionManager : IDisposable
                 await LoadConversationsAsync(agentId);
             }
             else if (state.ActiveConversationId is not null
-                && state.Conversations.TryGetValue(state.ActiveConversationId, out var conv)
-                && !conv.HistoryLoaded && !conv.IsLoadingHistory)
+                && !state.ConversationHistoryLoaded.Contains(state.ActiveConversationId))
             {
                 await LoadConversationHistoryAsync(agentId, state.ActiveConversationId);
             }
@@ -104,7 +103,7 @@ public sealed class AgentSessionManager : IDisposable
         if (!_sessions.TryGetValue(agentId, out var state))
             return;
 
-        state.Messages.Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));
         OnStateChanged?.Invoke();
 
         try
@@ -114,7 +113,7 @@ public sealed class AgentSessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            state.Messages.Add(new ChatMessage("Error", $"Send failed: {ex.Message}", DateTimeOffset.UtcNow));
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("Error", $"Send failed: {ex.Message}", DateTimeOffset.UtcNow));
             OnStateChanged?.Invoke();
         }
     }
@@ -125,7 +124,7 @@ public sealed class AgentSessionManager : IDisposable
         if (!_sessions.TryGetValue(agentId, out var state) || state.SessionId is null)
             return;
 
-        state.Messages.Add(new ChatMessage("User", $"🔀 {content}", DateTimeOffset.UtcNow));
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("User", $"🔀 {content}", DateTimeOffset.UtcNow));
         OnStateChanged?.Invoke();
 
         try
@@ -134,7 +133,7 @@ public sealed class AgentSessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            state.Messages.Add(new ChatMessage("Error", $"Steer failed: {ex.Message}", DateTimeOffset.UtcNow));
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("Error", $"Steer failed: {ex.Message}", DateTimeOffset.UtcNow));
             OnStateChanged?.Invoke();
         }
     }
@@ -145,7 +144,7 @@ public sealed class AgentSessionManager : IDisposable
         if (!_sessions.TryGetValue(agentId, out var state) || state.SessionId is null)
             return;
 
-        state.Messages.Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));
         OnStateChanged?.Invoke();
 
         try
@@ -154,7 +153,7 @@ public sealed class AgentSessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            state.Messages.Add(new ChatMessage("Error", $"Follow-up failed: {ex.Message}", DateTimeOffset.UtcNow));
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("Error", $"Follow-up failed: {ex.Message}", DateTimeOffset.UtcNow));
             OnStateChanged?.Invoke();
         }
     }
@@ -171,12 +170,10 @@ public sealed class AgentSessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            state.Messages.Add(new ChatMessage("Error", $"Abort failed: {ex.Message}", DateTimeOffset.UtcNow));
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("Error", $"Abort failed: {ex.Message}", DateTimeOffset.UtcNow));
             OnStateChanged?.Invoke();
         }
     }
-
-    /// <summary>Reset (archive) the agent's current session.</summary>
     public async Task ResetSessionAsync(string agentId)
     {
         if (!_sessions.TryGetValue(agentId, out var state) || state.SessionId is null)
@@ -189,12 +186,10 @@ public sealed class AgentSessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            state.Messages.Add(new ChatMessage("Error", $"Reset failed: {ex.Message}", DateTimeOffset.UtcNow));
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("Error", $"Reset failed: {ex.Message}", DateTimeOffset.UtcNow));
             OnStateChanged?.Invoke();
         }
     }
-
-    /// <summary>Compact the agent's current session to reduce token usage.</summary>
     public async Task<CompactSessionResult?> CompactSessionAsync(string agentId)
     {
         if (!_sessions.TryGetValue(agentId, out var state) || state.SessionId is null)
@@ -203,7 +198,7 @@ public sealed class AgentSessionManager : IDisposable
         try
         {
             var result = await _hub.CompactSessionAsync(agentId, state.SessionId);
-            state.Messages.Add(new ChatMessage("System",
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("System",
                 $"Session compacted: {result.Summarized} messages summarized, {result.Preserved} preserved. " +
                 $"Tokens: {result.TokensBefore} → {result.TokensAfter}",
                 DateTimeOffset.UtcNow));
@@ -212,7 +207,7 @@ public sealed class AgentSessionManager : IDisposable
         }
         catch (Exception ex)
         {
-            state.Messages.Add(new ChatMessage("Error", $"Compact failed: {ex.Message}", DateTimeOffset.UtcNow));
+            GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("Error", $"Compact failed: {ex.Message}", DateTimeOffset.UtcNow));
             OnStateChanged?.Invoke();
             return null;
         }
@@ -223,8 +218,12 @@ public sealed class AgentSessionManager : IDisposable
     {
         if (_sessions.TryGetValue(agentId, out var state))
         {
-            state.Messages.Clear();
-            state.Messages.Add(new ChatMessage("System", "Local messages cleared.", DateTimeOffset.UtcNow));
+            var store = GetOrCreateMessageStore(state, state.ActiveConversationId);
+            store.Clear();
+            store.Add(new ChatMessage("System", "Local messages cleared.", DateTimeOffset.UtcNow));
+            // Allow history to be re-fetched for this conversation
+            if (state.ActiveConversationId is not null)
+                state.ConversationHistoryLoaded.Remove(state.ActiveConversationId);
             OnStateChanged?.Invoke();
         }
     }
@@ -349,6 +348,10 @@ public sealed class AgentSessionManager : IDisposable
 
             state.ConversationsLoaded = true;
 
+            // Pre-create message stores for all known conversations (Change 6)
+            foreach (var conv in state.Conversations.Values)
+                state.ConversationMessageStores.TryAdd(conv.ConversationId, new List<ChatMessage>());
+
             // If this is the currently visible agent, load history now
             if (agentId == ActiveAgentId && state.ActiveConversationId is not null)
             {
@@ -377,21 +380,6 @@ public sealed class AgentSessionManager : IDisposable
         if (!state.Conversations.TryGetValue(conversationId, out var conv))
             return;
 
-        // Clear messages when switching conversations so we don't show stale history
-        if (state.ActiveConversationId != conversationId)
-        {
-            state.Messages.Clear();
-            // Reset history flags so the new conversation's history will be loaded
-            foreach (var c in state.Conversations.Values)
-            {
-                if (c.ConversationId == conversationId)
-                {
-                    c.HistoryLoaded = false;
-                    c.IsLoadingHistory = false;
-                }
-            }
-        }
-
         state.ActiveConversationId = conversationId;
 
         // Sync active session to the selected conversation's live session
@@ -401,10 +389,12 @@ public sealed class AgentSessionManager : IDisposable
         // Clear conversation unread count
         conv.UnreadCount = 0;
 
-        OnStateChanged?.Invoke();
-
-        if (!conv.HistoryLoaded && !conv.IsLoadingHistory)
+        // Lazy-load history ONLY if we have never loaded this conversation before.
+        // Do NOT clear messages — if they're already there (from streaming) keep them.
+        if (!state.ConversationHistoryLoaded.Contains(conversationId))
             await LoadConversationHistoryAsync(agentId, conversationId);
+
+        OnStateChanged?.Invoke();
     }
 
     /// <summary>Create a new conversation for the given agent.</summary>
@@ -434,11 +424,12 @@ public sealed class AgentSessionManager : IDisposable
                 UpdatedAt = dto.UpdatedAt
             };
 
+            // Initialise an empty store for the new conversation (Change 4)
+            state.ConversationMessageStores[dto.ConversationId] = new List<ChatMessage>();
+            state.ConversationHistoryLoaded.Add(dto.ConversationId); // brand new — nothing to load
+
             if (select)
             {
-                // New conversation — clear messages so we don't inherit previous history
-                if (_sessions.TryGetValue(agentId, out var st))
-                    st.Messages.Clear();
                 await SelectConversationAsync(agentId, dto.ConversationId);
             }
             else
@@ -570,8 +561,6 @@ public sealed class AgentSessionManager : IDisposable
                 var fallback = state.Conversations.Values.FirstOrDefault(c => c.IsDefault)
                     ?? state.Conversations.Values.OrderByDescending(c => c.UpdatedAt).FirstOrDefault();
                 state.ActiveConversationId = fallback?.ConversationId;
-                if (state.ActiveConversationId is null)
-                    state.Messages.Clear();
             }
         }
         catch (Exception ex)
@@ -606,8 +595,22 @@ public sealed class AgentSessionManager : IDisposable
             return;
         if (!state.Conversations.TryGetValue(conversationId, out var conv))
             return;
-        if (conv.HistoryLoaded || conv.IsLoadingHistory)
+        if (conv.IsLoadingHistory)
             return;
+
+        // Get or create the store for this conversation
+        if (!state.ConversationMessageStores.TryGetValue(conversationId, out var messages))
+        {
+            messages = new List<ChatMessage>();
+            state.ConversationMessageStores[conversationId] = messages;
+        }
+
+        // Only load if empty — never overwrite existing messages (streaming may have already populated it)
+        if (messages.Count > 0)
+        {
+            state.ConversationHistoryLoaded.Add(conversationId);
+            return;
+        }
 
         conv.IsLoadingHistory = true;
         OnStateChanged?.Invoke();
@@ -619,39 +622,34 @@ public sealed class AgentSessionManager : IDisposable
 
             if (response?.Entries is { Count: > 0 })
             {
-                // Only replace messages if this conversation is still active
-                if (state.ActiveConversationId == conversationId)
+                foreach (var entry in response.Entries)
                 {
-                    state.Messages.Clear();
-                    foreach (var entry in response.Entries)
+                    if (entry.Kind == "boundary")
                     {
-                        if (entry.Kind == "boundary")
+                        var label = $"Session \u00b7 {entry.Timestamp.ToLocalTime():MMM d HH:mm} \u00b7 {entry.SessionId}";
+                        messages.Add(new ChatMessage("System", string.Empty, entry.Timestamp)
                         {
-                            var label = $"Session \u00b7 {entry.Timestamp.ToLocalTime():MMM d HH:mm} \u00b7 {entry.SessionId}";
-                            state.Messages.Add(new ChatMessage("System", string.Empty, entry.Timestamp)
-                            {
-                                Kind = "boundary",
-                                BoundaryLabel = label,
-                                BoundarySessionId = entry.SessionId
-                            });
-                        }
-                        else
+                            Kind = "boundary",
+                            BoundaryLabel = label,
+                            BoundarySessionId = entry.SessionId
+                        });
+                    }
+                    else
+                    {
+                        messages.Add(new ChatMessage(
+                            MapRole(entry.Role ?? "system"),
+                            entry.Content ?? string.Empty,
+                            entry.Timestamp)
                         {
-                            state.Messages.Add(new ChatMessage(
-                                MapRole(entry.Role ?? "system"),
-                                entry.Content ?? string.Empty,
-                                entry.Timestamp)
-                            {
-                                ToolName = entry.ToolName,
-                                ToolCallId = entry.ToolCallId,
-                                IsToolCall = entry.ToolName is not null
-                            });
-                        }
+                            ToolName = entry.ToolName,
+                            ToolCallId = entry.ToolCallId,
+                            IsToolCall = entry.ToolName is not null
+                        });
                     }
                 }
             }
 
-            conv.HistoryLoaded = true;
+            state.ConversationHistoryLoaded.Add(conversationId);
 
             // Sync SessionId from the conversation after loading
             if (state.ActiveConversationId == conversationId && conv.ActiveSessionId is not null)
@@ -660,7 +658,7 @@ public sealed class AgentSessionManager : IDisposable
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Failed to load history for conversation {conversationId}: {ex.Message}");
-            conv.HistoryLoaded = true; // Don't retry on failure
+            state.ConversationHistoryLoaded.Add(conversationId); // Don't retry on failure
         }
         finally
         {
@@ -832,6 +830,10 @@ public sealed class AgentSessionManager : IDisposable
         var state = FindStateBySessionId(evt.SessionId);
         if (state is null) return;
 
+        var convId = FindConversationIdForSession(state, evt.SessionId) ?? state.ActiveConversationId;
+        if (convId is null) return;
+        var msgs = GetOrCreateMessageStore(state, convId);
+
         var toolCallId = evt.ToolCallId ?? Guid.NewGuid().ToString("N");
         var argsJson = evt.ToolArgs is not null
             ? JsonSerializer.Serialize(evt.ToolArgs, s_jsonOptions)
@@ -845,7 +847,7 @@ public sealed class AgentSessionManager : IDisposable
             IsToolCall = true
         };
 
-        state.Messages.Add(msg);
+        msgs.Add(msg);
         state.ActiveToolCalls[toolCallId] = new ActiveToolCall
         {
             ToolCallId = toolCallId,
@@ -853,6 +855,9 @@ public sealed class AgentSessionManager : IDisposable
             StartedAt = DateTimeOffset.UtcNow,
             MessageId = msg.Id
         };
+
+        if (convId != state.ActiveConversationId && state.Conversations.TryGetValue(convId, out var inactiveConv))
+            inactiveConv.UnreadCount++;
 
         state.ProcessingStage = $"🔧 Using tool: {evt.ToolName}";
         OnStateChanged?.Invoke();
@@ -862,6 +867,10 @@ public sealed class AgentSessionManager : IDisposable
     {
         var state = FindStateBySessionId(evt.SessionId);
         if (state is null) return;
+
+        var convId = FindConversationIdForSession(state, evt.SessionId) ?? state.ActiveConversationId;
+        if (convId is null) return;
+        var msgs = GetOrCreateMessageStore(state, convId);
 
         var toolCallId = evt.ToolCallId;
         TimeSpan? duration = null;
@@ -877,11 +886,11 @@ public sealed class AgentSessionManager : IDisposable
         // Try to update the ToolStart message in-place with result and duration
         if (messageId is not null)
         {
-            var index = state.Messages.FindIndex(m => m.Id == messageId);
+            var index = msgs.FindIndex(m => m.Id == messageId);
             if (index >= 0)
             {
-                var original = state.Messages[index];
-                state.Messages[index] = original with
+                var original = msgs[index];
+                msgs[index] = original with
                 {
                     Content = evt.ToolIsError == true
                         ? $"❌ {evt.ToolName} failed"
@@ -891,7 +900,6 @@ public sealed class AgentSessionManager : IDisposable
                     ToolDuration = duration
                 };
 
-                // Update processing stage — back to responding if still streaming
                 state.ProcessingStage = state.IsStreaming ? "🤖 Agent is responding…" : null;
                 OnStateChanged?.Invoke();
                 return;
@@ -899,7 +907,7 @@ public sealed class AgentSessionManager : IDisposable
         }
 
         // Fallback: add as a new message if the original was not found
-        state.Messages.Add(new ChatMessage("Tool",
+        msgs.Add(new ChatMessage("Tool",
             evt.ToolIsError == true ? $"❌ {evt.ToolName} failed" : $"✅ {evt.ToolName} completed",
             DateTimeOffset.UtcNow)
         {
@@ -911,6 +919,9 @@ public sealed class AgentSessionManager : IDisposable
             ToolDuration = duration
         });
 
+        if (convId != state.ActiveConversationId && state.Conversations.TryGetValue(convId, out var inactiveConv))
+            inactiveConv.UnreadCount++;
+
         state.ProcessingStage = state.IsStreaming ? "🤖 Agent is responding…" : null;
         OnStateChanged?.Invoke();
     }
@@ -920,12 +931,16 @@ public sealed class AgentSessionManager : IDisposable
         var state = FindStateBySessionId(evt.SessionId);
         if (state is null) return;
 
+        var convId = FindConversationIdForSession(state, evt.SessionId) ?? state.ActiveConversationId;
+        if (convId is null) return;
+        var msgs = GetOrCreateMessageStore(state, convId);
+
         // Finalize the thinking buffer + stream buffer into a single assistant message
         var thinkingContent = string.IsNullOrEmpty(state.ThinkingBuffer) ? null : state.ThinkingBuffer;
 
         if (!string.IsNullOrEmpty(state.CurrentStreamBuffer))
         {
-            state.Messages.Add(new ChatMessage("Assistant", state.CurrentStreamBuffer, DateTimeOffset.UtcNow)
+            msgs.Add(new ChatMessage("Assistant", state.CurrentStreamBuffer, DateTimeOffset.UtcNow)
             {
                 ThinkingContent = thinkingContent
             });
@@ -933,7 +948,7 @@ public sealed class AgentSessionManager : IDisposable
         else if (thinkingContent is not null)
         {
             // Thinking only, no visible content — still attach it
-            state.Messages.Add(new ChatMessage("Assistant", "", DateTimeOffset.UtcNow)
+            msgs.Add(new ChatMessage("Assistant", "", DateTimeOffset.UtcNow)
             {
                 ThinkingContent = thinkingContent
             });
@@ -946,17 +961,10 @@ public sealed class AgentSessionManager : IDisposable
 
         // Track unread for non-active agents, and per-conversation for non-active conversations
         if (state.AgentId != ActiveAgentId)
-        {
             state.UnreadCount++;
-        }
 
-        // Increment conversation unread count for the conversation whose live session fired this event
-        var activeConv = state.Conversations.Values
-            .FirstOrDefault(c => c.ActiveSessionId == evt.SessionId);
-        if (activeConv is not null && activeConv.ConversationId != state.ActiveConversationId)
-        {
+        if (convId != state.ActiveConversationId && state.Conversations.TryGetValue(convId, out var activeConv))
             activeConv.UnreadCount++;
-        }
 
         OnStateChanged?.Invoke();
     }
@@ -966,7 +974,8 @@ public sealed class AgentSessionManager : IDisposable
         var state = FindStateBySessionId(evt.SessionId);
         if (state is null) return;
 
-        state.Messages.Add(new ChatMessage("Error", evt.ErrorMessage ?? "An unknown error occurred.", DateTimeOffset.UtcNow));
+        var convId = FindConversationIdForSession(state, evt.SessionId) ?? state.ActiveConversationId;
+        GetOrCreateMessageStore(state, convId).Add(new ChatMessage("Error", evt.ErrorMessage ?? "An unknown error occurred.", DateTimeOffset.UtcNow));
         state.IsStreaming = false;
         state.CurrentStreamBuffer = "";
         state.ThinkingBuffer = "";
@@ -982,7 +991,6 @@ public sealed class AgentSessionManager : IDisposable
                 _sessionToAgent.Remove(state.SessionId);
 
             state.SessionId = null;
-            state.Messages.Clear();
             state.IsStreaming = false;
             state.CurrentStreamBuffer = "";
             state.ThinkingBuffer = "";
@@ -992,7 +1000,15 @@ public sealed class AgentSessionManager : IDisposable
             state.SubAgents.Clear();
             state.ProcessingStage = null;
 
-            state.Messages.Add(new ChatMessage("System", "Session reset. Start a new conversation.", DateTimeOffset.UtcNow));
+            // Clear the active conversation's store (session was reset, history is gone)
+            if (state.ActiveConversationId is not null)
+            {
+                state.ConversationMessageStores.TryGetValue(state.ActiveConversationId, out var store);
+                store?.Clear();
+                state.ConversationHistoryLoaded.Remove(state.ActiveConversationId);
+                GetOrCreateMessageStore(state, state.ActiveConversationId)
+                    .Add(new ChatMessage("System", "Session reset. Start a new conversation.", DateTimeOffset.UtcNow));
+            }
         }
 
         OnStateChanged?.Invoke();
@@ -1019,7 +1035,7 @@ public sealed class AgentSessionManager : IDisposable
         // Register the sub-agent's session in the session-to-agent mapping
         _sessionToAgent[payload.SubAgentId] = payload.SubAgentId;
 
-        state.Messages.Add(new ChatMessage("System",
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("System",
             $"🔄 Sub-agent spawned: {payload.Name ?? payload.SubAgentId} — {payload.Task}",
             DateTimeOffset.UtcNow));
 
@@ -1038,7 +1054,7 @@ public sealed class AgentSessionManager : IDisposable
             sub.ResultSummary = payload.ResultSummary;
         }
 
-        state.Messages.Add(new ChatMessage("System",
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("System",
             $"✅ Sub-agent completed: {payload.Name ?? payload.SubAgentId}" +
             (payload.ResultSummary is not null ? $" — {payload.ResultSummary}" : ""),
             DateTimeOffset.UtcNow));
@@ -1058,7 +1074,7 @@ public sealed class AgentSessionManager : IDisposable
             sub.ResultSummary = payload.ResultSummary;
         }
 
-        state.Messages.Add(new ChatMessage("System",
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("System",
             $"❌ Sub-agent failed: {payload.Name ?? payload.SubAgentId}" +
             (payload.ResultSummary is not null ? $" — {payload.ResultSummary}" : ""),
             DateTimeOffset.UtcNow));
@@ -1077,7 +1093,7 @@ public sealed class AgentSessionManager : IDisposable
             sub.CompletedAt = payload.CompletedAt;
         }
 
-        state.Messages.Add(new ChatMessage("System",
+        GetOrCreateMessageStore(state, state.ActiveConversationId).Add(new ChatMessage("System",
             $"⛔ Sub-agent killed: {payload.Name ?? payload.SubAgentId}",
             DateTimeOffset.UtcNow));
 
@@ -1151,6 +1167,27 @@ public sealed class AgentSessionManager : IDisposable
             && _sessions.TryGetValue(agentId, out var state)
             ? state
             : null;
+    }
+
+    /// <summary>Find the conversation ID whose active session matches the given session ID.</summary>
+    private static string? FindConversationIdForSession(AgentSessionState state, string? sessionId)
+    {
+        if (sessionId is null) return null;
+        return state.Conversations.Values
+            .FirstOrDefault(c => c.ActiveSessionId == sessionId)
+            ?.ConversationId;
+    }
+
+    /// <summary>Get or create the message store for a conversation.</summary>
+    private static List<ChatMessage> GetOrCreateMessageStore(AgentSessionState state, string? convId)
+    {
+        if (convId is null) return [];
+        if (!state.ConversationMessageStores.TryGetValue(convId, out var msgs))
+        {
+            msgs = new List<ChatMessage>();
+            state.ConversationMessageStores[convId] = msgs;
+        }
+        return msgs;
     }
 
     private static string MapRole(string role) => role.ToLowerInvariant() switch

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -125,7 +125,7 @@ public sealed class AgentSessionManager : IDisposable
 
         try
         {
-            var result = await _hub.SendMessageAsync(agentId, state.ChannelType ?? "signalr", content);
+            var result = await _hub.SendMessageAsync(agentId, state.ChannelType ?? "signalr", content, state.ActiveConversationId);
             RegisterSession(agentId, result.SessionId, result.ChannelType);
 
             // Refresh conversation list so the server-assigned ActiveSessionId is picked up.

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionState.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionState.cs
@@ -27,8 +27,24 @@ public sealed class AgentSessionState
     /// </summary>
     public bool IsReadOnly => SessionType == "agent-subagent";
 
-    /// <summary>All messages in this session, in chronological order.</summary>
-    public List<ChatMessage> Messages { get; } = [];
+    // ── Per-conversation message stores ──────────────────────────────────────
+
+    /// <summary>Per-conversation message stores, keyed by conversation ID.
+    /// SignalR events are always routed here — messages are never discarded on conversation switch.</summary>
+    public Dictionary<string, List<ChatMessage>> ConversationMessageStores { get; } = new();
+
+    /// <summary>Set of conversation IDs whose history has been loaded from REST.
+    /// Once in this set, we never re-fetch — streaming messages already buffered are preserved.</summary>
+    public HashSet<string> ConversationHistoryLoaded { get; } = new();
+
+    /// <summary>Messages for the currently active conversation (computed).
+    /// Read-only view — append via <see cref="ConversationMessageStores"/> directly.</summary>
+    public List<ChatMessage> Messages =>
+        ActiveConversationId is not null && ConversationMessageStores.TryGetValue(ActiveConversationId, out var msgs)
+            ? msgs
+            : _emptyMessages;
+
+    private static readonly List<ChatMessage> _emptyMessages = [];
 
     /// <summary>Whether the agent is currently streaming a response.</summary>
     public bool IsStreaming { get; set; }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
@@ -19,6 +19,9 @@ public sealed record CreateConversationRequestDto(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("title")] string? Title);
 
+public sealed record PatchConversationRequestDto(
+    [property: JsonPropertyName("title")] string Title);
+
 public sealed record ConversationResponseDto(
     [property: JsonPropertyName("conversationId")] string ConversationId,
     [property: JsonPropertyName("agentId")] string AgentId,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
@@ -117,8 +117,8 @@ public sealed class GatewayHubConnection : IAsyncDisposable
         => await _connection!.InvokeAsync<SubscribeAllResult>("SubscribeAll");
 
     /// <summary>Send a message to the specified agent.</summary>
-    public async Task<SendMessageResult> SendMessageAsync(string agentId, string channelType, string content)
-        => await _connection!.InvokeAsync<SendMessageResult>("SendMessage", agentId, channelType, content);
+    public async Task<SendMessageResult> SendMessageAsync(string agentId, string channelType, string content, string? conversationId = null)
+        => await _connection!.InvokeAsync<SendMessageResult>("SendMessage", agentId, channelType, content, conversationId);
 
     /// <summary>Steer an in-progress agent response.</summary>
     public async Task SteerAsync(string agentId, string sessionId, string content)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
@@ -118,7 +118,11 @@ public sealed class GatewayHubConnection : IAsyncDisposable
 
     /// <summary>Send a message to the specified agent.</summary>
     public async Task<SendMessageResult> SendMessageAsync(string agentId, string channelType, string content, string? conversationId = null)
-        => await _connection!.InvokeAsync<SendMessageResult>("SendMessage", agentId, channelType, content, conversationId);
+    {
+        if (!string.IsNullOrWhiteSpace(conversationId))
+            return await _connection!.InvokeAsync<SendMessageResult>("SendMessageToConversation", agentId, channelType, content, conversationId);
+        return await _connection!.InvokeAsync<SendMessageResult>("SendMessage", agentId, channelType, content);
+    }
 
     /// <summary>Steer an in-progress agent response.</summary>
     public async Task SteerAsync(string agentId, string sessionId, string content)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/chat.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/chat.js
@@ -42,6 +42,11 @@ window.chatScroll = {
      * so that Blazor's onkeydown handler can send the message without a stray newline.
      * Shift+Enter still inserts a newline normally.
      */
+    /** Returns true when the viewport matches the mobile breakpoint (≤768px). */
+    isMobileView: function () {
+        return window.innerWidth <= 768;
+    },
+
     preventEnterSubmit: function (element) {
         if (!element || element._preventEnterBound) return;
         element.addEventListener('keydown', function (e) {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -167,9 +167,23 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <param name="agentId">The agent id.</param>
     /// <param name="channelType">The channel type.</param>
     /// <param name="content">The content.</param>
-    /// <param name="conversationId">Optional explicit conversation ID. When supplied, routes into that conversation rather than resolving by channel binding.</param>
     /// <returns>The send message result.</returns>
-    public async Task<SendMessageResult> SendMessage(AgentId agentId, ChannelKey channelType, string content, string? conversationId = null)
+    public Task<SendMessageResult> SendMessage(AgentId agentId, ChannelKey channelType, string content)
+        => SendMessageCore(agentId, channelType, content, null);
+
+    /// <summary>
+    /// Sends a message routing into a specific conversation by ID.
+    /// Use this overload from portal clients that track the active conversation.
+    /// </summary>
+    /// <param name="agentId">The target agent.</param>
+    /// <param name="channelType">The channel type.</param>
+    /// <param name="content">The message content.</param>
+    /// <param name="conversationId">Explicit conversation ID to route into.</param>
+    /// <returns>The send message result.</returns>
+    public Task<SendMessageResult> SendMessageToConversation(AgentId agentId, ChannelKey channelType, string content, string conversationId)
+        => SendMessageCore(agentId, channelType, content, conversationId);
+
+    private async Task<SendMessageResult> SendMessageCore(AgentId agentId, ChannelKey channelType, string content, string? conversationId)
     {
         var typedAgentId = NormalizeAgentId(agentId);
         var typedChannelType = NormalizeChannelKey(channelType);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -8,6 +8,7 @@ using AgentId = BotNexus.Domain.Primitives.AgentId;
 using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
 using ParticipantType = BotNexus.Domain.Primitives.ParticipantType;
 using SessionId = BotNexus.Domain.Primitives.SessionId;
+using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
@@ -166,14 +167,17 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <param name="agentId">The agent id.</param>
     /// <param name="channelType">The channel type.</param>
     /// <param name="content">The content.</param>
+    /// <param name="conversationId">Optional explicit conversation ID. When supplied, routes into that conversation rather than resolving by channel binding.</param>
     /// <returns>The send message result.</returns>
-    public async Task<SendMessageResult> SendMessage(AgentId agentId, ChannelKey channelType, string content)
+    public async Task<SendMessageResult> SendMessage(AgentId agentId, ChannelKey channelType, string content, string? conversationId = null)
     {
         var typedAgentId = NormalizeAgentId(agentId);
         var typedChannelType = NormalizeChannelKey(channelType);
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
 
-        var session = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType);
+        var session = string.IsNullOrWhiteSpace(conversationId)
+            ? await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType)
+            : await ResolveOrCreateSessionByConversationAsync(typedAgentId, typedChannelType, conversationId);
         await SubscribeInternalAsync(session.SessionId);
 
         var connectionId = Context.ConnectionId;
@@ -529,6 +533,49 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             Context.ConnectionId,
             GetSessionGroup(sessionId),
             Context.ConnectionAborted);
+    }
+
+    private async Task<GatewaySession> ResolveOrCreateSessionByConversationAsync(AgentId agentId, ChannelKey channelType, string conversationId)
+    {
+        var routingResult = await _conversationRouter.ResolveInboundByConversationAsync(
+            ConversationId.From(conversationId),
+            agentId,
+            channelType,
+            Context.ConnectionId,
+            Context.ConnectionAborted);
+
+        var session = await _sessions.GetOrCreateAsync(routingResult.SessionId, agentId, Context.ConnectionAborted);
+
+        var needsSave = false;
+        if (session.Status == SessionStatus.Expired)
+        {
+            session.Status = SessionStatus.Active;
+            session.ExpiresAt = null;
+            needsSave = true;
+        }
+
+        if (!session.ChannelType.HasValue || !ChannelMatches(session.ChannelType.Value, channelType))
+        {
+            session.ChannelType = channelType;
+            needsSave = true;
+        }
+
+        if (!session.SessionType.Equals(SessionType.UserAgent))
+        {
+            session.SessionType = SessionType.UserAgent;
+            needsSave = true;
+        }
+
+        if (session.Participants.Count == 0)
+        {
+            session.Participants.Add(new SessionParticipant { Type = ParticipantType.User, Id = Context.ConnectionId });
+            needsSave = true;
+        }
+
+        if (needsSave)
+            await _sessions.SaveAsync(session, Context.ConnectionAborted);
+
+        return session;
     }
 
     private async Task<GatewaySession> ResolveOrCreateSessionAsync(AgentId agentId, ChannelKey channelType)

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -23,6 +23,18 @@ public interface IConversationRouter
         CancellationToken ct = default);
 
     /// <summary>
+    /// Resolves the conversation and session for an inbound message using an explicit conversation ID.
+    /// Use this when the client specifies which conversation a message belongs to (e.g. portal multi-conversation).
+    /// Creates a new session for the conversation if it has none active.
+    /// </summary>
+    Task<ConversationRoutingResult> ResolveInboundByConversationAsync(
+        ConversationId conversationId,
+        AgentId agentId,
+        ChannelKey channelType,
+        string channelAddress,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Returns channel bindings that should receive outbound fan-out for a session.
     /// Excludes the originating binding from fan-out to prevent echo.
     /// Only returns bindings with BindingMode.Interactive or BindingMode.NotifyOnly.

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -126,6 +126,72 @@ public sealed class DefaultConversationRouter : IConversationRouter
     }
 
     /// <inheritdoc />
+    public async Task<ConversationRoutingResult> ResolveInboundByConversationAsync(
+        ConversationId conversationId,
+        AgentId agentId,
+        ChannelKey channelType,
+        string channelAddress,
+        CancellationToken ct = default)
+    {
+        var conversation = await _conversationStore.GetAsync(conversationId, ct);
+        if (conversation is null)
+        {
+            _logger.LogWarning(
+                "ResolveInboundByConversation: conversation {ConversationId} not found — falling back to default routing",
+                conversationId);
+            return await ResolveInboundAsync(agentId, channelType, channelAddress, null, ct);
+        }
+
+        // Resolve or create session for this conversation
+        var isNewSession = false;
+        SessionId sessionId;
+
+        if (conversation.ActiveSessionId.HasValue)
+        {
+            var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
+            if (existingSession is { Status: not SessionStatus.Sealed and not SessionStatus.Expired })
+            {
+                sessionId = conversation.ActiveSessionId.Value;
+            }
+            else
+            {
+                sessionId = SessionId.Create();
+                isNewSession = true;
+                conversation.ActiveSessionId = null;
+            }
+        }
+        else
+        {
+            sessionId = SessionId.Create();
+            isNewSession = true;
+        }
+
+        var session = await _sessionStore.GetOrCreateAsync(sessionId, agentId, ct);
+        sessionId = session.SessionId;
+
+        var changed = false;
+        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
+        {
+            session.Session.ConversationId = conversation.ConversationId;
+            await _sessionStore.SaveAsync(session, ct);
+        }
+
+        if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
+        {
+            conversation.ActiveSessionId = sessionId;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            conversation.UpdatedAt = DateTimeOffset.UtcNow;
+            await _conversationStore.SaveAsync(conversation, ct);
+        }
+
+        return new ConversationRoutingResult(conversation, sessionId, isNewSession);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<ChannelBinding>> GetOutboundBindingsAsync(
         SessionId sessionId,
         string originatingChannelAddress,

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Helpers/TestSessionFactory.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Helpers/TestSessionFactory.cs
@@ -51,10 +51,15 @@ internal static class TestSessionFactory
         params (string Role, string Content)[] messages)
     {
         var state = CreateAgentState(agentId, displayName, isConnected: isConnected);
+
+        // Set up a default conversation so Messages computed property returns the right store
+        const string testConvId = "test-conv-1";
+        state.ActiveConversationId = testConvId;
+        var store = new System.Collections.Generic.List<ChatMessage>();
+        state.ConversationMessageStores[testConvId] = store;
+
         foreach (var (role, content) in messages)
-        {
-            state.Messages.Add(new ChatMessage(role, content, DateTimeOffset.UtcNow));
-        }
+            store.Add(new ChatMessage(role, content, DateTimeOffset.UtcNow));
 
         return state;
     }

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Helpers/ToolCallTestExtensions.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Helpers/ToolCallTestExtensions.cs
@@ -19,7 +19,7 @@ internal static class ToolCallTestExtensions
         bool isError = false,
         TimeSpan? duration = null)
     {
-        state.Messages.Add(new ChatMessage("Tool", $"✅ {toolName} completed", DateTimeOffset.UtcNow)
+        EnsureConversationStore(state).Add(new ChatMessage("Tool", $"✅ {toolName} completed", DateTimeOffset.UtcNow)
         {
             ToolName = toolName,
             ToolCallId = Guid.NewGuid().ToString("N"),
@@ -40,7 +40,7 @@ internal static class ToolCallTestExtensions
         this AgentSessionState state,
         string toolName = "run_query")
     {
-        state.Messages.Add(new ChatMessage("Tool", $"⏳ Calling {toolName}…", DateTimeOffset.UtcNow)
+        EnsureConversationStore(state).Add(new ChatMessage("Tool", $"⏳ Calling {toolName}…", DateTimeOffset.UtcNow)
         {
             ToolName = toolName,
             ToolCallId = Guid.NewGuid().ToString("N"),
@@ -48,5 +48,19 @@ internal static class ToolCallTestExtensions
         });
 
         return state;
+    }
+
+    private static List<ChatMessage> EnsureConversationStore(AgentSessionState state)
+    {
+        if (state.ActiveConversationId is null)
+        {
+            state.ActiveConversationId = "test-conv-1";
+        }
+        if (!state.ConversationMessageStores.TryGetValue(state.ActiveConversationId, out var msgs))
+        {
+            msgs = new List<ChatMessage>();
+            state.ConversationMessageStores[state.ActiveConversationId] = msgs;
+        }
+        return msgs;
     }
 }

--- a/tests/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
@@ -6,6 +6,9 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway;
 using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Api;
@@ -488,6 +491,9 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
                         services.Remove(descriptor);
 
                     services.AddSignalRChannelForTests();
+
+                    services.Replace(ServiceDescriptor.Singleton<ISessionStore, InMemorySessionStore>());
+                    services.Replace(ServiceDescriptor.Singleton<IConversationStore, InMemoryConversationStore>());
 
                     services.RemoveAll<IAgentConfigurationWriter>();
                     services.AddSingleton<IAgentConfigurationWriter, NoOpAgentConfigurationWriter>();

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -9,6 +9,7 @@ using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Api;
 using BotNexus.Extensions.Channels.SignalR;

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -809,7 +809,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
                     services.AddSignalRChannelForTests();
 
-                    // Tests always use InMemory stores for isolation
+                    // Force InMemory stores in tests — prevents SQLite file creation and ensures isolation
                     services.Replace(ServiceDescriptor.Singleton<ISessionStore, InMemorySessionStore>());
                     services.Replace(ServiceDescriptor.Singleton<IConversationStore, InMemoryConversationStore>());
 

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -16,6 +16,7 @@ using BotNexus.Extensions.Channels.SignalR;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Tests.Helpers;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR;

--- a/tests/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
@@ -7,6 +7,7 @@ using BotNexus.Gateway;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Api;
 using BotNexus.Extensions.Channels.SignalR;


### PR DESCRIPTION
## Summary

Fixes four conversation UI bugs in the Blazor SignalR client.

## Changes

### Bug #45 — Sidebar no longer collapses on desktop
- Added `_isMobile` field populated via `chatScroll.isMobileView()` JS interop on first render
- All sidebar-close calls in `MainLayout.razor` now guarded by `_isMobile`
- Applies to conversation selection, agent dropdown, sub-agent clicks, and nav clicks
- Added `isMobileView()` helper to `chat.js` (returns `window.innerWidth <= 768`)

### Bug #46 — Inline conversation title editing
- Chat panel header title span is now clickable; clicking enters edit mode
- Input shown on edit; blur or Enter saves via `PATCH /api/conversations/{id}`
- Escape cancels without saving
- Added `RenameConversationAsync` to `AgentSessionManager`
- Added `PatchConversationRequestDto` to `ConversationContracts.cs`

### Bug #47 — Agent list refreshes after config changes
- Wired `NavigationManager.LocationChanged` in `MainLayout.razor`
- When navigating back to the chat route (`/`), calls `RefreshAgentsAsync()`
- `RefreshAgentsAsync` calls `GET /api/agents` and adds any new agents to `Sessions`

### Bug #48 — Conversation history scoped per conversation + default on load
- `SelectConversationAsync` now clears `state.Messages` and resets history flags when switching conversations
- `CreateConversationAsync` clears messages before selecting a new conversation
- `LoadConversationsAsync` returns early (without marking loaded) when `_apiBaseUrl` is null, allowing retry
- `HandleConnected` now triggers `LoadConversationsAsync` for the active agent if not yet loaded

## Testing
- `dotnet build BotNexus.slnx` — 0 errors
- `dotnet test BotNexus.slnx` — 0 failures

Closes #45, Closes #46, Closes #47, Closes #48