### PR TITLE
feat(telegram): bind each Telegram bot to a configured agent

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 </Project>

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
@@ -2,20 +2,23 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace BotNexus.Extensions.Channels.Telegram;
 
+/// <summary>
+/// Thin HTTP client for the Telegram Bot API.
+/// One instance per bot token.
+/// </summary>
 public sealed class TelegramBotApiClient(
     HttpClient httpClient,
-    IOptions<TelegramOptions> optionsAccessor,
+    string botToken,
     ILogger<TelegramBotApiClient> logger)
 {
     private const int MaxRateLimitRetries = 3;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly HttpClient _httpClient = httpClient;
-    private readonly TelegramOptions _options = optionsAccessor.Value;
+    private readonly string _botToken = botToken;
     private readonly ILogger<TelegramBotApiClient> _logger = logger;
 
     public Task<TelegramMessage> SendMessageAsync(long chatId, string text, CancellationToken cancellationToken = default)
@@ -68,28 +71,21 @@ public sealed class TelegramBotApiClient(
     public Task SetWebhookAsync(string url, CancellationToken cancellationToken = default)
         => PostForResultAsync<bool>(
             "setWebhook",
-            new
-            {
-                url
-            },
+            new { url },
             cancellationToken);
 
     public Task DeleteWebhookAsync(CancellationToken cancellationToken = default)
         => PostForResultAsync<bool>(
             "deleteWebhook",
-            new
-            {
-                drop_pending_updates = false
-            },
+            new { drop_pending_updates = false },
             cancellationToken);
 
     private async Task<T> PostForResultAsync<T>(string methodName, object payload, CancellationToken cancellationToken)
     {
-        var token = _options.BotToken;
-        if (string.IsNullOrWhiteSpace(token))
+        if (string.IsNullOrWhiteSpace(_botToken))
             throw new InvalidOperationException("Telegram BotToken is required.");
 
-        var endpoint = $"https://api.telegram.org/bot{token}/{methodName}";
+        var endpoint = $"https://api.telegram.org/bot{_botToken}/{methodName}";
         for (var attempt = 0; attempt <= MaxRateLimitRetries; attempt++)
         {
             using var response = await _httpClient.PostAsJsonAsync(endpoint, payload, JsonOptions, cancellationToken);

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
@@ -7,34 +7,78 @@ namespace BotNexus.Extensions.Channels.Telegram;
 
 /// <summary>
 /// Thin HTTP client for the Telegram Bot API.
-/// One instance per bot token.
+/// One instance per bot token. Uses HTML parse_mode for outbound messages.
 /// </summary>
 public sealed class TelegramBotApiClient(
     HttpClient httpClient,
     string botToken,
-    ILogger<TelegramBotApiClient> logger)
+    ILogger logger)
 {
     private const int MaxRateLimitRetries = 3;
+
+    // Telegram only sends relevant update types — excludes noisy ones like inline_query.
+    private static readonly string[] AllowedUpdateTypes =
+    [
+        "message",
+        "edited_message",
+        "channel_post",
+        "edited_channel_post",
+        "message_reaction"
+    ];
+
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly HttpClient _httpClient = httpClient;
     private readonly string _botToken = botToken;
-    private readonly ILogger<TelegramBotApiClient> _logger = logger;
+    private readonly ILogger _logger = logger;
 
+    /// <summary>
+    /// Sends a text message to a chat, optionally into a forum topic thread.
+    /// HTML parse_mode is used. If Telegram rejects the HTML (400 Bad Request),
+    /// the message is retried as plain text without any parse_mode.
+    /// </summary>
+    /// <remarks>
+    /// General topic (threadId == 1) is a special case: Telegram rejects
+    /// <c>sendMessage</c> when <c>message_thread_id=1</c> is sent explicitly.
+    /// The field is omitted for threadId == 1.
+    /// </remarks>
     public Task<TelegramMessage> SendMessageAsync(long chatId, string text, CancellationToken cancellationToken = default)
         => SendMessageAsync(chatId, text, messageThreadId: null, cancellationToken);
 
     /// <summary>
     /// Sends a text message, optionally into a forum topic thread.
     /// </summary>
-    public Task<TelegramMessage> SendMessageAsync(long chatId, string text, int? messageThreadId, CancellationToken cancellationToken = default)
-        => PostForResultAsync<TelegramMessage>(
-            "sendMessage",
-            messageThreadId.HasValue
-                ? new { chat_id = chatId, text, parse_mode = "MarkdownV2", message_thread_id = messageThreadId.Value }
-                : (object)new { chat_id = chatId, text, parse_mode = "MarkdownV2" },
-            cancellationToken);
+    public async Task<TelegramMessage> SendMessageAsync(long chatId, string text, int? messageThreadId, CancellationToken cancellationToken = default)
+    {
+        // General topic (threadId == 1) must NOT include message_thread_id — Telegram rejects it.
+        // For other thread IDs, include message_thread_id as normal.
+        var isGeneralTopic = messageThreadId is 1;
+        var effectiveThreadId = isGeneralTopic ? null : messageThreadId;
 
+        // Try HTML first; fall back to plain text if Telegram rejects it (400).
+        try
+        {
+            var htmlPayload = effectiveThreadId.HasValue
+                ? (object)new { chat_id = chatId, text, parse_mode = "HTML", message_thread_id = effectiveThreadId.Value }
+                : new { chat_id = chatId, text, parse_mode = "HTML" };
+
+            return await PostForResultAsync<TelegramMessage>("sendMessage", htmlPayload, cancellationToken, allowHtmlFallback: true);
+        }
+        catch (TelegramHtmlParseException)
+        {
+            // HTML was rejected — retry as plain text
+            _logger.LogWarning("Telegram rejected HTML for sendMessage to chat {ChatId}; retrying as plain text", chatId);
+            var plainPayload = effectiveThreadId.HasValue
+                ? (object)new { chat_id = chatId, text, message_thread_id = effectiveThreadId.Value }
+                : new { chat_id = chatId, text };
+
+            return await PostForResultAsync<TelegramMessage>("sendMessage", plainPayload, cancellationToken, allowHtmlFallback: false);
+        }
+    }
+
+    /// <summary>
+    /// Edits an existing message's text. Uses HTML parse_mode.
+    /// </summary>
     public Task<TelegramMessage> EditMessageTextAsync(
         long chatId,
         int messageId,
@@ -42,15 +86,14 @@ public sealed class TelegramBotApiClient(
         CancellationToken cancellationToken = default)
         => PostForResultAsync<TelegramMessage>(
             "editMessageText",
-            new
-            {
-                chat_id = chatId,
-                message_id = messageId,
-                text,
-                parse_mode = "MarkdownV2"
-            },
-            cancellationToken);
+            new { chat_id = chatId, message_id = messageId, text, parse_mode = "HTML" },
+            cancellationToken,
+            allowHtmlFallback: false);
 
+    /// <summary>
+    /// Long-polls for new updates from the Telegram Bot API.
+    /// Specifies <c>allowed_updates</c> so Telegram only sends relevant update types.
+    /// </summary>
     public async Task<IReadOnlyList<TelegramUpdate>> GetUpdatesAsync(
         long? offset,
         int timeout,
@@ -61,26 +104,36 @@ public sealed class TelegramBotApiClient(
             new
             {
                 offset,
-                timeout
+                timeout,
+                allowed_updates = AllowedUpdateTypes
             },
-            cancellationToken);
+            cancellationToken,
+            allowHtmlFallback: false);
 
         return updates;
     }
 
+    /// <summary>
+    /// Registers a webhook URL with Telegram.
+    /// </summary>
     public Task SetWebhookAsync(string url, CancellationToken cancellationToken = default)
         => PostForResultAsync<bool>(
             "setWebhook",
             new { url },
-            cancellationToken);
+            cancellationToken,
+            allowHtmlFallback: false);
 
+    /// <summary>
+    /// Removes any previously registered webhook, reverting to long polling mode.
+    /// </summary>
     public Task DeleteWebhookAsync(CancellationToken cancellationToken = default)
         => PostForResultAsync<bool>(
             "deleteWebhook",
             new { drop_pending_updates = false },
-            cancellationToken);
+            cancellationToken,
+            allowHtmlFallback: false);
 
-    private async Task<T> PostForResultAsync<T>(string methodName, object payload, CancellationToken cancellationToken)
+    private async Task<T> PostForResultAsync<T>(string methodName, object payload, CancellationToken cancellationToken, bool allowHtmlFallback)
     {
         if (string.IsNullOrWhiteSpace(_botToken))
             throw new InvalidOperationException("Telegram BotToken is required.");
@@ -106,6 +159,10 @@ public sealed class TelegramBotApiClient(
                 await Task.Delay(TimeSpan.FromSeconds(retryAfter), cancellationToken);
                 continue;
             }
+
+            // 400 on sendMessage with HTML parse_mode means malformed HTML — signal fallback.
+            if (response.StatusCode == HttpStatusCode.BadRequest && allowHtmlFallback)
+                throw new TelegramHtmlParseException($"Telegram rejected HTML for {methodName}: {body}");
 
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException($"Telegram API call '{methodName}' failed ({(int)response.StatusCode}): {body}");
@@ -149,3 +206,9 @@ public sealed class TelegramBotApiClient(
         }
     }
 }
