### PR TITLE
fix(gateway): carry OriginatingBinding through processing — fixes ThreadId on direct sends and streaming

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -51,7 +51,14 @@ public interface IConversationRouter
 /// <param name="Conversation">The resolved or created conversation.</param>
 /// <param name="SessionId">The session to dispatch the message into.</param>
 /// <param name="IsNewSession">True if a new session was created for this message.</param>
+/// <param name="OriginatingBinding">
+/// The specific <see cref="ChannelBinding"/> that matched the inbound message's channel type,
+/// address, and thread id. Null when no exact binding match was found (e.g. new default conversation).
+/// Callers use this to stamp BindingId, ThreadId, and DisplayPrefix on outbound responses without
+/// a second lookup into the conversation's binding list.
+/// </param>
 public sealed record ConversationRoutingResult(
     Conversation Conversation,
     SessionId SessionId,
-    bool IsNewSession);
+    bool IsNewSession,
+    ChannelBinding? OriginatingBinding = null);

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -139,7 +139,14 @@ public sealed class DefaultConversationRouter : IConversationRouter
             await _conversationStore.SaveAsync(conversation, ct);
         }
 
-        return new ConversationRoutingResult(conversation, sessionId, isNewSession);
+        // Resolve the originating binding so callers don't need a second lookup into the binding list.
+        var originatingBinding = conversation.ChannelBindings
+            .FirstOrDefault(b =>
+                b.ChannelType == channelType &&
+                string.Equals(b.ChannelAddress, channelAddress, StringComparison.Ordinal) &&
+                string.Equals(b.ThreadId, threadId, StringComparison.Ordinal));
+
+        return new ConversationRoutingResult(conversation, sessionId, isNewSession, originatingBinding);
     }
 
     /// <inheritdoc />

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -257,6 +257,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             // Stamp ConversationId on the session when a conversation router is available.
             // Without this call Session.ConversationId remains null, breaking GatewayEventHandler routing.
             ConversationId? resolvedConversationId = null;
