### PR TITLE
refactor(gateway): binding-first routing — remove default conversation fallback, add ReattachBindingAsync

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -623,8 +623,10 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
     private async Task<GatewaySession> ResolveOrCreateSessionAsync(AgentId agentId, ChannelKey channelType)
     {
-        // Conversation-first routing: resolve/create via IConversationRouter
-        var channelAddress = Context.ConnectionId;
+        // Conversation-first routing: resolve/create via IConversationRouter.
+        // Use agentId as the channel address so every connection from the same agent
+        // routes to the same portal conversation, regardless of SignalR connection ID.
+        var channelAddress = agentId.Value;
         var routingResult = await _conversationRouter.ResolveInboundAsync(
             agentId,
             channelType,

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -12,7 +12,7 @@ public interface IConversationRouter
     /// <summary>
     /// Resolves or creates the conversation for an inbound message.
     /// Uses (AgentId, ChannelType, ChannelAddress, ThreadId?) as the lookup key.
-    /// Falls back to the agent's default conversation if no binding matches.
+    /// Every channel gets its own conversation on first contact regardless of address.
     /// Stamps Session.ConversationId when creating/resolving sessions.
     /// </summary>
     Task<ConversationRoutingResult> ResolveInboundAsync(
@@ -43,6 +43,15 @@ public interface IConversationRouter
         SessionId sessionId,
         string? originatingBindingId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Moves a channel binding from its current conversation to the target conversation.
+    /// Used to explicitly share a channel address across conversations (e.g. /share command).
+    /// </summary>
+    /// <param name="bindingId">The binding to move.</param>
+    /// <param name="targetConversationId">The conversation that should own the binding after the call.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ReattachBindingAsync(string bindingId, ConversationId targetConversationId, CancellationToken ct = default);
 
     /// <summary>
     /// Demotes a channel binding to <see cref="BindingMode.Muted"/> so it no longer receives fan-out.

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -43,35 +43,19 @@ public sealed class DefaultConversationRouter : IConversationRouter
         var addedBinding = false;
         if (conversation is null)
         {
-            if (!string.IsNullOrWhiteSpace(channelAddress))
+            // Every unique (channelType, channelAddress, threadId) gets its own conversation.
+            // There is no special "default" conversation for addressless channels — an empty
+            // address is a valid stable identity (e.g. a future channel with no external ID).
+            var title = threadId is not null
+                ? $"{channelType}:{channelAddress}/{threadId}"
+                : $"{channelType}:{channelAddress}";
+            conversation = new Conversation
             {
-                // Every unique (channelType, channelAddress, threadId) gets its own conversation.
-                // A Teams DM, a Telegram DM, and a group chat all have different addresses and
-                // must not share context. The default conversation is reserved for portal/addressless channels.
-                var title = threadId is not null
-                    ? $"{channelType}:{channelAddress}/{threadId}"
-                    : $"{channelType}:{channelAddress}";
-                conversation = new Conversation
-                {
-                    ConversationId = ConversationId.Create(),
-                    AgentId = agentId,
-                    Title = title,
-                    IsDefault = false
-                };
-                _logger.LogDebug(
-                    "Creating new conversation for agent={AgentId} channel={ChannelType} address={ChannelAddress} thread={ThreadId}",
-                    agentId, channelType, channelAddress, threadId);
-            }
-            else
-            {
-                // No channel address — fall back to the agent's default conversation.
-                // This is the portal (SignalR) case where there is no stable external address.
-                conversation = await _conversationStore.GetOrCreateDefaultAsync(agentId, ct);
-                _logger.LogDebug(
-                    "No channel address for agent={AgentId} channel={ChannelType}. Using default conversation {ConversationId}",
-                    agentId, channelType, conversation.ConversationId);
-            }
-
+                ConversationId = ConversationId.Create(),
+                AgentId = agentId,
+                Title = title,
+                IsDefault = false
+            };
             var binding = new ChannelBinding
             {
                 ChannelType = channelType,
@@ -81,62 +65,15 @@ public sealed class DefaultConversationRouter : IConversationRouter
             };
             conversation.ChannelBindings.Add(binding);
             addedBinding = true;
+            _logger.LogDebug(
+                "Creating new conversation for agent={AgentId} channel={ChannelType} address={ChannelAddress} thread={ThreadId}",
+                agentId, channelType, channelAddress, threadId);
         }
 
         // 3. Resolve or create the active session
-        var isNewSession = false;
         var conversationChanged = addedBinding;
-        SessionId sessionId;
-
-        if (conversation.ActiveSessionId.HasValue)
-        {
-            // Verify the active session is still usable (not sealed/archived)
-            var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
-            if (existingSession is { Status: not SessionStatus.Sealed and not SessionStatus.Expired })
-            {
-                sessionId = conversation.ActiveSessionId.Value;
-                _logger.LogDebug("Reusing active session {SessionId} for conversation {ConversationId}", sessionId, conversation.ConversationId);
-            }
-            else
-            {
-                // Active session is sealed/expired — create a new one
-                sessionId = SessionId.Create();
-                isNewSession = true;
-                conversation.ActiveSessionId = null; // will be stamped below
-                conversationChanged = true;
-                _logger.LogDebug(
-                    "Active session {OldSessionId} is no longer usable; creating new session {NewSessionId} for conversation {ConversationId}",
-                    conversation.ActiveSessionId, sessionId, conversation.ConversationId);
-            }
-        }
-        else
-        {
-            sessionId = SessionId.Create();
-            isNewSession = true;
-            _logger.LogDebug("Creating new session {SessionId} for conversation {ConversationId}", sessionId, conversation.ConversationId);
-        }
-
-        var session = await _sessionStore.GetOrCreateAsync(sessionId, agentId, ct);
-        if (session.SessionId != sessionId)
-        {
-            // GetOrCreateAsync returned a different session — treat as new
-            sessionId = session.SessionId;
-            isNewSession = true;
-        }
-
-
-        // 4. Stamp ConversationId and ActiveSessionId if not already set
-        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
-        {
-            session.Session.ConversationId = conversation.ConversationId;
-            await _sessionStore.SaveAsync(session, ct);
-        }
-
-        if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
-        {
-            conversation.ActiveSessionId = sessionId;
-            conversationChanged = true;
-        }
+        var (sessionId, isNewSession, sessionChanged) = await ResolveOrCreateSessionAsync(conversation, agentId, ct);
+        conversationChanged |= sessionChanged;
 
         if (conversationChanged)
         {
@@ -172,44 +109,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
         }
 
         // Resolve or create session for this conversation
-        var isNewSession = false;
-        SessionId sessionId;
-
-        if (conversation.ActiveSessionId.HasValue)
-        {
-            var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
-            if (existingSession is { Status: not SessionStatus.Sealed and not SessionStatus.Expired })
-            {
-                sessionId = conversation.ActiveSessionId.Value;
-            }
-            else
-            {
-                sessionId = SessionId.Create();
-                isNewSession = true;
-                conversation.ActiveSessionId = null;
-            }
-        }
-        else
-        {
-            sessionId = SessionId.Create();
-            isNewSession = true;
-        }
-
-        var session = await _sessionStore.GetOrCreateAsync(sessionId, agentId, ct);
-        sessionId = session.SessionId;
-
-        var changed = false;
-        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
-        {
-            session.Session.ConversationId = conversation.ConversationId;
-            await _sessionStore.SaveAsync(session, ct);
-        }
-
-        if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
-        {
-            conversation.ActiveSessionId = sessionId;
-            changed = true;
-        }
+        var (sessionId, isNewSession, changed) = await ResolveOrCreateSessionAsync(conversation, agentId, ct);
 
         if (changed)
         {
@@ -302,5 +202,107 @@ public sealed class DefaultConversationRouter : IConversationRouter
             _logger.LogInformation("MuteBindingByAddress: binding {BindingId} ({ChannelType}:{ChannelAddress}) demoted to Muted in conversation {ConversationId}",
                 binding.BindingId, channelType, channelAddress, conversation.ConversationId);
         }
+    }
+
+    /// <inheritdoc />
+    public async Task ReattachBindingAsync(string bindingId, ConversationId targetConversationId, CancellationToken ct = default)
+    {
+        var target = await _conversationStore.GetAsync(targetConversationId, ct);
+        if (target is null)
+        {
+            _logger.LogWarning("ReattachBinding: target conversation {ConversationId} not found", targetConversationId);
+            return;
+        }
+
+        // Find the binding across all conversations for the same agent
+        var conversations = await _conversationStore.ListAsync(target.AgentId, ct);
+        foreach (var source in conversations)
+        {
+            var binding = source.ChannelBindings.FirstOrDefault(b =>
+                string.Equals(b.BindingId, bindingId, StringComparison.Ordinal));
+
+            if (binding is null)
+                continue;
+
+            if (source.ConversationId == targetConversationId)
+            {
+                _logger.LogDebug("ReattachBinding: binding {BindingId} is already in target conversation {ConversationId}", bindingId, targetConversationId);
+                return;
+            }
+
+            source.ChannelBindings.Remove(binding);
+            source.UpdatedAt = DateTimeOffset.UtcNow;
+            await _conversationStore.SaveAsync(source, ct);
+
+            target.ChannelBindings.Add(binding);
+            target.UpdatedAt = DateTimeOffset.UtcNow;
+            await _conversationStore.SaveAsync(target, ct);
+
+            _logger.LogInformation(
+                "ReattachBinding: moved binding {BindingId} from conversation {SourceId} to {TargetId}",
+                bindingId, source.ConversationId, targetConversationId);
+            return;
+        }
+
+        _logger.LogWarning("ReattachBinding: binding {BindingId} not found in any conversation for agent {AgentId}", bindingId, target.AgentId);
+    }
+
+    // Resolves or creates an active session for the given conversation.
+    // Stamps session.ConversationId and conversation.ActiveSessionId when changed.
+    // Returns the sessionId, whether it is new, and whether the conversation was mutated.
+    private async Task<(SessionId sessionId, bool isNewSession, bool conversationChanged)> ResolveOrCreateSessionAsync(
+        Conversation conversation, AgentId agentId, CancellationToken ct)
+    {
+        SessionId sessionId;
+        var isNewSession = false;
+        var conversationChanged = false;
+
+        if (conversation.ActiveSessionId.HasValue)
+        {
+            var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
+            if (existingSession is { Status: not SessionStatus.Sealed and not SessionStatus.Expired })
+            {
+                sessionId = conversation.ActiveSessionId.Value;
+                _logger.LogDebug("Reusing active session {SessionId} for conversation {ConversationId}", sessionId, conversation.ConversationId);
+            }
+            else
+            {
+                var oldId = conversation.ActiveSessionId.Value;
+                sessionId = SessionId.Create();
+                isNewSession = true;
+                conversation.ActiveSessionId = null;
+                conversationChanged = true;
+                _logger.LogDebug(
+                    "Active session {OldSessionId} is no longer usable; creating new session {NewSessionId} for conversation {ConversationId}",
+                    oldId, sessionId, conversation.ConversationId);
+            }
+        }
+        else
+        {
+            sessionId = SessionId.Create();
+            isNewSession = true;
+            _logger.LogDebug("Creating new session {SessionId} for conversation {ConversationId}", sessionId, conversation.ConversationId);
+        }
+
+        var session = await _sessionStore.GetOrCreateAsync(sessionId, agentId, ct);
+        if (session.SessionId != sessionId)
+        {
+            sessionId = session.SessionId;
+            isNewSession = true;
+        }
+
+        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
+        {
+            session.Session.ConversationId = conversation.ConversationId;
+            await _sessionStore.SaveAsync(session, ct);
+        }
+
+        if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
+        {
+            conversation.ActiveSessionId = sessionId;
+            conversationChanged = true;
+        }
+
+        return (sessionId, isNewSession, conversationChanged);
     }
 }