+
+/// <summary>
+/// Thrown internally when Telegram returns a 400 for an HTML-formatted message,
+/// signalling that <see cref="TelegramBotApiClient"/> should retry as plain text.
+/// </summary>
+internal sealed class TelegramHtmlParseException(string message) : Exception(message);

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
@@ -40,6 +40,13 @@ public sealed class TelegramBotConfig
 
     /// <summary>
     /// Gets or sets the maximum Telegram message length before payload splitting.
+    /// Conservative default (4000) stays safely below the 4096-byte Telegram limit.
     /// </summary>
-    public int MaxMessageLength { get; set; } = 4096;
+    public int MaxMessageLength { get; set; } = 4000;
+
+    /// <summary>
+    /// Gets or sets the minimum time in milliseconds between error replies to this bot's chats.
+    /// Prevents error spam to users during outages or repeated failures.
+    /// </summary>
+    public int ErrorCooldownMs { get; set; } = 60_000;
 }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
@@ -1,0 +1,45 @@
+namespace BotNexus.Extensions.Channels.Telegram;
+
+/// <summary>
+/// Per-bot configuration for a single Telegram bot token / agent binding.
+/// </summary>
+public sealed class TelegramBotConfig
+{
+    /// <summary>
+    /// Gets or sets the Telegram bot token used to authenticate Bot API calls.
+    /// </summary>
+    public string? BotToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the BotNexus agent ID this bot routes to.
+    /// Every message received by this bot will target this agent.
+    /// </summary>
+    public string? AgentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the webhook URL when running in webhook mode.
+    /// When null or empty, the adapter uses long polling.
+    /// </summary>
+    public string? WebhookUrl { get; set; }
+
+    /// <summary>
+    /// Gets the allow-list of Telegram chat IDs that can interact with this bot.
+    /// An empty list allows all chats.
+    /// </summary>
+    public ICollection<long> AllowedChatIds { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the long polling timeout in seconds.
+    /// </summary>
+    public int PollingTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Gets or sets the flush interval in milliseconds for buffered streaming deltas.
+    /// </summary>
+    public int StreamingBufferMs { get; set; } = 500;
+
+    /// <summary>
+    /// Gets or sets the maximum Telegram message length before payload splitting.
+    /// </summary>
+    public int MaxMessageLength { get; set; } = 4096;
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -291,6 +291,10 @@ public sealed class TelegramChannelAdapter(
             SenderId = senderId,
             ChannelAddress = chatIdText,
             Content = message.Text,
+            // One Telegram bot represents one BotNexus agent. When AgentId is configured,
+            // stamp it directly so inbound Telegram messages target that agent instead of
+            // falling back to the platform default agent.
+            TargetAgentId = string.IsNullOrWhiteSpace(_options.AgentId) ? null : _options.AgentId,
             // Propagate Telegram forum-topic thread id so the conversation router
             // can route topics into their own conversation bindings.
             ThreadId = message.MessageThreadId.HasValue

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -1,14 +1,14 @@
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Net.Http;
+using System.Text;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Channels;
-using Microsoft.Extensions.Logging.Abstractions;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Channels;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using System.Collections.Concurrent;
-using System.Globalization;
-using System.Text;
 
 namespace BotNexus.Extensions.Channels.Telegram;
 
@@ -26,21 +26,20 @@ public sealed class TelegramChannelAdapter(
     private readonly ILogger<TelegramChannelAdapter> _logger = logger;
     private readonly TelegramGatewayOptions _options = optionsAccessor.Value;
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
-
     private readonly ConcurrentDictionary<string, BotRuntime> _bots = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Gets the channel type identifier.
+    /// Telegram channel identifier used by BotNexus routing.
     /// </summary>
     public override ChannelKey ChannelType => ChannelKey.From("telegram");
 
     /// <summary>
-    /// Gets the human-readable channel display name.
+    /// Human-readable name shown in logs and diagnostics.
     /// </summary>
     public override string DisplayName => "Telegram Bot";
 
     /// <summary>
-    /// Gets a value indicating whether this channel supports streaming deltas.
+    /// Telegram supports message streaming via send + edit.
     /// </summary>
     public override bool SupportsStreaming => true;
 
@@ -113,6 +112,7 @@ public sealed class TelegramChannelAdapter(
 
             runtime.PollingCancellation?.Dispose();
             runtime.StreamingStates.Clear();
+            runtime.LastErrorReplyUtcByChat.Clear();
         }
 
         _bots.Clear();
@@ -121,6 +121,7 @@ public sealed class TelegramChannelAdapter(
 
     /// <summary>
     /// Sends a complete outbound message through the Telegram adapter.
+    /// Content is escaped for Telegram HTML parse mode.
     /// </summary>
     public override async Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
     {
@@ -141,33 +142,29 @@ public sealed class TelegramChannelAdapter(
         var formatted = BuildOutboundText(message.Content, message.Metadata, message.DisplayPrefix);
 
         int? threadId = null;
-        if (!string.IsNullOrEmpty(message.ThreadId) && int.TryParse(message.ThreadId, out var parsedThreadId))
+        if (!string.IsNullOrEmpty(message.ThreadId) && int.TryParse(message.ThreadId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedThreadId))
             threadId = parsedThreadId;
 
         foreach (var chunk in SplitMessage(formatted, Math.Max(1, runtime.Config.MaxMessageLength)))
             await runtime.ApiClient.SendMessageAsync(chatId, chunk, threadId, cancellationToken);
     }
 
-    public override async Task SendStreamDeltaAsync(
-        string conversationId,
-        string delta,
-        CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public override async Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         EnsureBotsInitialized();
-        if (string.IsNullOrEmpty(delta))
-            return;
-
-        if (!TryParseChatId(conversationId, out var chatId))
+        if (string.IsNullOrEmpty(delta) || !TryParseChatId(conversationId, out var chatId))
             return;
 
         var runtime = ResolveSingleConfiguredBot();
         EnsureChatAllowed(runtime.Config, chatId);
         var state = runtime.StreamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId));
+
         await state.Lock.WaitAsync(cancellationToken);
         try
         {
-            state.Buffer.Append(EscapeMarkdownV2(delta));
+            state.Buffer.Append(EscapeHtml(delta));
             state.PendingCharacterCount += delta.Length;
             if (ShouldFlush(state, runtime.Config))
                 await FlushStreamingStateAsync(runtime, state, force: false, cancellationToken);
@@ -178,10 +175,8 @@ public sealed class TelegramChannelAdapter(
         }
     }
 
-    public async Task SendStreamEventAsync(
-        string conversationId,
-        AgentStreamEvent streamEvent,
-        CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public async Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         EnsureBotsInitialized();
@@ -191,6 +186,7 @@ public sealed class TelegramChannelAdapter(
         var runtime = ResolveSingleConfiguredBot();
         EnsureChatAllowed(runtime.Config, chatId);
         var state = runtime.StreamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId));
+
         await state.Lock.WaitAsync(cancellationToken);
         try
         {
@@ -199,44 +195,53 @@ public sealed class TelegramChannelAdapter(
                 case AgentStreamEventType.MessageStart:
                     state.Reset();
                     break;
+
                 case AgentStreamEventType.ContentDelta when streamEvent.ContentDelta is not null:
-                    state.Buffer.Append(EscapeMarkdownV2(streamEvent.ContentDelta));
+                    state.Buffer.Append(EscapeHtml(streamEvent.ContentDelta));
                     state.PendingCharacterCount += streamEvent.ContentDelta.Length;
                     break;
+
                 case AgentStreamEventType.ThinkingDelta when streamEvent.ThinkingContent is not null:
-                    state.Buffer.AppendLine();
-                    state.Buffer.Append("_Thinking:_ ");
-                    state.Buffer.Append(EscapeMarkdownV2(streamEvent.ThinkingContent));
+                    AppendLineIfNeeded(state.Buffer);
+                    state.Buffer.Append("Thinking: ");
+                    state.Buffer.Append(EscapeHtml(streamEvent.ThinkingContent));
                     state.PendingCharacterCount += streamEvent.ThinkingContent.Length;
                     break;
+
                 case AgentStreamEventType.ToolStart:
                 {
                     var toolName = streamEvent.ToolName ?? "tool";
-                    state.Buffer.AppendLine();
-                    state.Buffer.Append('`');
-                    state.Buffer.Append(EscapeInlineCode(toolName));
-                    state.Buffer.Append("` started");
-                    state.PendingCharacterCount += toolName.Length + 8;
+                    AppendLineIfNeeded(state.Buffer);
+                    state.Buffer.Append("[");
+                    state.Buffer.Append(EscapeHtml(toolName));
+                    state.Buffer.Append("] started");
+                    state.PendingCharacterCount += toolName.Length + 10;
                     break;
                 }
+
                 case AgentStreamEventType.ToolEnd:
                 {
                     var status = streamEvent.ToolIsError == true ? "failed" : "completed";
                     var toolName = streamEvent.ToolName ?? streamEvent.ToolCallId ?? "tool";
-                    state.Buffer.AppendLine();
-                    state.Buffer.Append('`');
-                    state.Buffer.Append(EscapeInlineCode(toolName));
-                    state.Buffer.Append("` ");
+                    AppendLineIfNeeded(state.Buffer);
+                    state.Buffer.Append("[");
+                    state.Buffer.Append(EscapeHtml(toolName));
+                    state.Buffer.Append("] ");
                     state.Buffer.Append(status);
-                    state.PendingCharacterCount += toolName.Length + status.Length + 2;
+                    state.PendingCharacterCount += toolName.Length + status.Length + 3;
                     break;
                 }
+
                 case AgentStreamEventType.Error when streamEvent.ErrorMessage is not null:
-                    state.Buffer.AppendLine();
+                    if (!ShouldSendErrorReply(runtime, chatId))
+                        return;
+
+                    AppendLineIfNeeded(state.Buffer);
                     state.Buffer.Append("⚠️ ");
-                    state.Buffer.Append(EscapeMarkdownV2(streamEvent.ErrorMessage));
+                    state.Buffer.Append(EscapeHtml(streamEvent.ErrorMessage));
                     state.PendingCharacterCount += streamEvent.ErrorMessage.Length + 2;
                     break;
+
                 case AgentStreamEventType.MessageEnd:
                     await FlushStreamingStateAsync(runtime, state, force: true, cancellationToken);
                     state.Reset();
@@ -397,10 +402,10 @@ public sealed class TelegramChannelAdapter(
         {
             if (_bots.TryGetValue(botName, out var runtimeByName))
                 return runtimeByName;
+
             throw new InvalidOperationException($"Telegram bot '{botName}' is not configured.");
         }
 
-        // If exactly one bot exists, use it implicitly.
         if (_bots.Count == 1)
             return _bots.Values.Single();
 
@@ -429,39 +434,57 @@ public sealed class TelegramChannelAdapter(
 
         if (!string.IsNullOrWhiteSpace(displayPrefix))
         {
-            builder.Append(EscapeMarkdownV2(displayPrefix));
+            builder.Append(EscapeHtml(displayPrefix));
             builder.Append(' ');
         }
 
         if (TryGetMetadataString(metadata, "thinking", out var thinking))
         {
-            builder.Append("_Thinking:_ ");
-            builder.Append(EscapeMarkdownV2(thinking));
+            builder.Append("Thinking: ");
+            builder.Append(EscapeHtml(thinking));
             builder.AppendLine();
             builder.AppendLine();
         }
 
-        builder.Append(EscapeMarkdownV2(content));
+        builder.Append(EscapeHtml(content));
 
         if (TryGetMetadataString(metadata, "toolCall", out var toolCall))
         {
             builder.AppendLine();
-            builder.Append('`');
-            builder.Append(EscapeInlineCode(toolCall));
-            builder.Append('`');
+            builder.Append('[');
+            builder.Append(EscapeHtml(toolCall));
+            builder.Append(']');
         }
 
         return builder.ToString();
     }
 
-    private static bool TryGetMetadataString(
-        IReadOnlyDictionary<string, object?> metadata,
-        string key,
-        out string value)
+    private bool ShouldSendErrorReply(BotRuntime runtime, long chatId)
     {
-        if (metadata.TryGetValue(key, out var raw) &&
-            raw is not null &&
-            !string.IsNullOrWhiteSpace(raw.ToString()))
+        var now = DateTimeOffset.UtcNow;
+        var cooldown = TimeSpan.FromMilliseconds(Math.Max(1, runtime.Config.ErrorCooldownMs));
+
+        while (true)
+        {
+            if (!runtime.LastErrorReplyUtcByChat.TryGetValue(chatId, out var lastSent))
+            {
+                if (runtime.LastErrorReplyUtcByChat.TryAdd(chatId, now))
+                    return true;
+
+                continue;
+            }
+
+            if (now - lastSent < cooldown)
+                return false;
+
+            if (runtime.LastErrorReplyUtcByChat.TryUpdate(chatId, now, lastSent))
+                return true;
+        }
+    }
+
+    private static bool TryGetMetadataString(IReadOnlyDictionary<string, object?> metadata, string key, out string value)
+    {
+        if (metadata.TryGetValue(key, out var raw) && raw is not null && !string.IsNullOrWhiteSpace(raw.ToString()))
         {
             value = raw.ToString()!;
             return true;
@@ -486,28 +509,21 @@ public sealed class TelegramChannelAdapter(
         }
     }
 
-    private static string EscapeInlineCode(string value)
-        => value.Replace(@"\", @"\\", StringComparison.Ordinal)
-            .Replace("`", "\\`", StringComparison.Ordinal);
+    private static void AppendLineIfNeeded(StringBuilder builder)
+    {
+        if (builder.Length > 0)
+            builder.AppendLine();
+    }
 
-    private static string EscapeMarkdownV2(string value)
+    private static string EscapeHtml(string value)
     {
         if (string.IsNullOrEmpty(value))
             return string.Empty;
 
-        var builder = new StringBuilder(value.Length + 16);
-        foreach (var ch in value)
-        {
-            if (ch is '_' or '*' or '[' or ']' or '(' or ')' or '~' or '`' or '>' or '#'
-                or '+' or '-' or '=' or '|' or '{' or '}' or '.' or '!' or '\\')
-            {
-                builder.Append('\\');
-            }
-
-            builder.Append(ch);
-        }
-
-        return builder.ToString();
+        return value
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
     }
 
     private sealed class BotRuntime(string botName, TelegramBotConfig config, TelegramBotApiClient apiClient)
@@ -516,6 +532,7 @@ public sealed class TelegramChannelAdapter(
         public TelegramBotConfig Config { get; } = config;
         public TelegramBotApiClient ApiClient { get; } = apiClient;
         public ConcurrentDictionary<string, StreamingState> StreamingStates { get; } = new(StringComparer.Ordinal);
+        public ConcurrentDictionary<long, DateTimeOffset> LastErrorReplyUtcByChat { get; } = new();
         public CancellationTokenSource? PollingCancellation { get; set; }
         public Task? PollingTask { get; set; }
     }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -1,7 +1,9 @@
-using BotNexus.Gateway.Channels;
-using BotNexus.Gateway.Abstractions.Channels;
-using BotNexus.Gateway.Abstractions.Models;
+using System.Net.Http;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
@@ -12,20 +14,20 @@ namespace BotNexus.Extensions.Channels.Telegram;
 
 /// <summary>
 /// Telegram Bot channel adapter.
+/// Supports one or more configured bot tokens; each bot represents one BotNexus agent.
 /// </summary>
 public sealed class TelegramChannelAdapter(
     ILogger<TelegramChannelAdapter> logger,
-    IOptions<TelegramOptions> optionsAccessor,
-    TelegramBotApiClient apiClient) : ChannelAdapterBase(logger), IStreamEventChannelAdapter
+    IOptions<TelegramGatewayOptions> optionsAccessor,
+    IHttpClientFactory httpClientFactory) : ChannelAdapterBase(logger), IStreamEventChannelAdapter
 {
     private const int StreamingFlushThresholdChars = 100;
 
     private readonly ILogger<TelegramChannelAdapter> _logger = logger;
-    private readonly TelegramOptions _options = optionsAccessor.Value;
-    private readonly TelegramBotApiClient _apiClient = apiClient;
-    private readonly ConcurrentDictionary<string, StreamingState> _streamingStates = new(StringComparer.Ordinal);
-    private CancellationTokenSource? _pollingCancellation;
-    private Task? _pollingTask;
+    private readonly TelegramGatewayOptions _options = optionsAccessor.Value;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+
+    private readonly ConcurrentDictionary<string, BotRuntime> _bots = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Gets the channel type identifier.
@@ -57,64 +59,73 @@ public sealed class TelegramChannelAdapter(
     /// <inheritdoc />
     protected override async Task OnStartAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(_options.BotToken))
-            throw new InvalidOperationException("Telegram channel requires BotToken.");
+        EnsureBotsInitialized();
 
-        if (!string.IsNullOrWhiteSpace(_options.WebhookUrl))
+        foreach (var runtime in _bots.Values)
         {
-            await _apiClient.SetWebhookAsync(_options.WebhookUrl, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(runtime.Config.WebhookUrl))
+            {
+                await runtime.ApiClient.SetWebhookAsync(runtime.Config.WebhookUrl, cancellationToken);
+                _logger.LogInformation(
+                    "{DisplayName} bot '{BotName}' configured webhook mode at {WebhookUrl}",
+                    DisplayName,
+                    runtime.BotName,
+                    runtime.Config.WebhookUrl);
+                continue;
+            }
+
+            await runtime.ApiClient.DeleteWebhookAsync(cancellationToken);
+
+            runtime.PollingCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            runtime.PollingTask = Task.Run(
+                () => RunPollingLoopAsync(runtime, Math.Max(1, runtime.Config.PollingTimeoutSeconds), runtime.PollingCancellation.Token),
+                CancellationToken.None);
+
             _logger.LogInformation(
-                "{DisplayName} configured webhook mode at {WebhookUrl}",
+                "{DisplayName} bot '{BotName}' polling mode started (AgentId: {AgentId}, AllowedChatCount: {AllowedChatCount}, PollingTimeoutSeconds: {PollingTimeoutSeconds})",
                 DisplayName,
-                _options.WebhookUrl);
-            return;
+                runtime.BotName,
+                runtime.Config.AgentId ?? "<default-router>",
+                runtime.Config.AllowedChatIds.Count,
+                Math.Max(1, runtime.Config.PollingTimeoutSeconds));
         }
-
-        await _apiClient.DeleteWebhookAsync(cancellationToken);
-
-        _pollingCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _pollingTask = Task.Run(
-            () => RunPollingLoopAsync(Math.Max(1, _options.PollingTimeoutSeconds), _pollingCancellation.Token),
-            CancellationToken.None);
-        _logger.LogInformation(
-            "{DisplayName} polling mode started (AllowedChatCount: {AllowedChatCount}, PollingTimeoutSeconds: {PollingTimeoutSeconds})",
-            DisplayName,
-            _options.AllowedChatIds.Count,
-            Math.Max(1, _options.PollingTimeoutSeconds));
     }
 
     /// <inheritdoc />
     protected override async Task OnStopAsync(CancellationToken cancellationToken)
     {
-        _pollingCancellation?.Cancel();
-        if (_pollingTask is not null)
+        foreach (var runtime in _bots.Values)
+            runtime.PollingCancellation?.Cancel();
+
+        foreach (var runtime in _bots.Values)
         {
-            try
+            if (runtime.PollingTask is not null)
             {
-                await _pollingTask;
+                try
+                {
+                    await runtime.PollingTask;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected during shutdown.
+                }
             }
-            catch (OperationCanceledException)
-            {
-                // Expected during shutdown.
-            }
+
+            runtime.PollingCancellation?.Dispose();
+            runtime.StreamingStates.Clear();
         }
 
-        _pollingCancellation?.Dispose();
-        _pollingCancellation = null;
-        _pollingTask = null;
-        _streamingStates.Clear();
+        _bots.Clear();
         _logger.LogInformation("{DisplayName} channel adapter stopped", DisplayName);
     }
 
     /// <summary>
-    /// Sends a complete outbound message through the Telegram adapter stub.
+    /// Sends a complete outbound message through the Telegram adapter.
     /// </summary>
-    /// <param name="message">Outbound message payload.</param>
-    /// <param name="cancellationToken">Cancellation token for send operations.</param>
-    /// <returns>A task that completes when all Telegram message chunks have been sent.</returns>
     public override async Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        EnsureBotsInitialized();
 
         if (!TryParseChatId(message.ChannelAddress, out var chatId))
         {
@@ -125,15 +136,16 @@ public sealed class TelegramChannelAdapter(
             return;
         }
 
-        EnsureChatAllowed(chatId);
-        var formatted = BuildOutboundText(message.Content, message.Metadata);
-        // Parse thread id from the outbound message so we can deliver into the correct forum topic.
+        var runtime = ResolveOutboundBot(message);
+        EnsureChatAllowed(runtime.Config, chatId);
+        var formatted = BuildOutboundText(message.Content, message.Metadata, message.DisplayPrefix);
+
         int? threadId = null;
         if (!string.IsNullOrEmpty(message.ThreadId) && int.TryParse(message.ThreadId, out var parsedThreadId))
             threadId = parsedThreadId;
 
-        foreach (var chunk in SplitMessage(formatted, Math.Max(1, _options.MaxMessageLength)))
-            await _apiClient.SendMessageAsync(chatId, chunk, threadId, cancellationToken);
+        foreach (var chunk in SplitMessage(formatted, Math.Max(1, runtime.Config.MaxMessageLength)))
+            await runtime.ApiClient.SendMessageAsync(chatId, chunk, threadId, cancellationToken);
     }
 
     public override async Task SendStreamDeltaAsync(
@@ -142,21 +154,23 @@ public sealed class TelegramChannelAdapter(
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        EnsureBotsInitialized();
         if (string.IsNullOrEmpty(delta))
             return;
 
         if (!TryParseChatId(conversationId, out var chatId))
             return;
 
-        EnsureChatAllowed(chatId);
-        var state = _streamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId));
+        var runtime = ResolveSingleConfiguredBot();
+        EnsureChatAllowed(runtime.Config, chatId);
+        var state = runtime.StreamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId));
         await state.Lock.WaitAsync(cancellationToken);
         try
         {
             state.Buffer.Append(EscapeMarkdownV2(delta));
             state.PendingCharacterCount += delta.Length;
-            if (ShouldFlush(state))
-                await FlushStreamingStateAsync(state, force: false, cancellationToken);
+            if (ShouldFlush(state, runtime.Config))
+                await FlushStreamingStateAsync(runtime, state, force: false, cancellationToken);
         }
         finally
         {
@@ -170,11 +184,13 @@ public sealed class TelegramChannelAdapter(
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        EnsureBotsInitialized();
         if (!TryParseChatId(conversationId, out var chatId))
             return;
 
-        EnsureChatAllowed(chatId);
-        var state = _streamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId));
+        var runtime = ResolveSingleConfiguredBot();
+        EnsureChatAllowed(runtime.Config, chatId);
+        var state = runtime.StreamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId));
         await state.Lock.WaitAsync(cancellationToken);
         try
         {
@@ -222,13 +238,13 @@ public sealed class TelegramChannelAdapter(
                     state.PendingCharacterCount += streamEvent.ErrorMessage.Length + 2;
                     break;
                 case AgentStreamEventType.MessageEnd:
-                    await FlushStreamingStateAsync(state, force: true, cancellationToken);
+                    await FlushStreamingStateAsync(runtime, state, force: true, cancellationToken);
                     state.Reset();
                     return;
             }
 
-            if (ShouldFlush(state))
-                await FlushStreamingStateAsync(state, force: false, cancellationToken);
+            if (ShouldFlush(state, runtime.Config))
+                await FlushStreamingStateAsync(runtime, state, force: false, cancellationToken);
         }
         finally
         {
@@ -236,18 +252,18 @@ public sealed class TelegramChannelAdapter(
         }
     }
 
-    private async Task RunPollingLoopAsync(int pollingTimeoutSeconds, CancellationToken cancellationToken)
+    private async Task RunPollingLoopAsync(BotRuntime runtime, int pollingTimeoutSeconds, CancellationToken cancellationToken)
     {
         long? offset = null;
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                var updates = await _apiClient.GetUpdatesAsync(offset, pollingTimeoutSeconds, cancellationToken);
+                var updates = await runtime.ApiClient.GetUpdatesAsync(offset, pollingTimeoutSeconds, cancellationToken);
                 foreach (var update in updates.OrderBy(u => u.UpdateId))
                 {
                     offset = update.UpdateId + 1;
-                    await HandleUpdateAsync(update, cancellationToken);
+                    await HandleUpdateAsync(runtime, update, cancellationToken);
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -256,7 +272,7 @@ public sealed class TelegramChannelAdapter(
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{DisplayName} polling loop error", DisplayName);
+                _logger.LogError(ex, "{DisplayName} bot '{BotName}' polling loop error", DisplayName, runtime.BotName);
                 try
                 {
                     await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
@@ -269,16 +285,16 @@ public sealed class TelegramChannelAdapter(
         }
     }
 
-    private async Task HandleUpdateAsync(TelegramUpdate update, CancellationToken cancellationToken)
+    private async Task HandleUpdateAsync(BotRuntime runtime, TelegramUpdate update, CancellationToken cancellationToken)
     {
         var message = update.Message ?? update.EditedMessage ?? update.ChannelPost;
         if (message?.Chat is null || string.IsNullOrWhiteSpace(message.Text))
             return;
 
         var chatId = message.Chat.Id;
-        if (!IsChatAllowed(chatId))
+        if (!IsChatAllowed(runtime.Config, chatId))
         {
-            _logger.LogDebug("{DisplayName} ignored message from unauthorized chat {ChatId}", DisplayName, chatId);
+            _logger.LogDebug("{DisplayName} bot '{BotName}' ignored message from unauthorized chat {ChatId}", DisplayName, runtime.BotName, chatId);
             return;
         }
 
@@ -291,17 +307,13 @@ public sealed class TelegramChannelAdapter(
             SenderId = senderId,
             ChannelAddress = chatIdText,
             Content = message.Text,
-            // One Telegram bot represents one BotNexus agent. When AgentId is configured,
-            // stamp it directly so inbound Telegram messages target that agent instead of
-            // falling back to the platform default agent.
-            TargetAgentId = string.IsNullOrWhiteSpace(_options.AgentId) ? null : _options.AgentId,
-            // Propagate Telegram forum-topic thread id so the conversation router
-            // can route topics into their own conversation bindings.
+            TargetAgentId = string.IsNullOrWhiteSpace(runtime.Config.AgentId) ? null : runtime.Config.AgentId,
             ThreadId = message.MessageThreadId.HasValue
                 ? message.MessageThreadId.Value.ToString(CultureInfo.InvariantCulture)
                 : null,
             Metadata = new Dictionary<string, object?>
             {
+                ["telegramBotName"] = runtime.BotName,
                 ["telegramUpdateId"] = update.UpdateId,
                 ["telegramMessageId"] = message.MessageId,
                 ["telegramChatId"] = chatId
@@ -309,64 +321,118 @@ public sealed class TelegramChannelAdapter(
         }, cancellationToken);
     }
 
-    private async Task FlushStreamingStateAsync(StreamingState state, bool force, CancellationToken cancellationToken)
+    private async Task FlushStreamingStateAsync(BotRuntime runtime, StreamingState state, bool force, CancellationToken cancellationToken)
     {
         if (state.Buffer.Length == 0)
             return;
 
-        var maxLength = Math.Max(1, _options.MaxMessageLength);
+        var maxLength = Math.Max(1, runtime.Config.MaxMessageLength);
         while (state.Buffer.Length > maxLength)
         {
             var chunk = state.Buffer.ToString(0, maxLength);
-            await SendOrEditStreamingMessageAsync(state, chunk, cancellationToken);
+            await SendOrEditStreamingMessageAsync(runtime, state, chunk, cancellationToken);
             state.MessageId = null;
             state.Buffer.Remove(0, maxLength);
         }
 
-        if (!force && !ShouldFlush(state))
+        if (!force && !ShouldFlush(state, runtime.Config))
             return;
 
         var text = state.Buffer.ToString();
         if (string.IsNullOrEmpty(text))
             return;
 
-        await SendOrEditStreamingMessageAsync(state, text, cancellationToken);
+        await SendOrEditStreamingMessageAsync(runtime, state, text, cancellationToken);
         state.LastFlushUtc = DateTimeOffset.UtcNow;
         state.PendingCharacterCount = 0;
     }
 
-    private async Task SendOrEditStreamingMessageAsync(StreamingState state, string text, CancellationToken cancellationToken)
+    private async Task SendOrEditStreamingMessageAsync(BotRuntime runtime, StreamingState state, string text, CancellationToken cancellationToken)
     {
         if (state.MessageId is null)
         {
-            var sent = await _apiClient.SendMessageAsync(state.ChatId, text, cancellationToken);
+            var sent = await runtime.ApiClient.SendMessageAsync(state.ChatId, text, cancellationToken);
             state.MessageId = sent.MessageId;
             return;
         }
 
-        var edited = await _apiClient.EditMessageTextAsync(state.ChatId, state.MessageId.Value, text, cancellationToken);
+        var edited = await runtime.ApiClient.EditMessageTextAsync(state.ChatId, state.MessageId.Value, text, cancellationToken);
         state.MessageId = edited.MessageId;
+    }
+
+    private void EnsureBotsInitialized()
+    {
+        if (_bots.Count > 0)
+            return;
+
+        var configs = _options.ResolveActiveBots();
+        if (configs.Count == 0)
+            throw new InvalidOperationException("Telegram channel requires at least one configured bot.");
+
+        foreach (var (botName, config) in configs)
+        {
+            if (string.IsNullOrWhiteSpace(config.BotToken))
+                throw new InvalidOperationException($"Telegram bot '{botName}' requires BotToken.");
+
+            var client = new TelegramBotApiClient(
+                _httpClientFactory.CreateClient(botName),
+                config.BotToken,
+                NullLogger<TelegramBotApiClient>.Instance);
+
+            _bots.TryAdd(botName, new BotRuntime(botName, config, client));
+        }
+    }
+
+    private BotRuntime ResolveSingleConfiguredBot()
+    {
+        if (_bots.Count == 1)
+            return _bots.Values.Single();
+
+        throw new InvalidOperationException("Streaming over Telegram requires a single configured bot or explicit bot routing metadata.");
+    }
+
+    private BotRuntime ResolveOutboundBot(OutboundMessage message)
+    {
+        if (message.Metadata.TryGetValue("telegramBotName", out var raw) && raw?.ToString() is { Length: > 0 } botName)
+        {
+            if (_bots.TryGetValue(botName, out var runtimeByName))
+                return runtimeByName;
+            throw new InvalidOperationException($"Telegram bot '{botName}' is not configured.");
+        }
+
+        // If exactly one bot exists, use it implicitly.
+        if (_bots.Count == 1)
+            return _bots.Values.Single();
+
+        throw new InvalidOperationException("Multiple Telegram bots are configured. Outbound Telegram messages must specify metadata['telegramBotName'].");
     }
 
     private static bool TryParseChatId(string conversationId, out long chatId)
         => long.TryParse(conversationId, NumberStyles.Integer, CultureInfo.InvariantCulture, out chatId);
 
-    private bool IsChatAllowed(long chatId)
-        => _options.AllowedChatIds.Count == 0 || _options.AllowedChatIds.Contains(chatId);
+    private static bool IsChatAllowed(TelegramBotConfig config, long chatId)
+        => config.AllowedChatIds.Count == 0 || config.AllowedChatIds.Contains(chatId);
 
-    private void EnsureChatAllowed(long chatId)
+    private static void EnsureChatAllowed(TelegramBotConfig config, long chatId)
     {
-        if (!IsChatAllowed(chatId))
-            throw new InvalidOperationException($"Telegram chat '{chatId}' is not allowed for this adapter.");
+        if (!IsChatAllowed(config, chatId))
+            throw new InvalidOperationException($"Telegram chat '{chatId}' is not allowed for this bot.");
     }
 
-    private bool ShouldFlush(StreamingState state)
+    private static bool ShouldFlush(StreamingState state, TelegramBotConfig config)
         => state.PendingCharacterCount >= StreamingFlushThresholdChars ||
-           DateTimeOffset.UtcNow - state.LastFlushUtc >= TimeSpan.FromMilliseconds(Math.Max(1, _options.StreamingBufferMs));
+           DateTimeOffset.UtcNow - state.LastFlushUtc >= TimeSpan.FromMilliseconds(Math.Max(1, config.StreamingBufferMs));
 
-    private static string BuildOutboundText(string content, IReadOnlyDictionary<string, object?> metadata)
+    private static string BuildOutboundText(string content, IReadOnlyDictionary<string, object?> metadata, string? displayPrefix)
     {
         var builder = new StringBuilder();
+
+        if (!string.IsNullOrWhiteSpace(displayPrefix))
+        {
+            builder.Append(EscapeMarkdownV2(displayPrefix));
+            builder.Append(' ');
+        }
+
         if (TryGetMetadataString(metadata, "thinking", out var thinking))
         {
             builder.Append("_Thinking:_ ");
@@ -442,6 +508,16 @@ public sealed class TelegramChannelAdapter(
         }
 
         return builder.ToString();
+    }
+
+    private sealed class BotRuntime(string botName, TelegramBotConfig config, TelegramBotApiClient apiClient)
+    {
+        public string BotName { get; } = botName;
+        public TelegramBotConfig Config { get; } = config;
+        public TelegramBotApiClient ApiClient { get; } = apiClient;
+        public ConcurrentDictionary<string, StreamingState> StreamingStates { get; } = new(StringComparer.Ordinal);
+        public CancellationTokenSource? PollingCancellation { get; set; }
+        public Task? PollingTask { get; set; }
     }
 
     private sealed class StreamingState(long chatId)

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramGatewayOptions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramGatewayOptions.cs
@@ -2,7 +2,7 @@ namespace BotNexus.Extensions.Channels.Telegram;
 
 /// <summary>
 /// Top-level gateway configuration for the Telegram channel extension.
-/// Supports both single-bot (legacy) and multi-bot configurations.
+/// Supports both single-bot (convenience) and multi-bot configurations.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -10,54 +10,56 @@ namespace BotNexus.Extensions.Channels.Telegram;
 /// Telegram bot token. Each entry maps a named bot to a BotNexus agent.
 /// </para>
 /// <para>
-/// <b>Single-bot (legacy):</b> set <see cref="BotToken"/> and optionally
+/// <b>Single-bot (convenience):</b> set <see cref="BotToken"/> and optionally
 /// <see cref="AgentId"/> at the top level. When <see cref="Bots"/> is empty and
 /// <see cref="BotToken"/> is set, the adapter synthesises a single bot entry named
 /// <c>default</c> from the top-level fields.
 /// </para>
 /// </remarks>
-public class TelegramGatewayOptions
+public sealed class TelegramGatewayOptions
 {
-    // ── Legacy single-bot fields ──────────────────────────────────────────────
+    // ── Single-bot convenience fields ─────────────────────────────────────────
 
     /// <summary>
-    /// Legacy: bot token for a single-bot deployment.
+    /// Bot token for a single-bot deployment.
     /// Ignored when <see cref="Bots"/> is non-empty.
     /// </summary>
     public string? BotToken { get; set; }
 
     /// <summary>
-    /// Legacy: agent ID for a single-bot deployment.
+    /// Agent ID for a single-bot deployment.
     /// Ignored when <see cref="Bots"/> is non-empty.
     /// </summary>
     public string? AgentId { get; set; }
 
     /// <summary>
-    /// Legacy: webhook URL for a single-bot deployment.
+    /// Webhook URL for a single-bot deployment.
     /// Ignored when <see cref="Bots"/> is non-empty.
     /// </summary>
     public string? WebhookUrl { get; set; }
 
     /// <summary>
-    /// Legacy: allow-list of chat IDs for a single-bot deployment.
+    /// Allow-list of chat IDs for a single-bot deployment.
     /// Ignored when <see cref="Bots"/> is non-empty.
+    /// An empty list allows all chats.
     /// </summary>
     public ICollection<long> AllowedChatIds { get; } = [];
 
     /// <summary>
-    /// Legacy: polling timeout in seconds for a single-bot deployment.
+    /// Long polling timeout in seconds. Clamped to a minimum of 1.
     /// </summary>
     public int PollingTimeoutSeconds { get; set; } = 30;
 
     /// <summary>
-    /// Legacy: streaming buffer flush interval in milliseconds.
+    /// Flush interval in milliseconds for buffered streaming deltas.
     /// </summary>
     public int StreamingBufferMs { get; set; } = 500;
 
     /// <summary>
-    /// Legacy: maximum Telegram message length before splitting.
+    /// Maximum Telegram message length before payload splitting.
+    /// Conservative default (4000) stays safely below the 4096-byte Telegram limit.
     /// </summary>
-    public int MaxMessageLength { get; set; } = 4096;
+    public int MaxMessageLength { get; set; } = 4000;
 
     // ── Multi-bot configuration ───────────────────────────────────────────────
 
@@ -66,44 +68,47 @@ public class TelegramGatewayOptions
     /// logging and HTTP client naming; each value holds the token and agent
     /// binding for that bot.
     /// When this dictionary is non-empty it takes precedence over the
-    /// legacy top-level fields.
+    /// single-bot convenience fields above.
     /// </summary>
     public Dictionary<string, TelegramBotConfig> Bots { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    // ── Error reply controls ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Minimum time in milliseconds between error replies to the same chat.
+    /// Prevents error spam to users during outages or repeated failures.
+    /// </summary>
+    public int ErrorCooldownMs { get; set; } = 60_000;
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /// <summary>
     /// Returns the effective list of bot configurations to activate.
     /// Uses <see cref="Bots"/> when populated; otherwise synthesises a single
-    /// <c>default</c> entry from the legacy top-level fields.
+    /// <c>default</c> entry from the single-bot convenience fields.
     /// </summary>
     internal IReadOnlyDictionary<string, TelegramBotConfig> ResolveActiveBots()
     {
         if (Bots.Count > 0)
             return Bots;
 
-        // Legacy fallback — synthesise a single "default" bot
-        var legacy = new TelegramBotConfig
+        // Single-bot fallback — synthesise a "default" bot entry
+        var single = new TelegramBotConfig
         {
             BotToken = BotToken,
             AgentId = AgentId,
             WebhookUrl = WebhookUrl,
             PollingTimeoutSeconds = PollingTimeoutSeconds,
             StreamingBufferMs = StreamingBufferMs,
-            MaxMessageLength = MaxMessageLength
+            MaxMessageLength = MaxMessageLength,
+            ErrorCooldownMs = ErrorCooldownMs
         };
         foreach (var id in AllowedChatIds)
-            legacy.AllowedChatIds.Add(id);
+            single.AllowedChatIds.Add(id);
 
         return new Dictionary<string, TelegramBotConfig>(StringComparer.OrdinalIgnoreCase)
         {
-            ["default"] = legacy
+            ["default"] = single
         };
     }
 }
-
-/// <summary>
-/// Alias kept for backward compatibility with existing code and tests that
-/// reference <see cref="TelegramOptions"/>.
-/// </summary>
-public sealed class TelegramOptions : TelegramGatewayOptions { }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramOptions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramOptions.cs
@@ -21,6 +21,13 @@ public sealed class TelegramOptions
     public string? WebhookUrl { get; set; }
 
     /// <summary>
+    /// Gets or sets the default BotNexus agent ID for this Telegram bot.
+    /// When set, every inbound Telegram message targets this agent directly,
+    /// which makes one bot token map to one BotNexus agent.
+    /// </summary>
+    public string? AgentId { get; set; }
+
+    /// <summary>
     /// Gets the allow-list of Telegram chat IDs that can interact with this bot.
     /// </summary>
     public ICollection<long> AllowedChatIds { get; } = [];

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramOptions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramOptions.cs
@@ -1,49 +1,109 @@
 namespace BotNexus.Extensions.Channels.Telegram;
 
 /// <summary>
-/// Configuration options for the Telegram channel adapter.
+/// Top-level gateway configuration for the Telegram channel extension.
+/// Supports both single-bot (legacy) and multi-bot configurations.
 /// </summary>
 /// <remarks>
-/// Phase 2 stub options used for DI wiring and host configuration validation.
-/// A full adapter would consume these values when creating Bot API clients and
-/// filtering inbound updates.
+/// <para>
+/// <b>Multi-bot (recommended):</b> populate <see cref="Bots"/> with one entry per
+/// Telegram bot token. Each entry maps a named bot to a BotNexus agent.
+/// </para>
+/// <para>
+/// <b>Single-bot (legacy):</b> set <see cref="BotToken"/> and optionally
+/// <see cref="AgentId"/> at the top level. When <see cref="Bots"/> is empty and
+/// <see cref="BotToken"/> is set, the adapter synthesises a single bot entry named
+/// <c>default</c> from the top-level fields.
+/// </para>
 /// </remarks>
-public sealed class TelegramOptions
+public class TelegramGatewayOptions
 {
+    // ── Legacy single-bot fields ──────────────────────────────────────────────
+
     /// <summary>
-    /// Gets or sets the Telegram bot token used to authenticate Bot API calls.
+    /// Legacy: bot token for a single-bot deployment.
+    /// Ignored when <see cref="Bots"/> is non-empty.
     /// </summary>
     public string? BotToken { get; set; }
 
     /// <summary>
-    /// Gets or sets the webhook URL when running in webhook mode.
-    /// </summary>
-    public string? WebhookUrl { get; set; }
-
-    /// <summary>
-    /// Gets or sets the default BotNexus agent ID for this Telegram bot.
-    /// When set, every inbound Telegram message targets this agent directly,
-    /// which makes one bot token map to one BotNexus agent.
+    /// Legacy: agent ID for a single-bot deployment.
+    /// Ignored when <see cref="Bots"/> is non-empty.
     /// </summary>
     public string? AgentId { get; set; }
 
     /// <summary>
-    /// Gets the allow-list of Telegram chat IDs that can interact with this bot.
+    /// Legacy: webhook URL for a single-bot deployment.
+    /// Ignored when <see cref="Bots"/> is non-empty.
+    /// </summary>
+    public string? WebhookUrl { get; set; }
+
+    /// <summary>
+    /// Legacy: allow-list of chat IDs for a single-bot deployment.
+    /// Ignored when <see cref="Bots"/> is non-empty.
     /// </summary>
     public ICollection<long> AllowedChatIds { get; } = [];
 
     /// <summary>
-    /// Gets or sets the long polling timeout, in seconds, for <c>getUpdates</c>.
+    /// Legacy: polling timeout in seconds for a single-bot deployment.
     /// </summary>
     public int PollingTimeoutSeconds { get; set; } = 30;
 
     /// <summary>
-    /// Gets or sets the flush interval, in milliseconds, for buffered streaming deltas.
+    /// Legacy: streaming buffer flush interval in milliseconds.
     /// </summary>
     public int StreamingBufferMs { get; set; } = 500;
 
     /// <summary>
-    /// Gets or sets the maximum Telegram message length before payload splitting.
+    /// Legacy: maximum Telegram message length before splitting.
     /// </summary>
     public int MaxMessageLength { get; set; } = 4096;
+
+    // ── Multi-bot configuration ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Named bot configurations. Each key is a logical bot name used for
+    /// logging and HTTP client naming; each value holds the token and agent
+    /// binding for that bot.
+    /// When this dictionary is non-empty it takes precedence over the
+    /// legacy top-level fields.
+    /// </summary>
+    public Dictionary<string, TelegramBotConfig> Bots { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the effective list of bot configurations to activate.
+    /// Uses <see cref="Bots"/> when populated; otherwise synthesises a single
+    /// <c>default</c> entry from the legacy top-level fields.
+    /// </summary>
+    internal IReadOnlyDictionary<string, TelegramBotConfig> ResolveActiveBots()
+    {
+        if (Bots.Count > 0)
+            return Bots;
+
+        // Legacy fallback — synthesise a single "default" bot
+        var legacy = new TelegramBotConfig
+        {
+            BotToken = BotToken,
+            AgentId = AgentId,
+            WebhookUrl = WebhookUrl,
+            PollingTimeoutSeconds = PollingTimeoutSeconds,
+            StreamingBufferMs = StreamingBufferMs,
+            MaxMessageLength = MaxMessageLength
+        };
+        foreach (var id in AllowedChatIds)
+            legacy.AllowedChatIds.Add(id);
+
+        return new Dictionary<string, TelegramBotConfig>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["default"] = legacy
+        };
+    }
 }
+
+/// <summary>
+/// Alias kept for backward compatibility with existing code and tests that
+/// reference <see cref="TelegramOptions"/>.
+/// </summary>
+public sealed class TelegramOptions : TelegramGatewayOptions { }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramServiceCollectionExtensions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using BotNexus.Gateway.Abstractions.Channels;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace BotNexus.Extensions.Channels.Telegram;
 
@@ -10,26 +9,22 @@ namespace BotNexus.Extensions.Channels.Telegram;
 public static class TelegramServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the Telegram channel adapter and configuration options.
+    /// Registers the Telegram channel adapter, options binding, and named HTTP client support
+    /// used to create one Telegram API client per configured bot.
     /// </summary>
     /// <param name="services">Service collection to update.</param>
     /// <param name="configure">Optional options configurator.</param>
     /// <returns>The same service collection for chaining.</returns>
-    /// <remarks>
-    /// Phase 2 stub registration for host integration. A full implementation would
-    /// also register Telegram API client dependencies.
-    /// </remarks>
     public static IServiceCollection AddBotNexusTelegramChannel(
         this IServiceCollection services,
-        Action<TelegramOptions>? configure = null)
+        Action<TelegramGatewayOptions>? configure = null)
     {
-        services.AddOptions<TelegramOptions>();
+        services.AddOptions<TelegramGatewayOptions>();
         if (configure is not null)
             services.Configure(configure);
-        services.TryAddSingleton<HttpClient>();
-        services.AddSingleton<TelegramBotApiClient>();
-        services.AddSingleton<IChannelAdapter, TelegramChannelAdapter>();
 
+        services.AddHttpClient();
+        services.AddSingleton<IChannelAdapter, TelegramChannelAdapter>();
         return services;
     }
 }

--- a/tests/BotNexus.Gateway.Tests/ChannelCapabilityTests.cs
+++ b/tests/BotNexus.Gateway.Tests/ChannelCapabilityTests.cs
@@ -55,16 +55,12 @@ public sealed class ChannelCapabilityTests
     [Fact]
     public void TelegramAdapter_SupportsStreamingThinkingAndToolDisplay()
     {
-        using var httpClient = new HttpClient();
-        var options = Options.Create(new TelegramOptions { BotToken = "token" });
-        var apiClient = new TelegramBotApiClient(
-            httpClient,
-            options,
-            NullLogger<TelegramBotApiClient>.Instance);
+        var options = Options.Create<TelegramGatewayOptions>(new TelegramOptions { BotToken = "token" });
+        var factory = new StubHttpClientFactory(_ => new HttpClient());
         var adapter = new TelegramChannelAdapter(
             NullLogger<TelegramChannelAdapter>.Instance,
             options,
-            apiClient);
+            factory);
 
         adapter.SupportsStreaming.ShouldBeTrue();
         adapter.SupportsSteering.ShouldBeFalse();
@@ -83,6 +79,11 @@ public sealed class ChannelCapabilityTests
         adapter.SupportsFollowUp.ShouldBeFalse();
         adapter.SupportsThinkingDisplay.ShouldBeTrue();
         adapter.SupportsToolDisplay.ShouldBeTrue();
+    }
+
+    private sealed class StubHttpClientFactory(Func<string, HttpClient> factory) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => factory(name);
     }
 
     private sealed class TestChannelAdapter : ChannelAdapterBase

--- a/tests/BotNexus.Gateway.Tests/ChannelCapabilityTests.cs
+++ b/tests/BotNexus.Gateway.Tests/ChannelCapabilityTests.cs
@@ -55,7 +55,7 @@ public sealed class ChannelCapabilityTests
     [Fact]
     public void TelegramAdapter_SupportsStreamingThinkingAndToolDisplay()
     {
-        var options = Options.Create<TelegramGatewayOptions>(new TelegramOptions { BotToken = "token" });
+        var options = Options.Create(new TelegramGatewayOptions { BotToken = "token" });
         var factory = new StubHttpClientFactory(_ => new HttpClient());
         var adapter = new TelegramChannelAdapter(
             NullLogger<TelegramChannelAdapter>.Instance,

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -379,6 +379,56 @@ public sealed class TelegramChannelAdapterTests
             .Message.ShouldContain("not allowed");
     }
 
+    [Fact]
+    public async Task Polling_WithConfiguredAgentId_StampsTargetAgentId_OnInboundMessage()
+    {
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "deleteWebhook" => JsonOk(true),
+                "getUpdates" => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 10,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 100,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Text = "hello"
+                        }
+                    }
+                }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramOptions
+        {
+            BotToken = "token",
+            AgentId = "larry",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var message = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        message.TargetAgentId.ShouldBe("larry");
+        message.ChannelAddress.ShouldBe("42");
+        message.Content.ShouldBe("hello");
+    }
+
     private static TelegramChannelAdapter CreateAdapter(TelegramOptions options, HttpMessageHandler handler)
     {
         var client = new HttpClient(handler);

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -55,7 +55,7 @@ public sealed class TelegramChannelAdapterTests
             };
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             PollingTimeoutSeconds = 1,
@@ -89,7 +89,7 @@ public sealed class TelegramChannelAdapterTests
             return JsonOk(new TelegramMessage { MessageId = calls.Count, Chat = new TelegramChat { Id = 42 } });
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             AllowedChatIds = { 42 },
@@ -110,7 +110,7 @@ public sealed class TelegramChannelAdapterTests
     }
 
     [Fact]
-    public async Task SendAsync_EscapesMarkdown()
+    public async Task SendAsync_EscapesHtml()
     {
         ApiCall? sendCall = null;
         var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
@@ -121,7 +121,7 @@ public sealed class TelegramChannelAdapterTests
             return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             AllowedChatIds = { 42 }
@@ -131,11 +131,12 @@ public sealed class TelegramChannelAdapterTests
         {
             ChannelType = ChannelKey.From("telegram"),
             ChannelAddress = "42",
-            Content = "_*[]()~`>#+-=|{}.!\\"
+            Content = "a < b && c > d"
         });
 
         sendCall.ShouldNotBeNull();
-        sendCall!.Text.ShouldBe("\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!\\\\");
+        sendCall!.Text.ShouldBe("a &lt; b &amp;&amp; c &gt; d");
+        sendCall.ParseMode.ShouldBe("HTML");
     }
 
     [Fact]
@@ -176,7 +177,7 @@ public sealed class TelegramChannelAdapterTests
             return JsonOk(true);
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             PollingTimeoutSeconds = 1,
@@ -214,7 +215,7 @@ public sealed class TelegramChannelAdapterTests
             return JsonOk(true);
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             PollingTimeoutSeconds = 1
@@ -238,7 +239,7 @@ public sealed class TelegramChannelAdapterTests
             return JsonOk(true);
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             WebhookUrl = "https://example.test/hook"
@@ -268,7 +269,7 @@ public sealed class TelegramChannelAdapterTests
                 : JsonOk(true);
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             PollingTimeoutSeconds = 1
@@ -299,7 +300,7 @@ public sealed class TelegramChannelAdapterTests
             };
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             AllowedChatIds = { 42 },
@@ -319,12 +320,216 @@ public sealed class TelegramChannelAdapterTests
     [Fact]
     public async Task StartAsync_WithoutBotToken_Throws()
     {
-        var adapter = CreateAdapter(new TelegramOptions(), new StubHttpMessageHandler((_, _) => Task.FromResult(JsonOk(true))));
+        var adapter = CreateAdapter(new TelegramGatewayOptions(), new StubHttpMessageHandler((_, _) => Task.FromResult(JsonOk(true))));
 
         Func<Task> act = () => adapter.StartAsync(Mock.Of<IChannelDispatcher>(), CancellationToken.None);
 
         (await act.ShouldThrowAsync<InvalidOperationException>())
             .Message.ShouldContain("BotToken");
+    }
+
+    [Fact]
+    public async Task General_topic_threadId1_omits_message_thread_id()
+    {
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "42",
+            ThreadId = "1",
+            Content = "general topic"
+        });
+
+        sendCall.ShouldNotBeNull();
+        sendCall!.MessageThreadId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Non_general_topic_threadId_includes_message_thread_id()
+    {
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "42",
+            ThreadId = "42",
+            Content = "topic reply"
+        });
+
+        sendCall.ShouldNotBeNull();
+        sendCall!.MessageThreadId.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task GetUpdates_includes_allowed_updates()
+    {
+        ApiCall? pollingCall = null;
+        var pollSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "getUpdates")
+            {
+                pollingCall = call;
+                pollSeen.TrySetResult();
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+
+            return JsonOk(true);
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1
+        }, handler);
+
+        await adapter.StartAsync(Mock.Of<IChannelDispatcher>(), CancellationToken.None);
+        await pollSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        pollingCall.ShouldNotBeNull();
+        pollingCall!.AllowedUpdates.ShouldBe(new[]
+        {
+            "message",
+            "edited_message",
+            "channel_post",
+            "edited_channel_post",
+            "message_reaction"
+        });
+    }
+
+    [Fact]
+    public async Task SendAsync_HtmlParseMode_used()
+    {
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "42",
+            Content = "hello"
+        });
+
+        sendCall.ShouldNotBeNull();
+        sendCall!.ParseMode.ShouldBe("HTML");
+    }
+
+    [Fact]
+    public async Task SendAsync_HtmlSendFails_FallsBackToPlainText()
+    {
+        var sendCalls = new List<ApiCall>();
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+            {
+                sendCalls.Add(call);
+                if (sendCalls.Count == 1)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        Content = new StringContent("{\"ok\":false,\"description\":\"Bad Request: can't parse entities\"}", Encoding.UTF8, "application/json")
+                    };
+                }
+            }
+
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "42",
+            Content = "hello"
+        });
+
+        sendCalls.Count.ShouldBe(2);
+        sendCalls[0].ParseMode.ShouldBe("HTML");
+        sendCalls[1].ParseMode.ShouldBeNull();
+        sendCalls[1].Text.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task ErrorCooldown_suppressesRepeatErrorReplies()
+    {
+        var sendCalls = new List<ApiCall>();
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCalls.Add(call);
+
+            return call.MethodName switch
+            {
+                "sendMessage" => JsonOk(new TelegramMessage { MessageId = sendCalls.Count, Chat = new TelegramChat { Id = 42 } }),
+                "editMessageText" => JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            ErrorCooldownMs = 60_000,
+            StreamingBufferMs = 60_000
+        }, handler);
+
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "first" });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "second" });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+
+        sendCalls.Count.ShouldBe(1);
+        sendCalls[0].Text.ShouldContain("first");
     }
 
     [Fact]
