### PR TITLE
fix(portal): consolidate new session buttons

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -48,12 +48,29 @@
             <button class="config-btn" @onclick="OpenConfig" title="Agent configuration">
                 ⚙
             </button>
-            <button class="new-chat-btn" @onclick="NewChat" title="New chat (reset session)">
-                ✚
+            <button class="new-chat-btn" @onclick="ConfirmNewSession" title="Start a new session in this conversation"
+                    disabled="@State.IsStreaming">
+                ↺ New session
             </button>
         </div>
         <SessionControls State="@State" Manager="@Manager" />
     </header>
+
+    @* ── New session confirmation dialog ─────────────────────────────── *@
+    @if (_showNewSessionConfirm)
+    {
+        <div class="reset-confirm-overlay" @onclick="CancelNewSession">
+            <div class="reset-confirm-dialog" @onclick:stopPropagation="true">
+                <p>Start a new session for <strong>@State.DisplayName</strong>?</p>
+                <p class="text-muted">The current session will be sealed. History stays in this conversation.</p>
+                <div class="reset-confirm-actions">
+                    <button class="cancel-btn" @onclick="CancelNewSession">Cancel</button>
+                    <button class="confirm-btn" @onclick="DoNewSession">New session</button>
+                </div>
+            </div>
+        </div>
+    }
+
 
     @* ── Read-only banner for sub-agent sessions ──────────────────── *@
     @if (State.IsReadOnly)
@@ -451,8 +468,14 @@
             await _configPanel.Open();
     }
 
-    private async Task NewChat()
+    private bool _showNewSessionConfirm;
+
+    private void ConfirmNewSession() => _showNewSessionConfirm = true;
+    private void CancelNewSession() => _showNewSessionConfirm = false;
+
+    private async Task DoNewSession()
     {
+        _showNewSessionConfirm = false;
         await Manager.ResetSessionAsync(State.AgentId);
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SessionControls.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SessionControls.razor
@@ -3,29 +3,12 @@
 <div class="session-controls">
     @if (State.SessionId is not null)
     {
-        <span class="session-id clickable" title="Click to copy: @State.SessionId"
+        <span class="session-id clickable" title="Click to copy session ID: @State.SessionId"
               @onclick="CopySessionId">
             📋 @State.SessionId[..Math.Min(8, State.SessionId.Length)]…
         </span>
-        <button class="reset-btn" @onclick="ConfirmReset" title="Reset session">
-            🔄 Reset
-        </button>
     }
 </div>
-
-@if (_showConfirm)
-{
-    <div class="reset-confirm-overlay" @onclick="CancelReset">
-        <div class="reset-confirm-dialog" @onclick:stopPropagation="true">
-            <p>Reset session for <strong>@State.DisplayName</strong>?</p>
-            <p class="text-muted">This will clear all messages and start a new session.</p>
-            <div class="reset-confirm-actions">
-                <button class="cancel-btn" @onclick="CancelReset">Cancel</button>
-                <button class="confirm-btn" @onclick="DoReset">Reset</button>
-            </div>
-        </div>
-    </div>
-}
 
 @if (_copied)
 {
@@ -39,17 +22,7 @@
     [Parameter, EditorRequired]
     public AgentSessionManager Manager { get; set; } = default!;
 
-    private bool _showConfirm;
     private bool _copied;
-
-    private void ConfirmReset() => _showConfirm = true;
-    private void CancelReset() => _showConfirm = false;
-
-    private async Task DoReset()
-    {
-        _showConfirm = false;
-        await Manager.ResetSessionAsync(State.AgentId);
-    }
 
     private async Task CopySessionId()
     {
@@ -63,9 +36,6 @@
             _copied = false;
             StateHasChanged();
         }
-        catch
-        {
-            // Clipboard API may not be available
-        }
+        catch { }
     }
 }

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionControlsTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionControlsTests.cs
@@ -7,6 +7,8 @@ namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
 /// <summary>
 /// bUnit tests for the <see cref="SessionControls"/> component.
+/// SessionControls now only shows the session ID copy badge — the reset/new-session
+/// button has moved to ChatPanel header.
 /// </summary>
 public sealed class SessionControlsTests : IDisposable
 {
@@ -24,8 +26,6 @@ public sealed class SessionControlsTests : IDisposable
         _manager.Dispose();
         _ctx.Dispose();
     }
-
-    // ── Session ID display ───────────────────────────────────────────────
 
     [Fact]
     public void Shows_truncated_session_id()
@@ -46,114 +46,29 @@ public sealed class SessionControlsTests : IDisposable
 
         var cut = RenderSessionControls(state);
 
