### PR TITLE
fix(cli): default listenUrl to 0.0.0.0:5005 — remote access via NetBird

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -50,7 +50,7 @@ internal sealed class InitCommand
         {
             Gateway = new GatewaySettingsConfig
             {
-                ListenUrl = "http://localhost:5005",
+                ListenUrl = "http://0.0.0.0:5005",
                 DefaultAgentId = "assistant",
                 SessionStore = new SessionStoreConfig
                 {

--- a/tests/BotNexus.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/BotNexus.Cli.Tests/Commands/InitCommandTests.cs
@@ -1,0 +1,37 @@
+using BotNexus.Cli.Commands;
+using Shouldly;
+
+namespace BotNexus.Cli.Tests.Commands;
+
+/// <summary>
+/// Tests for InitCommand default configuration values.
+/// </summary>
+public sealed class InitCommandTests
+{
+    [Fact]
+    public async Task Init_DefaultConfig_ListenUrl_BindsToAllInterfaces()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), $"botnexus-init-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+
+        try
+        {
+            var cmd = new InitCommand();
+
+            // Act
+            var result = await cmd.ExecuteAsync(tempHome, force: false, verbose: false, CancellationToken.None);
+
+            // Assert — listenUrl must bind to all interfaces so NetBird/remote access works
+            var configPath = Path.Combine(tempHome, "config.json");
+            var json = await File.ReadAllTextAsync(configPath);
+            json.ShouldContain("0.0.0.0");
+            json.ShouldNotContain("localhost:5005");
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+                Directory.Delete(tempHome, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #95

`InitCommand` was creating config with `listenUrl: http://localhost:5005` which binds the gateway to 127.0.0.1 only. Any remote access (NetBird, external network) would fail silently. Changed to `http://0.0.0.0:5005`.

Issue #94 (session migration) is tracked separately — more complex, requires a startup migration service.