### PR TITLE
fix(portal): clear stale session ID when switching to a new conversation

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -403,9 +403,10 @@ public sealed class AgentSessionManager : IDisposable
 
         state.ActiveConversationId = conversationId;
 
-        // Sync active session to the selected conversation's live session
-        if (conv.ActiveSessionId is not null)
-            state.SessionId = conv.ActiveSessionId;
+        // Sync active session to the selected conversation's live session.
+        // If the conversation has no session yet (brand new), clear the stale previous session ID
+        // so the UI doesn't show the wrong session until the first message is sent.
+        state.SessionId = conv.ActiveSessionId;
 
         // Clear conversation unread count
         conv.UnreadCount = 0;


### PR DESCRIPTION
When selecting a brand new conversation with no `ActiveSessionId`, the state kept the previous conversation's session ID, showing the wrong session in the UI until the first message was sent.

Fix: always sync `state.SessionId` to `conv.ActiveSessionId` (null for new conversations) on conversation select.