### PR TITLE
docs(design): auto-update feature — gateway self-update from portal UI

### DIFF
--- a/.squad/decisions/inbox/leela-auto-update-design-review.md
+++ b/.squad/decisions/inbox/leela-auto-update-design-review.md
@@ -1,0 +1,18 @@
+# Leela decision inbox — auto-update design review
+
+## Decision
+
+For issue #91 auto-update:
+- place `UpdateCheckService` in `BotNexus.Gateway`, not `BotNexus.Gateway.Api`
+- expose update state via a dedicated `GET /api/gateway/update/status` endpoint
+- require explicit `gateway.autoUpdate.cliPath` and `gateway.autoUpdate.sourcePath` config when enabled
+- keep `target` resolved from `BOTNEXUS_HOME` / `BotNexusHome`
+- return `202 Accepted`, then delay `StopApplication()` by 2 seconds after spawning updater
+
+## Rationale
+
+This keeps runtime concerns in the gateway core, keeps the API assembly thin, and avoids brittle path inference for self-update. Separate update status polling is cleaner than overloading `/api/gateway/info`, because info is currently loaded once while update state is dynamic.
+
+## Important finding
+
+Current `BotNexus.Cli` `update` command does **not** wait on the gateway health endpoint to drop before continuing. It builds first, then uses PID-based `StopAsync`. Wave 1 can still ship without CLI changes because the updater reaches stop late enough that the API-triggered delayed shutdown should already be happening or complete.