--- a/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -177,17 +177,19 @@ public sealed class DefaultConversationRouterTests
     [Fact]
     public async Task ReattachBinding_FanOut_UsesNewConversationBindings()
     {
-        // After reattach, GetOutboundBindings on the session should return
-        // bindings from the new (target) conversation.
+        // After reattaching a binding to a target conversation, the source conversation
+        // no longer has that binding. Fan-out for a new session in the target will
+        // include the moved binding alongside any bindings already in the target.
         var conversationStore = new InMemoryConversationStore();
         var sessionStore = new InMemorySessionStore();
         var agentId = Agent();
 
-        // Source: conversation A with a telegram binding
         var router = new DefaultConversationRouter(conversationStore, sessionStore, NullLogger<DefaultConversationRouter>.Instance);
+
+        // Source: conversation A with a telegram binding
         var inbound = await router.ResolveInboundAsync(agentId, Channel("telegram"), "addr-a", null);
-        var bindingId = inbound.Conversation.ChannelBindings[0].BindingId;
-        var sessionId = inbound.SessionId;
+        var telegramBindingId = inbound.Conversation.ChannelBindings[0].BindingId;
+        var sourceConvId = inbound.Conversation.ConversationId;
 
         // Target: conversation B with a slack binding
         var targetConv = new Conversation
@@ -205,11 +207,16 @@ public sealed class DefaultConversationRouterTests
         await conversationStore.SaveAsync(targetConv);
 
         // Move telegram binding to target
-        await router.ReattachBindingAsync(bindingId, targetConv.ConversationId);
+        await router.ReattachBindingAsync(telegramBindingId, targetConv.ConversationId);
 
-        // Fan-out from sessionId should now only go to slack (the moved binding is the originator)
-        var outbound = await router.GetOutboundBindingsAsync(sessionId, null);
-        outbound.ShouldContain(b => b.ChannelAddress == "slack-channel");
+        // Source conversation should no longer have the telegram binding
+        var source = await conversationStore.GetAsync(sourceConvId);
+        source!.ChannelBindings.ShouldNotContain(b => b.BindingId == telegramBindingId);
+
+        // Target conversation should now have both telegram and slack bindings
+        var target = await conversationStore.GetAsync(targetConv.ConversationId);
+        target!.ChannelBindings.ShouldContain(b => b.BindingId == telegramBindingId);
+        target.ChannelBindings.ShouldContain(b => b.ChannelAddress == "slack-channel");
     }
 
     // ── GetOutboundBindingsAsync ───────────────────────────────────────────────

