### PR TITLE
feat(blazor): FeatureFlagsService backed by localStorage

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -2,6 +2,7 @@
 @inject NavigationManager Nav
 @inject AgentSessionManager Manager
 @inject GatewayInfoService GatewayInfo
+@inject FeatureFlagsService FeatureFlags
 @inject IJSRuntime JS
 @implements IDisposable
 @implements IAsyncDisposable
@@ -215,6 +216,7 @@
     {
         if (firstRender)
         {
+            await FeatureFlags.InitializeAsync();
             var stored = await JS.InvokeAsync<string?>("localStorage.getItem", SidebarKey);
             _sidebarOpen = stored == "true";
             _isMobile = await JS.InvokeAsync<bool>("chatScroll.isMobileView");

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -12,5 +12,6 @@ builder.Services.AddScoped<GatewayHubConnection>();
 builder.Services.AddScoped<AgentSessionManager>();
 builder.Services.AddScoped<PlatformConfigService>();
 builder.Services.AddScoped<GatewayInfoService>();
+builder.Services.AddScoped<FeatureFlagsService>();
 
 await builder.Build().RunAsync();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/FeatureFlagsService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/FeatureFlagsService.cs
@@ -1,0 +1,50 @@
+using Microsoft.JSInterop;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Toggleable feature flags backed by browser localStorage.
+/// Flags are read on first access and can be changed at runtime via:
+///   localStorage.setItem('bn:feature:{flagName}', 'true')
+/// then hard-refresh.
+/// </summary>
+public sealed class FeatureFlagsService
+{
+    private readonly IJSRuntime _js;
+    private readonly Dictionary<string, bool> _cache = new();
+    private bool _initialized;
+
+    public FeatureFlagsService(IJSRuntime js) => _js = js;
+
+    /// <summary>
+    /// Cache conversation history in localStorage for instant render on revisit.
+    /// Default: false. Enable with localStorage.setItem('bn:feature:conversationHistoryCache', 'true')
+    /// </summary>
+    public bool ConversationHistoryCache => Get("conversationHistoryCache");
+
+    /// <summary>Loads all flags from localStorage. Call once in OnInitializedAsync.</summary>
+    public async Task InitializeAsync()
+    {
+        if (_initialized) return;
+        _initialized = true;
+
+        // Load known flags
+        await LoadFlag("conversationHistoryCache");
+    }
+
+    private bool Get(string flag) =>
+        _cache.TryGetValue(flag, out var v) ? v : false;
+
+    private async Task LoadFlag(string flag)
+    {
+        try
+        {
+            var val = await _js.InvokeAsync<string?>("localStorage.getItem", $"bn:feature:{flag}");
+            _cache[flag] = string.Equals(val, "true", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            _cache[flag] = false;
+        }
+    }
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/FeatureFlagsServiceTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/FeatureFlagsServiceTests.cs
@@ -1,0 +1,69 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for <see cref="FeatureFlagsService"/> — localStorage-backed feature flags.
+/// </summary>
+public sealed class FeatureFlagsServiceTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+
+    public void Dispose() => _ctx.Dispose();
+
+    private FeatureFlagsService CreateService()
+    {
+        _ctx.JSInterop.Mode = JSRuntimeMode.Strict;
+        return new FeatureFlagsService(_ctx.JSInterop.JSRuntime);
+    }
+
+    [Fact]
+    public async Task Flag_defaults_to_false_when_localStorage_returns_null()
+    {
+        var svc = CreateService();
+        _ctx.JSInterop.Setup<string?>("localStorage.getItem", "bn:feature:conversationHistoryCache")
+            .SetResult(null);
+
+        await svc.InitializeAsync();
+
+        svc.ConversationHistoryCache.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Flag_returns_true_when_localStorage_returns_true()
+    {
+        var svc = CreateService();
+        _ctx.JSInterop.Setup<string?>("localStorage.getItem", "bn:feature:conversationHistoryCache")
+            .SetResult("true");
+
+        await svc.InitializeAsync();
+
+        svc.ConversationHistoryCache.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Flag_returns_false_when_localStorage_returns_false()
+    {
+        var svc = CreateService();
+        _ctx.JSInterop.Setup<string?>("localStorage.getItem", "bn:feature:conversationHistoryCache")
+            .SetResult("false");
+
+        await svc.InitializeAsync();
+
+        svc.ConversationHistoryCache.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Flag_returns_false_when_localStorage_returns_arbitrary_string()
+    {
+        var svc = CreateService();
+        _ctx.JSInterop.Setup<string?>("localStorage.getItem", "bn:feature:conversationHistoryCache")
+            .SetResult("yes");
+
+        await svc.InitializeAsync();
+
+        svc.ConversationHistoryCache.ShouldBeFalse();
+    }
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -28,6 +28,7 @@ public sealed class MainLayoutTests : IDisposable
         _ctx.Services.AddSingleton(_manager.Hub);
         _ctx.Services.AddSingleton(new HttpClient());
         _ctx.Services.AddScoped(sp => new GatewayInfoService(sp.GetRequiredService<HttpClient>(), _manager));
+        _ctx.Services.AddScoped<FeatureFlagsService>();
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 


### PR DESCRIPTION
## Summary

Adds a `FeatureFlagsService` that reads toggleable feature flags from browser `localStorage`, enabling runtime opt-in to experimental features without redeployment.

## Changes

- **`FeatureFlagsService.cs`** — new scoped service; reads flags via `localStorage.getItem('bn:feature:{flag}')`; includes `ConversationHistoryCache` flag (default: false)
- **`Program.cs`** — registers `FeatureFlagsService` as scoped
- **`MainLayout.razor`** — injects service and calls `InitializeAsync()` on first render
- **`FeatureFlagsServiceTests.cs`** — 4 unit tests (null → false, 'true' → true, 'false' → false, arbitrary → false)
- **`MainLayoutTests.cs`** — registers `FeatureFlagsService` to keep layout tests green

## Usage

```js
// Enable in browser console, then hard-refresh
localStorage.setItem('bn:feature:conversationHistoryCache', 'true')
```

## Test Results

```
Passed! - Failed: 0, Passed: 94, Total: 94
```

Closes #75