### PR TITLE
fix(telegram): self-load config from config.json when IOptions is empty at startup

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
@@ -370,7 +371,14 @@ public sealed class TelegramChannelAdapter(
         if (_bots.Count > 0)
             return;
 
-        var configs = _options.ResolveActiveBots();
+        // IOptions<TelegramGatewayOptions> may be empty when the extension loader
+        // registered this adapter before gateway DI had a chance to bind the
+        // channels.telegram config section. Fall back to reading the config file directly.
+        var effectiveOptions = _options;
+        if (string.IsNullOrWhiteSpace(_options.BotToken) && _options.Bots.Count == 0)
+            effectiveOptions = LoadOptionsFromConfig() ?? _options;
+
+        var configs = effectiveOptions.ResolveActiveBots();
         if (configs.Count == 0)
             throw new InvalidOperationException("Telegram channel requires at least one configured bot.");
 
@@ -410,6 +418,44 @@ public sealed class TelegramChannelAdapter(
             return _bots.Values.Single();
 
         throw new InvalidOperationException("Multiple Telegram bots are configured. Outbound Telegram messages must specify metadata['telegramBotName'].");
+    }
+
+    /// <summary>
+    /// Fallback: reads channels.telegram directly from config.json when IOptions is empty.
+    /// This handles the case where the extension is loaded after DI service registration.
+    /// </summary>
+    private static TelegramGatewayOptions? LoadOptionsFromConfig()
+    {
+        try
+        {
+            // Resolve ~/.botnexus/config.json the same way BotNexusHome does
+            var homeOverride = Environment.GetEnvironmentVariable("BOTNEXUS_HOME");
+            var homePath = !string.IsNullOrWhiteSpace(homeOverride)
+                ? homeOverride
+                : Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) is { Length: > 0 } p
+                        ? p
+                        : Environment.GetEnvironmentVariable("HOME") ?? string.Empty,
+                    ".botnexus");
+
+            var configPath = Path.Combine(homePath, "config.json");
+            if (!File.Exists(configPath))
+                return null;
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+            if (!doc.RootElement.TryGetProperty("channels", out var channels))
+                return null;
+            if (!channels.TryGetProperty("telegram", out var telegramSection))
+                return null;
+
+            return JsonSerializer.Deserialize<TelegramGatewayOptions>(
+                telegramSection.GetRawText(),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool TryParseChatId(string conversationId, out long chatId)

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using BotNexus.Gateway.Abstractions.Channels;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Abstractions.Activity;
@@ -293,6 +295,12 @@ public static class GatewayServiceCollectionExtensions
             new ConfigBackupService(Path.Combine(Path.GetDirectoryName(resolvedConfigPath)!, "backups"), fileSystem)));
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
 
+        // Bind channels.* config sections into typed options so extension-provided
+        // channel adapters can access their configuration via IOptions<T>.
+        // Each channel section is re-read from the raw JSON and bound by convention:
+        //   channels.telegram -> TelegramGatewayOptions (from BotNexus.Extensions.Channels.Telegram)
+        BindChannelOptions(services, resolvedConfigPath, fileSystem);
+
         return services;
     }
 
@@ -494,4 +502,86 @@ public static class GatewayServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
         return services;
     }
+
+    /// <summary>
+    /// Reads the raw config JSON and binds known channel sections to their typed options.
+    /// This is needed because extension-provided adapters are registered by type-scanning
+    /// and never get their config wired otherwise.
+    /// Currently handles: channels.telegram -> TelegramGatewayOptions
+    /// </summary>
+    private static void BindChannelOptions(IServiceCollection services, string configPath, IFileSystem fileSystem)
+    {
+        if (!fileSystem.File.Exists(configPath))
+            return;
+
+        try
+        {
+            var json = fileSystem.File.ReadAllText(configPath);
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("channels", out var channels))
+                return;
+
+            // Telegram
+            if (channels.TryGetProperty("telegram", out var telegramJson))
+                BindSectionToOptions(services, telegramJson,
+                    "BotNexus.Extensions.Channels.Telegram.TelegramGatewayOptions, BotNexus.Extensions.Channels.Telegram");
+        }
+        catch
+        {
+            // Non-fatal — adapter will fail with a clear error on StartAsync
+        }
+    }
+
+    private static void BindSectionToOptions(IServiceCollection services, JsonElement section, string typeName)
+    {
+        // Type.GetType only searches the default AssemblyLoadContext.
+        // Extension assemblies are loaded in a custom context, so we must
+        // search all loaded assemblies by name.
+        var simpleTypeName = typeName.Split(',')[0].Trim();
+        var type = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(a => { try { return a.GetTypes(); } catch { return []; } })
+            .FirstOrDefault(t => t.FullName == simpleTypeName);
+
+        if (type is null)
+            return;
+
+        var jsonOpts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var instance = JsonSerializer.Deserialize(section.GetRawText(), type, jsonOpts);
+        if (instance is null)
+            return;
+
+        // Use Configure<T> via reflection since T is only known at runtime
+        var configureMethod = typeof(OptionsServiceCollectionExtensions)
+            .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .First(m => m.Name == nameof(OptionsServiceCollectionExtensions.Configure)
+                        && m.GetParameters().Length == 2
+                        && m.GetParameters()[1].ParameterType == typeof(Action<>).MakeGenericType(m.GetGenericArguments()[0]))
+            .MakeGenericMethod(type);
+
+        // Build Action<T> delegate that copies properties from deserialized instance
+        var param = System.Linq.Expressions.Expression.Parameter(type, "opts");
+        var props = type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            .Where(p => p.CanWrite && p.CanRead)
+            .ToArray();
+
+        var body = new List<System.Linq.Expressions.Expression>();
+        foreach (var prop in props)
+        {
+            var value = prop.GetValue(instance);
+            if (value is null) continue;
+            var assign = System.Linq.Expressions.Expression.Assign(
+                System.Linq.Expressions.Expression.Property(param, prop),
+                System.Linq.Expressions.Expression.Constant(value, prop.PropertyType));
+            body.Add(assign);
+        }
+
+        if (body.Count == 0) return;
+
+        var actionType = typeof(Action<>).MakeGenericType(type);
+        var lambda = System.Linq.Expressions.Expression.Lambda(actionType,
+            System.Linq.Expressions.Expression.Block(body), param);
+
+        configureMethod.Invoke(null, [services, lambda.Compile()]);
+    }
 }
