### PR TITLE
feat(blazor): refactor config page into dedicated panel components

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ApiKeyConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ApiKeyConfigPanel.razor
@@ -1,0 +1,24 @@
+@using System.Text.Json.Nodes
+
+<TextField Label="API Key" Value="@GetStr(Config, "apiKey")" ValueChanged="@(v => { SetRootStr("apiKey", v); MarkDirty(); })" InputType="password" Placeholder="(redacted — leave blank to keep)" />
+
+@code {
+    [Parameter] public JsonObject? Config { get; set; }
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private void MarkDirty() => OnChanged.InvokeAsync();
+
+    private static string GetStr(JsonObject? obj, string key)
+    {
+        var node = obj?[key];
+        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
+        return "";
+    }
+
+    private void SetRootStr(string key, string? value)
+    {
+        if (Config is null) return;
+        Config[key] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ChannelsConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ChannelsConfigPanel.razor
@@ -1,0 +1,94 @@
+@using System.Text.Json.Nodes
+
+<DictionarySection Title="" SectionPath="channels" Entries="@GetDict(Config, "channels")"
+                   OnAddEntry="@((string key) => AddTopDictEntry("channels", key))"
+                   OnDeleteEntry="@((string key) => DeleteTopDictEntry("channels", key))">
+    <EntryTemplate Context="entry">
+        <TextField Label="Channel Type" Value="@GetStr(entry.Value, "type")" ValueChanged="@(v => SetTopDictField("channels", entry.Key, "type", v))" />
+        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetTopDictBool("channels", entry.Key, "enabled", v))" />
+        @{ var settings = GetObject(entry.Value, "settings"); }
+        @if (settings is not null && settings.Count > 0)
+        {
+            <NestedSection Title="Settings">
+                @foreach (var (sk, sv) in settings)
+                {
+                    <TextField Label="@sk" Value="@(sv?.ToString() ?? "")" ValueChanged="@(v => SetTopDictDeep("channels", entry.Key, "settings", sk, v))" />
+                }
+            </NestedSection>
+        }
+    </EntryTemplate>
+</DictionarySection>
+
+@code {
+    [Parameter] public JsonObject? Config { get; set; }
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private void MarkDirty() => OnChanged.InvokeAsync();
+
+    private static JsonObject? GetObject(JsonObject? parent, string key) => parent?[key] as JsonObject;
+
+    private static string GetStr(JsonObject? obj, string key)
+    {
+        var node = obj?[key];
+        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
+        return "";
+    }
+
+    private static bool GetBool(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        return false;
+    }
+
+    private static Dictionary<string, JsonObject?> GetDict(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
+        return new();
+    }
+
+    private void SetTopDictField(string section, string entryKey, string field, string? value)
+    {
+        var dict = Config?[section] as JsonObject;
+        var entry = dict?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetTopDictBool(string section, string entryKey, string field, bool value)
+    {
+        var dict = Config?[section] as JsonObject;
+        var entry = dict?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = value;
+        MarkDirty();
+    }
+
+    private void SetTopDictDeep(string section, string entryKey, string sub, string field, string? value)
+    {
+        var dict = Config?[section] as JsonObject;
+        var entry = dict?[entryKey] as JsonObject;
+        if (entry is null) return;
+        if (entry[sub] is not JsonObject child) { child = new JsonObject(); entry[sub] = child; }
+        child[field] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void AddTopDictEntry(string section, string key)
+    {
+        if (Config is null || string.IsNullOrWhiteSpace(key)) return;
+        if (Config[section] is not JsonObject dict) { dict = new JsonObject(); Config[section] = dict; }
+        dict[key] = new JsonObject();
+        MarkDirty();
+        StateHasChanged();
+    }
+
+    private void DeleteTopDictEntry(string section, string key)
+    {
+        var dict = Config?[section] as JsonObject;
+        if (dict is null) return;
+        dict.Remove(key);
+        MarkDirty();
+        StateHasChanged();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/CronConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/CronConfigPanel.razor
@@ -1,0 +1,123 @@
+@using System.Text.Json.Nodes
+
+@{ var cron = GetObject(Config, "cron"); }
+
+<BoolField Label="Enabled" Value="@GetBool(cron, "enabled")" ValueChanged="@(v => SetNestedBool("cron", "enabled", v))" />
+<NumberField Label="Tick Interval (seconds)" Value="@GetNullableInt(cron, "tickIntervalSeconds")" ValueChanged="@(v => SetNestedNum("cron", "tickIntervalSeconds", v))" />
+
+<DictionarySection Title="Jobs" SectionPath="cron.jobs" Entries="@GetDict(cron, "jobs")"
+                   OnAddEntry="@((string key) => AddNestedDictEntry("cron", "jobs", key))"
+                   OnDeleteEntry="@((string key) => DeleteNestedDictEntry("cron", "jobs", key))">
+    <EntryTemplate Context="entry">
+        <TextField Label="Job Name" Value="@GetStr(entry.Value, "name")" ValueChanged="@(v => SetCronJobField(entry.Key, "name", v))" />
+        <TextField Label="Schedule (cron)" Value="@GetStr(entry.Value, "schedule")" ValueChanged="@(v => SetCronJobField(entry.Key, "schedule", v))" />
+        <SelectField Label="Action Type" Value="@GetStr(entry.Value, "actionType")" ValueChanged="@(v => SetCronJobField(entry.Key, "actionType", v))"
+                     Options="@(new[] { "agent-chat", "webhook", "shell" })" />
+        <TextField Label="Agent ID" Value="@GetStr(entry.Value, "agentId")" ValueChanged="@(v => SetCronJobField(entry.Key, "agentId", v))" />
+        <TextField Label="Message" Value="@GetStr(entry.Value, "message")" ValueChanged="@(v => SetCronJobField(entry.Key, "message", v))" />
+        <TextField Label="Webhook URL" Value="@GetStr(entry.Value, "webhookUrl")" ValueChanged="@(v => SetCronJobField(entry.Key, "webhookUrl", v))" />
+        <TextField Label="Shell Command" Value="@GetStr(entry.Value, "shellCommand")" ValueChanged="@(v => SetCronJobField(entry.Key, "shellCommand", v))" />
+        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetCronJobBool(entry.Key, "enabled", v))" />
+        <TextField Label="Created By" Value="@GetStr(entry.Value, "createdBy")" ValueChanged="@(v => SetCronJobField(entry.Key, "createdBy", v))" />
+    </EntryTemplate>
+</DictionarySection>
+
+@code {
+    [Parameter] public JsonObject? Config { get; set; }
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private void MarkDirty() => OnChanged.InvokeAsync();
+
+    private static JsonObject? GetObject(JsonObject? parent, string key) => parent?[key] as JsonObject;
+
+    private static string GetStr(JsonObject? obj, string key)
+    {
+        var node = obj?[key];
+        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
+        return "";
+    }
+
+    private static bool GetBool(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        return false;
+    }
+
+    private static int? GetNullableInt(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<int>(out var i)) return i;
+        return null;
+    }
+
+    private static Dictionary<string, JsonObject?> GetDict(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
+        return new();
+    }
+
+    private void SetNestedBool(string section, string key, bool value)
+    {
+        EnsureObject(section);
+        var obj = Config![section] as JsonObject;
+        if (obj is null) return;
+        obj[key] = value;
+        MarkDirty();
+    }
+
+    private void SetNestedNum(string section, string key, int? value)
+    {
+        EnsureObject(section);
+        var obj = Config![section] as JsonObject;
+        if (obj is null) return;
+        obj[key] = value.HasValue ? JsonValue.Create(value.Value) : null;
+        MarkDirty();
+    }
+
+    private void SetCronJobField(string jobKey, string field, string? value)
+    {
+        var cron = Config?["cron"] as JsonObject;
+        var jobs = cron?["jobs"] as JsonObject;
+        var job = jobs?[jobKey] as JsonObject;
+        if (job is null) return;
+        job[field] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetCronJobBool(string jobKey, string field, bool value)
+    {
+        var cron = Config?["cron"] as JsonObject;
+        var jobs = cron?["jobs"] as JsonObject;
+        var job = jobs?[jobKey] as JsonObject;
+        if (job is null) return;
+        job[field] = value;
+        MarkDirty();
+    }
+
+    private void AddNestedDictEntry(string section, string dict, string key)
+    {
+        if (Config is null || string.IsNullOrWhiteSpace(key)) return;
+        EnsureObject(section);
+        var parent = Config[section] as JsonObject;
+        if (parent is null) return;
+        if (parent[dict] is not JsonObject dictObj) { dictObj = new JsonObject(); parent[dict] = dictObj; }
+        dictObj[key] = new JsonObject();
+        MarkDirty();
+        StateHasChanged();
+    }
+
+    private void DeleteNestedDictEntry(string section, string dict, string key)
+    {
+        var parent = Config?[section] as JsonObject;
+        var dictObj = parent?[dict] as JsonObject;
+        if (dictObj is null) return;
+        dictObj.Remove(key);
+        MarkDirty();
+        StateHasChanged();
+    }
+
+    private void EnsureObject(string key)
+    {
+        if (Config is null) return;
+        if (Config[key] is not JsonObject) Config[key] = new JsonObject();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/GatewayConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/GatewayConfigPanel.razor
@@ -1,0 +1,254 @@
+@using System.Text.Json.Nodes
+
+@{ var gw = GetObject(Config, "gateway"); }
+
+<div class="pcfg-top-field">
+    <label>Config Version</label>
+    <input type="number" value="@GetInt("version")" @onchange="@(e => SetRootValue("version", e))" />
+</div>
+
+<TextField Label="Listen URL" Value="@GetStr(gw, "listenUrl")" ValueChanged="@(v => SetNested("gateway", "listenUrl", v))" Placeholder="http://localhost:5005" />
+<TextField Label="Default Agent ID" Value="@GetStr(gw, "defaultAgentId")" ValueChanged="@(v => SetNested("gateway", "defaultAgentId", v))" />
+<TextField Label="Agents Directory" Value="@GetStr(gw, "agentsDirectory")" ValueChanged="@(v => SetNested("gateway", "agentsDirectory", v))" />
+<TextField Label="Sessions Directory" Value="@GetStr(gw, "sessionsDirectory")" ValueChanged="@(v => SetNested("gateway", "sessionsDirectory", v))" />
+<SelectField Label="Log Level" Value="@GetStr(gw, "logLevel")" ValueChanged="@(v => SetNested("gateway", "logLevel", v))"
+             Options="@(new[] { "Trace", "Debug", "Information", "Warning", "Error", "Critical" })" />
+
+<NestedSection Title="Session Store">
+    @{ var ss = GetObject(gw, "sessionStore"); }
+    <TextField Label="Store Type" Value="@GetStr(ss, "type")" ValueChanged="@(v => SetDeep("gateway", "sessionStore", "type", v))" Placeholder="file" />
+    <TextField Label="File Path" Value="@GetStr(ss, "filePath")" ValueChanged="@(v => SetDeep("gateway", "sessionStore", "filePath", v))" />
+    <TextField Label="Connection String" Value="@GetStr(ss, "connectionString")" ValueChanged="@(v => SetDeep("gateway", "sessionStore", "connectionString", v))" />
+</NestedSection>
+
+<NestedSection Title="Compaction">
+    @{ var comp = GetObject(gw, "compaction"); }
+    <NumberField Label="Preserved Turns" Value="@GetNullableInt(comp, "preservedTurns")" ValueChanged="@(v => SetDeepNum("gateway", "compaction", "preservedTurns", v))" />
+    <NumberField Label="Max Summary Chars" Value="@GetNullableInt(comp, "maxSummaryChars")" ValueChanged="@(v => SetDeepNum("gateway", "compaction", "maxSummaryChars", v))" />
+    <TextField Label="Token Threshold Ratio" Value="@GetStr(comp, "tokenThresholdRatio")" ValueChanged="@(v => SetDeep("gateway", "compaction", "tokenThresholdRatio", v))" />
+    <NumberField Label="Context Window Tokens" Value="@GetNullableInt(comp, "contextWindowTokens")" ValueChanged="@(v => SetDeepNum("gateway", "compaction", "contextWindowTokens", v))" />
+    <TextField Label="Summarization Model" Value="@GetStr(comp, "summarizationModel")" ValueChanged="@(v => SetDeep("gateway", "compaction", "summarizationModel", v))" />
+    <TextField Label="Summarization Provider" Value="@GetStr(comp, "summarizationProvider")" ValueChanged="@(v => SetDeep("gateway", "compaction", "summarizationProvider", v))" />
+</NestedSection>
+
+<NestedSection Title="CORS">
+    @{ var cors = GetObject(gw, "cors"); }
+    <ListField Label="Allowed Origins" Items="@GetList(cors, "allowedOrigins")" ItemsChanged="@(v => SetDeepList("gateway", "cors", "allowedOrigins", v))" />
+</NestedSection>
+
+<NestedSection Title="Rate Limiting">
+    @{ var rl = GetObject(gw, "rateLimit"); }
+    <BoolField Label="Enabled" Value="@GetBool(rl, "enabled")" ValueChanged="@(v => SetDeepBool("gateway", "rateLimit", "enabled", v))" />
+    <NumberField Label="Requests Per Minute" Value="@GetNullableInt(rl, "requestsPerMinute")" ValueChanged="@(v => SetDeepNum("gateway", "rateLimit", "requestsPerMinute", v))" />
+    <NumberField Label="Window (seconds)" Value="@GetNullableInt(rl, "windowSeconds")" ValueChanged="@(v => SetDeepNum("gateway", "rateLimit", "windowSeconds", v))" />
+</NestedSection>
+
+<NestedSection Title="Extensions">
+    @{ var ext = GetObject(gw, "extensions"); }
+    <TextField Label="Extensions Path" Value="@GetStr(ext, "path")" ValueChanged="@(v => SetDeep("gateway", "extensions", "path", v))" />
+    <BoolField Label="Enabled" Value="@GetBool(ext, "enabled")" ValueChanged="@(v => SetDeepBool("gateway", "extensions", "enabled", v))" />
+</NestedSection>
+
+<NestedSection Title="World Identity">
+    @{ var world = GetObject(gw, "world"); }
+    <TextField Label="World ID" Value="@GetStr(world, "id")" ValueChanged="@(v => SetDeep("gateway", "world", "id", v))" />
+    <TextField Label="World Name" Value="@GetStr(world, "name")" ValueChanged="@(v => SetDeep("gateway", "world", "name", v))" />
+    <TextField Label="Description" Value="@GetStr(world, "description")" ValueChanged="@(v => SetDeep("gateway", "world", "description", v))" />
+    <TextField Label="Emoji" Value="@GetStr(world, "emoji")" ValueChanged="@(v => SetDeep("gateway", "world", "emoji", v))" Placeholder="🌍" />
+</NestedSection>
+
+<NestedSection Title="File Access Policy">
+    @{ var fa = GetObject(gw, "fileAccess"); }
+    <ListField Label="Allowed Read Paths" Items="@GetList(fa, "allowedReadPaths")" ItemsChanged="@(v => SetDeepList("gateway", "fileAccess", "allowedReadPaths", v))" />
+    <ListField Label="Allowed Write Paths" Items="@GetList(fa, "allowedWritePaths")" ItemsChanged="@(v => SetDeepList("gateway", "fileAccess", "allowedWritePaths", v))" />
+    <ListField Label="Denied Paths" Items="@GetList(fa, "deniedPaths")" ItemsChanged="@(v => SetDeepList("gateway", "fileAccess", "deniedPaths", v))" />
+</NestedSection>
+
+<DictionarySection Title="API Keys" SectionPath="gateway.apiKeys" Entries="@GetDict(gw, "apiKeys")"
+                   OnAddEntry="@((string key) => AddNestedDictEntry("gateway", "apiKeys", key))"
+                   OnDeleteEntry="@((string key) => DeleteNestedDictEntry("gateway", "apiKeys", key))">
+    <EntryTemplate Context="entry">
+        <TextField Label="API Key" Value="@GetStr(entry.Value, "apiKey")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "apiKey", v))" InputType="password" Placeholder="(redacted — leave blank to keep)" />
+        <TextField Label="Tenant ID" Value="@GetStr(entry.Value, "tenantId")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "tenantId", v))" />
+        <TextField Label="Caller ID" Value="@GetStr(entry.Value, "callerId")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "callerId", v))" />
+        <TextField Label="Display Name" Value="@GetStr(entry.Value, "displayName")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "displayName", v))" />
+        <ListField Label="Allowed Agents" Items="@GetList(entry.Value, "allowedAgents")" ItemsChanged="@(v => SetDictListField("gateway", "apiKeys", entry.Key, "allowedAgents", v))" />
+        <ListField Label="Permissions" Items="@GetList(entry.Value, "permissions")" ItemsChanged="@(v => SetDictListField("gateway", "apiKeys", entry.Key, "permissions", v))" />
+        <BoolField Label="Is Admin" Value="@GetBool(entry.Value, "isAdmin")" ValueChanged="@(v => SetDictBoolField("gateway", "apiKeys", entry.Key, "isAdmin", v))" />
+    </EntryTemplate>
+</DictionarySection>
+
+@code {
+    [Parameter] public JsonObject? Config { get; set; }
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private void MarkDirty() => OnChanged.InvokeAsync();
+
+    private static JsonObject? GetObject(JsonObject? parent, string key) => parent?[key] as JsonObject;
+
+    private static string GetStr(JsonObject? obj, string key)
+    {
+        var node = obj?[key];
+        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
+        return "";
+    }
+
+    private static bool GetBool(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        return false;
+    }
+
+    private int? GetInt(string key)
+    {
+        if (Config?[key] is JsonValue jv && jv.TryGetValue<int>(out var i)) return i;
+        return null;
+    }
+
+    private static int? GetNullableInt(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<int>(out var i)) return i;
+        return null;
+    }
+
+    private static List<string> GetList(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonArray arr) return arr.Select(n => n?.ToString() ?? "").ToList();
+        return [];
+    }
+
+    private static Dictionary<string, JsonObject?> GetDict(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
+        return new();
+    }
+
+    private void SetRootValue(string key, ChangeEventArgs e)
+    {
+        if (Config is null) return;
+        var val = e.Value?.ToString();
+        if (int.TryParse(val, out var intVal)) Config[key] = intVal;
+        else Config[key] = val;
+        MarkDirty();
+    }
+
+    private void SetNested(string section, string key, string? value)
+    {
+        EnsureObject(section);
+        var obj = Config![section] as JsonObject;
+        if (obj is null) return;
+        obj[key] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetDeep(string section, string sub, string key, string? value)
+    {
+        EnsureObject(section);
+        var parent = Config![section] as JsonObject;
+        if (parent is null) return;
+        EnsureChildObject(parent, sub);
+        var child = parent[sub] as JsonObject;
+        if (child is null) return;
+        child[key] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetDeepNum(string section, string sub, string key, int? value)
+    {
+        EnsureObject(section);
+        var parent = Config![section] as JsonObject;
+        if (parent is null) return;
+        EnsureChildObject(parent, sub);
+        var child = parent[sub] as JsonObject;
+        if (child is null) return;
+        child[key] = value.HasValue ? JsonValue.Create(value.Value) : null;
+        MarkDirty();
+    }
+
+    private void SetDeepBool(string section, string sub, string key, bool value)
+    {
+        EnsureObject(section);
+        var parent = Config![section] as JsonObject;
+        if (parent is null) return;
+        EnsureChildObject(parent, sub);
+        var child = parent[sub] as JsonObject;
+        if (child is null) return;
+        child[key] = value;
+        MarkDirty();
+    }
+
+    private void SetDeepList(string section, string sub, string key, List<string> value)
+    {
+        EnsureObject(section);
+        var parent = Config![section] as JsonObject;
+        if (parent is null) return;
+        EnsureChildObject(parent, sub);
+        var child = parent[sub] as JsonObject;
+        if (child is null) return;
+        child[key] = value.Count > 0 ? new JsonArray(value.Select(v => JsonValue.Create(v)).ToArray<JsonNode>()) : null;
+        MarkDirty();
+    }
+
+    private void SetDictField(string section, string dict, string entryKey, string field, string? value)
+    {
+        var parent = Config?[section] as JsonObject;
+        var dictObj = parent?[dict] as JsonObject;
+        var entry = dictObj?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetDictBoolField(string section, string dict, string entryKey, string field, bool value)
+    {
+        var parent = Config?[section] as JsonObject;
+        var dictObj = parent?[dict] as JsonObject;
+        var entry = dictObj?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = value;
+        MarkDirty();
+    }
+
+    private void SetDictListField(string section, string dict, string entryKey, string field, List<string> value)
+    {
+        var parent = Config?[section] as JsonObject;
+        var dictObj = parent?[dict] as JsonObject;
+        var entry = dictObj?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = value.Count > 0 ? new JsonArray(value.Select(v => JsonValue.Create(v)).ToArray<JsonNode>()) : null;
+        MarkDirty();
+    }
+
+    private void AddNestedDictEntry(string section, string dict, string key)
+    {
+        if (Config is null || string.IsNullOrWhiteSpace(key)) return;
+        EnsureObject(section);
+        var parent = Config[section] as JsonObject;
+        if (parent is null) return;
+        if (parent[dict] is not JsonObject dictObj) { dictObj = new JsonObject(); parent[dict] = dictObj; }
+        dictObj[key] = new JsonObject();
+        MarkDirty();
+        StateHasChanged();
+    }
+
+    private void DeleteNestedDictEntry(string section, string dict, string key)
+    {
+        var parent = Config?[section] as JsonObject;
+        var dictObj = parent?[dict] as JsonObject;
+        if (dictObj is null) return;
+        dictObj.Remove(key);
+        MarkDirty();
+        StateHasChanged();
+    }
+
+    private void EnsureObject(string key)
+    {
+        if (Config is null) return;
+        if (Config[key] is not JsonObject) Config[key] = new JsonObject();
+    }
+
+    private static void EnsureChildObject(JsonObject parent, string key)
+    {
+        if (parent[key] is not JsonObject) parent[key] = new JsonObject();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ProvidersConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ProvidersConfigPanel.razor
@@ -1,0 +1,90 @@
+@using System.Text.Json.Nodes
+
+<DictionarySection Title="" SectionPath="providers" Entries="@GetDict(Config, "providers")"
+                   OnAddEntry="@((string key) => AddTopDictEntry("providers", key))"
+                   OnDeleteEntry="@((string key) => DeleteTopDictEntry("providers", key))">
+    <EntryTemplate Context="entry">
+        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetTopDictBool("providers", entry.Key, "enabled", v))" />
+        <TextField Label="API Key" Value="@GetStr(entry.Value, "apiKey")" ValueChanged="@(v => SetTopDictField("providers", entry.Key, "apiKey", v))" InputType="password" Placeholder="(redacted — leave blank to keep)" />
+        <TextField Label="Base URL" Value="@GetStr(entry.Value, "baseUrl")" ValueChanged="@(v => SetTopDictField("providers", entry.Key, "baseUrl", v))" />
+        <TextField Label="Default Model" Value="@GetStr(entry.Value, "defaultModel")" ValueChanged="@(v => SetTopDictField("providers", entry.Key, "defaultModel", v))" />
+        <ListField Label="Models" Items="@GetList(entry.Value, "models")" ItemsChanged="@(v => SetTopDictList("providers", entry.Key, "models", v))" />
+    </EntryTemplate>
+</DictionarySection>
+
+@code {
+    [Parameter] public JsonObject? Config { get; set; }
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private void MarkDirty() => OnChanged.InvokeAsync();
+
+    private static string GetStr(JsonObject? obj, string key)
+    {
+        var node = obj?[key];
+        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
+        return "";
+    }
+
+    private static bool GetBool(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        return false;
+    }
+
+    private static List<string> GetList(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonArray arr) return arr.Select(n => n?.ToString() ?? "").ToList();
+        return [];
+    }
+
+    private static Dictionary<string, JsonObject?> GetDict(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
+        return new();
+    }
+
+    private void SetTopDictField(string section, string entryKey, string field, string? value)
+    {
+        var dict = Config?[section] as JsonObject;
+        var entry = dict?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetTopDictBool(string section, string entryKey, string field, bool value)
+    {
+        var dict = Config?[section] as JsonObject;
+        var entry = dict?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = value;
+        MarkDirty();
+    }
+
+    private void SetTopDictList(string section, string entryKey, string field, List<string> value)
+    {
+        var dict = Config?[section] as JsonObject;
+        var entry = dict?[entryKey] as JsonObject;
+        if (entry is null) return;
+        entry[field] = value.Count > 0 ? new JsonArray(value.Select(v => JsonValue.Create(v)).ToArray<JsonNode>()) : null;
+        MarkDirty();
+    }
+
+    private void AddTopDictEntry(string section, string key)
+    {
+        if (Config is null || string.IsNullOrWhiteSpace(key)) return;
+        if (Config[section] is not JsonObject dict) { dict = new JsonObject(); Config[section] = dict; }
+        dict[key] = new JsonObject();
+        MarkDirty();
+        StateHasChanged();
+    }
+
+    private void DeleteTopDictEntry(string section, string key)
+    {
+        var dict = Config?[section] as JsonObject;
+        if (dict is null) return;
+        dict.Remove(key);
+        MarkDirty();
+        StateHasChanged();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/WorldSettingsConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/WorldSettingsConfigPanel.razor
@@ -1,0 +1,121 @@
+@using System.Text.Json.Nodes
+
+@{
+    var agentsSection = GetObject(Config, "agents");
+    var agentDef = GetObject(agentsSection, "defaults");
+}
+
+<NestedSection Title="Agent Memory Defaults">
+    @{ var memDef = GetObject(agentDef, "memory"); }
+    <BoolField Label="Memory Enabled (default)" Value="@GetBool(memDef, "enabled")" ValueChanged="@(v => SetAgentDefaultBool("memory", "enabled", v))" />
+    <SelectField Label="Indexing (default)" Value="@GetStr(memDef, "indexing")" ValueChanged="@(v => SetAgentDefaultStr("memory", "indexing", v))"
+                 Options="@(new[] { "auto", "manual", "off" })" />
+</NestedSection>
+
+<NestedSection Title="Agent Heartbeat Defaults">
+    @{ var hbDef = GetObject(agentDef, "heartbeat"); }
+    <BoolField Label="Heartbeat Enabled (default)" Value="@GetBool(hbDef, "enabled")" ValueChanged="@(v => SetAgentDefaultBool("heartbeat", "enabled", v))" />
+    <NumberField Label="Interval Minutes (default)" Value="@GetNullableInt(hbDef, "intervalMinutes")" ValueChanged="@(v => SetAgentDefaultNum("heartbeat", "intervalMinutes", v))" />
+</NestedSection>
+
+<NestedSection Title="Default Tool IDs">
+    <ListField Label="Tool IDs" Items="@GetList(agentDef, "toolIds")" ItemsChanged="@(v => SetAgentDefaultList("toolIds", v))" />
+</NestedSection>
+
+@code {
+    [Parameter] public JsonObject? Config { get; set; }
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private void MarkDirty() => OnChanged.InvokeAsync();
+
+    private static JsonObject? GetObject(JsonObject? parent, string key) => parent?[key] as JsonObject;
+
+    private static string GetStr(JsonObject? obj, string key)
+    {
+        var node = obj?[key];
+        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
+        return "";
+    }
+
+    private static bool GetBool(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        return false;
+    }
+
+    private static int? GetNullableInt(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonValue jv && jv.TryGetValue<int>(out var i)) return i;
+        return null;
+    }
+
+    private static List<string> GetList(JsonObject? obj, string key)
+    {
+        if (obj?[key] is JsonArray arr) return arr.Select(n => n?.ToString() ?? "").ToList();
+        return [];
+    }
+
+    private void SetAgentDefaultBool(string section, string key, bool value)
+    {
+        if (Config is null) return;
+        EnsureObject("agents");
+        var agents = (Config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        EnsureChildObject(defaults, section);
+        var sectionObj = (defaults[section] as JsonObject)!;
+        sectionObj[key] = value;
+        MarkDirty();
+    }
+
+    private void SetAgentDefaultStr(string section, string key, string? value)
+    {
+        if (Config is null) return;
+        EnsureObject("agents");
+        var agents = (Config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        EnsureChildObject(defaults, section);
+        var sectionObj = (defaults[section] as JsonObject)!;
+        sectionObj[key] = value;
+        MarkDirty();
+    }
+
+    private void SetAgentDefaultNum(string section, string key, int? value)
+    {
+        if (Config is null) return;
+        EnsureObject("agents");
+        var agents = (Config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        EnsureChildObject(defaults, section);
+        var sectionObj = (defaults[section] as JsonObject)!;
+        if (value.HasValue) sectionObj[key] = value.Value;
+        else sectionObj.Remove(key);
+        MarkDirty();
+    }
+
+    private void SetAgentDefaultList(string key, List<string> value)
+    {
+        if (Config is null) return;
+        EnsureObject("agents");
+        var agents = (Config["agents"] as JsonObject)!;
+        EnsureChildObject(agents, "defaults");
+        var defaults = (agents["defaults"] as JsonObject)!;
+        var arr = new JsonArray();
+        foreach (var item in value) arr.Add(item);
+        defaults[key] = arr;
+        MarkDirty();
+    }
+
+    private void EnsureObject(string key)
+    {
+        if (Config is null) return;
+        if (Config[key] is not JsonObject) Config[key] = new JsonObject();
+    }
+
+    private static void EnsureChildObject(JsonObject parent, string key)
+    {
+        if (parent[key] is not JsonObject) parent[key] = new JsonObject();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -151,11 +151,12 @@
                 @if (IsOnPage("configuration"))
                 {
                     <div class="sidebar-subnav">
-                        <a href="configuration#cfg-gateway"  class="sidebar-subnav-item" @onclick="CloseSidebar">🌐 Gateway</a>
-                        <a href="configuration#cfg-providers" class="sidebar-subnav-item" @onclick="CloseSidebar">🔌 Providers</a>
-                        <a href="configuration#cfg-channels"  class="sidebar-subnav-item" @onclick="CloseSidebar">📡 Channels</a>
-                        <a href="configuration#cfg-cron"      class="sidebar-subnav-item" @onclick="CloseSidebar">⏰ Cron</a>
-                        <a href="configuration#cfg-apikey"    class="sidebar-subnav-item" @onclick="CloseSidebar">🔑 Global API Key</a>
+                        <a href="configuration/gateway"   class="sidebar-subnav-item" @onclick="CloseSidebar">🌐 Gateway</a>
+                        <a href="configuration/providers" class="sidebar-subnav-item" @onclick="CloseSidebar">🔌 Providers</a>
+                        <a href="configuration/channels"  class="sidebar-subnav-item" @onclick="CloseSidebar">📡 Channels</a>
+                        <a href="configuration/world"     class="sidebar-subnav-item" @onclick="CloseSidebar">🌍 World Settings</a>
+                        <a href="configuration/cron"      class="sidebar-subnav-item" @onclick="CloseSidebar">⏰ Cron</a>
+                        <a href="configuration/apikey"    class="sidebar-subnav-item" @onclick="CloseSidebar">🔑 Global API Key</a>
                     </div>
                 }
 
@@ -297,7 +298,8 @@
     private bool IsOnPage(string page)
     {
         var uri = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
-        return string.Equals(uri, page, StringComparison.OrdinalIgnoreCase);
+        return uri.Equals(page, StringComparison.OrdinalIgnoreCase)
+            || uri.StartsWith(page + "/", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task OnAgentSelected(ChangeEventArgs e)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
@@ -1,4 +1,5 @@
 @page "/configuration"
+@page "/configuration/{Section}"
 @inject PlatformConfigService ConfigService
 @inject IJSRuntime JS
 @implements IDisposable
@@ -34,190 +35,33 @@
     }
     else
     {
-        <div class="platform-config-sections">
-            @* ── Version ─────────────────────────────────────────── *@
-            <div class="pcfg-top-field">
-                <label>Config Version</label>
-                <input type="number" value="@GetInt("version")" @onchange="@(e => SetValue("version", e))" />
-            </div>
-
-            @* ── Gateway ─────────────────────────────────────────── *@
-            <ConfigSection Id="cfg-gateway" Title="🌐 Gateway" Description="Core gateway settings — listen URL, default agent, directories, logging, and server identity." StartExpanded="true">
-                @{ var gw = GetObject("gateway"); }
-                <TextField Label="Listen URL" Value="@GetStr(gw, "listenUrl")" ValueChanged="@(v => SetNested("gateway", "listenUrl", v))" Placeholder="http://localhost:5005" />
-                <TextField Label="Default Agent ID" Value="@GetStr(gw, "defaultAgentId")" ValueChanged="@(v => SetNested("gateway", "defaultAgentId", v))" />
-                <TextField Label="Agents Directory" Value="@GetStr(gw, "agentsDirectory")" ValueChanged="@(v => SetNested("gateway", "agentsDirectory", v))" />
-                <TextField Label="Sessions Directory" Value="@GetStr(gw, "sessionsDirectory")" ValueChanged="@(v => SetNested("gateway", "sessionsDirectory", v))" />
-                <SelectField Label="Log Level" Value="@GetStr(gw, "logLevel")" ValueChanged="@(v => SetNested("gateway", "logLevel", v))"
-                             Options="@(new[] { "Trace", "Debug", "Information", "Warning", "Error", "Critical" })" />
-
-                @* Session Store *@
-                <NestedSection Title="Session Store">
-                    @{ var ss = GetObject(gw, "sessionStore"); }
-                    <TextField Label="Store Type" Value="@GetStr(ss, "type")" ValueChanged="@(v => SetDeep("gateway", "sessionStore", "type", v))" Placeholder="file" />
-                    <TextField Label="File Path" Value="@GetStr(ss, "filePath")" ValueChanged="@(v => SetDeep("gateway", "sessionStore", "filePath", v))" />
-                    <TextField Label="Connection String" Value="@GetStr(ss, "connectionString")" ValueChanged="@(v => SetDeep("gateway", "sessionStore", "connectionString", v))" />
-                </NestedSection>
-
-                @* Compaction *@
-                <NestedSection Title="Compaction">
-                    @{ var comp = GetObject(gw, "compaction"); }
-                    <NumberField Label="Preserved Turns" Value="@GetNullableInt(comp, "preservedTurns")" ValueChanged="@(v => SetDeepNum("gateway", "compaction", "preservedTurns", v))" />
-                    <NumberField Label="Max Summary Chars" Value="@GetNullableInt(comp, "maxSummaryChars")" ValueChanged="@(v => SetDeepNum("gateway", "compaction", "maxSummaryChars", v))" />
-                    <TextField Label="Token Threshold Ratio" Value="@GetStr(comp, "tokenThresholdRatio")" ValueChanged="@(v => SetDeep("gateway", "compaction", "tokenThresholdRatio", v))" />
-                    <NumberField Label="Context Window Tokens" Value="@GetNullableInt(comp, "contextWindowTokens")" ValueChanged="@(v => SetDeepNum("gateway", "compaction", "contextWindowTokens", v))" />
-                    <TextField Label="Summarization Model" Value="@GetStr(comp, "summarizationModel")" ValueChanged="@(v => SetDeep("gateway", "compaction", "summarizationModel", v))" />
-                    <TextField Label="Summarization Provider" Value="@GetStr(comp, "summarizationProvider")" ValueChanged="@(v => SetDeep("gateway", "compaction", "summarizationProvider", v))" />
-                </NestedSection>
-
-                @* CORS *@
-                <NestedSection Title="CORS">
-                    @{ var cors = GetObject(gw, "cors"); }
-                    <ListField Label="Allowed Origins" Items="@GetList(cors, "allowedOrigins")" ItemsChanged="@(v => SetDeepList("gateway", "cors", "allowedOrigins", v))" />
-                </NestedSection>
-
-                @* Rate Limiting *@
-                <NestedSection Title="Rate Limiting">
-                    @{ var rl = GetObject(gw, "rateLimit"); }
-                    <BoolField Label="Enabled" Value="@GetBool(rl, "enabled")" ValueChanged="@(v => SetDeepBool("gateway", "rateLimit", "enabled", v))" />
-                    <NumberField Label="Requests Per Minute" Value="@GetNullableInt(rl, "requestsPerMinute")" ValueChanged="@(v => SetDeepNum("gateway", "rateLimit", "requestsPerMinute", v))" />
-                    <NumberField Label="Window (seconds)" Value="@GetNullableInt(rl, "windowSeconds")" ValueChanged="@(v => SetDeepNum("gateway", "rateLimit", "windowSeconds", v))" />
-                </NestedSection>
-
-                @* Extensions *@
-                <NestedSection Title="Extensions">
-                    @{ var ext = GetObject(gw, "extensions"); }
-                    <TextField Label="Extensions Path" Value="@GetStr(ext, "path")" ValueChanged="@(v => SetDeep("gateway", "extensions", "path", v))" />
-                    <BoolField Label="Enabled" Value="@GetBool(ext, "enabled")" ValueChanged="@(v => SetDeepBool("gateway", "extensions", "enabled", v))" />
-                </NestedSection>
-
-                @* World Identity *@
-                <NestedSection Title="World Identity">
-                    @{ var world = GetObject(gw, "world"); }
-                    <TextField Label="World ID" Value="@GetStr(world, "id")" ValueChanged="@(v => SetDeep("gateway", "world", "id", v))" />
-                    <TextField Label="World Name" Value="@GetStr(world, "name")" ValueChanged="@(v => SetDeep("gateway", "world", "name", v))" />
-                    <TextField Label="Description" Value="@GetStr(world, "description")" ValueChanged="@(v => SetDeep("gateway", "world", "description", v))" />
-                    <TextField Label="Emoji" Value="@GetStr(world, "emoji")" ValueChanged="@(v => SetDeep("gateway", "world", "emoji", v))" Placeholder="🌍" />
-                </NestedSection>
-
-                @* File Access *@
-                <NestedSection Title="File Access Policy">
-                    @{ var fa = GetObject(gw, "fileAccess"); }
-                    <ListField Label="Allowed Read Paths" Items="@GetList(fa, "allowedReadPaths")" ItemsChanged="@(v => SetDeepList("gateway", "fileAccess", "allowedReadPaths", v))" />
-                    <ListField Label="Allowed Write Paths" Items="@GetList(fa, "allowedWritePaths")" ItemsChanged="@(v => SetDeepList("gateway", "fileAccess", "allowedWritePaths", v))" />
-                    <ListField Label="Denied Paths" Items="@GetList(fa, "deniedPaths")" ItemsChanged="@(v => SetDeepList("gateway", "fileAccess", "deniedPaths", v))" />
-                </NestedSection>
-
-                @* API Keys (dictionary) *@
-                <DictionarySection Title="API Keys" SectionPath="gateway.apiKeys" Entries="@GetDict(gw, "apiKeys")"
-                                   OnAddEntry="@((string key) => AddNestedDictEntry("gateway", "apiKeys", key))"
-                                   OnDeleteEntry="@((string key) => DeleteNestedDictEntry("gateway", "apiKeys", key))">
-                    <EntryTemplate Context="entry">
-                        <TextField Label="API Key" Value="@GetStr(entry.Value, "apiKey")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "apiKey", v))" InputType="password" Placeholder="(redacted — leave blank to keep)" />
-                        <TextField Label="Tenant ID" Value="@GetStr(entry.Value, "tenantId")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "tenantId", v))" />
-                        <TextField Label="Caller ID" Value="@GetStr(entry.Value, "callerId")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "callerId", v))" />
-                        <TextField Label="Display Name" Value="@GetStr(entry.Value, "displayName")" ValueChanged="@(v => SetDictField("gateway", "apiKeys", entry.Key, "displayName", v))" />
-                        <ListField Label="Allowed Agents" Items="@GetList(entry.Value, "allowedAgents")" ItemsChanged="@(v => SetDictListField("gateway", "apiKeys", entry.Key, "allowedAgents", v))" />
-                        <ListField Label="Permissions" Items="@GetList(entry.Value, "permissions")" ItemsChanged="@(v => SetDictListField("gateway", "apiKeys", entry.Key, "permissions", v))" />
-                        <BoolField Label="Is Admin" Value="@GetBool(entry.Value, "isAdmin")" ValueChanged="@(v => SetDictBoolField("gateway", "apiKeys", entry.Key, "isAdmin", v))" />
-                    </EntryTemplate>
-                </DictionarySection>
-            </ConfigSection>
-
-            @* ── Providers ───────────────────────────────────────── *@
-            <ConfigSection Id="cfg-providers" Title="🔌 Providers" Description="LLM provider connections — API keys, endpoints, and available models.">
-                <DictionarySection Title="" SectionPath="providers" Entries="@GetDict("providers")"
-                                   OnAddEntry="@((string key) => AddTopDictEntry("providers", key))"
-                                   OnDeleteEntry="@((string key) => DeleteTopDictEntry("providers", key))">
-                    <EntryTemplate Context="entry">
-                        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetTopDictBool("providers", entry.Key, "enabled", v))" />
-                        <TextField Label="API Key" Value="@GetStr(entry.Value, "apiKey")" ValueChanged="@(v => SetTopDictField("providers", entry.Key, "apiKey", v))" InputType="password" Placeholder="(redacted — leave blank to keep)" />
-                        <TextField Label="Base URL" Value="@GetStr(entry.Value, "baseUrl")" ValueChanged="@(v => SetTopDictField("providers", entry.Key, "baseUrl", v))" />
-                        <TextField Label="Default Model" Value="@GetStr(entry.Value, "defaultModel")" ValueChanged="@(v => SetTopDictField("providers", entry.Key, "defaultModel", v))" />
-                        <ListField Label="Models" Items="@GetList(entry.Value, "models")" ItemsChanged="@(v => SetTopDictList("providers", entry.Key, "models", v))" />
-                    </EntryTemplate>
-                </DictionarySection>
-            </ConfigSection>
-
-            @* ── Channels ────────────────────────────────────────── *@
-            <ConfigSection Id="cfg-channels" Title="📡 Channels" Description="Communication channels — websocket, SignalR, Telegram, Discord, etc.">
-                <DictionarySection Title="" SectionPath="channels" Entries="@GetDict("channels")"
-                                   OnAddEntry="@((string key) => AddTopDictEntry("channels", key))"
-                                   OnDeleteEntry="@((string key) => DeleteTopDictEntry("channels", key))">
-                    <EntryTemplate Context="entry">
-                        <TextField Label="Channel Type" Value="@GetStr(entry.Value, "type")" ValueChanged="@(v => SetTopDictField("channels", entry.Key, "type", v))" />
-                        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetTopDictBool("channels", entry.Key, "enabled", v))" />
-                        @* Render settings sub-object if present *@
-                        @{ var settings = GetObject(entry.Value, "settings"); }
-                        @if (settings is not null && settings.Count > 0)
-                        {
-                            <NestedSection Title="Settings">
-                                @foreach (var (sk, sv) in settings)
-                                {
-                                    <TextField Label="@sk" Value="@(sv?.ToString() ?? "")" ValueChanged="@(v => SetTopDictDeep("channels", entry.Key, "settings", sk, v))" />
-                                }
-                            </NestedSection>
-                        }
-                    </EntryTemplate>
-                </DictionarySection>
-            </ConfigSection>
-
-            @* ── Agent World Defaults ────────────────────────────── *@
-            <ConfigSection Id="cfg-agent-defaults" Title="🌍 World Settings" Description="World-level agent defaults — inherited by all agents unless explicitly overridden.">
-                @{
-                    var agentsSection = GetObject("agents");
-                    var agentDef = GetObject(agentsSection, "defaults");
+        <div class="config-page">
+            <div class="config-panel-canvas">
+                @switch (Section?.ToLowerInvariant() ?? "gateway")
+                {
+                    case "gateway":
+                        <GatewayConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
+                    case "providers":
+                        <ProvidersConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
+                    case "channels":
+                        <ChannelsConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
+                    case "world":
+                        <WorldSettingsConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
+                    case "cron":
+                        <CronConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
+                    case "apikey":
+                        <ApiKeyConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
+                    default:
+                        <GatewayConfigPanel Config="@_config" OnChanged="MarkDirty" />
+                        break;
                 }
-
-                @* Memory defaults *@
-                <NestedSection Title="Agent Memory Defaults">
-                    @{ var memDef = GetObject(agentDef, "memory"); }
-                    <BoolField Label="Memory Enabled (default)" Value="@GetBool(memDef, "enabled")" ValueChanged="@(v => SetAgentDefaultBool("memory", "enabled", v))" />
-                    <SelectField Label="Indexing (default)" Value="@GetStr(memDef, "indexing")" ValueChanged="@(v => SetAgentDefaultStr("memory", "indexing", v))"
-                                 Options="@(new[] { "auto", "manual", "off" })" />
-                </NestedSection>
-
-                @* Heartbeat defaults *@
-                <NestedSection Title="Agent Heartbeat Defaults">
-                    @{ var hbDef = GetObject(agentDef, "heartbeat"); }
-                    <BoolField Label="Heartbeat Enabled (default)" Value="@GetBool(hbDef, "enabled")" ValueChanged="@(v => SetAgentDefaultBool("heartbeat", "enabled", v))" />
-                    <NumberField Label="Interval Minutes (default)" Value="@GetNullableInt(hbDef, "intervalMinutes")" ValueChanged="@(v => SetAgentDefaultNum("heartbeat", "intervalMinutes", v))" />
-                </NestedSection>
-
-                @* Default tool IDs *@
-                <NestedSection Title="Default Tool IDs">
-                    <ListField Label="Tool IDs" Items="@GetList(agentDef, "toolIds")" ItemsChanged="@(v => SetAgentDefaultList("toolIds", v))" />
-                </NestedSection>
-            </ConfigSection>
-
-            @* ── Cron ────────────────────────────────────────────── *@
-            <ConfigSection Id="cfg-cron" Title="⏰ Cron" Description="Scheduled job configuration — enable cron, set tick interval, and manage jobs.">
-                @{ var cron = GetObject("cron"); }
-                <BoolField Label="Enabled" Value="@GetBool(cron, "enabled")" ValueChanged="@(v => SetNestedBool("cron", "enabled", v))" />
-                <NumberField Label="Tick Interval (seconds)" Value="@GetNullableInt(cron, "tickIntervalSeconds")" ValueChanged="@(v => SetNestedNum("cron", "tickIntervalSeconds", v))" />
-
-                <DictionarySection Title="Jobs" SectionPath="cron.jobs" Entries="@GetDict(cron, "jobs")"
-                                   OnAddEntry="@((string key) => AddNestedDictEntry("cron", "jobs", key))"
-                                   OnDeleteEntry="@((string key) => DeleteNestedDictEntry("cron", "jobs", key))">
-                    <EntryTemplate Context="entry">
-                        <TextField Label="Job Name" Value="@GetStr(entry.Value, "name")" ValueChanged="@(v => SetCronJobField(entry.Key, "name", v))" />
-                        <TextField Label="Schedule (cron)" Value="@GetStr(entry.Value, "schedule")" ValueChanged="@(v => SetCronJobField(entry.Key, "schedule", v))" />
-                        <SelectField Label="Action Type" Value="@GetStr(entry.Value, "actionType")" ValueChanged="@(v => SetCronJobField(entry.Key, "actionType", v))"
-                                     Options="@(new[] { "agent-chat", "webhook", "shell" })" />
-                        <TextField Label="Agent ID" Value="@GetStr(entry.Value, "agentId")" ValueChanged="@(v => SetCronJobField(entry.Key, "agentId", v))" />
-                        <TextField Label="Message" Value="@GetStr(entry.Value, "message")" ValueChanged="@(v => SetCronJobField(entry.Key, "message", v))" />
-                        <TextField Label="Webhook URL" Value="@GetStr(entry.Value, "webhookUrl")" ValueChanged="@(v => SetCronJobField(entry.Key, "webhookUrl", v))" />
-                        <TextField Label="Shell Command" Value="@GetStr(entry.Value, "shellCommand")" ValueChanged="@(v => SetCronJobField(entry.Key, "shellCommand", v))" />
-                        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetCronJobBool(entry.Key, "enabled", v))" />
-                        <TextField Label="Created By" Value="@GetStr(entry.Value, "createdBy")" ValueChanged="@(v => SetCronJobField(entry.Key, "createdBy", v))" />
-                    </EntryTemplate>
-                </DictionarySection>
-            </ConfigSection>
-
-            @* ── Global API Key ──────────────────────────────────── *@
-            <ConfigSection Id="cfg-apikey" Title="🔑 Global API Key" Description="A global API key used for platform authentication.">
-                <TextField Label="API Key" Value="@GetStr(_config, "apiKey")" ValueChanged="@(v => { SetValue("apiKey", v); MarkDirty(); })" InputType="password" Placeholder="(redacted — leave blank to keep)" />
-            </ConfigSection>
+            </div>
         </div>
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor.cs
@@ -6,6 +6,8 @@ namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Pages;
 
 public partial class Configuration : IDisposable
 {
+    [Parameter] public string? Section { get; set; }
+
     private JsonObject? _config;
     private bool _loading = true;
     private bool _saving;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -2626,3 +2626,18 @@ details[open] > .thinking-summary::before {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* ── Config Panel Layout ──────────────────────────────────────────────────── */
+
+.config-page {
+    display: flex;
+    flex-direction: row;
+    gap: 0;
+    height: 100%;
+}
+
+.config-panel-canvas {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+}


### PR DESCRIPTION
## Summary

Replaces the monolithic `Configuration.razor` (766 lines) with a thin router + 6 dedicated panel components.

## Changes

### New: `Components/Config/`
- `GatewayConfigPanel.razor` — listen URL, default agent, directories, log level, session store, compaction, CORS, rate limits, extensions, world identity, file access, API keys
- `ProvidersConfigPanel.razor` — LLM providers dictionary (add/edit/delete)
- `ChannelsConfigPanel.razor` — channels dictionary (type, enabled, settings)
- `WorldSettingsConfigPanel.razor` — agent defaults (memory, heartbeat, tool IDs)
- `CronConfigPanel.razor` — enabled toggle, tick interval, jobs dictionary
- `ApiKeyConfigPanel.razor` — global API key field

### Updated
- `Configuration.razor` — thin router with `@page "/configuration/{Section}"`; switch dispatches to panel by section name, defaults to gateway
- `Configuration.razor.cs` — added `[Parameter] string? Section`; save/load/validate logic unchanged
- `MainLayout.razor` — sidebar sub-nav links changed from `#cfg-*` anchors to `/configuration/{section}` routes; `IsOnPage()` updated to match sub-routes

### CSS
Added `.config-page`, `.config-panel-canvas` layout styles to `app.css`.

## Done Checklist
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 0 failures (1439 passed)
- [x] `/configuration` defaults to Gateway panel
- [x] `/configuration/cron` shows only Cron panel
- [x] Sidebar links updated

Closes #71