### PR TITLE
fix(sessions): migrate orphaned sessions to default conversation on startup

### DIFF
--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -8,6 +8,7 @@ using SessionType = BotNexus.Domain.Primitives.SessionType;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
@@ -36,9 +37,26 @@ public sealed class SqliteSessionStore : SessionStoreBase
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public SqliteSessionStore(string connectionString, ILogger<SqliteSessionStore> logger)
+    private readonly IConversationStore? _conversationStore;
+    private readonly ILogger<SqliteSessionStore> _logger;
+
+    /// <summary>
+    /// Initialises a new <see cref="SqliteSessionStore"/>.
+    /// </summary>
+    /// <param name="connectionString">SQLite connection string for the sessions database.</param>
+    /// <param name="logger">Logger for diagnostic output including migration summaries.</param>
+    /// <param name="conversationStore">
+    /// When provided, a startup migration links any orphaned sessions (those with no
+    /// <c>conversation_id</c>) to their agent's default conversation.
+    /// </param>
+    public SqliteSessionStore(
+        string connectionString,
+        ILogger<SqliteSessionStore> logger,
+        IConversationStore? conversationStore = null)
     {
         _connectionString = connectionString;
+        _logger = logger;
+        _conversationStore = conversationStore;
     }
 
     /// <inheritdoc />
@@ -252,6 +270,10 @@ public sealed class SqliteSessionStore : SessionStoreBase
             // Migrate: add tool columns to existing databases
             await MigrateAsync(connection, cancellationToken).ConfigureAwait(false);
 
+            // Migrate: link orphaned sessions to their agent's default conversation
+            if (_conversationStore is not null)
+                await MigrateOrphanedSessionsAsync(connection, _conversationStore, cancellationToken).ConfigureAwait(false);
+
             _initialized = true;
         }
         finally { _initLock.Release(); }