@@ -345,7 +550,7 @@ public sealed class TelegramChannelAdapterTests
             return JsonOk(true);
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             PollingTimeoutSeconds = -5
@@ -362,7 +567,7 @@ public sealed class TelegramChannelAdapterTests
     [Fact]
     public async Task SendAsync_WhenChatNotAllowed_Throws()
     {
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             AllowedChatIds = { 42 }
@@ -407,7 +612,7 @@ public sealed class TelegramChannelAdapterTests
             };
         });
 
-        var adapter = CreateAdapter(new TelegramOptions
+        var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
             AgentId = "larry",
@@ -429,12 +634,12 @@ public sealed class TelegramChannelAdapterTests
         message.Content.ShouldBe("hello");
     }
 
-    private static TelegramChannelAdapter CreateAdapter(TelegramOptions options, HttpMessageHandler handler)
+    private static TelegramChannelAdapter CreateAdapter(TelegramGatewayOptions options, HttpMessageHandler handler)
     {
         var factory = new StubHttpClientFactory(_ => new HttpClient(handler));
         return new TelegramChannelAdapter(
             NullLogger<TelegramChannelAdapter>.Instance,
-            Options.Create((TelegramGatewayOptions)options),
+            Options.Create(options),
             factory);
     }
 
@@ -466,8 +671,11 @@ public sealed class TelegramChannelAdapterTests
     private sealed record ApiCall(string MethodName, string Body)
     {
         public string? Text => TryGetString("text");
+        public string? ParseMode => TryGetString("parse_mode");
         public long? Offset => TryGetLong("offset");
         public int? Timeout => TryGetInt("timeout");
+        public int? MessageThreadId => TryGetInt("message_thread_id");
+        public string[] AllowedUpdates => TryGetStringArray("allowed_updates");
 
         public static async Task<ApiCall> FromRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -500,6 +708,18 @@ public sealed class TelegramChannelAdapterTests
             return json.RootElement.TryGetProperty(property, out var element) && element.ValueKind == JsonValueKind.Number
                 ? element.GetInt32()
                 : null;
+        }
+
+        private string[] TryGetStringArray(string property)
+        {
+            using var json = JsonDocument.Parse(Body);
+            if (!json.RootElement.TryGetProperty(property, out var element) || element.ValueKind != JsonValueKind.Array)
+                return [];
+
+            return element.EnumerateArray()
+                .Where(x => x.ValueKind == JsonValueKind.String)
+                .Select(x => x.GetString()!)
+                .ToArray();
         }
     }
 }

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -431,12 +431,11 @@ public sealed class TelegramChannelAdapterTests
 
     private static TelegramChannelAdapter CreateAdapter(TelegramOptions options, HttpMessageHandler handler)
     {
-        var client = new HttpClient(handler);
-        var apiClient = new TelegramBotApiClient(client, Options.Create(options), NullLogger<TelegramBotApiClient>.Instance);
+        var factory = new StubHttpClientFactory(_ => new HttpClient(handler));
         return new TelegramChannelAdapter(
             NullLogger<TelegramChannelAdapter>.Instance,
-            Options.Create(options),
-            apiClient);
+            Options.Create((TelegramGatewayOptions)options),
+            factory);
     }
 
     private static HttpResponseMessage JsonOk<T>(T result)
