### PR TITLE
feat(cli): make BotNexus.Cli a publishable dotnet global tool

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,43 +1,134 @@
-name: Publish CLI to NuGet
+name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 0.1.0)'
+        description: 'Version to release (e.g. 0.1.0)'
         required: true
+      prerelease:
+        description: 'Mark as pre-release?'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history for changelog generation
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
 
-      - name: Set version
-        id: version
+      - name: Configure git
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION=${{ github.event.inputs.version }}
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Pack
+      - name: Bump version in Directory.Build.props
         run: |
+          VERSION="${{ github.event.inputs.version }}"
+          sed -i "s|<Version>.*</Version>|<Version>${VERSION}</Version>|" Directory.Build.props
+          sed -i "s|<InformationalVersion>.*</InformationalVersion>|<InformationalVersion>${VERSION}</InformationalVersion>|" Directory.Build.props
+          echo "Bumped version to ${VERSION}"
+          grep "<Version>" Directory.Build.props
+
+      - name: Commit version bump
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git add Directory.Build.props
+          git diff --staged --quiet || git commit -m "chore(release): bump version to ${VERSION}"
+
+      - name: Tag release
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git tag "v${VERSION}" -m "Release v${VERSION}"
+          git push origin HEAD:main
+          git push origin "v${VERSION}"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag — including all commits"
+            RANGE="HEAD"
+          else
+            echo "Changelog from ${PREV_TAG} to HEAD"
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+
+          # Group by conventional commit type
+          {
+            echo "## What's Changed"
+            echo ""
+
+            FEATURES=$(git log $RANGE --pretty=format:"%s" | grep -E "^feat(\(.+\))?:" | sed 's/^feat[^:]*: //')
+            FIXES=$(git log $RANGE --pretty=format:"%s" | grep -E "^fix(\(.+\))?:" | sed 's/^fix[^:]*: //')
+            IMPROVEMENTS=$(git log $RANGE --pretty=format:"%s" | grep -E "^(refactor|perf|improvement)(\(.+\))?:" | sed 's/^[^:]*: //')
+            DOCS=$(git log $RANGE --pretty=format:"%s" | grep -E "^docs(\(.+\))?:" | sed 's/^docs[^:]*: //')
+            OTHER=$(git log $RANGE --pretty=format:"%s" | grep -vE "^(feat|fix|refactor|perf|improvement|docs|chore|test|ci)(\(.+\))?:" | grep -v "^Merge")
+
+            if [ -n "$FEATURES" ]; then
+              echo "### ✨ New Features"
+              echo "$FEATURES" | while read -r line; do echo "- $line"; done
+              echo ""
+            fi
+
+            if [ -n "$FIXES" ]; then
+              echo "### 🐛 Bug Fixes"
+              echo "$FIXES" | while read -r line; do echo "- $line"; done
+              echo ""
+            fi
+
+            if [ -n "$IMPROVEMENTS" ]; then
+              echo "### 🔧 Improvements"
+              echo "$IMPROVEMENTS" | while read -r line; do echo "- $line"; done
+              echo ""
+            fi
+
+            if [ -n "$DOCS" ]; then
+              echo "### 📚 Documentation"
+              echo "$DOCS" | while read -r line; do echo "- $line"; done
+              echo ""
+            fi
+
+            echo "**Full changelog:** https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${VERSION}"
+          } > RELEASE_NOTES.md
+
+          cat RELEASE_NOTES.md
+          echo "NOTES<<EOF" >> $GITHUB_OUTPUT
+          cat RELEASE_NOTES.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Build and pack
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
           dotnet pack src/gateway/BotNexus.Cli \
             -c Release \
             --nologo \
-            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -p:Version=${VERSION} \
             -p:SourceRevisionId=${{ github.sha }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
+          body: ${{ steps.changelog.outputs.NOTES }}
+          prerelease: ${{ github.event.inputs.prerelease }}
+          files: src/gateway/BotNexus.Cli/bin/Release/*.nupkg
 
       - name: Push to NuGet
         run: |

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,47 @@
+name: Publish CLI to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.1.0)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Set version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=${{ github.event.inputs.version }}
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Pack
+        run: |
+          dotnet pack src/gateway/BotNexus.Cli \
+            -c Release \
+            --nologo \
+            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -p:SourceRevisionId=${{ github.sha }}
+
+      - name: Push to NuGet
+        run: |
+          dotnet nuget push src/gateway/BotNexus.Cli/bin/Release/*.nupkg \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.0.0-dev</Version>
-    <InformationalVersion>0.0.0-dev</InformationalVersion>
+    <Version>0.1.0-dev</Version>
+    <InformationalVersion>0.1.0-dev</InformationalVersion>
   </PropertyGroup>
 </Project>

--- a/docs/getting-started-release.md
+++ b/docs/getting-started-release.md
@@ -4,6 +4,27 @@
 
 ---
 
+## Install
+
+```bash
+# Install the CLI as a global dotnet tool
+dotnet tool install -g BotNexus.Cli
+
+# Clone and build the platform (one-time setup)
+botnexus install
+
+# Set up your home directory and configure a provider
+botnexus init
+botnexus provider setup
+
+# Start the gateway
+botnexus gateway start
+
+# Open the portal at http://localhost:5005
+```
+
+---
+
 ## Prerequisites
 
 | Requirement | Details |

--- a/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
+++ b/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
@@ -3,7 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>BotNexus.Cli</RootNamespace>
-    <Description>BotNexus platform CLI for local and remote configuration validation.</Description>
+    <Description>BotNexus platform CLI — install and run the BotNexus AI agent platform.</Description>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>botnexus</ToolCommandName>
+    <PackageId>BotNexus.Cli</PackageId>
+    <Authors>Jon Bullen</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/sytone/botnexus</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/sytone/botnexus</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>ai;agent;botnexus;dotnet;cli</PackageTags>
     <!-- When the CLI invokes 'dotnet build' on the solution, it passes SkipCli=true
          so the CLI project skips rebuilding itself (the DLL is already loaded and locked). -->
     <IsExcludedFromBuild Condition="'$(SkipCli)' == 'true'">true</IsExcludedFromBuild>


### PR DESCRIPTION
## Summary

Makes `BotNexus.Cli` a proper `dotnet tool install -g` target.

## Changes

- **`BotNexus.Cli.csproj`** — added `PackAsTool`, `ToolCommandName`, `PackageId`, `Authors`, `PackageLicenseExpression`, repo URLs, and package tags
- **`Directory.Build.props`** — bumped version baseline from `0.0.0-dev` → `0.1.0-dev`
- **`.github/workflows/publish-cli.yml`** — new workflow to pack and push to NuGet on `v*` tags or `workflow_dispatch` (requires `NUGET_API_KEY` secret)
- **`docs/getting-started-release.md`** — added `## Install` section with `dotnet tool install -g BotNexus.Cli` quickstart

## Verification

- `dotnet pack` → `BotNexus.Cli.0.1.0-dev.nupkg` ✅
- `botnexus --version` → `0.1.0-dev+unknown` ✅
- `dotnet build BotNexus.slnx` → 0 errors ✅
- `dotnet test BotNexus.slnx` → 1281 passed, 0 failed ✅

> **Note:** Jon needs to add `NUGET_API_KEY` to the repo secrets before the publish workflow can push to NuGet.

Closes #58