### PR TITLE
fix(portal): show tool results correctly when loading conversation history

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -244,6 +244,12 @@ public sealed record SessionEntry
     /// <summary>Tool call ID for correlating requests and results.</summary>
     public string? ToolCallId { get; init; }
 
+    /// <summary>Serialized JSON args for tool call (when Role is <see cref="MessageRole.Tool"/> and this is a ToolStart entry).</summary>
+    public string? ToolArgs { get; init; }
+
+    /// <summary>True if the tool call resulted in an error.</summary>
+    public bool ToolIsError { get; init; }
+
     /// <summary>True if this entry is a compaction summary (not a real conversation message).</summary>
     public bool IsCompactionSummary { get; init; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -669,7 +669,9 @@ public sealed class AgentSessionManager : IDisposable
                             IsToolCall = isToolCall,
                             // When restoring tool history, Content IS the result text.
                             // Set ToolResult so ChatPanel renders it correctly (not as pending hourglass).
-                            ToolResult = isToolCall ? entry.Content : null
+                            ToolResult = isToolCall ? entry.Content : null,
+                            ToolArgs = entry.ToolArgs,
+                            ToolIsError = entry.ToolIsError
                         });
                     }
                 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -658,6 +658,7 @@ public sealed class AgentSessionManager : IDisposable
                     }
                     else
                     {
+                        var isToolCall = entry.ToolName is not null;
                         messages.Add(new ChatMessage(
                             MapRole(entry.Role ?? "system"),
                             entry.Content ?? string.Empty,
@@ -665,7 +666,10 @@ public sealed class AgentSessionManager : IDisposable
                         {
                             ToolName = entry.ToolName,
                             ToolCallId = entry.ToolCallId,
-                            IsToolCall = entry.ToolName is not null
+                            IsToolCall = isToolCall,
+                            // When restoring tool history, Content IS the result text.
+                            // Set ToolResult so ChatPanel renders it correctly (not as pending hourglass).
+                            ToolResult = isToolCall ? entry.Content : null
                         });
                     }
                 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
@@ -73,6 +73,12 @@ public sealed class ConversationHistoryEntryDto
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; init; }
 
