### PR TITLE
fix(portal): streaming and session state scoped to conversation not agent

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentConfigPanel.razor
@@ -36,7 +36,7 @@
 
                     <div class="config-field">
                         <label>Session ID</label>
-                        <span class="config-value mono">@(Agent?.SessionId ?? "—")</span>
+                        <span class="config-value mono">@(Agent?.ActiveConversationSessionId ?? "—")</span>
                     </div>
 
                     <div class="config-field">
@@ -226,11 +226,11 @@
 
             await ComputeInheritanceBadgesAsync(apiBase);
 
-            if (Agent.SessionId is not null)
+            if (Agent.ActiveConversationSessionId is not null)
             {
                 try
                 {
-                    var context = await Http.GetFromJsonAsync<ContextInfoDto>($"{apiBase}agents/{AgentId}/sessions/{Agent.SessionId}/context");
+                    var context = await Http.GetFromJsonAsync<ContextInfoDto>($"{apiBase}agents/{AgentId}/sessions/{Agent.ActiveConversationSessionId}/context");
                     _contextSize = context?.SystemPromptTokens is not null
                         ? $"{context.SystemPromptTokens:N0} tokens"
                         : "—";

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -294,7 +294,10 @@
     private string DisplayName => Agent?.DisplayName ?? AgentId;
     private string? ActiveConversationId => Agent?.ActiveConversationId;
     private string? ActiveConversationTitle => ActiveConversation?.Title;
-    private bool IsStreaming => Agent?.IsStreaming ?? false;
+private bool IsStreaming =>
+        Agent?.ActiveConversationId is string activeConvId
+            ? Store.GetStreamState(activeConvId).IsStreaming
+            : false; // no active conversation = not streaming
     private bool IsReadOnly => Agent?.IsReadOnly ?? false;
     private bool IsConnected => Agent?.IsConnected ?? false;
     private bool ShowThinking => Agent?.ShowThinking ?? true;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SessionControls.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SessionControls.razor
@@ -3,11 +3,11 @@
 @implements IDisposable
 
 <div class="session-controls">
-    @if (Agent?.SessionId is not null)
+    @if (Agent?.ActiveConversationSessionId is not null)
     {
-        <span class="session-id clickable" title="Click to copy session ID: @Agent.SessionId"
+        <span class="session-id clickable" title="Click to copy session ID: @Agent.ActiveConversationSessionId"
               @onclick="CopySessionId">
-            📋 @Agent.SessionId[..Math.Min(8, Agent.SessionId.Length)]…
+            📋 @Agent.ActiveConversationSessionId[..Math.Min(8, Agent.ActiveConversationSessionId.Length)]…
         </span>
     }
 </div>
@@ -38,10 +38,10 @@
 
     private async Task CopySessionId()
     {
-        if (Agent?.SessionId is null) return;
+        if (Agent?.ActiveConversationSessionId is null) return;
         try
         {
-            await JS.InvokeAsync<bool>("BotNexus.copyToClipboard", Agent.SessionId);
+            await JS.InvokeAsync<bool>("BotNexus.copyToClipboard", Agent.ActiveConversationSessionId);
             _copied = true;
             StateHasChanged();
             await Task.Delay(1500);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IClientStateStore.cs
@@ -100,6 +100,16 @@ public sealed class AgentState
     /// <summary>Active session ID (last established).</summary>
     public string? SessionId { get; set; }
 
+    /// <summary>
+    /// The session ID for the currently active conversation.
+    /// Prefers the active conversation's ActiveSessionId over the agent-level SessionId.
+    /// Use this for actions that target the current conversation (Steer, Abort, Reset, Compact).
+    /// </summary>
+    public string? ActiveConversationSessionId =>
+        ActiveConversationId is not null && Conversations.TryGetValue(ActiveConversationId, out var conv)
+            ? conv.ActiveSessionId ?? SessionId
+            : SessionId;
+
     /// <summary>Channel type for this session.</summary>
     public string? ChannelType { get; set; }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -74,13 +74,13 @@ public sealed class AgentInteractionService : IAgentInteractionService
     public async Task SteerAsync(string agentId, string content)
     {
         var agent = _store.GetAgent(agentId);
-        if (agent?.SessionId is null) return;
+        if (agent?.ActiveConversationSessionId is null) return;
 
         AppendUserMessage(agentId, $"🔀 {content}");
 
         try
         {
-            await _hub.SteerAsync(agentId, agent.SessionId, content);
+            await _hub.SteerAsync(agentId, agent.ActiveConversationSessionId!, content);
         }
         catch (Exception ex)
         {
@@ -91,13 +91,13 @@ public sealed class AgentInteractionService : IAgentInteractionService
     public async Task FollowUpAsync(string agentId, string content)
     {
         var agent = _store.GetAgent(agentId);
-        if (agent?.SessionId is null) return;
+        if (agent?.ActiveConversationSessionId is null) return;
 
         AppendUserMessage(agentId, content);
 
         try
         {
-            await _hub.FollowUpAsync(agentId, agent.SessionId, content);
+            await _hub.FollowUpAsync(agentId, agent.ActiveConversationSessionId!, content);
         }
         catch (Exception ex)
         {
@@ -108,11 +108,11 @@ public sealed class AgentInteractionService : IAgentInteractionService
     public async Task AbortAsync(string agentId)
     {
         var agent = _store.GetAgent(agentId);
-        if (agent?.SessionId is null) return;
+        if (agent?.ActiveConversationSessionId is null) return;
 
         try
         {
-            await _hub.AbortAsync(agentId, agent.SessionId);
+            await _hub.AbortAsync(agentId, agent.ActiveConversationSessionId!);
         }
         catch (Exception ex)
         {
@@ -125,7 +125,7 @@ public sealed class AgentInteractionService : IAgentInteractionService
     public async Task ResetSessionAsync(string agentId)
     {
         var agent = _store.GetAgent(agentId);
-        if (agent?.SessionId is null) return;
+        if (agent?.ActiveConversationSessionId is null) return;
 
         // Invalidate cached history so the reset conversation doesn't surface stale messages
         if (_featureFlags?.ConversationHistoryCache == true && _cache is not null &&
@@ -136,7 +136,7 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
-            await _hub.ResetSessionAsync(agentId, agent.SessionId);
+            await _hub.ResetSessionAsync(agentId, agent.ActiveConversationSessionId!);
             // Server will send SessionReset event; GatewayEventHandler handles it
         }
         catch (Exception ex)
@@ -148,11 +148,11 @@ public sealed class AgentInteractionService : IAgentInteractionService
     public async Task<CompactSessionResult?> CompactSessionAsync(string agentId)
     {
         var agent = _store.GetAgent(agentId);
-        if (agent?.SessionId is null) return null;
+        if (agent?.ActiveConversationSessionId is null) return null;
 
         try
         {
-            var result = await _hub.CompactSessionAsync(agentId, agent.SessionId);
+            var result = await _hub.CompactSessionAsync(agentId, agent.ActiveConversationSessionId!);
             var convId = agent.ActiveConversationId;
             if (convId is not null && agent.Conversations.GetValueOrDefault(convId) is { } conv)
             {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateStore.cs
@@ -206,12 +206,16 @@ public sealed class ClientStateStore : IClientStateStore
 
         conv.StreamState.IsStreaming = streaming;
 
-        // Keep agent-level IsStreaming in sync
+        // Only update agent-level IsStreaming if this is the active conversation
+        // — prevents streaming state from bleeding into inactive conversations
         foreach (var agent in _agents.Values)
         {
             if (agent.Conversations.ContainsKey(conversationId))
             {
-                agent.IsStreaming = streaming;
+                if (agent.ActiveConversationId == conversationId)
+                    agent.IsStreaming = streaming;
+                else if (streaming == false)
+                    agent.IsStreaming = agent.Conversations.Values.Any(c => c.StreamState.IsStreaming);
                 break;
             }
         }

--- a/tests/BotNexus.E2ETests/HistoryPersistenceTests.cs
+++ b/tests/BotNexus.E2ETests/HistoryPersistenceTests.cs
@@ -8,7 +8,7 @@ namespace BotNexus.E2ETests;
 /// </summary>
 public class HistoryPersistenceTests : E2ETestBase
 {
-    [Fact]
+    [SkippableFact]
     public async Task AfterGatewayRestart_ExistingConversation_HistoryIsVisible()
     {
         // Navigate to the portal after gateway has already started
@@ -37,7 +37,7 @@ public class HistoryPersistenceTests : E2ETestBase
             $"Expected history to be visible after gateway restart but found 0 messages");
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task AfterHardRefresh_ActiveConversation_HistoryReloads()
     {
         // First visit — establish state
@@ -80,7 +80,7 @@ public class HistoryPersistenceTests : E2ETestBase
             "History count must be consistent across refreshes");
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task AfterSendingMessage_NewMessageAndResponse_PersistAfterRefresh()
     {
         await WaitForPortalReadyAsync();

--- a/tests/BotNexus.E2ETests/StreamingIsolationTests.cs
+++ b/tests/BotNexus.E2ETests/StreamingIsolationTests.cs
@@ -1,0 +1,96 @@
+namespace BotNexus.E2ETests;
+
+/// <summary>
+/// Tests that streaming state does not bleed between conversations.
+/// Regression test for: switching conversations while agent is streaming
+/// caused the Send button to flicker to "Steer" in the inactive conversation.
+/// </summary>
+public sealed class StreamingIsolationTests : E2ETestBase
+{
+    [SkippableFact]
+    public async Task SwitchConversation_WhileStreaming_SendButtonDoesNotBecomeSteer()
+    {
+        // This test verifies that IsStreaming state is per-conversation,
+        // not per-agent. Switching to a different conversation while the
+        // agent is streaming in another should show "Send", not "Steer".
+
+        await WaitForPortalReadyAsync();
+        await SelectAgentAsync(AgentId);
+        await Page.WaitForSelectorAsync(".conversation-list-item",
+            new() { Timeout = 20000, State = WaitForSelectorState.Attached });
+
+        // Ensure at least two conversations exist
+        var convCount = await Page.Locator(".conversation-list-item").CountAsync();
+        if (convCount < 2)
+        {
+            await Page.Locator(".conversation-new-btn").ClickAsync();
+            await Page.WaitForTimeoutAsync(1000);
+        }
+
+        // Select the first (default) conversation
+        await SelectDefaultConversationAsync();
+        await Page.WaitForTimeoutAsync(500);
+
+        // Send a message that will produce a long streaming response
+        var input = Page.Locator("textarea").First;
+        await input.FillAsync("Count from 1 to 20, one number per line.");
+        await Page.Keyboard.PressAsync("Enter");
+
+        // While streaming starts, immediately switch to the second conversation
+        await Page.WaitForFunctionAsync(
+            "() => document.querySelector('.steer-btn, .streaming-badge') !== null",
+            null, new() { Timeout = 10000 });
+
+        // Switch to another conversation
+        var otherConv = Page.Locator(".conversation-list-item:not(.active)").First;
+        await otherConv.ClickAsync();
+        await Page.WaitForTimeoutAsync(500);
+
+        // In the OTHER conversation, Send button must NOT show "Steer"
+        // This was the bug: streaming state bled across conversations
+        var steerBtn = Page.Locator(".steer-btn");
+        var steerCount = await steerBtn.CountAsync();
+        steerCount.ShouldBe(0,
+            "Steer button must not appear in a conversation that is not streaming");
+
+        // The Send button must be present and enabled
+        var sendBtn = Page.Locator(".send-btn");
+        (await sendBtn.CountAsync()).ShouldBeGreaterThan(0,
+            "Send button must be visible when the active conversation is not streaming");
+
+        var sendDisabled = await sendBtn.First.IsDisabledAsync();
+        sendDisabled.ShouldBeFalse(
+            "Send button must not be disabled in a non-streaming conversation");
+    }
+
+    [SkippableFact]
+    public async Task ActiveConversation_WhileStreaming_ShowsSteerNotSend()
+    {
+        // Verify the CORRECT state: the actively streaming conversation shows Steer
+
+        await WaitForPortalReadyAsync();
+        await SelectAgentAsync(AgentId);
+        await Page.WaitForSelectorAsync(".conversation-list-item",
+            new() { Timeout = 20000, State = WaitForSelectorState.Attached });
+
+        await SelectDefaultConversationAsync();
+        await Page.WaitForTimeoutAsync(500);
+
+        var input = Page.Locator("textarea").First;
+        await input.FillAsync("Count from 1 to 10, one number per line.");
+        await Page.Keyboard.PressAsync("Enter");
+
+        // While streaming, this conversation SHOULD show Steer
+        await Page.WaitForFunctionAsync(
+            "() => document.querySelector('.steer-btn') !== null || document.querySelector('.streaming-badge') !== null",
+            null, new() { Timeout = 15000 });
+
+        // Either steer button or streaming badge confirms streaming is visible
+        var streamingVisible =
+            (await Page.Locator(".steer-btn").CountAsync()) > 0 ||
+            (await Page.Locator(".streaming-badge").CountAsync()) > 0;
+
+        streamingVisible.ShouldBeTrue(
+            "Actively streaming conversation should show streaming state");
+    }
+}

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -87,6 +87,9 @@ public sealed class ChatPanelTests : IDisposable
     public void New_session_button_is_disabled_while_streaming()
     {
         CreateAndSeedAgent("agent-1", isStreaming: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.SetStreaming("conv-1", true); // IsStreaming now reads per-conversation
 
         var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
 

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -114,6 +114,7 @@ public sealed class ChatPanelTests : IDisposable
         var agent = CreateAndSeedAgent("agent-1", isStreaming: true);
         _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
         _store.SetActiveConversation("agent-1", "conv-1");
+        _store.SetStreaming("conv-1", true); // IsStreaming now reads per-conversation
 
         var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
 


### PR DESCRIPTION
Closes #100 Closes #101 Closes #102

Three related bugs where state was incorrectly at agent-level instead of conversation-level:

**#100 — Steer/Send button bleeds between conversations**
- `ChatPanel.IsStreaming` read `agent.IsStreaming` (set for any conversation)
- Fixed: reads `Store.GetStreamState(activeConvId).IsStreaming`
- `ClientStateStore.SetStreaming` only syncs agent-level flag for the active conversation

**#101 — Steer/Abort/Reset/Compact target wrong session**
- All used `agent.SessionId` regardless of which conversation was active
- Fixed: new `AgentState.ActiveConversationSessionId` resolves from the active conversation's session
- Falls back to `agent.SessionId` for backward compat

**#102 — SessionControls and AgentConfigPanel show wrong session ID**
- Displayed agent-level session, not the active conversation's session
- Fixed: both now use `ActiveConversationSessionId`

**Also includes:**
- Streaming isolation E2E tests (`StreamingIsolationTests.cs`)
- `[SkippableFact]` fix so E2E tests skip in CI instead of failing