@@ -457,6 +456,11 @@ public sealed class TelegramChannelAdapterTests
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => responder(request, cancellationToken);
+    }
+
+    private sealed class StubHttpClientFactory(Func<string, HttpClient> factory) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => factory(name);
     }
 
     private sealed record ApiCall(string MethodName, string Body)

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramMultiBotTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramMultiBotTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using BotNexus.Extensions.Channels.Telegram;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+public sealed class TelegramMultiBotTests
+{
+    /// <summary>
+    /// When two bots are configured, messages from each arrive with the correct
+    /// TargetAgentId and ChannelAddress.
+    /// </summary>
+    [Fact]
+    public async Task MultiBotConfig_EachBot_RoutesToCorrectAgent()
+    {
+        var dispatchedMessages = new List<InboundMessage>();
+        var twoMessagesSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Bot 1 returns one update; bot 2 returns one update; subsequent polls empty.
+        var bot1Polls = 0;
+        var bot2Polls = 0;
+
+        HttpResponseMessage Bot1Handler(HttpRequestMessage req)
+        {
+            var method = req.RequestUri?.Segments.LastOrDefault()?.Trim('/');
+            if (method == "deleteWebhook") return JsonOk(true);
+            if (method == "getUpdates")
+            {
+                bot1Polls++;
+                if (bot1Polls == 1)
+                    return JsonOk(new[] { MakeUpdate(10, 101, "hello from bot1") });
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+            return JsonOk(true);
+        }
+
+        HttpResponseMessage Bot2Handler(HttpRequestMessage req)
+        {
+            var method = req.RequestUri?.Segments.LastOrDefault()?.Trim('/');
+            if (method == "deleteWebhook") return JsonOk(true);
+            if (method == "getUpdates")
+            {
+                bot2Polls++;
+                if (bot2Polls == 1)
+                    return JsonOk(new[] { MakeUpdate(20, 202, "hello from bot2") });
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+            return JsonOk(true);
+        }
+
+        var options = new TelegramGatewayOptions
+        {
+            Bots =
+            {
+                ["larry-bot"] = new TelegramBotConfig
+                {
+                    BotToken = "token-larry",
+                    AgentId = "larry",
+                    AllowedChatIds = { 101 },
+                    PollingTimeoutSeconds = 1
+                },
+                ["assistant-bot"] = new TelegramBotConfig
+                {
+                    BotToken = "token-assistant",
+                    AgentId = "assistant",
+                    AllowedChatIds = { 202 },
+                    PollingTimeoutSeconds = 1
+                }
+            }
+        };
+
+        var httpFactory = new StubHttpClientFactory(name => name == "larry-bot"
+            ? new HttpClient(new StubHandler(req => Task.FromResult(Bot1Handler(req))))
+            : new HttpClient(new StubHandler(req => Task.FromResult(Bot2Handler(req)))));
+
+        var adapter = new TelegramChannelAdapter(
+            NullLogger<TelegramChannelAdapter>.Instance,
+            Options.Create(options),
+            httpFactory);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) =>
+            {
+                lock (dispatchedMessages) dispatchedMessages.Add(m);
+                if (dispatchedMessages.Count >= 2) twoMessagesSeen.TrySetResult();
+            });
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        await twoMessagesSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        dispatchedMessages.ShouldContain(m => m.TargetAgentId == "larry" && m.Content == "hello from bot1");
+        dispatchedMessages.ShouldContain(m => m.TargetAgentId == "assistant" && m.Content == "hello from bot2");
+    }
+
+    /// <summary>
+    /// When only legacy single-bot fields are set (no Bots dict), the adapter still works.
+    /// </summary>
+    [Fact]
+    public async Task SingleBotLegacyConfig_StillWorks()
+    {
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TelegramGatewayOptions
+        {
+            BotToken = "legacy-token",
+            AgentId = "legacy-agent",
+            AllowedChatIds = { 42 },
+            PollingTimeoutSeconds = 1
+        };
+
+        var httpFactory = new StubHttpClientFactory(_ =>
+        {
+            var polls = 0;
+            return new HttpClient(new StubHandler(req =>
+            {
+                var method = req.RequestUri?.Segments.LastOrDefault()?.Trim('/');
+                if (method == "deleteWebhook") return Task.FromResult(JsonOk(true));
+                if (method == "getUpdates")
+                {
+                    polls++;
+                    return Task.FromResult(polls == 1
+                        ? JsonOk(new[] { MakeUpdate(10, 42, "legacy message") })
+                        : JsonOk(Array.Empty<TelegramUpdate>()));
+                }
+                return Task.FromResult(JsonOk(true));
+            }));
+        });
+
+        var adapter = new TelegramChannelAdapter(
+            NullLogger<TelegramChannelAdapter>.Instance,
+            Options.Create(options),
+            httpFactory);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var message = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        message.TargetAgentId.ShouldBe("legacy-agent");
+        message.Content.ShouldBe("legacy message");
+    }
+
+    private static TelegramUpdate MakeUpdate(int updateId, long chatId, string text) =>
+        new()
+        {
+            UpdateId = updateId,
+            Message = new TelegramMessage
+            {
+                MessageId = updateId * 10,
+                Chat = new TelegramChat { Id = chatId },
+                From = new TelegramUser { Id = chatId },
+                Text = text
+            }
+        };
+
+    private static HttpResponseMessage JsonOk<T>(T result)
+    {
+        var payload = JsonSerializer.Serialize(new TelegramApiResponse<T> { Ok = true, Result = result });
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => responder(request);
+    }
+
+    private sealed class StubHttpClientFactory(Func<string, HttpClient> factory) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => factory(name);
+    }
+}


### PR DESCRIPTION
Implements the initial Telegram routing model:

- one Telegram bot token = one BotNexus agent
- inbound Telegram messages stamp `TargetAgentId` from `TelegramOptions.AgentId`
- conversation routing remains per `(channelType=telegram, chatId, threadId)`
  - DM/default chat => its own default Telegram conversation if not already present
  - forum/group topic => separate conversation per thread
- separate from SignalR default conversations because bindings differ by channel type/address

Includes failing-test-first coverage in `TelegramChannelAdapterTests`.