+            ChannelBinding? originatingBinding = null;
             if (_conversationRouter is not null)
             {
                 var routingResult = await _conversationRouter.ResolveInboundAsync(
@@ -268,19 +269,13 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 sessionId = routingResult.SessionId.Value;
                 resolvedConversationId = routingResult.Conversation.ConversationId;
 
-                // Stamp the originating BindingId on the message so FanOutResponseAsync
-                // can exclude it — preventing the originating channel from receiving
-                // the response twice (once direct, once via fan-out).
-                if (message.BindingId is null)
-                {
-                    var originatingBinding = routingResult.Conversation.ChannelBindings
-                        .FirstOrDefault(b =>
-                            b.ChannelType == message.ChannelType &&
-                            string.Equals(b.ChannelAddress, message.ChannelAddress, StringComparison.Ordinal) &&
-                            string.Equals(b.ThreadId, message.ThreadId, StringComparison.Ordinal));
-                    if (originatingBinding is not null)
-                        message = message with { BindingId = originatingBinding.BindingId };
-                }
+                // OriginatingBinding carries ThreadId, BindingId, and DisplayPrefix for the inbound
+                // channel address — used below to stamp outbound responses and fan-out exclusion.
+                // This replaces the duplicate lookup that was added as the #123 hotfix workaround.
+                originatingBinding = routingResult.OriginatingBinding;
+                // Stamp BindingId on the message for fan-out exclusion (replaces #123 hotfix workaround)
+                if (message.BindingId is null && originatingBinding is not null)
+                    message = message with { BindingId = originatingBinding.BindingId };
             }
 
             var existingSessionTask = _sessions.GetAsync(SessionId.From(sessionId), cancellationToken);
@@ -395,6 +390,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
 
                 if (resolvedChannel is { SupportsStreaming: true } channel)
                 {
+                    // Capture the originating binding for the lambda closure so the
+                    // streaming conversationId includes the ThreadId (fixes #125).
+                    var streamingBinding = originatingBinding;
                     await StreamingSessionHelper.ProcessAndSaveAsync(
                         handle.StreamAsync(message.Content, cancellationToken),
                         session,
@@ -409,11 +407,20 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                                     ? evt with { AgentId = Domain.Primitives.AgentId.From(agentId) }
                                     : evt;
 
+                                // Build the conversationId that the channel adapter uses to
+                                // route the stream to the correct chat thread/topic.
+                                // For channels like Telegram that support forum topics, the
+                                // bare chatId is not enough — we encode threadId into the key
+                                // so the adapter can split them apart (fixes #125).
+                                var streamConversationId = streamingBinding?.ThreadId is not null
+                                    ? $"{message.ChannelAddress}:{streamingBinding.ThreadId}"
+                                    : message.ChannelAddress;
+
                                 if (channel is IStreamEventChannelAdapter streamEventChannel)
-                                    return new ValueTask(streamEventChannel.SendStreamEventAsync(message.ChannelAddress, enriched, ct));
+                                    return new ValueTask(streamEventChannel.SendStreamEventAsync(streamConversationId, enriched, ct));
 
                                 if (evt.Type == AgentStreamEventType.ContentDelta && evt.ContentDelta is not null)
-                                    return new ValueTask(channel.SendStreamDeltaAsync(message.ChannelAddress, evt.ContentDelta, ct));
+                                    return new ValueTask(channel.SendStreamDeltaAsync(streamConversationId, evt.ContentDelta, ct));
 
                                 return ValueTask.CompletedTask;
                             }),
@@ -435,7 +442,12 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                             ChannelType = message.ChannelType,
                             ChannelAddress = message.ChannelAddress,
                             Content = response.Content,
-                            SessionId = sessionId
+                            SessionId = sessionId,
+                            // Binding-aware fields from originating binding fix #126:
+                            // ensure replies go to the correct thread/topic and carry decoration.
+                            ThreadId = originatingBinding?.ThreadId ?? message.ThreadId,
+                            BindingId = originatingBinding?.BindingId,
+                            DisplayPrefix = originatingBinding?.DisplayPrefix
                         }, cancellationToken);
                     }
 

--- a/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -50,7 +50,8 @@ public sealed class GatewayHostBindingRoutingTests
         var routingResult = new ConversationRoutingResult(
             conversation,
             SessionId.From(SessionIdStr),
-            false);
+            false,
+            OriginatingBinding: binding);
 
         var convRouter = new Mock<IConversationRouter>();
         convRouter
@@ -122,7 +123,8 @@ public sealed class GatewayHostBindingRoutingTests
         var routingResult = new ConversationRoutingResult(
             conversation,
             SessionId.From(SessionIdStr),
-            false);
+            false,
+            OriginatingBinding: binding);
 
         var convRouter = new Mock<IConversationRouter>();
         convRouter
@@ -173,6 +175,7 @@ public sealed class GatewayHostBindingRoutingTests
         });
 
         capturedStreamConversationIds.ShouldNotBeEmpty("SendStreamDeltaAsync must be called");
+        // The conversationId must encode the thread context, not just the bare chatId.
         capturedStreamConversationIds.ShouldAllBe(
             cid => cid.Contains("topic-99"),
             "Streaming conversationId must include ThreadId so Telegram sends to the correct topic");
@@ -204,7 +207,8 @@ public sealed class GatewayHostBindingRoutingTests
         var routingResult = new ConversationRoutingResult(
             conversation,
             SessionId.From(SessionIdStr),
-            false);
+            false,
+            OriginatingBinding: binding);
 
         string? capturedOriginatingBindingId = null;
         var convRouter = new Mock<IConversationRouter>();