--- a/docs/planning/feature-auto-update/design-review.md
+++ b/docs/planning/feature-auto-update/design-review.md
@@ -1,0 +1,468 @@
+# Auto-update design review
+
+## Key decisions
+
+### 1. `UpdateCheckService` belongs in `BotNexus.Gateway`
+
+Put the background polling service in `BotNexus.Gateway` and register it from `GatewayServiceCollectionExtensions` as a hosted service.
+
+Why:
+- Polling for upstream state is gateway runtime behavior, not API surface behavior.
+- `BotNexus.Gateway.Api` should stay thin: controllers, DTOs, composition root.
+- The service needs to be available to both controllers and any future non-HTTP consumers.
+- Existing architecture already registers core hosted services from `BotNexus.Gateway` (`GatewayHost`, `SessionCleanupService`, `MemoryIndexer`, `AgentConfigurationHostedService`). This fits that pattern.
+
+Recommendation:
+- `UpdateCheckService` implements both a query contract and `IHostedService`.
+- Register the concrete service once, then expose it as the interface and hosted service from DI.
+
+### 2. GitHub polling contract
+
+Use `HttpClient` with:
+- `User-Agent: BotNexus/1.0`
+- `Accept: application/vnd.github+json`
+
+Endpoint:
+- `GET https://api.github.com/repos/{owner}/{repo}/commits/{branch}`
+
+Defaults:
+- owner: `sytone`
+- repo: `botnexus`
+- branch: `main`
+- interval: 60 minutes
+
+These should be configurable because forks and release branches are valid deployment shapes.
+
+### 3. Self-update invocation contract
+
+Use explicit config for the two values the gateway cannot reliably infer at runtime:
+- `gateway.autoUpdate.cliPath`
+- `gateway.autoUpdate.sourcePath`
+
+Do **not** depend on relative probing of `AppContext.BaseDirectory` as the primary contract. That is too fragile across:
+- `dotnet <dll>` launches
+- single-file/self-contained publish
+- dev worktrees
+- service manager launchers
+- future packaging changes
+
+Runtime resolution rules:
+1. `cliPath` from config is authoritative.
+2. `sourcePath` from config is authoritative.
+3. `target` should come from `BotNexusHome` / `BOTNEXUS_HOME` runtime resolution already used by the gateway.
+4. The port passed to CLI update should be derived from the configured listen URL at startup and cached as an integer.
+
+Process launch shape:
+- If `cliPath` ends with `.dll`, launch `dotnet "<cliPath>" update --source "<sourcePath>" --target "<targetPath>" --port <port>`
+- Otherwise launch `"<cliPath>" update --source ...`
+
+### 4. Shutdown timing and current CLI behavior
+
+The API should:
+1. validate prerequisites
+2. spawn the update process
+3. return `202 Accepted`
+4. schedule `StopApplication()` after ~2 seconds
+
+That delay is sufficient.
+
+Important finding from current `UpdateCommand` implementation:
+- It does **not** poll the gateway health endpoint waiting for shutdown before proceeding.
+- It performs `git pull`, build, deploy, then calls `_processManager.StopAsync(home)`.
+- `GatewayProcessManager.StopAsync` is PID-based and forceful, not an HTTP graceful shutdown.
+
+That means the current child updater does **not** rely on the gateway to stop itself first. This is acceptable for v1 of the feature because:
+- the spawned updater spends time on pull/build/deploy before attempting stop
+- by the time it reaches stop, the API-triggered delayed shutdown will usually already be in progress or complete
+- if the gateway is already down, `StopAsync` treats that as success
+
+So no CLI change is strictly required for wave 1. A later hardening pass could add an explicit `--expect-external-shutdown` mode, but that is not necessary to ship the badge + self-update flow.
+
+### 5. Portal badge should use a separate endpoint
+
+Recommendation: add `GET /api/gateway/update/status` rather than extending `/api/gateway/info`.
+
+Why:
+- `GatewayInfoService` currently loads build/runtime info once after portal readiness; it is not a periodic poller.
+- Update availability is dynamic and should be refreshed on a timer.
+- `gateway/info` is stable build/runtime metadata; update state is operational state with fetch timestamps, errors, and in-progress flags.
+- Keeping them separate avoids changing every existing `GatewayInfo` consumer when only the sidebar badge needs this state.
+
+Portal behavior:
+- Keep the existing one-time `gateway/info` load.
+- Add a lightweight periodic poll for `update/status` in the same service or a new update-status service.
+- Show the badge next to the footer SHA/restart metadata.
+
+### 6. Config schema
+
+Add a nested `AutoUpdateConfig` under `GatewaySettingsConfig`.
+
+This is the minimum useful shape:
+- `enabled`
+- `checkIntervalMinutes`
+- `repositoryOwner`
+- `repositoryName`
+- `branch`
+- `cliPath`
+- `sourcePath`
+- `shutdownDelaySeconds`
+
+No `targetPath` property is needed for wave 1 because the gateway already has a canonical runtime home path.
+
+---
+
+## Interface contracts
+
+### `IUpdateCheckService`
+
+```csharp
+namespace BotNexus.Gateway.Updates;
+
+public interface IUpdateCheckService
+{
+    UpdateStatusResult GetCurrentStatus();
+    Task<UpdateStatusResult> CheckNowAsync(CancellationToken cancellationToken = default);
+    Task<UpdateStartResult> StartUpdateAsync(CancellationToken cancellationToken = default);
+}
+```
+
+Rationale:
+- `GetCurrentStatus()` is synchronous because the service should expose cached state.
+- `CheckNowAsync()` gives the controller and future admin tooling a way to force refresh.
+- `StartUpdateAsync()` keeps process-spawn and concurrency logic in one place instead of in the controller.
+
+### `UpdateStatusResult`
+
+```csharp
+namespace BotNexus.Gateway.Updates;
+
+public sealed record UpdateStatusResult(
+    bool Enabled,
+    bool IsChecking,
+    bool IsUpdateAvailable,
+    bool IsUpdateInProgress,
+    string CurrentCommitSha,
+    string CurrentCommitShort,
+    string? LatestCommitSha,
+    string? LatestCommitShort,
+    DateTimeOffset? LastCheckedAt,
+    DateTimeOffset? NextCheckAt,
+    string? RepositoryOwner,
+    string? RepositoryName,
+    string? Branch,
+    string? CompareUrl,
+    string? Error);
+```
+
+Notes:
+- Include current and latest commit values so the portal does not have to join two payloads.
+- Include `IsUpdateInProgress` so the UI can disable the button.
+- Keep `Error` as a string for operator visibility without leaking exception details structurally.
+
+### `UpdateStartResult`
+
+```csharp
+namespace BotNexus.Gateway.Updates;
+
+public sealed record UpdateStartResult(
+    bool Started,
+    int? ProcessId,
+    string Message);
+```
+
+### `GatewaySettingsConfig`
+
+```csharp
+public sealed class GatewaySettingsConfig
+{
+    public string? ListenUrl { get; set; }
+    public string? DefaultAgentId { get; set; }
+    public string? AgentsDirectory { get; set; }
+    public string? SessionsDirectory { get; set; }
+    public SessionStoreConfig? SessionStore { get; set; }
+    public CompactionOptions? Compaction { get; set; }
+    public CorsConfig? Cors { get; set; }
+    public RateLimitConfig? RateLimit { get; set; }
+    public string? LogLevel { get; set; }
+    public Dictionary<string, ApiKeyConfig>? ApiKeys { get; set; }
+    public ExtensionsConfig? Extensions { get; set; }
+    public WorldIdentity? World { get; set; }
+    public Dictionary<string, LocationConfig>? Locations { get; set; }
+    public List<CrossWorldPermissionConfig>? CrossWorldPermissions { get; set; }
+    public CrossWorldFederationConfig? CrossWorld { get; set; }
+    public FileAccessPolicyConfig? FileAccess { get; set; }
+    public string? ShellPreference { get; set; }
+    public AutoUpdateConfig? AutoUpdate { get; set; }
+}
+
+public sealed class AutoUpdateConfig
+{
+    public bool Enabled { get; set; } = false;
+    public int CheckIntervalMinutes { get; set; } = 60;
+    public string RepositoryOwner { get; set; } = "sytone";
+    public string RepositoryName { get; set; } = "botnexus";
+    public string Branch { get; set; } = "main";
+    public string? CliPath { get; set; }
+    public string? SourcePath { get; set; }
+    public int ShutdownDelaySeconds { get; set; } = 2;
+}
+```
+
+Validation rules:
+- if `Enabled == true`, `CliPath` is required
+- if `Enabled == true`, `SourcePath` is required
+- `CheckIntervalMinutes >= 5`
+- `ShutdownDelaySeconds >= 1`
+
+### `UpdateController`
+
+```csharp
+using BotNexus.Gateway.Updates;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+[ApiController]
+[Route("api/gateway/update")]
+public sealed class UpdateController(IUpdateCheckService updateCheckService) : ControllerBase
+{
+    [HttpGet("status")]
+    [ProducesResponseType<UpdateStatusResult>(StatusCodes.Status200OK)]
+    public ActionResult<UpdateStatusResult> GetStatus();
+
+    [HttpPost("check")]
+    [ProducesResponseType<UpdateStatusResult>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<UpdateStatusResult>> CheckNow(CancellationToken cancellationToken);
+
+    [HttpPost("start")]
+    [ProducesResponseType<UpdateStartResult>(StatusCodes.Status202Accepted)]
+    [ProducesResponseType<UpdateStartResult>(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<UpdateStartResult>(StatusCodes.Status412PreconditionFailed)]
+    public async Task<ActionResult<UpdateStartResult>> Start(CancellationToken cancellationToken);
+}
+```
+
+HTTP behavior:
+- `GET status` returns cached state.
+- `POST check` forces an immediate GitHub refresh.
+- `POST start` returns:
+  - `202 Accepted` when updater process spawned successfully
+  - `409 Conflict` when an update is already in progress
+  - `412 PreconditionFailed` when config/prerequisites are missing (`cliPath`, `sourcePath`, target home, invalid port)
+
+---
+
+## Sequence diagrams
+
+### 1. Startup → first check → status available
+
+```mermaid
+sequenceDiagram
+    participant Host as Gateway Host
+    participant Service as UpdateCheckService
+    participant GH as GitHub API
+    participant API as UpdateController
+    participant Portal as Portal
+
+    Host->>Service: StartAsync()
+    Service->>Service: Load current commit from GatewayBuildInfo
+    Service->>GH: GET /repos/{owner}/{repo}/commits/{branch}
+    GH-->>Service: latest commit SHA
+    Service->>Service: Cache UpdateStatusResult
+    Portal->>API: GET /api/gateway/update/status
+    API->>Service: GetCurrentStatus()
+    Service-->>API: cached status
+    API-->>Portal: 200 OK + status payload
+```
+
+### 2. User triggers update → gateway self-update flow
+
+```mermaid
+sequenceDiagram
+    participant Portal as Portal
+    participant API as UpdateController
+    participant Service as UpdateCheckService
+    participant Proc as Updater Process
+    participant Host as Gateway Host
+    participant CLI as BotNexus CLI update
+
+    Portal->>API: POST /api/gateway/update/start
+    API->>Service: StartUpdateAsync()
+    Service->>Service: Validate autoUpdate config
+    Service->>Proc: Spawn CLI update process
+    Proc->>CLI: update --source --target --port
+    Service-->>API: UpdateStartResult(started=true, pid)
+    API-->>Portal: 202 Accepted
+    Service->>Host: schedule StopApplication() after 2s
+    Note over CLI: git pull, build, deploy extensions
+    CLI->>Host: stop old gateway process (PID-based)
+    Host-->>CLI: process exits
+    CLI->>CLI: start new gateway
+```
+
+### 3. Portal polling → badge appears → user clicks
+
+```mermaid
+sequenceDiagram
+    participant Portal as GatewayInfoService/Update UI
+    participant API as UpdateController
+    participant Service as UpdateCheckService
+
+    loop every N seconds in portal
+        Portal->>API: GET /api/gateway/update/status
+        API->>Service: GetCurrentStatus()
+        Service-->>API: cached status
+        API-->>Portal: 200 OK + status
+    end
+
+    alt update available
+        Portal->>Portal: Show update badge beside commit SHA
+        User->>Portal: Click update badge/button
+        Portal->>API: POST /api/gateway/update/start
+        API-->>Portal: 202 Accepted
+        Portal->>Portal: Show "Updating…" state / disable action
+    end
+```
+
+---
+
+## Wave breakdown
+
+### Wave 1 — Farnsworth (gateway)
+
+Owns all server-side work:
+- add `AutoUpdateConfig` to `GatewaySettingsConfig`
+- add config validation / normalization
+- implement `IUpdateCheckService` + `UpdateCheckService`
+- register service in `GatewayServiceCollectionExtensions`
+- create GitHub polling client logic with required headers
+- create `UpdateController`
+- implement process spawn logic for CLI update
+- wire delayed `StopApplication()` after `202 Accepted`
+- add update state to tests where appropriate
+- add docs/example config if needed
+
+Deliverable boundary:
+- a running gateway can expose update status and trigger self-update via HTTP without portal changes
+
+### Wave 2 — Fry (portal)
+
+Owns all client-side work:
+- add update-status polling to sidebar data flow
+- add UI badge/button near footer commit SHA + restart time
+- show latest commit short SHA / available state
+- disable button and show progress when `IsUpdateInProgress`
+- gracefully handle polling errors or disabled auto-update
+
+Deliverable boundary:
+- portal surfaces availability and can invoke the new endpoint cleanly
+
+Why this split is clean:
+- Farnsworth owns runtime/process/config concerns.
+- Fry owns the Blazor sidebar and polling UX.
+- Shared contract is only the `UpdateStatusResult` JSON shape and controller endpoints.
+
+---
+
+## Risks and mitigations
+
+### 1. CLI path missing or wrong
+
+Risk:
+- gateway cannot start update process
+
+Mitigation:
+- treat `cliPath` as explicit required config when auto-update is enabled
+- `POST /start` returns `412 Precondition Failed` with a clear operator message
+- do not call `StopApplication()` unless process spawn succeeds
+
+### 2. Source path missing or not a git repo
+
+Risk:
+- updater starts but fails during `git pull` / build
+
+Mitigation:
+- pre-validate `sourcePath` exists before spawn
+- child updater remains responsible for repo/build validation
+- keep the failure message in gateway logs and child process output
+
+### 3. Gateway shuts down before HTTP response is flushed
+
+Risk:
+- portal sees network failure instead of accepted state
+
+Mitigation:
+- always return `202 Accepted` first
+- schedule shutdown on a delayed background task after response path completes
+- keep default delay at 2 seconds
+
+### 4. Double-start / repeated clicks
+
+Risk:
+- multiple updater processes race
+
+Mitigation:
+- `UpdateCheckService` owns a single in-progress flag/lock
+- `POST /start` returns `409 Conflict` when update already started
+- portal disables the button while `IsUpdateInProgress`
+
+### 5. Current CLI stop behavior is forceful, not graceful
+
+Risk:
+- abrupt process termination during shutdown window
+
+Mitigation:
+- acceptable for wave 1 because the current CLI already uses PID-based stop semantics
+- the API-triggered graceful stop is additive, not relied upon for correctness
+- later enhancement: teach CLI update to prefer `/api/gateway/shutdown` when self-updating local gateway
+
+### 6. GitHub API failures or rate limiting
+
+Risk:
+- badge becomes stale or noisy
+
+Mitigation:
+- cache last known status
+- surface transient error in `Error`
+- do not clear a previously known `LatestCommitSha` just because one poll failed
+- default hourly polling is safely under unauthenticated rate limits
+
+### 7. Listen URL cannot be converted cleanly to a localhost port
+
+Risk:
+- gateway cannot construct `--port` value for CLI update
+
+Mitigation:
+- derive port once from configured `ListenUrl`
+- if parsing fails, reject `POST /start` with `412 Precondition Failed`
+- keep the contract explicit instead of guessing across multiple URLs or protocols
+
+---
+
+## Recommended implementation notes
+
+- Keep `GatewayController.Info()` unchanged for wave 1 except possibly adding a link field later; do not overload it with update state.
+- Store status in-memory only; no persistence is required.
+- Make the first GitHub check run immediately on startup, then wait `CheckIntervalMinutes` between polls.
+- Log at info level when an update first becomes available, debug level for normal polls, warning level for failures.
+- Use `GatewayBuildInfo.CommitSha` as the local comparison value. If it is `unknown`, report status but never claim update availability.
+
+## Proposed JSON example
+
+```json
+{
+  "gateway": {
+    "listenUrl": "http://localhost:5005",
+    "autoUpdate": {
+      "enabled": true,
+      "checkIntervalMinutes": 60,
+      "repositoryOwner": "sytone",
+      "repositoryName": "botnexus",
+      "branch": "main",
+      "cliPath": "/home/jon/botnexus/src/gateway/BotNexus.Cli/bin/Debug/net10.0/BotNexus.Cli.dll",
+      "sourcePath": "/home/jon/botnexus",
+      "shutdownDelaySeconds": 2
+    }
+  }
+}
+```

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -6,6 +6,7 @@
 @inject GatewayInfoService GatewayInfo
 @inject FeatureFlagsService FeatureFlags
 @inject GatewayHubConnection Hub
