### PR TITLE
test(blazor-client): restore Blazor component test coverage for Wave 3 architecture

### DIFF
--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -1,0 +1,285 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class ChatPanelTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly ClientStateStore _store;
+    private readonly IAgentInteractionService _interaction;
+
+    public ChatPanelTests()
+    {
+        _store = new ClientStateStore();
+        _interaction = Substitute.For<IAgentInteractionService>();
+
+        _ctx.Services.AddSingleton<IClientStateStore>(_store);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private AgentState CreateAndSeedAgent(string agentId, string displayName = "Test Agent",
+        bool isConnected = false, bool isStreaming = false)
+    {
+        var agent = new AgentState
+        {
+            AgentId = agentId,
+            DisplayName = displayName,
+            IsConnected = isConnected,
+            IsStreaming = isStreaming
+        };
+        _store.UpsertAgent(agent);
+        return agent;
+    }
+
+    private static ConversationSummaryDto MakeConvDto(string convId, string agentId, string title = "Test Conv", bool isDefault = false) =>
+        new ConversationSummaryDto(
+            ConversationId: convId,
+            AgentId: agentId,
+            Title: title,
+            IsDefault: isDefault,
+            Status: "Active",
+            ActiveSessionId: null,
+            BindingCount: 0,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void Renders_agent_display_name_in_header()
+    {
+        CreateAndSeedAgent("agent-1", "My Assistant");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("My Assistant", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_agent_id_label_in_header()
+    {
+        CreateAndSeedAgent("agent-xyz");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-xyz"));
+
+        Assert.Contains("agent-xyz", cut.Markup);
+    }
+
+    [Fact]
+    public void New_session_button_is_present_in_header()
+    {
+        CreateAndSeedAgent("agent-1");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var btn = cut.Find(".new-chat-btn");
+        Assert.NotNull(btn);
+    }
+
+    [Fact]
+    public void New_session_button_is_disabled_while_streaming()
+    {
+        CreateAndSeedAgent("agent-1", isStreaming: true);
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var btn = cut.Find(".new-chat-btn");
+        Assert.True(btn.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void New_session_button_is_enabled_when_not_streaming()
+    {
+        CreateAndSeedAgent("agent-1", isStreaming: false);
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var btn = cut.Find(".new-chat-btn");
+        Assert.False(btn.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Shows_streaming_badge_when_agent_is_streaming()
+    {
+        var agent = CreateAndSeedAgent("agent-1", isStreaming: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        cut.Find(".streaming-badge");
+    }
+
+    [Fact]
+    public void Does_not_show_streaming_badge_when_not_streaming()
+    {
+        CreateAndSeedAgent("agent-1", isStreaming: false);
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Empty(cut.FindAll(".streaming-badge"));
+    }
+
+    [Fact]
+    public void Shows_empty_state_when_no_active_conversation()
+    {
+        CreateAndSeedAgent("agent-1");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("Select a conversation", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_user_message_with_user_css_class()
+    {
+        CreateAndSeedAgent("agent-1", isConnected: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("User", "Hello!", DateTimeOffset.UtcNow));
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var userMsgs = cut.FindAll(".message.user");
+        Assert.NotEmpty(userMsgs);
+    }
+
+    [Fact]
+    public void Renders_user_message_content()
+    {
+        CreateAndSeedAgent("agent-1", isConnected: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("User", "Hello from user!", DateTimeOffset.UtcNow));
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("Hello from user!", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_assistant_message_with_assistant_css_class()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("Assistant", "Hello!", DateTimeOffset.UtcNow));
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var msgs = cut.FindAll(".message.assistant");
+        Assert.NotEmpty(msgs);
+    }
+
+    [Fact]
+    public void Renders_tool_call_with_tool_name()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("Tool", "", DateTimeOffset.UtcNow)
+        {
+            IsToolCall = true,
+            ToolName = "search_files",
+            ToolResult = "found 3 files"
+        });
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("search_files", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_pending_tool_hourglass_when_result_is_null()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("Tool", "", DateTimeOffset.UtcNow)
+        {
+            IsToolCall = true,
+            ToolName = "some_tool",
+            ToolResult = null
+        });
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("⏳", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_checkmark_when_tool_result_is_set()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("Tool", "", DateTimeOffset.UtcNow)
+        {
+            IsToolCall = true,
+            ToolName = "done_tool",
+            ToolResult = "success",
+            ToolIsError = false
+        });
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("✅", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_error_icon_when_tool_is_error()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("Tool", "", DateTimeOffset.UtcNow)
+        {
+            IsToolCall = true,
+            ToolName = "failing_tool",
+            ToolResult = "error details",
+            ToolIsError = true
+        });
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("❌", cut.Markup);
+        Assert.Contains("tool-error", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_session_boundary_divider_with_label()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("system", "", DateTimeOffset.UtcNow)
+        {
+            Kind = "boundary",
+            BoundaryLabel = "Session started"
+        });
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        cut.Find(".session-boundary");
+        Assert.Contains("Session started", cut.Markup);
+    }
+
+    [Fact]
+    public void Renders_conversation_title_in_header_when_active_conversation_is_set()
+    {
+        CreateAndSeedAgent("agent-1");
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1", title: "My Important Conversation")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("My Important Conversation", cut.Markup);
+    }
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
@@ -1,0 +1,145 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Pages;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class HomePageTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store;
+    private readonly IPortalLoadService _portalLoad;
+
+    public HomePageTests()
+    {
+        _store = Substitute.For<IClientStateStore>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+
+        _portalLoad.IsReady.Returns(false);
+        _portalLoad.IsLoading.Returns(true);
+        _portalLoad.LoadError.Returns((string?)null);
+        _store.Agents.Returns(new Dictionary<string, AgentState>().AsReadOnly());
+        _store.ActiveAgentId.Returns((string?)null);
+
+        _ctx.Services.AddSingleton(_store);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void Shows_connecting_spinner_when_not_ready()
+    {
+        _portalLoad.IsReady.Returns(false);
+        _portalLoad.LoadError.Returns((string?)null);
+
+        var cut = _ctx.Render<Home>();
+
+        Assert.Contains("Connecting", cut.Markup);
+    }
+
+    [Fact]
+    public void Shows_portal_loading_container_when_not_ready()
+    {
+        _portalLoad.IsReady.Returns(false);
+
+        var cut = _ctx.Render<Home>();
+
+        cut.Find(".portal-loading");
+    }
+
+    [Fact]
+    public void Shows_error_message_when_LoadError_is_set()
+    {
+        _portalLoad.IsReady.Returns(false);
+        _portalLoad.LoadError.Returns("Connection refused");
+
+        var cut = _ctx.Render<Home>();
+
+        Assert.Contains("Connection refused", cut.Markup);
+        cut.Find(".portal-load-error");
+    }
+
+    [Fact]
+    public void Does_not_render_spinner_when_error_is_set()
+    {
+        _portalLoad.IsReady.Returns(false);
+        _portalLoad.LoadError.Returns("Something failed");
+
+        var cut = _ctx.Render<Home>();
+
+        Assert.Empty(cut.FindAll(".portal-load-spinner"));
+    }
+
+    [Fact]
+    public void Renders_main_UI_when_ready_with_no_active_agent()
+    {
+        _portalLoad.IsReady.Returns(true);
+        _store.ActiveAgentId.Returns((string?)null);
+
+        var cut = _ctx.Render<Home>();
+
+        Assert.Empty(cut.FindAll(".portal-loading"));
+        Assert.Contains("Select an agent", cut.Markup);
+    }
+
+    [Fact]
+    public void Does_not_render_loading_when_portal_is_ready()
+    {
+        _portalLoad.IsReady.Returns(true);
+
+        var cut = _ctx.Render<Home>();
+
+        Assert.Empty(cut.FindAll(".portal-loading"));
+    }
+
+    [Fact]
+    public void Renders_chat_panel_wrapper_for_each_agent_when_ready()
+    {
+        _portalLoad.IsReady.Returns(true);
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-1"] = new AgentState { AgentId = "agent-1", DisplayName = "Alpha" },
+            ["agent-2"] = new AgentState { AgentId = "agent-2", DisplayName = "Beta" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.ActiveAgentId.Returns("agent-1");
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+
+        // Register additional services needed by ChatPanel
+        _ctx.Services.AddSingleton(Substitute.For<IAgentInteractionService>());
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        var cut = _ctx.Render<Home>();
+
+        var wrappers = cut.FindAll(".chat-panel-wrapper");
+        Assert.Equal(2, wrappers.Count);
+    }
+
+    [Fact]
+    public void Active_agent_wrapper_has_active_class()
+    {
+        _portalLoad.IsReady.Returns(true);
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-1"] = new AgentState { AgentId = "agent-1", DisplayName = "Alpha" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.ActiveAgentId.Returns("agent-1");
+        _store.GetAgent("agent-1").Returns(agents["agent-1"]);
+
+        _ctx.Services.AddSingleton(Substitute.For<IAgentInteractionService>());
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        var cut = _ctx.Render<Home>();
+
+        var wrapper = cut.Find(".chat-panel-wrapper");
+        Assert.Contains("active", wrapper.ClassList);
+    }
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -1,0 +1,193 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class MainLayoutTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly ClientStateStore _store;
+    private readonly IAgentInteractionService _interaction;
+    private readonly IPortalLoadService _portalLoad;
+
+    public MainLayoutTests()
+    {
+        _store = new ClientStateStore();
+        _interaction = Substitute.For<IAgentInteractionService>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+
+        _portalLoad.IsReady.Returns(false);
+        _portalLoad.IsLoading.Returns(true);
+        _portalLoad.LoadError.Returns((string?)null);
+
+        var hub = new GatewayHubConnection();
+        var restClient = Substitute.For<IGatewayRestClient>();
+        restClient.ApiBaseUrl.Returns("");
+        var http = new HttpClient { BaseAddress = new Uri("http://localhost/") };
+        var gatewayInfo = new GatewayInfoService(http, restClient);
+        var featureFlags = new FeatureFlagsService(_ctx.JSInterop.JSRuntime);
+
+        _ctx.Services.AddSingleton<IClientStateStore>(_store);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(hub);
+        _ctx.Services.AddSingleton(gatewayInfo);
+        _ctx.Services.AddSingleton(featureFlags);
+        _ctx.Services.AddSingleton(restClient);
+        _ctx.Services.AddSingleton(http);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private IRenderedComponent<MainLayout> RenderLayout() =>
+        _ctx.Render<MainLayout>(p => p
+            .Add(c => c.Body, (Microsoft.AspNetCore.Components.RenderFragment)(_ => { })));
+
+    [Fact]
+    public void Renders_app_shell_container()
+    {
+        var cut = RenderLayout();
+        cut.Find(".app-shell");
+    }
+
+    [Fact]
+    public void Renders_sidebar_closed_by_default()
+    {
+        var cut = RenderLayout();
+        cut.Find(".sidebar-closed");
+    }
+
+    [Fact]
+    public void Burger_button_is_present()
+    {
+        var cut = RenderLayout();
+        var burger = cut.Find(".burger-btn");
+        Assert.NotNull(burger);
+    }
+
+    [Fact]
+    public void Clicking_burger_opens_sidebar()
+    {
+        var cut = RenderLayout();
+
+        cut.Find(".burger-btn").Click();
+
+        cut.Find(".sidebar-open");
+    }
+
+    [Fact]
+    public void Clicking_burger_twice_closes_sidebar()
+    {
+        var cut = RenderLayout();
+
+        cut.Find(".burger-btn").Click();
+        cut.Find(".burger-btn").Click();
+
+        cut.Find(".sidebar-closed");
+    }
+
+    [Fact]
+    public void Does_not_show_agent_dropdown_when_no_agents()
+    {
+        var cut = RenderLayout();
+        Assert.Empty(cut.FindAll(".agent-dropdown-select"));
+    }
+
+    [Fact]
+    public void Shows_agent_dropdown_when_agents_are_seeded()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.NotifyChanged();
+
+        var cut = RenderLayout();
+
+        cut.Find(".agent-dropdown-select");
+    }
+
+    [Fact]
+    public void Shows_agent_display_name_in_dropdown()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha Agent")]);
+        _store.NotifyChanged();
+
+        var cut = RenderLayout();
+
+        Assert.Contains("Alpha Agent", cut.Markup);
+    }
+
+    [Fact]
+    public void New_conversation_button_is_present_when_agent_is_active()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", []);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        cut.Find(".conversation-new-btn");
+    }
+
+    [Fact]
+    public void Shows_conversation_list_when_agent_has_conversations()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Chat 1", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        Assert.Contains("Chat 1", cut.Markup);
+    }
+
+    [Fact]
+    public void Shows_default_badge_on_default_conversation()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Default Chat", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        cut.Find(".conversation-default-badge");
+    }
+
+    [Fact]
+    public void Shows_unread_dot_when_conversation_has_unread_messages()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Active Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+        var conv = _store.GetAgent("a-1")!.Conversations["c-1"];
+        conv.UnreadCount = 3;
+
+        var cut = RenderLayout();
+
+        cut.Find(".conversation-unread-dot");
+    }
+
+    [Fact]
+    public void Active_conversation_has_active_css_class()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Active Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.SetActiveConversation("a-1", "c-1");
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        var activeConv = cut.Find(".conversation-list-item.active");
+        Assert.NotNull(activeConv);
+    }
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionControlsTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionControlsTests.cs
@@ -1,0 +1,89 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class SessionControlsTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly ClientStateStore _store;
+
+    public SessionControlsTests()
+    {
+        _store = new ClientStateStore();
+        _ctx.Services.AddSingleton<IClientStateStore>(_store);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private static AgentState MakeAgent(string agentId, string? sessionId = null) =>
+        new AgentState { AgentId = agentId, DisplayName = agentId, SessionId = sessionId };
+
+    [Fact]
+    public void Shows_truncated_session_ID_when_session_exists()
+    {
+        _store.UpsertAgent(MakeAgent("agent-1", "abcdefghijklmnop"));
+
+        var cut = _ctx.Render<SessionControls>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("abcdefgh", cut.Markup);
+    }
+
+    [Fact]
+    public void Shows_copy_icon_and_tooltip_with_full_session_ID()
+    {
+        const string fullId = "full-session-id-12345";
+        _store.UpsertAgent(MakeAgent("agent-1", fullId));
+
+        var cut = _ctx.Render<SessionControls>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var span = cut.Find(".session-id");
+        Assert.Contains(fullId, span.GetAttribute("title") ?? "");
+    }
+
+    [Fact]
+    public void Does_not_render_session_id_element_when_session_is_null()
+    {
+        _store.UpsertAgent(MakeAgent("agent-1", sessionId: null));
+
+        var cut = _ctx.Render<SessionControls>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Empty(cut.FindAll(".session-id"));
+    }
+
+    [Fact]
+    public void Does_not_render_reset_button()
+    {
+        _store.UpsertAgent(MakeAgent("agent-1", "some-session-id"));
+
+        var cut = _ctx.Render<SessionControls>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        // Reset button was removed in the refactor — confirm absent
+        Assert.Empty(cut.FindAll(".reset-btn"));
+        Assert.Empty(cut.FindAll("button"));
+    }
+
+    [Fact]
+    public void Shows_session_controls_container()
+    {
+        _store.UpsertAgent(MakeAgent("agent-1", "some-id"));
+
+        var cut = _ctx.Render<SessionControls>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        cut.Find(".session-controls");
+    }
+
+    [Fact]
+    public void Session_ID_truncated_to_8_chars_with_ellipsis()
+    {
+        _store.UpsertAgent(MakeAgent("agent-1", "1234567890abcdef"));
+
+        var cut = _ctx.Render<SessionControls>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("12345678", cut.Markup);
+        Assert.Contains("…", cut.Markup);
+    }
+}


### PR DESCRIPTION
## Summary

Restores all Blazor component tests deleted in PR #83 (Wave 3 refactor). Tests are rewritten for the new `IClientStateStore` / `IAgentInteractionService` / `IPortalLoadService` architecture.

## Test files

| File | Tests | Coverage |
|------|-------|----------|
| `HomePageTests.cs` | 8 | Loading gate (spinner, error, ready), agent wrapper rendering |
| `ChatPanelTests.cs` | 16 | Message roles, tool calls (pending/success/error), session boundary, streaming badge, conversation title |
| `SessionControlsTests.cs` | 6 | Session ID display, truncation, tooltip, no reset button |
| `MainLayoutTests.cs` | 14 | App shell, sidebar toggle, agent dropdown, conversation list, Default badge, unread dot, active conversation |
| **Total** | **44** | |

## Verification

- All 84 BlazorClient tests pass
- Full solution: 0 failures (1047+ tests across all projects)
- No references to deleted `AgentSessionManager`
- Uses NSubstitute + bUnit `BunitContext` pattern consistent with existing tests

## Architecture

- `IPortalLoadService` mocked with NSubstitute for loading gate tests
- `ClientStateStore` (concrete) used directly for state setup — seeded via its public API
- `IAgentInteractionService` mocked with NSubstitute
- `JSInterop.Mode = JSRuntimeMode.Loose` for JS calls
- `GatewayHubConnection` instantiated without a real connection (safe — returns Disconnected state)