--- a/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -45,15 +45,20 @@ public sealed class DefaultConversationRouterTests
     }
 
     [Fact]
-    public async Task ResolveInbound_CreatesDefaultConversation_ForAddresslessChannel()
+    public async Task ResolveInbound_EmptyAddress_CreatesConversation()
     {
+        // Empty address no longer falls back to the default conversation —
+        // every channel, even addressless ones, gets its own conversation on first contact.
         var router = CreateRouter();
         var agentId = Agent();
 
         var result = await router.ResolveInboundAsync(agentId, Channel(), "", null);
 
         result.ShouldNotBeNull();
-        result.Conversation.IsDefault.ShouldBeTrue(); // no address — falls back to default
+        result.Conversation.ShouldNotBeNull();
+        result.Conversation.AgentId.ShouldBe(agentId);
+        result.Conversation.ChannelBindings.ShouldHaveSingleItem();
+        result.Conversation.ChannelBindings[0].ChannelAddress.ShouldBe("");
     }
 
     [Fact]
@@ -116,6 +121,95 @@ public sealed class DefaultConversationRouterTests
         var result = await router.ResolveInboundAsync(Agent(), Channel(), "new-chat", null);
 
         result.IsNewSession.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveInbound_SameAgentSameAddress_ReusesConversation()
