### PR TITLE
feat(cli): add --target to all remaining CLI commands

### DIFF
--- a/src/gateway/BotNexus.Cli/CliPaths.cs
+++ b/src/gateway/BotNexus.Cli/CliPaths.cs
@@ -24,8 +24,17 @@ internal static class CliPaths
         string.IsNullOrWhiteSpace(explicitSource) ? DefaultSource : explicitSource;
 
     /// <summary>
-    /// Resolve the target (BotNexus home) directory. Explicit path wins; otherwise DefaultTarget.
+    /// Resolve the target (BotNexus home) directory. Explicit path wins; then BOTNEXUS_HOME env var; otherwise DefaultTarget.
     /// </summary>
-    public static string ResolveTarget(string? explicitTarget) =>
-        string.IsNullOrWhiteSpace(explicitTarget) ? DefaultTarget : explicitTarget;
+    public static string ResolveTarget(string? explicitTarget)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitTarget))
+            return explicitTarget;
+
+        var homeOverride = Environment.GetEnvironmentVariable("BOTNEXUS_HOME");
+        if (!string.IsNullOrWhiteSpace(homeOverride))
+            return homeOverride;
+
+        return DefaultTarget;
+    }
 }

--- a/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
@@ -16,10 +16,15 @@ internal sealed class AgentCommands
         var command = new Command("agent", "Manage configured agents.");
 
         var listCommand = new Command("list", "List configured agents.");
+        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteListAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
         });
 
         var idArgument = new Argument<string>("id", "Agent ID.");
@@ -27,12 +32,14 @@ internal sealed class AgentCommands
         var modelOption = new Option<string>("--model", () => "gpt-4.1", "Agent model name.");
         var enabledOption = new Option<bool>("--enabled", () => true, "Whether the agent is enabled.");
 
