### PR TITLE
fix(gateway): demote stale SignalR bindings on disconnect and fan-out failure

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -488,6 +488,35 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         await base.OnConnectedAsync();
     }
 
+    /// <summary>
+    /// Executes on disconnected async. Mutes all channel bindings for this SignalR connection
+    /// so fan-out stops delivering to dead connections on future requests.
+    /// </summary>
+    /// <param name="exception">The disconnect exception, if any.</param>
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        _logger.LogInformation("Hub OnDisconnected: connection={ConnectionId}", Context.ConnectionId);
+
+        // Best-effort: mute any Interactive/NotifyOnly bindings keyed to this connection ID.
+        // If the store lookup fails, fan-out self-healing via StaleChannelConnectionException
+        // will catch remaining deliveries on the next send attempt.
+        try
+        {
+            await _conversationRouter.MuteBindingByAddressAsync(
+                // Pass null to search all agents' conversations for bindings keyed to this connection.
+                agentId: null,
+                ChannelKey.From("signalr"),
+                Context.ConnectionId,
+                Context.ConnectionAborted);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Hub OnDisconnected: failed to mute bindings for connection {ConnectionId}", Context.ConnectionId);
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+
     private static string GetSessionGroup(SessionId sessionId) => $"session:{sessionId.Value}";
 
     private static AgentId ParseAgentId(string agentId)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/StaleSignalRConnectionException.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/StaleSignalRConnectionException.cs
@@ -1,0 +1,19 @@
+using BotNexus.Gateway.Abstractions.Channels;
+
+namespace BotNexus.Extensions.Channels.SignalR;
+
+/// <summary>
+/// Thrown by <see cref="SignalRChannelAdapter"/> when a send fails because the target
+/// SignalR connection no longer exists. Inherits <see cref="StaleChannelConnectionException"/>
+/// so GatewayHost's fan-out loop can catch the base type to demote the binding to Muted.
+/// </summary>
+public sealed class StaleSignalRConnectionException : StaleChannelConnectionException
+{
+    /// <summary>
+    /// Initialises a new instance describing a stale SignalR connection for a specific binding.
+    /// </summary>
+    public StaleSignalRConnectionException(string bindingId, string conversationId, Exception? inner = null)
+        : base(bindingId, conversationId, inner)
+    {
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/StaleChannelConnectionException.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/StaleChannelConnectionException.cs
@@ -1,0 +1,27 @@
+namespace BotNexus.Gateway.Abstractions.Channels;
+
+/// <summary>
+/// Thrown by a channel adapter's <c>SendAsync</c> when the target connection no longer
+/// exists (e.g. a SignalR client that has disconnected). GatewayHost's fan-out loop
+/// catches this to demote the binding to
+/// <see cref="BotNexus.Gateway.Abstractions.Models.BindingMode.Muted"/>, preventing
+/// silent delivery to dead connections on future fan-outs.
+/// </summary>
+public class StaleChannelConnectionException : Exception
+{
+    /// <summary>Gets the binding ID whose underlying connection is gone.</summary>
+    public string BindingId { get; }
+
+    /// <summary>Gets the conversation ID the binding belongs to.</summary>
+    public string ConversationId { get; }
+
+    /// <summary>
+    /// Initialises a new instance describing a stale connection for a specific binding.
+    /// </summary>
+    public StaleChannelConnectionException(string bindingId, string conversationId, Exception? inner = null)
+        : base($"Channel send failed — connection for binding {bindingId} in conversation {conversationId} is gone.", inner)
+    {
+        BindingId = bindingId;
+        ConversationId = conversationId;
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -43,6 +43,25 @@ public interface IConversationRouter
         SessionId sessionId,
         string? originatingBindingId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Demotes a channel binding to <see cref="BindingMode.Muted"/> so it no longer receives fan-out.
+    /// Used to self-heal stale bindings when a send attempt fails (e.g. SignalR connection gone).
+    /// </summary>
+    /// <param name="conversationId">The conversation that owns the binding.</param>
+    /// <param name="bindingId">The binding to silence.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task MuteBindingAsync(ConversationId conversationId, string bindingId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds and mutes the binding associated with the given channel type and address.
+    /// Used by SignalR OnDisconnectedAsync to silence stale bindings by connection ID.
+    /// </summary>
+    /// <param name="agentId">The agent whose conversations should be searched, or <c>null</c> to search all agents.</param>
+    /// <param name="channelType">The channel type (e.g. signalr).</param>
+    /// <param name="channelAddress">The channel address (e.g. SignalR connection ID).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -254,4 +254,53 @@ public sealed class DefaultConversationRouter : IConversationRouter
             .Where(b => originatingBindingId is null || !string.Equals(b.BindingId, originatingBindingId, StringComparison.Ordinal))
             .ToList();
     }
+
+    /// <inheritdoc />
+    public async Task MuteBindingAsync(ConversationId conversationId, string bindingId, CancellationToken ct = default)
+    {
+        var conversation = await _conversationStore.GetAsync(conversationId, ct);
+        if (conversation is null)
+        {
+            _logger.LogDebug("MuteBinding: conversation {ConversationId} not found", conversationId);
+            return;
+        }
+
+        var binding = conversation.ChannelBindings.FirstOrDefault(b =>
+            string.Equals(b.BindingId, bindingId, StringComparison.Ordinal));
+
+        if (binding is null)
+        {
+            _logger.LogDebug("MuteBinding: binding {BindingId} not found in conversation {ConversationId}", bindingId, conversationId);
+            return;
+        }
+
+        if (binding.Mode == BindingMode.Muted)
+            return;
+
+        binding.Mode = BindingMode.Muted;
+        await _conversationStore.SaveAsync(conversation, ct);
+        _logger.LogInformation("MuteBinding: binding {BindingId} ({ChannelType}:{ChannelAddress}) demoted to Muted in conversation {ConversationId}",
+            bindingId, binding.ChannelType, binding.ChannelAddress, conversationId);
+    }
+
+    /// <inheritdoc />
+    public async Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default)
+    {
+        var conversations = await _conversationStore.ListAsync(agentId, ct);
+        foreach (var conversation in conversations)
+        {
+            var binding = conversation.ChannelBindings.FirstOrDefault(b =>
+                b.ChannelType.Equals(channelType) &&
+                string.Equals(b.ChannelAddress, channelAddress, StringComparison.Ordinal) &&
+                b.Mode != BindingMode.Muted);
+
+            if (binding is null)
+                continue;
+
+            binding.Mode = BindingMode.Muted;
+            await _conversationStore.SaveAsync(conversation, ct);
+            _logger.LogInformation("MuteBindingByAddress: binding {BindingId} ({ChannelType}:{ChannelAddress}) demoted to Muted in conversation {ConversationId}",
+                binding.BindingId, channelType, channelAddress, conversation.ConversationId);
+        }
+    }
 }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -835,6 +835,17 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         "Fan-out delivered to {ChannelType}:{ChannelAddress} for session {SessionId}",
                         binding.ChannelType, binding.ChannelAddress, sessionId);
                 }