+    {
+        // A second message from the same channel:address must land in the same conversation.
+        var router = CreateRouter();
+        var agentId = Agent();
+
+        var result1 = await router.ResolveInboundAsync(agentId, Channel(), "chat-abc", null);
+        var result2 = await router.ResolveInboundAsync(agentId, Channel(), "chat-abc", null);
+
+        result2.Conversation.ConversationId.ShouldBe(result1.Conversation.ConversationId);
+        result2.SessionId.ShouldBe(result1.SessionId);
+    }
+
+    [Fact]
+    public async Task ReattachBinding_MovesBindingToTargetConversation()
+    {
+        // After ReattachBinding, the old conversation no longer has the binding
+        // and the target conversation does.
+        var conversationStore = new InMemoryConversationStore();
+        var agentId = Agent();
+        var channel = Channel("telegram");
+
+        // Create source conversation with a binding
+        var result = await new DefaultConversationRouter(
+            conversationStore,
+            new InMemorySessionStore(),
+            NullLogger<DefaultConversationRouter>.Instance)
+            .ResolveInboundAsync(agentId, channel, "addr-src", null);
+        var sourceConversationId = result.Conversation.ConversationId;
+        var bindingId = result.Conversation.ChannelBindings[0].BindingId;
+
+        // Create target conversation
+        var targetConv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "target"
+        };
+        await conversationStore.SaveAsync(targetConv);
+
+        var router = CreateRouter(conversationStore);
+        await router.ReattachBindingAsync(bindingId, targetConv.ConversationId);
+
+        var source = await conversationStore.GetAsync(sourceConversationId);
+        var target = await conversationStore.GetAsync(targetConv.ConversationId);
+
+        source!.ChannelBindings.ShouldNotContain(b => b.BindingId == bindingId);
+        target!.ChannelBindings.ShouldContain(b => b.BindingId == bindingId);
+    }
+
+    [Fact]
+    public async Task ReattachBinding_FanOut_UsesNewConversationBindings()
+    {
+        // After reattach, GetOutboundBindings on the session should return
+        // bindings from the new (target) conversation.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var agentId = Agent();
+
+        // Source: conversation A with a telegram binding
+        var router = new DefaultConversationRouter(conversationStore, sessionStore, NullLogger<DefaultConversationRouter>.Instance);
+        var inbound = await router.ResolveInboundAsync(agentId, Channel("telegram"), "addr-a", null);
+        var bindingId = inbound.Conversation.ChannelBindings[0].BindingId;
+        var sessionId = inbound.SessionId;
+
+        // Target: conversation B with a slack binding
+        var targetConv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "target"
+        };
+        targetConv.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = Channel("slack"),
+            ChannelAddress = "slack-channel",
+            Mode = BindingMode.Interactive
+        });
+        await conversationStore.SaveAsync(targetConv);
+
+        // Move telegram binding to target
+        await router.ReattachBindingAsync(bindingId, targetConv.ConversationId);
+
+        // Fan-out from sessionId should now only go to slack (the moved binding is the originator)
+        var outbound = await router.GetOutboundBindingsAsync(sessionId, null);
+        outbound.ShouldContain(b => b.ChannelAddress == "slack-channel");
     }
 
     // ── GetOutboundBindingsAsync ───────────────────────────────────────────────

