### PR TITLE
feat(telegram): add extension manifest so CLI deploys Telegram channel on build/update

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
@@ -3,6 +3,9 @@
     <RootNamespace>BotNexus.Extensions.Channels.Telegram</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="botnexus-extension.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/botnexus-extension.json
@@ -1,0 +1,10 @@
+{
+  "id": "botnexus-telegram",
+  "name": "Telegram Channel",
+  "description": "Telegram Bot API channel adapter — long polling, DMs and group topics",
+  "version": "1.0.0",
+  "entryAssembly": "BotNexus.Extensions.Channels.Telegram.dll",
+  "extensionTypes": [
+    "channel"
+  ]
+}


### PR DESCRIPTION
Without `botnexus-extension.json`, `ServeCommand.DeployExtensions` and `UpdateCommand` skip the Telegram extension entirely — it was never copied to `~/.botnexus/extensions/` during a build or update.

Adds the manifest and wires it into the csproj as `CopyToOutputDirectory=PreserveNewest` (same pattern as the SignalR extension).