@@ -303,6 +325,89 @@ public sealed class SqliteSessionStore : SessionStoreBase
             WHERE lower(status) = 'closed'
             """;
         await renameStatus.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Finds every session with no <c>conversation_id</c>, groups them by agent, and
+    /// links each group to the agent's default conversation.  The most recently updated
+    /// orphaned session becomes <see cref="Conversation.ActiveSessionId"/>.
+    /// Safe to run on every startup — no-op when there are no orphaned rows.
+    /// </summary>
+    private async Task MigrateOrphanedSessionsAsync(
+        SqliteConnection connection,
+        IConversationStore conversationStore,
+        CancellationToken cancellationToken)
+    {
+        // Collect distinct agents that have at least one orphaned session.
+        await using var agentCmd = connection.CreateCommand();
+        agentCmd.CommandText = """
+            SELECT DISTINCT agent_id
+            FROM sessions
+            WHERE conversation_id IS NULL
+              AND agent_id IS NOT NULL
+            """;
+
+        var agents = new List<string>();
+        await using (var agentReader = await agentCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await agentReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                agents.Add(agentReader.GetString(0));
+        }
+
+        if (agents.Count == 0)
+            return;
+
+        var totalMigrated = 0;
+
+        foreach (var agentIdValue in agents)
+        {
+            var agentId = AgentId.From(agentIdValue);
+
+            // Resolve (or create) the default conversation for this agent.
+            var conversation = await conversationStore
+                .GetOrCreateDefaultAsync(agentId, cancellationToken)
+                .ConfigureAwait(false);
+
+            var convIdValue = conversation.ConversationId.Value;
+
+            // Find the most recently updated orphaned session for this agent.
+            await using var latestCmd = connection.CreateCommand();
+            latestCmd.CommandText = """
+                SELECT id
+                FROM sessions
+                WHERE conversation_id IS NULL
+                  AND agent_id = $agentId
+                ORDER BY updated_at DESC
+                LIMIT 1
+                """;
+            latestCmd.Parameters.AddWithValue("$agentId", agentIdValue);
+            var latestSessionId = (string?)await latestCmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+
+            // Bulk-update all orphaned sessions for this agent.
+            await using var updateCmd = connection.CreateCommand();
+            updateCmd.CommandText = """
+                UPDATE sessions
+                SET conversation_id = $convId
+                WHERE conversation_id IS NULL
+                  AND agent_id = $agentId
+                """;
+            updateCmd.Parameters.AddWithValue("$convId", convIdValue);
+            updateCmd.Parameters.AddWithValue("$agentId", agentIdValue);
+            var count = await updateCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            totalMigrated += count;
+
+            // Point the conversation at the most recently active orphaned session,
+            // but only if it has no active session already.
+            if (latestSessionId is not null && conversation.ActiveSessionId is null)
+            {
+                conversation.ActiveSessionId = SessionId.From(latestSessionId);
+                await conversationStore.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        _logger.LogInformation(
+            "Orphaned session migration: linked {Count} session(s) across {AgentCount} agent(s) to their default conversations.",
+            totalMigrated, agents.Count);
     }
 
     private async Task<GatewaySession?> LoadSessionAsync(SessionId sessionId, CancellationToken cancellationToken)

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -387,7 +387,8 @@ public static class GatewayServiceCollectionExtensions
             services.Replace(ServiceDescriptor.Singleton<ISessionStore>(serviceProvider =>
                 new SqliteSessionStore(
                     connectionString,
-                    serviceProvider.GetRequiredService<ILogger<SqliteSessionStore>>())));
+                    serviceProvider.GetRequiredService<ILogger<SqliteSessionStore>>(),
+                    serviceProvider.GetRequiredService<IConversationStore>())));
             return;
         }
 

--- a/tests/BotNexus.Gateway.Tests/SqliteSessionStoreMigrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteSessionStoreMigrationTests.cs
@@ -1,0 +1,195 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for the startup migration that links orphaned sessions (those with no
+/// <c>conversation_id</c>) to their agent's default conversation.
+/// Runs in-process against a real SQLite database to exercise the actual migration SQL.
+/// </summary>
+public sealed class SqliteSessionStoreMigrationTests : IDisposable
+{
+    private readonly string _directoryPath;
+    private readonly string _sessionDbPath;
+    private readonly string _conversationDbPath;
+
+    public SqliteSessionStoreMigrationTests()
+    {
+        _directoryPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "SqliteSessionStoreMigrationTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directoryPath);
+        _sessionDbPath = Path.Combine(_directoryPath, "sessions.db");
+        _conversationDbPath = Path.Combine(_directoryPath, "conversations.db");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directoryPath))
+            Directory.Delete(_directoryPath, recursive: true);
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private SqliteConversationStore CreateConversationStore()
+        => new($"Data Source={_conversationDbPath};Pooling=False",
+               NullLogger<SqliteConversationStore>.Instance);
+
+    private SqliteSessionStore CreateSessionStore(SqliteConversationStore conversationStore)
+        => new($"Data Source={_sessionDbPath};Pooling=False",
+               NullLogger<SqliteSessionStore>.Instance,
+               conversationStore);
+
+    /// <summary>
+    /// Inserts a session row directly, bypassing the store so we can set
+    /// <c>conversation_id</c> to NULL (simulating a pre-conversation-model row).
+    /// </summary>
+    private static async Task InsertOrphanedSessionAsync(
+        string connectionString,
+        string sessionId,
+        string agentId,
+        DateTimeOffset updatedAt)
+    {
+        await using var conn = new SqliteConnection(connectionString);
+        await conn.OpenAsync();
+
+        // Ensure schema exists first by opening the store (which runs EnsureCreatedAsync).
+        // We skip that here because we call InsertOrphanedSessionAsync only after the store
+        // has been initialised at least once (via a prior store operation).
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT OR REPLACE INTO sessions
+                (id, agent_id, channel_type, caller_id, session_type, participants_json,
+                 status, metadata, created_at, updated_at, conversation_id)
+            VALUES
+                ($id, $agentId, 'test', NULL, 'standard', '[]',
+                 'Active', '{}', $createdAt, $updatedAt, NULL)
+            """;
+        cmd.Parameters.AddWithValue("$id", sessionId);
+        cmd.Parameters.AddWithValue("$agentId", agentId);
+        cmd.Parameters.AddWithValue("$createdAt", updatedAt.AddMinutes(-5).ToString("O"));
+        cmd.Parameters.AddWithValue("$updatedAt", updatedAt.ToString("O"));
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<string?> ReadConversationIdAsync(string connectionString, string sessionId)
+    {
+        await using var conn = new SqliteConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT conversation_id FROM sessions WHERE id = $id";
+        cmd.Parameters.AddWithValue("$id", sessionId);
+        var result = await cmd.ExecuteScalarAsync();
+        return result is DBNull or null ? null : (string)result;
+    }
+
+    // ─── tests ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Migration_OrphanedSessions_LinkedToDefaultConversation()
+    {
+        var agentId = AgentId.From("agent-orphan");
+
+        // Arrange: bootstrap the schema, then poke in orphaned rows.
+        var convStore = CreateConversationStore();
+        var sessionStore = CreateSessionStore(convStore);
+        // Prime the schema by doing one store operation.
+        _ = await sessionStore.GetAsync(SessionId.From("probe"), CancellationToken.None);
+
+        var t1 = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var t2 = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await InsertOrphanedSessionAsync(
+            $"Data Source={_sessionDbPath};Pooling=False", "s-orphan-1", agentId.Value, t1);
+        await InsertOrphanedSessionAsync(
+            $"Data Source={_sessionDbPath};Pooling=False", "s-orphan-2", agentId.Value, t2);
+
+        // Act: create a fresh store; the migration runs during initialisation.
+        var convStore2 = CreateConversationStore();
+        var sessionStore2 = CreateSessionStore(convStore2);
+        // Trigger init by loading a session (any operation calls EnsureCreatedAsync).
+        _ = await sessionStore2.GetAsync(SessionId.From("probe"), CancellationToken.None);
+
+        // Assert: both orphaned sessions now have the default conversation id.
+        var conv = await convStore2.GetOrCreateDefaultAsync(agentId);
+        var cid1 = await ReadConversationIdAsync($"Data Source={_sessionDbPath};Pooling=False", "s-orphan-1");
+        var cid2 = await ReadConversationIdAsync($"Data Source={_sessionDbPath};Pooling=False", "s-orphan-2");
+
+        cid1.ShouldNotBeNull();
+        cid2.ShouldNotBeNull();
+        cid1.ShouldBe(conv.ConversationId.Value);
+        cid2.ShouldBe(conv.ConversationId.Value);
+
+        // The most recently updated session should be the conversation's active session.
+        conv.ActiveSessionId.ShouldNotBeNull();
+        conv.ActiveSessionId!.Value.Value.ShouldBe("s-orphan-2");
+    }
+
+    [Fact]
+    public async Task Migration_NoOrphanedSessions_IsNoOp()
+    {
+        var agentId = AgentId.From("agent-clean");
+
+        // Arrange: create a session the normal way (it will have a conversation_id).
+        var convStore = CreateConversationStore();
+        var sessionStore = CreateSessionStore(convStore);
+        var session = await sessionStore.GetOrCreateAsync(SessionId.From("s-clean-1"), agentId);
+        session.Session.ConversationId = (await convStore.GetOrCreateDefaultAsync(agentId)).ConversationId;
+        await sessionStore.SaveAsync(session);
+
+        // Remember how many conversations exist before.
+        var convsBefore = await convStore.ListAsync(agentId);
+
+        // Act: re-open — migration should be a no-op.
+        var convStore2 = CreateConversationStore();
+        var sessionStore2 = CreateSessionStore(convStore2);
+        _ = await sessionStore2.GetAsync(SessionId.From("probe"), CancellationToken.None);
+
+        var convsAfter = await convStore2.ListAsync(agentId);
+
+        // No extra conversations created.
+        convsAfter.Count.ShouldBe(convsBefore.Count);
+    }
+
+    [Fact]
+    public async Task Migration_IsIdempotent_RunningTwiceHasNoEffect()
+    {
+        var agentId = AgentId.From("agent-idem");
+
+        // Arrange: orphaned sessions in the DB.
+        var convStore = CreateConversationStore();
+        var sessionStore = CreateSessionStore(convStore);
+        _ = await sessionStore.GetAsync(SessionId.From("probe"), CancellationToken.None);
+
+        await InsertOrphanedSessionAsync(
+            $"Data Source={_sessionDbPath};Pooling=False", "s-idem-1", agentId.Value,
+            DateTimeOffset.UtcNow.AddMinutes(-10));
+
+        // First migration run.
+        var convStore2 = CreateConversationStore();
+        var sessionStore2 = CreateSessionStore(convStore2);
+        _ = await sessionStore2.GetAsync(SessionId.From("probe"), CancellationToken.None);
+
+        var cidAfterFirst = await ReadConversationIdAsync(
+            $"Data Source={_sessionDbPath};Pooling=False", "s-idem-1");
+        var convsAfterFirst = await convStore2.ListAsync(agentId);
+
+        // Second migration run (new store instance, _initialized is false again).
+        var convStore3 = CreateConversationStore();
+        var sessionStore3 = CreateSessionStore(convStore3);
+        _ = await sessionStore3.GetAsync(SessionId.From("probe"), CancellationToken.None);
+
+        var cidAfterSecond = await ReadConversationIdAsync(
+            $"Data Source={_sessionDbPath};Pooling=False", "s-idem-1");
+        var convsAfterSecond = await convStore3.ListAsync(agentId);
+
+        // Same conversation id, no duplicate default conversations.
+        cidAfterSecond.ShouldBe(cidAfterFirst);
+        convsAfterSecond.Count.ShouldBe(convsAfterFirst.Count);
+    }
+}


### PR DESCRIPTION
Closes #94

Sessions created before the conversation model shipped have no `conversationId`. On restart they appear in the sessions list but history is inaccessible via the conversation API.

## Fix

`SqliteSessionStore.EnsureCreatedAsync` now calls `MigrateOrphanedSessionsAsync` when an `IConversationStore` is available:

1. Find all sessions with `conversation_id IS NULL` grouped by agent
2. For each agent — get or create the default conversation
3. Bulk-update orphaned session rows to link to that conversation
4. Set `conversation.ActiveSessionId` to the most recently updated session (if not already set)
5. Log a summary

**Idempotent** — rows already assigned a `conversation_id` are excluded by the `WHERE` clause. Safe to run on every startup.

## Tests
- `Migration_OrphanedSessions_LinkedToDefaultConversation`
- `Migration_NoOrphanedSessions_IsNoOp`
- `Migration_IsIdempotent_RunningTwiceHasNoEffect`