+    [JsonPropertyName("toolArgs")]
+    public string? ToolArgs { get; init; }
+
+    [JsonPropertyName("toolIsError")]
+    public bool ToolIsError { get; init; }
+
     [JsonPropertyName("reason")]
     public string? Reason { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
@@ -70,6 +70,12 @@ public sealed class ConversationHistoryEntry
     /// <summary>Tool call correlation ID (for kind = "message" with tool role).</summary>
     public string? ToolCallId { get; init; }
 
+    /// <summary>Serialized JSON tool arguments (for ToolStart entries).</summary>
+    public string? ToolArgs { get; init; }
+
+    /// <summary>True if the tool call returned an error.</summary>
+    public bool ToolIsError { get; init; }
+
     /// <summary>Reason for the boundary (for kind = "boundary").</summary>
     public string? Reason { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -268,7 +268,9 @@ public sealed class ConversationsController : ControllerBase
                     Content = entry.Content,
                     Timestamp = entry.Timestamp,
                     ToolName = entry.ToolName,
-                    ToolCallId = entry.ToolCallId
+                    ToolCallId = entry.ToolCallId,
+                    ToolArgs = entry.ToolArgs,
+                    ToolIsError = entry.ToolIsError
                 });
             }
         }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -264,7 +264,9 @@ public sealed class SqliteSessionStore : SessionStoreBase
                  {
                      ("tool_name", "TEXT"),
                      ("tool_call_id", "TEXT"),
-                     ("is_compaction_summary", "INTEGER NOT NULL DEFAULT 0")
+                     ("is_compaction_summary", "INTEGER NOT NULL DEFAULT 0"),
+                     ("tool_args", "TEXT"),
+                     ("tool_is_error", "INTEGER NOT NULL DEFAULT 0")
                  })
         {
             try
@@ -352,7 +354,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
         await using var historyCommand = connection.CreateCommand();
         historyCommand.CommandText = """
-            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary
+            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error
             FROM session_history
             WHERE session_id = $sessionId
             ORDER BY id ASC
@@ -370,7 +372,9 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 Timestamp = ParseTimestamp(historyReader.IsDBNull(2) ? null : historyReader.GetString(2)),
                 ToolName = historyReader.IsDBNull(3) ? null : historyReader.GetString(3),
                 ToolCallId = historyReader.IsDBNull(4) ? null : historyReader.GetString(4),
-                IsCompactionSummary = !historyReader.IsDBNull(5) && historyReader.GetInt64(5) != 0
+                IsCompactionSummary = !historyReader.IsDBNull(5) && historyReader.GetInt64(5) != 0,
+                ToolArgs = historyReader.FieldCount > 6 && !historyReader.IsDBNull(6) ? historyReader.GetString(6) : null,
+                ToolIsError = historyReader.FieldCount > 7 && !historyReader.IsDBNull(7) && historyReader.GetInt64(7) != 0
             });
         }
 
@@ -431,8 +435,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
             await using var insertCommand = connection.CreateCommand();
             insertCommand.Transaction = transaction;
             insertCommand.CommandText = """
-                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary)
-                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary)
+                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error)
+                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError)
                 """;
             insertCommand.Parameters.AddWithValue("$sessionId", session.SessionId.Value);
             insertCommand.Parameters.AddWithValue("$role", entry.Role.Value);
@@ -441,6 +445,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
             insertCommand.Parameters.AddWithValue("$toolName", (object?)entry.ToolName ?? DBNull.Value);
             insertCommand.Parameters.AddWithValue("$toolCallId", (object?)entry.ToolCallId ?? DBNull.Value);
             insertCommand.Parameters.AddWithValue("$isCompactionSummary", entry.IsCompactionSummary ? 1 : 0);
+            insertCommand.Parameters.AddWithValue("$toolArgs", (object?)entry.ToolArgs ?? DBNull.Value);
+            insertCommand.Parameters.AddWithValue("$toolIsError", entry.ToolIsError ? 1 : 0);
             await insertCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -46,7 +46,10 @@ public static class StreamingSessionHelper
                         Role = MessageRole.Tool,
                         Content = $"Tool '{evt.ToolName ?? "unknown"}' started.",
                         ToolName = evt.ToolName,
-                        ToolCallId = evt.ToolCallId
+                        ToolCallId = evt.ToolCallId,
+                        ToolArgs = evt.ToolArgs is { Count: > 0 }
+                            ? System.Text.Json.JsonSerializer.Serialize(evt.ToolArgs)
+                            : null
                     });
                     break;
                 case AgentStreamEventType.ToolEnd when evt.ToolCallId is not null || evt.ToolName is not null:
@@ -55,7 +58,8 @@ public static class StreamingSessionHelper
                         Role = MessageRole.Tool,
                         Content = evt.ToolResult ?? (evt.ToolIsError == true ? "Tool execution failed." : "Tool execution completed."),
                         ToolName = evt.ToolName,
-                        ToolCallId = evt.ToolCallId
+                        ToolCallId = evt.ToolCallId,
+                        ToolIsError = evt.ToolIsError == true
                     });
                     break;
                 case AgentStreamEventType.Error when options.IncludeErrorsInHistory && !string.IsNullOrWhiteSpace(evt.ErrorMessage):

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentSessionManagerTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentSessionManagerTests.cs
@@ -1,5 +1,8 @@
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.Helpers;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -209,5 +212,182 @@ public sealed class AgentSessionManagerTests : IDisposable
 
         await _manager.ViewSubAgentAsync(secondSubAgent);
         _manager.ActiveAgentId.ShouldBe("sub-2");
+    }
+}
+
+/// <summary>
+/// Tests for LoadConversationHistoryAsync mapping via SelectConversationAsync.
+/// Uses a fake HttpMessageHandler to return canned history responses.
+/// </summary>
+public sealed class AgentSessionManagerHistoryMappingTests : IDisposable
+{
+    private readonly FakeHttpHandler _handler;
+    private readonly AgentSessionManager _manager;
+
+    public AgentSessionManagerHistoryMappingTests()
+    {
+        _handler = new FakeHttpHandler();
+        var http = new HttpClient(_handler) { BaseAddress = new Uri("http://test") };
+        var hub = new GatewayHubConnection();
+        _manager = new AgentSessionManager(hub, http);
+        // Set _apiBaseUrl via reflection since InitializeAsync would require a real hub
+        var field = typeof(AgentSessionManager).GetField("_apiBaseUrl", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        field.SetValue(_manager, "http://test/api/");
+    }
+
+    public void Dispose() => _manager.Dispose();
+
+    private void SetupAgentWithConversation(string agentId, string conversationId)
+    {
+        // Add agent session state
+        var sessions = (Dictionary<string, AgentSessionState>)typeof(AgentSessionManager)
+            .GetField("_sessions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(_manager)!;
+
+        var state = new AgentSessionState { AgentId = agentId, DisplayName = agentId, IsConnected = true };
+        state.Conversations[conversationId] = new ConversationListItemState
+        {
+            ConversationId = conversationId,
+            Title = "Test",
+            IsDefault = false,
+            Status = "active",
+            ActiveSessionId = "sess-1",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        sessions[agentId] = state;
+    }
+
+    private void SetupHistoryResponse(string conversationId, IReadOnlyList<ConversationHistoryEntryDto> entries)
+    {
+        var response = new ConversationHistoryResponseDto(conversationId, entries.Count, 0, 200, entries);
+        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        _handler.Responses[$"/api/conversations/{Uri.EscapeDataString(conversationId)}/history?limit=200"] = json;
+    }
+
+    [Fact]
+    public async Task SelectConversation_ToolEntry_MapsIsToolCallAndToolResult()
+    {
+        const string agentId = "agent-1";
+        const string convId = "conv-1";
+        SetupAgentWithConversation(agentId, convId);
+        SetupHistoryResponse(convId,
+        [
+            new ConversationHistoryEntryDto
+            {
+                Kind = "message",
+                SessionId = "sess-1",
+                Timestamp = DateTimeOffset.UtcNow,
+                Role = "tool",
+                Content = "search result",
+                ToolName = "search",
+                ToolCallId = "tc1",
+                ToolArgs = "{\"q\":\"test\"}",
+                ToolIsError = true
+            }
+        ]);
+
+        await _manager.SelectConversationAsync(agentId, convId);
+
+        var state = _manager.Sessions[agentId];
+        var msg = state.Messages.ShouldHaveSingleItem();
+        msg.IsToolCall.ShouldBeTrue();
+        msg.ToolResult.ShouldBe("search result");
+        msg.ToolArgs.ShouldBe("{\"q\":\"test\"}");
+        msg.ToolIsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SelectConversation_ToolEntry_WithToolIsErrorFalse_ToolIsErrorIsFalse()
+    {
+        const string agentId = "agent-2";
+        const string convId = "conv-2";
+        SetupAgentWithConversation(agentId, convId);
+        SetupHistoryResponse(convId,
+        [
+            new ConversationHistoryEntryDto
+            {
+                Kind = "message",
+                SessionId = "sess-1",
+                Timestamp = DateTimeOffset.UtcNow,
+                Role = "tool",
+                Content = "ok",
+                ToolName = "run",
+                ToolCallId = "tc2",
+                ToolIsError = false
+            }
+        ]);
+
+        await _manager.SelectConversationAsync(agentId, convId);
+
+        var msg = _manager.Sessions[agentId].Messages.ShouldHaveSingleItem();
+        msg.IsToolCall.ShouldBeTrue();
+        msg.ToolIsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SelectConversation_NonToolEntry_IsToolCallFalse_ToolResultNull()
+    {
+        const string agentId = "agent-3";
+        const string convId = "conv-3";
+        SetupAgentWithConversation(agentId, convId);
+        SetupHistoryResponse(convId,
+        [
+            new ConversationHistoryEntryDto
+            {
+                Kind = "message",
+                SessionId = "sess-1",
+                Timestamp = DateTimeOffset.UtcNow,
+                Role = "user",
+                Content = "hello",
+                ToolName = null
+            }
+        ]);
+
+        await _manager.SelectConversationAsync(agentId, convId);
+
+        var msg = _manager.Sessions[agentId].Messages.ShouldHaveSingleItem();
+        msg.IsToolCall.ShouldBeFalse();
+        msg.ToolResult.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SelectConversation_BoundaryEntry_IsBoundaryTrueNotToolCall()
+    {
+        const string agentId = "agent-4";
+        const string convId = "conv-4";
+        SetupAgentWithConversation(agentId, convId);
+        SetupHistoryResponse(convId,
+        [
+            new ConversationHistoryEntryDto
+            {
+                Kind = "boundary",
+                SessionId = "sess-old",
+                Timestamp = DateTimeOffset.UtcNow
+            }
+        ]);
+
+        await _manager.SelectConversationAsync(agentId, convId);
+
+        var msg = _manager.Sessions[agentId].Messages.ShouldHaveSingleItem();
+        msg.Kind.ShouldBe("boundary");
+        msg.IsToolCall.ShouldBeFalse();
+    }
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        public Dictionary<string, string> Responses { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.PathAndQuery;
+            if (Responses.TryGetValue(path, out var json))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
     }
 }

--- a/tests/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -428,6 +428,136 @@ public sealed class SqliteSessionStoreTests
         mode.ShouldBe("wal", StringCompareShould.IgnoreCase);
     }
 
+    // ── Tool field persistence tests ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveAsync_WithToolArgsAndToolIsError_RoundTripsCorrectly()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync("s-tool", "agent-a");
+        session.AddEntries([
+            new SessionEntry { Role = MessageRole.Tool, Content = "started", ToolName = "search", ToolCallId = "tc1", ToolArgs = "{\"query\":\"dotnet\"}" },
+            new SessionEntry { Role = MessageRole.Tool, Content = "result", ToolName = "search", ToolCallId = "tc1", ToolIsError = false }
+        ]);
+
+        await store.SaveAsync(session);
+        var reloaded = await fixture.CreateStore().GetAsync("s-tool");
+
+        reloaded.ShouldNotBeNull();
+        var startEntry = reloaded!.History.First(e => e.ToolArgs is not null);
+        startEntry.ToolArgs.ShouldBe("{\"query\":\"dotnet\"}");
+        var endEntry = reloaded.History.First(e => e.Content == "result");
+        endEntry.ToolIsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SaveAsync_ToolIsErrorTrue_PersistedAndReadBackAsTrue()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync("s-iserr", "agent-a");
+        session.AddEntry(new SessionEntry { Role = MessageRole.Tool, Content = "fail", ToolName = "run", ToolCallId = "tc2", ToolIsError = true });
+
+        await store.SaveAsync(session);
+        var reloaded = await fixture.CreateStore().GetAsync("s-iserr");
+
+        reloaded.ShouldNotBeNull();
+        reloaded!.History.ShouldHaveSingleItem();
+        reloaded.History[0].ToolIsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_ToolIsErrorFalse_PersistedAndReadBackAsFalse()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync("s-noerr", "agent-a");
+        session.AddEntry(new SessionEntry { Role = MessageRole.Tool, Content = "ok", ToolName = "run", ToolCallId = "tc3", ToolIsError = false });
+
+        await store.SaveAsync(session);
+        var reloaded = await fixture.CreateStore().GetAsync("s-noerr");
+
+        reloaded.ShouldNotBeNull();
+        reloaded!.History[0].ToolIsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SaveAsync_ToolArgsJsonString_RoundTripsThroughSqlite()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync("s-toolargs", "agent-a");
+        const string args = "{\"key\":\"value\",\"num\":42}";
+        session.AddEntry(new SessionEntry { Role = MessageRole.Tool, Content = "started", ToolName = "fn", ToolCallId = "tc4", ToolArgs = args });
+
+        await store.SaveAsync(session);
+        var reloaded = await fixture.CreateStore().GetAsync("s-toolargs");
+
+        reloaded.ShouldNotBeNull();
+        reloaded!.History[0].ToolArgs.ShouldBe(args);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithLegacySchema_MigratesToolColumns()
+    {
+        using var fixture = new StoreFixture();
+        // Create a pre-existing DB without tool_args / tool_is_error columns
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT,
+                    channel_type TEXT,
+                    caller_id TEXT,
+                    status TEXT,
+                    metadata TEXT,
+                    created_at TEXT,
+                    updated_at TEXT
+                );
+
+                CREATE TABLE session_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT,
+                    role TEXT,
+                    content TEXT,
+                    timestamp TEXT,
+                    tool_name TEXT,
+                    tool_call_id TEXT,
+                    is_compaction_summary INTEGER NOT NULL DEFAULT 0
+                );
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Open with current store — migration should add the new columns
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync("s-migrate", "agent-a");
+        session.AddEntry(new SessionEntry { Role = MessageRole.Tool, Content = "ok", ToolName = "fn", ToolCallId = "tc5", ToolArgs = "{}", ToolIsError = false });
+        await store.SaveAsync(session);
+
+        // Verify columns now exist
+        await using var verifyConnection = new SqliteConnection(fixture.ConnectionString);
+        await verifyConnection.OpenAsync();
+        await using var colCmd = verifyConnection.CreateCommand();
+        colCmd.CommandText = "PRAGMA table_info(session_history)";
+        var columns = new List<string>();
+        await using var colReader = await colCmd.ExecuteReaderAsync();
+        while (await colReader.ReadAsync())
+            columns.Add(colReader.GetString(1));
+
+        columns.ShouldContain("tool_args");
+        columns.ShouldContain("tool_is_error");
+
+        // And values were saved
+        var reloaded = await fixture.CreateStore().GetAsync("s-migrate");
+        reloaded.ShouldNotBeNull();
+        reloaded!.History[0].ToolArgs.ShouldBe("{}");
+    }
+
     private sealed class StoreFixture : IDisposable
     {
         public StoreFixture()

--- a/tests/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
+++ b/tests/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
@@ -77,6 +77,159 @@ public sealed class StreamingSessionHelperTests
         session.History.ShouldBeEmpty();
     }
 
+    // ── ToolArgs tests ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ToolStart_WithArgs_PopulatesToolArgsAsJson()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-args"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        var result = await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ToolStart,
+                    ToolCallId = "tc1",
+                    ToolName = "search",
+                    ToolArgs = new Dictionary<string, object?> { ["query"] = "dotnet", ["limit"] = (object?)5 }
+                }
+            ]),
+            session,
+            store.Object);
+
+        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        entry.ToolArgs.ShouldNotBeNull();
+        entry.ToolArgs.ShouldContain("query");
+        entry.ToolArgs.ShouldContain("dotnet");
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ToolStart_WithNoArgs_ToolArgsIsNull()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-noargs"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        var result = await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ToolStart,
+                    ToolCallId = "tc1",
+                    ToolName = "noop",
+                    ToolArgs = null
+                }
+            ]),
+            session,
+            store.Object);
+
+        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        entry.ToolArgs.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ToolStart_WithEmptyArgs_ToolArgsIsNull()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-emptyargs"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        var result = await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ToolStart,
+                    ToolCallId = "tc1",
+                    ToolName = "noop",
+                    ToolArgs = new Dictionary<string, object?>()
+                }
+            ]),
+            session,
+            store.Object);
+
+        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        entry.ToolArgs.ShouldBeNull();
+    }
+
+    // ── ToolIsError tests ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ToolEnd_WithToolIsErrorTrue_SetsToolIsErrorTrue()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-iserr"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        var result = await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ToolEnd,
+                    ToolCallId = "tc1",
+                    ToolName = "search",
+                    ToolResult = "Something went wrong",
+                    ToolIsError = true
+                }
+            ]),
+            session,
+            store.Object);
+
+        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        entry.ToolIsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ToolEnd_WithToolIsErrorFalse_SetsToolIsErrorFalse()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-noerr"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        var result = await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ToolEnd,
+                    ToolCallId = "tc1",
+                    ToolName = "search",
+                    ToolResult = "ok",
+                    ToolIsError = false
+                }
+            ]),
+            session,
+            store.Object);
+
+        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        entry.ToolIsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ToolEnd_WithResult_ContentContainsResult()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-res"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        var result = await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent
+                {
+                    Type = AgentStreamEventType.ToolEnd,
+                    ToolCallId = "tc1",
+                    ToolName = "fetch",
+                    ToolResult = "the result text",
+                    ToolIsError = false
+                }
+            ]),
+            session,
+            store.Object);
+
+        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        entry.Content.ShouldBe("the result text");
+    }
+
     private static async IAsyncEnumerable<AgentStreamEvent> ToAsyncEnumerable(IEnumerable<AgentStreamEvent> events)
     {
         foreach (var evt in events)


### PR DESCRIPTION
Closes #67

Tool call entries in conversation history were showing as pending (hourglass) with no content. The result was stored in `Content` by `StreamingSessionHelper` but the Blazor history loader wasn't mapping it to `ToolResult`. One-line fix.