### PR TITLE
feat(config): backup config.json before every write

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -36,7 +36,7 @@ BotNexus is a **domain-driven, multi-agent execution platform** for building AI 
 │  │  ┌─────────────┐  ┌──────────────┐  ┌──────────────────┐ │  │
 │  │  │   Agents     │  │   Sessions   │  │   Channels       │ │  │
 │  │  │  (per World) │  │  (per agent  │  │  SignalR, TG,    │ │  │
-│  │  │             │  │   + channel) │  │  TUI, Cron       │ │  │
+│  │  │             │  │   + channel) │  │  TUI, Cron, TG   │ │  │
 │  │  └──────┬──────┘  └──────────────┘  └──────────────────┘ │  │
 │  │         │                                                  │  │
 │  │         │ uses                                             │  │
@@ -183,7 +183,7 @@ Agents reference Locations by name (`@repo-botnexus`) rather than raw paths. Thi
 | **Tools** | `IAgentTool` | Agent capabilities (file ops, web, MCP, skills, memory) |
 | **Hooks** | `IHookHandler` | Intercept tool execution (validation, audit, policy) |
 | **Prompt Sections** | `IPromptSection` | Customize system prompts |
-| **Session Stores** | `ISessionStore` | Persistence backends (InMemory, File, SQLite) |
+| **Session Stores** | `ISessionStore` | Persistence backends (InMemory, SQLite) |
 | **Internal Triggers** | `IInternalTrigger` | Non-channel session creation (Cron, Soul) |
 
 ---

--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -206,7 +206,7 @@ AgentCore and Providers are **independent libraries** — they have no knowledge
 | Resource | Scope | Path Pattern |
 |----------|-------|--------------|
 | Workspace | Per-agent | `~/.botnexus/workspaces/{agentId}/` |
-| Session | Per (agent, session) | `~/.botnexus/sessions/{sessionId}.jsonl` |
+| Session | Per (agent, session) | `~/.botnexus/sessions.sqlite` |
 | Memory | Per agent or session | `~/.botnexus/memory/{agentId}/{sessionId?}/` |
 | Logs | Per agent/session/world | `~/.botnexus/logs/{agentId}/{sessionId?}/` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ On startup, BotNexus creates this structure if it does not already exist:
 │   ├── channels/
 │   └── tools/
 ├── tokens/
-├── sessions/
+├── sessions.sqlite
 └── logs/
 ```
 

--- a/docs/development/message-flow.md
+++ b/docs/development/message-flow.md
@@ -275,7 +275,6 @@ public record SessionParticipant
 Sessions are persisted via `ISessionStore`:
 
 - **InMemorySessionStore**: Dev/testing (not durable)
-- **FileSessionStore**: JSON files in `~/.botnexus/sessions/`
 - **SqliteSessionStore**: SQLite database (production default)
 
 **Session Structure:**

--- a/docs/development/session-stores.md
+++ b/docs/development/session-stores.md
@@ -4,10 +4,9 @@ This document describes BotNexus's session storage architecture, including persi
 
 ## Overview
 
-Sessions are persisted via `ISessionStore`, which supports multiple backend implementations:
+Sessions are persisted via `ISessionStore`, which supports two backend implementations:
 
-- **InMemorySessionStore**: Non-durable, for testing
-- **FileSessionStore**: JSON files, simple deployments
+- **InMemorySessionStore**: Non-durable, for testing and development
 - **SqliteSessionStore**: SQLite database, production default
 
 All implementations share common query patterns and lifecycle operations.
@@ -98,28 +97,6 @@ Uses `ConcurrentDictionary<string, GatewaySession>` for O(1) lookups. Non-durabl
 
 See [InMemorySessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs)
 
-## FileSessionStore
-
-**Characteristics:**
-
-- Durable (survives restarts)
-- Simple deployment (no database)
-- File per session (inefficient for large counts)
-- No cross-process concurrency (file locking)
-
-**Storage Layout:**
-
-```text
-~/.botnexus/sessions/
-├── {sessionId}.json
-├── {sessionId}.json
-└── {sessionId}.json
-```
-
-**Key behaviors:** Atomic writes via temp file + rename, JSON serialization with camelCase naming, one file per session. Skips `.tmp` files during enumeration and logs warnings for corrupt session files.
-
-See [FileSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs)
-
 ## SqliteSessionStore
 
 **Characteristics:**
@@ -133,29 +110,38 @@ See [FileSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/FileSessio
 **Schema:**
 
 ```sql
