### PR TITLE
feat(blazor-client): add client state store

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -9,6 +9,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddScoped<GatewayHubConnection>();
+builder.Services.AddScoped<IClientStateStore, ClientStateStore>();
 builder.Services.AddScoped<AgentSessionManager>();
 builder.Services.AddScoped<IGatewayRestClient, GatewayRestClient>();
 builder.Services.AddScoped<IPortalLoadService, PortalLoadService>();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IClientStateStore.cs
@@ -1,0 +1,196 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Single in-memory source of truth for all portal state.
+/// Components subscribe to <see cref="OnChanged"/> to trigger re-renders.
+/// </summary>
+public interface IClientStateStore
+{
+    // ── Global ───────────────────────────────────────────────────────────────
+
+    /// <summary>Fired whenever any state mutates. Components subscribe here for re-render.</summary>
+    event Action? OnChanged;
+
+    // ── Agent-level ──────────────────────────────────────────────────────────
+
+    /// <summary>All known agents keyed by agent ID.</summary>
+    IReadOnlyDictionary<string, AgentState> Agents { get; }
+
+    /// <summary>The currently visible/active agent tab.</summary>
+    string? ActiveAgentId { get; set; }
+
+    /// <summary>Seed initial agent list from hub or REST.</summary>
+    void SeedAgents(IEnumerable<AgentSummary> agents);
+
+    /// <summary>Get a single agent state by ID, or null if not found.</summary>
+    AgentState? GetAgent(string agentId);
+
+    /// <summary>Upsert agent state (adds or updates display name/connection).</summary>
+    void UpsertAgent(AgentState agent);
+
+    // ── Conversation-level ───────────────────────────────────────────────────
+
+    /// <summary>Seed the conversation list for a given agent.</summary>
+    void SeedConversations(string agentId, IEnumerable<ConversationSummaryDto> conversations);
+
+    /// <summary>Get a conversation state by conversation ID (searches all agents).</summary>
+    ConversationState? GetConversation(string conversationId);
+
+    /// <summary>Set active conversation for an agent, updating both agent and global selection.</summary>
+    void SetActiveConversation(string agentId, string conversationId);
+
+    /// <summary>The active conversation ID for the active agent.</summary>
+    string? ActiveConversationId { get; }
+
+    // ── Message operations ───────────────────────────────────────────────────
+
+    /// <summary>Get messages for the given conversation.</summary>
+    IReadOnlyList<ChatMessage> GetMessages(string conversationId);
+
+    /// <summary>Append a message to the end of the conversation's timeline.</summary>
+    void AppendMessage(string conversationId, ChatMessage message);
+
+    /// <summary>Prepend older messages (pagination) to the start of the timeline.</summary>
+    void PrependMessages(string conversationId, IEnumerable<ChatMessage> messages);
+
+    /// <summary>Clear all messages for a conversation.</summary>
+    void ClearMessages(string conversationId);
+
+    // ── Streaming state ──────────────────────────────────────────────────────
+
+    /// <summary>Get streaming state for a conversation.</summary>
+    ConversationStreamState GetStreamState(string conversationId);
+
+    /// <summary>Set whether a conversation is currently streaming.</summary>
+    void SetStreaming(string conversationId, bool streaming);
+
+    /// <summary>Append a delta string to the conversation's stream buffer.</summary>
+    void AppendStreamBuffer(string conversationId, string delta);
+
+    /// <summary>Commit the stream buffer as a final assistant message in the conversation.</summary>
+    void CommitStreamBuffer(string conversationId, string? thinkingContent = null);
+}
+
+/// <summary>Agent-level state for the portal sidebar and chat panel.</summary>
+public sealed class AgentState
+{
+    /// <summary>Unique agent identifier.</summary>
+    public required string AgentId { get; init; }
+
+    /// <summary>Human-readable display name.</summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>Active session ID (last established).</summary>
+    public string? SessionId { get; set; }
+
+    /// <summary>Channel type for this session.</summary>
+    public string? ChannelType { get; set; }
+
+    /// <summary>Session type — user-agent, agent-subagent, etc.</summary>
+    public string SessionType { get; set; } = "user-agent";
+
+    /// <summary>Whether this session is read-only (sub-agent observer).</summary>
+    public bool IsReadOnly => SessionType == "agent-subagent";
+
+    /// <summary>Whether the SignalR hub connection is live.</summary>
+    public bool IsConnected { get; set; }
+
+    /// <summary>Whether this agent is actively streaming a response.</summary>
+    public bool IsStreaming { get; set; }
+
+    /// <summary>Count of unread messages while this agent is not the active tab.</summary>
+    public int UnreadCount { get; set; }
+
+    /// <summary>Current processing stage description for the status bar.</summary>
+    public string? ProcessingStage { get; set; }
+
+    /// <summary>Whether tool messages are visible in the chat panel.</summary>
+    public bool ShowTools { get; set; } = true;
+
+    /// <summary>Whether thinking blocks are visible in the chat panel.</summary>
+    public bool ShowThinking { get; set; } = true;
+
+    /// <summary>The currently selected conversation ID for this agent.</summary>
+    public string? ActiveConversationId { get; set; }
+
+    /// <summary>Whether the conversation list has been loaded from REST.</summary>
+    public bool ConversationsLoaded { get; set; }
+
+    /// <summary>Whether a conversation list fetch is currently in-flight.</summary>
+    public bool IsLoadingConversations { get; set; }
+
+    /// <summary>All conversations for this agent keyed by conversation ID.</summary>
+    public Dictionary<string, ConversationState> Conversations { get; } = new();
+
+    /// <summary>In-progress tool calls keyed by tool-call ID.</summary>
+    public Dictionary<string, ActiveToolCall> ActiveToolCalls { get; } = new();
+
+    /// <summary>Sub-agents spawned by this agent keyed by sub-agent ID.</summary>
+    public Dictionary<string, SubAgentInfo> SubAgents { get; } = new();
+}
+
+/// <summary>Conversation-level state: messages, stream buffers, pagination flags.</summary>
+public sealed class ConversationState
+{
+    /// <summary>Unique conversation identifier.</summary>
+    public required string ConversationId { get; init; }
+
+    /// <summary>Display title.</summary>
+    public string Title { get; set; } = "New conversation";
+
+    /// <summary>Whether this is the agent's default conversation.</summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>Conversation status (Active, Archived, etc.).</summary>
+    public string Status { get; set; } = "Active";
+
+    /// <summary>The live session ID associated with this conversation.</summary>
+    public string? ActiveSessionId { get; set; }
+
+    /// <summary>Count of unread messages while this conversation is not active.</summary>
+    public int UnreadCount { get; set; }
+
+    /// <summary>When the conversation was created.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>When the conversation was last updated.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    // ── History flags ────────────────────────────────────────────────────────
+
+    /// <summary>Whether the latest page of history has been loaded.</summary>
+    public bool HistoryLoaded { get; set; }
+
+    /// <summary>Whether a history fetch is currently in-flight.</summary>
+    public bool IsLoadingHistory { get; set; }
+
+    /// <summary>Whether there are older messages available for pagination.</summary>
+    public bool HasMoreHistory { get; set; }
+
+    /// <summary>Cursor for fetching the next (older) page of history.</summary>
+    public string? NextBeforeCursor { get; set; }
+
+    // ── Messages + streaming ─────────────────────────────────────────────────
+
+    /// <summary>Messages in this conversation's timeline.</summary>
+    public List<ChatMessage> Messages { get; } = new();
+
+    /// <summary>Streaming state for this conversation.</summary>
+    public ConversationStreamState StreamState { get; } = new();
+}
+
+/// <summary>Stream-buffer state for an active or recently active conversation.</summary>
+public sealed class ConversationStreamState
+{
+    /// <summary>Whether the conversation is currently receiving a streaming response.</summary>
+    public bool IsStreaming { get; set; }
+
+    /// <summary>Accumulated content delta buffer during streaming.</summary>
+    public string Buffer { get; set; } = "";
+
+    /// <summary>Accumulated thinking-content buffer during streaming.</summary>
+    public string ThinkingBuffer { get; set; } = "";
+
+    /// <summary>In-progress tool calls for this conversation keyed by tool-call ID.</summary>
+    public Dictionary<string, ActiveToolCall> ActiveToolCalls { get; } = new();
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionManager.cs
@@ -14,6 +14,7 @@ public sealed class AgentSessionManager : IDisposable
 
     private readonly GatewayHubConnection _hub;
     private readonly HttpClient _http;
+    private readonly IClientStateStore _store;
     private readonly Dictionary<string, AgentSessionState> _sessions = new();
     private readonly Dictionary<string, string> _sessionToAgent = new(); // sessionId → agentId
     private readonly HashSet<string> _streamingWhenDisconnected = new();
@@ -36,9 +37,16 @@ public sealed class AgentSessionManager : IDisposable
     public string? ApiBaseUrl => _apiBaseUrl;
 
     public AgentSessionManager(GatewayHubConnection hub, HttpClient http)
+        : this(hub, http, new ClientStateStore())
+    {
+    }
+
+    public AgentSessionManager(GatewayHubConnection hub, HttpClient http, IClientStateStore store)
     {
         _hub = hub;
         _http = http;
+        _store = store;
+        _store.OnChanged += HandleStoreChanged;
         _hub.OnConnected += HandleConnected;
         _hub.OnMessageStart += HandleMessageStart;
         _hub.OnContentDelta += HandleContentDelta;
@@ -61,6 +69,7 @@ public sealed class AgentSessionManager : IDisposable
     public async Task SetActiveAgentAsync(string? agentId)
     {
         ActiveAgentId = agentId;
+        _store.ActiveAgentId = agentId;
         if (agentId is not null && _sessions.TryGetValue(agentId, out var state))
         {
             state.UnreadCount = 0;
@@ -481,12 +490,13 @@ public sealed class AgentSessionManager : IDisposable
             {
                 if (!_sessions.ContainsKey(agent.AgentId))
                 {
-                    _sessions[agent.AgentId] = new AgentSessionState
+                    _store.UpsertAgent(new AgentState
                     {
                         AgentId = agent.AgentId,
                         DisplayName = agent.DisplayName,
                         IsConnected = true
-                    };
+                    });
+                    _sessions[agent.AgentId] = new AgentSessionState(_store, agent.AgentId);
                 }
                 else
                 {
@@ -704,14 +714,15 @@ public sealed class AgentSessionManager : IDisposable
         // Register or reuse the sub-agent's session state
         if (!_sessions.TryGetValue(subAgentId, out var state))
         {
-            state = new AgentSessionState
+            _store.UpsertAgent(new AgentState
             {
                 AgentId = subAgentId,
                 DisplayName = subAgent.Name ?? $"Sub-agent {subAgentId[..Math.Min(8, subAgentId.Length)]}",
-                SessionId = subAgentId, // For sub-agents, session ID == sub-agent ID
+                SessionId = subAgentId,
                 SessionType = "agent-subagent",
                 IsConnected = true
-            };
+            });
+            state = new AgentSessionState(_store, subAgentId);
             _sessions[subAgentId] = state;
             _sessionToAgent[subAgentId] = subAgentId;
         }
@@ -799,12 +810,13 @@ public sealed class AgentSessionManager : IDisposable
 
         foreach (var agent in payload.Agents)
         {
-            _sessions[agent.AgentId] = new AgentSessionState
+            _store.UpsertAgent(new AgentState
             {
                 AgentId = agent.AgentId,
                 DisplayName = agent.DisplayName,
                 IsConnected = true
-            };
+            });
+            _sessions[agent.AgentId] = new AgentSessionState(_store, agent.AgentId);
         }
 
         // Retry loading conversations for ALL sessions — on first page load ActiveAgentId
@@ -1252,5 +1264,8 @@ public sealed class AgentSessionManager : IDisposable
         _hub.OnSubAgentCompleted -= HandleSubAgentCompleted;
         _hub.OnSubAgentFailed -= HandleSubAgentFailed;
         _hub.OnSubAgentKilled -= HandleSubAgentKilled;
+        _store.OnChanged -= HandleStoreChanged;
     }
+
+    private void HandleStoreChanged() => OnStateChanged?.Invoke();
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionState.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentSessionState.cs
@@ -1,125 +1,474 @@
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 /// <summary>
-/// Independent state for one agent's session. No global shared state —
-/// each chat panel is scoped to exactly one <see cref="AgentSessionState"/>.
+/// Thin facade over <see cref="IClientStateStore"/> for a single agent.
+/// Components continue to bind to this object in Wave 2 while the store becomes
+/// the single backing state model.
 /// </summary>
 public sealed class AgentSessionState
 {
+    private readonly IClientStateStore _store;
+    private static readonly List<ChatMessage> s_emptyMessages = [];
+    private StoreConversationMap? _conversations;
+    private StoreMessageStores? _messageStores;
+    private StoreHistoryLoadedSet? _historyLoaded;
+
+    public AgentSessionState()
+    {
+        _store = new ClientStateStore();
+    }
+
+    public AgentSessionState(IClientStateStore store, string agentId)
+    {
+        _store = store;
+        AgentId = agentId;
+    }
+
     /// <summary>The agent's unique identifier.</summary>
-    public required string AgentId { get; init; }
+    public string AgentId { get; init; } = "";
+
+    private AgentState EnsureData()
+    {
+        var existing = _store.GetAgent(AgentId);
+        if (existing is not null)
+            return existing;
+
+        var created = new AgentState { AgentId = AgentId };
+        _store.UpsertAgent(created);
+        return created;
+    }
+
+    private AgentState? Data => _store.GetAgent(AgentId);
 
     /// <summary>Human-friendly display name for the agent.</summary>
-    public string DisplayName { get; set; } = "";
+    public string DisplayName
+    {
+        get => Data?.DisplayName ?? "";
+        set => EnsureData().DisplayName = value;
+    }
 
     /// <summary>Active session ID (set after first message exchange).</summary>
-    public string? SessionId { get; set; }
+    public string? SessionId
+    {
+        get => Data?.SessionId;
+        set => EnsureData().SessionId = value;
+    }
 
     /// <summary>Channel type for this session.</summary>
-    public string? ChannelType { get; set; }
+    public string? ChannelType
+    {
+        get => Data?.ChannelType;
+        set => EnsureData().ChannelType = value;
+    }
 
     /// <summary>Session type — user-agent, agent-subagent, etc. Determines read-only behavior.</summary>
-    public string SessionType { get; set; } = "user-agent";
+    public string SessionType
+    {
+        get => Data?.SessionType ?? "user-agent";
+        set => EnsureData().SessionType = value;
+    }
 
     /// <summary>
     /// Whether this session is read-only. True for sub-agent sessions — users can observe
     /// but cannot send messages.
     /// </summary>
-    public bool IsReadOnly => SessionType == "agent-subagent";
-
-    // ── Per-conversation message stores ──────────────────────────────────────
-
-    /// <summary>Per-conversation message stores, keyed by conversation ID.
-    /// SignalR events are always routed here — messages are never discarded on conversation switch.</summary>
-    public Dictionary<string, List<ChatMessage>> ConversationMessageStores { get; } = new();
-
-    /// <summary>Set of conversation IDs whose history has been loaded from REST.
-    /// Once in this set, we never re-fetch — streaming messages already buffered are preserved.</summary>
-    public HashSet<string> ConversationHistoryLoaded { get; } = new();
-
-    /// <summary>Messages for the currently active conversation (computed).
-    /// Read-only view — append via <see cref="ConversationMessageStores"/> directly.</summary>
-    public List<ChatMessage> Messages =>
-        ActiveConversationId is not null && ConversationMessageStores.TryGetValue(ActiveConversationId, out var msgs)
-            ? msgs
-            : _emptyMessages;
-
-    private static readonly List<ChatMessage> _emptyMessages = [];
+    public bool IsReadOnly => Data?.IsReadOnly ?? false;
 
     /// <summary>Whether the agent is currently streaming a response.</summary>
-    public bool IsStreaming { get; set; }
+    public bool IsStreaming
+    {
+        get => Data?.IsStreaming ?? false;
+        set => EnsureData().IsStreaming = value;
+    }
 
     /// <summary>Buffer for the in-progress streaming response.</summary>
-    public string CurrentStreamBuffer { get; set; } = "";
+    public string CurrentStreamBuffer
+    {
+        get => ActiveConversationId is not null ? _store.GetStreamState(ActiveConversationId).Buffer : "";
+        set
+        {
+            if (ActiveConversationId is not null)
+                _store.GetStreamState(ActiveConversationId).Buffer = value;
+        }
+    }
 
     /// <summary>Buffer for in-progress thinking content during streaming.</summary>
-    public string ThinkingBuffer { get; set; } = "";
+    public string ThinkingBuffer
+    {
+        get => ActiveConversationId is not null ? _store.GetStreamState(ActiveConversationId).ThinkingBuffer : "";
+        set
+        {
+            if (ActiveConversationId is not null)
+                _store.GetStreamState(ActiveConversationId).ThinkingBuffer = value;
+        }
+    }
 
     /// <summary>Whether the hub connection is active.</summary>
-    public bool IsConnected { get; set; }
+    public bool IsConnected
+    {
+        get => Data?.IsConnected ?? false;
+        set => EnsureData().IsConnected = value;
+    }
 
     /// <summary>Count of unread messages while this agent's tab is not active.</summary>
-    public int UnreadCount { get; set; }
+    public int UnreadCount
+    {
+        get => Data?.UnreadCount ?? 0;
+        set => EnsureData().UnreadCount = value;
+    }
 
-    /// <summary>Whether history has been loaded from the REST API for this agent.</summary>
+    /// <summary>Legacy agent-level history flag kept for API compatibility in Wave 2.</summary>
     public bool HistoryLoaded { get; set; }
 
-    /// <summary>Whether a history fetch is currently in-flight.</summary>
+    /// <summary>Legacy agent-level in-flight history flag kept for API compatibility in Wave 2.</summary>
     public bool IsLoadingHistory { get; set; }
 
     /// <summary>In-progress tool calls keyed by tool-call ID.</summary>
-    public Dictionary<string, ActiveToolCall> ActiveToolCalls { get; } = new();
+    public Dictionary<string, ActiveToolCall> ActiveToolCalls => EnsureData().ActiveToolCalls;
 
     /// <summary>Sub-agents spawned by this agent, keyed by sub-agent ID.</summary>
-    public Dictionary<string, SubAgentInfo> SubAgents { get; } = new();
+    public Dictionary<string, SubAgentInfo> SubAgents => EnsureData().SubAgents;
 
-    /// <summary>Current processing stage description for the status bar (e.g. "Thinking…", "Using tool: grep").</summary>
-    public string? ProcessingStage { get; set; }
+    /// <summary>Current processing stage description for the status bar.</summary>
+    public string? ProcessingStage
+    {
+        get => Data?.ProcessingStage;
+        set => EnsureData().ProcessingStage = value;
+    }
 
     /// <summary>Whether tool messages are visible in the chat panel.</summary>
-    public bool ShowTools { get; set; } = true;
+    public bool ShowTools
+    {
+        get => Data?.ShowTools ?? true;
+        set => EnsureData().ShowTools = value;
+    }
 
     /// <summary>Whether thinking blocks are visible in the chat panel.</summary>
-    public bool ShowThinking { get; set; } = true;
-
-    // ── Conversation-awareness ─────────────────────────────────────────────
+    public bool ShowThinking
+    {
+        get => Data?.ShowThinking ?? true;
+        set => EnsureData().ShowThinking = value;
+    }
 
     /// <summary>All conversations for this agent, keyed by conversation ID.</summary>
-    public Dictionary<string, ConversationListItemState> Conversations { get; } = new();
+    public StoreConversationMap Conversations => _conversations ??= new StoreConversationMap(_store, AgentId);
 
     /// <summary>The currently selected conversation ID.</summary>
-    public string? ActiveConversationId { get; set; }
+    public string? ActiveConversationId
+    {
+        get => Data?.ActiveConversationId;
+        set => EnsureData().ActiveConversationId = value;
+    }
 
     /// <summary>Whether the conversation list has been loaded from the REST API.</summary>
-    public bool ConversationsLoaded { get; set; }
+    public bool ConversationsLoaded
+    {
+        get => Data?.ConversationsLoaded ?? false;
+        set => EnsureData().ConversationsLoaded = value;
+    }
 
     /// <summary>Whether a conversation list fetch is currently in-flight.</summary>
-    public bool IsLoadingConversations { get; set; }
+    public bool IsLoadingConversations
+    {
+        get => Data?.IsLoadingConversations ?? false;
+        set => EnsureData().IsLoadingConversations = value;
+    }
 
     /// <summary>Display title of the active conversation, or null if none selected.</summary>
     public string? ActiveConversationTitle =>
         ActiveConversationId is not null && Conversations.TryGetValue(ActiveConversationId, out var c)
             ? c.Title
             : null;
+
+    /// <summary>Messages for the currently active conversation (computed).</summary>
+    public List<ChatMessage> Messages =>
+        ActiveConversationId is not null && Data?.Conversations.TryGetValue(ActiveConversationId, out var conversation) == true
+            ? conversation.Messages
+            : s_emptyMessages;
+
+    /// <summary>Per-conversation message stores keyed by conversation ID.</summary>
+    public StoreMessageStores ConversationMessageStores => _messageStores ??= new StoreMessageStores(_store, AgentId);
+
+    /// <summary>Set of conversation IDs whose history has been loaded from REST.</summary>
+    public StoreHistoryLoadedSet ConversationHistoryLoaded => _historyLoaded ??= new StoreHistoryLoadedSet(_store, AgentId);
+}
+
+/// <summary>
+/// Dictionary-like facade over the store's conversation nodes.
+/// </summary>
+public sealed class StoreConversationMap
+{
+    private readonly IClientStateStore _store;
+    private readonly string _agentId;
+
+    public StoreConversationMap(IClientStateStore store, string agentId)
+    {
+        _store = store;
+        _agentId = agentId;
+    }
+
+    private AgentState? Agent => _store.GetAgent(_agentId);
+
+    public ConversationListItemState this[string conversationId]
+    {
+        get => new ConversationListItemState(_store, _agentId, conversationId) { ConversationId = conversationId };
+        set
+        {
+            var agent = Agent;
+            if (agent is null)
+                return;
+
+            if (!agent.Conversations.TryGetValue(conversationId, out var conversation))
+            {
+                conversation = new ConversationState { ConversationId = conversationId };
+                agent.Conversations[conversationId] = conversation;
+            }
+
+            conversation.Title = value.Title;
+            conversation.IsDefault = value.IsDefault;
+            conversation.Status = value.Status;
+            conversation.ActiveSessionId = value.ActiveSessionId;
+            conversation.UnreadCount = value.UnreadCount;
+            conversation.CreatedAt = value.CreatedAt;
+            conversation.UpdatedAt = value.UpdatedAt;
+            conversation.HistoryLoaded = value.HistoryLoaded;
+            conversation.IsLoadingHistory = value.IsLoadingHistory;
+        }
+    }
+
+    public ICollection<string> Keys => Agent?.Conversations.Keys.ToList() ?? [];
+    public ICollection<ConversationListItemState> Values =>
+        Agent?.Conversations.Keys.Select(id => new ConversationListItemState(_store, _agentId, id) { ConversationId = id }).ToList()
+        ?? [];
+    public int Count => Agent?.Conversations.Count ?? 0;
+
+    public bool TryGetValue(string conversationId, out ConversationListItemState state)
+    {
+        if (Agent?.Conversations.ContainsKey(conversationId) == true)
+        {
+            state = new ConversationListItemState(_store, _agentId, conversationId) { ConversationId = conversationId };
+            return true;
+        }
+
+        state = null!;
+        return false;
+    }
+
+    public ConversationListItemState? GetValueOrDefault(string? conversationId)
+    {
+        if (conversationId is null)
+            return null;
+
+        return TryGetValue(conversationId, out var state) ? state : null;
+    }
+
+    public void Clear() => Agent?.Conversations.Clear();
+
+    public bool Remove(string conversationId) => Agent?.Conversations.Remove(conversationId) == true;
+
+    public bool ContainsKey(string conversationId) => Agent?.Conversations.ContainsKey(conversationId) == true;
+}
+
+/// <summary>
+/// Dict-like facade over per-conversation message lists backed by the store.
+/// </summary>
+public sealed class StoreMessageStores
+{
+    private readonly IClientStateStore _store;
+    private readonly string _agentId;
+
+    public StoreMessageStores(IClientStateStore store, string agentId)
+    {
+        _store = store;
+        _agentId = agentId;
+    }
+
+    private AgentState? Agent => _store.GetAgent(_agentId);
+
+    public List<ChatMessage> this[string convId]
+    {
+        get => GetOrCreate(convId);
+        set
+        {
+            var list = GetOrCreate(convId);
+            list.Clear();
+            list.AddRange(value);
+        }
+    }
+
+    public bool TryGetValue(string convId, out List<ChatMessage> messages)
+    {
+        if (Agent?.Conversations.TryGetValue(convId, out var conv) == true)
+        {
+            messages = conv.Messages;
+            return true;
+        }
+
+        messages = [];
+        return false;
+    }
+
+    public bool TryAdd(string convId, List<ChatMessage> messages)
+    {
+        var agent = Agent;
+        if (agent is null)
+            return false;
+        if (agent.Conversations.ContainsKey(convId))
+            return false;
+
+        agent.Conversations[convId] = new ConversationState
+        {
+            ConversationId = convId,
+            Messages = { }
+        };
+        agent.Conversations[convId].Messages.AddRange(messages);
+        return true;
+    }
+
+    public bool ContainsKey(string convId) => Agent?.Conversations.ContainsKey(convId) == true;
+
+    private List<ChatMessage> GetOrCreate(string convId)
+    {
+        var agent = Agent;
+        if (agent is null)
+            return [];
+
+        if (!agent.Conversations.TryGetValue(convId, out var conv))
+        {
+            conv = new ConversationState { ConversationId = convId };
+            agent.Conversations[convId] = conv;
+        }
+
+        return conv.Messages;
+    }
+}
+
+/// <summary>
+/// Set-like facade for conversation history-loaded tracking backed by the store.
+/// </summary>
+public sealed class StoreHistoryLoadedSet
+{
+    private readonly IClientStateStore _store;
+    private readonly string _agentId;
+
+    public StoreHistoryLoadedSet(IClientStateStore store, string agentId)
+    {
+        _store = store;
+        _agentId = agentId;
+    }
+
+    private AgentState? Agent => _store.GetAgent(_agentId);
+
+    public bool Contains(string convId) =>
+        Agent?.Conversations.GetValueOrDefault(convId)?.HistoryLoaded == true;
+
+    public void Add(string convId)
+    {
+        var conv = Agent?.Conversations.GetValueOrDefault(convId);
+        if (conv is not null)
+            conv.HistoryLoaded = true;
+    }
+
+    public bool Remove(string convId)
+    {
+        var conv = Agent?.Conversations.GetValueOrDefault(convId);
+        if (conv is null)
+            return false;
+
+        conv.HistoryLoaded = false;
+        return true;
+    }
 }
 
 /// <summary>
 /// Client-side view-model for one conversation in the sidebar list.
+/// In Wave 2 this is a thin facade over <see cref="ConversationState"/>.
 /// </summary>
 public sealed class ConversationListItemState
 {
-    public required string ConversationId { get; init; }
-    public string Title { get; set; } = "New conversation";
-    public bool IsDefault { get; set; }
-    public string Status { get; set; } = "Active";
-    public string? ActiveSessionId { get; set; }
-    public int UnreadCount { get; set; }
-    public DateTimeOffset CreatedAt { get; set; }
-    public DateTimeOffset UpdatedAt { get; set; }
+    private readonly IClientStateStore? _store;
+    private readonly string? _agentId;
 
-    // UI-only state
-    public bool HistoryLoaded { get; set; }
-    public bool IsLoadingHistory { get; set; }
+    public ConversationListItemState()
+    {
+    }
+
+    public ConversationListItemState(IClientStateStore store, string agentId, string conversationId)
+    {
+        _store = store;
+        _agentId = agentId;
+        ConversationId = conversationId;
+    }
+
+    private ConversationState? Data =>
+        _store is not null && _agentId is not null
+            ? _store.GetAgent(_agentId)?.Conversations.GetValueOrDefault(ConversationId)
+            : null;
+
+    public string ConversationId { get; init; } = "";
+
+    public string Title
+    {
+        get => Data?.Title ?? _title;
+        set { if (Data is not null) Data.Title = value; else _title = value; }
+    }
+    private string _title = "New conversation";
+
+    public bool IsDefault
+    {
+        get => Data?.IsDefault ?? _isDefault;
+        set { if (Data is not null) Data.IsDefault = value; else _isDefault = value; }
+    }
+    private bool _isDefault;
+
+    public string Status
+    {
+        get => Data?.Status ?? _status;
+        set { if (Data is not null) Data.Status = value; else _status = value; }
+    }
+    private string _status = "Active";
+
+    public string? ActiveSessionId
+    {
+        get => Data?.ActiveSessionId ?? _activeSessionId;
+        set { if (Data is not null) Data.ActiveSessionId = value; else _activeSessionId = value; }
+    }
+    private string? _activeSessionId;
+
+    public int UnreadCount
+    {
+        get => Data?.UnreadCount ?? _unreadCount;
+        set { if (Data is not null) Data.UnreadCount = value; else _unreadCount = value; }
+    }
+    private int _unreadCount;
+
+    public DateTimeOffset CreatedAt
+    {
+        get => Data?.CreatedAt ?? _createdAt;
+        set { if (Data is not null) Data.CreatedAt = value; else _createdAt = value; }
+    }
+    private DateTimeOffset _createdAt;
+
+    public DateTimeOffset UpdatedAt
+    {
+        get => Data?.UpdatedAt ?? _updatedAt;
+        set { if (Data is not null) Data.UpdatedAt = value; else _updatedAt = value; }
+    }
+    private DateTimeOffset _updatedAt;
+
+    public bool HistoryLoaded
+    {
+        get => Data?.HistoryLoaded ?? _historyLoaded;
+        set { if (Data is not null) Data.HistoryLoaded = value; else _historyLoaded = value; }
+    }
+    private bool _historyLoaded;
+
+    public bool IsLoadingHistory
+    {
+        get => Data?.IsLoadingHistory ?? _isLoadingHistory;
+        set { if (Data is not null) Data.IsLoadingHistory = value; else _isLoadingHistory = value; }
+    }
+    private bool _isLoadingHistory;
 }
 
 /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateStore.cs
@@ -1,0 +1,272 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Scoped in-memory state store for the portal. Single source of truth for all agent,
+/// conversation, and message state. UI components subscribe to <see cref="OnChanged"/> to re-render.
+/// </summary>
+public sealed class ClientStateStore : IClientStateStore
+{
+    private readonly Dictionary<string, AgentState> _agents = new();
+
+    // ── IClientStateStore ────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public event Action? OnChanged;
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, AgentState> Agents => _agents;
+
+    /// <inheritdoc />
+    public string? ActiveAgentId { get; set; }
+
+    /// <inheritdoc />
+    public void SeedAgents(IEnumerable<AgentSummary> agents)
+    {
+        foreach (var a in agents)
+        {
+            if (!_agents.TryGetValue(a.AgentId, out var existing))
+            {
+                _agents[a.AgentId] = new AgentState
+                {
+                    AgentId = a.AgentId,
+                    DisplayName = a.DisplayName,
+                    IsConnected = true
+                };
+            }
+            else
+            {
+                existing.DisplayName = a.DisplayName;
+            }
+        }
+
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public AgentState? GetAgent(string agentId) =>
+        _agents.GetValueOrDefault(agentId);
+
+    /// <inheritdoc />
+    public void UpsertAgent(AgentState agent)
+    {
+        _agents[agent.AgentId] = agent;
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public void SeedConversations(string agentId, IEnumerable<ConversationSummaryDto> conversations)
+    {
+        if (!_agents.TryGetValue(agentId, out var agent))
+            return;
+
+        var incoming = conversations.ToList();
+
+        foreach (var dto in incoming)
+        {
+            if (agent.Conversations.TryGetValue(dto.ConversationId, out var existing))
+            {
+                // Preserve local-only state; update server-sourced fields
+                existing.Title = dto.Title;
+                existing.IsDefault = dto.IsDefault;
+                existing.Status = dto.Status;
+                existing.ActiveSessionId = dto.ActiveSessionId;
+                existing.CreatedAt = dto.CreatedAt;
+                existing.UpdatedAt = dto.UpdatedAt;
+            }
+            else
+            {
+                agent.Conversations[dto.ConversationId] = new ConversationState
+                {
+                    ConversationId = dto.ConversationId,
+                    Title = dto.Title,
+                    IsDefault = dto.IsDefault,
+                    Status = dto.Status,
+                    ActiveSessionId = dto.ActiveSessionId,
+                    CreatedAt = dto.CreatedAt,
+                    UpdatedAt = dto.UpdatedAt
+                };
+            }
+        }
+
+        // Remove conversations no longer in the list
+        var incomingIds = incoming.Select(d => d.ConversationId).ToHashSet();
+        foreach (var id in agent.Conversations.Keys.Where(k => !incomingIds.Contains(k)).ToList())
+            agent.Conversations.Remove(id);
+
+        // Auto-select a conversation if none is selected
+        if (agent.ActiveConversationId is null && agent.Conversations.Count > 0)
+        {
+            var defaultConv = agent.Conversations.Values.FirstOrDefault(c => c.IsDefault)
+                ?? agent.Conversations.Values.OrderByDescending(c => c.UpdatedAt).First();
+            agent.ActiveConversationId = defaultConv.ConversationId;
+            if (defaultConv.ActiveSessionId is not null)
+                agent.SessionId = defaultConv.ActiveSessionId;
+        }
+
+        agent.ConversationsLoaded = true;
+        agent.IsLoadingConversations = false;
+
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public ConversationState? GetConversation(string conversationId)
+    {
+        foreach (var agent in _agents.Values)
+        {
+            if (agent.Conversations.TryGetValue(conversationId, out var conv))
+                return conv;
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public void SetActiveConversation(string agentId, string conversationId)
+    {
+        if (!_agents.TryGetValue(agentId, out var agent))
+            return;
+
+        agent.ActiveConversationId = conversationId;
+
+        if (agent.Conversations.TryGetValue(conversationId, out var conv))
+        {
+            conv.UnreadCount = 0;
+            agent.SessionId = conv.ActiveSessionId;
+        }
+
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public string? ActiveConversationId =>
+        ActiveAgentId is not null && _agents.TryGetValue(ActiveAgentId, out var a)
+            ? a.ActiveConversationId
+            : null;
+
+    // ── Message operations ───────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public IReadOnlyList<ChatMessage> GetMessages(string conversationId)
+    {
+        var conv = GetConversation(conversationId);
+        return conv?.Messages ?? (IReadOnlyList<ChatMessage>)[];
+    }
+
+    /// <inheritdoc />
+    public void AppendMessage(string conversationId, ChatMessage message)
+    {
+        var conv = GetConversation(conversationId);
+        if (conv is null)
+            return;
+
+        conv.Messages.Add(message);
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public void PrependMessages(string conversationId, IEnumerable<ChatMessage> messages)
+    {
+        var conv = GetConversation(conversationId);
+        if (conv is null)
+            return;
+
+        conv.Messages.InsertRange(0, messages);
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public void ClearMessages(string conversationId)
+    {
+        var conv = GetConversation(conversationId);
+        if (conv is null)
+            return;
+
+        conv.Messages.Clear();
+        conv.HistoryLoaded = false;
+        NotifyChanged();
+    }
+
+    // ── Streaming state ──────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public ConversationStreamState GetStreamState(string conversationId)
+    {
+        var conv = GetConversation(conversationId);
+        return conv?.StreamState ?? new ConversationStreamState();
+    }
+
+    /// <inheritdoc />
+    public void SetStreaming(string conversationId, bool streaming)
+    {
+        var conv = GetConversation(conversationId);
+        if (conv is null)
+            return;
+
+        conv.StreamState.IsStreaming = streaming;
+
+        // Keep agent-level IsStreaming in sync
+        foreach (var agent in _agents.Values)
+        {
+            if (agent.Conversations.ContainsKey(conversationId))
+            {
+                agent.IsStreaming = streaming;
+                break;
+            }
+        }
+
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public void AppendStreamBuffer(string conversationId, string delta)
+    {
+        var conv = GetConversation(conversationId);
+        if (conv is null)
+            return;
+
+        conv.StreamState.Buffer += delta;
+        NotifyChanged();
+    }
+
+    /// <inheritdoc />
+    public void CommitStreamBuffer(string conversationId, string? thinkingContent = null)
+    {
+        var conv = GetConversation(conversationId);
+        if (conv is null)
+            return;
+
+        var buffer = conv.StreamState.Buffer;
+        var thinking = thinkingContent ?? (string.IsNullOrEmpty(conv.StreamState.ThinkingBuffer)
+            ? null
+            : conv.StreamState.ThinkingBuffer);
+
+        if (!string.IsNullOrEmpty(buffer) || thinking is not null)
+        {
+            conv.Messages.Add(new ChatMessage("Assistant", buffer ?? "", DateTimeOffset.UtcNow)
+            {
+                ThinkingContent = thinking
+            });
+        }
+
+        conv.StreamState.Buffer = "";
+        conv.StreamState.ThinkingBuffer = "";
+        conv.StreamState.IsStreaming = false;
+
+        // Keep agent-level state in sync
+        foreach (var agent in _agents.Values)
+        {
+            if (agent.Conversations.ContainsKey(conversationId))
+            {
+                agent.IsStreaming = false;
+                break;
+            }
+        }
+
+        NotifyChanged();
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
+    private void NotifyChanged() => OnChanged?.Invoke();
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/PortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/PortalLoadService.cs
@@ -9,6 +9,7 @@ public sealed class PortalLoadService : IPortalLoadService
     private readonly IGatewayRestClient _restClient;
     private readonly GatewayHubConnection _hub;
     private readonly AgentSessionManager _manager;
+    private readonly IClientStateStore _store;
 
     /// <inheritdoc />
     public bool IsReady { get; private set; }
@@ -25,11 +26,13 @@ public sealed class PortalLoadService : IPortalLoadService
     public PortalLoadService(
         IGatewayRestClient restClient,
         GatewayHubConnection hub,
-        AgentSessionManager manager)
+        AgentSessionManager manager,
+        IClientStateStore store)
     {
         _restClient = restClient;
         _hub = hub;
         _manager = manager;
+        _store = store;
     }
 
     /// <inheritdoc />
@@ -59,14 +62,16 @@ public sealed class PortalLoadService : IPortalLoadService
 
             foreach (var agent in agents)
             {
+                _store.UpsertAgent(new AgentState
+                {
+                    AgentId = agent.AgentId,
+                    DisplayName = agent.DisplayName,
+                    IsConnected = true
+                });
+
                 if (!sessions.ContainsKey(agent.AgentId))
                 {
-                    sessions[agent.AgentId] = new AgentSessionState
-                    {
-                        AgentId = agent.AgentId,
-                        DisplayName = agent.DisplayName,
-                        IsConnected = true
-                    };
+                    sessions[agent.AgentId] = new AgentSessionState(_store, agent.AgentId);
                 }
                 else
                 {

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ClientStateStoreTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ClientStateStoreTests.cs
@@ -1,0 +1,223 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class ClientStateStoreTests
+{
+    [Fact]
+    public void SeedAgents_adds_agents()
+    {
+        var store = new ClientStateStore();
+
+        store.SeedAgents([
+            new AgentSummary("a-1", "Alpha"),
+            new AgentSummary("a-2", "Beta")
+        ]);
+
+        Assert.Equal(2, store.Agents.Count);
+        Assert.Equal("Alpha", store.GetAgent("a-1")?.DisplayName);
+        Assert.Equal("Beta", store.GetAgent("a-2")?.DisplayName);
+    }
+
+    [Fact]
+    public void SeedAgents_updates_existing_agent()
+    {
+        var store = new ClientStateStore();
+        store.SeedAgents([new AgentSummary("a-1", "Old")]);
+
+        store.SeedAgents([new AgentSummary("a-1", "New")]);
+
+        Assert.Equal("New", store.GetAgent("a-1")?.DisplayName);
+    }
+
+    [Fact]
+    public void UpsertAgent_replaces_or_adds_agent()
+    {
+        var store = new ClientStateStore();
+
+        store.UpsertAgent(new AgentState { AgentId = "a-1", DisplayName = "Agent", IsConnected = true });
+
+        Assert.True(store.GetAgent("a-1")?.IsConnected);
+    }
+
+    [Fact]
+    public void SeedConversations_populates_agent_conversations_and_selects_default()
+    {
+        var store = CreateSeededStore();
+
+        store.SeedConversations("a-1", [
+            CreateConversation("c-1", "a-1", "General", isDefault: false, updatedAt: DateTimeOffset.UtcNow.AddMinutes(-1)),
+            CreateConversation("c-2", "a-1", "Default", isDefault: true, updatedAt: DateTimeOffset.UtcNow)
+        ]);
+
+        var agent = store.GetAgent("a-1");
+        Assert.NotNull(agent);
+        Assert.Equal(2, agent.Conversations.Count);
+        Assert.Equal("c-2", agent.ActiveConversationId);
+    }
+
+    [Fact]
+    public void SetActiveConversation_updates_agent_and_clears_conversation_unread()
+    {
+        var store = CreateSeededStore();
+        store.SeedConversations("a-1", [CreateConversation("c-1", "a-1", "General")]);
+        store.GetAgent("a-1")!.Conversations["c-1"].UnreadCount = 3;
+
+        store.SetActiveConversation("a-1", "c-1");
+
+        Assert.Equal("c-1", store.GetAgent("a-1")?.ActiveConversationId);
+        Assert.Equal(0, store.GetConversation("c-1")?.UnreadCount);
+    }
+
+    [Fact]
+    public void GetConversation_searches_all_agents()
+    {
+        var store = CreateSeededStore();
+        store.SeedConversations("a-1", [CreateConversation("c-1", "a-1", "One")]);
+        store.SeedConversations("a-2", [CreateConversation("c-2", "a-2", "Two")]);
+
+        Assert.Equal("Two", store.GetConversation("c-2")?.Title);
+    }
+
+    [Fact]
+    public void AppendMessage_adds_message_to_conversation()
+    {
+        var store = CreateConversationStore();
+
+        store.AppendMessage("c-1", new ChatMessage("User", "hello", DateTimeOffset.UtcNow));
+
+        Assert.Single(store.GetMessages("c-1"));
+        Assert.Equal("hello", store.GetMessages("c-1")[0].Content);
+    }
+
+    [Fact]
+    public void PrependMessages_inserts_messages_at_start()
+    {
+        var store = CreateConversationStore();
+        store.AppendMessage("c-1", new ChatMessage("Assistant", "newer", DateTimeOffset.UtcNow));
+
+        store.PrependMessages("c-1", [
+            new ChatMessage("User", "older-1", DateTimeOffset.UtcNow.AddMinutes(-2)),
+            new ChatMessage("Assistant", "older-2", DateTimeOffset.UtcNow.AddMinutes(-1))
+        ]);
+
+        Assert.Equal(3, store.GetMessages("c-1").Count);
+        Assert.Equal("older-1", store.GetMessages("c-1")[0].Content);
+        Assert.Equal("older-2", store.GetMessages("c-1")[1].Content);
+        Assert.Equal("newer", store.GetMessages("c-1")[2].Content);
+    }
+
+    [Fact]
+    public void ClearMessages_clears_messages_and_marks_history_not_loaded()
+    {
+        var store = CreateConversationStore();
+        store.GetConversation("c-1")!.HistoryLoaded = true;
+        store.AppendMessage("c-1", new ChatMessage("User", "hello", DateTimeOffset.UtcNow));
+
+        store.ClearMessages("c-1");
+
+        Assert.Empty(store.GetMessages("c-1"));
+        Assert.False(store.GetConversation("c-1")!.HistoryLoaded);
+    }
+
+    [Fact]
+    public void SetStreaming_updates_conversation_and_agent_state()
+    {
+        var store = CreateConversationStore();
+
+        store.SetStreaming("c-1", true);
+
+        Assert.True(store.GetStreamState("c-1").IsStreaming);
+        Assert.True(store.GetAgent("a-1")!.IsStreaming);
+    }
+
+    [Fact]
+    public void AppendStreamBuffer_accumulates_delta_content()
+    {
+        var store = CreateConversationStore();
+
+        store.AppendStreamBuffer("c-1", "hel");
+        store.AppendStreamBuffer("c-1", "lo");
+
+        Assert.Equal("hello", store.GetStreamState("c-1").Buffer);
+    }
+
+    [Fact]
+    public void CommitStreamBuffer_appends_assistant_message_and_resets_stream_state()
+    {
+        var store = CreateConversationStore();
+        store.SetStreaming("c-1", true);
+        store.AppendStreamBuffer("c-1", "hello");
+        store.GetStreamState("c-1").ThinkingBuffer = "thinking";
+
+        store.CommitStreamBuffer("c-1");
+
+        var messages = store.GetMessages("c-1");
+        Assert.Single(messages);
+        Assert.Equal("Assistant", messages[0].Role);
+        Assert.Equal("hello", messages[0].Content);
+        Assert.Equal("thinking", messages[0].ThinkingContent);
+        Assert.False(store.GetStreamState("c-1").IsStreaming);
+        Assert.Equal(string.Empty, store.GetStreamState("c-1").Buffer);
+        Assert.Equal(string.Empty, store.GetStreamState("c-1").ThinkingBuffer);
+    }
+
+    [Fact]
+    public void OnChanged_fires_for_mutations()
+    {
+        var store = CreateConversationStore();
+        var count = 0;
+        store.OnChanged += () => count++;
+
+        store.AppendMessage("c-1", new ChatMessage("User", "hello", DateTimeOffset.UtcNow));
+        store.SetStreaming("c-1", true);
+        store.AppendStreamBuffer("c-1", "x");
+
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public void ActiveConversationId_returns_active_conversation_for_active_agent()
+    {
+        var store = CreateSeededStore();
+        store.SeedConversations("a-1", [CreateConversation("c-1", "a-1", "One")]);
+        store.ActiveAgentId = "a-1";
+        store.SetActiveConversation("a-1", "c-1");
+
+        Assert.Equal("c-1", store.ActiveConversationId);
+    }
+
+    private static ClientStateStore CreateSeededStore()
+    {
+        var store = new ClientStateStore();
+        store.SeedAgents([
+            new AgentSummary("a-1", "Alpha"),
+            new AgentSummary("a-2", "Beta")
+        ]);
+        return store;
+    }
+
+    private static ClientStateStore CreateConversationStore()
+    {
+        var store = CreateSeededStore();
+        store.SeedConversations("a-1", [CreateConversation("c-1", "a-1", "General")]);
+        return store;
+    }
+
+    private static ConversationSummaryDto CreateConversation(
+        string conversationId,
+        string agentId,
+        string title,
+        bool isDefault = false,
+        DateTimeOffset? updatedAt = null) =>
+        new(
+            conversationId,
+            agentId,
+            title,
+            isDefault,
+            "Active",
+            null,
+            0,
+            DateTimeOffset.UtcNow.AddHours(-1),
+            updatedAt ?? DateTimeOffset.UtcNow);
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Helpers/TestSessionFactory.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Helpers/TestSessionFactory.cs
@@ -31,14 +31,29 @@ internal static class TestSessionFactory
         bool isConnected = true,
         bool isStreaming = false)
     {
-        return new AgentSessionState
+        const string testConvId = "test-conv-1";
+
+        var state = new AgentSessionState
         {
             AgentId = agentId,
             DisplayName = displayName,
             SessionId = sessionId,
             IsConnected = isConnected,
-            IsStreaming = isStreaming
+            IsStreaming = isStreaming,
+            ActiveConversationId = testConvId
         };
+
+        state.Conversations[testConvId] = new ConversationListItemState
+        {
+            ConversationId = testConvId,
+            Title = "Test conversation",
+            ActiveSessionId = sessionId,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        state.ConversationMessageStores[testConvId] = [];
+        return state;
     }
 
     /// <summary>
@@ -52,11 +67,7 @@ internal static class TestSessionFactory
     {
         var state = CreateAgentState(agentId, displayName, isConnected: isConnected);
 
-        // Set up a default conversation so Messages computed property returns the right store
-        const string testConvId = "test-conv-1";
-        state.ActiveConversationId = testConvId;
-        var store = new System.Collections.Generic.List<ChatMessage>();
-        state.ConversationMessageStores[testConvId] = store;
+        var store = state.ConversationMessageStores[state.ActiveConversationId!];
 
         foreach (var (role, content) in messages)
             store.Add(new ChatMessage(role, content, DateTimeOffset.UtcNow));


### PR DESCRIPTION
## Summary
- add a scoped `IClientStateStore` and `ClientStateStore` as the backing state model for the SignalR Blazor client
- migrate `AgentSessionManager` and portal load seeding to write through the store while keeping the existing component-facing API stable
- keep `AgentSessionState` as a Wave 2 facade over the store and add focused store tests

## Testing
- dotnet test BotNexus.slnx --nologo --tl:off