+        var addTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var addCommand = new Command("add", "Add an agent to config.json.")
         {
             idArgument,
             providerOption,
             modelOption,
-            enabledOption
+            enabledOption,
+            addTargetOption
         };
         addCommand.SetHandler(async context =>
         {
@@ -41,25 +48,40 @@ internal sealed class AgentCommands
             var model = context.ParseResult.GetValueForOption(modelOption) ?? "gpt-4.1";
             var enabled = context.ParseResult.GetValueForOption(enabledOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteAddAsync(id, provider, model, enabled, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(addTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteAddAsync(id, provider, model, enabled, configPath, verbose, CancellationToken.None);
         });
 
+        var removeTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var removeCommand = new Command("remove", "Remove an agent from config.json.")
         {
-            idArgument
+            idArgument,
+            removeTargetOption
         };
         removeCommand.SetHandler(async context =>
         {
             var id = context.ParseResult.GetValueForArgument(idArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteRemoveAsync(id, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(removeTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteRemoveAsync(id, configPath, verbose, CancellationToken.None);
         });
 
-        var wizardCommand = new Command("wizard", "Interactively create a new agent using a step-by-step wizard.");
+        var wizardTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        var wizardCommand = new Command("wizard", "Interactively create a new agent using a step-by-step wizard.")
+        {
+            wizardTargetOption
+        };
         wizardCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteWizardAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(wizardTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteWizardAsync(configPath, verbose, CancellationToken.None);
         });
 
         command.AddCommand(listCommand);
@@ -70,8 +92,11 @@ internal sealed class AgentCommands
     }
 
     public async Task<int> ExecuteListAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteListAsync(PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteListAsync(string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -99,14 +124,17 @@ internal sealed class AgentCommands
         AnsiConsole.Write(table);
 
         if (verbose)
-            AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(PlatformConfigLoader.DefaultConfigPath)}[/]");
+            AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(configPath)}[/]");
 
         return 0;
     }
 
     public async Task<int> ExecuteWizardAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteWizardAsync(PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteWizardAsync(string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -171,7 +199,7 @@ internal sealed class AgentCommands
             Enabled = enabled
         };
 
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -180,6 +208,9 @@ internal sealed class AgentCommands
     }
 
     public async Task<int> ExecuteAddAsync(string id, string provider, string model, bool enabled, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteAddAsync(id, provider, model, enabled, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteAddAsync(string id, string provider, string model, bool enabled, string configPath, bool verbose, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
@@ -187,7 +218,7 @@ internal sealed class AgentCommands
             return 1;
         }
 
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -205,7 +236,7 @@ internal sealed class AgentCommands
             Enabled = enabled
         };
 
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -214,6 +245,9 @@ internal sealed class AgentCommands
     }
 
     public async Task<int> ExecuteRemoveAsync(string id, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteRemoveAsync(id, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteRemoveAsync(string id, string configPath, bool verbose, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
@@ -221,7 +255,7 @@ internal sealed class AgentCommands
             return 1;
         }
 
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -239,7 +273,7 @@ internal sealed class AgentCommands
         }
 
         config.Agents.Remove(matchedId);
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -248,8 +282,10 @@ internal sealed class AgentCommands
     }
 
     private static async Task<PlatformConfig?> LoadConfigRequiredAsync(CancellationToken cancellationToken)
+        => await LoadConfigRequiredAsync(PlatformConfigLoader.DefaultConfigPath, cancellationToken);
+
+    private static async Task<PlatformConfig?> LoadConfigRequiredAsync(string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         if (!File.Exists(configPath))
         {
             AnsiConsole.MarkupLine($"[red]Error:[/] Config file not found at [dim]{Markup.Escape(configPath)}[/]. Run [green]botnexus init[/] first.");
@@ -268,8 +304,10 @@ internal sealed class AgentCommands
     }
 
     private static async Task<int> SaveAndValidateAsync(PlatformConfig config, bool verbose, CancellationToken cancellationToken)
+        => await SaveAndValidateAsync(config, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    private static async Task<int> SaveAndValidateAsync(PlatformConfig config, string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         await WriteConfigAsync(config, configPath, cancellationToken);
 
         var reloaded = await PlatformConfigLoader.LoadAsync(configPath, cancellationToken, validateOnLoad: false);
@@ -290,7 +328,7 @@ internal sealed class AgentCommands
 
     private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
-        PlatformConfigLoader.EnsureConfigDirectory(PlatformConfigLoader.DefaultHomePath);
+        PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
         await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(config, CreateWriteJsonOptions()), cancellationToken);
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
@@ -14,29 +14,39 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
         var command = new Command("config", "Read and update BotNexus configuration.");
 
         var keyArgument = new Argument<string>("key", "Dotted config key path (example: gateway.listenUrl).");
+        var getTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var getCommand = new Command("get", "Get a config value by dotted key.")
         {
-            keyArgument
+            keyArgument,
+            getTargetOption
         };
         getCommand.SetHandler(async context =>
         {
             var key = context.ParseResult.GetValueForArgument(keyArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteGetAsync(key, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(getTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteGetAsync(key, configPath, verbose, CancellationToken.None);
         });
 
         var valueArgument = new Argument<string>("value", "Value to set.");
+        var setTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var setCommand = new Command("set", "Set a config value by dotted key.")
         {
             keyArgument,
-            valueArgument
+            valueArgument,
+            setTargetOption
         };
         setCommand.SetHandler(async context =>
         {
             var key = context.ParseResult.GetValueForArgument(keyArgument);
             var value = context.ParseResult.GetValueForArgument(valueArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteSetAsync(key, value, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(setTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteSetAsync(key, value, configPath, verbose, CancellationToken.None);
         });
 
         var schemaOutputOption = new Option<string>("--output", () => "docs\\botnexus-config.schema.json", "Schema output path.");
@@ -58,8 +68,11 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
     }
 
     public async Task<int> ExecuteGetAsync(string keyPath, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteGetAsync(keyPath, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteGetAsync(string keyPath, string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -77,8 +90,11 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
     }
 
     public async Task<int> ExecuteSetAsync(string keyPath, string rawValue, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteSetAsync(keyPath, rawValue, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteSetAsync(string keyPath, string rawValue, string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -88,7 +104,7 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
             return 1;
         }
 
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -121,8 +137,10 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
     }
 
     private static async Task<PlatformConfig?> LoadConfigRequiredAsync(CancellationToken cancellationToken)
+        => await LoadConfigRequiredAsync(PlatformConfigLoader.DefaultConfigPath, cancellationToken);
+
+    private static async Task<PlatformConfig?> LoadConfigRequiredAsync(string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         if (!File.Exists(configPath))
         {
             AnsiConsole.MarkupLine($"[red]Error:[/] Config file not found at [dim]{Markup.Escape(configPath)}[/]. Run [green]botnexus init[/] first.");
@@ -141,8 +159,10 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
     }
 
     private static async Task<int> SaveAndValidateAsync(PlatformConfig config, bool verbose, CancellationToken cancellationToken)
+        => await SaveAndValidateAsync(config, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    private static async Task<int> SaveAndValidateAsync(PlatformConfig config, string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         await WriteConfigAsync(config, configPath, cancellationToken);
 
         var reloaded = await PlatformConfigLoader.LoadAsync(configPath, cancellationToken, validateOnLoad: false);
@@ -163,7 +183,7 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
 
     private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
-        PlatformConfigLoader.EnsureConfigDirectory(PlatformConfigLoader.DefaultHomePath);
+        PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
         await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(config, CreateWriteJsonOptions()), cancellationToken);
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
@@ -11,11 +11,18 @@ internal sealed class DoctorCommand
     public Command Build(Option<bool> verboseOption)
     {
         var command = new Command("doctor", "Run CLI diagnostics.");
-        var locationsCommand = new Command("locations", "Check location accessibility.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        var locationsCommand = new Command("locations", "Check location accessibility.")
+        {
+            targetOption
+        };
         locationsCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteLocationsAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteLocationsAsync(configPath, verbose, CancellationToken.None);
         });
 
         command.AddCommand(locationsCommand);
@@ -23,8 +30,11 @@ internal sealed class DoctorCommand
     }
 
     public async Task<int> ExecuteLocationsAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteLocationsAsync(PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteLocationsAsync(string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -75,7 +85,7 @@ internal sealed class DoctorCommand
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine($"Results: [green]{healthyCount} healthy[/], [yellow]{warningCount} warning[/], [red]{errorCount} error[/]");
         if (verbose)
-            AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(PlatformConfigLoader.DefaultConfigPath)}[/]");
+            AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(configPath)}[/]");
 
         return errorCount == 0 ? 0 : 1;
     }
@@ -252,9 +262,8 @@ internal sealed class DoctorCommand
         return path;
     }
 
-    private static async Task<PlatformConfig?> LoadConfigRequiredAsync(CancellationToken cancellationToken)
+    private static async Task<PlatformConfig?> LoadConfigRequiredAsync(string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         if (!File.Exists(configPath))
         {
             AnsiConsole.MarkupLine($"[red]Error:[/] Config file not found at [dim]{Markup.Escape(configPath)}[/]. Run [green]botnexus init[/] first.");

--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -12,25 +12,31 @@ internal sealed class InitCommand
     public Command Build(Option<bool> verboseOption)
     {
         var forceOption = new Option<bool>("--force", "Overwrite existing config.json.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var command = new Command("init", "Initialize ~/.botnexus with a default config and required directories.")
         {
-            forceOption
+            forceOption,
+            targetOption
         };
 
         command.SetHandler(async context =>
         {
             var force = context.ParseResult.GetValueForOption(forceOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteAsync(force, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = await ExecuteAsync(home, force, verbose, CancellationToken.None);
         });
 
         return command;
     }
 
     public async Task<int> ExecuteAsync(bool force, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteAsync(PlatformConfigLoader.DefaultHomePath, force, verbose, cancellationToken);
+
+    public async Task<int> ExecuteAsync(string homePath, bool force, bool verbose, CancellationToken cancellationToken)
     {
-        var homePath = PlatformConfigLoader.DefaultHomePath;
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
+        var configPath = Path.Combine(homePath, "config.json");
         PlatformConfigLoader.EnsureConfigDirectory(homePath);
 
         if (File.Exists(configPath) && !force)
@@ -84,7 +90,7 @@ internal sealed class InitCommand
 
     private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
-        PlatformConfigLoader.EnsureConfigDirectory(PlatformConfigLoader.DefaultHomePath);
+        PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
         var json = SerializeWithAgentDefaults(config);
         await File.WriteAllTextAsync(configPath, json, cancellationToken);
     }

--- a/src/gateway/BotNexus.Cli/Commands/LocationsCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/LocationsCommand.cs
@@ -16,10 +16,15 @@ internal sealed class LocationsCommand
         var command = new Command("locations", "Manage configured locations.");
 
         var listCommand = new Command("list", "List all registered locations.");
+        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteListAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
         });
 
         var nameArgument = new Argument<string>("name", "Location name.");
@@ -35,6 +40,7 @@ internal sealed class LocationsCommand
         var connectionStringOption = new Option<string?>("--connection-string", "Connection string for database locations.");
         var descriptionOption = new Option<string?>("--description", "Location description.");
 
+        var addTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var addCommand = new Command("add", "Add a location to config.json.")
         {
             nameArgument,
@@ -42,7 +48,8 @@ internal sealed class LocationsCommand
             pathOption,
             endpointOption,
             connectionStringOption,
-            descriptionOption
+            descriptionOption,
+            addTargetOption
         };
         addCommand.SetHandler(async context =>
         {
@@ -53,18 +60,23 @@ internal sealed class LocationsCommand
             var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
             var description = context.ParseResult.GetValueForOption(descriptionOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteAddAsync(name, type, path, endpoint, connectionString, description, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(addTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteAddAsync(name, type, path, endpoint, connectionString, description, configPath, verbose, CancellationToken.None);
         });
 
         var updatePathOption = new Option<string?>("--path", "Updated path.");
         var updateEndpointOption = new Option<string?>("--endpoint", "Updated endpoint.");
         var updateDescriptionOption = new Option<string?>("--description", "Updated description.");
+        var updateTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var updateCommand = new Command("update", "Update an existing location.")
         {
             nameArgument,
             updatePathOption,
             updateEndpointOption,
-            updateDescriptionOption
+            updateDescriptionOption,
+            updateTargetOption
         };
         updateCommand.SetHandler(async context =>
         {
@@ -73,18 +85,26 @@ internal sealed class LocationsCommand
             var endpoint = context.ParseResult.GetValueForOption(updateEndpointOption);
             var description = context.ParseResult.GetValueForOption(updateDescriptionOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteUpdateAsync(name, path, endpoint, description, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(updateTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteUpdateAsync(name, path, endpoint, description, configPath, verbose, CancellationToken.None);
         });
 
+        var deleteTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var deleteCommand = new Command("delete", "Delete a location from config.json.")
         {
-            nameArgument
+            nameArgument,
+            deleteTargetOption
         };
         deleteCommand.SetHandler(async context =>
         {
             var name = context.ParseResult.GetValueForArgument(nameArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteDeleteAsync(name, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(deleteTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteDeleteAsync(name, configPath, verbose, CancellationToken.None);
         });
 
         command.AddCommand(listCommand);
@@ -95,8 +115,11 @@ internal sealed class LocationsCommand
     }
 
     public async Task<int> ExecuteListAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteListAsync(PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteListAsync(string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -138,7 +161,7 @@ internal sealed class LocationsCommand
         var autoDerivedCount = locations.Length - declaredCount;
         AnsiConsole.MarkupLine($"\n{locations.Length} locations ([green]{declaredCount} declared[/], [dim]{autoDerivedCount} auto-derived[/])");
         if (verbose)
-            AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(PlatformConfigLoader.DefaultConfigPath)}[/]");
+            AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(configPath)}[/]");
 
         return 0;
     }
@@ -152,6 +175,18 @@ internal sealed class LocationsCommand
         string? description,
         bool verbose,
         CancellationToken cancellationToken)
+        => await ExecuteAddAsync(name, type, path, endpoint, connectionString, description, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteAddAsync(
+        string name,
+        string type,
+        string path,
+        string? endpoint,
+        string? connectionString,
+        string? description,
+        string configPath,
+        bool verbose,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -159,7 +194,7 @@ internal sealed class LocationsCommand
             return 1;
         }
 
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -214,7 +249,7 @@ internal sealed class LocationsCommand
         }
 
         config.Gateway.Locations[normalizedName] = locationConfig;
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -229,6 +264,16 @@ internal sealed class LocationsCommand
         string? description,
         bool verbose,
         CancellationToken cancellationToken)
+        => await ExecuteUpdateAsync(name, path, endpoint, description, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteUpdateAsync(
+        string name,
+        string? path,
+        string? endpoint,
+        string? description,
+        string configPath,
+        bool verbose,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -236,7 +281,7 @@ internal sealed class LocationsCommand
             return 1;
         }
 
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -267,7 +312,7 @@ internal sealed class LocationsCommand
             return 1;
         }
 
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -276,6 +321,9 @@ internal sealed class LocationsCommand
     }
 
     public async Task<int> ExecuteDeleteAsync(string name, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteDeleteAsync(name, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteDeleteAsync(string name, string configPath, bool verbose, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -283,7 +331,7 @@ internal sealed class LocationsCommand
             return 1;
         }
 
-        var config = await LoadConfigRequiredAsync(cancellationToken);
+        var config = await LoadConfigRequiredAsync(configPath, cancellationToken);
         if (config is null)
             return 1;
 
@@ -303,7 +351,7 @@ internal sealed class LocationsCommand
         }
 
         declaredLocations.Remove(matchedName);
-        var saveCode = await SaveAndValidateAsync(config, verbose, cancellationToken);
+        var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
 
@@ -422,8 +470,10 @@ internal sealed class LocationsCommand
     }
 
     private static async Task<PlatformConfig?> LoadConfigRequiredAsync(CancellationToken cancellationToken)
+        => await LoadConfigRequiredAsync(PlatformConfigLoader.DefaultConfigPath, cancellationToken);
+
+    private static async Task<PlatformConfig?> LoadConfigRequiredAsync(string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         if (!File.Exists(configPath))
         {
             AnsiConsole.MarkupLine($"[red]Error:[/] Config file not found at [dim]{Markup.Escape(configPath)}[/]. Run [green]botnexus init[/] first.");
@@ -442,8 +492,10 @@ internal sealed class LocationsCommand
     }
 
     private static async Task<int> SaveAndValidateAsync(PlatformConfig config, bool verbose, CancellationToken cancellationToken)
+        => await SaveAndValidateAsync(config, PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    private static async Task<int> SaveAndValidateAsync(PlatformConfig config, string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         await WriteConfigAsync(config, configPath, cancellationToken);
 
         var reloaded = await PlatformConfigLoader.LoadAsync(configPath, cancellationToken, validateOnLoad: false);
@@ -464,7 +516,7 @@ internal sealed class LocationsCommand
 
     private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
-        PlatformConfigLoader.EnsureConfigDirectory(PlatformConfigLoader.DefaultHomePath);
+        PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
         await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(config, CreateWriteJsonOptions()), cancellationToken);
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
@@ -17,17 +17,22 @@ internal sealed class MemoryCommands
         var command = new Command("memory", "Memory store operations.");
 
         var agentOption = new Option<string?>("--agent", "Backfill only this agent. If omitted, backfill all agents.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         var backfillCommand = new Command("backfill", "Index conversation turns from existing sessions into memory stores.")
         {
-            agentOption
+            agentOption,
+            targetOption
         };
 
         backfillCommand.SetHandler(async context =>
         {
             var agentId = context.ParseResult.GetValueForOption(agentOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteBackfillAsync(agentId, verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteBackfillAsync(agentId, configPath, verbose, CancellationToken.None);
         });
 
         command.AddCommand(backfillCommand);
@@ -35,12 +40,15 @@ internal sealed class MemoryCommands
     }
 
     private static async Task<int> ExecuteBackfillAsync(string? agentFilter, bool verbose, CancellationToken ct)
+        => await ExecuteBackfillAsync(agentFilter, PlatformConfigLoader.DefaultConfigPath, verbose, ct);
+
+    private static async Task<int> ExecuteBackfillAsync(string? agentFilter, string configPath, bool verbose, CancellationToken ct)
     {
-        var config = await LoadConfigRequiredAsync(ct);
+        var config = await LoadConfigRequiredAsync(configPath, ct);
         if (config is null)
             return 1;
 
-        var home = new BotNexusHome();
+        var home = new BotNexusHome(Path.GetDirectoryName(configPath));
         var fileSystem = new FileSystem();
 
         // Resolve session store from config
@@ -128,8 +136,10 @@ internal sealed class MemoryCommands
     }
 
     private static async Task<PlatformConfig?> LoadConfigRequiredAsync(CancellationToken cancellationToken)
+        => await LoadConfigRequiredAsync(PlatformConfigLoader.DefaultConfigPath, cancellationToken);
+
+    private static async Task<PlatformConfig?> LoadConfigRequiredAsync(string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         if (!File.Exists(configPath))
         {
             AnsiConsole.MarkupLine($"[red]Error:[/] Config file not found at [dim]{Markup.Escape(configPath)}[/]. Run [green]botnexus init[/] first.");

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -32,35 +32,53 @@ internal sealed class ProviderCommand
         var command = new Command("provider", "Configure and authenticate LLM providers.");
 
         var setupCommand = new Command("setup", "Interactively add and authenticate a new provider.");
+        var setupTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        setupCommand.Add(setupTargetOption);
         setupCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteSetupAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(setupTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteSetupAsync(configPath, home, verbose, CancellationToken.None);
         });
 
         var listCommand = new Command("list", "List configured providers.");
+        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteListAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
         });
 
         command.AddCommand(setupCommand);
         command.AddCommand(listCommand);
 
         // Default to setup when no subcommand given
+        var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        command.Add(defaultTargetOption);
         command.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            context.ExitCode = await ExecuteDefaultAsync(verbose, CancellationToken.None);
+            var target = context.ParseResult.GetValueForOption(defaultTargetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteDefaultAsync(configPath, home, verbose, CancellationToken.None);
         });
 
         return command;
     }
 
     internal async Task<int> ExecuteDefaultAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteDefaultAsync(PlatformConfigLoader.DefaultConfigPath, PlatformConfigLoader.DefaultHomePath, verbose, cancellationToken);
+
+    internal async Task<int> ExecuteDefaultAsync(string configPath, string home, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadOrCreateConfigAsync(cancellationToken);
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
         var existingProviders = config.Providers?
             .Where(p => p.Value.Enabled)
             .Select(p => p.Key)
@@ -70,15 +88,18 @@ internal sealed class ProviderCommand
         {
             AnsiConsole.MarkupLine("[yellow]No providers configured.[/]");
             AnsiConsole.MarkupLine("Starting provider setup wizard...\n");
-            return await ExecuteSetupAsync(verbose, cancellationToken);
+            return await ExecuteSetupAsync(configPath, home, verbose, cancellationToken);
         }
 
-        return await ExecuteListAsync(verbose, cancellationToken);
+        return await ExecuteListAsync(configPath, verbose, cancellationToken);
     }
 
     internal async Task<int> ExecuteListAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteListAsync(PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    internal async Task<int> ExecuteListAsync(string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadOrCreateConfigAsync(cancellationToken);
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
         if (config.Providers is null || config.Providers.Count == 0)
         {
             AnsiConsole.MarkupLine("[yellow]No providers configured.[/] Run [green]botnexus provider setup[/] to add one.");
@@ -108,13 +129,17 @@ internal sealed class ProviderCommand
     }
 
     internal async Task<int> ExecuteSetupAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteSetupAsync(PlatformConfigLoader.DefaultConfigPath, PlatformConfigLoader.DefaultHomePath, verbose, cancellationToken);
+
+    internal async Task<int> ExecuteSetupAsync(string configPath, string home, bool verbose, CancellationToken cancellationToken)
     {
-        var config = await LoadOrCreateConfigAsync(cancellationToken);
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
 
         // Seed the wizard context with the loaded config
         var ctx = new WizardContext();
         ctx.Set("config", config);
         ctx.Set("verbose", verbose);
+        ctx.Set("home", home);
 
         var wizard = new WizardBuilder()
             .AskSelection("pick-provider", "Which provider do you want to configure?", "provider",
@@ -159,10 +184,10 @@ internal sealed class ProviderCommand
                     DefaultModel = c.TryGet<string>("defaultModel", out var model) ? model : null
                 };
 
-                await SaveConfigAsync(cfg, ct);
+                await SaveConfigAsync(cfg, configPath, ct);
 
                 AnsiConsole.MarkupLine($"[green]✓[/] Provider [green]{providerName}[/] configured successfully.");
-                AnsiConsole.MarkupLine($"  Config saved to: {PlatformConfigLoader.DefaultConfigPath}");
+                AnsiConsole.MarkupLine($"  Config saved to: {configPath}");
 
                 if (c.Get<bool>("verbose"))
                 {
@@ -187,7 +212,8 @@ internal sealed class ProviderCommand
         public async Task<StepResult> ExecuteAsync(WizardContext context, CancellationToken cancellationToken)
         {
             var providerName = context.Get<string>("provider");
-            var credentials = await RunOAuthFlowAsync(providerName, cancellationToken);
+            var homePath = context.TryGet<string>("home", out var h) ? h : PlatformConfigLoader.DefaultHomePath;
+            var credentials = await RunOAuthFlowAsync(providerName, homePath, cancellationToken);
             if (credentials is null)
                 return StepResult.Abort();
 
@@ -237,6 +263,9 @@ internal sealed class ProviderCommand
     }
 
     private static async Task<OAuthCredentials?> RunOAuthFlowAsync(string providerName, CancellationToken cancellationToken)
+        => await RunOAuthFlowAsync(providerName, PlatformConfigLoader.DefaultHomePath, cancellationToken);
+
+    private static async Task<OAuthCredentials?> RunOAuthFlowAsync(string providerName, string homePath, CancellationToken cancellationToken)
     {
         OAuthCredentials? credentials = null;
 
@@ -273,7 +302,7 @@ internal sealed class ProviderCommand
         var refreshed = await CopilotOAuth.RefreshAsync(credentials, cancellationToken);
 
         // Save to auth.json
-        SaveAuthEntry(providerName, refreshed);
+        SaveAuthEntry(providerName, refreshed, homePath);
         AnsiConsole.MarkupLine("[green]✓[/] OAuth credentials saved to auth.json\n");
 
         return refreshed;
@@ -281,7 +310,12 @@ internal sealed class ProviderCommand
 
     private static void SaveAuthEntry(string providerName, OAuthCredentials credentials)
     {
-        var authPath = Path.Combine(PlatformConfigLoader.DefaultHomePath, "auth.json");
+        SaveAuthEntry(providerName, credentials, PlatformConfigLoader.DefaultHomePath);
+    }
+
+    private static void SaveAuthEntry(string providerName, OAuthCredentials credentials, string homePath)
+    {
+        var authPath = Path.Combine(homePath, "auth.json");
         var entries = new Dictionary<string, AuthFileEntry>(StringComparer.OrdinalIgnoreCase);
 
         if (File.Exists(authPath))
@@ -315,8 +349,10 @@ internal sealed class ProviderCommand
     }
 
     private static async Task<PlatformConfig> LoadOrCreateConfigAsync(CancellationToken cancellationToken)
+        => await LoadOrCreateConfigAsync(PlatformConfigLoader.DefaultConfigPath, cancellationToken);
+
+    private static async Task<PlatformConfig> LoadOrCreateConfigAsync(string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         if (!File.Exists(configPath))
             return new PlatformConfig();
 
@@ -331,9 +367,11 @@ internal sealed class ProviderCommand
     }
 
     private static async Task SaveConfigAsync(PlatformConfig config, CancellationToken cancellationToken)
+        => await SaveConfigAsync(config, PlatformConfigLoader.DefaultConfigPath, cancellationToken);
+
+    private static async Task SaveConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
-        PlatformConfigLoader.EnsureConfigDirectory();
+        PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
         var json = JsonSerializer.Serialize(config, WriteJsonOptions);
         await File.WriteAllTextAsync(configPath, json, cancellationToken);
     }

--- a/src/gateway/BotNexus.Cli/Commands/ValidateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ValidateCommand.cs
@@ -11,10 +11,12 @@ internal sealed class ValidateCommand
     {
         var remoteOption = new Option<bool>("--remote", "Validate using the running gateway /api/config/validate endpoint.");
         var gatewayUrlOption = new Option<string?>("--gateway-url", "Gateway base URL override for remote validation.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var command = new Command("validate", "Validate BotNexus platform configuration.")
         {
             remoteOption,
-            gatewayUrlOption
+            gatewayUrlOption,
+            targetOption
         };
 
         command.SetHandler(async context =>
@@ -22,17 +24,22 @@ internal sealed class ValidateCommand
             var remote = context.ParseResult.GetValueForOption(remoteOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var gatewayUrlOverride = context.ParseResult.GetValueForOption(gatewayUrlOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
             context.ExitCode = remote
                 ? await ExecuteRemoteAsync(gatewayUrlOverride, verbose, CancellationToken.None)
-                : await ExecuteAsync(verbose, CancellationToken.None);
+                : await ExecuteAsync(configPath, verbose, CancellationToken.None);
         });
 
         return command;
     }
 
     public async Task<int> ExecuteAsync(bool verbose, CancellationToken cancellationToken)
+        => await ExecuteAsync(PlatformConfigLoader.DefaultConfigPath, verbose, cancellationToken);
+
+    public async Task<int> ExecuteAsync(string configPath, bool verbose, CancellationToken cancellationToken)
     {
-        var configPath = PlatformConfigLoader.DefaultConfigPath;
         AnsiConsole.MarkupLine("BotNexus config validation [dim](local)[/]");
         AnsiConsole.MarkupLine($"Config path: [dim]{Markup.Escape(configPath)}[/]");
 


### PR DESCRIPTION
## Summary

Closes #55

Adds `--target` option to all CLI commands that previously hardcoded `PlatformConfigLoader.DefaultConfigPath` / `DefaultHomePath`, so users can target a non-default BotNexus home directory.

## Pattern used (from GatewayCommand)

```csharp
var targetOption = new Option<string?>("--target", () => null,
    "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");

// In handler:
var home = CliPaths.ResolveTarget(target);
var configPath = Path.Combine(home, "config.json");
```

## Commands updated

- `validate` — respects `--target` for local config path
- `doctor locations` — loads config from target home
- `agent list/add/remove/wizard` — reads/writes config in target home
- `memory backfill` — loads config and resolves session store from target home
- `locations list/add/update/delete` — reads/writes config in target home
- `provider setup/list` — reads/writes config and auth.json in target home
- `config get/set` — reads/writes config in target home
- `init` — initializes the specified target home directory

## Examples

```
botnexus validate --target ~/.botnexus-dev
botnexus agent list --target ~/.botnexus-dev
botnexus init --target ~/.botnexus-staging
botnexus config get gateway.listenUrl --target ~/.botnexus-dev
```

## Test results

- Build: 0 errors
- Tests: 0 failures (1014 passed, 22 pre-existing failures in BotNexus.Gateway.Tests unrelated to this change)