--- a/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -1,0 +1,327 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Routing;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+/// <summary>
+/// Tests proving that the originating ChannelBinding fields (ThreadId, BindingId, DisplayPrefix)
+/// are carried through to both streaming and non-streaming direct sends.
+/// Covers issues #125, #126, and #123 cleanup.
+/// </summary>
+public sealed class GatewayHostBindingRoutingTests
+{
+    private const string AgentIdStr = "agent-a";
+    private const string SessionIdStr = "session-bind-1";
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #126 — Non-streaming direct send must include ThreadId, BindingId, DisplayPrefix
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NonStreamingPath_MessageWithThreadId_DirectSendIncludesThreadId()
+    {
+        var binding = new ChannelBinding
+        {
+            BindingId = "bind-tg-1",
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "chat-100",
+            ThreadId = "topic-42",
+            DisplayPrefix = "[Bot]",
+            Mode = BindingMode.Interactive
+        };
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-thread-test"),
+            AgentId = AgentId.From(AgentIdStr)
+        };
+        conversation.ChannelBindings.Add(binding);
+
+        var routingResult = new ConversationRoutingResult(
+            conversation,
+            SessionId.From(SessionIdStr),
+            false);
+
+        var convRouter = new Mock<IConversationRouter>();
+        convRouter
+            .Setup(r => r.ResolveInboundAsync(
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(routingResult);
+        convRouter
+            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var handle = CreatePromptHandle(AgentIdStr, SessionIdStr, "response text");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                AgentId.From(AgentIdStr), SessionId.From(SessionIdStr), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        await sessions.GetOrCreateAsync(SessionId.From(SessionIdStr), AgentId.From(AgentIdStr));
+
+        var channel = CreateChannelAdapter("telegram", supportsStreaming: false);
+        OutboundMessage? capturedOutbound = null;
+        channel
+            .Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<OutboundMessage, CancellationToken>((m, _) => capturedOutbound = m)
+            .Returns(Task.CompletedTask);
+
+        await using var host = CreateHost(supervisor.Object, sessions, convRouter.Object, CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(new InboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            SenderId = "user-1",
+            ChannelAddress = "chat-100",
+            ThreadId = "topic-42",
+            Content = "hello",
+            Metadata = new Dictionary<string, object?>()
+        });
+
+        capturedOutbound.ShouldNotBeNull("adapter.SendAsync should have been called for non-streaming path");
+        capturedOutbound!.ThreadId.ShouldBe("topic-42", "ThreadId from originating binding must be stamped on direct send");
+        capturedOutbound.BindingId.ShouldBe("bind-tg-1", "BindingId from originating binding must be stamped on direct send");
+        capturedOutbound.DisplayPrefix.ShouldBe("[Bot]", "DisplayPrefix from originating binding must be stamped on direct send");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #125 — Streaming direct send must use ThreadId-aware conversationId
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StreamingPath_MessageWithThreadId_StreamingUsesCorrectConversationId()
+    {
+        var binding = new ChannelBinding
+        {
+            BindingId = "bind-tg-2",
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "chat-200",
+            ThreadId = "topic-99",
+            Mode = BindingMode.Interactive
+        };
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-stream-test"),
+            AgentId = AgentId.From(AgentIdStr)
+        };
+        conversation.ChannelBindings.Add(binding);
+
+        var routingResult = new ConversationRoutingResult(
+            conversation,
+            SessionId.From(SessionIdStr),
+            false);
+
+        var convRouter = new Mock<IConversationRouter>();
+        convRouter
+            .Setup(r => r.ResolveInboundAsync(
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(routingResult);
+        convRouter
+            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentIdStr);
+        handle.SetupGet(h => h.SessionId).Returns(SessionIdStr);
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.StreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ToAsyncEnumerable([
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hello world" }
+            ]));
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                AgentId.From(AgentIdStr), SessionId.From(SessionIdStr), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        await sessions.GetOrCreateAsync(SessionId.From(SessionIdStr), AgentId.From(AgentIdStr));
+
+        var capturedStreamConversationIds = new List<string>();
+        var channel = new Mock<IChannelAdapter>();
+        channel.SetupGet(c => c.ChannelType).Returns(ChannelKey.From("telegram"));
+        channel.SetupGet(c => c.DisplayName).Returns("telegram");
+        channel.SetupGet(c => c.SupportsStreaming).Returns(true);
+        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, CancellationToken>((cid, _, _) => capturedStreamConversationIds.Add(cid))
+            .Returns(Task.CompletedTask);
+
+        await using var host = CreateHost(supervisor.Object, sessions, convRouter.Object, CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(new InboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            SenderId = "user-1",
+            ChannelAddress = "chat-200",
+            ThreadId = "topic-99",
+            Content = "hello",
+            Metadata = new Dictionary<string, object?>()
+        });
+
+        capturedStreamConversationIds.ShouldNotBeEmpty("SendStreamDeltaAsync must be called");
+        capturedStreamConversationIds.ShouldAllBe(
+            cid => cid.Contains("topic-99"),
+            "Streaming conversationId must include ThreadId so Telegram sends to the correct topic");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #123 cleanup — BindingId should come from resolved binding for fan-out exclusion
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MultiChannelFanOut_OriginatingBinding_UsedForBindingIdStamp()
+    {
+        var binding = new ChannelBinding
+        {
+            BindingId = "bind-origin",
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = "chat-300",
+            ThreadId = null,
+            Mode = BindingMode.Interactive
+        };
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-fanout-test"),
+            AgentId = AgentId.From(AgentIdStr)
+        };
+        conversation.ChannelBindings.Add(binding);
+
+        var routingResult = new ConversationRoutingResult(
+            conversation,
+            SessionId.From(SessionIdStr),
+            false);
+
+        string? capturedOriginatingBindingId = null;
+        var convRouter = new Mock<IConversationRouter>();
+        convRouter
+            .Setup(r => r.ResolveInboundAsync(
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(routingResult);
+        convRouter
+            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<SessionId, string?, CancellationToken>((_, bindId, _) => capturedOriginatingBindingId = bindId)
+            .ReturnsAsync([]);
+
+        var handle = CreatePromptHandle(AgentIdStr, SessionIdStr, "ok");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                AgentId.From(AgentIdStr), SessionId.From(SessionIdStr), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        await sessions.GetOrCreateAsync(SessionId.From(SessionIdStr), AgentId.From(AgentIdStr));
+
+        var channel = CreateChannelAdapter("telegram", supportsStreaming: false);
+
+        await using var host = CreateHost(supervisor.Object, sessions, convRouter.Object, CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(new InboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            SenderId = "user-1",
+            ChannelAddress = "chat-300",
+            ThreadId = null,
+            Content = "hello",
+            Metadata = new Dictionary<string, object?>()
+        });
+
+        capturedOriginatingBindingId.ShouldBe("bind-origin",
+            "The originating BindingId from the resolved binding must be passed to GetOutboundBindingsAsync for fan-out exclusion");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static Mock<IAgentHandle> CreatePromptHandle(string agentId, string sessionId, string content)
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(agentId);
+        handle.SetupGet(h => h.SessionId).Returns(sessionId);
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = content });
+        return handle;
+    }
+
+    private static Mock<IChannelAdapter> CreateChannelAdapter(string channelType, bool supportsStreaming)
+    {
+        var channel = new Mock<IChannelAdapter>();
+        channel.SetupGet(c => c.ChannelType).Returns(ChannelKey.From(channelType));
+        channel.SetupGet(c => c.DisplayName).Returns(channelType);
+        channel.SetupGet(c => c.SupportsStreaming).Returns(supportsStreaming);
+        channel.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        return channel;
+    }
+
+    private static IChannelManager CreateChannelManager(IChannelAdapter? adapter = null)
+    {
+        var manager = new Mock<IChannelManager>();
+        manager.SetupGet(m => m.Adapters).Returns(adapter is null ? [] : [adapter]);
+        manager.Setup(m => m.Get(It.IsAny<ChannelKey>())).Returns((ChannelKey channelType) =>
+            adapter is not null && channelType.Equals(adapter.ChannelType) ? adapter : null);
+        return manager.Object;
+    }
+
+    private static GatewayHost CreateHost(
+        IAgentSupervisor supervisor,
+        ISessionStore sessions,
+        IConversationRouter? conversationRouter,
+        IChannelManager channelManager)
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AgentIdStr]);
+
+        return new GatewayHost(
+            supervisor,
+            router.Object,
+            sessions,
+            new NullActivityBroadcaster(),
+            channelManager,
+            Mock.Of<ISessionCompactor>(),
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            NullLogger<GatewayHost>.Instance,
+            conversationRouter: conversationRouter);
+    }
+
+    private static async IAsyncEnumerable<AgentStreamEvent> ToAsyncEnumerable(IEnumerable<AgentStreamEvent> events)
+    {
+        foreach (var evt in events)
+        {
+            yield return evt;
+            await Task.Yield();
+        }
+    }
+
+    private sealed class NullActivityBroadcaster : IActivityBroadcaster
+    {
+        public ValueTask PublishAsync(GatewayActivity activity, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public async IAsyncEnumerable<GatewayActivity> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+                await Task.Delay(10, cancellationToken);
+            yield break;
+        }
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -168,12 +168,12 @@ public sealed class MultiChannelFanOutTests
 
         await harness.Host.DispatchAsync(harness.CreateMessage("root", "telegram", "100", threadId: null));
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ThreadId.ShouldBeNull();
+        harness.Telegram.Messages[0].ThreadId.ShouldBeNull(); // root chat, no thread
 
         harness.ClearOutbound();
         await harness.Host.DispatchAsync(harness.CreateMessage("topic", "telegram", "100", threadId: "42"));
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ThreadId.ShouldBeNull();
+        harness.Telegram.Messages[0].ThreadId.ShouldBe("42"); // fix #126: ThreadId now correctly set on direct send
 
         var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
         conversations.Count.ShouldBe(2);
@@ -190,9 +190,9 @@ public sealed class MultiChannelFanOutTests
         await harness.Host.DispatchAsync(harness.CreateMessage("topic", "telegram", "100", threadId: "42"));
 
         harness.SignalR.Messages.Count.ShouldBe(1);
-        harness.SignalR.Messages[0].ThreadId.ShouldBe("42");
+        harness.SignalR.Messages[0].ThreadId.ShouldBe("42"); // fan-out carries thread
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ThreadId.ShouldBeNull();
+        harness.Telegram.Messages[0].ThreadId.ShouldBe("42"); // fix #126: direct send now carries ThreadId
     }
 
     [Fact]


