### PR TITLE
fix(telegram): harden inbound message security — allowedUserIds, reject channel posts, disable edited messages by default

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
@@ -29,6 +29,19 @@ public sealed class TelegramBotConfig
     public ICollection<long> AllowedChatIds { get; } = [];
 
     /// <summary>
+    /// Gets the allow-list of Telegram user IDs that can send messages to this bot.
+    /// Filters message.from.id. An empty list allows any user (subject to AllowedChatIds).
+    /// For a personal bot, set this to your Telegram user ID.
+    /// </summary>
+    public ICollection<long> AllowedUserIds { get; } = [];
+
+    /// <summary>
+    /// When true, edited messages are processed the same as new messages.
+    /// Defaults to false \u2014 edited messages are ignored to prevent replay.
+    /// </summary>
+    public bool ProcessEditedMessages { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets the long polling timeout in seconds.
     /// </summary>
     public int PollingTimeoutSeconds { get; set; } = 30;

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -314,7 +314,9 @@ public sealed class TelegramChannelAdapter(
 
     private async Task HandleUpdateAsync(BotRuntime runtime, TelegramUpdate update, CancellationToken cancellationToken)
     {
-        var message = update.Message ?? update.EditedMessage ?? update.ChannelPost;
+        // Only process real user messages \u2014 not channel posts (no authenticated sender)
+        var message = update.Message
+            ?? (runtime.Config.ProcessEditedMessages ? update.EditedMessage : null);
         if (message?.Chat is null || string.IsNullOrWhiteSpace(message.Text))
             return;
 
@@ -326,7 +328,20 @@ public sealed class TelegramChannelAdapter(
         }
 
         var chatIdText = chatId.ToString(CultureInfo.InvariantCulture);
-        var senderId = (message.From?.Id ?? chatId).ToString(CultureInfo.InvariantCulture);
+        if (message.From is null)
+        {
+            _logger.LogDebug("bot '{BotName}' ignored message with no sender (updateId={UpdateId})", runtime.BotName, update.UpdateId);
+            return;
+        }
+
+        var fromId = message.From.Id;
+        if (!IsUserAllowed(runtime.Config, fromId))
+        {
+            _logger.LogDebug("bot '{BotName}' ignored message from unauthorized user {UserId}", runtime.BotName, fromId);
+            return;
+        }
+
+        var senderId = message.From.Id.ToString(CultureInfo.InvariantCulture);
 
         await DispatchInboundAsync(new InboundMessage
         {
@@ -439,6 +454,9 @@ public sealed class TelegramChannelAdapter(
 
     private static bool IsChatAllowed(TelegramBotConfig config, long chatId)
         => config.AllowedChatIds.Count == 0 || config.AllowedChatIds.Contains(chatId);
+
+    private static bool IsUserAllowed(TelegramBotConfig config, long userId)
+        => config.AllowedUserIds.Count == 0 || config.AllowedUserIds.Contains(userId);
 
     private static void EnsureChatAllowed(TelegramBotConfig config, long chatId)
     {

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramGatewayOptions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramGatewayOptions.cs
@@ -46,6 +46,19 @@ public sealed class TelegramGatewayOptions
     public ICollection<long> AllowedChatIds { get; } = [];
 
     /// <summary>
+    /// Gets the allow-list of Telegram user IDs that can send messages to this bot.
+    /// Filters message.from.id. An empty list allows any user (subject to AllowedChatIds).
+    /// For a personal bot, set this to your Telegram user ID.
+    /// </summary>
+    public ICollection<long> AllowedUserIds { get; } = [];
+
+    /// <summary>
+    /// When true, edited messages are processed the same as new messages.
+    /// Defaults to false 2014 edited messages are ignored to prevent replay.
+    /// </summary>
+    public bool ProcessEditedMessages { get; set; } = false;
+
+    /// <summary>
     /// Long polling timeout in seconds. Clamped to a minimum of 1.
     /// </summary>
     public int PollingTimeoutSeconds { get; set; } = 30;
@@ -101,10 +114,13 @@ public sealed class TelegramGatewayOptions
             PollingTimeoutSeconds = PollingTimeoutSeconds,
             StreamingBufferMs = StreamingBufferMs,
             MaxMessageLength = MaxMessageLength,
-            ErrorCooldownMs = ErrorCooldownMs
+            ErrorCooldownMs = ErrorCooldownMs,
+            ProcessEditedMessages = ProcessEditedMessages
         };
         foreach (var id in AllowedChatIds)
             single.AllowedChatIds.Add(id);
+        foreach (var id in AllowedUserIds)
+            single.AllowedUserIds.Add(id);
 
         return new Dictionary<string, TelegramBotConfig>(StringComparer.OrdinalIgnoreCase)
         {

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -165,7 +165,8 @@ public sealed class TelegramChannelAdapterTests
                             {
                                 MessageId = 200,
                                 Chat = new TelegramChat { Id = 42 },
-                                Text = "once"
+                                Text = "once",
+                                From = new TelegramUser { Id = 1 },
                             }
                         }
                     });
@@ -686,6 +687,383 @@ public sealed class TelegramChannelAdapterTests
         // Adapter dispatches without BindingId — GatewayHost stamps it after routing
         message.BindingId.ShouldBeNull();
         message.ChannelAddress.ShouldBe("42");
+    }
+
+    // ── Security: AllowedUserIds ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Polling_MessageFromUnauthorizedUser_IsBlocked()
+    {
+        var dispatched = false;
+        var updatesSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "getUpdates")
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return JsonOk(new[]
+                    {
+                        new TelegramUpdate
+                        {
+                            UpdateId = 10,
+                            Message = new TelegramMessage
+                            {
+                                MessageId = 100,
+                                Chat = new TelegramChat { Id = 42 },
+                                From = new TelegramUser { Id = 99 }, // unauthorized user
+                                Text = "blocked"
+                            }
+                        }
+                    });
+                }
+
+                updatesSeen.TrySetResult();
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+
+            return JsonOk(true);
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 },
+            AllowedUserIds = { 42 } // only user 42 allowed; message is from 99
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback(() => dispatched = true);
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        await updatesSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        dispatched.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Polling_MessageFromAuthorizedUser_IsDelivered()
+    {
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "deleteWebhook" => JsonOk(true),
+                "getUpdates" => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 10,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 100,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 42 }, // authorized user
+                            Text = "hello"
+                        }
+                    }
+                }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 },
+            AllowedUserIds = { 42 }
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        msg.Content.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task Polling_EmptyAllowedUserIds_AllowsAnyUser()
+    {
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "deleteWebhook" => JsonOk(true),
+                "getUpdates" => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 10,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 100,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 9999 }, // any user
+                            Text = "hello"
+                        }
+                    }
+                }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 }
+            // AllowedUserIds empty — all users allowed
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        msg.Content.ShouldBe("hello");
+    }
+
+    // ── Security: ChannelPost ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Polling_ChannelPost_IsIgnored()
+    {
+        var dispatched = false;
+        var updatesSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "getUpdates")
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return JsonOk(new[]
+                    {
+                        new TelegramUpdate
+                        {
+                            UpdateId = 10,
+                            // No Message — only ChannelPost (no authenticated sender)
+                            ChannelPost = new TelegramMessage
+                            {
+                                MessageId = 100,
+                                Chat = new TelegramChat { Id = 42 },
+                                Text = "channel announcement"
+                            }
+                        }
+                    });
+                }
+
+                updatesSeen.TrySetResult();
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+
+            return JsonOk(true);
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback(() => dispatched = true);
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        await updatesSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        dispatched.ShouldBeFalse();
+    }
+
+    // ── Security: EditedMessage ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Polling_EditedMessage_IgnoredByDefault()
+    {
+        var dispatched = false;
+        var updatesSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "getUpdates")
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return JsonOk(new[]
+                    {
+                        new TelegramUpdate
+                        {
+                            UpdateId = 10,
+                            EditedMessage = new TelegramMessage
+                            {
+                                MessageId = 100,
+                                Chat = new TelegramChat { Id = 42 },
+                                From = new TelegramUser { Id = 7 },
+                                Text = "edited text"
+                            }
+                        }
+                    });
+                }
+
+                updatesSeen.TrySetResult();
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+
+            return JsonOk(true);
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 }
+            // ProcessEditedMessages defaults to false
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback(() => dispatched = true);
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        await updatesSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        dispatched.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Polling_EditedMessage_ProcessedWhenEnabled()
+    {
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "deleteWebhook" => JsonOk(true),
+                "getUpdates" => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 10,
+                        EditedMessage = new TelegramMessage
+                        {
+                            MessageId = 100,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Text = "edited text"
+                        }
+                    }
+                }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 },
+            ProcessEditedMessages = true
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        msg.Content.ShouldBe("edited text");
+    }
+
+    // ── Security: Null From ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Polling_MessageWithNullFrom_IsIgnored()
+    {
+        var dispatched = false;
+        var updatesSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "getUpdates")
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return JsonOk(new[]
+                    {
+                        new TelegramUpdate
+                        {
+                            UpdateId = 10,
+                            Message = new TelegramMessage
+                            {
+                                MessageId = 100,
+                                Chat = new TelegramChat { Id = 42 },
+                                From = null, // no sender
+                                Text = "mysterious message"
+                            }
+                        }
+                    });
+                }
+
+                updatesSeen.TrySetResult();
+                return JsonOk(Array.Empty<TelegramUpdate>());
+            }
+
+            return JsonOk(true);
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1,
+            AllowedChatIds = { 42 }
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback(() => dispatched = true);
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        await updatesSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        dispatched.ShouldBeFalse();
     }
 
     private static TelegramChannelAdapter CreateAdapter(TelegramGatewayOptions options, HttpMessageHandler handler)