-CREATE TABLE sessions (
-    session_id TEXT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
     agent_id TEXT NOT NULL,
-    session_type TEXT NOT NULL,
-    status TEXT NOT NULL,
     channel_type TEXT,
     caller_id TEXT,
+    session_type TEXT NOT NULL DEFAULT 'user-agent',
+    participants_json TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    metadata TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    expires_at TEXT,
-    participants_json TEXT,
-    history_json TEXT,
-    metadata_json TEXT
+    conversation_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS session_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    role TEXT,
+    content TEXT,
+    timestamp TEXT,
+    tool_name TEXT,
+    tool_call_id TEXT,
+    is_compaction_summary INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
 CREATE INDEX idx_sessions_status ON sessions(status);
 CREATE INDEX idx_sessions_session_type ON sessions(session_type);
 CREATE INDEX idx_sessions_created_at ON sessions(created_at);
-CREATE INDEX idx_sessions_expires_at ON sessions(expires_at) WHERE expires_at IS NOT NULL;
 ```
 
-**Key behaviors:** Parameterized queries throughout, `INSERT OR REPLACE` for upserts, JSON serialization for complex fields (`participants_json`, `history_json`, `metadata_json`), lazy schema initialization via `EnsureSchemaAsync`, and ISO 8601 date formatting.
+**Key behaviors:** Parameterized queries throughout, `INSERT OR REPLACE` for upserts, JSON serialization for complex fields (`participants_json`, `metadata`). Session history stored in the separate `session_history` table. Lazy schema initialization via `EnsureSchemaAsync`, and ISO 8601 date formatting.
 
 See [SqliteSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs)
 
@@ -267,7 +253,6 @@ See [SessionWarmupService.cs](../../src/gateway/BotNexus.Gateway/Sessions/Sessio
 | Store | Durability | Performance | Concurrency | Use Case |
 |-------|-----------|-------------|-------------|----------|
 | InMemory | None | Fastest | Single process | Testing, dev |
-| File | Durable | Moderate | Single process | Simple deployments |
 | SQLite | Durable | Fast | Multi-process | Production |
 
 **Key Architectural Decisions:**
@@ -283,9 +268,9 @@ See [SessionWarmupService.cs](../../src/gateway/BotNexus.Gateway/Sessions/Sessio
 **Performance Characteristics:**
 
 - **Get**: O(1) for in-memory, O(log N) for SQLite (indexed)
-- **List by agent**: O(N) for file store, O(log M) for SQLite (where M = sessions per agent)
-- **Query**: O(N) for in-memory/file, O(log N) for SQLite (with indexes)
-- **Save**: O(1) for in-memory, O(1) disk I/O for file, O(log N) for SQLite
+- **List by agent**: O(log M) for SQLite (where M = sessions per agent)
+- **Query**: O(N) for in-memory, O(log N) for SQLite (with indexes)
+- **Save**: O(1) for in-memory, O(log N) for SQLite
 
 **Best Practices:**
 
@@ -294,4 +279,3 @@ See [SessionWarmupService.cs](../../src/gateway/BotNexus.Gateway/Sessions/Sessio
 3. Index frequently queried fields (agent_id, status, session_type)
 4. Run cleanup service to prevent unbounded growth
 5. Use session warmup to avoid N+1 queries in UI
-6. Archive old sessions instead of deleting (for audit trail)

--- a/docs/development/workspace-and-memory.md
+++ b/docs/development/workspace-and-memory.md
@@ -31,7 +31,7 @@ An **agent workspace** is a persistent file system directory where each BotNexus
 - **Persistence**: Workspace survives agent restarts and redeployments
 - **Accessibility**: Files are plain Markdown — human-readable and editable
 - **Composability**: Workspace files form the foundation of the system prompt assembled per session
-- **Separation of Concerns**: Distinct from `~/.botnexus/workspace/sessions/` (transient conversation history) and `~/.botnexus/extensions/` (deployed binaries)
+- **Separation of Concerns**: Distinct from session data in `~/.botnexus/sessions.sqlite` and `~/.botnexus/extensions/` (deployed binaries)
 
 ---
 
@@ -333,7 +333,7 @@ Recommended sections (not enforced):
 ## Architecture Learnings
 - The core platform has 17 projects with clean dependency inversion
 - Extensions are loaded dynamically from `~/.botnexus/extensions/{type}/{name}/`
-- SessionManager persists conversation history to JSONL under `~/.botnexus/workspace/sessions/`
+- SessionManager persists conversation history to `~/.botnexus/sessions.sqlite`
 
 ## User Preferences
 - Async-first communication

--- a/docs/user-guide/agents.md
+++ b/docs/user-guide/agents.md
@@ -601,7 +601,7 @@ Remove an agent by:
 2. Removing its JSON file from `~/.botnexus/agents/`
 3. Configuration reload applies changes
 
-Session history is preserved in `~/.botnexus/workspace/sessions/`.
+Session history is preserved in `~/.botnexus/sessions.sqlite`.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -53,10 +53,9 @@ Gateway-level settings control the HTTP server, routing, and runtime behavior.
     "listenUrl": "http://localhost:5005",
     "defaultAgentId": "assistant",
     "agentsDirectory": "~/.botnexus/agents",
-    "sessionsDirectory": "~/.botnexus/workspace/sessions",
     "sessionStore": {
-      "type": "File",
-      "filePath": "~/.botnexus/workspace/sessions"
+      "type": "Sqlite",
+      "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
     },
     "compaction": {
       "maxMessagesBeforeCompaction": 100,
@@ -89,9 +88,7 @@ Gateway-level settings control the HTTP server, routing, and runtime behavior.
 | `listenUrl` | string | `http://localhost:5005` | HTTP listen URL for REST API and WebUI |
 | `defaultAgentId` | string | `null` | Agent to route to when none specified |
 | `agentsDirectory` | string | `~/.botnexus/agents` | Directory containing agent descriptor JSON files |
-| `sessionsDirectory` | string | `~/.botnexus/workspace/sessions` | Directory for session persistence |
-| `sessionStore.type` | string | `File` | Session store type: `File`, `InMemory`, or `Sqlite` |
-| `sessionStore.filePath` | string | (same as sessionsDirectory) | Path for file-based session store |
+| `sessionStore.type` | string | `Sqlite` | Session store type: `InMemory` or `Sqlite` |
 | `sessionStore.connectionString` | string | `null` | SQLite connection string (when type=Sqlite) |
 | `compaction.maxMessagesBeforeCompaction` | int | `100` | Trigger compaction after this many messages |
 | `compaction.retainLastMessages` | int | `20` | Keep this many recent messages after compaction |
@@ -367,12 +364,10 @@ Channels route messages from external sources (Telegram, WebUI, TUI) to agents.
       "settings": {}
     },
     "telegram": {
-      "type": "telegram",
-      "enabled": true,
-      "settings": {
-        "botToken": "${TELEGRAM_BOT_TOKEN}",
-        "allowedUsers": ["123456789"]
-      }
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "agentId": "assistant",
+      "allowedChatIds": [123456789],
+      "pollingTimeoutSeconds": 30
     },
     "tui": {
       "type": "tui",
@@ -387,13 +382,7 @@ Channels route messages from external sources (Telegram, WebUI, TUI) to agents.
 
 ### Channel Settings Reference
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `type` | string | (required) | Channel adapter type: `signalr`, `telegram`, `tui` |
-| `enabled` | bool | `true` | Enable/disable this channel |
-| `settings` | object | `{}` | Channel-specific settings |
-
-### Channel-Specific Settings
+Channel configuration is extension-specific. The channel type is determined by the extension ID (the key under `channels`).
 
 **SignalR (WebUI):**
 - No additional settings required. WebUI is served at the Gateway root URL.
@@ -401,9 +390,36 @@ Channels route messages from external sources (Telegram, WebUI, TUI) to agents.
 **Telegram:**
 ```json
 {
-  "settings": {
-    "botToken": "${TELEGRAM_BOT_TOKEN}",
-    "allowedUsers": ["123456789", "987654321"]
+  "channels": {
+    "telegram": {
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "agentId": "assistant",
+      "allowedChatIds": [123456789, 987654321],
+      "pollingTimeoutSeconds": 30
+    }
+  }
+}
+```
+
+Uses long polling by default (no public URL required). For webhook mode, add `"webhookUrl": "https://your-host/telegram/webhook"`.
+
+**Multi-bot Telegram config:**
+```json
+{
+  "channels": {
+    "telegram": {
+      "bots": {
+        "larry-bot": {
+          "botToken": "111:AAA...",
+          "agentId": "larry",
+          "allowedChatIds": [123456789]
+        },
+        "assistant-bot": {
+          "botToken": "222:BBB...",
+          "agentId": "assistant"
+        }
+      }
+    }
   }
 }
 ```
@@ -560,15 +576,14 @@ Schedule recurring tasks like heartbeats, reports, or maintenance jobs.
 
 ## Session Management
 
-Sessions persist conversation history to disk.
+Sessions are persisted to a SQLite database by default.
 
 ```json
 {
   "gateway": {
-    "sessionsDirectory": "~/.botnexus/workspace/sessions",
     "sessionStore": {
-      "type": "File",
-      "filePath": "~/.botnexus/workspace/sessions"
+      "type": "Sqlite",
+      "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
     },
     "compaction": {
       "maxMessagesBeforeCompaction": 100,
@@ -580,31 +595,21 @@ Sessions persist conversation history to disk.
 
 **Session Store Types:**
 
-1. **File** (default): JSONL files in `sessionsDirectory`
-   ```json
-   {
-     "sessionStore": {
-       "type": "File",
-       "filePath": "~/.botnexus/workspace/sessions"
-     }
-   }
-   ```
-
-2. **InMemory**: Ephemeral (lost on restart)
-   ```json
-   {
-     "sessionStore": {
-       "type": "InMemory"
-     }
-   }
-   ```
-
-3. **Sqlite**: SQLite database
+1. **Sqlite** (default): SQLite database
    ```json
    {
      "sessionStore": {
        "type": "Sqlite",
-       "connectionString": "Data Source=~/.botnexus/sessions.db"
+       "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
+     }
+   }
+   ```
+
+2. **InMemory**: Ephemeral (lost on restart — for testing/dev only)
+   ```json
+   {
+     "sessionStore": {
+       "type": "InMemory"
      }
    }
    ```
@@ -693,9 +698,9 @@ A production-ready configuration with multiple agents, providers, and extensions
     "listenUrl": "http://localhost:5005",
     "defaultAgentId": "assistant",
     "agentsDirectory": "~/.botnexus/agents",
-    "sessionsDirectory": "~/.botnexus/workspace/sessions",
     "sessionStore": {
-      "type": "File"
+      "type": "Sqlite",
+      "connectionString": "Data Source=~/.botnexus/sessions.sqlite"
     },
     "compaction": {
       "maxMessagesBeforeCompaction": 100,
@@ -784,12 +789,9 @@ A production-ready configuration with multiple agents, providers, and extensions
       "enabled": true
     },
     "telegram": {
-      "type": "telegram",
-      "enabled": true,
-      "settings": {
-        "botToken": "${TELEGRAM_BOT_TOKEN}",
-        "allowedUsers": ["123456789"]
-      }
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "agentId": "assistant",
+      "allowedChatIds": [123456789]
     }
   },
   "cron": {

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -143,10 +143,12 @@ On first run, BotNexus creates a home directory at `~/.botnexus/` with a default
 ```text
 ~/.botnexus/
 ├── config.json          # Main configuration (agents, providers, channels)
+├── sessions.sqlite      # Session database
+├── conversations.sqlite # Conversations database
 ├── extensions/          # Extension binaries (auto-populated)
 ├── tokens/              # OAuth tokens (GitHub Copilot)
-├── workspace/
-│   └── sessions/        # Conversation history (JSONL format)
+├── agents/              # Per-agent workspace directories
+│   └── <agentId>/       # Agent workspace (SOUL.md, IDENTITY.md, etc.)
 └── logs/                # Application logs
 ```
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -895,11 +895,6 @@ Set credentials before using model 'your-model:latest'.
 ~/.botnexus/logs/gateway-YYYYMMDD.log
 ```
 
-**Session logs:**
-```text
-~/.botnexus/workspace/sessions/<agentId>/<sessionId>.jsonl
-```
-
 ### Viewing Logs
 
 **Real-time:**

--- a/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
@@ -326,9 +326,12 @@ internal sealed class AgentCommands
         return 0;
     }
 
