### PR TITLE
docs: sync user docs with current architecture

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -36,7 +36,7 @@ BotNexus is a **domain-driven, multi-agent execution platform** for building AI 
 │  │  ┌─────────────┐  ┌──────────────┐  ┌──────────────────┐ │  │
 │  │  │   Agents     │  │   Sessions   │  │   Channels       │ │  │
 │  │  │  (per World) │  │  (per agent  │  │  SignalR, TG,    │ │  │
-│  │  │             │  │   + channel) │  │  TUI, Cron       │ │  │
+│  │  │             │  │   + channel) │  │  TUI, Cron, TG   │ │  │
 │  │  └──────┬──────┘  └──────────────┘  └──────────────────┘ │  │
 │  │         │                                                  │  │
 │  │         │ uses                                             │  │
@@ -183,7 +183,7 @@ Agents reference Locations by name (`@repo-botnexus`) rather than raw paths. Thi
 | **Tools** | `IAgentTool` | Agent capabilities (file ops, web, MCP, skills, memory) |
 | **Hooks** | `IHookHandler` | Intercept tool execution (validation, audit, policy) |
 | **Prompt Sections** | `IPromptSection` | Customize system prompts |
-| **Session Stores** | `ISessionStore` | Persistence backends (InMemory, File, SQLite) |
+| **Session Stores** | `ISessionStore` | Persistence backends (InMemory, SQLite) |
 | **Internal Triggers** | `IInternalTrigger` | Non-channel session creation (Cron, Soul) |
 
 ---

--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -206,7 +206,7 @@ AgentCore and Providers are **independent libraries** — they have no knowledge
 | Resource | Scope | Path Pattern |
 |----------|-------|--------------|
 | Workspace | Per-agent | `~/.botnexus/workspaces/{agentId}/` |
-| Session | Per (agent, session) | `~/.botnexus/sessions/{sessionId}.jsonl` |
+| Session | Per (agent, session) | `~/.botnexus/sessions.sqlite` |
 | Memory | Per agent or session | `~/.botnexus/memory/{agentId}/{sessionId?}/` |
 | Logs | Per agent/session/world | `~/.botnexus/logs/{agentId}/{sessionId?}/` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ On startup, BotNexus creates this structure if it does not already exist:
 │   ├── channels/
 │   └── tools/
 ├── tokens/
-├── sessions/
+├── sessions.sqlite
 └── logs/
 ```
 

--- a/docs/development/message-flow.md
+++ b/docs/development/message-flow.md
@@ -275,7 +275,6 @@ public record SessionParticipant
 Sessions are persisted via `ISessionStore`:
 
 - **InMemorySessionStore**: Dev/testing (not durable)
-- **FileSessionStore**: JSON files in `~/.botnexus/sessions/`
 - **SqliteSessionStore**: SQLite database (production default)
 
 **Session Structure:**

--- a/docs/development/session-stores.md
+++ b/docs/development/session-stores.md
@@ -4,10 +4,9 @@ This document describes BotNexus's session storage architecture, including persi
 
 ## Overview
 
-Sessions are persisted via `ISessionStore`, which supports multiple backend implementations:
+Sessions are persisted via `ISessionStore`, which supports two backend implementations:
 
-- **InMemorySessionStore**: Non-durable, for testing
-- **FileSessionStore**: JSON files, simple deployments
+- **InMemorySessionStore**: Non-durable, for testing and development
 - **SqliteSessionStore**: SQLite database, production default
 
 All implementations share common query patterns and lifecycle operations.
@@ -98,28 +97,6 @@ Uses `ConcurrentDictionary<string, GatewaySession>` for O(1) lookups. Non-durabl
 
 See [InMemorySessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs)
 
-## FileSessionStore
-
-**Characteristics:**
-
-- Durable (survives restarts)
-- Simple deployment (no database)
-- File per session (inefficient for large counts)
-- No cross-process concurrency (file locking)
-
-**Storage Layout:**
-
-```text
-~/.botnexus/sessions/
-├── {sessionId}.json
-├── {sessionId}.json
-└── {sessionId}.json
-```
-
-**Key behaviors:** Atomic writes via temp file + rename, JSON serialization with camelCase naming, one file per session. Skips `.tmp` files during enumeration and logs warnings for corrupt session files.
-
-See [FileSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs)
-
 ## SqliteSessionStore
 
 **Characteristics:**
@@ -133,29 +110,38 @@ See [FileSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/FileSessio
 **Schema:**
 
 ```sql
