### PR TITLE
fix(gateway): per-address conversation routing

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/user-guide/getting-started' },
           { text: 'Agents', link: '/user-guide/agents' },
+          { text: 'Conversations', link: '/user-guide/conversations' },
           { text: 'Configuration', link: '/user-guide/configuration' },
           { text: 'Extensions', link: '/user-guide/extensions' },
           {

--- a/docs/user-guide/conversations.md
+++ b/docs/user-guide/conversations.md
@@ -22,7 +22,7 @@ These are distinct things that are often confused.
 | **What it is** | The full history of a dialogue | The agent's active context window |
 | **Scope** | Permanent (until archived) | Temporary — ends when reset or expired |
 | **Contains** | All messages, all sessions | Recent messages the agent is currently aware of |
-| **Survives restart** | Yes | No (new session on restart) |
+| **Survives restart** | Yes | Yes — session is resumed if still Active |
 | **Visible in portal** | Always | Only the current one |
 
 A conversation can contain many sessions. When you click **New session**, the agent's context is cleared but the conversation history is not. A `─── New session started ───` divider marks the boundary in the portal.
@@ -69,6 +69,8 @@ Sessions come and go; the conversation persists. This has practical implications
 
 - **Portal refresh** — if the SignalR connection drops and reconnects, the portal re-loads the conversation history from the database. Nothing is lost.
 - **New session** — the agent starts with no context, but history is still visible in the portal above the session divider.
+- **Gateway restart** — the session is persisted in the database. When the next message arrives the router reloads the conversation, finds the `ActiveSessionId`, and resumes it. The agent picks up where it left off.
+- **Session creation** — a new session is only created when: the conversation has no active session yet, the previous session was explicitly reset by the user, or the session was sealed/expired by compaction or a timeout.
 - **Compaction** — `/compact` summarises the current session to reduce token usage while preserving the full history in the database.
 - **Multiple sessions** — an agent can only have one active session per conversation at a time. Starting a new session seals the previous one.
 
@@ -203,12 +205,12 @@ Archiving is currently manual. Archived conversations do not appear in fan-out a
 |---|---|---|
 | Conversation history | Yes | SQLite (`~/.botnexus/sessions.sqlite`) |
 | Channel bindings | Yes | SQLite |
-| Session context (agent memory) | No | In-process only |
+| Session context (agent memory) | Yes — if session is still Active | SQLite (`~/.botnexus/sessions.sqlite`) |
 | Streaming state | No | In-process only |
 | SignalR connection | No | Reconnects on page load |
 | Unread counts | No | In-process only |
 
-After a gateway restart, conversations and their history are fully restored. The agent starts a new session with no prior context unless memory/RAG is configured.
+After a gateway restart, conversations, history, and active sessions are fully restored from the database. The agent resumes the existing session — no context is lost unless the session was sealed or the user explicitly started a new one.
 
 ---
 
@@ -224,7 +226,7 @@ User (Portal)   ──► Channel Binding ─┘         │
 ```
 
 - **Conversation** = persistent history, lives forever
-- **Session** = agent's current context window, temporary
+- **Session** = agent's current context window; persists across restarts, ends only when explicitly reset or expired
 - **Channel binding** = how a channel address connects to a conversation
 - **Fan-out** = one response delivered to all active bindings
 - **Agent** = owns one or more conversations; does not share them

--- a/docs/user-guide/conversations.md
+++ b/docs/user-guide/conversations.md
@@ -1,0 +1,230 @@
+# Conversations
+
+A **conversation** is the fundamental unit of context in BotNexus. It is a persistent, named thread of messages that:
+
+- belongs to one agent
+- spans any number of sessions
+- can be reached from multiple channels simultaneously
+- persists across gateway restarts
+
+Understanding conversations is the key to understanding how messages flow between users, agents, and channels.
+
+---
+
+## Core concepts
+
+### Conversation vs session
+
+These are distinct things that are often confused.
+
+| | Conversation | Session |
+|---|---|---|
+| **What it is** | The full history of a dialogue | The agent's active context window |
+| **Scope** | Permanent (until archived) | Temporary — ends when reset or expired |
+| **Contains** | All messages, all sessions | Recent messages the agent is currently aware of |
+| **Survives restart** | Yes | No (new session on restart) |
+| **Visible in portal** | Always | Only the current one |
+
+A conversation can contain many sessions. When you click **New session**, the agent's context is cleared but the conversation history is not. A `─── New session started ───` divider marks the boundary in the portal.
+
+```
+Conversation: "Support thread with Jon"
+├── Session 1  [2024-01-10]  ← agent remembered these messages
+│   ├── user: How do I configure X?
+│   └── agent: Here's how...
+├── ── New session started ──
+└── Session 2  [2024-01-15]  ← agent starts fresh, history still visible
+    ├── user: What did we discuss about X?
+    └── agent: I don't have that context — could you recap?
+```
+
+### Channel bindings
+
+A **channel binding** connects a conversation to a specific address on a specific channel. Each binding records:
+
+- `channelType` — e.g. `telegram`, `signalr`, `teams`
+- `channelAddress` — e.g. a Telegram chat ID, a Teams channel ID
+- `threadId` — optional; for forum topics, Teams threads, etc.
+- `mode` — controls fan-out participation (see below)
+
+One conversation can have many bindings. This is how a single dialogue can be visible on Telegram and in the web portal at the same time.
+
+---
+
+## How a message is routed
+
+When a message arrives from any channel, the gateway resolves which conversation it belongs to:
+
+1. **Find an existing binding** — look for a `ChannelBinding` that matches `(channelType, channelAddress, threadId)`. If found, use that conversation.
+2. **Thread fallback** — if no binding found and `threadId` is non-null, create a new conversation for this thread.
+3. **Default conversation** — if no binding found and `threadId` is null, use the agent's default conversation and add this channel as a new binding.
+
+This means **the first message from a new channel auto-attaches to the agent's default conversation**. Subsequent messages from the same address always route to the same conversation.
+
+---
+
+## Conversations across sessions
+
+Sessions come and go; the conversation persists. This has practical implications:
+
+- **Portal refresh** — if the SignalR connection drops and reconnects, the portal re-loads the conversation history from the database. Nothing is lost.
+- **New session** — the agent starts with no context, but history is still visible in the portal above the session divider.
+- **Compaction** — `/compact` summarises the current session to reduce token usage while preserving the full history in the database.
+- **Multiple sessions** — an agent can only have one active session per conversation at a time. Starting a new session seals the previous one.
+
+---
+
+## Conversations between channels (fan-out)
+
+When an agent responds, the response is delivered to **all active bindings** on that conversation — not just the channel the message came from. This is called **fan-out**.
+
+```
+User sends from Telegram
+        │
+        ▼
+  Conversation: "Jon's chat"
+  ├── Binding: telegram / chat-id-123   ← inbound arrived here
+  ├── Binding: signalr / browser-tab    ← fan-out delivers here too
+  └── Binding: teams / channel-abc      ← and here
+        │
+        ▼
+  Agent responds once
+        │
+  ┌─────┴──────────────────────────────────┐
+  │                                        │
+  ▼                                        ▼
+Telegram reply                    Portal + Teams update
+```
+
+The originating binding is **excluded from fan-out** — it receives the direct response instead, preventing duplicates.
+
+### Binding modes
+
+Each binding has a `mode` that controls how it participates in fan-out:
+
+| Mode | Inbound | Outbound fan-out | Use case |
+|---|---|---|---|
+| `Interactive` | ✓ | ✓ | Normal two-way channel |
+| `NotifyOnly` | ✗ | ✓ | Receive responses but not send (e.g. a monitoring dashboard) |
+| `Muted` | ✗ | ✗ | Silenced — no traffic in or out |
+
+Stale bindings (e.g. closed browser tabs) should be `Muted` to avoid delivering to dead connections.
+
+---
+
+## Conversations between agents
+
+Each conversation belongs to exactly **one agent**. Agents do not share conversations.
+
+If you want two agents to collaborate, you use one of:
+
+- **Sub-agents** — one agent spawns another as a tool call. The sub-agent's output feeds back into the parent's session.
+- **Separate conversations** — the user opens a new conversation with a different agent. There is no automatic cross-agent memory sharing.
+- **Shared memory** — agents can read from shared memory files/databases if configured, but this is outside the conversation model.
+
+```
+Agent: larry          Agent: assistant
+│                     │
+Conversation A        Conversation B
+(Jon ↔ larry)         (Jon ↔ assistant)
+```
+
+These are independent. A message sent to larry does not reach assistant.
+
+---
+
+## Conversations between users and agents
+
+### Default conversation
+
+Every agent has one **default conversation**. This is:
+- Created automatically the first time any channel connects to the agent
+- The landing point for any channel address that hasn't been seen before
+- Marked `IsDefault: true` in the database
+
+For a personal bot (one user, one agent), you will typically have exactly one default conversation and all your channels are bound to it.
+
+### Multiple users
+
+If multiple users message the same Telegram bot, each user's chat ID is a different `channelAddress`. The router will:
+- Give the first user the default conversation
+- Create new conversations for subsequent users (if no existing binding matches)
+
+::: tip For a personal bot
+Set `allowedUserIds` and `allowedChatIds` in the Telegram config to ensure only your ID can create bindings. See [Telegram — Security](./telegram#security).
+:::
+
+### Multiple conversations with one agent
+
+An agent can have multiple conversations — one per channel address, or one per forum topic. Each has its own history and its own session. Switching between them in the portal switches the active context.
+
+---
+
+## Threading
+
+Some channels support native threads or topics (Telegram forum groups, Teams channels, Slack threads). BotNexus maps each thread to its own conversation with a `threadId` binding:
+
+```
+Telegram group: chat-id-100
+├── General topic     → Conversation A  (threadId: null)
+├── Topic: Help       → Conversation B  (threadId: "42")
+└── Topic: Dev        → Conversation C  (threadId: "99")
+```
+
+A message posted in the "Help" topic only routes to Conversation B. The other topics are independent.
+
+The `ThreadingMode` on a binding controls this:
+
+| Mode | Behaviour |
+|---|---|
+| `Single` | One conversation per channel address (DMs, SMS) |
+| `NativeThread` | Maps to a native thread or topic |
+| `Prefix` | Prepends the conversation name to messages (SMS fallback) |
+
+---
+
+## Conversation lifecycle
+
+```
+Created ──► Active ──► Archived
+                         (read-only)
+```
+
+- **Active** — accepts new sessions and messages
+- **Archived** — read-only history, no new sessions
+
+Archiving is currently manual. Archived conversations do not appear in fan-out and cannot receive new messages.
+
+---
+
+## What persists and what doesn't
+
+| Data | Persists | Where |
+|---|---|---|
+| Conversation history | Yes | SQLite (`~/.botnexus/sessions.sqlite`) |
+| Channel bindings | Yes | SQLite |
+| Session context (agent memory) | No | In-process only |
+| Streaming state | No | In-process only |
+| SignalR connection | No | Reconnects on page load |
+| Unread counts | No | In-process only |
+
+After a gateway restart, conversations and their history are fully restored. The agent starts a new session with no prior context unless memory/RAG is configured.
+
+---
+
+## Summary
+
+```
+User (Telegram) ──► Channel Binding ─┐
+                                      ├──► Conversation ──► Session ──► Agent
+User (Portal)   ──► Channel Binding ─┘         │
+                                               fan-out
+                                          ┌────┴────┐
+                                    Telegram    Portal
+```
+
+- **Conversation** = persistent history, lives forever
+- **Session** = agent's current context window, temporary
+- **Channel binding** = how a channel address connects to a conversation
+- **Fan-out** = one response delivered to all active bindings
+- **Agent** = owns one or more conversations; does not share them

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -43,28 +43,33 @@ public sealed class DefaultConversationRouter : IConversationRouter
         var addedBinding = false;
         if (conversation is null)
         {
-            if (threadId is not null)
+            if (!string.IsNullOrWhiteSpace(channelAddress))
             {
-                // A non-null thread id means this is a distinct sub-channel (e.g. Telegram topic).
-                // Create a new conversation so the thread gets its own history.
+                // Every unique (channelType, channelAddress, threadId) gets its own conversation.
+                // A Teams DM, a Telegram DM, and a group chat all have different addresses and
+                // must not share context. The default conversation is reserved for portal/addressless channels.
+                var title = threadId is not null
+                    ? $"{channelType}:{channelAddress}/{threadId}"
+                    : $"{channelType}:{channelAddress}";
                 conversation = new Conversation
                 {
                     ConversationId = ConversationId.Create(),
                     AgentId = agentId,
-                    Title = $"{channelType}:{channelAddress}/{threadId}",
+                    Title = title,
                     IsDefault = false
                 };
                 _logger.LogDebug(
-                    "Creating new conversation for thread agent={AgentId} channel={ChannelType} address={ChannelAddress} thread={ThreadId}",
+                    "Creating new conversation for agent={AgentId} channel={ChannelType} address={ChannelAddress} thread={ThreadId}",
                     agentId, channelType, channelAddress, threadId);
             }
             else
             {
-                // 2. Fall back to the agent's default conversation and add a binding
+                // No channel address — fall back to the agent's default conversation.
+                // This is the portal (SignalR) case where there is no stable external address.
                 conversation = await _conversationStore.GetOrCreateDefaultAsync(agentId, ct);
                 _logger.LogDebug(
-                    "No conversation found for agent={AgentId} channel={ChannelType} address={ChannelAddress}. Using default conversation {ConversationId}",
-                    agentId, channelType, channelAddress, conversation.ConversationId);
+                    "No channel address for agent={AgentId} channel={ChannelType}. Using default conversation {ConversationId}",
+                    agentId, channelType, conversation.ConversationId);
             }
 
             var binding = new ChannelBinding

--- a/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -29,7 +29,7 @@ public sealed class DefaultConversationRouterTests
     // ── ResolveInboundAsync ────────────────────────────────────────────────────
 
     [Fact]
-    public async Task ResolveInbound_CreatesDefaultConversation_ForNewChannelAddress()
+    public async Task ResolveInbound_CreatesPerAddressConversation_ForNewChannelAddress()
     {
         var router = CreateRouter();
         var agentId = Agent();
@@ -39,7 +39,21 @@ public sealed class DefaultConversationRouterTests
         result.ShouldNotBeNull();
         result.Conversation.ShouldNotBeNull();
         result.Conversation.AgentId.ShouldBe(agentId);
-        result.Conversation.IsDefault.ShouldBeTrue();
+        result.Conversation.IsDefault.ShouldBeFalse(); // per-address conversation, not the default
+        result.Conversation.ChannelBindings.ShouldHaveSingleItem();
+        result.Conversation.ChannelBindings[0].ChannelAddress.ShouldBe("chat-123");
+    }
+
+    [Fact]
+    public async Task ResolveInbound_CreatesDefaultConversation_ForAddresslessChannel()
+    {
+        var router = CreateRouter();
+        var agentId = Agent();
+
+        var result = await router.ResolveInboundAsync(agentId, Channel(), "", null);
+
+        result.ShouldNotBeNull();
+        result.Conversation.IsDefault.ShouldBeTrue(); // no address — falls back to default
     }
 
     [Fact]

--- a/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -54,8 +54,7 @@ public sealed class MultiChannelFanOutTests
     public async Task TwoChannels_MessageFromSignalR_FansOutToTelegram()
     {
         var harness = CreateHarness(responseContent: "fanout");
-        await harness.SeedBindingAsync("signalr", "chat-1");
-        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"));
         harness.ClearOutbound();
 
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
@@ -71,8 +70,7 @@ public sealed class MultiChannelFanOutTests
     public async Task TwoChannels_MessageFromTelegram_FansOutToSignalR()
     {
         var harness = CreateHarness(responseContent: "fanout");
-        await harness.SeedBindingAsync("signalr", "chat-1");
-        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"));
         harness.ClearOutbound();
 
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
@@ -87,8 +85,7 @@ public sealed class MultiChannelFanOutTests
     public async Task TwoChannels_MessageFromTelegram_TelegramReceivesExactlyOnce()
     {
         var harness = CreateHarness(responseContent: "fanout");
-        await harness.SeedBindingAsync("signalr", "chat-1");
-        await harness.SeedBindingAsync("telegram", "chat-100");
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"));
         harness.ClearOutbound();
 
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
@@ -100,9 +97,9 @@ public sealed class MultiChannelFanOutTests
     [Fact]
     public async Task TwoChannels_NewConversation_BothChannelsGetSubsequentMessages()
     {
+        // Explicitly bind both channels to the same conversation, then verify fan-out
         var harness = CreateHarness(responseContent: "follow-up");
-        await harness.Host.DispatchAsync(harness.CreateMessage("first", "signalr", "chat-1"));
-        await harness.Host.DispatchAsync(harness.CreateMessage("join", "telegram", "chat-100"));
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"));
         harness.ClearOutbound();
 
         await harness.Host.DispatchAsync(harness.CreateMessage("second", "signalr", "chat-1"));
@@ -117,9 +114,7 @@ public sealed class MultiChannelFanOutTests
     public async Task ThreeChannels_MessageFromA_FansOutToBAndC()
     {
         var harness = CreateHarness(responseContent: "matrix");
-        await harness.SeedBindingAsync("signalr", "chat-1");
-        await harness.SeedBindingAsync("telegram", "chat-100");
-        await harness.SeedBindingAsync("tui", "terminal-1");
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"), ("tui", "terminal-1"));
         harness.ClearOutbound();
 
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
@@ -133,9 +128,7 @@ public sealed class MultiChannelFanOutTests
     public async Task ThreeChannels_MessageFromB_FansOutToAAndC()
     {
         var harness = CreateHarness(responseContent: "matrix");
-        await harness.SeedBindingAsync("signalr", "chat-1");
-        await harness.SeedBindingAsync("telegram", "chat-100");
-        await harness.SeedBindingAsync("tui", "terminal-1");
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"), ("tui", "terminal-1"));
         harness.ClearOutbound();
 
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
@@ -149,9 +142,7 @@ public sealed class MultiChannelFanOutTests
     public async Task ThreeChannels_EachChannelSends_OthersTwoReceive_NoDuplicates()
     {
         var harness = CreateHarness(responseContent: "matrix");
-        await harness.SeedBindingAsync("signalr", "chat-1");
-        await harness.SeedBindingAsync("telegram", "chat-100");
-        await harness.SeedBindingAsync("tui", "terminal-1");
+        await harness.SeedSharedConversationAsync(("signalr", "chat-1"), ("telegram", "chat-100"), ("tui", "terminal-1"));
 
         await AssertPerSendAsync(harness, harness.CreateMessage("from-a", "signalr", "chat-1"));
         await AssertPerSendAsync(harness, harness.CreateMessage("from-b", "telegram", "chat-100"));
@@ -262,6 +253,71 @@ public sealed class MultiChannelFanOutTests
         harness.SignalR.Messages.Count.ShouldBe(1);
         harness.Telegram.Messages.Count.ShouldBe(1);
     }
+
+    [Fact]
+    public async Task DifferentChannelAddresses_GetSeparateConversations()
+    {
+        // Regression for #138: a Teams DM and a Telegram DM must not share the default conversation
+        var harness = CreateHarness(responseContent: "isolated");
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
+        await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "browser-1"));
+
+        var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        conversations.Count.ShouldBe(2, "each channel address must get its own conversation");
+
+        var telegramConv = conversations.FirstOrDefault(c =>
+            c.ChannelBindings.Any(b => b.ChannelType == ChannelKey.From("telegram")));
+        var signalrConv = conversations.FirstOrDefault(c =>
+            c.ChannelBindings.Any(b => b.ChannelType == ChannelKey.From("signalr")));
+
+        telegramConv.ShouldNotBeNull();
+        signalrConv.ShouldNotBeNull();
+        telegramConv!.ConversationId.ShouldNotBe(signalrConv!.ConversationId);
+    }
+
+    [Fact]
+    public async Task SameChannelAddress_SecondMessage_ReusesConversation()
+    {
+        // Same (channelType, channelAddress) must always route to the same conversation
+        var harness = CreateHarness(responseContent: "reuse");
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("first", "telegram", "chat-100"));
+        await harness.Host.DispatchAsync(harness.CreateMessage("second", "telegram", "chat-100"));
+
+        var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        conversations.Count.ShouldBe(1, "same address must reuse the same conversation");
+    }
+
+    [Fact]
+    public async Task GroupChat_AndDM_SameChannelType_GetSeparateConversations()
+    {
+        // A Telegram group (chat-id: -1001234) and a DM (chat-id: 1234567) must be separate
+        var harness = CreateHarness(responseContent: "group-isolated");
+
+        await harness.Host.DispatchAsync(harness.CreateMessage("hi from DM", "telegram", "1234567"));
+        await harness.Host.DispatchAsync(harness.CreateMessage("hi from group", "telegram", "-1001234567"));
+
+        var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        conversations.Count.ShouldBe(2, "DM and group chat must have separate conversations");
+    }
+
+    [Fact]
+    public async Task NoChannelAddress_UsesDefaultConversation()
+    {
+        // When channelAddress is empty/null, fall back to default conversation (portal edge case)
+        var harness = CreateHarness(responseContent: "default");
+
+        var msg1 = harness.CreateMessage("first", "signalr", "");
+        var msg2 = harness.CreateMessage("second", "signalr", "");
+        await harness.Host.DispatchAsync(msg1);
+        await harness.Host.DispatchAsync(msg2);
+
+        var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
+        conversations.Count.ShouldBe(1, "addressless messages should share the default conversation");
+        conversations[0].IsDefault.ShouldBeTrue();
+    }
+
 
     private static async Task AssertPerSendAsync(TestHarness harness, InboundMessage message)
     {
@@ -378,7 +434,35 @@ public sealed class MultiChannelFanOutTests
 
         public async Task SeedBindingAsync(string channelType, string channelAddress, string? threadId = null)
         {
+            // Dispatch a seed message — the router will find or create the correct conversation
+            // per (channelType, channelAddress, threadId). For fan-out tests that need multiple
+            // channels in one conversation, use SeedSharedConversationAsync or AttachBindingToConversationAsync directly.
             await Host.DispatchAsync(CreateMessage($"seed-{channelType}", channelType, channelAddress, threadId));
+        }
+
+        /// <summary>
+        /// Creates a shared conversation with all given (channelType, channelAddress) bindings.
+        /// The first address seeds the conversation via dispatch; the rest are attached directly.
+        /// Use this for fan-out tests where multiple channels must share one conversation.
+        /// </summary>
+        public async Task SeedSharedConversationAsync(params (string channelType, string channelAddress)[] bindings)
+        {
+            if (bindings.Length == 0) return;
+            // First binding seeds the conversation
+            await Host.DispatchAsync(CreateMessage($"seed-{bindings[0].channelType}", bindings[0].channelType, bindings[0].channelAddress));
+            var conversations = await Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
+            var conversation = conversations.Last();
+            // Remaining bindings attached directly to the same conversation
+            foreach (var (channelType, channelAddress) in bindings.Skip(1))
+            {
+                conversation.ChannelBindings.Add(new ChannelBinding
+                {
+                    ChannelType = ChannelKey.From(channelType),
+                    ChannelAddress = channelAddress,
+                    Mode = BindingMode.Interactive
+                });
+            }
+            await Conversations.SaveAsync(conversation);
         }
 
         public Conversation GetConversationFor(string channelType, string channelAddress, string? threadId)


### PR DESCRIPTION
Closes #138

## Problem

All non-threaded inbound messages fell back to the agent's default conversation regardless of channel address. A Teams DM, a Telegram DM, and a group chat all ended up in the same conversation.

## Fix

When no binding is found:
- **Non-empty `channelAddress`** → create a new conversation keyed to that address
- **Empty/null `channelAddress`** → fall back to default conversation (portal/addressless channels only)

```
Teams DM (addr: user-jon)     → Conversation A  ✓
Telegram DM (addr: 1234567)   → Conversation B  ✓
Telegram group (addr: -100x)  → Conversation C  ✓
Portal SignalR (addr: "")     → Default conversation  ✓
```

## Tests — 4 new
- `DifferentChannelAddresses_GetSeparateConversations`
- `SameChannelAddress_SecondMessage_ReusesConversation`
- `GroupChat_AndDM_SameChannelType_GetSeparateConversations`
- `NoChannelAddress_UsesDefaultConversation`

All 1203 tests pass.