### PR DESCRIPTION
Security hardening for the Telegram channel adapter.

## Changes

### New config fields

`allowedUserIds` — filters `message.from.id` (the actual sender). An empty list allows any user.
`processEditedMessages` — defaults `false`. Opt-in to process edited messages.

```json
{
  "channels": {
    "telegram": {
      "botToken": "...",
      "agentId": "larry",
      "allowedChatIds": [5067802539],
      "allowedUserIds": [5067802539]
    }
  }
}
```

### Behaviour fixes

| Issue | Fix |
|---|---|
| Channel posts processed despite no authenticated sender | Removed `?? update.ChannelPost` — only `Message` and optionally `EditedMessage` are processed |
| Edited messages re-trigger agent as new input | Ignored by default; opt-in with `processEditedMessages: true` |
| `null` `message.From` fell back to `chatId` as fake senderId | Return early with debug log when `From` is null |
| No per-sender filtering | Added `IsUserAllowed()` check on `message.from.id` after chat allow-list check |

## Tests

7 new tests (test commit precedes implementation):
- `Polling_MessageFromUnauthorizedUser_IsBlocked`
- `Polling_MessageFromAuthorizedUser_IsDelivered`
- `Polling_ChannelPost_IsIgnored`
- `Polling_EditedMessage_IgnoredByDefault`
- `Polling_EditedMessage_ProcessedWhenEnabled`
- `Polling_MessageWithNullFrom_IsIgnored`
- `Polling_EmptyAllowedUserIds_AllowsAnyUser`

## Docs

New page: `docs/user-guide/channels/telegram.md` — covers config, security model, polling vs webhook, troubleshooting.

## Note

Pre-existing flaky test `TwoThreads_SameChat_IndependentConversations` filed as #133 — not introduced by this PR.