### PR TITLE
fix(cli): check StopAsync result and port availability in update command

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -1,6 +1,6 @@
 using System.CommandLine;
 using System.Diagnostics;
-using BotNexus.Cli.Services;
+using System.Net.Sockets;
 using BotNexus.Cli.Services;
 using Spectre.Console;
 
@@ -9,7 +9,7 @@ namespace BotNexus.Cli.Commands;
 /// <summary>
 /// Update command: pull latest source, build, deploy extensions, and restart the gateway.
 /// </summary>
-internal sealed class UpdateCommand
+internal class UpdateCommand
 {
     private readonly IGatewayProcessManager _processManager;
 
@@ -46,6 +46,20 @@ internal sealed class UpdateCommand
     }
 
     internal async Task<int> ExecuteAsync(string repoRoot, string home, int port, bool verbose, CancellationToken cancellationToken)
+    {
+        // Steps 1–3: git pull, build, deploy extensions
+        var preStopResult = await RunPreStopStepsAsync(repoRoot, home, verbose, cancellationToken);
+        if (preStopResult != 0)
+            return preStopResult;
+
+        return await RunRestartAsync(home, port, repoRoot, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs git pull, build, and extension deploy steps before the gateway restart.
+    /// Protected virtual so tests can override it to skip real git/build operations.
+    /// </summary>
+    protected virtual async Task<int> RunPreStopStepsAsync(string repoRoot, string home, bool verbose, CancellationToken cancellationToken)
     {
         // Step 1: git pull
         AnsiConsole.MarkupLine("[blue][[update]][/] Checking for updates...");
@@ -87,11 +101,29 @@ internal sealed class UpdateCommand
         ServeCommand.DeployExtensions(repoRoot, home, verbose);
         AnsiConsole.MarkupLine("[blue][[update]][/] [green]\u2713[/] Extensions deployed");
 
-        // Step 4: Stop old gateway
+        return 0;
+    }
+
+    private async Task<int> RunRestartAsync(string home, int port, string repoRoot, CancellationToken cancellationToken)
+    {
         AnsiConsole.MarkupLine("[blue][[update]][/] Restarting gateway...");
-        await _processManager.StopAsync(home, cancellationToken);
+        var stopResult = await _processManager.StopAsync(home, cancellationToken);
+        if (!stopResult.Success)
+        {
+            AnsiConsole.MarkupLine($"[red][[update]][/] \u2717 Failed to stop gateway: {Markup.Escape(stopResult.Message ?? "Unknown")}");
+            AnsiConsole.MarkupLine("[yellow][[update]][/] Tip: try 'botnexus gateway stop' manually first.");
+            return 1;
+        }
 
         await Task.Delay(1000, cancellationToken);
+
+        // Step 4b: Verify the port is actually free before starting new gateway
+        if (!IsPortAvailable(port))
+        {
+            AnsiConsole.MarkupLine($"[red][[update]][/] \u2717 Port {port} is still in use after stopping gateway.");
+            AnsiConsole.MarkupLine("[yellow][[update]][/] Tip: try 'botnexus gateway stop' manually or kill the process on that port.");
+            return 1;
+        }
 
         // Step 5: Start new gateway
         var gatewayDll = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Gateway.Api", "bin", "Release", "net10.0", "BotNexus.Gateway.Api.dll");
@@ -201,4 +233,24 @@ internal sealed class UpdateCommand
     }
 
     private static string Short(string sha) => sha.Length >= 7 ? sha[..7] : sha;
+
+    /// <summary>
+    /// Checks if a TCP port is available for binding. Mirrors ServeCommand.IsPortAvailable.
+    /// Used to verify the port is free before starting the new gateway process.
+    /// </summary>
+    internal static bool IsPortAvailable(int port)
+    {
+        try
+        {
+            using var listener = new TcpListener(System.Net.IPAddress.Loopback, port);
+            listener.Server.ExclusiveAddressUse = true;
+            listener.Start();
+            listener.Stop();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
+++ b/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
@@ -13,11 +13,23 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
 {
     private readonly IHealthChecker _healthChecker;
     private readonly ILogger<GatewayProcessManager> _logger;
+    // Timeout for WaitForExit after Kill(). Defaults to 5 seconds in production;
+    // injectable for tests to simulate the timeout path without actually waiting.
+    private readonly TimeSpan _waitForExitTimeout;
+    // Allows tests to inject a custom WaitForExit implementation to simulate timeout scenarios
+    // without relying on OS-level process termination timing.
+    private readonly Func<Process, int, bool>? _waitForExitOverride;
 
-    public GatewayProcessManager(IHealthChecker healthChecker, ILogger<GatewayProcessManager> logger)
+    public GatewayProcessManager(
+        IHealthChecker healthChecker,
+        ILogger<GatewayProcessManager> logger,
+        TimeSpan? waitForExitTimeout = null,
+        Func<Process, int, bool>? waitForExitOverride = null)
     {
         _healthChecker = healthChecker;
         _logger = logger;
+        _waitForExitTimeout = waitForExitTimeout ?? TimeSpan.FromSeconds(5);
+        _waitForExitOverride = waitForExitOverride;
     }
 
     /// <summary>
@@ -213,11 +225,20 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
                 Message: $"Gateway process {pid.Value} already exited");
         }
 
-        // Wait up to 5 seconds for exit
-        var exited = await Task.Run(() => process.WaitForExit(5000), cancellationToken);
+        // Wait for process to exit after kill
+        var timeoutMs = (int)_waitForExitTimeout.TotalMilliseconds;
+        var exited = _waitForExitOverride is not null
+            ? _waitForExitOverride(process, timeoutMs)
+            : await Task.Run(() => process.WaitForExit(timeoutMs), cancellationToken);
         if (!exited)
         {
-            _logger.LogWarning("Gateway process {Pid} did not exit within 5 seconds", pid.Value);
+            _logger.LogWarning("Gateway process {Pid} did not exit within {Timeout}s", pid.Value, _waitForExitTimeout.TotalSeconds);
+            // Do NOT clean up the PID file — the process is still running.
+            // Returning success here would be incorrect and would allow StartAsync
+            // to launch a second gateway that conflicts on the same port.
+            return new GatewayStopResult(
+                Success: false,
+                Message: $"Gateway process {pid.Value} did not exit within {_waitForExitTimeout.TotalSeconds}s. It may still be running.");
         }
         else
         {

--- a/tests/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -7,6 +7,18 @@ namespace BotNexus.Cli.Tests.Commands;
 
 public class UpdateCommandTests
 {
+    /// <summary>
+    /// Test subclass that bypasses git pull and build steps so unit tests
+    /// can focus on the stop/restart logic without running real git/dotnet build.
+    /// </summary>
+    private sealed class NoOpPreStopUpdateCommand(IGatewayProcessManager processManager)
+        : UpdateCommand(processManager)
+    {
+        protected override Task<int> RunPreStopStepsAsync(
+            string repoRoot, string home, bool verbose, CancellationToken cancellationToken)
+            => Task.FromResult(0);
+    }
+
     private static UpdateCommand BuildCommand()
     {
         var pm = Substitute.For<IGatewayProcessManager>();
@@ -36,6 +48,72 @@ public class UpdateCommandTests
         names.ShouldContain("source");
         names.ShouldContain("target");
         names.ShouldContain("port");
+    }
+
+    [Fact]
+    public async Task Update_WhenStopFails_ReturnsNonZeroAndDoesNotStartGateway()
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        pm.StopAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new GatewayStopResult(false, "Kill failed"));
+        var cmd = new NoOpPreStopUpdateCommand(pm);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"botnexus-update-stopfail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var exitCode = await cmd.ExecuteAsync(
+                repoRoot: tempDir,
+                home: tempDir,
+                port: 5005,
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+
+            exitCode.ShouldNotBe(0);
+            await pm.DidNotReceive().StartAsync(Arg.Any<GatewayStartOptions>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Update_WhenGatewayStillRunningAfterStop_DoesNotStartGateway()
+    {
+        // Bind a real TCP port so IsPortAvailable(port) returns false.
+        // This simulates the gateway surviving stop (port still in use).
+        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var busyPort = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+
+        var pm = Substitute.For<IGatewayProcessManager>();
+        pm.StopAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new GatewayStopResult(true, "Stopped"));
+        var cmd = new NoOpPreStopUpdateCommand(pm);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"botnexus-update-portbusy-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var exitCode = await cmd.ExecuteAsync(
+                repoRoot: tempDir,
+                home: tempDir,
+                port: busyPort,
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+
+            // Should fail because port is still in use after stop
+            exitCode.ShouldNotBe(0);
+            await pm.DidNotReceive().StartAsync(Arg.Any<GatewayStartOptions>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            listener.Stop();
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/BotNexus.Cli.Tests/Services/GatewayProcessManagerTests.cs
+++ b/tests/BotNexus.Cli.Tests/Services/GatewayProcessManagerTests.cs
@@ -266,6 +266,47 @@ public sealed class GatewayProcessManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task StopAsync_WhenProcessDoesNotExitInTime_ReturnsFailed()
+    {
+        // The GatewayProcessManager supports an injectable waitForExitOverride for testability.
+        // We inject a delegate that always returns false (process never exits) so the !exited
+        // path is reliably triggered without relying on OS-level timing.
+        // This test FAILS before the fix because StopAsync currently returns Success=true
+        // even when !exited.
+        var neverExitsManager = new GatewayProcessManager(
+            _healthChecker,
+            NullLogger<GatewayProcessManager>.Instance,
+            waitForExitTimeout: TimeSpan.FromMilliseconds(1),
+            waitForExitOverride: (_, _) => false); // always report: process did not exit
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sleep",
+            Arguments = OperatingSystem.IsWindows() ? "/c timeout /t 30" : "30",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        var process = Process.Start(psi);
+        process.ShouldNotBeNull();
+
+        try
+        {
+            await WritePidFileAsync(process.Id);
+
+            var result = await neverExitsManager.StopAsync(_testPidDirectory);
+
+            // Process reported as still running (override returned false) — MUST return failure.
+            result.Success.ShouldBeFalse();
+            result.Message.ShouldContain("did not exit");
+        }
+        finally
+        {
+            try { if (!process.HasExited) process.Kill(); } catch { }
+        }
+    }
+
+    [Fact]
     public void IsRunning_WhenNoPidFile_ReturnsFalse()
     {
         _manager.IsRunning(_testPidDirectory).ShouldBeFalse();


### PR DESCRIPTION
## Summary

Fixes three scenarios where `botnexus update` could silently fail to restart the gateway.

### Scenario 1 — StopAsync return value ignored
`UpdateCommand.ExecuteAsync` called `StopAsync` but discarded the result. If stop failed (permission error, process wouldn't die), the update continued and `StartAsync` failed with "already running".

**Fix:** Check `stopResult.Success` and return 1 with a helpful tip if false.

### Scenario 2 — No force-kill after 5s timeout
`GatewayProcessManager.StopAsync` waited 5 seconds for process exit but returned `Success: true` regardless of whether the process actually exited. The old gateway was still running but the PID file was deleted — `StartAsync` didn't detect the conflict and the new gateway crashed on port bind.

**Fix:** Return `GatewayStopResult(Success: false)` from the `!exited` path, and don't clean up the PID file (process is still running).

### Scenario 3 — No port check before starting new gateway
Even after a successful stop, if the port was still in use (stale PID pointed to wrong process, gateway started manually), `StartAsync` would fail with a confusing error.

**Fix:** `IsPortAvailable` check before `StartAsync`; fail fast with a clear message and tip.

## Tests Added
- `Update_WhenStopFails_ReturnsNonZeroAndDoesNotStartGateway`
- `Update_WhenGatewayStillRunningAfterStop_DoesNotStartGateway`  
- `StopAsync_WhenProcessDoesNotExitInTime_ReturnsFailed`

All three tests were confirmed failing before the fix.

## Testability Improvements
- `UpdateCommand.ExecuteAsync` refactored to extract `RunPreStopStepsAsync` (protected virtual) so unit tests can bypass git pull + build without running real external processes.
- `GatewayProcessManager` gains an optional `waitForExitOverride` constructor parameter so tests can inject an always-false delegate to reliably exercise the `!exited` code path.