### PR TITLE
fix(sessions): ResolveByBindingAsync null threadId must only match null-thread bindings

### DIFF
--- a/src/gateway/BotNexus.Gateway.Sessions/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileConversationStore.cs
@@ -140,7 +140,7 @@ public sealed class FileConversationStore : IConversationStore
                 c.ChannelBindings.Any(b =>
                     b.ChannelType == channelType &&
                     string.Equals(b.ChannelAddress, channelAddress, StringComparison.OrdinalIgnoreCase) &&
-                    (threadId is null || string.Equals(b.ThreadId, threadId, StringComparison.OrdinalIgnoreCase))));
+                    string.Equals(b.ThreadId, threadId, StringComparison.OrdinalIgnoreCase)));
         }
         finally { _lock.Release(); }
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/InMemoryConversationStore.cs
@@ -90,7 +90,7 @@ public sealed class InMemoryConversationStore : IConversationStore
             c.ChannelBindings.Any(b =>
                 b.ChannelType == channelType &&
                 string.Equals(b.ChannelAddress, channelAddress, StringComparison.OrdinalIgnoreCase) &&
-                (threadId is null || string.Equals(b.ThreadId, threadId, StringComparison.OrdinalIgnoreCase))));
+                string.Equals(b.ThreadId, threadId, StringComparison.OrdinalIgnoreCase)));
 
         return Task.FromResult(match);
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
@@ -293,8 +293,10 @@ public sealed class SqliteConversationStore : IConversationStore
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = threadId is null
-            ? """
+        // Use a single query that matches thread_id exactly (including NULL = NULL).
+        // The previous two-branch approach matched any binding when threadId was null,
+        // causing root-chat messages to resolve into thread-specific conversations.
+        command.CommandText = """
                 SELECT c.id
                 FROM conversations c
                 INNER JOIN conversation_bindings b ON b.conversation_id = c.id
@@ -302,28 +304,16 @@ public sealed class SqliteConversationStore : IConversationStore
                   AND c.status = $status
                   AND b.channel_type = $channelType
                   AND lower(b.channel_address) = lower($channelAddress)
-                ORDER BY c.updated_at DESC
-                LIMIT 1
-                """
-            : """
-                SELECT c.id
-                FROM conversations c
-                INNER JOIN conversation_bindings b ON b.conversation_id = c.id
-                WHERE c.agent_id = $agentId
-                  AND c.status = $status
-                  AND b.channel_type = $channelType
-                  AND lower(b.channel_address) = lower($channelAddress)
-                  AND lower(ifnull(b.thread_id, '')) = lower($threadId)
+                  AND (($threadId IS NULL AND b.thread_id IS NULL)
+                       OR ($threadId IS NOT NULL AND lower(ifnull(b.thread_id, '')) = lower($threadId)))
                 ORDER BY c.updated_at DESC
                 LIMIT 1
                 """;
+        command.Parameters.AddWithValue("$threadId", (object?)threadId ?? DBNull.Value);
         command.Parameters.AddWithValue("$agentId", agentId.Value);
         command.Parameters.AddWithValue("$status", ConversationStatus.Active.ToString());
         command.Parameters.AddWithValue("$channelType", channelType.Value);
         command.Parameters.AddWithValue("$channelAddress", channelAddress);
-        if (threadId is not null)
-            command.Parameters.AddWithValue("$threadId", threadId);
-
         var id = (string?)await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(id)
             ? null

--- a/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
@@ -123,11 +123,30 @@ public sealed class SqliteConversationStoreTests
     }
 
     [Fact]
-    public async Task ResolveByBindingAsync_WithoutThreadId_MatchesOnAddressOnly()
+    public async Task ResolveByBindingAsync_WithNullThreadId_OnlyMatchesNullThreadBinding()
     {
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
+        // Conversation bound to thread-42 only — no null-thread binding
         var expected = CreateConversation(Agent("agent-a"), "Address", CreateBinding("teams", "channel-1", "thread-42"));
+        await store.CreateAsync(expected);
+
+        // Querying with null threadId should NOT match the thread-42 binding
+        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", null);
+        resolved.ShouldBeNull();
+
+        // But querying with the actual thread-42 should match
+        var resolvedWithThread = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", "thread-42");
+        resolvedWithThread.ShouldNotBeNull();
+        resolvedWithThread!.ConversationId.ShouldBe(expected.ConversationId);
+    }
+
+    [Fact]
+    public async Task ResolveByBindingAsync_WithNullThreadId_MatchesNullThreadBinding()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var expected = CreateConversation(Agent("agent-a"), "Address", CreateBinding("teams", "channel-1", null));
         await store.CreateAsync(expected);
 
         var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", null);


### PR DESCRIPTION
Closes #133

## Root cause

All three conversation stores had a bug in `ResolveByBindingAsync`: when called with `threadId=null`, the query matched **any** binding regardless of thread — including thread-specific bindings.

- **InMemory / File:** `(threadId is null || string.Equals(b.ThreadId, threadId, ...))` — short-circuits to `true` when `threadId` is null
- **SQLite:** separate query branch that omitted the `thread_id` WHERE clause entirely

Result: a root-chat message on `(telegram, 100, null)` could resolve to the thread-42 conversation if it was created first. Fan-out then delivered to both, causing duplicate responses and the flaky `TwoThreads_SameChat_IndependentConversations` test.

## Fix

Exact match on `threadId` including NULL=NULL in all three stores.

SQLite query:
```sql
AND (($threadId IS NULL AND b.thread_id IS NULL)
     OR ($threadId IS NOT NULL AND lower(ifnull(b.thread_id, '')) = lower($threadId)))
```

## Tests

- `TwoThreads_SameChat_IndependentConversations`: 5/5 passes (was ~2/3 fail)  
- Updated SQLite store test to assert correct semantics  
- Added `ResolveByBindingAsync_WithNullThreadId_MatchesNullThreadBinding` positive case