+                catch (BotNexus.Gateway.Abstractions.Channels.StaleChannelConnectionException ex)
+                {
+                    // Self-heal: demote stale bindings to Muted so future fan-outs skip them.
+                    _logger.LogWarning(
+                        ex,
+                        "Fan-out: stale connection for binding {BindingId} in conversation {ConversationId}. Demoting to Muted.",
+                        ex.BindingId, ex.ConversationId);
+
+                    if (session?.Session.ConversationId is { } convId)
+                        await _conversationRouter.MuteBindingAsync(convId, ex.BindingId, cancellationToken);
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(

--- a/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
@@ -129,4 +129,10 @@ internal sealed class CapturingConversationRouter : IConversationRouter
     public Task<IReadOnlyList<ChannelBinding>> GetOutboundBindingsAsync(
         SessionId sessionId, string originatingChannelAddress, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<ChannelBinding>>([]);
+
+    public Task MuteBindingAsync(ConversationId conversationId, string bindingId, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default)
+        => Task.CompletedTask;
 }

--- a/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -1,0 +1,210 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Extensions.Channels.SignalR;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Routing;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for GatewayHost.FanOutResponseAsync stale-binding self-healing (Issue #130).
+/// When a fan-out send throws <see cref="StaleSignalRConnectionException"/>,
+/// the binding should be demoted to Muted so future fan-outs skip it.
+/// </summary>
+public sealed class FanOutStaleBindingTests
+{
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static Mock<IAgentHandle> CreatePromptHandle(string agentId, string sessionId, string content)
+    {
+        var h = new Mock<IAgentHandle>();
+        h.SetupGet(x => x.AgentId).Returns(agentId);
+        h.SetupGet(x => x.SessionId).Returns(sessionId);
+        h.Setup(x => x.IsRunning).Returns(false);
+        h.Setup(x => x.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = content });
+        return h;
+    }
+
+    private static InboundMessage CreateMessage(string content, string sessionId = "session-1", string channelType = "web", string conversationId = "conv-1")
+        => new()
+        {
+            ChannelType = channelType,
+            SenderId = "sender-1",
+            ChannelAddress = conversationId,
+            Content = content,
+            SessionId = sessionId,
+            Metadata = new Dictionary<string, object?>()
+        };
+
+    private static GatewayHost CreateHost(
+        IAgentSupervisor supervisor,
+        IMessageRouter router,
+        ISessionStore sessions,
+        IChannelManager channelManager,
+        IConversationRouter conversationRouter)
+        => new(
+            supervisor,
+            router,
+            sessions,
+            Mock.Of<IActivityBroadcaster>(),
+            channelManager,
+            Mock.Of<ISessionCompactor>(),
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            NullLogger<GatewayHost>.Instance,
+            conversationRouter: conversationRouter);
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FanOut_WhenSignalRSendFails_DemotesBindingToMuted()
+    {
+        // Arrange
+        const string agentId = "agent-a";
+        const string sessionId = "session-1";
+        const string convId = "conv-fanout-stale";
+        const string bindingId = "binding-signalr-1";
+
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([agentId]);
+
+        var handle = CreatePromptHandle(agentId, sessionId, "hello fan-out");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(AgentId.From(agentId), SessionId.From(sessionId), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        var session = await sessions.GetOrCreateAsync(sessionId, agentId);
+        session.Session.ConversationId = ConversationId.From(convId);
+        await sessions.SaveAsync(session);
+
+        // Primary (originating) adapter
+        var primaryAdapter = new Mock<IChannelAdapter>();
+        primaryAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("web"));
+        primaryAdapter.Setup(a => a.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // SignalR (fan-out) adapter — throws StaleSignalRConnectionException
+        var signalrAdapter = new Mock<IChannelAdapter>();
+        signalrAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("signalr"));
+        signalrAdapter
+            .Setup(a => a.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new StaleSignalRConnectionException(bindingId, convId));
+
+        var channelManager = new Mock<IChannelManager>();
+        channelManager.SetupGet(m => m.Adapters).Returns([primaryAdapter.Object, signalrAdapter.Object]);
+        channelManager.Setup(m => m.Get(ChannelKey.From("web"))).Returns(primaryAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("signalr"))).Returns(signalrAdapter.Object);
+
+        // Conversation with a stale signalr binding
+        var staleBinding = new ChannelBinding
+        {
+            BindingId = bindingId,
+            ChannelType = ChannelKey.From("signalr"),
+            ChannelAddress = "conn-dead-1",
+            Mode = BindingMode.Interactive
+        };
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From(convId),
+            AgentId = AgentId.From(agentId),
+            ChannelBindings = [staleBinding]
+        };
+
+        var convRouter = new Mock<IConversationRouter>();
+        convRouter
+            .Setup(r => r.ResolveInboundAsync(
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
+
+        // Return the stale binding for fan-out
+        convRouter
+            .Setup(r => r.GetOutboundBindingsAsync(SessionId.From(sessionId), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([staleBinding]);
+
+        convRouter
+            .Setup(r => r.MuteBindingByAddressAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId?>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await using var host = CreateHost(supervisor.Object, router.Object, sessions, channelManager.Object, convRouter.Object);
+
+        // Act
+        await host.DispatchAsync(CreateMessage("hello", sessionId: sessionId));
+
+        // Assert — binding should have been muted
+        convRouter.Verify(r => r.MuteBindingAsync(ConversationId.From(convId), bindingId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FanOut_AfterBindingMuted_SkipsBinding()
+    {
+        // Arrange: GetOutboundBindingsAsync returns empty list (as it would after muting)
+        const string agentId = "agent-a";
+        const string sessionId = "session-2";
+        const string convId = "conv-fanout-muted";
+
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([agentId]);
+
+        var handle = CreatePromptHandle(agentId, sessionId, "reply");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(AgentId.From(agentId), SessionId.From(sessionId), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        var session = await sessions.GetOrCreateAsync(sessionId, agentId);
+        session.Session.ConversationId = ConversationId.From(convId);
+        await sessions.SaveAsync(session);
+
+        var primaryAdapter = new Mock<IChannelAdapter>();
+        primaryAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("web"));
+        primaryAdapter.Setup(a => a.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var signalrAdapter = new Mock<IChannelAdapter>();
+        signalrAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("signalr"));
+
+        var channelManager = new Mock<IChannelManager>();
+        channelManager.SetupGet(m => m.Adapters).Returns([primaryAdapter.Object, signalrAdapter.Object]);
+        channelManager.Setup(m => m.Get(ChannelKey.From("web"))).Returns(primaryAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("signalr"))).Returns(signalrAdapter.Object);
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From(convId),
+            AgentId = AgentId.From(agentId),
+        };
+
+        var convRouter = new Mock<IConversationRouter>();
+        convRouter
+            .Setup(r => r.ResolveInboundAsync(
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
+
+        // Empty list = already muted / no fan-out targets
+        convRouter
+            .Setup(r => r.GetOutboundBindingsAsync(SessionId.From(sessionId), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await using var host = CreateHost(supervisor.Object, router.Object, sessions, channelManager.Object, convRouter.Object);
+
+        // Act
+        await host.DispatchAsync(CreateMessage("ping", sessionId: sessionId));
+
+        // Assert — signalr adapter's SendAsync was never called
+        signalrAdapter.Verify(a => a.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()), Times.Never,
+            "Muted/absent bindings must not receive fan-out");
+    }
+}


### PR DESCRIPTION
Closes #130

Two complementary mechanisms to prevent fan-out delivering to dead SignalR connections.

## Fix

**1. Eager cleanup on disconnect**
`GatewayHub.OnDisconnectedAsync` immediately mutes any `Interactive`/`NotifyOnly` binding for the disconnected connection ID.

**2. Self-healing fan-out**
`GatewayHost.FanOutResponseAsync` catches `StaleChannelConnectionException` and demotes the binding to `Muted`. Catches anything the disconnect handler missed (e.g. connections that dropped without a clean disconnect event).

## New types
- `StaleChannelConnectionException` — channel-agnostic base exception
- `StaleSignalRConnectionException` — derives from base, thrown by SignalR adapter when connection is gone
- `IConversationRouter.MuteBindingAsync` / `MuteBindingByAddressAsync`

## Tests
- `FanOut_WhenSignalRSendFails_DemotesBindingToMuted`
- `FanOut_AfterBindingMuted_SkipsBinding`