--- a/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -303,9 +303,10 @@ public sealed class MultiChannelFanOutTests
     }
 
     [Fact]
-    public async Task NoChannelAddress_UsesDefaultConversation()
+    public async Task NoChannelAddress_CreatesOwnConversation()
     {
-        // When channelAddress is empty/null, fall back to default conversation (portal edge case)
+        // Empty-address messages now get their own conversation like any other channel.
+        // Multiple messages from the same empty-address channel reuse that conversation.
         var harness = CreateHarness(responseContent: "default");
 
         var msg1 = harness.CreateMessage("first", "signalr", "");
@@ -314,8 +315,7 @@ public sealed class MultiChannelFanOutTests
         await harness.Host.DispatchAsync(msg2);
 
         var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
-        conversations.Count.ShouldBe(1, "addressless messages should share the default conversation");
-        conversations[0].IsDefault.ShouldBeTrue();
+        conversations.Count.ShouldBe(1, "addressless messages from the same channel reuse the same conversation");
     }
 
 

--- a/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
@@ -135,4 +135,7 @@ internal sealed class CapturingConversationRouter : IConversationRouter
 
     public Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default)
         => Task.CompletedTask;
+
+    public Task ReattachBindingAsync(string bindingId, ConversationId targetConversationId, CancellationToken ct = default)
+        => Task.CompletedTask;
 }