-    private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
+    private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken, string reason = "before-config-write")
     {
         PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
+        var backupsDir = Path.Combine(BotNexusHome.ResolveHomePath(), "backups");
+        var backup = new ConfigBackupService(backupsDir, new System.IO.Abstractions.FileSystem());
+        backup.Backup(configPath, reason);
         await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(config, CreateWriteJsonOptions()), cancellationToken);
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
@@ -184,6 +184,9 @@ internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
     private static async Task WriteConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
         PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
+        var backupsDir = Path.Combine(BotNexusHome.ResolveHomePath(), "backups");
+        var backup = new ConfigBackupService(backupsDir, new System.IO.Abstractions.FileSystem());
+        backup.Backup(configPath, "before-config-set");
         await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(config, CreateWriteJsonOptions()), cancellationToken);
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -372,6 +372,9 @@ internal sealed class ProviderCommand
     private static async Task SaveConfigAsync(PlatformConfig config, string configPath, CancellationToken cancellationToken)
     {
         PlatformConfigLoader.EnsureConfigDirectory(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath);
+        var backupsDir = Path.Combine(BotNexusHome.ResolveHomePath(), "backups");
+        var backup = new ConfigBackupService(backupsDir, new System.IO.Abstractions.FileSystem());
+        backup.Backup(configPath, "before-provider-update");
         var json = JsonSerializer.Serialize(config, WriteJsonOptions);
         await File.WriteAllTextAsync(configPath, json, cancellationToken);
     }