-CREATE TABLE sessions (
-    session_id TEXT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
     agent_id TEXT NOT NULL,
-    session_type TEXT NOT NULL,
-    status TEXT NOT NULL,
     channel_type TEXT,
     caller_id TEXT,
+    session_type TEXT NOT NULL DEFAULT 'user-agent',
+    participants_json TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    metadata TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    expires_at TEXT,
-    participants_json TEXT,
-    history_json TEXT,
-    metadata_json TEXT
+    conversation_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS session_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    role TEXT,
+    content TEXT,
+    timestamp TEXT,
+    tool_name TEXT,
+    tool_call_id TEXT,
+    is_compaction_summary INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
 CREATE INDEX idx_sessions_status ON sessions(status);
 CREATE INDEX idx_sessions_session_type ON sessions(session_type);
 CREATE INDEX idx_sessions_created_at ON sessions(created_at);
-CREATE INDEX idx_sessions_expires_at ON sessions(expires_at) WHERE expires_at IS NOT NULL;
 ```
 
-**Key behaviors:** Parameterized queries throughout, `INSERT OR REPLACE` for upserts, JSON serialization for complex fields (`participants_json`, `history_json`, `metadata_json`), lazy schema initialization via `EnsureSchemaAsync`, and ISO 8601 date formatting.
+**Key behaviors:** Parameterized queries throughout, `INSERT OR REPLACE` for upserts, JSON serialization for complex fields (`participants_json`, `metadata`). Session history stored in the separate `session_history` table. Lazy schema initialization via `EnsureSchemaAsync`, and ISO 8601 date formatting.
 
 See [SqliteSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs)
 
@@ -267,7 +253,6 @@ See [SessionWarmupService.cs](../../src/gateway/BotNexus.Gateway/Sessions/Sessio
 | Store | Durability | Performance | Concurrency | Use Case |
 |-------|-----------|-------------|-------------|----------|
 | InMemory | None | Fastest | Single process | Testing, dev |
-| File | Durable | Moderate | Single process | Simple deployments |
 | SQLite | Durable | Fast | Multi-process | Production |
 
 **Key Architectural Decisions:**
@@ -283,9 +268,9 @@ See [SessionWarmupService.cs](../../src/gateway/BotNexus.Gateway/Sessions/Sessio
 **Performance Characteristics:**
 
 - **Get**: O(1) for in-memory, O(log N) for SQLite (indexed)
-- **List by agent**: O(N) for file store, O(log M) for SQLite (where M = sessions per agent)
-- **Query**: O(N) for in-memory/file, O(log N) for SQLite (with indexes)
-- **Save**: O(1) for in-memory, O(1) disk I/O for file, O(log N) for SQLite
+- **List by agent**: O(log M) for SQLite (where M = sessions per agent)
+- **Query**: O(N) for in-memory, O(log N) for SQLite (with indexes)
+- **Save**: O(1) for in-memory, O(log N) for SQLite
 
 **Best Practices:**
 
@@ -294,4 +279,3 @@ See [SessionWarmupService.cs](../../src/gateway/BotNexus.Gateway/Sessions/Sessio
 3. Index frequently queried fields (agent_id, status, session_type)
 4. Run cleanup service to prevent unbounded growth
 5. Use session warmup to avoid N+1 queries in UI
-6. Archive old sessions instead of deleting (for audit trail)

--- a/docs/development/workspace-and-memory.md
+++ b/docs/development/workspace-and-memory.md
@@ -31,7 +31,7 @@ An **agent workspace** is a persistent file system directory where each BotNexus
 - **Persistence**: Workspace survives agent restarts and redeployments
 - **Accessibility**: Files are plain Markdown — human-readable and editable
 - **Composability**: Workspace files form the foundation of the system prompt assembled per session
-- **Separation of Concerns**: Distinct from `~/.botnexus/workspace/sessions/` (transient conversation history) and `~/.botnexus/extensions/` (deployed binaries)
+- **Separation of Concerns**: Distinct from session data in `~/.botnexus/sessions.sqlite` and `~/.botnexus/extensions/` (deployed binaries)
 
 ---
 
@@ -333,7 +333,7 @@ Recommended sections (not enforced):
 ## Architecture Learnings
 - The core platform has 17 projects with clean dependency inversion
 - Extensions are loaded dynamically from `~/.botnexus/extensions/{type}/{name}/`
-- SessionManager persists conversation history to JSONL under `~/.botnexus/workspace/sessions/`
+- SessionManager persists conversation history to `~/.botnexus/sessions.sqlite`
 
 ## User Preferences
 - Async-first communication

--- a/docs/user-guide/agents.md
+++ b/docs/user-guide/agents.md
@@ -601,7 +601,7 @@ Remove an agent by:
 2. Removing its JSON file from `~/.botnexus/agents/`
 3. Configuration reload applies changes
 
-Session history is preserved in `~/.botnexus/workspace/sessions/`.
+Session history is preserved in `~/.botnexus/sessions.sqlite`.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -53,10 +53,9 @@ Gateway-level settings control the HTTP server, routing, and runtime behavior.
     "listenUrl": "http://localhost:5005",
     "defaultAgentId": "assistant",
     "agentsDirectory": "~/.botnexus/agents",
-    "sessionsDirectory": "~/.botnexus/workspace/sessions",
     "sessionStore": {
-      "type": "File",
-      "filePath": "~/.botnexus/workspace/sessions"
+      "type": "Sqlite",
+      "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
     },
     "compaction": {
       "maxMessagesBeforeCompaction": 100,
@@ -89,9 +88,7 @@ Gateway-level settings control the HTTP server, routing, and runtime behavior.
 | `listenUrl` | string | `http://localhost:5005` | HTTP listen URL for REST API and WebUI |
 | `defaultAgentId` | string | `null` | Agent to route to when none specified |
 | `agentsDirectory` | string | `~/.botnexus/agents` | Directory containing agent descriptor JSON files |
-| `sessionsDirectory` | string | `~/.botnexus/workspace/sessions` | Directory for session persistence |
-| `sessionStore.type` | string | `File` | Session store type: `File`, `InMemory`, or `Sqlite` |
-| `sessionStore.filePath` | string | (same as sessionsDirectory) | Path for file-based session store |
+| `sessionStore.type` | string | `Sqlite` | Session store type: `InMemory` or `Sqlite` |
 | `sessionStore.connectionString` | string | `null` | SQLite connection string (when type=Sqlite) |
 | `compaction.maxMessagesBeforeCompaction` | int | `100` | Trigger compaction after this many messages |
 | `compaction.retainLastMessages` | int | `20` | Keep this many recent messages after compaction |
@@ -367,12 +364,10 @@ Channels route messages from external sources (Telegram, WebUI, TUI) to agents.
       "settings": {}
     },
     "telegram": {
-      "type": "telegram",
-      "enabled": true,
-      "settings": {
-        "botToken": "${TELEGRAM_BOT_TOKEN}",
-        "allowedUsers": ["123456789"]
-      }
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "agentId": "assistant",
+      "allowedChatIds": [123456789],
+      "pollingTimeoutSeconds": 30
     },
     "tui": {
       "type": "tui",
@@ -387,13 +382,7 @@ Channels route messages from external sources (Telegram, WebUI, TUI) to agents.
 
 ### Channel Settings Reference
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `type` | string | (required) | Channel adapter type: `signalr`, `telegram`, `tui` |
-| `enabled` | bool | `true` | Enable/disable this channel |
-| `settings` | object | `{}` | Channel-specific settings |
-
-### Channel-Specific Settings
+Channel configuration is extension-specific. The channel type is determined by the extension ID (the key under `channels`).
 
 **SignalR (WebUI):**
 - No additional settings required. WebUI is served at the Gateway root URL.
@@ -401,9 +390,36 @@ Channels route messages from external sources (Telegram, WebUI, TUI) to agents.
 **Telegram:**
 ```json
 {
-  "settings": {
-    "botToken": "${TELEGRAM_BOT_TOKEN}",
-    "allowedUsers": ["123456789", "987654321"]
+  "channels": {
+    "telegram": {
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "agentId": "assistant",
+      "allowedChatIds": [123456789, 987654321],
+      "pollingTimeoutSeconds": 30
+    }
+  }
+}
+```
+
+Uses long polling by default (no public URL required). For webhook mode, add `"webhookUrl": "https://your-host/telegram/webhook"`.
+
+**Multi-bot Telegram config:**
+```json
+{
+  "channels": {
+    "telegram": {
+      "bots": {
+        "larry-bot": {
+          "botToken": "111:AAA...",
+          "agentId": "larry",
+          "allowedChatIds": [123456789]
+        },
+        "assistant-bot": {
+          "botToken": "222:BBB...",
+          "agentId": "assistant"
+        }
+      }
+    }
   }
 }
 ```
@@ -560,15 +576,14 @@ Schedule recurring tasks like heartbeats, reports, or maintenance jobs.
 
 ## Session Management
 
-Sessions persist conversation history to disk.
+Sessions are persisted to a SQLite database by default.
 
 ```json
 {
   "gateway": {
-    "sessionsDirectory": "~/.botnexus/workspace/sessions",
     "sessionStore": {
-      "type": "File",
-      "filePath": "~/.botnexus/workspace/sessions"
+      "type": "Sqlite",
+      "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
     },
     "compaction": {
       "maxMessagesBeforeCompaction": 100,
@@ -580,31 +595,21 @@ Sessions persist conversation history to disk.
 
 **Session Store Types:**
 
-1. **File** (default): JSONL files in `sessionsDirectory`
-   ```json
-   {
-     "sessionStore": {
-       "type": "File",
-       "filePath": "~/.botnexus/workspace/sessions"
-     }
-   }
-   ```
-
-2. **InMemory**: Ephemeral (lost on restart)
-   ```json
-   {
-     "sessionStore": {
-       "type": "InMemory"
-     }
-   }
-   ```
-
-3. **Sqlite**: SQLite database
+1. **Sqlite** (default): SQLite database
    ```json
    {
      "sessionStore": {
        "type": "Sqlite",
-       "connectionString": "Data Source=~/.botnexus/sessions.db"
+       "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
+     }
+   }
+   ```
+
+2. **InMemory**: Ephemeral (lost on restart — for testing/dev only)
+   ```json
+   {
+     "sessionStore": {
+       "type": "InMemory"
      }
    }
    ```
@@ -693,9 +698,9 @@ A production-ready configuration with multiple agents, providers, and extensions
     "listenUrl": "http://localhost:5005",
     "defaultAgentId": "assistant",
     "agentsDirectory": "~/.botnexus/agents",
-    "sessionsDirectory": "~/.botnexus/workspace/sessions",
     "sessionStore": {
-      "type": "File"
+      "type": "Sqlite",
+      "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
     },
     "compaction": {
       "maxMessagesBeforeCompaction": 100,
@@ -784,12 +789,9 @@ A production-ready configuration with multiple agents, providers, and extensions
       "enabled": true
     },
     "telegram": {
-      "type": "telegram",
-      "enabled": true,
-      "settings": {
-        "botToken": "${TELEGRAM_BOT_TOKEN}",
-        "allowedUsers": ["123456789"]
-      }
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "agentId": "assistant",
+      "allowedChatIds": [123456789]
     }
   },
   "cron": {

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -143,10 +143,12 @@ On first run, BotNexus creates a home directory at `~/.botnexus/` with a default
 ```text
 ~/.botnexus/
 ├── config.json          # Main configuration (agents, providers, channels)
+├── sessions.sqlite      # Session database
+├── conversations.sqlite # Conversations database
 ├── extensions/          # Extension binaries (auto-populated)
 ├── tokens/              # OAuth tokens (GitHub Copilot)
-├── workspace/
-│   └── sessions/        # Conversation history (JSONL format)
+├── agents/              # Per-agent workspace directories
+│   └── <agentId>/       # Agent workspace (SOUL.md, IDENTITY.md, etc.)
 └── logs/                # Application logs
 ```
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -895,11 +895,6 @@ Set credentials before using model 'your-model:latest'.
 ~/.botnexus/logs/gateway-YYYYMMDD.log
 ```
 
-**Session logs:**
-```text
-~/.botnexus/workspace/sessions/<agentId>/<sessionId>.jsonl
-```
-
 ### Viewing Logs
 
 **Real-time:**


### PR DESCRIPTION
Brings user-facing documentation in sync with the current codebase.

## What changed

**Session store**
- Removed all references to `FileSessionStore` — the class does not exist
- Removed `type: "File"` as a session store option throughout
- Fixed SQLite schema: added `conversation_id` column, replaced `history_json` with separate `session_history` table
- Updated default session store type to `Sqlite`
- Removed `sessionsDirectory` and `sessionStore.filePath` config keys (not real)
- Updated home directory structure: `workspace/sessions/*.jsonl` → `sessions.sqlite`

**Telegram channel**
- Updated config shape to current flat format (`botToken`, `agentId`, `allowedChatIds`)
- Added multi-bot `bots` dictionary example
- Removed stale `type: "telegram"` / nested `settings` / `allowedUsers` config shape

**Conversation model**
- Added documentation of the conversation model: `ConversationId` on sessions, `ChannelBinding`, `ThreadId` routing, fan-out

**Files changed:**
- `docs/user-guide/configuration.md`
- `docs/development/session-stores.md`
- `docs/user-guide/getting-started.md`
- `docs/user-guide/troubleshooting.md`
- `docs/user-guide/agents.md`
- `docs/architecture/overview.md`
- `docs/configuration.md`
- `docs/development/message-flow.md`
- `docs/development/workspace-and-memory.md`
- `docs/architecture/principles.md`