### PR TITLE
fix(signalr): use empty ChannelAddress so portal routes to default conversation

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -243,7 +243,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
-                    ChannelAddress = session.SessionId.Value,
+                    ChannelAddress = string.Empty, // SignalR has no stable external address — routes to default conversation
                     SessionId = session.SessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
@@ -266,7 +266,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
-                ChannelAddress = typedSessionId.Value,
+                ChannelAddress = string.Empty, // SignalR has no stable external address — routes to default conversation
                 SessionId = typedSessionId.Value,
                 TargetAgentId = typedAgentId.Value,
                 Content = content,
@@ -346,7 +346,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
-                    ChannelAddress = typedSessionId.Value,
+                    ChannelAddress = string.Empty, // SignalR has no stable external address — routes to default conversation
                     SessionId = typedSessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,


### PR DESCRIPTION
Regression introduced by #139 (per-address conversation routing).

## Problem

`GatewayHub` was setting `ChannelAddress = sessionId.Value` on every inbound message. After #139, any non-empty channel address creates its own conversation, so each portal session got a new conversation (and each reconnect created another one — visible as `signalr:0e0c9119fae14a808a...` in the sidebar).

## Fix

Set `ChannelAddress = string.Empty` in all three `GatewayHub` dispatch paths. Empty address falls through to the default conversation per the #139 routing logic.

SignalR is an addressless channel — the stable identity is the agent + session, not the connection ID. The connection ID is already tracked separately for response routing via `SessionId`.

## Note

5 `MultiAgentConcurrencyTests` failures are pre-existing on `main` and not caused by this change.