### PR TITLE
fix(blazor-client): reliable conversation history load on first page visit

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -236,22 +236,6 @@
             });
         }
 
-        // Ensure conversations are loaded for the active agent on the Blazor thread.
-        // This handles the race where HandleConnected fires before the component is ready,
-        // or where Task.Run in AgentSessionManager fires OnStateChanged off-thread before
-        // history has finished loading.
-        if (Manager.ApiBaseUrl is not null && Manager.ActiveAgentId is not null
-            && Manager.Sessions.TryGetValue(Manager.ActiveAgentId, out var activeState)
-            && !activeState.ConversationsLoaded && !activeState.IsLoadingConversations)
-        {
-            var agentId = Manager.ActiveAgentId;
-            _ = InvokeAsync(async () =>
-            {
-                await Manager.LoadConversationsAsync(agentId);
-                StateHasChanged();
-            });
-        }
-
         InvokeAsync(StateHasChanged);
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -87,6 +87,21 @@ public sealed class AgentSessionManager : IDisposable
             {
                 await LoadConversationsAsync(agentId);
             }
+            else if (!state.ConversationsLoaded && state.IsLoadingConversations)
+            {
+                // Loading already in progress (from HandleConnected retry)
+                // Poll briefly — it should complete within a few hundred ms
+                for (var i = 0; i < 20 && !state.ConversationsLoaded; i++)
+                    await Task.Delay(100);
+
+                // Select default conversation if loaded
+                if (state.ConversationsLoaded && state.ActiveConversationId is null && state.Conversations.Count > 0)
+                {
+                    var defaultConv = state.Conversations.Values.FirstOrDefault(c => c.IsDefault)
+                        ?? state.Conversations.Values.OrderByDescending(c => c.UpdatedAt).First();
+                    await SelectConversationAsync(agentId, defaultConv.ConversationId);
+                }
+            }
             else if (state.ActiveConversationId is not null
                 && !state.ConversationHistoryLoaded.Contains(state.ActiveConversationId))
             {
@@ -809,22 +824,20 @@ public sealed class AgentSessionManager : IDisposable
             };
         }
 
-        // Retry loading conversations for the active agent if not yet loaded.
-        // Use Task.Run but capture the agentId to avoid closure issues.
-        // OnStateChanged is fired inside LoadConversationsAsync so the component
-        // re-renders when data arrives.
-        if (ActiveAgentId is not null
-            && _sessions.TryGetValue(ActiveAgentId, out var activeState)
-            && !activeState.ConversationsLoaded)
+        // Retry loading conversations for ALL sessions — on first page load ActiveAgentId
+        // may not be set yet when HandleConnected fires, so iterate all sessions and
+        // pre-load conversations for any that haven't been loaded yet.
+        if (_apiBaseUrl is not null)
         {
-            var agentIdToLoad = ActiveAgentId;
-            _ = Task.Run(async () =>
+            foreach (var agentId in _sessions.Keys.ToList())
             {
-                await LoadConversationsAsync(agentIdToLoad);
-                // Fire an extra StateChanged after history loads so the component
-                // re-renders even if it missed the one from inside LoadConversationsAsync.
-                OnStateChanged?.Invoke();
-            });
+                var state = _sessions[agentId];
+                if (!state.ConversationsLoaded && !state.IsLoadingConversations)
+                {
+                    var id = agentId;
+                    _ = Task.Run(() => LoadConversationsAsync(id));
+                }
+            }
         }
 
         OnStateChanged?.Invoke();


### PR DESCRIPTION
## Problem

Conversation history reliably failed to load on the first page visit due to a timing race:

1. `MainLayout` renders → sidebar calls `SetActiveAgentAsync("assistant")`
2. `SetActiveAgentAsync` calls `LoadConversationsAsync`
3. `LoadConversationsAsync` checks `_apiBaseUrl` — may be null if `InitializeAsync` hasn't finished
4. Returns early silently, `ConversationsLoaded` stays false
5. `HandleConnected` fires later — only retried if `ActiveAgentId` was already set (often wasn't)
6. `MainLayout.HandleStateChanged` ALSO fired a load, creating a parallel race

## Fix

### Change 1 — Remove duplicate retry in `MainLayout.HandleStateChanged`
Removed the block that checked for unloaded conversations and fired `LoadConversationsAsync`. `HandleConnected` is the correct and sufficient retry point.

### Change 2 — `HandleConnected`: load conversations for ALL sessions
Previously only retried for `ActiveAgentId` (which may not be set yet). Now iterates all sessions and pre-loads any that haven't been loaded — data is ready by the time `SetActiveAgentAsync` runs.

### Change 3 — `SetActiveAgentAsync`: wait when load already in progress
Added an `else if` branch: when `IsLoadingConversations` is true (kicked off by `HandleConnected`), polls up to 2s then auto-selects the default conversation.

## Testing
- `dotnet test BotNexus.slnx` — **1047 passed, 0 failed**
- Could not verify against live dev gateway (not running in CI environment)