+@inject IUpdateStatusService UpdateStatus
 @inject IJSRuntime JS
 @implements IDisposable
 @implements IAsyncDisposable
@@ -186,8 +187,42 @@
                         </a>
                     </div>
                 }
+
+                @if (UpdateStatus.Status?.IsUpdateAvailable == true)
+                {
+                    <div class="update-badge @(UpdateStatus.Status.IsUpdateInProgress ? "update-badge-in-progress" : "")"
+                         @onclick="ShowUpdateConfirm"
+                         title="Update to @UpdateStatus.Status.LatestCommitShort">
+                        @if (UpdateStatus.Status.IsUpdateInProgress)
+                        {
+                            <span>⏳ Updating…</span>
+                        }
+                        else
+                        {
+                            <span>↑ @UpdateStatus.Status.LatestCommitShort available</span>
+                        }
+                    </div>
+                }
             </div>
         </aside>
+
+        @* Update confirmation overlay *@
+        @if (_showUpdateConfirm)
+        {
+            <div class="update-confirm-overlay" @onclick="CancelUpdate">
+                <div class="update-confirm-dialog" @onclick:stopPropagation="true">
+                    <p>Update BotNexus to <strong>@UpdateStatus.Status?.LatestCommitShort</strong>?</p>
+                    <p class="text-muted">The gateway will restart. You will reconnect automatically.</p>
+                    <div class="update-confirm-actions">
+                        <button class="cancel-btn" @onclick="CancelUpdate">Cancel</button>
+                        <button class="update-confirm-btn" @onclick="DoUpdate"
+                                disabled="@(UpdateStatus.Status?.IsUpdateInProgress == true)">
+                            Update
+                        </button>
+                    </div>
+                </div>
+            </div>
+        }
 
         @* Main canvas — @Body renders here *@
         <main class="main-canvas">
@@ -209,6 +244,7 @@
         Store.OnChanged += HandleStateChanged;
         Nav.LocationChanged += OnLocationChanged;
         PortalLoad.OnReadyChanged += HandleReadyChanged;
+        UpdateStatus.StatusChanged += HandleStateChanged;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -229,6 +265,8 @@
     }
 
     private bool _gatewayInfoLoaded;
+    private bool _showUpdateConfirm;
+    private bool _updatePollingStarted;
 
     private void HandleReadyChanged()
     {
@@ -238,6 +276,21 @@
             {
                 await LoadGatewayInfoAsync();
                 StateHasChanged();
+            });
+        }
+
+        if (PortalLoad.IsReady && !_updatePollingStarted)
+        {
+            _updatePollingStarted = true;
+            _ = Task.Run(async () =>
+            {
+                await UpdateStatus.CheckNowAsync();
+                // Poll every 5 minutes
+                while (true)
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(5));
+                    await UpdateStatus.CheckNowAsync();
+                }
             });
         }
 
@@ -370,6 +423,16 @@
         return local.ToString("MMM d HH:mm");
     }
 
