### PR TITLE
refactor(config): complete IOptionsMonitor migration — remove PlatformConfig singleton

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Federation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
 namespace BotNexus.Gateway.Api.Controllers;
@@ -24,9 +25,9 @@ public sealed class CrossWorldFederationController(
     IAgentSupervisor supervisor,
     ISessionStore sessionStore,
     CrossWorldInboundAuthService inboundAuthService,
-    PlatformConfig platformConfig) : ControllerBase
+    IOptionsMonitor<PlatformConfig> platformConfig) : ControllerBase
 {
-    private readonly string _localWorldId = WorldIdentityResolver.Resolve(platformConfig).Id;
+    private readonly string _localWorldId = WorldIdentityResolver.Resolve(platformConfig.CurrentValue).Id;
 
     /// <summary>
     /// Executes relay async.

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -253,7 +253,7 @@ using (var bootstrapLoggerFactory = new Serilog.Extensions.Logging.SerilogLogger
 
 var app = builder.Build();
 
-var platformConfig = app.Services.GetRequiredService<PlatformConfig>();
+var platformConfig = app.Services.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue;
 var worldDescriptor = WorldDescriptorBuilder.Build(
     platformConfig,
     app.Services.GetRequiredService<IAgentRegistry>(),

--- a/src/gateway/BotNexus.Gateway.Api/RateLimitingMiddleware.cs
+++ b/src/gateway/BotNexus.Gateway.Api/RateLimitingMiddleware.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Api;
 
@@ -16,7 +17,7 @@ public sealed class RateLimitingMiddleware
     private static readonly TimeSpan MinimumRetryAfter = TimeSpan.FromSeconds(1);
 
     private readonly RequestDelegate _next;
-    private readonly PlatformConfig _platformConfig;
+    private readonly IOptions<PlatformConfig> _platformConfig;
     private readonly ConcurrentDictionary<string, ClientWindow> _clientWindows = new(StringComparer.Ordinal);
     private long _lastCleanupTicks;
 
@@ -25,7 +26,7 @@ public sealed class RateLimitingMiddleware
     /// </summary>
     /// <param name="next">The next middleware in the pipeline.</param>
     /// <param name="platformConfig">Loaded platform configuration.</param>
-    public RateLimitingMiddleware(RequestDelegate next, PlatformConfig platformConfig)
+    public RateLimitingMiddleware(RequestDelegate next, IOptions<PlatformConfig> platformConfig)
     {
         _next = next;
         _platformConfig = platformConfig;
@@ -39,7 +40,7 @@ public sealed class RateLimitingMiddleware
     public async Task InvokeAsync(HttpContext context)
     {
         // Rate limiting is opt-in. Disabled by default for local development.
-        var configuredRateLimit = _platformConfig.Gateway?.RateLimit;
+        var configuredRateLimit = _platformConfig.Value.Gateway?.RateLimit;
         if (configuredRateLimit?.Enabled != true)
         {
             await _next(context);

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -23,7 +23,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
     private readonly ISessionStore _sessionStore;
     private readonly IOptions<Gateway.Configuration.GatewayOptions> _options;
     private readonly ILogger<AgentExchangeService> _logger;
-    private readonly PlatformConfig _platformConfig;
+    private readonly IOptions<PlatformConfig> _platformConfigOptions;
     private readonly CrossWorldChannelAdapter _crossWorldChannelAdapter;
     private readonly string _sourceWorldId;
 
@@ -33,7 +33,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
         ISessionStore sessionStore,
         IOptions<Gateway.Configuration.GatewayOptions> options,
         ILogger<AgentExchangeService> logger,
-        PlatformConfig? platformConfig = null,
+        IOptions<PlatformConfig>? platformConfigOptions = null,
         CrossWorldChannelAdapter? crossWorldChannelAdapter = null)
     {
         _registry = registry;
@@ -41,11 +41,11 @@ public sealed class AgentExchangeService : IAgentExchangeService
         _sessionStore = sessionStore;
         _options = options;
         _logger = logger;
-        _platformConfig = platformConfig ?? new PlatformConfig();
+        _platformConfigOptions = platformConfigOptions ?? Options.Create(new PlatformConfig());
         _crossWorldChannelAdapter = crossWorldChannelAdapter ?? new CrossWorldChannelAdapter(
             NullLogger<CrossWorldChannelAdapter>.Instance,
             new HttpClient());
-        _sourceWorldId = WorldIdentityResolver.Resolve(_platformConfig).Id;
+        _sourceWorldId = WorldIdentityResolver.Resolve(_platformConfigOptions.Value).Id;
     }
 
     /// <inheritdoc />
@@ -332,7 +332,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
     private CrossWorldPermissionConfig? ResolveOutboundPermission(string worldId, AgentId initiatorId)
     {
-        var permission = _platformConfig.Gateway?.CrossWorldPermissions?
+        var permission = _platformConfigOptions.Value.Gateway?.CrossWorldPermissions?
             .FirstOrDefault(item => string.Equals(item.TargetWorldId, worldId, StringComparison.OrdinalIgnoreCase));
         if (permission is null)
             return null;
@@ -347,7 +347,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
     private CrossWorldPeerConfig? ResolvePeer(string worldId)
     {
-        var peers = _platformConfig.Gateway?.CrossWorld?.Peers;
+        var peers = _platformConfigOptions.Value.Gateway?.CrossWorld?.Peers;
         if (peers is null || peers.Count == 0)
             return null;
 
@@ -362,7 +362,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
     private CrossWorldAgentReference ResolveTarget(CrossWorldAgentReference fallback, AgentId requestedTarget)
     {
-        var explicitTargets = _platformConfig.Gateway?.CrossWorld?.Agents;
+        var explicitTargets = _platformConfigOptions.Value.Gateway?.CrossWorld?.Agents;
         if (explicitTargets is null || !explicitTargets.TryGetValue(requestedTarget.Value, out var configuredTarget))
             return fallback;
 

--- a/src/gateway/BotNexus.Gateway/Configuration/GatewayAuthManager.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/GatewayAuthManager.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using BotNexus.Agent.Providers.Copilot;
 using BotNexus.Agent.Providers.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Configuration;
 
@@ -13,7 +14,7 @@ namespace BotNexus.Gateway.Configuration;
 public sealed class GatewayAuthManager
 {
     private const string AuthFileName = "auth.json";
-    private readonly PlatformConfig _platformConfig;
+    private readonly IOptionsMonitor<PlatformConfig> _platformConfig;
     private readonly ILogger<GatewayAuthManager> _logger;
     private readonly IFileSystem _fileSystem;
     private readonly string _authFilePath;
@@ -22,7 +23,7 @@ public sealed class GatewayAuthManager
     private Dictionary<string, AuthEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private bool _loaded;
 
-    public GatewayAuthManager(PlatformConfig platformConfig, ILogger<GatewayAuthManager> logger, IFileSystem fileSystem)
+    public GatewayAuthManager(IOptionsMonitor<PlatformConfig> platformConfig, ILogger<GatewayAuthManager> logger, IFileSystem fileSystem)
     {
         _platformConfig = platformConfig;
         _logger = logger;
@@ -45,8 +46,8 @@ public sealed class GatewayAuthManager
         if (TryGetAuthEntry(provider, out var entry) && !string.IsNullOrWhiteSpace(entry.Endpoint))
             return entry.Endpoint;
 
-        if (_platformConfig.Providers is not null &&
-            TryGetProviderConfig(_platformConfig.Providers, provider, out var providerConfig) &&
+        if (_platformConfig.CurrentValue.Providers is not null &&
+            TryGetProviderConfig(_platformConfig.CurrentValue.Providers, provider, out var providerConfig) &&
             !string.IsNullOrWhiteSpace(providerConfig?.BaseUrl))
             return providerConfig.BaseUrl;
 
@@ -80,12 +81,12 @@ public sealed class GatewayAuthManager
 
     private async Task<string?> ResolveProviderConfigApiKeyAsync(string provider, CancellationToken cancellationToken)
     {
-        if (_platformConfig.Providers is null)
+        if (_platformConfig.CurrentValue.Providers is null)
         {
             return null;
         }
 
-        if (!TryGetProviderConfig(_platformConfig.Providers, provider, out var providerConfig) ||
+        if (!TryGetProviderConfig(_platformConfig.CurrentValue.Providers, provider, out var providerConfig) ||
             string.IsNullOrWhiteSpace(providerConfig?.ApiKey))
         {
             return null;

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
@@ -30,10 +30,7 @@ public static class PlatformConfigLoader
     public static string GetDefaultConfigDirectory(IFileSystem fileSystem)
         => new BotNexusHome(fileSystem).RootPath;
 
-    public static string GetDefaultHomePath(IFileSystem fileSystem)
-        => GetDefaultConfigDirectory(fileSystem);
-
-    public static string GetDefaultConfigPath(IFileSystem fileSystem)
+        public static string GetDefaultConfigPath(IFileSystem fileSystem)
         => Path.Combine(GetDefaultConfigDirectory(fileSystem), "config.json");
 
     /// <summary>Loads config from disk and optionally validates it.</summary>

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -251,8 +251,6 @@ public static class GatewayServiceCollectionExtensions
                 });
         }
 
-        services.Replace(ServiceDescriptor.Singleton(serviceProvider =>
-            serviceProvider.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue));
         services.TryAddSingleton<GatewayAuthManager>();
         services.TryAddSingleton<ILocationResolver>(serviceProvider =>
             new DefaultLocationResolver(

--- a/src/gateway/BotNexus.Gateway/Federation/CrossWorldInboundAuthService.cs
+++ b/src/gateway/BotNexus.Gateway/Federation/CrossWorldInboundAuthService.cs
@@ -1,11 +1,12 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Federation;
 
-public sealed class CrossWorldInboundAuthService(PlatformConfig platformConfig)
+public sealed class CrossWorldInboundAuthService(IOptionsMonitor<PlatformConfig> platformConfig)
 {
-    private readonly PlatformConfig _platformConfig = platformConfig;
+    private readonly IOptionsMonitor<PlatformConfig> _platformConfig = platformConfig;
 
     public bool TryAuthorize(
         string sourceWorldId,
@@ -13,7 +14,7 @@ public sealed class CrossWorldInboundAuthService(PlatformConfig platformConfig)
         string? presentedApiKey,
         out string error)
     {
-        var inbound = _platformConfig.Gateway?.CrossWorld?.Inbound;
+        var inbound = _platformConfig.CurrentValue.Gateway?.CrossWorld?.Inbound;
         if (inbound is null || !inbound.Enabled)
         {
             error = "Cross-world inbound federation is disabled.";
@@ -65,7 +66,7 @@ public sealed class CrossWorldInboundAuthService(PlatformConfig platformConfig)
     }
 
     private CrossWorldPermissionConfig? ResolvePermission(string sourceWorldId)
-        => _platformConfig.Gateway?.CrossWorldPermissions?
+        => _platformConfig.CurrentValue.Gateway?.CrossWorldPermissions?
             .FirstOrDefault(permission => string.Equals(permission.TargetWorldId, sourceWorldId, StringComparison.OrdinalIgnoreCase));
 
     private static bool TryGetApiKey(IReadOnlyDictionary<string, string> keys, string sourceWorldId, out string? apiKey)

--- a/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -173,7 +173,7 @@ public sealed class AgentExchangeServiceTests
             sessionStore,
             Options.Create(new GatewayOptions()),
             NullLogger<AgentExchangeService>.Instance,
-            new PlatformConfig
+            Options.Create(new PlatformConfig
             {
                 Gateway = new GatewaySettingsConfig
                 {
@@ -200,7 +200,7 @@ public sealed class AgentExchangeServiceTests
                         }
                     }
                 }
-            },
+            }),
             adapter);
 
         var result = await service.ConverseAsync(new AgentExchangeRequest
@@ -238,7 +238,7 @@ public sealed class AgentExchangeServiceTests
             new InMemorySessionStore(),
             Options.Create(new GatewayOptions()),
             NullLogger<AgentExchangeService>.Instance,
-            new PlatformConfig
+            Options.Create(new PlatformConfig
             {
                 Gateway = new GatewaySettingsConfig
                 {
@@ -264,7 +264,7 @@ public sealed class AgentExchangeServiceTests
                         }
                     }
                 }
-            });
+            }));
 
         Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {

--- a/tests/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -199,7 +199,7 @@ public sealed class SubAgentIntegrationTests
 
         return new InProcessIsolationStrategy(
             new LlmClient(new ApiProviderRegistry(), modelRegistry),
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new EmptyToolFactory(),
             new TestWorkspaceManager(),
@@ -263,4 +263,11 @@ public sealed class SubAgentIntegrationTests
         public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -7,6 +7,7 @@ using BotNexus.Gateway.Federation;
 using BotNexus.Gateway.Sessions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace BotNexus.Gateway.Tests;
@@ -51,13 +52,14 @@ public sealed class CrossWorldFederationControllerTests
         supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From("leela"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
         var sessions = new InMemorySessionStore();
+        var platformConfigMonitor = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
 
         var controller = new CrossWorldFederationController(
             registry.Object,
             supervisor.Object,
             sessions,
-            new CrossWorldInboundAuthService(platformConfig),
-            platformConfig)
+            new CrossWorldInboundAuthService(platformConfigMonitor),
+            platformConfigMonitor)
         {
             ControllerContext = new ControllerContext
             {
@@ -119,12 +121,13 @@ public sealed class CrossWorldFederationControllerTests
 
         var registry = new Mock<IAgentRegistry>();
         registry.Setup(r => r.Contains(AgentId.From("leela"))).Returns(true);
+        var platformConfigMonitor2 = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
         var controller = new CrossWorldFederationController(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             new InMemorySessionStore(),
-            new CrossWorldInboundAuthService(platformConfig),
-            platformConfig)
+            new CrossWorldInboundAuthService(platformConfigMonitor2),
+            platformConfigMonitor2)
         {
             ControllerContext = new ControllerContext
             {
@@ -146,4 +149,11 @@ public sealed class CrossWorldFederationControllerTests
 
         result.Result.ShouldBeOfType<UnauthorizedObjectResult>();
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using System.IO.Abstractions.TestingHelpers;
 
 namespace BotNexus.Gateway.Tests;
@@ -266,7 +267,8 @@ public sealed class GatewayAuthManagerTests : IDisposable
 
     private GatewayAuthManager CreateManager(PlatformConfig platformConfig, bool usePrimaryAuthPath = true)
     {
-        var manager = new GatewayAuthManager(platformConfig, NullLogger<GatewayAuthManager>.Instance, _fileSystem);
+        var monitor = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
+        var manager = new GatewayAuthManager(monitor, NullLogger<GatewayAuthManager>.Instance, _fileSystem);
         var authPathField = typeof(GatewayAuthManager).GetField("_authFilePath", BindingFlags.NonPublic | BindingFlags.Instance);
         var legacyAuthPathField = typeof(GatewayAuthManager).GetField("_legacyAuthFilePath", BindingFlags.NonPublic | BindingFlags.Instance);
         authPathField.ShouldNotBeNull();
@@ -283,5 +285,13 @@ public sealed class GatewayAuthManagerTests : IDisposable
 
         Environment.SetEnvironmentVariable(name, value);
     }
+}
+
+/// <summary>Minimal IOptionsMonitor wrapper for tests that don't need change callbacks.</summary>
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }
 

--- a/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -8,6 +8,7 @@ using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Isolation;
+using Microsoft.Extensions.Options;
 using BotNexus.Gateway.Tools;
 using BotNexus.Memory;
 using BotNexus.Memory.Models;
@@ -43,7 +44,7 @@ public sealed class InProcessIsolationStrategyTests
         var llmClient = new LlmClient(new ApiProviderRegistry(), new ModelRegistry());
         var strategy = new InProcessIsolationStrategy(
             llmClient,
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new StaticAgentToolFactory(),
             new TestWorkspaceManager(),
@@ -173,7 +174,7 @@ public sealed class InProcessIsolationStrategyTests
         var llmClient = new LlmClient(new ApiProviderRegistry(), modelRegistry);
         return new InProcessIsolationStrategy(
             llmClient,
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new StaticAgentToolFactory(),
             new TestWorkspaceManager(),
@@ -247,4 +248,11 @@ public sealed class InProcessIsolationStrategyTests
         public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -556,7 +556,7 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
 
     private GatewayAuthManager CreateGatewayAuthManagerWithTempAuthPath()
     {
-        var authManager = new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem());
+        var authManager = new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem());
         var authPathField = typeof(GatewayAuthManager).GetField("_authFilePath", BindingFlags.NonPublic | BindingFlags.Instance);
         authPathField.ShouldNotBeNull();
         authPathField!.SetValue(authManager, Path.Combine(_configDirectory, "auth.json"));
@@ -818,4 +818,11 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
         public IReadOnlyList<Location> GetAll()
             => [];
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -1011,3 +1011,6 @@ public sealed class PlatformConfigurationTests
         registration.ShouldBeNull("PlatformConfig must not be registered as a singleton; use IOptionsMonitor<PlatformConfig>");
     }
 }
+
+// Note: GetDefaultHomePath(IFileSystem) was dead code removed in refactor/iconfiguration-cleanup.
+// Confirmed not called by any gateway or CLI code (only defined in PlatformConfigLoader).

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -986,4 +986,28 @@ public sealed class PlatformConfigurationTests
         public string? ResolvePath(string locationName) => null;
         public IReadOnlyList<Location> GetAll() => [];
     }
+
+    // -------------------------------------------------------------------------
+    // Issue #120: PlatformConfig singleton removal
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AddPlatformConfiguration_DoesNotRegisterBare_PlatformConfig_AsSingletonInDI()
+    {
+        // Arrange — AddPlatformConfiguration must NOT register a bare PlatformConfig singleton.
+        // All consumers must resolve via IOptionsMonitor<PlatformConfig> or IOptions<PlatformConfig>.
+        using var fixture = new PlatformConfigFixture();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddBotNexusGateway();
+        services.AddSingleton<ILocationResolver>(new StubLocationResolver());
+        services.AddPlatformConfiguration(fixture.ConfigPath);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Act & Assert — direct resolution must fail; use IOptionsMonitor<PlatformConfig> instead.
+        var registration = provider.GetService<PlatformConfig>();
+        registration.ShouldBeNull("PlatformConfig must not be registered as a singleton; use IOptionsMonitor<PlatformConfig>");
+    }
 }

--- a/tests/BotNexus.Gateway.Tests/RateLimitingMiddlewareTests.cs
+++ b/tests/BotNexus.Gateway.Tests/RateLimitingMiddlewareTests.cs
@@ -3,6 +3,7 @@ using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using System.Reflection;
 
 namespace BotNexus.Gateway.Tests;
@@ -331,8 +332,8 @@ public sealed class RateLimitingMiddlewareTests
         rateLimit.WindowSeconds.ShouldBe(45);
     }
 
-    private static PlatformConfig CreateConfig(int requestsPerMinute, int windowSeconds)
-        => new()
+    private static IOptions<PlatformConfig> CreateConfig(int requestsPerMinute, int windowSeconds)
+        => Microsoft.Extensions.Options.Options.Create(new PlatformConfig
         {
             Gateway = new GatewaySettingsConfig
             {
@@ -343,7 +344,7 @@ public sealed class RateLimitingMiddlewareTests
                     WindowSeconds = windowSeconds
                 }
             }
-        };
+        });
 
     private static DefaultHttpContext CreateContext(string remoteIpAddress)
     {

--- a/tests/BotNexus.Gateway.Tests/Security/RateLimitingAdversarialTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Security/RateLimitingAdversarialTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Tests.Security;
 
@@ -80,8 +81,8 @@ public sealed class RateLimitingAdversarialTests
         thirdRequest.Response.StatusCode.ShouldBe(StatusCodes.Status200OK);
     }
 
-    private static PlatformConfig CreateConfig(int requestsPerMinute, int windowSeconds)
-        => new()
+    private static IOptions<PlatformConfig> CreateConfig(int requestsPerMinute, int windowSeconds)
+        => Options.Create(new PlatformConfig()
         {
             Gateway = new GatewaySettingsConfig
             {
@@ -92,7 +93,7 @@ public sealed class RateLimitingAdversarialTests
                     WindowSeconds = windowSeconds
                 }
             }
-        };
+        });
 
     private static DefaultHttpContext CreateContext(string remoteIpAddress, string? xForwardedFor = null)
     {

--- a/tests/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
+++ b/tests/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Options;
 using BotNexus.Gateway.Hooks;
 using BotNexus.Gateway.Isolation;
 using BotNexus.Gateway.Tools;
@@ -147,7 +148,7 @@ public sealed class ToolHookWiringTests
 
         return new InProcessIsolationStrategy(
             llmClient,
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new StaticToolFactory(),
             new StubWorkspaceManager(),
@@ -221,4 +222,11 @@ public sealed class ToolHookWiringTests
         public Task<TResult?> HandleAsync(TEvent hookEvent, CancellationToken ct = default)
             => Task.FromResult(handler(hookEvent));
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }


### PR DESCRIPTION
Completes the IConfiguration migration started in #119.

## What changed

**PlatformConfig singleton removed**
- `services.Replace(ServiceDescriptor.Singleton(sp => sp.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue))` removed from DI
- `Program.cs` now uses `IOptionsMonitor<PlatformConfig>.CurrentValue` at startup read points

**All gateway components use IOptionsMonitor or IOptions**
- `GatewayAuthManager` → `IOptionsMonitor<PlatformConfig>` (reads per auth call — picks up hot-reload)
- `CrossWorldInboundAuthService` → `IOptionsMonitor<PlatformConfig>`
- `RateLimitingMiddleware` → `IOptions<PlatformConfig>`
- `CrossWorldFederationController` → `IOptionsMonitor<PlatformConfig>`
- `AgentExchangeService` → `IOptions<PlatformConfig>?`

**Dead code removed**
- `PlatformConfigLoader.GetDefaultHomePath(IFileSystem)` — no callers, deleted

## TDD
- Failing test written first (`test(config):` commit), then fix (`refactor(config):` commit)

## CLI unchanged
CLI commands still use `PlatformConfigLoader.Load()` directly — correct for one-shot tools.