### PR TITLE
fix(config): remove mandatory type validation for channel entries

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
@@ -411,16 +411,10 @@ public static class PlatformConfigLoader
         if (channels is null)
             return;
 
-        foreach (var (channelKey, channelConfig) in channels)
+        foreach (var (channelKey, _) in channels)
         {
             if (string.IsNullOrWhiteSpace(channelKey))
-            {
                 errors.Add("channels contains an empty channel key. Use a channel ID (example: 'web').");
-                continue;
-            }
-
-            if (string.IsNullOrWhiteSpace(channelConfig.Type))
-                errors.Add($"channels.{channelKey}.type is required (example: 'signalr' or 'slack').");
         }
     }
 


### PR DESCRIPTION
Extension-provided channels like Telegram register themselves by key (`channels.telegram`) without a `type` field — the channel key is the identifier. The validator was rejecting this as an error.

Removes the `channels.{key}.type is required` validation. The channel key empty-string check is kept.