### PR TITLE
fix(portal): ensure conversation history loads on first page load

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -365,6 +365,8 @@
 
     private bool _forceScrollNext;
     private bool _wasActive;
+    private string? _lastActiveConversationId;
+    private int _lastRenderedMessageCount;
 
     // ── Toggle state ──────────────────────────────────────────────────────
 
@@ -521,6 +523,27 @@
             if (isActive && !_wasActive)
                 _forceScrollNext = true;
             _wasActive = isActive;
+
+            // Force-scroll when the active conversation changes or history batch-loads.
+            // A large jump in message count means history arrived — scroll to bottom.
+            var currentConvId = State.ActiveConversationId;
+            var currentCount = State.Messages.Count;
+            if (currentConvId != _lastActiveConversationId)
+            {
+                _forceScrollNext = true;
+                _lastActiveConversationId = currentConvId;
+                _lastRenderedMessageCount = currentCount;
+            }
+            else if (currentCount > _lastRenderedMessageCount + 5)
+            {
+                // More than 5 new messages at once = history batch load, not streaming
+                _forceScrollNext = true;
+                _lastRenderedMessageCount = currentCount;
+            }
+            else
+            {
+                _lastRenderedMessageCount = currentCount;
+            }
 
             // Force-scroll on first render, after sending, or on session switch.
             // Otherwise smart-scroll (only if near bottom).

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -235,6 +235,23 @@
                 StateHasChanged();
             });
         }
+
+        // Ensure conversations are loaded for the active agent on the Blazor thread.
+        // This handles the race where HandleConnected fires before the component is ready,
+        // or where Task.Run in AgentSessionManager fires OnStateChanged off-thread before
+        // history has finished loading.
+        if (Manager.ApiBaseUrl is not null && Manager.ActiveAgentId is not null
+            && Manager.Sessions.TryGetValue(Manager.ActiveAgentId, out var activeState)
+            && !activeState.ConversationsLoaded && !activeState.IsLoadingConversations)
+        {
+            var agentId = Manager.ActiveAgentId;
+            _ = InvokeAsync(async () =>
+            {
+                await Manager.LoadConversationsAsync(agentId);
+                StateHasChanged();
+            });
+        }
+
         InvokeAsync(StateHasChanged);
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -803,13 +803,22 @@ public sealed class AgentSessionManager : IDisposable
             };
         }
 
-        // Retry loading conversations for the active agent if not yet loaded
-        // (handles race where SetActiveAgentAsync was called before _apiBaseUrl was set)
+        // Retry loading conversations for the active agent if not yet loaded.
+        // Use Task.Run but capture the agentId to avoid closure issues.
+        // OnStateChanged is fired inside LoadConversationsAsync so the component
+        // re-renders when data arrives.
         if (ActiveAgentId is not null
             && _sessions.TryGetValue(ActiveAgentId, out var activeState)
             && !activeState.ConversationsLoaded)
         {
-            _ = Task.Run(() => LoadConversationsAsync(ActiveAgentId));
+            var agentIdToLoad = ActiveAgentId;
+            _ = Task.Run(async () =>
+            {
+                await LoadConversationsAsync(agentIdToLoad);
+                // Fire an extra StateChanged after history loads so the component
+                // re-renders even if it missed the one from inside LoadConversationsAsync.
+                OnStateChanged?.Invoke();
+            });
         }
 
         OnStateChanged?.Invoke();

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -65,10 +65,12 @@ public sealed class ChatPanelTests : IDisposable
                 .ToList();
 
             identifiers.ShouldContain("BotNexus.renderMarkdown");
-            identifiers.ShouldContain("chatScroll.scrollToBottom");
+            identifiers.ShouldContainAny("chatScroll.scrollToBottom", "chatScroll.forceScrollToBottom");
 
             var markdownIndex = identifiers.IndexOf("BotNexus.renderMarkdown");
-            var scrollIndex = identifiers.IndexOf("chatScroll.scrollToBottom");
+            var scrollIndex = Math.Min(
+                identifiers.IndexOf("chatScroll.scrollToBottom") is var si && si >= 0 ? si : int.MaxValue,
+                identifiers.IndexOf("chatScroll.forceScrollToBottom") is var fsi && fsi >= 0 ? fsi : int.MaxValue);
             markdownIndex.ShouldBeLessThan(scrollIndex);
         });
     }

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -65,7 +65,8 @@ public sealed class ChatPanelTests : IDisposable
                 .ToList();
 
             identifiers.ShouldContain("BotNexus.renderMarkdown");
-            identifiers.ShouldContainAny("chatScroll.scrollToBottom", "chatScroll.forceScrollToBottom");
+            (identifiers.Contains("chatScroll.scrollToBottom") ||
+             identifiers.Contains("chatScroll.forceScrollToBottom")).ShouldBeTrue("Expected a scroll call");
 
             var markdownIndex = identifiers.IndexOf("BotNexus.renderMarkdown");
             var scrollIndex = Math.Min(


### PR DESCRIPTION
Closes #64

History was missing on first load but appeared after refresh. Two-part fix:
- Retry in HandleConnected fires extra StateChanged after async completes
- MainLayout.HandleStateChanged retries LoadConversationsAsync on the Blazor sync context when conversations aren't loaded yet