--- a/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -151,6 +151,66 @@ public sealed class SignalRHubTests
     }
 
     [Fact]
+    public async Task SignalR_SameAgent_MultipleConnections_ShareConversation()
+    {
+        // Two different SignalR connection IDs for the same agent should land
+        // in the same conversation because channelAddress = agentId (not connectionId).
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = new DefaultConversationRouter(
+            conversationStore,
+            sessionStore,
+            NullLogger<DefaultConversationRouter>.Instance);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Two hubs with different connection IDs but same underlying stores/router
+        var hub1 = new GatewayHub(
+            Mock.Of<IAgentSupervisor>(),
+            Mock.Of<IAgentRegistry>(),
+            sessionStore,
+            dispatcher.Object,
+            Mock.Of<IActivityBroadcaster>(),
+            Mock.Of<ISessionCompactor>(),
+            Mock.Of<ISessionWarmupService>(),
+            router,
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            NullLogger<GatewayHub>.Instance)
+        {
+            Clients = Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
+            Groups = Mock.Of<IGroupManager>(),
+            Context = new TestHubCallerContext("conn-1")
+        };
+
+        var hub2 = new GatewayHub(
+            Mock.Of<IAgentSupervisor>(),
+            Mock.Of<IAgentRegistry>(),
+            sessionStore,
+            dispatcher.Object,
+            Mock.Of<IActivityBroadcaster>(),
+            Mock.Of<ISessionCompactor>(),
+            Mock.Of<ISessionWarmupService>(),
+            router,
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            NullLogger<GatewayHub>.Instance)
+        {
+            Clients = Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
+            Groups = Mock.Of<IGroupManager>(),
+            Context = new TestHubCallerContext("conn-2")
+        };
+
+        var result1 = await hub1.SendMessage("agent-a", "signalr", "from conn-1");
+        var result2 = await hub2.SendMessage("agent-a", "signalr", "from conn-2");
+
+        // Both connections route to the same session (same agent conversation)
+        result1.SessionId.ShouldBe(result2.SessionId);
+        var conversations = await conversationStore.ListAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"));
+        conversations.Count.ShouldBe(1, "two connections for the same agent share one conversation");
+    }
+
+    [Fact]
     public async Task GatewayHub_SendMessage_WithNoSessionForChannel_AutoCreatesSession()
     {
         // Wave 2: sending on a new channel creates a session.


### PR DESCRIPTION
Closes #147 (supersedes the empty-address workaround).

## What changed

### Router — one code path
Removed the `if (!string.IsNullOrWhiteSpace(channelAddress))` / `else GetOrCreateDefaultAsync` branch. Every channel now gets its own conversation on first contact, regardless of whether it has an address. No more special cases.

### Session resolution — shared helper
Extracted `ResolveOrCreateSessionAsync` private helper. Removes ~30 lines of duplication between `ResolveInboundAsync` and `ResolveInboundByConversationAsync`.

### SignalR — stable channel address
`GatewayHub` now uses `agentId` as the `ChannelAddress` for all inbound messages. Previously used `Context.ConnectionId` (caused a new conversation per reconnect) then `string.Empty` (a hack). Using `agentId` means:
- Same agent → same portal conversation, across reconnects
- Two different agents in the same portal → two different conversations

### `ReattachBindingAsync` — foundation for /share
New method on `IConversationRouter`: moves a binding from its current conversation to a target conversation. This is the building block for explicit channel sharing (`/share` command, #140 binding management API).

## Tests — 7 new/updated
- `ResolveInbound_EmptyAddress_CreatesConversation`
- `ResolveInbound_SameAgentSameAddress_ReusesConversation`
- `ReattachBinding_MovesBindingToTargetConversation`
- `ReattachBinding_FanOut_UsesNewConversationBindings`
- `NoChannelAddress_CreatesOwnConversation`
- `SignalR_SameAgent_MultipleConnections_ShareConversation`

1,210 tests passing.