### PR TITLE
fix(gateway): stamp BindingId after routing to prevent duplicate Telegram messages

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -267,6 +267,20 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     cancellationToken);
                 sessionId = routingResult.SessionId.Value;
                 resolvedConversationId = routingResult.Conversation.ConversationId;
+
+                // Stamp the originating BindingId on the message so FanOutResponseAsync
+                // can exclude it — preventing the originating channel from receiving
+                // the response twice (once direct, once via fan-out).
+                if (message.BindingId is null)
+                {
+                    var originatingBinding = routingResult.Conversation.ChannelBindings
+                        .FirstOrDefault(b =>
+                            b.ChannelType == message.ChannelType &&
+                            string.Equals(b.ChannelAddress, message.ChannelAddress, StringComparison.Ordinal) &&
+                            string.Equals(b.ThreadId, message.ThreadId, StringComparison.Ordinal));
+                    if (originatingBinding is not null)
+                        message = message with { BindingId = originatingBinding.BindingId };
+                }
             }
 
             var existingSessionTask = _sessions.GetAsync(SessionId.From(sessionId), cancellationToken);

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -635,6 +635,59 @@ public sealed class TelegramChannelAdapterTests
         message.Content.ShouldBe("hello");
     }
 
+    [Fact]
+    public async Task Polling_InboundMessage_BindingIdIsNull_RouterStampsIt()
+    {
+        // The adapter does NOT stamp BindingId — GatewayHost stamps it after
+        // ResolveInboundAsync returns the matching conversation binding.
+        // This test documents that contract: adapter dispatches without BindingId,
+        // GatewayHost is responsible for stamping it to prevent self-fanout.
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "deleteWebhook" => JsonOk(true),
+                "getUpdates" => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 10,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 100,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Text = "hello"
+                        }
+                    }
+                }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var message = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        // Adapter dispatches without BindingId — GatewayHost stamps it after routing
+        message.BindingId.ShouldBeNull();
+        message.ChannelAddress.ShouldBe("42");
+    }
+
     private static TelegramChannelAdapter CreateAdapter(TelegramGatewayOptions options, HttpMessageHandler handler)
     {
         var factory = new StubHttpClientFactory(_ => new HttpClient(handler));

--- a/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -1,0 +1,434 @@
+using BotNexus.Gateway;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Routing;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+public sealed class MultiChannelFanOutTests
+{
+    private const string AgentName = "agent-a";
+
+    [Fact]
+    public async Task SingleChannel_InboundMessage_ResponseSentOnce()
+    {
+        var harness = CreateHarness(responseContent: "single-channel-response");
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
+
+        harness.SignalR.Messages.ShouldHaveSingleItem();
+        harness.SignalR.Messages[0].Content.ShouldBe("single-channel-response");
+        harness.SignalR.Messages[0].ChannelType.ShouldBe(ChannelKey.From("signalr"));
+        harness.Telegram.Messages.ShouldBeEmpty();
+        harness.Tui.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task SingleChannel_InboundMessage_BindingId_StampedFromConversation()
+    {
+        var harness = CreateHarness();
+        var inbound = harness.CreateMessage("hello", "signalr", "chat-1");
+
+        await harness.Host.DispatchAsync(inbound);
+
+        var conversation = (await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName))).ShouldHaveSingleItem();
+        conversation.ChannelBindings.ShouldHaveSingleItem();
+        inbound.BindingId.ShouldBeNull();
+
+        var session = (await harness.Sessions.ListAsync()).ShouldHaveSingleItem();
+        session.Session.ConversationId.ShouldBe(conversation.ConversationId);
+
+        var outboundBindings = await harness.Router.GetOutboundBindingsAsync(session.SessionId, originatingBindingId: null);
+        outboundBindings.ShouldHaveSingleItem();
+        outboundBindings[0].BindingId.ShouldBe(conversation.ChannelBindings[0].BindingId);
+    }
+
+    [Fact]
+    public async Task TwoChannels_MessageFromSignalR_FansOutToTelegram()
+    {
+        var harness = CreateHarness(responseContent: "fanout");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.SignalR.Messages[0].ChannelAddress.ShouldBe("chat-1");
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages[0].ChannelAddress.ShouldBe("chat-100");
+        harness.Tui.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task TwoChannels_MessageFromTelegram_FansOutToSignalR()
+    {
+        var harness = CreateHarness(responseContent: "fanout");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.SignalR.Messages[0].ChannelAddress.ShouldBe("chat-1");
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages[0].ChannelAddress.ShouldBe("chat-100");
+    }
+
+    [Fact]
+    public async Task TwoChannels_MessageFromTelegram_TelegramReceivesExactlyOnce()
+    {
+        var harness = CreateHarness(responseContent: "fanout");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
+
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.SignalR.Messages.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task TwoChannels_NewConversation_BothChannelsGetSubsequentMessages()
+    {
+        var harness = CreateHarness(responseContent: "follow-up");
+        await harness.Host.DispatchAsync(harness.CreateMessage("first", "signalr", "chat-1"));
+        await harness.Host.DispatchAsync(harness.CreateMessage("join", "telegram", "chat-100"));
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("second", "signalr", "chat-1"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.SignalR.Messages[0].Content.ShouldBe("follow-up");
+        harness.Telegram.Messages[0].Content.ShouldBe("follow-up");
+    }
+
+    [Fact]
+    public async Task ThreeChannels_MessageFromA_FansOutToBAndC()
+    {
+        var harness = CreateHarness(responseContent: "matrix");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SeedBindingAsync("tui", "terminal-1");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Tui.Messages.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ThreeChannels_MessageFromB_FansOutToAAndC()
+    {
+        var harness = CreateHarness(responseContent: "matrix");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SeedBindingAsync("tui", "terminal-1");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Tui.Messages.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ThreeChannels_EachChannelSends_OthersTwoReceive_NoDuplicates()
+    {
+        var harness = CreateHarness(responseContent: "matrix");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SeedBindingAsync("tui", "terminal-1");
+
+        await AssertPerSendAsync(harness, harness.CreateMessage("from-a", "signalr", "chat-1"));
+        await AssertPerSendAsync(harness, harness.CreateMessage("from-b", "telegram", "chat-100"));
+        await AssertPerSendAsync(harness, harness.CreateMessage("from-c", "tui", "terminal-1"));
+    }
+
+    [Fact]
+    public async Task TwoThreads_SameChat_IndependentConversations()
+    {
+        var harness = CreateHarness(responseContent: "threaded");
+        await harness.SeedBindingAsync("telegram", "100", threadId: null);
+        await harness.SeedBindingAsync("telegram", "100", threadId: "42");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("root", "telegram", "100", threadId: null));
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages[0].ThreadId.ShouldBeNull();
+
+        harness.ClearOutbound();
+        await harness.Host.DispatchAsync(harness.CreateMessage("topic", "telegram", "100", threadId: "42"));
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages[0].ThreadId.ShouldBeNull();
+
+        var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        conversations.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Thread_MessageFromTelegram_FansOutWithCorrectThreadId()
+    {
+        var harness = CreateHarness(responseContent: "threaded");
+        await harness.SeedBindingAsync("telegram", "100", threadId: "42");
+        await harness.AttachBindingToConversationAsync("signalr", "chat-1", harness.GetConversationFor("telegram", "100", "42").ConversationId, threadId: "42");
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("topic", "telegram", "100", threadId: "42"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.SignalR.Messages[0].ThreadId.ShouldBe("42");
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages[0].ThreadId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MutedBinding_DoesNotReceiveFanOut()
+    {
+        var harness = CreateHarness(responseContent: "muted");
+        await harness.SeedBindingAsync("signalr", "chat-1");
+        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SetBindingModeAsync("telegram", "chat-100", null, BindingMode.Muted);
+        harness.ClearOutbound();
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task EmptyConversation_NoBindings_NoFanOut()
+    {
+        var harness = CreateHarness(responseContent: "orphan");
+        var session = await harness.Sessions.GetOrCreateAsync(BotNexus.Domain.Primitives.SessionId.From("session-empty"), BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        var conversation = new Conversation
+        {
+            ConversationId = BotNexus.Domain.Primitives.ConversationId.Create(),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From(AgentName),
+            Title = "Empty",
+            ActiveSessionId = session.SessionId
+        };
+        session.Session.ConversationId = conversation.ConversationId;
+        await harness.Sessions.SaveAsync(session);
+        await harness.Conversations.CreateAsync(conversation);
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1", sessionId: "session-empty"));
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.ShouldBeEmpty();
+        harness.Tui.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Conversation_WhenOriginatingBindingIdIsNull_FansOutToAll()
+    {
+        var harness = CreateHarness(responseContent: "legacy-broken");
+        var conversation = new Conversation
+        {
+            ConversationId = BotNexus.Domain.Primitives.ConversationId.Create(),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From(AgentName),
+            Title = "Legacy",
+            ActiveSessionId = BotNexus.Domain.Primitives.SessionId.From("legacy-session"),
+            ChannelBindings =
+            [
+                new ChannelBinding { BindingId = "sig", ChannelType = ChannelKey.From("signalr"), ChannelAddress = "chat-1" },
+                new ChannelBinding { BindingId = "tel", ChannelType = ChannelKey.From("telegram"), ChannelAddress = "chat-100" }
+            ]
+        };
+        await harness.Conversations.CreateAsync(conversation);
+
+        var session = await harness.Sessions.GetOrCreateAsync(BotNexus.Domain.Primitives.SessionId.From("legacy-session"), BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        session.Session.ConversationId = conversation.ConversationId;
+        await harness.Sessions.SaveAsync(session);
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "legacy-broken" });
+        await harness.Sessions.SaveAsync(session);
+
+        await InvokeFanOutAsync(harness.Host, harness.CreateMessage("hello", "telegram", "chat-100"), "legacy-session");
+
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.Count.ShouldBe(1);
+    }
+
+    private static async Task AssertPerSendAsync(TestHarness harness, InboundMessage message)
+    {
+        harness.ClearOutbound();
+        await harness.Host.DispatchAsync(message);
+        harness.SignalR.Messages.Count.ShouldBe(1);
+        harness.Telegram.Messages.Count.ShouldBe(1);
+        harness.Tui.Messages.Count.ShouldBe(1);
+    }
+
+    private static TestHarness CreateHarness(string responseContent = "agent-response")
+    {
+        var messageRouter = new Mock<IMessageRouter>();
+        messageRouter.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AgentName]);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentName);
+        handle.SetupGet(h => h.SessionId).Returns("dynamic");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = responseContent });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        supervisor.Setup(s => s.StopAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+        var router = new DefaultConversationRouter(conversations, sessions, NullLogger<DefaultConversationRouter>.Instance);
+
+        var signalr = CreateChannelRecorder("signalr");
+        var telegram = CreateChannelRecorder("telegram");
+        var tui = CreateChannelRecorder("tui");
+        var manager = CreateChannelManager(signalr.Adapter.Object, telegram.Adapter.Object, tui.Adapter.Object);
+
+        var host = new GatewayHost(
+            supervisor.Object,
+            messageRouter.Object,
+            sessions,
+            new RecordingActivityBroadcaster(),
+            manager,
+            Mock.Of<BotNexus.Gateway.Abstractions.Sessions.ISessionCompactor>(),
+            new TestOptionsMonitor<BotNexus.Gateway.Abstractions.Sessions.CompactionOptions>(new BotNexus.Gateway.Abstractions.Sessions.CompactionOptions()),
+            NullLogger<GatewayHost>.Instance,
+            conversationRouter: router);
+
+        return new TestHarness(host, router, sessions, conversations, signalr, telegram, tui);
+    }
+
+    private static ChannelRecorder CreateChannelRecorder(string channelType)
+    {
+        var messages = new List<OutboundMessage>();
+        var adapter = new Mock<IChannelAdapter>();
+        adapter.SetupGet(c => c.ChannelType).Returns(ChannelKey.From(channelType));
+        adapter.SetupGet(c => c.DisplayName).Returns(channelType);
+        adapter.SetupGet(c => c.SupportsStreaming).Returns(false);
+        adapter.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<OutboundMessage, CancellationToken>((m, _) => messages.Add(m))
+            .Returns(Task.CompletedTask);
+        adapter.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return new ChannelRecorder(adapter, messages);
+    }
+
+    private static IChannelManager CreateChannelManager(params IChannelAdapter[] adapters)
+    {
+        var manager = new Mock<IChannelManager>();
+        manager.SetupGet(m => m.Adapters).Returns(adapters);
+        manager.Setup(m => m.Get(It.IsAny<ChannelKey>()))
+            .Returns((ChannelKey key) => adapters.FirstOrDefault(a => a.ChannelType == key));
+        return manager.Object;
+    }
+
+    private sealed record ChannelRecorder(Mock<IChannelAdapter> Adapter, List<OutboundMessage> Messages);
+
+    private sealed class TestHarness(
+        GatewayHost host,
+        DefaultConversationRouter router,
+        InMemorySessionStore sessions,
+        InMemoryConversationStore conversations,
+        ChannelRecorder signalr,
+        ChannelRecorder telegram,
+        ChannelRecorder tui)
+    {
+        public GatewayHost Host { get; } = host;
+        public DefaultConversationRouter Router { get; } = router;
+        public InMemorySessionStore Sessions { get; } = sessions;
+        public InMemoryConversationStore Conversations { get; } = conversations;
+        public ChannelRecorder SignalR { get; } = signalr;
+        public ChannelRecorder Telegram { get; } = telegram;
+        public ChannelRecorder Tui { get; } = tui;
+
+        public InboundMessage CreateMessage(string content, string channelType, string channelAddress, string? threadId = null, string? sessionId = null)
+            => new()
+            {
+                ChannelType = ChannelKey.From(channelType),
+                SenderId = $"sender-{channelType}",
+                ChannelAddress = channelAddress,
+                Content = content,
+                SessionId = sessionId,
+                ThreadId = threadId,
+                Metadata = new Dictionary<string, object?>()
+            };
+
+        public void ClearOutbound()
+        {
+            SignalR.Messages.Clear();
+            Telegram.Messages.Clear();
+            Tui.Messages.Clear();
+        }
+
+        public async Task SeedBindingAsync(string channelType, string channelAddress, string? threadId = null)
+        {
+            await Host.DispatchAsync(CreateMessage($"seed-{channelType}", channelType, channelAddress, threadId));
+        }
+
+        public Conversation GetConversationFor(string channelType, string channelAddress, string? threadId)
+            => Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName)).Result
+                .Single(c => c.ChannelBindings.Any(b =>
+                    b.ChannelType == ChannelKey.From(channelType) &&
+                    b.ChannelAddress == channelAddress &&
+                    b.ThreadId == threadId));
+
+        public async Task AttachBindingToConversationAsync(string channelType, string channelAddress, BotNexus.Domain.Primitives.ConversationId conversationId, string? threadId = null)
+        {
+            var conversation = (await Conversations.GetAsync(conversationId))!;
+            conversation.ChannelBindings.Add(new ChannelBinding
+            {
+                ChannelType = ChannelKey.From(channelType),
+                ChannelAddress = channelAddress,
+                ThreadId = threadId,
+                Mode = BindingMode.Interactive
+            });
+            await Conversations.SaveAsync(conversation);
+        }
+
+        public async Task SetBindingModeAsync(string channelType, string channelAddress, string? threadId, BindingMode mode)
+        {
+            var conversation = GetConversationFor(channelType, channelAddress, threadId);
+            var binding = conversation.ChannelBindings.Single(b =>
+                b.ChannelType == ChannelKey.From(channelType) &&
+                b.ChannelAddress == channelAddress &&
+                b.ThreadId == threadId);
+            binding.Mode = mode;
+            await Conversations.SaveAsync(conversation);
+        }
+    }
+
+    private static Task InvokeFanOutAsync(GatewayHost host, InboundMessage message, string sessionId)
+    {
+        var method = typeof(GatewayHost).GetMethod("FanOutResponseAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(host, [message, sessionId, CancellationToken.None])!;
+    }
+
+    private sealed class RecordingActivityBroadcaster : IActivityBroadcaster
+    {
+        public ValueTask PublishAsync(GatewayActivity activity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public async IAsyncEnumerable<GatewayActivity> SubscribeAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+                await Task.Delay(10, cancellationToken);
+
+            yield break;
+        }
+    }
+}


### PR DESCRIPTION
Closes #123

## Problem

Telegram was delivering every agent response **twice**:
1. Direct send from the response path (correct)
2. Fan-out — because `message.BindingId` was `null`, the originating Telegram binding wasn't excluded

## Fix

After `ResolveInboundAsync` returns the conversation, `GatewayHost` stamps the matching `ChannelBinding.BindingId` onto the inbound message. `FanOutResponseAsync` then correctly excludes that binding.

Applies to all channel adapters — not just Telegram.

## Tests — 14 new tests in `MultiChannelFanOutTests.cs`

| Test | What it covers |
|---|---|
| `SingleChannel_InboundMessage_ResponseSentOnce` | No duplicate on single channel |
| `SingleChannel_InboundMessage_BindingId_StampedFromConversation` | BindingId regression for #123 |
| `TwoChannels_MessageFromSignalR_FansOutToTelegram` | Fan-out delivers to other channel |
| `TwoChannels_MessageFromTelegram_FansOutToSignalR` | Reverse fan-out |
| `TwoChannels_MessageFromTelegram_TelegramReceivesExactlyOnce` | **Core regression — no duplicate** |
| `TwoChannels_NewConversation_BothChannelsGetSubsequentMessages` | Subsequent messages fan-out correctly |
| `ThreeChannels_MessageFromA_FansOutToBAndC` | 3-way fan-out matrix |
| `ThreeChannels_MessageFromB_FansOutToAAndC` | |
| `ThreeChannels_EachChannelSends_OthersTwoReceive_NoDuplicates` | No duplicates across all 3 directions |
| `TwoThreads_SameChat_IndependentConversations` | Thread isolation — no cross-thread leakage |
| `Thread_MessageFromTelegram_FansOutWithCorrectThreadId` | ThreadId preserved in fan-out |
| `MutedBinding_DoesNotReceiveFanOut` | Muted bindings excluded |
| `EmptyConversation_NoBindings_NoFanOut` | No crash on empty bindings |
| `Conversation_WhenOriginatingBindingIdIsNull_FansOutToAll` | Legacy null-BindingId behaviour documented |

## Related issues filed (separate fixes)
- #125 — Streaming path ignores ThreadId for Telegram topics
- #126 — Non-streaming direct send missing ThreadId
- #127 — Multi-bot Telegram fan-out wrong adapter
- #128 — Fan-out streaming gap (design gap)