### PR TITLE
fix(config): populate JsonElement fields from raw JSON in PostConfigure

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Federation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
 namespace BotNexus.Gateway.Api.Controllers;
@@ -24,9 +25,9 @@ public sealed class CrossWorldFederationController(
     IAgentSupervisor supervisor,
     ISessionStore sessionStore,
     CrossWorldInboundAuthService inboundAuthService,
-    PlatformConfig platformConfig) : ControllerBase
+    IOptionsMonitor<PlatformConfig> platformConfig) : ControllerBase
 {
-    private readonly string _localWorldId = WorldIdentityResolver.Resolve(platformConfig).Id;
+    private readonly string _localWorldId = WorldIdentityResolver.Resolve(platformConfig.CurrentValue).Id;
 
     /// <summary>
     /// Executes relay async.

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -253,7 +253,7 @@ using (var bootstrapLoggerFactory = new Serilog.Extensions.Logging.SerilogLogger
 
 var app = builder.Build();
 
-var platformConfig = app.Services.GetRequiredService<PlatformConfig>();
+var platformConfig = app.Services.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue;
 var worldDescriptor = WorldDescriptorBuilder.Build(
     platformConfig,
     app.Services.GetRequiredService<IAgentRegistry>(),

--- a/src/gateway/BotNexus.Gateway.Api/RateLimitingMiddleware.cs
+++ b/src/gateway/BotNexus.Gateway.Api/RateLimitingMiddleware.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Api;
 
@@ -16,7 +17,7 @@ public sealed class RateLimitingMiddleware
     private static readonly TimeSpan MinimumRetryAfter = TimeSpan.FromSeconds(1);
 
     private readonly RequestDelegate _next;
-    private readonly PlatformConfig _platformConfig;
+    private readonly IOptions<PlatformConfig> _platformConfig;
     private readonly ConcurrentDictionary<string, ClientWindow> _clientWindows = new(StringComparer.Ordinal);
     private long _lastCleanupTicks;
 
@@ -25,7 +26,7 @@ public sealed class RateLimitingMiddleware
     /// </summary>
     /// <param name="next">The next middleware in the pipeline.</param>
     /// <param name="platformConfig">Loaded platform configuration.</param>
-    public RateLimitingMiddleware(RequestDelegate next, PlatformConfig platformConfig)
+    public RateLimitingMiddleware(RequestDelegate next, IOptions<PlatformConfig> platformConfig)
     {
         _next = next;
         _platformConfig = platformConfig;
@@ -39,7 +40,7 @@ public sealed class RateLimitingMiddleware
     public async Task InvokeAsync(HttpContext context)
     {
         // Rate limiting is opt-in. Disabled by default for local development.
-        var configuredRateLimit = _platformConfig.Gateway?.RateLimit;
+        var configuredRateLimit = _platformConfig.Value.Gateway?.RateLimit;
         if (configuredRateLimit?.Enabled != true)
         {
             await _next(context);

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -23,7 +23,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
     private readonly ISessionStore _sessionStore;
     private readonly IOptions<Gateway.Configuration.GatewayOptions> _options;
     private readonly ILogger<AgentExchangeService> _logger;
-    private readonly PlatformConfig _platformConfig;
+    private readonly IOptions<PlatformConfig> _platformConfigOptions;
     private readonly CrossWorldChannelAdapter _crossWorldChannelAdapter;
     private readonly string _sourceWorldId;
 
@@ -33,7 +33,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
         ISessionStore sessionStore,
         IOptions<Gateway.Configuration.GatewayOptions> options,
         ILogger<AgentExchangeService> logger,
-        PlatformConfig? platformConfig = null,
+        IOptions<PlatformConfig>? platformConfigOptions = null,
         CrossWorldChannelAdapter? crossWorldChannelAdapter = null)
     {
         _registry = registry;
@@ -41,11 +41,11 @@ public sealed class AgentExchangeService : IAgentExchangeService
         _sessionStore = sessionStore;
         _options = options;
         _logger = logger;
-        _platformConfig = platformConfig ?? new PlatformConfig();
+        _platformConfigOptions = platformConfigOptions ?? Options.Create(new PlatformConfig());
         _crossWorldChannelAdapter = crossWorldChannelAdapter ?? new CrossWorldChannelAdapter(
             NullLogger<CrossWorldChannelAdapter>.Instance,
             new HttpClient());
-        _sourceWorldId = WorldIdentityResolver.Resolve(_platformConfig).Id;
+        _sourceWorldId = WorldIdentityResolver.Resolve(_platformConfigOptions.Value).Id;
     }
 
     /// <inheritdoc />
@@ -332,7 +332,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
     private CrossWorldPermissionConfig? ResolveOutboundPermission(string worldId, AgentId initiatorId)
     {
-        var permission = _platformConfig.Gateway?.CrossWorldPermissions?
+        var permission = _platformConfigOptions.Value.Gateway?.CrossWorldPermissions?
             .FirstOrDefault(item => string.Equals(item.TargetWorldId, worldId, StringComparison.OrdinalIgnoreCase));
         if (permission is null)
             return null;
@@ -347,7 +347,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
     private CrossWorldPeerConfig? ResolvePeer(string worldId)
     {
-        var peers = _platformConfig.Gateway?.CrossWorld?.Peers;
+        var peers = _platformConfigOptions.Value.Gateway?.CrossWorld?.Peers;
         if (peers is null || peers.Count == 0)
             return null;
 
@@ -362,7 +362,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
     private CrossWorldAgentReference ResolveTarget(CrossWorldAgentReference fallback, AgentId requestedTarget)
     {
-        var explicitTargets = _platformConfig.Gateway?.CrossWorld?.Agents;
+        var explicitTargets = _platformConfigOptions.Value.Gateway?.CrossWorld?.Agents;
         if (explicitTargets is null || !explicitTargets.TryGetValue(requestedTarget.Value, out var configuredTarget))
             return fallback;
 

--- a/src/gateway/BotNexus.Gateway/Configuration/GatewayAuthManager.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/GatewayAuthManager.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using BotNexus.Agent.Providers.Copilot;
 using BotNexus.Agent.Providers.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Configuration;
 
@@ -13,7 +14,7 @@ namespace BotNexus.Gateway.Configuration;
 public sealed class GatewayAuthManager
 {
     private const string AuthFileName = "auth.json";
-    private readonly PlatformConfig _platformConfig;
+    private readonly IOptionsMonitor<PlatformConfig> _platformConfig;
     private readonly ILogger<GatewayAuthManager> _logger;
     private readonly IFileSystem _fileSystem;
     private readonly string _authFilePath;
@@ -22,7 +23,7 @@ public sealed class GatewayAuthManager
     private Dictionary<string, AuthEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private bool _loaded;
 
-    public GatewayAuthManager(PlatformConfig platformConfig, ILogger<GatewayAuthManager> logger, IFileSystem fileSystem)
+    public GatewayAuthManager(IOptionsMonitor<PlatformConfig> platformConfig, ILogger<GatewayAuthManager> logger, IFileSystem fileSystem)
     {
         _platformConfig = platformConfig;
         _logger = logger;
@@ -45,8 +46,8 @@ public sealed class GatewayAuthManager
         if (TryGetAuthEntry(provider, out var entry) && !string.IsNullOrWhiteSpace(entry.Endpoint))
             return entry.Endpoint;
 
-        if (_platformConfig.Providers is not null &&
-            TryGetProviderConfig(_platformConfig.Providers, provider, out var providerConfig) &&
+        if (_platformConfig.CurrentValue.Providers is not null &&
+            TryGetProviderConfig(_platformConfig.CurrentValue.Providers, provider, out var providerConfig) &&
             !string.IsNullOrWhiteSpace(providerConfig?.BaseUrl))
             return providerConfig.BaseUrl;
 
@@ -80,12 +81,12 @@ public sealed class GatewayAuthManager
 
     private async Task<string?> ResolveProviderConfigApiKeyAsync(string provider, CancellationToken cancellationToken)
     {
-        if (_platformConfig.Providers is null)
+        if (_platformConfig.CurrentValue.Providers is null)
         {
             return null;
         }
 
-        if (!TryGetProviderConfig(_platformConfig.Providers, provider, out var providerConfig) ||
+        if (!TryGetProviderConfig(_platformConfig.CurrentValue.Providers, provider, out var providerConfig) ||
             string.IsNullOrWhiteSpace(providerConfig?.ApiKey))
         {
             return null;

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
@@ -30,10 +30,7 @@ public static class PlatformConfigLoader
     public static string GetDefaultConfigDirectory(IFileSystem fileSystem)
         => new BotNexusHome(fileSystem).RootPath;
 
-    public static string GetDefaultHomePath(IFileSystem fileSystem)
-        => GetDefaultConfigDirectory(fileSystem);
-
-    public static string GetDefaultConfigPath(IFileSystem fileSystem)
+        public static string GetDefaultConfigPath(IFileSystem fileSystem)
         => Path.Combine(GetDefaultConfigDirectory(fileSystem), "config.json");
 
     /// <summary>Loads config from disk and optionally validates it.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigPostConfigure.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigPostConfigure.cs
@@ -6,7 +6,8 @@ namespace BotNexus.Gateway.Configuration;
 
 /// <summary>
 /// Applies BotNexus-specific normalization to <see cref="PlatformConfig"/> after standard IConfiguration binding.
-/// Handles agents.defaults extraction, AgentRawElements capture, and legacy root-level gateway field migration.
+/// Handles agents.defaults extraction, AgentRawElements capture, JsonElement field population,
+/// and legacy root-level gateway field migration.
 /// </summary>
 public sealed class PlatformConfigPostConfigure(IConfiguration configuration, string? configFilePath = null) : IPostConfigureOptions<PlatformConfig>
 {
@@ -15,9 +16,6 @@ public sealed class PlatformConfigPostConfigure(IConfiguration configuration, st
     /// <inheritdoc />
     public void PostConfigure(string? name, PlatformConfig config)
     {
-        // Re-read the raw JSON from the config file path to support presence-aware merging
-        // (AgentRawElements) and legacy root-level gateway migration.
-        // IConfiguration alone does not preserve original JSON element structure.
         var rawJson = configFilePath is not null && File.Exists(configFilePath)
             ? TryReadFile(configFilePath)
             : ReadRawJson(configuration);
@@ -26,11 +24,10 @@ public sealed class PlatformConfigPostConfigure(IConfiguration configuration, st
         {
             PlatformConfigLoader.MigrateLegacyGatewaySettings(config, rawJson);
             PlatformConfigLoader.ExtractAgentDefaults(config, rawJson);
+            PopulateJsonElementFields(config, rawJson);
         }
         else
         {
-            // No raw JSON available (e.g., no file) — still strip the reserved "defaults" key
-            // from the Agents dictionary to prevent it from being treated as a real agent.
             if (config.Agents is not null)
             {
                 var keysToRemove = config.Agents.Keys
@@ -38,6 +35,97 @@ public sealed class PlatformConfigPostConfigure(IConfiguration configuration, st
                     .ToList();
                 foreach (var key in keysToRemove)
                     config.Agents.Remove(key);
+            }
+        }
+
+        // IConfiguration cannot bind JsonElement fields — null out any that were left in
+        // an invalid/undefined state to prevent serialization crashes (e.g. schema validation).
+        NullifyInvalidJsonElements(config);
+    }
+
+    /// <summary>
+    /// Populate JsonElement fields on AgentDefinitionConfig from raw JSON.
+    /// IConfiguration cannot bind JsonElement — these fields are left invalid after binding.
+    /// </summary>
+    private static void PopulateJsonElementFields(PlatformConfig config, string rawJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(rawJson);
+
+            // Populate gateway.extensions.defaults (Dictionary<string, JsonElement>)
+            if (config.Gateway?.Extensions is not null &&
+                doc.RootElement.TryGetProperty("gateway", out var gatewayEl) &&
+                gatewayEl.TryGetProperty("extensions", out var extEl) &&
+                extEl.TryGetProperty("defaults", out var defaultsEl) &&
+                defaultsEl.ValueKind == JsonValueKind.Object)
+            {
+                config.Gateway.Extensions.Defaults = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+                foreach (var prop in defaultsEl.EnumerateObject())
+                    config.Gateway.Extensions.Defaults[prop.Name] = prop.Value.Clone();
+            }
+
+            // Populate per-agent JsonElement fields
+            if (config.Agents is not null && config.Agents.Count > 0 &&
+                doc.RootElement.TryGetProperty("agents", out var agentsEl))
+            {
+                foreach (var (agentId, agentConfig) in config.Agents)
+                {
+                    if (!agentsEl.TryGetProperty(agentId, out var agentEl))
+                        continue;
+
+                    if (agentEl.TryGetProperty("metadata", out var meta))
+                        agentConfig.Metadata = meta.Clone();
+                    if (agentEl.TryGetProperty("isolationOptions", out var iso))
+                        agentConfig.IsolationOptions = iso.Clone();
+                    if (agentEl.TryGetProperty("extensions", out var ext) &&
+                        ext.ValueKind == JsonValueKind.Object)
+                    {
+                        agentConfig.Extensions = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var prop in ext.EnumerateObject())
+                            agentConfig.Extensions[prop.Name] = prop.Value.Clone();
+                    }
+                }
+            }
+        }
+        catch { /* non-fatal */ }
+    }
+
+    /// <summary>
+    /// Null out any JsonElement fields left in an undefined state by IConfiguration binding.
+    /// </summary>
+    private static void NullifyInvalidJsonElements(PlatformConfig config)
+    {
+        // gateway.extensions.defaults
+        if (config.Gateway?.Extensions?.Defaults is not null)
+        {
+            var badKeys = config.Gateway.Extensions.Defaults
+                .Where(kvp => kvp.Value.ValueKind == JsonValueKind.Undefined)
+                .Select(kvp => kvp.Key).ToList();
+            foreach (var key in badKeys)
+                config.Gateway.Extensions.Defaults.Remove(key);
+            if (config.Gateway.Extensions.Defaults.Count == 0)
+                config.Gateway.Extensions.Defaults = null;
+        }
+
+        if (config.Agents is null)
+            return;
+
+        foreach (var agentConfig in config.Agents.Values)
+        {
+            if (agentConfig.Metadata.HasValue && agentConfig.Metadata.Value.ValueKind == JsonValueKind.Undefined)
+                agentConfig.Metadata = null;
+            if (agentConfig.IsolationOptions.HasValue && agentConfig.IsolationOptions.Value.ValueKind == JsonValueKind.Undefined)
+                agentConfig.IsolationOptions = null;
+            if (agentConfig.Extensions is not null)
+            {
+                var badKeys = agentConfig.Extensions
+                    .Where(kvp => kvp.Value.ValueKind == JsonValueKind.Undefined)
+                    .Select(kvp => kvp.Key).ToList();
+                foreach (var key in badKeys)
+                    agentConfig.Extensions.Remove(key);
+                if (agentConfig.Extensions.Count == 0)
+                    agentConfig.Extensions = null;
             }
         }
     }
@@ -50,19 +138,15 @@ public sealed class PlatformConfigPostConfigure(IConfiguration configuration, st
 
     private static string? ReadRawJson(IConfiguration configuration)
     {
-        // IConfigurationRoot exposes the providers; find the JSON file provider and read its path.
-        // Fallback: walk IConfigurationProvider looking for a file-based one.
         if (configuration is not IConfigurationRoot root)
             return null;
 
         foreach (var provider in root.Providers.Reverse())
         {
-            // Microsoft.Extensions.Configuration.Json.JsonConfigurationProvider has an internal Source.Path
             var type = provider.GetType();
             if (!type.FullName!.Contains("Json", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            // Get the path via the Source property (JsonConfigurationProvider -> JsonConfigurationSource -> Path)
             var sourceProp = type.GetProperty("Source");
             if (sourceProp?.GetValue(provider) is not { } source)
                 continue;
@@ -71,21 +155,14 @@ public sealed class PlatformConfigPostConfigure(IConfiguration configuration, st
             if (pathProp?.GetValue(source) is not string filePath || string.IsNullOrWhiteSpace(filePath))
                 continue;
 
-            // Only read BotNexus config files (not appsettings.json etc.)
             if (!filePath.EndsWith("config.json", StringComparison.OrdinalIgnoreCase))
                 continue;
 
             if (!File.Exists(filePath))
                 return null;
 
-            try
-            {
-                return File.ReadAllText(filePath);
-            }
-            catch
-            {
-                return null;
-            }
+            try { return File.ReadAllText(filePath); }
+            catch { return null; }
         }
 
         return null;

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -251,8 +251,6 @@ public static class GatewayServiceCollectionExtensions
                 });
         }
 
-        services.Replace(ServiceDescriptor.Singleton(serviceProvider =>
-            serviceProvider.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue));
         services.TryAddSingleton<GatewayAuthManager>();
         services.TryAddSingleton<ILocationResolver>(serviceProvider =>
             new DefaultLocationResolver(

--- a/src/gateway/BotNexus.Gateway/Federation/CrossWorldInboundAuthService.cs
+++ b/src/gateway/BotNexus.Gateway/Federation/CrossWorldInboundAuthService.cs
@@ -1,11 +1,12 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Federation;
 
-public sealed class CrossWorldInboundAuthService(PlatformConfig platformConfig)
+public sealed class CrossWorldInboundAuthService(IOptionsMonitor<PlatformConfig> platformConfig)
 {
-    private readonly PlatformConfig _platformConfig = platformConfig;
+    private readonly IOptionsMonitor<PlatformConfig> _platformConfig = platformConfig;
 
     public bool TryAuthorize(
         string sourceWorldId,
@@ -13,7 +14,7 @@ public sealed class CrossWorldInboundAuthService(PlatformConfig platformConfig)
         string? presentedApiKey,
         out string error)
     {
-        var inbound = _platformConfig.Gateway?.CrossWorld?.Inbound;
+        var inbound = _platformConfig.CurrentValue.Gateway?.CrossWorld?.Inbound;
         if (inbound is null || !inbound.Enabled)
         {
             error = "Cross-world inbound federation is disabled.";
@@ -65,7 +66,7 @@ public sealed class CrossWorldInboundAuthService(PlatformConfig platformConfig)
     }
 
     private CrossWorldPermissionConfig? ResolvePermission(string sourceWorldId)
-        => _platformConfig.Gateway?.CrossWorldPermissions?
+        => _platformConfig.CurrentValue.Gateway?.CrossWorldPermissions?
             .FirstOrDefault(permission => string.Equals(permission.TargetWorldId, sourceWorldId, StringComparison.OrdinalIgnoreCase));
 
     private static bool TryGetApiKey(IReadOnlyDictionary<string, string> keys, string sourceWorldId, out string? apiKey)

--- a/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -173,7 +173,7 @@ public sealed class AgentExchangeServiceTests
             sessionStore,
             Options.Create(new GatewayOptions()),
             NullLogger<AgentExchangeService>.Instance,
-            new PlatformConfig
+            Options.Create(new PlatformConfig
             {
                 Gateway = new GatewaySettingsConfig
                 {
@@ -200,7 +200,7 @@ public sealed class AgentExchangeServiceTests
                         }
                     }
                 }
-            },
+            }),
             adapter);
 
         var result = await service.ConverseAsync(new AgentExchangeRequest
@@ -238,7 +238,7 @@ public sealed class AgentExchangeServiceTests
             new InMemorySessionStore(),
             Options.Create(new GatewayOptions()),
             NullLogger<AgentExchangeService>.Instance,
-            new PlatformConfig
+            Options.Create(new PlatformConfig
             {
                 Gateway = new GatewaySettingsConfig
                 {
@@ -264,7 +264,7 @@ public sealed class AgentExchangeServiceTests
                         }
                     }
                 }
-            });
+            }));
 
         Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {

--- a/tests/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -199,7 +199,7 @@ public sealed class SubAgentIntegrationTests
 
         return new InProcessIsolationStrategy(
             new LlmClient(new ApiProviderRegistry(), modelRegistry),
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new EmptyToolFactory(),
             new TestWorkspaceManager(),
@@ -263,4 +263,11 @@ public sealed class SubAgentIntegrationTests
         public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
@@ -1,0 +1,1712 @@
+using System.Text.Json;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public sealed class PlatformConfigValidationTests
+{
+    [Fact]
+    public Task Validate_MinimalValidConfig_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "version": 1,
+              "providers": {
+                "copilot": {
+                  "apiKey": "test-key"
+                }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+
+                errors.ShouldBeEmpty();
+                config.Version.ShouldBe(1);
+                config.Agents.ShouldContainKey("assistant");
+                config.Providers.ShouldContainKey("copilot");
+            });
+
+    [Fact]
+    public Task Validate_FullGatewaySectionWithInMemorySessionStore_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "version": 1,
+              "gateway": {
+                "listenUrl": "http://localhost:5005",
+                "defaultAgentId": "assistant",
+                "sessionStore": {
+                  "type": "InMemory"
+                },
+                "cors": {
+                  "allowedOrigins": ["https://app.example.test"]
+                },
+                "rateLimit": {
+                  "enabled": true,
+                  "requestsPerMinute": 120,
+                  "windowSeconds": 60
+                },
+                "extensions": {
+                  "path": "extensions",
+                  "defaults": {
+                    "botnexus-skills": { "enabled": true },
+                    "botnexus-exec": { "timeout": 30 }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+
+                errors.ShouldBeEmpty();
+                config.Gateway.ShouldNotBeNull();
+                config.Gateway!.SessionStore!.Type.ShouldBe("InMemory");
+                config.Gateway.Extensions!.Defaults!.ShouldContainKey("botnexus-skills");
+                config.Gateway.Extensions.Defaults["botnexus-skills"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
+                SerializeShouldNotThrow(config);
+            });
+
+    [Fact]
+    public Task Validate_FullGatewaySectionWithSqliteSessionStore_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "listenUrl": "https://gateway.example.test",
+                "defaultAgentId": "assistant",
+                "sessionStore": {
+                  "type": "Sqlite",
+                  "connectionString": "Data Source=sessions.db"
+                },
+                "cors": {
+                  "allowedOrigins": ["https://app.example.test"]
+                },
+                "rateLimit": {
+                  "enabled": true,
+                  "requestsPerMinute": 100,
+                  "windowSeconds": 120
+                },
+                "extensions": {
+                  "path": "extensions",
+                  "defaults": {
+                    "botnexus-mcp": { "enabled": true }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+
+                errors.ShouldBeEmpty();
+                config.Gateway!.SessionStore!.Type.ShouldBe("Sqlite");
+                config.Gateway.SessionStore.ConnectionString.ShouldBe("Data Source=sessions.db");
+                SerializeShouldNotThrow(config);
+            });
+
+    [Fact]
+    public Task Validate_LegacyRootListenUrl_MigratesToGatewaySection()
+        => WithConfigFileAsync(
+            """
+            {
+              "listenUrl": "http://localhost:5005",
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+
+                errors.ShouldBeEmpty();
+                config.Gateway.ShouldNotBeNull();
+                config.Gateway!.ListenUrl.ShouldBe("http://localhost:5005");
+            });
+
+    [Fact]
+    public Task Validate_MissingGatewaySection_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway.ShouldBeNull();
+            });
+
+    [Fact]
+    public async Task Validate_InvalidSessionStoreType_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "sessionStore": {
+                  "type": "Redis"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.sessionStore.type must be either 'InMemory', 'File', or 'Sqlite'.");
+            });
+    }
+
+    [Fact]
+    public async Task Validate_InvalidListenUrlFormat_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "listenUrl": "not-a-url"
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.listenUrl must be a valid absolute URL (example: http://localhost:5005).");
+            });
+    }
+
+    [Fact]
+    public async Task Validate_InvalidListenUrlScheme_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "listenUrl": "ftp://localhost:5005"
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.listenUrl must use http or https.");
+            });
+    }
+
+    [Fact]
+    public Task Validate_SingleAgentMinimal_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+
+                errors.ShouldBeEmpty();
+                config.Agents!["assistant"].Provider.ShouldBe("copilot");
+                config.Agents["assistant"].Model.ShouldBe("gpt-4.1");
+            });
+
+    [Fact]
+    public Task Validate_AgentWithAllOptionalFields_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "displayName": "Assistant",
+                  "description": "General helper",
+                  "model": "gpt-4.1",
+                  "systemPromptFile": "SOUL.md",
+                  "systemPromptFiles": ["SOUL.md", "IDENTITY.md"],
+                  "toolIds": ["read", "write"],
+                  "allowedModels": ["gpt-4.1", "gpt-4o"],
+                  "subAgents": ["scribe", "hermes"],
+                  "isolationStrategy": "in-process",
+                  "maxConcurrentSessions": 3,
+                  "memory": {
+                    "enabled": true,
+                    "indexing": "auto",
+                    "search": {
+                      "defaultTopK": 5,
+                      "temporalDecay": {
+                        "enabled": true,
+                        "halfLifeDays": 14
+                      }
+                    }
+                  },
+                  "soul": {
+                    "enabled": true,
+                    "timezone": "America/Los_Angeles",
+                    "dayBoundary": "05:00",
+                    "reflectionOnSeal": true,
+                    "reflectionPrompt": "Reflect before sealing."
+                  },
+                  "heartbeat": {
+                    "enabled": true,
+                    "intervalMinutes": 15,
+                    "prompt": "Check heartbeat tasks.",
+                    "quietHours": {
+                      "enabled": true,
+                      "start": "23:00",
+                      "end": "07:00",
+                      "timezone": "America/Los_Angeles"
+                    }
+                  },
+                  "sessionAccess": {
+                    "level": "allowlist",
+                    "allowedAgents": ["scribe"]
+                  },
+                  "fileAccess": {
+                    "allowedReadPaths": ["./docs/**"],
+                    "allowedWritePaths": ["./out/**"],
+                    "deniedPaths": ["./secrets/**"]
+                  },
+                  "extensions": {
+                    "botnexus-mcp": { "enabled": true, "servers": ["filesystem"] }
+                  },
+                  "metadata": {
+                    "owner": "jon",
+                    "priority": 1
+                  }
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+                var agent = config.Agents!["assistant"];
+
+                errors.ShouldBeEmpty();
+                agent.DisplayName.ShouldBe("Assistant");
+                agent.SystemPromptFiles.ShouldBe(["SOUL.md", "IDENTITY.md"]);
+                agent.ToolIds.ShouldBe(["read", "write"]);
+                agent.AllowedModels.ShouldBe(["gpt-4.1", "gpt-4o"]);
+                agent.SubAgents.ShouldBe(["scribe", "hermes"]);
+                agent.Memory.ShouldNotBeNull();
+                agent.Soul.ShouldNotBeNull();
+                agent.Heartbeat.ShouldNotBeNull();
+                agent.SessionAccess.ShouldNotBeNull();
+                agent.FileAccess.ShouldNotBeNull();
+                agent.Extensions.ShouldContainKey("botnexus-mcp");
+                agent.Extensions!["botnexus-mcp"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
+                agent.Metadata.ShouldNotBeNull();
+                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("jon");
+                SerializeShouldNotThrow(config);
+            });
+
+    [Fact]
+    public Task Validate_AgentsDefaultsKey_IsStrippedAndStoredAsAgentDefaults()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "defaults": {
+                  "toolIds": ["read", "write"],
+                  "memory": {
+                    "enabled": true,
+                    "indexing": "auto"
+                  },
+                  "heartbeat": {
+                    "enabled": true,
+                    "intervalMinutes": 10
+                  },
+                  "fileAccess": {
+                    "allowedReadPaths": ["./docs/**"]
+                  }
+                },
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var errors = PlatformConfigLoader.Validate(config);
+
+                errors.ShouldBeEmpty();
+                config.AgentDefaults.ShouldNotBeNull();
+                config.AgentDefaults!.ToolIds.ShouldBe(["read", "write"]);
+                config.Agents.ShouldContainKey("assistant");
+                config.Agents.ShouldNotContainKey("defaults");
+                config.AgentRawElements.ShouldContainKey("assistant");
+            });
+
+    [Fact]
+    public Task Validate_MultipleAgents_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                },
+                "scribe": {
+                  "provider": "copilot",
+                  "model": "gpt-4o-mini"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Agents!.Count.ShouldBe(2);
+            });
+
+    [Fact]
+    public Task Validate_AgentEnabledFalse_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1",
+                  "enabled": false
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Agents!["assistant"].Enabled.ShouldBeFalse();
+            });
+
+    [Fact]
+    public async Task Validate_AgentMissingProvider_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("agents.assistant.provider is required (example: 'copilot').");
+            });
+    }
+
+    [Fact]
+    public async Task Validate_AgentMissingModel_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("agents.assistant.model is required (example: 'gpt-4.1').");
+            });
+    }
+
+    [Fact]
+    public Task Validate_AgentWithExtensionsAndMetadataNestedObjects_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1",
+                  "extensions": {
+                    "botnexus-exec": {
+                      "enabled": true,
+                      "limits": {
+                        "timeout": 30
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "team": {
+                      "name": "platform"
+                    }
+                  }
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var agent = config.Agents!["assistant"];
+
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                agent.Extensions.ShouldContainKey("botnexus-exec");
+                agent.Extensions!["botnexus-exec"].GetProperty("limits").GetProperty("timeout").GetInt32().ShouldBe(30);
+                agent.Metadata!.Value.GetProperty("team").GetProperty("name").GetString().ShouldBe("platform");
+                SerializeShouldNotThrow(config);
+            });
+
+    [Fact]
+    public Task Validate_CopilotProviderWithApiKey_NoErrors()
+        => WithProviderConfigAsync(
+            "copilot",
+            """{ "apiKey": "copilot-key" }""",
+            config =>
+            {
+                config.Providers!["copilot"].ApiKey.ShouldBe("copilot-key");
+            });
+
+    [Fact]
+    public Task Validate_AnthropicProvider_NoErrors()
+        => WithProviderConfigAsync(
+            "anthropic",
+            """{ "apiKey": "anthropic-key", "defaultModel": "claude-sonnet-4-5" }""",
+            config =>
+            {
+                config.Providers!["anthropic"].DefaultModel.ShouldBe("claude-sonnet-4-5");
+            });
+
+    [Fact]
+    public Task Validate_OpenAiProvider_NoErrors()
+        => WithProviderConfigAsync(
+            "openai",
+            """{ "apiKey": "openai-key", "defaultModel": "gpt-4.1" }""",
+            config =>
+            {
+                config.Providers!["openai"].DefaultModel.ShouldBe("gpt-4.1");
+            });
+
+    [Fact]
+    public Task Validate_OpenAiCompatProviderWithBaseUrl_NoErrors()
+        => WithProviderConfigAsync(
+            "openai-compat",
+            """{ "apiKey": "compat-key", "baseUrl": "https://llm.example.test/v1" }""",
+            config =>
+            {
+                config.Providers!["openai-compat"].BaseUrl.ShouldBe("https://llm.example.test/v1");
+            });
+
+    [Fact]
+    public Task Validate_ProviderEnabledFalse_NoErrors()
+        => WithProviderConfigAsync(
+            "copilot",
+            """{ "enabled": false, "baseUrl": "not-a-url" }""",
+            config =>
+            {
+                config.Providers!["copilot"].Enabled.ShouldBeFalse();
+            });
+
+    [Fact]
+    public Task Validate_ProviderMissingApiKey_NoErrors()
+        => WithProviderConfigAsync(
+            "copilot",
+            """{ "defaultModel": "gpt-4.1" }""",
+            config =>
+            {
+                config.Providers!["copilot"].ApiKey.ShouldBeNull();
+            });
+
+    [Fact]
+    public Task Validate_MultipleProviders_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "copilot-key" },
+                "anthropic": { "apiKey": "anthropic-key" },
+                "openai": { "apiKey": "openai-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Providers!.Count.ShouldBe(3);
+            });
+
+    [Fact]
+    public async Task Validate_ProviderWithInvalidBaseUrl_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "openai-compat": {
+                  "apiKey": "compat-key",
+                  "baseUrl": "notaurl"
+                }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "openai-compat",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("providers.openai-compat.baseUrl must be a valid http or https absolute URL.");
+            });
+    }
+
+    [Fact]
+    public Task Validate_TelegramFlatChannelConfig_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "channels": {
+                "telegram": {
+                  "botToken": "123:abc",
+                  "agentId": "assistant",
+                  "allowedChatIds": [12345, 67890]
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Channels.ShouldContainKey("telegram");
+            });
+
+    [Fact]
+    public Task Validate_TelegramMultiBotChannelConfig_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "channels": {
+                "telegram": {
+                  "bots": {
+                    "alpha": {
+                      "botToken": "111:aaa",
+                      "agentId": "assistant"
+                    },
+                    "beta": {
+                      "botToken": "222:bbb",
+                      "agentId": "scribe",
+                      "allowedChatIds": [98765]
+                    }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                },
+                "scribe": {
+                  "provider": "copilot",
+                  "model": "gpt-4o-mini"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Channels.ShouldContainKey("telegram");
+            });
+
+    [Fact]
+    public Task Validate_TelegramChannelWithWebhookUrl_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "channels": {
+                "telegram": {
+                  "botToken": "123:abc",
+                  "agentId": "assistant",
+                  "webhookUrl": "https://gateway.example.test/telegram/webhook"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Channels.ShouldContainKey("telegram");
+            });
+
+    [Fact]
+    public Task Validate_ChannelWithoutTypeField_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "channels": {
+                "telegram": {
+                  "enabled": true,
+                  "botToken": "123:abc"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+            });
+
+    [Fact]
+    public Task Validate_NoChannelsSection_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Channels.ShouldBeNull();
+            });
+
+    [Fact]
+    public Task Validate_GatewayExtensionsDefaultsWithMultipleExtensions_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "extensions": {
+                  "defaults": {
+                    "botnexus-skills": {
+                      "enabled": true,
+                      "paths": ["skills"]
+                    },
+                    "botnexus-exec": {
+                      "enabled": true,
+                      "timeout": 30
+                    }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.Extensions!.Defaults.ShouldContainKey("botnexus-skills");
+                config.Gateway.Extensions.Defaults.ShouldContainKey("botnexus-exec");
+                config.Gateway.Extensions.Defaults["botnexus-exec"].GetProperty("timeout").GetInt32().ShouldBe(30);
+                SerializeShouldNotThrow(config);
+            });
+
+    [Fact]
+    public Task Validate_GatewayExtensionsDefaultsEmpty_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "extensions": {
+                  "defaults": {}
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.Extensions!.Defaults.ShouldNotBeNull();
+                config.Gateway.Extensions.Defaults.ShouldBeEmpty();
+            });
+
+    [Fact]
+    public Task Validate_NoExtensionsSection_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "listenUrl": "http://localhost:5005"
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.Extensions.ShouldBeNull();
+            });
+
+    [Fact]
+    public Task Validate_CronEnabledWithJobs_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "cron": {
+                "enabled": true,
+                "tickIntervalSeconds": 30,
+                "jobs": {
+                  "daily-summary": {
+                    "name": "Daily summary",
+                    "schedule": "0 9 * * *",
+                    "actionType": "agent-prompt",
+                    "agentId": "assistant",
+                    "message": "Summarize the day"
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Cron!.Jobs.ShouldContainKey("daily-summary");
+            });
+
+    [Fact]
+    public Task Validate_CronDisabled_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "cron": {
+                "enabled": false,
+                "tickIntervalSeconds": 60
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Cron!.Enabled.ShouldBeFalse();
+            });
+
+    [Fact]
+    public Task Validate_NoCronSection_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Cron.ShouldBeNull();
+            });
+
+    [Fact]
+    public async Task Validate_CronJobMissingSchedule_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "cron": {
+                "jobs": {
+                  "daily-summary": {
+                    "actionType": "agent-prompt"
+                  }
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("cron.jobs.daily-summary.schedule is required.");
+            });
+    }
+
+    [Fact]
+    public Task Validate_InMemorySessionStore_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "sessionStore": {
+                  "type": "InMemory"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.SessionStore!.Type.ShouldBe("InMemory");
+            });
+
+    [Fact]
+    public Task Validate_SqliteSessionStoreWithConnectionString_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "sessionStore": {
+                  "type": "Sqlite",
+                  "connectionString": "Data Source=sessions.db"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+            });
+
+    [Fact]
+    public Task Validate_NoSessionStore_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "listenUrl": "http://localhost:5005"
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.SessionStore.ShouldBeNull();
+            });
+
+    [Fact]
+    public async Task Validate_SqliteSessionStoreMissingConnectionString_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "sessionStore": {
+                  "type": "Sqlite"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.sessionStore.connectionString is required when gateway.sessionStore.type is 'Sqlite'.");
+            });
+    }
+
+    [Fact]
+    public async Task Validate_FileSessionStoreMissingFilePath_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "sessionStore": {
+                  "type": "File"
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.sessionStore.filePath is required when gateway.sessionStore.type is 'File'.");
+            });
+    }
+
+    [Fact]
+    public Task Validate_RootApiKeySet_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "apiKey": "root-key",
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.ApiKey.ShouldBe("root-key");
+            });
+
+    [Fact]
+    public Task Validate_NoApiKey_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.ApiKey.ShouldBeNull();
+            });
+
+    [Fact]
+    public Task Validate_PerKeyApiKeysWithPermissionsAndAllowedAgents_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "apiKeys": {
+                  "tenant-a": {
+                    "apiKey": "secret-a",
+                    "tenantId": "tenant-a",
+                    "callerId": "svc-a",
+                    "displayName": "Tenant A",
+                    "allowedAgents": ["assistant"],
+                    "permissions": ["chat:send", "sessions:read"],
+                    "isAdmin": false
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.ApiKeys!.ShouldContainKey("tenant-a");
+                config.Gateway.ApiKeys["tenant-a"].AllowedAgents.ShouldBe(["assistant"]);
+            });
+
+    [Fact]
+    public async Task Validate_ApiKeyEntryMissingRequiredFields_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "apiKeys": {
+                  "tenant-a": {
+                    "displayName": "Tenant A"
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.apiKeys.tenant-a.apiKey is required.");
+                ex.Failures.ShouldContain("gateway.apiKeys.tenant-a.tenantId is required.");
+                ex.Failures.ShouldContain("gateway.apiKeys.tenant-a.permissions must contain at least one permission (example: ['chat:send']).");
+            });
+    }
+
+    [Fact]
+    public Task Validate_LocationsSectionWithFilesystemType_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "locations": {
+                  "workspace": {
+                    "type": "filesystem",
+                    "path": "."
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.Locations!.ShouldContainKey("workspace");
+            });
+
+    [Fact]
+    public Task Validate_LocationsSectionWithDatabaseType_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "locations": {
+                  "memory-db": {
+                    "type": "database",
+                    "connectionString": "Data Source=:memory:"
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+            });
+
+    [Fact]
+    public Task Validate_NoLocations_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway?.Locations.ShouldBeNull();
+            });
+
+    [Fact]
+    public async Task Validate_LocationWithUnsupportedGitType_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "locations": {
+                  "repo": {
+                    "type": "git",
+                    "path": "."
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.locations.repo.type must be one of: filesystem, api, mcp-server, database, remote-node.");
+            });
+    }
+
+    [Fact]
+    public Task Validate_CrossWorldWithPeers_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "crossWorld": {
+                  "peers": {
+                    "world-b": {
+                      "worldId": "world-b",
+                      "endpoint": "https://world-b.example.test",
+                      "apiKey": "peer-key",
+                      "enabled": true
+                    }
+                  },
+                  "inbound": {
+                    "enabled": true,
+                    "allowedWorlds": ["world-b"],
+                    "apiKeys": {
+                      "world-b": "peer-key"
+                    }
+                  },
+                  "agents": {
+                    "remote-assistant": {
+                      "worldId": "world-b",
+                      "agentId": "assistant",
+                      "description": "Remote assistant"
+                    }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.CrossWorld!.Peers.ShouldContainKey("world-b");
+            });
+
+    [Fact]
+    public Task Validate_NoCrossWorld_NoErrors()
+        => WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway?.CrossWorld.ShouldBeNull();
+            });
+
+    [Fact]
+    public async Task Validate_CrossWorldInboundMissingAllowedWorlds_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "crossWorld": {
+                  "inbound": {
+                    "enabled": true,
+                    "apiKeys": {
+                      "world-b": "peer-key"
+                    }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.crossWorld.inbound.allowedWorlds must contain at least one world when inbound is enabled.");
+            });
+    }
+
+    [Fact]
+    public async Task Validate_CrossWorldPeerWithInvalidEndpoint_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "crossWorld": {
+                  "peers": {
+                    "world-b": {
+                      "endpoint": "notaurl"
+                    }
+                  },
+                  "inbound": {
+                    "enabled": false
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.crossWorld.peers.world-b.endpoint must be a valid http or https absolute URL.");
+            });
+    }
+
+    [Fact]
+    public Task Validate_ConfigWithJsonElementFields_SerializesWithoutThrowing()
+        => WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "extensions": {
+                  "defaults": {
+                    "botnexus-skills": {
+                      "enabled": true,
+                      "paths": ["skills"]
+                    }
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1",
+                  "metadata": {
+                    "owner": "jon",
+                    "tags": ["core", "test"]
+                  },
+                  "isolationOptions": {
+                    "timeout": 30,
+                    "mode": "strict"
+                  },
+                  "extensions": {
+                    "botnexus-exec": {
+                      "enabled": true,
+                      "shell": "bash"
+                    }
+                  }
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                var agent = config.Agents!["assistant"];
+
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Gateway!.Extensions!.Defaults!["botnexus-skills"].GetProperty("paths")[0].GetString().ShouldBe("skills");
+                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("jon");
+                agent.IsolationOptions!.Value.GetProperty("timeout").GetInt32().ShouldBe(30);
+                agent.Extensions!["botnexus-exec"].GetProperty("shell").GetString().ShouldBe("bash");
+                SerializeShouldNotThrow(config);
+            });
+
+    [Fact]
+    public async Task Validate_CorsOriginWithInvalidUrl_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "gateway": {
+                "cors": {
+                  "allowedOrigins": ["notaurl"]
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("gateway.cors.allowedOrigins[0] must be a valid http or https absolute URL.");
+            });
+    }
+
+    [Fact]
+    public async Task Validate_AgentDefaultsWithBlankToolId_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "defaults": {
+                  "toolIds": [""]
+                },
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("agents.defaults.toolIds[0] must be a non-empty string.");
+            });
+    }
+
+    private static Task WithProviderConfigAsync(string providerKey, string providerJson, Action<PlatformConfig> assertConfig)
+        => WithConfigFileAsync(
+            $$"""
+            {
+              "providers": {
+                "{{providerKey}}": {{providerJson}}
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "{{providerKey}}",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                assertConfig(config);
+            });
+
+    private static async Task WithConfigFileAsync(string json, Func<string, Task> test)
+    {
+        var rootPath = Path.Combine(Path.GetTempPath(), "botnexus-platform-config-validation-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+        var configPath = Path.Combine(rootPath, "config.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(configPath, json);
+            await test(configPath);
+        }
+        finally
+        {
+            if (Directory.Exists(rootPath))
+                Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    private static void SerializeShouldNotThrow(PlatformConfig config)
+    {
+        var exception = Record.Exception(() => JsonSerializer.Serialize(config));
+        exception.ShouldBeNull();
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/Configuration/SchemaValidationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/SchemaValidationTests.cs
@@ -189,5 +189,59 @@ public sealed class SchemaValidationTests
                 Directory.Delete(rootPath, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task Validate_ConfigWithExtensionsDefaultsAndAgentJsonElements_DoesNotCrash()
+    {
+        // Regression: IConfiguration cannot bind JsonElement. gateway.extensions.defaults
+        // and per-agent extensions/metadata/isolationOptions were left undefined after
+        // IConfiguration.Bind(), causing serialization crashes in PlatformConfigSchema
+        // validation at startup.
+        var rootPath = Path.Combine(Path.GetTempPath(), "botnexus-jsonelement-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+        var configPath = Path.Combine(rootPath, "config.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(configPath, """
+                {
+                  "gateway": {
+                    "extensions": {
+                      "defaults": {
+                        "botnexus-skills": { "enabled": true },
+                        "botnexus-exec": { "enabled": true }
+                      }
+                    }
+                  },
+                  "providers": { "copilot": { "enabled": true, "apiKey": "test" } },
+                  "agents": {
+                    "larry": {
+                      "provider": "copilot",
+                      "model": "gpt-4.1",
+                      "extensions": { "botnexus-mcp": { "enabled": true } },
+                      "metadata": { "owner": "jon" },
+                      "isolationOptions": { "timeout": 30 }
+                    }
+                  }
+                }
+                """);
+
+            var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+            var errors = PlatformConfigLoader.Validate(config);
+
+            errors.ShouldBeEmpty();
+            config.Gateway?.Extensions?.Defaults.ShouldNotBeNull();
+            config.Gateway!.Extensions!.Defaults!.ShouldContainKey("botnexus-skills");
+            config.Agents!["larry"].Extensions.ShouldNotBeNull();
+            config.Agents["larry"].Extensions!.ShouldContainKey("botnexus-mcp");
+        }
+        finally
+        {
+            if (Directory.Exists(rootPath))
+                Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
 }
+
 

--- a/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -7,6 +7,7 @@ using BotNexus.Gateway.Federation;
 using BotNexus.Gateway.Sessions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace BotNexus.Gateway.Tests;
@@ -51,13 +52,14 @@ public sealed class CrossWorldFederationControllerTests
         supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From("leela"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
         var sessions = new InMemorySessionStore();
+        var platformConfigMonitor = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
 
         var controller = new CrossWorldFederationController(
             registry.Object,
             supervisor.Object,
             sessions,
-            new CrossWorldInboundAuthService(platformConfig),
-            platformConfig)
+            new CrossWorldInboundAuthService(platformConfigMonitor),
+            platformConfigMonitor)
         {
             ControllerContext = new ControllerContext
             {
@@ -119,12 +121,13 @@ public sealed class CrossWorldFederationControllerTests
 
         var registry = new Mock<IAgentRegistry>();
         registry.Setup(r => r.Contains(AgentId.From("leela"))).Returns(true);
+        var platformConfigMonitor2 = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
         var controller = new CrossWorldFederationController(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             new InMemorySessionStore(),
-            new CrossWorldInboundAuthService(platformConfig),
-            platformConfig)
+            new CrossWorldInboundAuthService(platformConfigMonitor2),
+            platformConfigMonitor2)
         {
             ControllerContext = new ControllerContext
             {
@@ -146,4 +149,11 @@ public sealed class CrossWorldFederationControllerTests
 
         result.Result.ShouldBeOfType<UnauthorizedObjectResult>();
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/GatewayAuthManagerTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using System.IO.Abstractions.TestingHelpers;
 
 namespace BotNexus.Gateway.Tests;
@@ -266,7 +267,8 @@ public sealed class GatewayAuthManagerTests : IDisposable
 
     private GatewayAuthManager CreateManager(PlatformConfig platformConfig, bool usePrimaryAuthPath = true)
     {
-        var manager = new GatewayAuthManager(platformConfig, NullLogger<GatewayAuthManager>.Instance, _fileSystem);
+        var monitor = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
+        var manager = new GatewayAuthManager(monitor, NullLogger<GatewayAuthManager>.Instance, _fileSystem);
         var authPathField = typeof(GatewayAuthManager).GetField("_authFilePath", BindingFlags.NonPublic | BindingFlags.Instance);
         var legacyAuthPathField = typeof(GatewayAuthManager).GetField("_legacyAuthFilePath", BindingFlags.NonPublic | BindingFlags.Instance);
         authPathField.ShouldNotBeNull();
@@ -283,5 +285,13 @@ public sealed class GatewayAuthManagerTests : IDisposable
 
         Environment.SetEnvironmentVariable(name, value);
     }
+}
+
+/// <summary>Minimal IOptionsMonitor wrapper for tests that don't need change callbacks.</summary>
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }
 

--- a/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -8,6 +8,7 @@ using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Isolation;
+using Microsoft.Extensions.Options;
 using BotNexus.Gateway.Tools;
 using BotNexus.Memory;
 using BotNexus.Memory.Models;
@@ -43,7 +44,7 @@ public sealed class InProcessIsolationStrategyTests
         var llmClient = new LlmClient(new ApiProviderRegistry(), new ModelRegistry());
         var strategy = new InProcessIsolationStrategy(
             llmClient,
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new StaticAgentToolFactory(),
             new TestWorkspaceManager(),
@@ -173,7 +174,7 @@ public sealed class InProcessIsolationStrategyTests
         var llmClient = new LlmClient(new ApiProviderRegistry(), modelRegistry);
         return new InProcessIsolationStrategy(
             llmClient,
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new StaticAgentToolFactory(),
             new TestWorkspaceManager(),
@@ -247,4 +248,11 @@ public sealed class InProcessIsolationStrategyTests
         public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -556,7 +556,7 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
 
     private GatewayAuthManager CreateGatewayAuthManagerWithTempAuthPath()
     {
-        var authManager = new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem());
+        var authManager = new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem());
         var authPathField = typeof(GatewayAuthManager).GetField("_authFilePath", BindingFlags.NonPublic | BindingFlags.Instance);
         authPathField.ShouldNotBeNull();
         authPathField!.SetValue(authManager, Path.Combine(_configDirectory, "auth.json"));
@@ -818,4 +818,11 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
         public IReadOnlyList<Location> GetAll()
             => [];
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -1011,3 +1011,6 @@ public sealed class PlatformConfigurationTests
         registration.ShouldBeNull("PlatformConfig must not be registered as a singleton; use IOptionsMonitor<PlatformConfig>");
     }
 }
+
+// Note: GetDefaultHomePath(IFileSystem) was dead code removed in refactor/iconfiguration-cleanup.
+// Confirmed not called by any gateway or CLI code (only defined in PlatformConfigLoader).

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -986,4 +986,28 @@ public sealed class PlatformConfigurationTests
         public string? ResolvePath(string locationName) => null;
         public IReadOnlyList<Location> GetAll() => [];
     }
+
+    // -------------------------------------------------------------------------
+    // Issue #120: PlatformConfig singleton removal
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AddPlatformConfiguration_DoesNotRegisterBare_PlatformConfig_AsSingletonInDI()
+    {
+        // Arrange — AddPlatformConfiguration must NOT register a bare PlatformConfig singleton.
+        // All consumers must resolve via IOptionsMonitor<PlatformConfig> or IOptions<PlatformConfig>.
+        using var fixture = new PlatformConfigFixture();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddBotNexusGateway();
+        services.AddSingleton<ILocationResolver>(new StubLocationResolver());
+        services.AddPlatformConfiguration(fixture.ConfigPath);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Act & Assert — direct resolution must fail; use IOptionsMonitor<PlatformConfig> instead.
+        var registration = provider.GetService<PlatformConfig>();
+        registration.ShouldBeNull("PlatformConfig must not be registered as a singleton; use IOptionsMonitor<PlatformConfig>");
+    }
 }

--- a/tests/BotNexus.Gateway.Tests/RateLimitingMiddlewareTests.cs
+++ b/tests/BotNexus.Gateway.Tests/RateLimitingMiddlewareTests.cs
@@ -3,6 +3,7 @@ using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using System.Reflection;
 
 namespace BotNexus.Gateway.Tests;
@@ -331,8 +332,8 @@ public sealed class RateLimitingMiddlewareTests
         rateLimit.WindowSeconds.ShouldBe(45);
     }
 
-    private static PlatformConfig CreateConfig(int requestsPerMinute, int windowSeconds)
-        => new()
+    private static IOptions<PlatformConfig> CreateConfig(int requestsPerMinute, int windowSeconds)
+        => Microsoft.Extensions.Options.Options.Create(new PlatformConfig
         {
             Gateway = new GatewaySettingsConfig
             {
@@ -343,7 +344,7 @@ public sealed class RateLimitingMiddlewareTests
                     WindowSeconds = windowSeconds
                 }
             }
-        };
+        });
 
     private static DefaultHttpContext CreateContext(string remoteIpAddress)
     {

--- a/tests/BotNexus.Gateway.Tests/Security/RateLimitingAdversarialTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Security/RateLimitingAdversarialTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Tests.Security;
 
@@ -80,8 +81,8 @@ public sealed class RateLimitingAdversarialTests
         thirdRequest.Response.StatusCode.ShouldBe(StatusCodes.Status200OK);
     }
 
-    private static PlatformConfig CreateConfig(int requestsPerMinute, int windowSeconds)
-        => new()
+    private static IOptions<PlatformConfig> CreateConfig(int requestsPerMinute, int windowSeconds)
+        => Options.Create(new PlatformConfig()
         {
             Gateway = new GatewaySettingsConfig
             {
@@ -92,7 +93,7 @@ public sealed class RateLimitingAdversarialTests
                     WindowSeconds = windowSeconds
                 }
             }
-        };
+        });
 
     private static DefaultHttpContext CreateContext(string remoteIpAddress, string? xForwardedFor = null)
     {

--- a/tests/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
+++ b/tests/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Options;
 using BotNexus.Gateway.Hooks;
 using BotNexus.Gateway.Isolation;
 using BotNexus.Gateway.Tools;
@@ -147,7 +148,7 @@ public sealed class ToolHookWiringTests
 
         return new InProcessIsolationStrategy(
             llmClient,
-            new GatewayAuthManager(new PlatformConfig(), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
+            new GatewayAuthManager(new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()), NullLogger<GatewayAuthManager>.Instance, new FileSystem()),
             new PassthroughContextBuilder(),
             new StaticToolFactory(),
             new StubWorkspaceManager(),
@@ -221,4 +222,11 @@ public sealed class ToolHookWiringTests
         public Task<TResult?> HandleAsync(TEvent hookEvent, CancellationToken ct = default)
             => Task.FromResult(handler(hookEvent));
     }
+}
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
 }


### PR DESCRIPTION
## Problem

After the IConfiguration migration (#119, #121), startup crashed with:

```
System.InvalidOperationException: Operation is not valid due to the current state of the object.
  at PlatformConfigSchema.ValidateObject(PlatformConfig config)
```

Root cause: `IConfiguration` cannot bind `JsonElement` types — fields including:
- `gateway.extensions.defaults` (`Dictionary<string, JsonElement>`)
- per-agent `extensions`, `metadata`, `isolationOptions`

...were left in an undefined/invalid state after `IConfiguration.Bind()`. The schema validator then tried to serialize the `PlatformConfig` to JSON and crashed on the invalid elements.

## Fix

`PlatformConfigPostConfigure` now:
1. Re-reads the raw config JSON
2. Populates all `JsonElement` fields with properly `.Clone()`d values
3. Nullifies any that remain undefined (belt-and-suspenders)

## Also includes
- `PlatformConfig` singleton removed from DI (uses `IOptionsMonitor` everywhere)
- `GatewayAuthManager`, `CrossWorldInboundAuthService`, `RateLimitingMiddleware`, `CrossWorldFederationController`, `AgentExchangeService` all migrated to `IOptionsMonitor<PlatformConfig>` / `IOptions<PlatformConfig>`
- Dead `PlatformConfigLoader.GetDefaultHomePath(IFileSystem)` deleted