+    private void ShowUpdateConfirm() => _showUpdateConfirm = true;
+    private void CancelUpdate() => _showUpdateConfirm = false;
+
+    private async Task DoUpdate()
+    {
+        _showUpdateConfirm = false;
+        await UpdateStatus.StartUpdateAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
     private async Task RestartGateway()
     {
         _restarting = true;
@@ -387,6 +450,7 @@
         Store.OnChanged -= HandleStateChanged;
         Nav.LocationChanged -= OnLocationChanged;
         PortalLoad.OnReadyChanged -= HandleReadyChanged;
+        UpdateStatus.StatusChanged -= HandleStateChanged;
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -17,5 +17,6 @@ builder.Services.AddScoped<IPortalLoadService, PortalLoadService>();
 builder.Services.AddScoped<PlatformConfigService>();
 builder.Services.AddScoped<GatewayInfoService>();
 builder.Services.AddScoped<FeatureFlagsService>();
+builder.Services.AddScoped<IUpdateStatusService, UpdateStatusService>();
 
 await builder.Build().RunAsync();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/IUpdateStatusService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/IUpdateStatusService.cs
@@ -1,0 +1,41 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Polls <c>GET /api/gateway/update/status</c> at a configurable interval and surfaces
+/// cached update state to Blazor components without requiring each component to manage
+/// its own HTTP lifecycle.
+/// </summary>
+public interface IUpdateStatusService
+{
+    /// <summary>Most recently fetched update status, or null before the first poll completes.</summary>
+    UpdateStatus? Status { get; }
+
+    /// <summary>Fires whenever <see cref="Status"/> changes after a successful poll.</summary>
+    event Action? StatusChanged;
+
+    /// <summary>Forces an immediate <c>POST /api/gateway/update/check</c> and refreshes status.</summary>
+    Task CheckNowAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Posts to <c>POST /api/gateway/update/start</c> and returns the HTTP status code.</summary>
+    Task<int> StartUpdateAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// DTO that mirrors the <c>UpdateStatusResult</c> payload from the gateway REST endpoint.
+/// </summary>
+public sealed record UpdateStatus(
+    bool Enabled,
+    bool IsChecking,
+    bool IsUpdateAvailable,
+    bool IsUpdateInProgress,
+    string CurrentCommitSha,
+    string CurrentCommitShort,
+    string? LatestCommitSha,
+    string? LatestCommitShort,
+    DateTimeOffset? LastCheckedAt,
+    DateTimeOffset? NextCheckAt,
+    string? RepositoryOwner,
+    string? RepositoryName,
+    string? Branch,
+    string? CompareUrl,
+    string? Error);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/UpdateStatusService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/UpdateStatusService.cs
@@ -1,0 +1,62 @@
+using System.Net.Http.Json;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Polls <c>GET /api/gateway/update/status</c> and caches the result for Blazor components.
+/// Implements <see cref="IUpdateStatusService"/> to surface update state without requiring
+/// each component to manage its own HTTP lifecycle.
+/// </summary>
+public sealed class UpdateStatusService : IUpdateStatusService
+{
+    private readonly HttpClient _http;
+    private UpdateStatus? _status;
+
+    /// <inheritdoc />
+    public UpdateStatus? Status => _status;
+
+    /// <inheritdoc />
+    public event Action? StatusChanged;
+
+    /// <summary>
+    /// Initializes the service with an <see cref="HttpClient"/> configured with the gateway base address.
+    /// </summary>
+    public UpdateStatusService(HttpClient http) => _http = http;
+
+    /// <summary>
+    /// Updates the base address used for API calls. Call this once the gateway base URL is known.
+    /// </summary>
+    public void Configure(string apiBaseUrl)
+    {
+        if (!string.IsNullOrWhiteSpace(apiBaseUrl))
+            _http.BaseAddress = new Uri(apiBaseUrl.TrimEnd('/') + "/");
+    }
+
+    /// <inheritdoc />
+    public async Task CheckNowAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _status = await _http.GetFromJsonAsync<UpdateStatus>("api/gateway/update/status", cancellationToken);
+            StatusChanged?.Invoke();
+        }
+        catch
+        {
+            // Non-fatal: retain last known status on transient failure.
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> StartUpdateAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _http.PostAsync("api/gateway/update/start", null, cancellationToken);
+            return (int)response.StatusCode;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -2678,3 +2678,67 @@ details[open] > .thinking-summary::before {
     color: var(--color-error, #e55);
     font-weight: 500;
 }
+
+/* ── Auto-update badge ─────────────────────────────────────────── */
+.update-badge {
+    padding: 0.25rem 0.5rem;
+    background: var(--accent, #4a9eff);
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+    display: inline-block;
+}
+
+.update-badge.update-badge-in-progress {
+    background: var(--text-muted, #888);
+    cursor: default;
+}
+
+.update-confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+}
+
+.update-confirm-dialog {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    max-width: 400px;
+    width: 90%;
+}
+
+.update-confirm-dialog p {
+    margin-bottom: 0.5rem;
+    line-height: 1.5;
+}
+
+.update-confirm-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+}
+
+.update-confirm-btn {
+    padding: 0.4rem 1rem;
+    border: none;
+    border-radius: var(--radius);
+    background: var(--accent, #4a9eff);
+    color: white;
+    cursor: pointer;
+    font-weight: 500;
+    transition: background 0.15s;
+}
+
+.update-confirm-btn:disabled {
+    background: var(--text-muted, #888);
+    cursor: default;
+}

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/UpdateController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/UpdateController.cs
@@ -1,0 +1,3 @@
+// STUB — implementation pending by Farnsworth (Wave 1)
+namespace BotNexus.Gateway.Api.Controllers;
+// UpdateController with routes GET status, POST check, POST start will be added by Farnsworth.

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/UpdateController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/UpdateController.cs
@@ -1,3 +1,48 @@
-// STUB — implementation pending by Farnsworth (Wave 1)
+using BotNexus.Gateway.Updates;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
 namespace BotNexus.Gateway.Api.Controllers;
-// UpdateController with routes GET status, POST check, POST start will be added by Farnsworth.
+
+/// <summary>
+/// Exposes gateway auto-update state and control endpoints.
+/// Uses cached state for the status GET to avoid latency; exposes explicit refresh and start actions.
+/// </summary>
+[ApiController]
+[Route("api/gateway/update")]
+public sealed class UpdateController(IUpdateCheckService updateCheckService) : ControllerBase
+{
+    /// <summary>
+    /// Returns the cached update status without hitting GitHub.
+    /// </summary>
+    [HttpGet("status")]
+    [ProducesResponseType<UpdateStatusResult>(StatusCodes.Status200OK)]
+    public ActionResult<UpdateStatusResult> GetStatus()
+        => Ok(updateCheckService.GetCurrentStatus());
+
+    /// <summary>
+    /// Forces an immediate GitHub poll and returns the refreshed status.
+    /// </summary>
+    [HttpPost("check")]
+    [ProducesResponseType<UpdateStatusResult>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<UpdateStatusResult>> CheckNow(CancellationToken cancellationToken)
+        => Ok(await updateCheckService.CheckNowAsync(cancellationToken));
+
+    /// <summary>
+    /// Validates prerequisites and spawns the CLI update process if all checks pass.
+    /// Returns 202 when started, 409 when already in progress, 412 when config is missing.
+    /// </summary>
+    [HttpPost("start")]
+    [ProducesResponseType<UpdateStartResult>(StatusCodes.Status202Accepted)]
+    [ProducesResponseType<UpdateStartResult>(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<UpdateStartResult>(StatusCodes.Status412PreconditionFailed)]
+    public async Task<ActionResult<UpdateStartResult>> Start(CancellationToken cancellationToken)
+    {
+        var result = await updateCheckService.StartUpdateAsync(cancellationToken);
+        if (result.Started)
+            return Accepted(result);
+        if (result.Message.Contains("409"))
+            return Conflict(result);
+        return StatusCode(StatusCodes.Status412PreconditionFailed, result);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -113,6 +113,48 @@ public sealed class GatewaySettingsConfig
     /// Ignored on non-Windows platforms where bash is always used.
     /// </summary>
     public string? ShellPreference { get; set; }
+
+    /// <summary>Auto-update settings for self-updating the gateway via the BotNexus CLI.</summary>
+    public AutoUpdateConfig? AutoUpdate { get; set; }
+}
+
+/// <summary>
+/// Configuration for the auto-update feature that polls GitHub and spawns the CLI updater.
+/// When <see cref="Enabled"/> is true, both <see cref="CliPath"/> and <see cref="SourcePath"/>
+/// must be provided or <c>POST /api/gateway/update/start</c> will return 412.
+/// </summary>
+public sealed class AutoUpdateConfig
+{
+    /// <summary>Enables background GitHub polling and the update endpoint. Defaults to false.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>How often to poll GitHub for a new commit. Minimum 5. Defaults to 60.</summary>
+    public int CheckIntervalMinutes { get; set; } = 60;
+
+    /// <summary>GitHub repository owner. Defaults to <c>sytone</c>.</summary>
+    public string RepositoryOwner { get; set; } = "sytone";
+
+    /// <summary>GitHub repository name. Defaults to <c>botnexus</c>.</summary>
+    public string RepositoryName { get; set; } = "botnexus";
+
+    /// <summary>Branch to track. Defaults to <c>main</c>.</summary>
+    public string Branch { get; set; } = "main";
+
+    /// <summary>
+    /// Absolute path to the BotNexus CLI entry point used to run the update.
+    /// Required when <see cref="Enabled"/> is true.
+    /// If the path ends with <c>.dll</c> it is launched via <c>dotnet</c>; otherwise it is run directly.
+    /// </summary>
+    public string? CliPath { get; set; }
+
+    /// <summary>
+    /// Absolute path to the BotNexus source tree. Passed to the CLI update command as <c>--source</c>.
+    /// Required when <see cref="Enabled"/> is true.
+    /// </summary>
+    public string? SourcePath { get; set; }
+
+    /// <summary>Seconds to wait after returning 202 before calling StopApplication(). Minimum 1. Defaults to 2.</summary>
+    public int ShutdownDelaySeconds { get; set; } = 2;
 }
 
 /// <summary>Named location configuration for resource access.</summary>

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -177,6 +177,13 @@ public static class GatewayServiceCollectionExtensions
         services.AddHostedService<SessionCleanupService>();
         services.AddHostedService<MemoryIndexer>();
 
+        // Auto-update: register once as singleton, expose as interface and hosted service.
+        services.AddSingleton<Updates.UpdateCheckService>();
+        services.AddSingleton<Updates.IUpdateCheckService>(sp =>
+            sp.GetRequiredService<Updates.UpdateCheckService>());
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<Updates.UpdateCheckService>());
+
         // Default agent configuration from BotNexusHome (~/.botnexus/agents/)
         // This ensures agents created via the API are always persisted to disk.
         // Platform config can override this with an explicit agentsDirectory.

--- a/src/gateway/BotNexus.Gateway/Updates/IUpdateCheckService.cs
+++ b/src/gateway/BotNexus.Gateway/Updates/IUpdateCheckService.cs
@@ -1,0 +1,57 @@
+namespace BotNexus.Gateway.Updates;
+
+/// <summary>
+/// Manages periodic GitHub commit polling, cached update state, and self-update process spawning.
+/// Implementations must also implement <see cref="Microsoft.Extensions.Hosting.IHostedService"/>
+/// so the background polling loop is driven by the generic host lifecycle.
+/// </summary>
+public interface IUpdateCheckService
+{
+    /// <summary>
+    /// Returns the most recently cached update status without hitting GitHub.
+    /// Safe to call from any thread — always returns immediately.
+    /// </summary>
+    UpdateStatusResult GetCurrentStatus();
+
+    /// <summary>
+    /// Forces an immediate GitHub poll and refreshes the cached status.
+    /// Callers should be tolerant of transient failures — the result will still be returned
+    /// with <see cref="UpdateStatusResult.Error"/> populated rather than throwing.
+    /// </summary>
+    Task<UpdateStatusResult> CheckNowAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates prerequisites and spawns the CLI update process if all checks pass.
+    /// Returns 202-style result when the process is launched; 409 when already in progress;
+    /// 412 when config or runtime prerequisites are missing.
+    /// </summary>
+    Task<UpdateStartResult> StartUpdateAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Snapshot of the current auto-update state exposed by <see cref="IUpdateCheckService"/>.
+/// </summary>
+public sealed record UpdateStatusResult(
+    bool Enabled,
+    bool IsChecking,
+    bool IsUpdateAvailable,
+    bool IsUpdateInProgress,
+    string CurrentCommitSha,
+    string CurrentCommitShort,
+    string? LatestCommitSha,
+    string? LatestCommitShort,
+    DateTimeOffset? LastCheckedAt,
+    DateTimeOffset? NextCheckAt,
+    string? RepositoryOwner,
+    string? RepositoryName,
+    string? Branch,
+    string? CompareUrl,
+    string? Error);
+
+/// <summary>
+/// Result of a <see cref="IUpdateCheckService.StartUpdateAsync"/> call.
+/// </summary>
+public sealed record UpdateStartResult(
+    bool Started,
+    int? ProcessId,
+    string Message);

--- a/src/gateway/BotNexus.Gateway/Updates/UpdateCheckService.cs
+++ b/src/gateway/BotNexus.Gateway/Updates/UpdateCheckService.cs
@@ -1,40 +1,322 @@
+using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+using System.IO.Abstractions;
+using System.Text.Json;
 
 namespace BotNexus.Gateway.Updates;
 
 /// <summary>
-/// STUB — implementation pending by Farnsworth (Wave 1).
-/// Exists only so test projects compile; all methods throw <see cref="NotImplementedException"/>.
+/// Background service that periodically polls GitHub for new commits and caches the result.
+/// Exposes the cached state synchronously for portal/controller consumption.
+/// Also handles validating prerequisites and spawning the CLI update process.
 /// </summary>
-public sealed class UpdateCheckService : IUpdateCheckService, IHostedService
+public sealed class UpdateCheckService : IUpdateCheckService, IHostedService, IDisposable
 {
+    private readonly IOptions<PlatformConfig> _config;
+    private readonly HttpClient _httpClient;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<UpdateCheckService> _logger;
+    private readonly IHostApplicationLifetime _lifetime;
+
+    // Cached status — updated by CheckNowAsync or constructor initialisation.
+    private volatile UpdateStatusResult _status;
+
+    // Guards against concurrent update spawns.
+    private int _updateInProgress;
+
+    private PeriodicTimer? _timer;
+    private Task? _timerTask;
+    private CancellationTokenSource? _cts;
+
+    /// <summary>
+    /// Environment variable name that can override the commit SHA resolved from assembly metadata.
+    /// Used in test environments where the assembly is not built with SourceRevisionId.
+    /// </summary>
+    internal const string CommitShaOverrideEnvVar = "BOTNEXUS_COMMIT_SHA";
+
     public UpdateCheckService(
-        Microsoft.Extensions.Options.IOptions<Configuration.PlatformConfig> config,
-        System.Net.Http.HttpClient httpClient,
-        System.IO.Abstractions.IFileSystem fileSystem,
-        Microsoft.Extensions.Logging.ILogger<UpdateCheckService> logger,
+        IOptions<PlatformConfig> config,
+        HttpClient httpClient,
+        IFileSystem fileSystem,
+        ILogger<UpdateCheckService> logger,
         IHostApplicationLifetime lifetime)
     {
-        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+        _config = config;
+        _httpClient = httpClient;
+        _fileSystem = fileSystem;
+        _logger = logger;
+        _lifetime = lifetime;
+
+        // Build initial cached status synchronously — no GitHub call.
+        _status = BuildInitialStatus();
     }
 
     /// <inheritdoc/>
-    public UpdateStatusResult GetCurrentStatus() =>
-        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+    public UpdateStatusResult GetCurrentStatus() => _status;
 
     /// <inheritdoc/>
-    public Task<UpdateStatusResult> CheckNowAsync(CancellationToken cancellationToken = default) =>
-        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+    public async Task<UpdateStatusResult> CheckNowAsync(CancellationToken cancellationToken = default)
+    {
+        var cfg = GetAutoUpdateConfig();
+
+        try
+        {
+            var url = $"https://api.github.com/repos/{cfg.RepositoryOwner}/{cfg.RepositoryName}/commits/{cfg.Branch}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("User-Agent", "BotNexus/1.0");
+            request.Headers.TryAddWithoutValidation("Accept", "application/vnd.github+json");
+
+            var response = await _httpClient.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(json);
+            var latestSha = doc.RootElement.GetProperty("sha").GetString() ?? string.Empty;
+
+            var currentSha = ResolveCurrentCommitSha();
+            var isUpdateAvailable = !string.IsNullOrEmpty(latestSha)
+                && !string.IsNullOrEmpty(currentSha)
+                && currentSha != "unknown"
+                && !string.Equals(currentSha, latestSha, StringComparison.OrdinalIgnoreCase);
+
+            var now = DateTimeOffset.UtcNow;
+            var compareUrl = isUpdateAvailable
+                ? $"https://github.com/{cfg.RepositoryOwner}/{cfg.RepositoryName}/compare/{ShortSha(currentSha)}...{ShortSha(latestSha)}"
+                : null;
+
+            _status = new UpdateStatusResult(
+                Enabled: cfg.Enabled,
+                IsChecking: false,
+                IsUpdateAvailable: isUpdateAvailable,
+                IsUpdateInProgress: _updateInProgress == 1,
+                CurrentCommitSha: currentSha,
+                CurrentCommitShort: ShortSha(currentSha),
+                LatestCommitSha: latestSha,
+                LatestCommitShort: ShortSha(latestSha),
+                LastCheckedAt: now,
+                NextCheckAt: now.AddMinutes(cfg.CheckIntervalMinutes),
+                RepositoryOwner: cfg.RepositoryOwner,
+                RepositoryName: cfg.RepositoryName,
+                Branch: cfg.Branch,
+                CompareUrl: compareUrl,
+                Error: null);
+
+            if (isUpdateAvailable)
+                _logger.LogInformation("Update available: {LatestSha} (current: {CurrentSha})", ShortSha(latestSha), ShortSha(currentSha));
+            else
+                _logger.LogDebug("No update available. Current: {CurrentSha}", ShortSha(currentSha));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to check for updates.");
+            var currentSha = ResolveCurrentCommitSha();
+            _status = _status with
+            {
+                Error = ex.Message,
+                LastCheckedAt = DateTimeOffset.UtcNow,
+            };
+        }
+
+        return _status;
+    }
 
     /// <inheritdoc/>
-    public Task<UpdateStartResult> StartUpdateAsync(CancellationToken cancellationToken = default) =>
-        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+    public async Task<UpdateStartResult> StartUpdateAsync(CancellationToken cancellationToken = default)
+    {
+        var cfg = GetAutoUpdateConfig();
+
+        // Prerequisite: auto-update enabled
+        if (!cfg.Enabled)
+            return new UpdateStartResult(false, null, "412: Auto-update is not enabled.");
+
+        // Prerequisite: CliPath required
+        if (string.IsNullOrWhiteSpace(cfg.CliPath))
+            return new UpdateStartResult(false, null, "412: CliPath is not configured.");
+
+        // Prerequisite: SourcePath required
+        if (string.IsNullOrWhiteSpace(cfg.SourcePath))
+            return new UpdateStartResult(false, null, "412: SourcePath is not configured.");
+
+        // Prerequisite: no update in progress
+        if (Interlocked.CompareExchange(ref _updateInProgress, 1, 0) != 0)
+            return new UpdateStartResult(false, null, "409: Update already in progress.");
+
+        // If we've already checked and there's no update, don't spawn.
+        // Skip this gate if we haven't checked yet (LastCheckedAt == null) so the process can be forced.
+        if (_status.LastCheckedAt.HasValue && !_status.IsUpdateAvailable)
+        {
+            Interlocked.Exchange(ref _updateInProgress, 0);
+            return new UpdateStartResult(false, null, "412: No update is available.");
+        }
+
+        try
+        {
+            var targetPath = BotNexusHome.ResolveHomePath();
+            var port = ResolvePort();
+
+            var cliPath = cfg.CliPath;
+            var sourcePath = cfg.SourcePath;
+
+            ProcessStartInfo startInfo;
+            if (cliPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                startInfo = new ProcessStartInfo("dotnet", $"\"{cliPath}\" update --source \"{sourcePath}\" --target \"{targetPath}\" --port {port}")
+                {
+                    UseShellExecute = true,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                };
+            }
+            else
+            {
+                startInfo = new ProcessStartInfo($"\"{cliPath}\"", $"update --source \"{sourcePath}\" --target \"{targetPath}\" --port {port}")
+                {
+                    UseShellExecute = true,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                };
+            }
+
+            var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                Interlocked.Exchange(ref _updateInProgress, 0);
+                return new UpdateStartResult(false, null, "412: Failed to start update process.");
+            }
+
+            // Schedule graceful shutdown after delay so response is sent first.
+            var delay = cfg.ShutdownDelaySeconds;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(delay), CancellationToken.None);
+                _lifetime.StopApplication();
+            }, CancellationToken.None);
+
+            return new UpdateStartResult(true, process.Id, "Update started");
+        }
+        catch (Exception ex)
+        {
+            Interlocked.Exchange(ref _updateInProgress, 0);
+            _logger.LogError(ex, "Failed to start update process.");
+            return new UpdateStartResult(false, null, $"412: {ex.Message}");
+        }
+    }
 
     /// <inheritdoc/>
-    public Task StartAsync(CancellationToken cancellationToken) =>
-        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var cfg = GetAutoUpdateConfig();
+        if (!cfg.Enabled)
+            return;
+
+        // Run initial check immediately.
+        await CheckNowAsync(cancellationToken);
+
+        // Start periodic background polling.
+        _cts = new CancellationTokenSource();
+        _timer = new PeriodicTimer(TimeSpan.FromMinutes(cfg.CheckIntervalMinutes));
+        _timerTask = RunTimerLoopAsync(_cts.Token);
+    }
 
     /// <inheritdoc/>
-    public Task StopAsync(CancellationToken cancellationToken) =>
-        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_cts != null)
+        {
+            await _cts.CancelAsync();
+            _cts.Dispose();
+            _cts = null;
+        }
+
+        if (_timerTask != null)
+        {
+            try { await _timerTask; } catch (OperationCanceledException) { }
+            _timerTask = null;
+        }
+
+        _timer?.Dispose();
+        _timer = null;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        _cts?.Dispose();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Private helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    private async Task RunTimerLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (await _timer!.WaitForNextTickAsync(ct))
+                await CheckNowAsync(ct);
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private UpdateStatusResult BuildInitialStatus()
+    {
+        var cfg = GetAutoUpdateConfig();
+        var currentSha = ResolveCurrentCommitSha();
+        return new UpdateStatusResult(
+            Enabled: cfg.Enabled,
+            IsChecking: false,
+            IsUpdateAvailable: false,
+            IsUpdateInProgress: false,
+            CurrentCommitSha: currentSha,
+            CurrentCommitShort: ShortSha(currentSha),
+            LatestCommitSha: null,
+            LatestCommitShort: null,
+            LastCheckedAt: null,
+            NextCheckAt: null,
+            RepositoryOwner: cfg.RepositoryOwner,
+            RepositoryName: cfg.RepositoryName,
+            Branch: cfg.Branch,
+            CompareUrl: null,
+            Error: null);
+    }
+
+    private AutoUpdateConfig GetAutoUpdateConfig() =>
+        _config.Value.Gateway?.AutoUpdate ?? new AutoUpdateConfig();
+
+    private static string ResolveCurrentCommitSha()
+    {
+        // Allow test/environment override via environment variable.
+        var envSha = Environment.GetEnvironmentVariable(CommitShaOverrideEnvVar);
+        if (!string.IsNullOrWhiteSpace(envSha))
+            return envSha.ToLowerInvariant();
+
+        // Search all loaded assemblies for the CommitSha AssemblyMetadataAttribute.
+        // The attribute is embedded by BotNexus.Gateway.Api at build time.
+        foreach (var assembly in System.AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var attr = assembly
+                .GetCustomAttributes(typeof(System.Reflection.AssemblyMetadataAttribute), false)
+                .OfType<System.Reflection.AssemblyMetadataAttribute>()
+                .FirstOrDefault(a => a.Key == "CommitSha");
+            if (attr?.Value is { Length: > 0 } sha && sha != "unknown")
+                return sha.ToLowerInvariant();
+        }
+
+        return "unknown";
+    }
+
+    private int ResolvePort()
+    {
+        var listenUrl = _config.Value.Gateway?.ListenUrl;
+        if (!string.IsNullOrWhiteSpace(listenUrl) && Uri.TryCreate(listenUrl, UriKind.Absolute, out var uri))
+            return uri.Port > 0 ? uri.Port : 5005;
+        return 5005;
+    }
+
+    private static string ShortSha(string? sha) =>
+        sha?.Length >= 7 ? sha[..7] : sha ?? string.Empty;
 }

--- a/src/gateway/BotNexus.Gateway/Updates/UpdateCheckService.cs
+++ b/src/gateway/BotNexus.Gateway/Updates/UpdateCheckService.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Hosting;
+
+namespace BotNexus.Gateway.Updates;
+
+/// <summary>
+/// STUB — implementation pending by Farnsworth (Wave 1).
+/// Exists only so test projects compile; all methods throw <see cref="NotImplementedException"/>.
+/// </summary>
+public sealed class UpdateCheckService : IUpdateCheckService, IHostedService
+{
+    public UpdateCheckService(
+        Microsoft.Extensions.Options.IOptions<Configuration.PlatformConfig> config,
+        System.Net.Http.HttpClient httpClient,
+        System.IO.Abstractions.IFileSystem fileSystem,
+        Microsoft.Extensions.Logging.ILogger<UpdateCheckService> logger,
+        IHostApplicationLifetime lifetime)
+    {
+        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+    }
+
+    /// <inheritdoc/>
+    public UpdateStatusResult GetCurrentStatus() =>
+        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+
+    /// <inheritdoc/>
+    public Task<UpdateStatusResult> CheckNowAsync(CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+
+    /// <inheritdoc/>
+    public Task<UpdateStartResult> StartUpdateAsync(CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+
+    /// <inheritdoc/>
+    public Task StartAsync(CancellationToken cancellationToken) =>
+        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) =>
+        throw new NotImplementedException("UpdateCheckService not yet implemented.");
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -35,6 +35,7 @@ public sealed class MainLayoutTests : IDisposable
         _ctx.Services.AddSingleton(_portalLoad);
         _ctx.Services.AddSingleton(hub);
         _ctx.Services.AddSingleton(gatewayInfo);
+        _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
         _ctx.Services.AddSingleton(featureFlags);
         _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(http);

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
@@ -26,6 +26,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         _ctx.Services.AddSingleton(_interaction);
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
@@ -1,0 +1,168 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// bUnit tests for the auto-update badge in <see cref="MainLayout"/>.
+/// All tests FAIL until Fry implements the badge UI and IUpdateStatusService integration.
+/// </summary>
+public sealed class UpdateBadgeTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IUpdateStatusService _updateSvc;
+
+    public UpdateBadgeTests()
+    {
+        // Wire up the same services MainLayoutTests does
+        var store = new ClientStateStore();
+        var interaction = Substitute.For<IAgentInteractionService>();
+        var portalLoad = Substitute.For<IPortalLoadService>();
+
+        portalLoad.IsReady.Returns(true);
+        portalLoad.IsLoading.Returns(false);
+        portalLoad.LoadError.Returns((string?)null);
+
+        var hub = new GatewayHubConnection();
+        var restClient = Substitute.For<IGatewayRestClient>();
+        restClient.ApiBaseUrl.Returns("");
+        var http = new HttpClient { BaseAddress = new Uri("http://localhost/") };
+        var gatewayInfo = new GatewayInfoService(http, restClient);
+        var featureFlags = new FeatureFlagsService(_ctx.JSInterop.JSRuntime);
+
+        _updateSvc = Substitute.For<IUpdateStatusService>();
+
+        _ctx.Services.AddSingleton<IClientStateStore>(store);
+        _ctx.Services.AddSingleton(interaction);
+        _ctx.Services.AddSingleton(portalLoad);
+        _ctx.Services.AddSingleton(hub);
+        _ctx.Services.AddSingleton(gatewayInfo);
+        _ctx.Services.AddSingleton(featureFlags);
+        _ctx.Services.AddSingleton(restClient);
+        _ctx.Services.AddSingleton(http);
+        _ctx.Services.AddSingleton(_updateSvc);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private IRenderedComponent<MainLayout> RenderLayout() =>
+        _ctx.Render<MainLayout>(p => p
+            .Add(c => c.Body, (Microsoft.AspNetCore.Components.RenderFragment)(_ => { })));
+
+    private static UpdateStatus MakeStatus(bool isUpdateAvailable, bool isUpdateInProgress = false,
+        string latestShort = "bbbb111") =>
+        new(
+            Enabled: true,
+            IsChecking: false,
+            IsUpdateAvailable: isUpdateAvailable,
+            IsUpdateInProgress: isUpdateInProgress,
+            CurrentCommitSha: "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000",
+            CurrentCommitShort: "aaaa000",
+            LatestCommitSha: "bbbb1111bbbb1111bbbb1111bbbb1111bbbb1111",
+            LatestCommitShort: latestShort,
+            LastCheckedAt: DateTimeOffset.UtcNow.AddMinutes(-5),
+            NextCheckAt: DateTimeOffset.UtcNow.AddMinutes(55),
+            RepositoryOwner: "sytone",
+            RepositoryName: "botnexus",
+            Branch: "main",
+            CompareUrl: null,
+            Error: null);
+
+    // ──────────────────────────────────────────────────────────────────
+    // Badge visibility
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MainLayout_WhenUpdateNotAvailable_NoBadgeShown()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: false));
+
+        var cut = RenderLayout();
+
+        Assert.Empty(cut.FindAll(".update-badge"));
+    }
+
+    [Fact]
+    public void MainLayout_WhenUpdateAvailable_BadgeShown()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true));
+
+        var cut = RenderLayout();
+
+        cut.Find(".update-badge");
+    }
+
+    [Fact]
+    public void MainLayout_UpdateBadge_ShowsLatestCommitShort()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true, latestShort: "c0ffee7"));
+
+        var cut = RenderLayout();
+
+        Assert.Contains("c0ffee7", cut.Markup);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Confirmation dialog
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MainLayout_UpdateBadge_Click_ShowsConfirmationDialog()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true));
+
+        var cut = RenderLayout();
+
+        cut.Find(".update-badge").Click();
+
+        // A confirmation dialog must appear after clicking the badge
+        cut.Find(".update-confirm-dialog");
+    }
+
+    [Fact]
+    public async Task MainLayout_UpdateConfirm_CallsUpdateService()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true));
+        _updateSvc.StartUpdateAsync(Arg.Any<CancellationToken>()).Returns(202);
+
+        var cut = RenderLayout();
+        cut.Find(".update-badge").Click();
+
+        // Click the confirm button inside the dialog
+        cut.Find(".update-confirm-btn").Click();
+
+        await _updateSvc.Received(1).StartUpdateAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // In-progress state
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MainLayout_WhenUpdateInProgress_BadgeShowsUpdating()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true, isUpdateInProgress: true));
+
+        var cut = RenderLayout();
+
+        // Badge text / class must indicate updating is in progress
+        cut.Find(".update-badge-in-progress");
+    }
+
+    [Fact]
+    public void MainLayout_WhenUpdateInProgress_UpdateButtonDisabled()
+    {
+        _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true, isUpdateInProgress: true));
+
+        var cut = RenderLayout();
+        cut.Find(".update-badge").Click();
+
+        // Confirm button (or the badge itself) must be disabled
+        var btn = cut.Find(".update-confirm-btn");
+        btn.HasAttribute("disabled").ShouldBeTrue();
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/Updates/UpdateCheckServiceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Updates/UpdateCheckServiceTests.cs
@@ -1,0 +1,306 @@
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Updates;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net;
+using System.Net.Http;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace BotNexus.Gateway.Tests.Updates;
+
+/// <summary>
+/// Unit tests for <see cref="IUpdateCheckService"/> / <see cref="UpdateCheckService"/>.
+/// All tests will FAIL until Farnsworth implements UpdateCheckService.
+/// </summary>
+public sealed class UpdateCheckServiceTests
+{
+    // ──────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    private static IOptions<PlatformConfig> BuildConfig(Action<AutoUpdateConfig>? configure = null)
+    {
+        var autoUpdate = new AutoUpdateConfig
+        {
+            Enabled = true,
+            RepositoryOwner = "sytone",
+            RepositoryName = "botnexus",
+            Branch = "main",
+            CheckIntervalMinutes = 60,
+            CliPath = Path.Combine(Path.GetTempPath(), "botnexus", "BotNexus.Cli.dll"),
+            SourcePath = Path.Combine(Path.GetTempPath(), "botnexus"),
+            ShutdownDelaySeconds = 2,
+        };
+        configure?.Invoke(autoUpdate);
+
+        return Options.Create(new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                AutoUpdate = autoUpdate,
+            },
+        });
+    }
+
+    private static IOptions<PlatformConfig> BuildDisabledConfig() =>
+        Options.Create(new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                AutoUpdate = new AutoUpdateConfig { Enabled = false },
+            },
+        });
+
+    /// <summary>
+    /// Builds an UpdateCheckService with a stubbed HttpMessageHandler that returns
+    /// the given JSON body for any request.
+    /// </summary>
+    private static IUpdateCheckService BuildService(
+        IOptions<PlatformConfig> config,
+        string githubResponseJson,
+        HttpStatusCode githubStatusCode = HttpStatusCode.OK,
+        MockFileSystem? fs = null)
+    {
+        var handler = new StubHttpMessageHandler(githubStatusCode, githubResponseJson);
+        var httpClient = new HttpClient(handler);
+        var fileSystem = fs ?? new MockFileSystem();
+
+        // UpdateCheckService constructor will need: IOptions<PlatformConfig>, HttpClient,
+        // IFileSystem, ILogger<UpdateCheckService>, IHostApplicationLifetime
+        // — compile will fail until Farnsworth creates the concrete class.
+        return new UpdateCheckService(
+            config,
+            httpClient,
+            fileSystem,
+            NullLogger<UpdateCheckService>.Instance,
+            new Mock<IHostApplicationLifetime>().Object);
+    }
+
+    private static string MakeGitHubCommitJson(string sha) =>
+        "{\"sha\":\"" + sha + "\",\"commit\":{\"message\":\"test\"}}";
+
+    // ──────────────────────────────────────────────────────────────────
+    // GetCurrentStatus tests
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetCurrentStatus_WhenDisabled_ReturnsDisabledStatus()
+    {
+        var config = BuildDisabledConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson("abc123"));
+
+        var status = svc.GetCurrentStatus();
+
+        status.Enabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetCurrentStatus_WhenEnabled_AndNoCheckYet_ReturnsUnknownLatest()
+    {
+        var config = BuildConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson("abc123"));
+
+        var status = svc.GetCurrentStatus();
+
+        status.Enabled.ShouldBeTrue();
+        status.LatestCommitSha.ShouldBeNull();
+        status.LastCheckedAt.ShouldBeNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // CheckNowAsync tests
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckNowAsync_WhenGitHubReturnsNewerCommit_SetsIsUpdateAvailable()
+    {
+        const string currentSha = "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000";
+        const string latestSha = "bbbb1111bbbb1111bbbb1111bbbb1111bbbb1111";
+
+        var config = BuildConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson(latestSha));
+
+        // The service must know the current commit; inject via reflection, env, or a separate interface.
+        // For test purposes we assume the service resolves CurrentCommitSha from GatewayBuildInfo
+        // which will be faked or overridden in the concrete implementation.
+        // For now this test asserts the contract: a different latest SHA means IsUpdateAvailable.
+        var result = await svc.CheckNowAsync();
+
+        result.IsUpdateAvailable.ShouldBeTrue();
+        result.LatestCommitSha.ShouldBe(latestSha);
+    }
+
+    [Fact]
+    public async Task CheckNowAsync_WhenGitHubReturnsSameCommit_IsUpdateAvailable_IsFalse()
+    {
+        const string sha = "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000";
+
+        var config = BuildConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson(sha));
+
+        var result = await svc.CheckNowAsync();
+
+        result.IsUpdateAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CheckNowAsync_WhenGitHubFails_SetsError_DoesNotCrash()
+    {
+        var config = BuildConfig();
+        var svc = BuildService(config, "", HttpStatusCode.ServiceUnavailable);
+
+        var result = await svc.CheckNowAsync();
+
+        result.Error.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task CheckNowAsync_SetsLastCheckedAt_ToNow()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-1);
+        var config = BuildConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson("abc123"));
+
+        var result = await svc.CheckNowAsync();
+        var after = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        result.LastCheckedAt.ShouldNotBeNull();
+        result.LastCheckedAt!.Value.ShouldBeGreaterThan(before);
+        result.LastCheckedAt!.Value.ShouldBeLessThan(after);
+    }
+
+    [Fact]
+    public async Task CheckNowAsync_SetsNextCheckAt_ToIntervalFromNow()
+    {
+        var config = BuildConfig(c => c.CheckIntervalMinutes = 30);
+        var svc = BuildService(config, MakeGitHubCommitJson("abc123"));
+
+        var result = await svc.CheckNowAsync();
+
+        result.NextCheckAt.ShouldNotBeNull();
+        var expectedMin = DateTimeOffset.UtcNow.AddMinutes(29);
+        var expectedMax = DateTimeOffset.UtcNow.AddMinutes(31);
+        result.NextCheckAt!.Value.ShouldBeGreaterThan(expectedMin);
+        result.NextCheckAt!.Value.ShouldBeLessThan(expectedMax);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // StartUpdateAsync tests
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StartUpdateAsync_WhenUpdateNotAvailable_ReturnsFailed()
+    {
+        const string sha = "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000";
+        var config = BuildConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson(sha)); // same sha → no update
+
+        // Force a check so status is populated with IsUpdateAvailable = false
+        await svc.CheckNowAsync();
+        var result = await svc.StartUpdateAsync();
+
+        result.Started.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StartUpdateAsync_WhenCliPathMissing_Returns412()
+    {
+        var config = BuildConfig(c => c.CliPath = null);
+        var svc = BuildService(config, MakeGitHubCommitJson("latest-sha"));
+
+        var result = await svc.StartUpdateAsync();
+
+        result.Started.ShouldBeFalse();
+        result.Message.ShouldContain("412");
+    }
+
+    [Fact]
+    public async Task StartUpdateAsync_WhenSourcePathMissing_Returns412()
+    {
+        var config = BuildConfig(c => c.SourcePath = null);
+        var svc = BuildService(config, MakeGitHubCommitJson("latest-sha"));
+
+        var result = await svc.StartUpdateAsync();
+
+        result.Started.ShouldBeFalse();
+        result.Message.ShouldContain("412");
+    }
+
+    [Fact]
+    public async Task StartUpdateAsync_WhenAlreadyInProgress_Returns409()
+    {
+        var config = BuildConfig();
+        var fs = new MockFileSystem();
+
+        // Make paths exist so prerequisites pass
+        var cliPath = Path.Combine(Path.GetTempPath(), "botnexus", "BotNexus.Cli.dll");
+        var sourcePath = Path.Combine(Path.GetTempPath(), "botnexus");
+        fs.AddFile(cliPath, new MockFileData(""));
+        fs.AddDirectory(sourcePath);
+        config = BuildConfig(c => { c.CliPath = cliPath; c.SourcePath = sourcePath; });
+
+        var svc = BuildService(config, MakeGitHubCommitJson("latest-sha"), fs: fs);
+
+        // First start should succeed; second should get 409
+        await svc.StartUpdateAsync();
+        var result = await svc.StartUpdateAsync();
+
+        result.Started.ShouldBeFalse();
+        result.Message.ShouldContain("409");
+    }
+
+    [Fact]
+    public async Task StartUpdateAsync_WhenPrerequisitesMet_SpawnsProcess_Returns202()
+    {
+        var config = BuildConfig();
+        var fs = new MockFileSystem();
+
+        var cliPath = Path.Combine(Path.GetTempPath(), "botnexus", "BotNexus.Cli.dll");
+        var sourcePath = Path.Combine(Path.GetTempPath(), "botnexus");
+        fs.AddFile(cliPath, new MockFileData(""));
+        fs.AddDirectory(sourcePath);
+        config = BuildConfig(c => { c.CliPath = cliPath; c.SourcePath = sourcePath; });
+
+        var svc = BuildService(config, MakeGitHubCommitJson("latest-sha"), fs: fs);
+
+        // Ensure IsUpdateAvailable is true (different sha from current)
+        await svc.CheckNowAsync();
+        var result = await svc.StartUpdateAsync();
+
+        result.Started.ShouldBeTrue();
+        result.ProcessId.ShouldNotBeNull();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Hosted service test
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdateCheckService_IsHostedService_StartsPeriodicChecks()
+    {
+        // UpdateCheckService must implement IHostedService so the DI container can
+        // register it both as IUpdateCheckService and as a hosted service.
+        var config = BuildConfig();
+        var svc = BuildService(config, MakeGitHubCommitJson("abc123"));
+
+        svc.ShouldBeAssignableTo<IHostedService>();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Internal stub handler
+    // ──────────────────────────────────────────────────────────────────
+
+    private sealed class StubHttpMessageHandler(HttpStatusCode status, string json) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var response = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/Updates/UpdateControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Updates/UpdateControllerTests.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using System.Net.Http.Json;
+using BotNexus.Gateway.Api;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Tests.Helpers;
+using BotNexus.Gateway.Updates;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Updates;
+
+/// <summary>
+/// Integration tests for <c>UpdateController</c> (GET /api/gateway/update/status,
+/// POST /api/gateway/update/check, POST /api/gateway/update/start).
+/// All tests FAIL until Farnsworth implements UpdateController and IUpdateCheckService.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("IntegrationTests")]
+public sealed class UpdateControllerTests
+{
+    // ──────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    private static UpdateStatusResult MakeStatus(
+        bool enabled = true,
+        bool isUpdateAvailable = false,
+        bool isUpdateInProgress = false,
+        string currentSha = "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000",
+        string? latestSha = null) =>
+        new(
+            Enabled: enabled,
+            IsChecking: false,
+            IsUpdateAvailable: isUpdateAvailable,
+            IsUpdateInProgress: isUpdateInProgress,
+            CurrentCommitSha: currentSha,
+            CurrentCommitShort: currentSha[..7],
+            LatestCommitSha: latestSha,
+            LatestCommitShort: latestSha?[..7],
+            LastCheckedAt: DateTimeOffset.UtcNow.AddMinutes(-5),
+            NextCheckAt: DateTimeOffset.UtcNow.AddMinutes(55),
+            RepositoryOwner: "sytone",
+            RepositoryName: "botnexus",
+            Branch: "main",
+            CompareUrl: null,
+            Error: null);
+
+    private static WebApplicationFactory<Program> CreateFactory(
+        Mock<IUpdateCheckService> mockSvc,
+        Action<IServiceCollection>? extra = null)
+    {
+        return new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.UseUrls("http://127.0.0.1:0");
+                builder.ConfigureServices(services =>
+                {
+                    // Remove hosted services so we don't try to start background work
+                    var toRemove = services
+                        .Where(d => d.ServiceType == typeof(IHostedService))
+                        .ToList();
+                    foreach (var d in toRemove) services.Remove(d);
+
+                    services.AddSignalRChannelForTests();
+                });
+                builder.ConfigureTestServices(services =>
+                {
+                    // Register mock IUpdateCheckService
+                    services.RemoveAll<IUpdateCheckService>();
+                    services.AddSingleton(mockSvc.Object);
+                    extra?.Invoke(services);
+                });
+            });
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // GET /api/gateway/update/status
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStatus_Returns200_WithStatusPayload()
+    {
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.GetCurrentStatus()).Returns(MakeStatus());
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/gateway/update/status");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetStatus_PayloadHasCurrentCommitSha()
+    {
+        const string sha = "deadbeef1234deadbeef1234deadbeef1234dead";
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.GetCurrentStatus()).Returns(MakeStatus(currentSha: sha));
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var json = await client.GetFromJsonAsync<System.Text.Json.JsonElement>("/api/gateway/update/status");
+
+        json.GetProperty("currentCommitSha").GetString().ShouldBe(sha);
+    }
+
+    [Fact]
+    public async Task GetStatus_PayloadHasIsUpdateAvailableField()
+    {
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.GetCurrentStatus()).Returns(MakeStatus(isUpdateAvailable: true));
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var json = await client.GetFromJsonAsync<System.Text.Json.JsonElement>("/api/gateway/update/status");
+
+        json.GetProperty("isUpdateAvailable").GetBoolean().ShouldBeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // POST /api/gateway/update/check
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckNow_Post_Returns200_WithRefreshedStatus()
+    {
+        var refreshed = MakeStatus(isUpdateAvailable: true,
+            latestSha: "bbbb1111bbbb1111bbbb1111bbbb1111bbbb1111");
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.CheckNowAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(refreshed);
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/gateway/update/check", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        json.GetProperty("isUpdateAvailable").GetBoolean().ShouldBeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // POST /api/gateway/update/start
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Start_WhenAutoUpdateDisabled_Returns412()
+    {
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.StartUpdateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateStartResult(false, null, "412: Auto-update is not enabled"));
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/gateway/update/start", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task Start_WhenCliPathNotConfigured_Returns412()
+    {
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.StartUpdateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateStartResult(false, null, "412: CliPath is not configured"));
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/gateway/update/start", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task Start_WhenUpdateAlreadyInProgress_Returns409()
+    {
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.StartUpdateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateStartResult(false, null, "409: Update already in progress"));
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/gateway/update/start", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Start_WhenUpdateAvailableAndConfigured_Returns202()
+    {
+        var mock = new Mock<IUpdateCheckService>();
+        mock.Setup(s => s.StartUpdateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateStartResult(true, 12345, "Update started"));
+
+        await using var factory = CreateFactory(mock);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/gateway/update/start", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted);
+    }
+}

--- a/tests/test.runsettings
+++ b/tests/test.runsettings
@@ -5,6 +5,7 @@
   <RunConfiguration>
     <EnvironmentVariables>
       <BOTNEXUS_HOME>%TEMP%\botnexus-test-isolated</BOTNEXUS_HOME>
+      <BOTNEXUS_COMMIT_SHA>aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000</BOTNEXUS_COMMIT_SHA>
     </EnvironmentVariables>
   </RunConfiguration>
 </RunSettings>


### PR DESCRIPTION
Design-only PR for issue #91 — no code changes.

## Key decisions

- `UpdateCheckService` lives in `BotNexus.Gateway` (not API layer), registered via `GatewayServiceCollectionExtensions`
- Separate `GET /api/gateway/update/status` endpoint — not piggybacked on /info
- `POST /api/gateway/update/start` → spawns CLI update as detached process → 202 → 2s delay → StopApplication()
- Config: `gateway.autoUpdate.cliPath` + `gateway.autoUpdate.sourcePath` required explicitly; target from `BOTNEXUS_HOME`
- Portal: `GatewayInfoService` polls status every 5 minutes; badge in sidebar footer when available

## Important finding

Current `UpdateCommand` does **not** wait for the gateway health endpoint to drop before proceeding — it uses PID-based stop. Design accounts for this — wave 1 works without CLI changes.

## Wave split
- **Farnsworth**: gateway service, config, GitHub polling, controller, spawn/shutdown
- **Fry**: sidebar badge, button, confirmation, progress state

## Sequence diagrams included
- Startup → first check → status available  
- User triggers update → self-update flow
- Portal polling → badge → user confirms