-        cut.Find(".session-id").GetAttribute("title").ShouldBe("Click to copy: abcdef1234567890");
+        cut.Find(".session-id").GetAttribute("title").ShouldContain("abcdef1234567890");
     }
 
     [Fact]
-    public void Does_not_render_controls_when_no_session_id()
+    public void Does_not_render_session_id_when_no_session()
     {
         var state = TestSessionFactory.CreateAgentState(sessionId: null);
 
         var cut = RenderSessionControls(state);
 
         cut.FindAll(".session-id").ShouldBeEmpty();
-        cut.FindAll(".reset-btn").ShouldBeEmpty();
     }
 
-    // ── Reset button ─────────────────────────────────────────────────────
-
     [Fact]
-    public void Reset_button_is_present_when_session_exists()
+    public void Reset_button_is_not_present_in_session_controls()
     {
+        // Reset/new-session moved to ChatPanel header — not in SessionControls
         var state = TestSessionFactory.CreateAgentState(sessionId: "test-session-123");
 
         var cut = RenderSessionControls(state);
 
-        var resetBtn = cut.Find(".reset-btn");
-        resetBtn.ShouldNotBeNull();
-        resetBtn.TextContent.ShouldContain("Reset");
+        cut.FindAll(".reset-btn").ShouldBeEmpty();
     }
-
-    // ── Reset confirmation dialog ────────────────────────────────────────
-
-    [Fact]
-    public void Confirmation_dialog_not_shown_initially()
-    {
-        var state = TestSessionFactory.CreateAgentState();
-
-        var cut = RenderSessionControls(state);
-
-        cut.FindAll(".reset-confirm-overlay").ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void Clicking_reset_shows_confirmation_dialog()
-    {
-        var state = TestSessionFactory.CreateAgentState(displayName: "Nova");
-
-        var cut = RenderSessionControls(state);
-
-        cut.Find(".reset-btn").Click();
-
-        cut.Find(".reset-confirm-dialog").ShouldNotBeNull();
-        cut.Markup.ShouldContain("Reset session for");
-        cut.Markup.ShouldContain("Nova");
-    }
-
-    [Fact]
-    public void Confirmation_dialog_has_cancel_and_confirm_buttons()
-    {
-        var state = TestSessionFactory.CreateAgentState();
-        var cut = RenderSessionControls(state);
-
-        cut.Find(".reset-btn").Click();
-
-        cut.Find(".cancel-btn").ShouldNotBeNull();
-        cut.Find(".confirm-btn").ShouldNotBeNull();
-    }
-
-    [Fact]
-    public void Clicking_cancel_hides_confirmation_dialog()
-    {
-        var state = TestSessionFactory.CreateAgentState();
-        var cut = RenderSessionControls(state);
-
-        // Open the dialog
-        cut.Find(".reset-btn").Click();
-        cut.FindAll(".reset-confirm-overlay").ShouldNotBeEmpty();
-
-        // Cancel
-        cut.Find(".cancel-btn").Click();
-        cut.FindAll(".reset-confirm-overlay").ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void Clicking_overlay_hides_confirmation_dialog()
-    {
-        var state = TestSessionFactory.CreateAgentState();
-        var cut = RenderSessionControls(state);
-
-        // Open the dialog
-        cut.Find(".reset-btn").Click();
-        cut.FindAll(".reset-confirm-overlay").ShouldNotBeEmpty();
-
-        // Click overlay background
-        cut.Find(".reset-confirm-overlay").Click();
-        cut.FindAll(".reset-confirm-overlay").ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void Confirmation_dialog_mentions_clearing_messages()
-    {
-        var state = TestSessionFactory.CreateAgentState();
-        var cut = RenderSessionControls(state);
-
-        cut.Find(".reset-btn").Click();
-
-        cut.Markup.ShouldContain("clear all messages");
-    }
-
-    // ── Short session IDs ────────────────────────────────────────────────
 
     [Fact]
     public void Handles_short_session_id_without_error()
@@ -162,11 +77,8 @@ public sealed class SessionControlsTests : IDisposable
 
         var cut = RenderSessionControls(state);
 
-        var sessionId = cut.Find(".session-id");
-        sessionId.TextContent.ShouldContain("abc");
+        cut.Find(".session-id").TextContent.ShouldContain("abc");
     }
-
-    // ── Helpers ───────────────────────────────────────────────────────────
 
     private IRenderedComponent<SessionControls> RenderSessionControls(AgentSessionState state)
     {


### PR DESCRIPTION
Closes #61

Two buttons were doing the same thing (ResetSessionAsync). Consolidated into one `↺ New session` button in the chat panel header with a confirmation dialog. SessionControls now only shows the session ID copy badge.