### PR TITLE
fix(portal): session reset preserves conversation history

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
@@ -284,9 +284,11 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
             conv.StreamState.ThinkingBuffer = "";
             conv.StreamState.IsStreaming = false;
             conv.StreamState.ActiveToolCalls.Clear();
-            conv.HistoryLoaded = false;
-            conv.Messages.Clear();
-            conv.Messages.Add(new ChatMessage("System", "Session reset. Start a new conversation.", DateTimeOffset.UtcNow));
+            // Do NOT clear conv.Messages or set HistoryLoaded=false.
+            // Session reset clears the agent's context window — it does not
+            // erase conversation history. The portal should keep showing all
+            // prior messages with a visual divider marking the new session.
+            conv.Messages.Add(new ChatMessage("System", "─── New session started ───", DateTimeOffset.UtcNow));
         }
 
         agent.ActiveToolCalls.Clear();

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -125,20 +125,24 @@ public sealed class GatewayEventHandlerTests
     }
 
     [Fact]
-    public void HandleSessionReset_clears_state_and_adds_system_message()
+    public void HandleSessionReset_preserves_history_and_adds_session_boundary_divider()
     {
         var agent = _store.GetAgent("agent-1")!;
         var conv = agent.Conversations["conv-1"];
         agent.SessionId = "sess-1";
-        conv.Messages.Add(new ChatMessage("User", "before", DateTimeOffset.UtcNow));
+        conv.Messages.Add(new ChatMessage("User", "before reset", DateTimeOffset.UtcNow));
         conv.HistoryLoaded = true;
 
         _handler.HandleSessionReset(new SessionResetPayload("agent-1", "sess-1"));
 
         Assert.Null(agent.SessionId);
         Assert.False(agent.IsStreaming);
-        Assert.False(conv.HistoryLoaded);
-        Assert.Single(conv.Messages);
-        Assert.Equal("System", conv.Messages[0].Role);
+        // History is preserved — session reset only clears agent context, not visible history
+        Assert.True(conv.HistoryLoaded);
+        Assert.Equal(2, conv.Messages.Count); // original + divider
+        Assert.Equal("User", conv.Messages[0].Role);
+        Assert.Equal("before reset", conv.Messages[0].Content);
+        Assert.Equal("System", conv.Messages[1].Role);
+        Assert.Contains("───", conv.Messages[1].Content); // visual divider
     }
 }


### PR DESCRIPTION
Closes #131

## Problem

Clicking 'New session' wiped all conversation history from the portal. The handler called `conv.Messages.Clear()` and set `HistoryLoaded = false`.

## Fix

- Remove `conv.Messages.Clear()`
- Remove `HistoryLoaded = false`  
- Add a visual divider message instead: `─── New session started ───`

The conversation history stays visible. The divider shows where the new agent context begins. This correctly reflects what actually happened — the agent's context window was reset, but the conversation itself continues.