### PR TITLE
fix(portal): expand only targeted config section when navigating via URL fragment

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ConfigSection.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ConfigSection.razor
@@ -24,11 +24,29 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public bool StartExpanded { get; set; }
 
+    /// <summary>
+    /// When set by the parent (e.g. from a URL fragment), overrides the internal
+    /// collapsed state. Null means the section manages its own state.
+    /// </summary>
+    [Parameter] public bool? IsExpanded { get; set; }
+
     private bool _collapsed;
+    private bool? _lastIsExpanded;
 
     protected override void OnInitialized()
     {
         _collapsed = !StartExpanded;
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Only override collapsed state when IsExpanded actually changes
+        // so user toggles within a session still work.
+        if (IsExpanded.HasValue && IsExpanded != _lastIsExpanded)
+        {
+            _collapsed = !IsExpanded.Value;
+            _lastIsExpanded = IsExpanded;
+        }
     }
 
     private void Toggle() => _collapsed = !_collapsed;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
@@ -42,7 +42,7 @@
             </div>
 
             @* ── Gateway ─────────────────────────────────────────── *@
-            <ConfigSection Id="cfg-gateway" Title="🌐 Gateway" Description="Core gateway settings — listen URL, default agent, directories, logging, and server identity." StartExpanded="true">
+            <ConfigSection Id="cfg-gateway" Title="🌐 Gateway" Description="Core gateway settings — listen URL, default agent, directories, logging, and server identity." StartExpanded="true" IsExpanded="@(_activeSection == null ? true : _activeSection == "cfg-gateway")">
                 @{ var gw = GetObject("gateway"); }
                 <TextField Label="Listen URL" Value="@GetStr(gw, "listenUrl")" ValueChanged="@(v => SetNested("gateway", "listenUrl", v))" Placeholder="http://localhost:5005" />
                 <TextField Label="Default Agent ID" Value="@GetStr(gw, "defaultAgentId")" ValueChanged="@(v => SetNested("gateway", "defaultAgentId", v))" />
@@ -125,7 +125,7 @@
             </ConfigSection>
 
             @* ── Providers ───────────────────────────────────────── *@
-            <ConfigSection Id="cfg-providers" Title="🔌 Providers" Description="LLM provider connections — API keys, endpoints, and available models.">
+            <ConfigSection Id="cfg-providers" Title="🔌 Providers" Description="LLM provider connections — API keys, endpoints, and available models." IsExpanded="@(_activeSection == null ? false : _activeSection == \"cfg-providers\")">
                 <DictionarySection Title="" SectionPath="providers" Entries="@GetDict("providers")"
                                    OnAddEntry="@((string key) => AddTopDictEntry("providers", key))"
                                    OnDeleteEntry="@((string key) => DeleteTopDictEntry("providers", key))">
@@ -140,7 +140,7 @@
             </ConfigSection>
 
             @* ── Channels ────────────────────────────────────────── *@
-            <ConfigSection Id="cfg-channels" Title="📡 Channels" Description="Communication channels — websocket, SignalR, Telegram, Discord, etc.">
+            <ConfigSection Id="cfg-channels" Title="📡 Channels" Description="Communication channels — websocket, SignalR, Telegram, Discord, etc." IsExpanded="@(_activeSection == null ? false : _activeSection == \"cfg-channels\")">
                 <DictionarySection Title="" SectionPath="channels" Entries="@GetDict("channels")"
                                    OnAddEntry="@((string key) => AddTopDictEntry("channels", key))"
                                    OnDeleteEntry="@((string key) => DeleteTopDictEntry("channels", key))">
@@ -163,7 +163,7 @@
             </ConfigSection>
 
             @* ── Agent World Defaults ────────────────────────────── *@
-            <ConfigSection Id="cfg-agent-defaults" Title="🌍 World Settings" Description="World-level agent defaults — inherited by all agents unless explicitly overridden.">
+            <ConfigSection Id="cfg-agent-defaults" Title="🌍 World Settings" Description="World-level agent defaults — inherited by all agents unless explicitly overridden." IsExpanded="@(_activeSection == null ? false : _activeSection == \"cfg-agent-defaults\")">
                 @{
                     var agentsSection = GetObject("agents");
                     var agentDef = GetObject(agentsSection, "defaults");
@@ -191,7 +191,7 @@
             </ConfigSection>
 
             @* ── Cron ────────────────────────────────────────────── *@
-            <ConfigSection Id="cfg-cron" Title="⏰ Cron" Description="Scheduled job configuration — enable cron, set tick interval, and manage jobs.">
+            <ConfigSection Id="cfg-cron" Title="⏰ Cron" Description="Scheduled job configuration — enable cron, set tick interval, and manage jobs." IsExpanded="@(_activeSection == null ? false : _activeSection == \"cfg-cron\")">
                 @{ var cron = GetObject("cron"); }
                 <BoolField Label="Enabled" Value="@GetBool(cron, "enabled")" ValueChanged="@(v => SetNestedBool("cron", "enabled", v))" />
                 <NumberField Label="Tick Interval (seconds)" Value="@GetNullableInt(cron, "tickIntervalSeconds")" ValueChanged="@(v => SetNestedNum("cron", "tickIntervalSeconds", v))" />
@@ -215,7 +215,7 @@
             </ConfigSection>
 
             @* ── Global API Key ──────────────────────────────────── *@
-            <ConfigSection Id="cfg-apikey" Title="🔑 Global API Key" Description="A global API key used for platform authentication.">
+            <ConfigSection Id="cfg-apikey" Title="🔑 Global API Key" Description="A global API key used for platform authentication." IsExpanded="@(_activeSection == null ? false : _activeSection == \"cfg-apikey\")">
                 <TextField Label="API Key" Value="@GetStr(_config, "apiKey")" ValueChanged="@(v => { SetValue("apiKey", v); MarkDirty(); })" InputType="password" Placeholder="(redacted — leave blank to keep)" />
             </ConfigSection>
         </div>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor.cs
@@ -1,11 +1,15 @@
 using System.Text.Json.Nodes;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Pages;
 
 public partial class Configuration : IDisposable
 {
+    [Inject] private NavigationManager Nav { get; set; } = default!;
+
+    private string? _activeSection;
     private JsonObject? _config;
     private bool _loading = true;
     private bool _saving;
@@ -17,7 +21,21 @@ public partial class Configuration : IDisposable
 
     protected override async Task OnInitializedAsync()
     {
+        Nav.LocationChanged += OnLocationChanged;
+        _activeSection = GetFragment(Nav.Uri);
         await LoadConfig();
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        _activeSection = GetFragment(e.Location);
+        StateHasChanged();
+    }
+
+    private static string? GetFragment(string uri)
+    {
+        var idx = uri.IndexOf('#');
+        return idx >= 0 ? uri[(idx + 1)..] : null;
     }
 
     private async Task LoadConfig()
@@ -499,6 +517,7 @@ public partial class Configuration : IDisposable
 
     public void Dispose()
     {
+        Nav.LocationChanged -= OnLocationChanged;
         _statusTimer?.Stop();
         _statusTimer?.Dispose();
     }


### PR DESCRIPTION
Closes #69

Navigating to `configuration#cfg-cron` now expands only Cron and collapses everything else. No fragment = Gateway expanded by default. User can still toggle sections manually.