--- a/src/gateway/BotNexus.Gateway/Configuration/BotNexusHome.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/BotNexusHome.cs
@@ -13,7 +13,8 @@ public sealed class BotNexusHome
         "tokens",
         "sessions",
         "logs",
-        "agents"
+        "agents",
+        "backups"
     ];
 
     private static readonly string[] WorkspaceScaffoldFiles =

--- a/src/gateway/BotNexus.Gateway/Configuration/ConfigBackupService.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/ConfigBackupService.cs
@@ -1,0 +1,73 @@
+using System.IO.Abstractions;
+using System.Text.RegularExpressions;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Creates timestamped backups of config.json before writes,
+/// retaining at most <see cref="MaxBackups"/> copies. Callers pass a
+/// short reason slug that appears in the filename so operators can
+/// identify what triggered each backup without opening the file.
+/// </summary>
+public sealed class ConfigBackupService
+{
+    /// <summary>Maximum number of backup files to retain in the backups directory.</summary>
+    public const int MaxBackups = 50;
+
+    private static readonly Regex UnsafeChars = new(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
+
+    private readonly string _backupsDirectory;
+    private readonly IFileSystem _fileSystem;
+
+    /// <summary>
+    /// Initialises the service. The backups directory is created on first
+    /// <see cref="Backup"/> call if it does not yet exist.
+    /// </summary>
+    public ConfigBackupService(string backupsDirectory, IFileSystem fileSystem)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(backupsDirectory);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        _backupsDirectory = backupsDirectory;
+        _fileSystem = fileSystem;
+    }
+
+    /// <summary>
+    /// Copies <paramref name="configPath"/> into the backups directory as
+    /// <c>config-{timestamp}-{reason}.json</c>.
+    /// No-op if the config file does not exist yet.
+    /// Prunes oldest backups when the count would exceed <see cref="MaxBackups"/>.
+    /// </summary>
+    public void Backup(string configPath, string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        if (!_fileSystem.File.Exists(configPath))
+            return;
+
+        _fileSystem.Directory.CreateDirectory(_backupsDirectory);
+
+        var safeReason = UnsafeChars.Replace(reason, "-");
+        var timestamp = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+        var backupName = $"config-{timestamp}-{safeReason}.json";
+        var backupPath = _fileSystem.Path.Combine(_backupsDirectory, backupName);
+
+        _fileSystem.File.Copy(configPath, backupPath, overwrite: true);
+
+        Prune();
+    }
+
+    // Deletes oldest backup files when the directory exceeds MaxBackups.
+    private void Prune()
+    {
+        var files = _fileSystem.Directory
+            .GetFiles(_backupsDirectory, "config-*.json")
+            .OrderBy(f => _fileSystem.File.GetCreationTimeUtc(f))
+            .ToList();
+
+        var excess = files.Count - MaxBackups;
+        for (var i = 0; i < excess; i++)
+            _fileSystem.File.Delete(files[i]);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentWriter.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentWriter.cs
@@ -17,9 +17,10 @@ public sealed class PlatformConfigAgentWriter : IAgentConfigurationWriter
     private readonly string _configPath;
     private readonly BotNexusHome _botNexusHome;
     private readonly IFileSystem _fileSystem;
+    private readonly ConfigBackupService? _backup;
     private readonly SemaphoreSlim _writeGate = new(1, 1);
 
-    public PlatformConfigAgentWriter(string configPath, BotNexusHome botNexusHome, IFileSystem fileSystem)
+    public PlatformConfigAgentWriter(string configPath, BotNexusHome botNexusHome, IFileSystem fileSystem, ConfigBackupService? backup = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
         ArgumentNullException.ThrowIfNull(botNexusHome);
@@ -27,6 +28,7 @@ public sealed class PlatformConfigAgentWriter : IAgentConfigurationWriter
         _configPath = Path.GetFullPath(configPath);
         _botNexusHome = botNexusHome;
         _fileSystem = fileSystem;
+        _backup = backup;
     }
 
     public async Task SaveAsync(AgentDescriptor descriptor, CancellationToken cancellationToken = default)
@@ -41,6 +43,7 @@ public sealed class PlatformConfigAgentWriter : IAgentConfigurationWriter
         {
             var root = await ReadRootAsync(cancellationToken);
             var agents = EnsureAgentsObject(root);
+            var isNew = agents[descriptor.AgentId] is null;
             var entry = GetOrCreateAgentEntry(agents, descriptor.AgentId);
 
             entry["provider"] = descriptor.ApiProvider;
@@ -58,7 +61,10 @@ public sealed class PlatformConfigAgentWriter : IAgentConfigurationWriter
             SetOptionalObject(entry, "isolationOptions", descriptor.IsolationOptions);
             SetOptionalNode(entry, "soul", descriptor.Soul);
 
-            await WriteRootAtomicallyAsync(root, cancellationToken);
+            var saveReason = isNew
+                ? $"before-agent-create-{descriptor.AgentId}"
+                : $"before-agent-update-{descriptor.AgentId}";
+            await WriteRootAtomicallyAsync(root, saveReason, cancellationToken);
         }
         finally
         {
@@ -85,7 +91,7 @@ public sealed class PlatformConfigAgentWriter : IAgentConfigurationWriter
             if (!agents.Remove(agentId))
                 return;
 
-            await WriteRootAtomicallyAsync(root, cancellationToken);
+            await WriteRootAtomicallyAsync(root, $"before-agent-delete-{agentId}", cancellationToken);
         }
         finally
         {
@@ -158,8 +164,9 @@ public sealed class PlatformConfigAgentWriter : IAgentConfigurationWriter
         return node as JsonObject ?? new JsonObject();
     }
 
-    private async Task WriteRootAtomicallyAsync(JsonObject root, CancellationToken cancellationToken)
+    private async Task WriteRootAtomicallyAsync(JsonObject root, string reason, CancellationToken cancellationToken)
     {
+        _backup?.Backup(_configPath, reason);
         _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(_configPath)!);
 
         var tempPath = _configPath + "." + Guid.NewGuid().ToString("N") + ".tmp";

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigWriter.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigWriter.cs
@@ -13,11 +13,13 @@ public sealed class PlatformConfigWriter
     private static readonly SemaphoreSlim WriteLock = new(1, 1);
     private readonly string _configPath;
     private readonly IFileSystem _fileSystem;
+    private readonly ConfigBackupService? _backup;
 
-    public PlatformConfigWriter(string configPath, IFileSystem fileSystem)
+    public PlatformConfigWriter(string configPath, IFileSystem fileSystem, ConfigBackupService? backup = null)
     {
         _configPath = configPath;
         _fileSystem = fileSystem;
+        _backup = backup;
     }
 
     /// <summary>
@@ -40,6 +42,7 @@ public sealed class PlatformConfigWriter
         await WriteLock.WaitAsync(ct);
         try
         {
+            _backup?.Backup(_configPath, $"before-{sectionName}-update");
             var root = await ReadAsync(ct);
             root[sectionName] = value;
             var options = new JsonSerializerOptions { WriteIndented = true };
@@ -60,6 +63,7 @@ public sealed class PlatformConfigWriter
         await WriteLock.WaitAsync(ct);
         try
         {
+            _backup?.Backup(_configPath, $"before-{sectionName}-update");
             var root = await ReadAsync(ct);
             if (root[sectionName] is not JsonObject section)
             {
@@ -86,6 +90,7 @@ public sealed class PlatformConfigWriter
         await WriteLock.WaitAsync(ct);
         try
         {
+            _backup?.Backup(_configPath, $"before-{sectionName}-remove");
             var root = await ReadAsync(ct);
             if (root[sectionName] is JsonObject section)
             {

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -202,7 +202,10 @@ public static class GatewayServiceCollectionExtensions
             {
                 var home = serviceProvider.GetRequiredService<BotNexusHome>();
                 var defaultConfigPath = Path.Combine(home.RootPath, "config.json");
-                return new PlatformConfigAgentWriter(defaultConfigPath, home, serviceProvider.GetRequiredService<IFileSystem>());
+                var backup = new ConfigBackupService(
+                    Path.Combine(home.RootPath, "backups"),
+                    serviceProvider.GetRequiredService<IFileSystem>());
+                return new PlatformConfigAgentWriter(defaultConfigPath, home, serviceProvider.GetRequiredService<IFileSystem>(), backup);
             }));
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
         }
@@ -281,9 +284,13 @@ public static class GatewayServiceCollectionExtensions
         services.Replace(ServiceDescriptor.Singleton<IAgentConfigurationWriter>(serviceProvider =>
         {
             var home = serviceProvider.GetRequiredService<BotNexusHome>();
-            return new PlatformConfigAgentWriter(resolvedConfigPath, home, serviceProvider.GetRequiredService<IFileSystem>());
+            var backup = new ConfigBackupService(
+                Path.Combine(home.RootPath, "backups"),
+                serviceProvider.GetRequiredService<IFileSystem>());
+            return new PlatformConfigAgentWriter(resolvedConfigPath, home, serviceProvider.GetRequiredService<IFileSystem>(), backup);
         }));
-        services.AddSingleton(new PlatformConfigWriter(resolvedConfigPath, fileSystem));
+        services.AddSingleton(new PlatformConfigWriter(resolvedConfigPath, fileSystem,
+            new ConfigBackupService(Path.Combine(Path.GetDirectoryName(resolvedConfigPath)!, "backups"), fileSystem)));
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
 
         return services;

--- a/tests/BotNexus.Gateway.Tests/Configuration/ConfigBackupServiceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/ConfigBackupServiceTests.cs
@@ -1,0 +1,117 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.RegularExpressions;
+using BotNexus.Gateway.Configuration;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public sealed class ConfigBackupServiceTests
+{
+    private static string MakeBackupsDir() =>
+        Path.Combine(Path.GetTempPath(), "botnexus-tests", Guid.NewGuid().ToString("N"), "backups");
+
+    // 1. Backup creates a timestamped file in the backups directory
+    [Fact]
+    public void Backup_CreatesTimestampedFile_InBackupsDirectory()
+    {
+        var fs = new MockFileSystem();
+        var backupsDir = MakeBackupsDir();
+        fs.Directory.CreateDirectory(backupsDir);
+
+        var configPath = Path.Combine(Path.GetTempPath(), "config.json");
+        fs.File.WriteAllText(configPath, "{}");
+
+        var sut = new ConfigBackupService(backupsDir, fs);
+        sut.Backup(configPath, "before-agent-create-larry");
+
+        var files = fs.Directory.GetFiles(backupsDir);
+        files.Length.ShouldBe(1);
+
+        var name = Path.GetFileName(files[0]);
+        name.ShouldMatch(@"^config-\d{8}-\d{6}-before-agent-create-larry\.json$");
+    }
+
+    // 2. Backup is a no-op when config file does not exist
+    [Fact]
+    public void Backup_WhenConfigDoesNotExist_IsNoOp()
+    {
+        var fs = new MockFileSystem();
+        var backupsDir = MakeBackupsDir();
+        fs.Directory.CreateDirectory(backupsDir);
+
+        var configPath = Path.Combine(Path.GetTempPath(), "nonexistent-config.json");
+
+        var sut = new ConfigBackupService(backupsDir, fs);
+        sut.Backup(configPath, "before-agent-create-larry");
+
+        var files = fs.Directory.GetFiles(backupsDir);
+        files.Length.ShouldBe(0);
+    }
+
+    // 3. Backup prunes oldest when exceeding MaxBackups
+    [Fact]
+    public void Backup_PrunesOldestWhenExceedsMax()
+    {
+        var fs = new MockFileSystem();
+        var backupsDir = MakeBackupsDir();
+        fs.Directory.CreateDirectory(backupsDir);
+
+        // Seed 50 existing backups with staggered timestamps
+        for (var i = 0; i < ConfigBackupService.MaxBackups; i++)
+        {
+            var ts = new DateTime(2026, 1, 1, 0, 0, i, DateTimeKind.Local);
+            var name = $"config-{ts:yyyyMMdd-HHmmss}-old-backup.json";
+            fs.File.WriteAllText(Path.Combine(backupsDir, name), "{}");
+        }
+
+        var configPath = Path.Combine(Path.GetTempPath(), "config.json");
+        fs.File.WriteAllText(configPath, "{}");
+
+        var sut = new ConfigBackupService(backupsDir, fs);
+        sut.Backup(configPath, "new-backup");
+
+        var files = fs.Directory.GetFiles(backupsDir);
+        files.Length.ShouldBe(ConfigBackupService.MaxBackups);
+    }
+
+    // 4. Reason slug appears in filename
+    [Fact]
+    public void Backup_ReasonSlug_AppearsInFilename()
+    {
+        var fs = new MockFileSystem();
+        var backupsDir = MakeBackupsDir();
+        fs.Directory.CreateDirectory(backupsDir);
+
+        var configPath = Path.Combine(Path.GetTempPath(), "config.json");
+        fs.File.WriteAllText(configPath, "{}");
+
+        var sut = new ConfigBackupService(backupsDir, fs);
+        sut.Backup(configPath, "my-custom-reason");
+
+        var files = fs.Directory.GetFiles(backupsDir);
+        files.Length.ShouldBe(1);
+        Path.GetFileName(files[0]).ShouldContain("my-custom-reason");
+    }
+
+    // 5. Special chars in reason are sanitized to hyphens
+    [Fact]
+    public void Backup_SpecialCharsInReason_AreSanitized()
+    {
+        var fs = new MockFileSystem();
+        var backupsDir = MakeBackupsDir();
+        fs.Directory.CreateDirectory(backupsDir);
+
+        var configPath = Path.Combine(Path.GetTempPath(), "config.json");
+        fs.File.WriteAllText(configPath, "{}");
+
+        var sut = new ConfigBackupService(backupsDir, fs);
+        sut.Backup(configPath, "before/agent create larry");
+
+        var files = fs.Directory.GetFiles(backupsDir);
+        files.Length.ShouldBe(1);
+        var name = Path.GetFileName(files[0]);
+        name.ShouldContain("before-agent-create-larry");
+        name.ShouldNotContain("/");
+        name.ShouldNotContain(" ");
+    }
+}


### PR DESCRIPTION
Before every write to `config.json`, a timestamped backup is saved to `~/.botnexus/backups/`. Retains the last 50 backups, deletes older ones automatically.

## Backup naming
```
~/.botnexus/backups/
  config-20260503-152700-before-agent-update-larry.json
  config-20260503-151100-before-agent-create-researcher.json
  config-20260503-150900-before-agent-delete-assistant.json
```

## Coverage
- Gateway API writes (`POST/PUT/DELETE /api/agents`, provider updates) — via `PlatformConfigAgentWriter` and `PlatformConfigWriter` wired into DI
- CLI writes (`botnexus agent`, `botnexus config`, `botnexus provider`) — inline `ConfigBackupService` before each write

## What's new
- `ConfigBackupService` — single class, testable via `IFileSystem`
- `BotNexusHome` — creates `backups/` dir on `Initialize()`
- 5 tests in `ConfigBackupServiceTests`