### PR TITLE
fix(config): support toolIds ["*"] as all-tools wildcard

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -100,12 +100,17 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         var workspaceTools = _toolFactory.CreateTools(workspacePath, pathValidator);
         var workspaceToolNames = new HashSet<string>(workspaceTools.Select(tool => tool.Name), StringComparer.OrdinalIgnoreCase);
 
-        IReadOnlyList<IAgentTool> selectedWorkspaceTools = descriptor.ToolIds.Count > 0
-            ? [.. workspaceTools.Where(tool => descriptor.ToolIds.Contains(tool.Name, StringComparer.OrdinalIgnoreCase))]
+        // Normalise toolIds: ["*"] is a user-friendly alias for [] (all tools).
+        var effectiveToolIds = IsWildcardToolIds(descriptor.ToolIds)
+            ? (IReadOnlyList<string>)[]
+            : descriptor.ToolIds;
+
+        IReadOnlyList<IAgentTool> selectedWorkspaceTools = effectiveToolIds.Count > 0
+            ? [.. workspaceTools.Where(tool => effectiveToolIds.Contains(tool.Name, StringComparer.OrdinalIgnoreCase))]
             : workspaceTools;
 
-        var extensionTools = descriptor.ToolIds.Count > 0
-            ? _toolRegistry.ResolveTools(descriptor.ToolIds)
+        var extensionTools = effectiveToolIds.Count > 0
+            ? _toolRegistry.ResolveTools(effectiveToolIds)
             : _toolRegistry.GetAll();
 
         var tools = selectedWorkspaceTools
@@ -115,7 +120,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         _logger.LogInformation(
             "Tool setup for '{AgentId}': workspace={WorkspaceCount} extension={ExtCount} total={Total} toolIds={ToolIdCount} workspace={WorkspacePath}",
             descriptor.AgentId, workspaceTools.Count, extensionTools.Count(), tools.Count,
-            descriptor.ToolIds.Count, workspacePath);
+            effectiveToolIds.Count, workspacePath);
 
         if (descriptor.Memory?.Enabled == true)
         {
@@ -128,8 +133,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             tools.Add(new MemoryStoreTool(memoryStore, descriptor.AgentId));
         }
 
-        var cronEnabled = descriptor.ToolIds.Count == 0
-                          || descriptor.ToolIds.Contains("cron", StringComparer.OrdinalIgnoreCase);
+        var cronEnabled = effectiveToolIds.Count == 0
+                          || effectiveToolIds.Contains("cron", StringComparer.OrdinalIgnoreCase);
         var hasCronTool = tools.Any(tool => string.Equals(tool.Name, "cron", StringComparison.OrdinalIgnoreCase));
         if (cronEnabled && !hasCronTool)
         {
@@ -163,12 +168,12 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             subAgentOptions is { MaxDepth: > 0 } &&
             !isSubAgentSession)
         {
-            var includeSpawn = descriptor.ToolIds.Count == 0
-                || descriptor.ToolIds.Contains("spawn_subagent", StringComparer.OrdinalIgnoreCase);
-            var includeList = descriptor.ToolIds.Count == 0
-                || descriptor.ToolIds.Contains("list_subagents", StringComparer.OrdinalIgnoreCase);
-            var includeManage = descriptor.ToolIds.Count == 0
-                || descriptor.ToolIds.Contains("manage_subagent", StringComparer.OrdinalIgnoreCase);
+            var includeSpawn = effectiveToolIds.Count == 0
+                || effectiveToolIds.Contains("spawn_subagent", StringComparer.OrdinalIgnoreCase);
+            var includeList = effectiveToolIds.Count == 0
+                || effectiveToolIds.Contains("list_subagents", StringComparer.OrdinalIgnoreCase);
+            var includeManage = effectiveToolIds.Count == 0
+                || effectiveToolIds.Contains("manage_subagent", StringComparer.OrdinalIgnoreCase);
 
             if (includeSpawn)
                 tools.Add(new SubAgentSpawnTool(subAgentManager, descriptor.AgentId, context.SessionId));
@@ -181,8 +186,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         var conversationService = _serviceProvider.GetService<IAgentExchangeService>();
         if (conversationService is not null && sessionStore is not null)
         {
-            var includeConverse = descriptor.ToolIds.Count == 0
-                || descriptor.ToolIds.Contains("agent_converse", StringComparer.OrdinalIgnoreCase);
+            var includeConverse = effectiveToolIds.Count == 0
+                || effectiveToolIds.Contains("agent_converse", StringComparer.OrdinalIgnoreCase);
             if (includeConverse)
                 tools.Add(new AgentConverseTool(conversationService, sessionStore, descriptor.AgentId, context.SessionId));
         }
@@ -409,6 +414,13 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 serverId, agentId);
         }
     }