+

--- a/tests/BotNexus.Gateway.Tests/Configuration/ChannelOptionsBindingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/ChannelOptionsBindingTests.cs
@@ -1,0 +1,94 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+/// <summary>
+/// Verifies that channels.telegram in config.json is bound to TelegramGatewayOptions
+/// when the Telegram extension assembly is loaded.
+/// </summary>
+public sealed class ChannelOptionsBindingTests
+{
+    [Fact]
+    public void BindChannelOptions_TelegramSection_BindsTelegramGatewayOptions()
+    {
+        // Arrange: config with channels.telegram containing botToken + agentId
+        const string configJson = """
+            {
+              "version": 1,
+              "channels": {
+                "telegram": {
+                  "botToken": "123:ABC",
+                  "agentId": "larry",
+                  "allowedChatIds": [5067802539],
+                  "pollingTimeoutSeconds": 60
+                }
+              }
+            }
+            """;
+
+        var configPath = "/home/test/.botnexus/config.json";
+        var fs = new MockFileSystem();
+        fs.AddFile(configPath, new MockFileData(configJson));
+
+        // Force the Telegram assembly to be loaded so Type.GetType can resolve it
+        var telegramType = typeof(BotNexus.Extensions.Channels.Telegram.TelegramGatewayOptions);
+        Assert.NotNull(telegramType); // keeps reference alive
+
+        var services = new ServiceCollection();
+
+        // Act: call BindChannelOptions via AddPlatformConfiguration which invokes it
+        // We test it indirectly by calling the private method via the public surface
+        services.AddBotNexusGateway();
+        // Use reflection to call BindChannelOptions directly
+        var method = typeof(GatewayServiceCollectionExtensions)
+            .GetMethod("BindChannelOptions",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        method.Invoke(null, [services, configPath, fs]);
+
+        var sp = services.BuildServiceProvider();
+        var opts = sp.GetService<IOptions<BotNexus.Extensions.Channels.Telegram.TelegramGatewayOptions>>();
+
+        // Assert
+        Assert.NotNull(opts);
+        Assert.Equal("123:ABC", opts.Value.BotToken);
+        Assert.Equal("larry", opts.Value.AgentId);
+        Assert.Equal(60, opts.Value.PollingTimeoutSeconds);
+    }
+
+    [Fact]
+    public void BindChannelOptions_NoChannelsSection_IsNoOp()
+    {
+        const string configJson = """{ "version": 1 }""";
+        var configPath = "/home/test/.botnexus/config.json";
+        var fs = new MockFileSystem();
+        fs.AddFile(configPath, new MockFileData(configJson));
+
+        var services = new ServiceCollection();
+        var method = typeof(GatewayServiceCollectionExtensions)
+            .GetMethod("BindChannelOptions",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+
+        // Should not throw
+        method.Invoke(null, [services, configPath, fs]);
+    }
+
+    [Fact]
+    public void BindChannelOptions_MissingConfigFile_IsNoOp()
+    {
+        var fs = new MockFileSystem();
+        var services = new ServiceCollection();
+        var method = typeof(GatewayServiceCollectionExtensions)
+            .GetMethod("BindChannelOptions",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+
+        // Should not throw
+        method.Invoke(null, [services, "/nonexistent/config.json", fs]);
+    }
+}


### PR DESCRIPTION
## Problem

Extension adapters (including Telegram) are loaded via a custom `AssemblyLoadContext` **after** DI service registration completes. This means `IOptions<TelegramGatewayOptions>` is always resolved to an empty default instance — the `channels.telegram` config section is never bound.

Result: `Telegram bot 'default' requires BotToken` on every gateway start.

## Fix

`TelegramChannelAdapter.EnsureBotsInitialized()` now falls back to reading `channels.telegram` directly from `~/.botnexus/config.json` when `IOptions` is empty (no `BotToken` and no `Bots`).

Also adds `GatewayServiceCollectionExtensions.BindChannelOptions()` which attempts post-registration binding for forward-compatibility.

## Tests
3 new tests in `ChannelOptionsBindingTests`