### PR TITLE
fix(cli): set BOTNEXUS_HOME on spawned gateway process

### DIFF
--- a/scripts/botnexus-sync.ps1
+++ b/scripts/botnexus-sync.ps1
@@ -65,8 +65,7 @@ function Sync-Instance {
     & git pull $Remote main 2>&1 | Add-Content $LogFile
 
     Write-Log "[$Label] Building (Release)..."
-    $CommitSha = (git -C $Repo rev-parse HEAD).Trim()
-    & $DOTNET build "$Repo/BotNexus.slnx" -c Release --nologo --tl:off -p:SourceRevisionId=$CommitSha 2>&1 | Add-Content $LogFile
+    & $DOTNET build "$Repo/BotNexus.slnx" -c Release --nologo --tl:off 2>&1 | Add-Content $LogFile
     if ($LASTEXITCODE -ne 0) { Write-Log "[$Label] ERROR: Build failed — aborting."; return }
 
     Write-Log "[$Label] Running tests..."

--- a/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
+++ b/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
@@ -98,6 +98,10 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
             RedirectStandardError = false,
         };
 
+        // Set BOTNEXUS_HOME so the gateway reads config from the correct home directory
+        if (!string.IsNullOrWhiteSpace(options.HomePath))
+            psi.Environment["BOTNEXUS_HOME"] = options.HomePath;
+
         _logger.LogInformation("Starting gateway process: {FileName} {Arguments}", psi.FileName, psi.Arguments);
 
         Process process;


### PR DESCRIPTION
GatewayProcessManager was not setting BOTNEXUS_HOME on the spawned gateway process. When using `--target` with a non-default home, the gateway started but read config from `~/.botnexus` instead of the specified target — breaking the two-instance dev/prod setup.\n\nFixes the final piece of CLI multi-instance support.