+
+    /// <summary>
+    /// Returns true when <paramref name="toolIds"/> represents the all-tools wildcard — either an
+    /// empty list (legacy behaviour) or a list whose sole entry is <c>"*"</c> (intuitive form).
+    /// </summary>
+    private static bool IsWildcardToolIds(IReadOnlyList<string> toolIds)
+        => toolIds.Count == 0 || (toolIds.Count == 1 && toolIds[0] == "*");
 
     private static bool ResolveAllowCrossAgentCron(AgentDescriptor descriptor)
     {

--- a/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -156,6 +156,71 @@ public sealed class InProcessIsolationStrategyTests
         messages[4].ShouldBe(new AssistantAgentMessage("You're welcome!"));
     }
 
+    [Fact]
+    public async Task CreateAsync_WithWildcardToolIds_ReturnsAllToolsLikeEmptyList()
+    {
+        // toolIds: ["*"] should behave identically to toolIds: [] (all tools available)
+        var strategy = CreateStrategyWithRegisteredModel();
+        var wildcardDescriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-wc"),
+            DisplayName = "Wildcard Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            SystemPrompt = "You are a test agent.",
+            ToolIds = ["*"]
+        };
+        var emptyDescriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-empty"),
+            DisplayName = "Empty ToolIds Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            SystemPrompt = "You are a test agent.",
+            ToolIds = []
+        };
+
+        var wildcardHandle = await strategy.CreateAsync(wildcardDescriptor, new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-wc") });
+        var emptyHandle = await strategy.CreateAsync(emptyDescriptor, new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-empty") });
+
+        var wildcardTools = GetTools(wildcardHandle);
+        var emptyTools = GetTools(emptyHandle);
+
+        wildcardTools.Count.ShouldBe(emptyTools.Count);
+        wildcardTools.Select(t => t.Name).ShouldBe(emptyTools.Select(t => t.Name), ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithWildcardToolIds_IncludesWorkspaceTools()
+    {
+        // Ensures workspace tools (like read) are not filtered out when toolIds is ["*"]
+        var strategy = CreateStrategyWithRegisteredModel();
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-wc2"),
+            DisplayName = "Wildcard Agent 2",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            SystemPrompt = "You are a test agent.",
+            ToolIds = ["*"]
+        };
+
+        var handle = await strategy.CreateAsync(descriptor, new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-wc2") });
+        var tools = GetTools(handle);
+
+        // StaticAgentToolFactory always registers a ReadTool — it must be present with wildcard
+        tools.ShouldContain(t => string.Equals(t.Name, "read", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IReadOnlyList<IAgentTool> GetTools(IAgentHandle handle)
+    {
+        var agentField = handle.GetType().GetField("_agent", BindingFlags.Instance | BindingFlags.NonPublic);
+        agentField.ShouldNotBeNull();
+        var agent = agentField!.GetValue(handle) as BotNexus.Agent.Core.Agent;
+        agent.ShouldNotBeNull();
+        return agent!.State.Tools;
+    }
+
     private static InProcessIsolationStrategy CreateStrategyWithRegisteredModel()
     {
         var modelRegistry = new ModelRegistry();


### PR DESCRIPTION
Closes #114

`toolIds: ["*"]` now behaves identically to `toolIds: []` — all tools available. Makes intent explicit in config.

```json
{ "toolIds": ["*"] }  // clear: all tools
{ "toolIds": [] }      // still works, but ambiguous to a reader
```

## Tests
- `CreateAsync_WithWildcardToolIds_ReturnsAllToolsLikeEmptyList`
- `CreateAsync_WithWildcardToolIds_IncludesWorkspaceTools`