### PR DESCRIPTION
Closes #125 Closes #126. Supersedes the inline #123 workaround.

## Root cause

`GatewayHost.ProcessInboundMessageAsync` resolved the inbound `ChannelBinding` via `ResolveInboundAsync` but immediately discarded it — only `sessionId` and `conversationId` survived. Everything downstream that needed binding context (ThreadId, BindingId, DisplayPrefix) had to reconstruct it or go without.

## Fix — carry `OriginatingBinding` through the pipeline

### `ConversationRoutingResult` gets `OriginatingBinding?`
The router already has the matching binding at resolution time. Now it returns it:
```csharp
public sealed record ConversationRoutingResult(
    Conversation Conversation,
    SessionId SessionId,
    bool IsNewSession,
    ChannelBinding? OriginatingBinding = null);  // ← new
```

### `GatewayHost` extracts it once, uses it everywhere
- **#123 cleanup**: `message.BindingId` stamped from `routingResult.OriginatingBinding` — no second lookup
- **#126 fix**: non-streaming `SendAsync` passes `ThreadId`, `BindingId`, `DisplayPrefix` from binding
- **#125 fix**: streaming closure captures binding; `streamConversationId` includes thread when non-null

## Tests — 3 new
- `NonStreamingPath_MessageWithThreadId_DirectSendIncludesThreadId`
- `StreamingPath_MessageWithThreadId_StreamingUsesCorrectConversationId`
- `MultiChannelFanOut_OriginatingBinding_UsedForBindingIdStamp`

## Not in this PR
- **#127** (multi-bot adapter resolution) — needs `IChannelManager` extension, separate PR
- **#128** (streaming fan-out) — design gap, separate discussion