### PR TITLE
fix(portal): filter NO_REPLY sentinel from conversation UI

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
@@ -207,6 +207,10 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _store.NotifyChanged();
     }
 
+    // Agents use this exact string to indicate they have nothing to say in a turn.
+    // Suppress it silently — users must never see "NO_REPLY" as a chat message.
+    private const string NoReplySentinel = "NO_REPLY";
+
     public void HandleMessageEnd(AgentStreamEvent evt)
     {
         if (!ResolveAgent(evt.SessionId, out var agentId, out var agent)) return;
@@ -220,7 +224,9 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
             ? null
             : conv.StreamState.ThinkingBuffer;
 
-        if (!string.IsNullOrEmpty(conv.StreamState.Buffer) || thinkingContent is not null)
+        var isNoReply = string.Equals(conv.StreamState.Buffer.Trim(), NoReplySentinel, StringComparison.Ordinal);
+
+        if (!isNoReply && (!string.IsNullOrEmpty(conv.StreamState.Buffer) || thinkingContent is not null))
         {
             conv.Messages.Add(new ChatMessage("Assistant", conv.StreamState.Buffer, DateTimeOffset.UtcNow)
             {

--- a/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -125,6 +125,60 @@ public sealed class GatewayEventHandlerTests
     }
 
     [Fact]
+    public void HandleMessageEnd_no_reply_sentinel_does_not_add_message_to_conversation()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        // Buffer contains exactly the NO_REPLY sentinel
+        conv.StreamState.Buffer = "NO_REPLY";
+        conv.StreamState.ThinkingBuffer = "";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        // Streaming state should be cleared
+        Assert.False(agent.IsStreaming);
+        Assert.False(conv.StreamState.IsStreaming);
+        Assert.Equal(string.Empty, conv.StreamState.Buffer);
+        // No message must be added — NO_REPLY is a silent sentinel
+        Assert.Empty(conv.Messages);
+    }
+
+    [Fact]
+    public void HandleMessageEnd_no_reply_sentinel_with_whitespace_does_not_add_message()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        // Gateway may emit the sentinel with surrounding whitespace
+        conv.StreamState.Buffer = "  NO_REPLY  ";
+        conv.StreamState.ThinkingBuffer = "";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.False(agent.IsStreaming);
+        Assert.Empty(conv.Messages);
+    }
+
+    [Fact]
+    public void HandleMessageEnd_non_sentinel_content_is_added_normally()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "Hello world";
+        conv.StreamState.ThinkingBuffer = "";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.Single(conv.Messages);
+        Assert.Equal("Hello world", conv.Messages[0].Content);
+    }
+
+    [Fact]
     public void HandleSessionReset_preserves_history_and_adds_session_boundary_divider()
     {
         var agent = _store.GetAgent("agent-1")!;


### PR DESCRIPTION
Closes #25

When an agent responds with `NO_REPLY`, the Blazor portal was rendering it as a literal chat message. 

## Fix

In `GatewayEventHandler.HandleMessageEnd`, skip adding a `ChatMessage` when the stream buffer content (trimmed) equals `"NO_REPLY"`. Streaming state clears normally regardless.

## Tests
- `HandleMessageEnd_no_reply_sentinel_does_not_add_message_to_conversation`
- `HandleMessageEnd_no_reply_sentinel_with_whitespace_does_not_add_message`
- `HandleMessageEnd_non_sentinel_content_is_added_normally`