### PR TITLE
fix(config): default session and conversation store to SQLite not InMemory

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -45,7 +45,12 @@ internal sealed class InitCommand
             Gateway = new GatewaySettingsConfig
             {
                 ListenUrl = "http://localhost:5005",
-                DefaultAgentId = "assistant"
+                DefaultAgentId = "assistant",
+                SessionStore = new SessionStoreConfig
+                {
+                    Type = "Sqlite",
+                    ConnectionString = $"Data Source={Path.Combine(homePath, "sessions.sqlite")}"
+                }
             },
             Cron = new CronConfig
             {

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -326,7 +326,7 @@ public static class GatewayServiceCollectionExtensions
             ? explicitType
             : !string.IsNullOrWhiteSpace(sessionsDirectory)
                 ? "File"
-                : "InMemory";
+                : "Sqlite"; // Default to SQLite — InMemory loses all data on restart
 
         if (resolvedType.Equals("InMemory", StringComparison.OrdinalIgnoreCase))
         {
@@ -355,9 +355,10 @@ public static class GatewayServiceCollectionExtensions
 
         if (resolvedType.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
         {
-            var connectionString = sessionStore?.ConnectionString;
-            if (string.IsNullOrWhiteSpace(connectionString))
-                throw new OptionsValidationException(nameof(PlatformConfig), typeof(PlatformConfig), ["gateway.sessionStore.connectionString is required when gateway.sessionStore.type is 'Sqlite'."]);
+            // Use explicit connection string, or default to sessions.sqlite in the config directory
+            var connectionString = !string.IsNullOrWhiteSpace(sessionStore?.ConnectionString)
+                ? sessionStore!.ConnectionString!
+                : $"Data Source={Path.Combine(configDirectory, "sessions.sqlite")}";
 
             services.Replace(ServiceDescriptor.Singleton<ISessionStore>(serviceProvider =>
                 new SqliteSessionStore(
@@ -378,7 +379,7 @@ public static class GatewayServiceCollectionExtensions
             ? explicitType
             : !string.IsNullOrWhiteSpace(sessionsDirectory)
                 ? "File"
-                : "InMemory";
+                : "Sqlite"; // Default to SQLite — InMemory loses all data on restart
 
         if (resolvedType.Equals("InMemory", StringComparison.OrdinalIgnoreCase))
         {
@@ -407,9 +408,9 @@ public static class GatewayServiceCollectionExtensions
 
         if (resolvedType.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
         {
-            var connectionString = sessionStore?.ConnectionString;
-            if (string.IsNullOrWhiteSpace(connectionString))
-                throw new OptionsValidationException(nameof(PlatformConfig), typeof(PlatformConfig), ["gateway.sessionStore.connectionString is required when gateway.sessionStore.type is 'Sqlite'."]);
+            var connectionString = !string.IsNullOrWhiteSpace(sessionStore?.ConnectionString)
+                ? sessionStore!.ConnectionString!
+                : $"Data Source={Path.Combine(configDirectory, "sessions.sqlite")}";
 
             services.Replace(ServiceDescriptor.Singleton<IConversationStore>(serviceProvider =>
                 new SqliteConversationStore(

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -8,7 +8,8 @@ using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
-using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Api;
 using BotNexus.Extensions.Channels.SignalR;
 using BotNexus.Gateway.Configuration;
@@ -807,6 +808,10 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
                     services.AddSingleton<IAgentConfigurationWriter, NoOpAgentConfigurationWriter>();
 
                     services.AddSignalRChannelForTests();
+
+                    // Tests always use InMemory stores for isolation
+                    services.Replace(ServiceDescriptor.Singleton<ISessionStore, InMemorySessionStore>());
+                    services.Replace(ServiceDescriptor.Singleton<IConversationStore, InMemoryConversationStore>());
 
                     configureServices?.Invoke(services);
                 });

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -550,7 +550,7 @@ public sealed class PlatformConfigurationTests
     }
 
     [Fact]
-    public void AddPlatformConfiguration_WithNoSessionStoreConfigured_DefaultsToInMemory()
+    public void AddPlatformConfiguration_WithNoSessionStoreConfigured_DefaultsToSqlite()
     {
         var root = Path.Combine(Path.GetTempPath(), "botnexus-platform-config-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -567,7 +567,7 @@ public sealed class PlatformConfigurationTests
 
             using var provider = services.BuildServiceProvider();
             var sessionStore = provider.GetRequiredService<ISessionStore>();
-            sessionStore.ShouldBeOfType<InMemorySessionStore>();
+            sessionStore.ShouldBeOfType<SqliteSessionStore>();
         }
         finally
         {

--- a/tests/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
@@ -6,7 +6,8 @@ using BotNexus.Domain.Primitives;
 using BotNexus.Gateway;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
-using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Api;
 using BotNexus.Extensions.Channels.SignalR;
 using BotNexus.Gateway.Configuration;
@@ -230,6 +231,10 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
                         services.Remove(descriptor);
 
                     services.AddSignalRChannelForTests();
+
+                    // Tests always use InMemory stores for isolation
+                    services.Replace(ServiceDescriptor.Singleton<ISessionStore, InMemorySessionStore>());
+                    services.Replace(ServiceDescriptor.Singleton<IConversationStore, InMemoryConversationStore>());
 
                     services.RemoveAll<IAgentConfigurationWriter>();
                     services.AddSingleton<IAgentConfigurationWriter, NoOpAgentConfigurationWriter>();


### PR DESCRIPTION
Closes #51

SQLite is now the default store. InMemory was losing all data on restart.

- Default fallback in `GatewayServiceCollectionExtensions` changed from `InMemory` → `Sqlite`
- SQLite path defaults to `${configDirectory}/sessions.sqlite` when no connection string is configured
- `InitCommand` default config now includes explicit SQLite sessionStore
- Integration test factories explicitly register `InMemoryStore` for isolation