### PR TITLE
fix(cli): skip building CLI project when invoked via gateway start

### DIFF
--- a/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
+++ b/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>BotNexus.Cli</RootNamespace>
     <Description>BotNexus platform CLI for local and remote configuration validation.</Description>
+    <!-- When the CLI invokes 'dotnet build' on the solution, it passes SkipCli=true
+         so the CLI project skips rebuilding itself (the DLL is already loaded and locked). -->
+    <IsExcludedFromBuild Condition="'$(SkipCli)' == 'true'">true</IsExcludedFromBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
+++ b/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
@@ -24,7 +24,7 @@ internal static partial class BuildOutputStreamer
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"build \"{solution}\" -c Release --nologo --tl:off /p:SkipTests=true /p:SourceRevisionId={commitSha}",
+            Arguments = $"build \"{solution}\" -c Release --nologo --tl:off /p:SkipTests=true /p:SkipCli=true /p:SourceRevisionId={commitSha}",
             WorkingDirectory = workingDirectory,
             UseShellExecute = false,
             RedirectStandardOutput = true,


### PR DESCRIPTION
When `botnexus gateway start` calls `dotnet build`, the CLI project tries to rebuild itself. Since the CLI DLL is already loaded and running, the file is locked and the build fails.

Fix: pass `/p:SkipCli=true` during the solution build, and add a condition in `BotNexus.Cli.csproj` to skip itself when that property is set.