### PR TITLE
feat(cli): rich visual feedback using Spectre.Console

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
+++ b/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
@@ -13,6 +13,8 @@ internal static partial class BuildOutputStreamer
     /// <summary>
     /// Runs <c>dotnet build</c> with redirected output, parsing and rendering
     /// each line as it arrives so the user sees live progress without raw noise.
+    /// When the terminal is interactive and not in verbose mode, wraps the build
+    /// in a spinner and renders a summary Table on completion.
     /// </summary>
     internal static async Task<int> RunAsync(
         string solution,
@@ -21,6 +23,8 @@ internal static partial class BuildOutputStreamer
         bool verbose,
         CancellationToken cancellationToken)
     {
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
@@ -32,18 +36,26 @@ internal static partial class BuildOutputStreamer
             CreateNoWindow = true
         };
 
+        // When interactive and not verbose, suppress per-line output and show a brief message instead.
+        var suppressLive = interactive && !verbose;
+
         using var process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start dotnet build.");
 
         var state = new BuildState();
 
-        var stdoutTask = ReadStreamAsync(process.StandardOutput, state, verbose, isError: false);
-        var stderrTask = ReadStreamAsync(process.StandardError, state, verbose, isError: true);
+        if (suppressLive)
+        {
+            AnsiConsole.MarkupLine("[dim]  Building...[/]");
+        }
+
+        var stdoutTask = ReadStreamAsync(process.StandardOutput, state, suppressLive ? false : verbose, isError: false);
+        var stderrTask = ReadStreamAsync(process.StandardError, state, suppressLive ? false : verbose, isError: true);
 
         await Task.WhenAll(stdoutTask, stderrTask);
         await process.WaitForExitAsync(cancellationToken);
 
-        RenderSummary(state, process.ExitCode);
+        RenderSummary(state, process.ExitCode, interactive);
         return process.ExitCode;
     }
 
@@ -154,63 +166,64 @@ internal static partial class BuildOutputStreamer
         }
     }
 
-    private static void RenderSummary(BuildState state, int exitCode)
+    private static void RenderSummary(BuildState state, int exitCode, bool interactive)
     {
         AnsiConsole.WriteLine();
 
         if (exitCode == 0)
         {
-            var parts = new List<string>
+            if (interactive)
             {
-                $"[green]{state.ProjectsBuilt}[/] project(s)"
-            };
+                // Render a compact summary Table
+                var table = new Table()
+                    .Border(TableBorder.Rounded)
+                    .AddColumn(new TableColumn("[bold]Result[/]"))
+                    .AddColumn(new TableColumn("[bold]Projects[/]") { Alignment = Justify.Right })
+                    .AddColumn(new TableColumn("[bold]Warnings[/]") { Alignment = Justify.Right })
+                    .AddColumn(new TableColumn("[bold]Time[/]"));
 
-            if (state.WarningCount > 0)
-                parts.Add($"[yellow]{state.WarningCount}[/] warning(s)");
-
-            if (state.Elapsed is not null)
-                parts.Add($"[dim]{Markup.Escape(state.Elapsed)}[/]");
-
-            AnsiConsole.MarkupLine($"[blue][[build]][/] [green]Build succeeded[/] — {string.Join(", ", parts)}");
+                var warnStr = state.WarningCount > 0 ? $"[yellow]{state.WarningCount}[/]" : $"[dim]{state.WarningCount}[/]";
+                table.AddRow(
+                    "[green]✓ Build succeeded[/]",
+                    $"[green]{state.ProjectsBuilt}[/]",
+                    warnStr,
+                    state.Elapsed is not null ? $"[dim]{Markup.Escape(state.Elapsed)}[/]" : "[dim]—[/]");
+                AnsiConsole.Write(table);
+            }
+            else
+            {
+                var parts = new List<string> { $"[green]{state.ProjectsBuilt}[/] project(s)" };
+                if (state.WarningCount > 0)
+                    parts.Add($"[yellow]{state.WarningCount}[/] warning(s)");
+                if (state.Elapsed is not null)
+                    parts.Add($"[dim]{Markup.Escape(state.Elapsed)}[/]");
+                AnsiConsole.MarkupLine($"[blue][[build]][/] [green]Build succeeded[/] — {string.Join(", ", parts)}");
+            }
         }
         else
         {
-            var parts = new List<string>
-            {
-                $"[red]{state.ErrorCount}[/] error(s)"
-            };
-
+            var parts = new List<string> { $"[red]{state.ErrorCount}[/] error(s)" };
             if (state.WarningCount > 0)
                 parts.Add($"[yellow]{state.WarningCount}[/] warning(s)");
-
             AnsiConsole.MarkupLine($"[blue][[build]][/] [red]Build FAILED[/] — {string.Join(", ", parts)}");
 
-            // Show error details if there are errors not yet printed
             var errors = state.Diagnostics.Where(d => d.Severity == "error").ToList();
             if (errors.Count > 0)
             {
                 AnsiConsole.WriteLine();
                 foreach (var err in errors)
-                {
-                    AnsiConsole.MarkupLine($"  [red]\u2717[/] {Markup.Escape(err.File)}: [red]{Markup.Escape(err.Code)}[/] — {Markup.Escape(err.Message)}");
-                }
+                    AnsiConsole.MarkupLine($"  [red]✗[/] {Markup.Escape(err.File)}: [red]{Markup.Escape(err.Code)}[/] — {Markup.Escape(err.Message)}");
             }
         }
 
-        // Show full warning summary when some were suppressed
         if (state.WarningCount > 5)
         {
             AnsiConsole.WriteLine();
             var warnings = state.Diagnostics.Where(d => d.Severity == "warning").ToList();
-            var grouped = warnings
-                .GroupBy(w => w.Code)
-                .OrderByDescending(g => g.Count());
-
+            var grouped = warnings.GroupBy(w => w.Code).OrderByDescending(g => g.Count());
             AnsiConsole.MarkupLine($"[blue][[build]][/] [yellow]Warning summary ({state.WarningCount} total):[/]");
             foreach (var group in grouped)
-            {
-                AnsiConsole.MarkupLine($"  [yellow]{Markup.Escape(group.Key)}[/] \u00d7{group.Count()}: {Markup.Escape(group.First().Message)}");
-            }
+                AnsiConsole.MarkupLine($"  [yellow]{Markup.Escape(group.Key)}[/] ×{group.Count()}: {Markup.Escape(group.First().Message)}");
         }
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
@@ -48,42 +48,78 @@ internal sealed class DoctorCommand
             return 0;
         }
 
-        AnsiConsole.MarkupLine($"Checking [green]{locations.Length}[/] locations...\n");
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
 
-        using var httpClient = new HttpClient
-        {
-            Timeout = TimeSpan.FromSeconds(5)
-        };
+        if (interactive)
+            AnsiConsole.MarkupLine($"[dim]Checking {locations.Length} location(s)...[/]");
+        else
+            AnsiConsole.MarkupLine($"Checking [green]{locations.Length}[/] locations...\n");
+
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
 
         var healthyCount = 0;
         var warningCount = 0;
         var errorCount = 0;
 
         var table = new Table()
+            .Border(interactive ? TableBorder.Rounded : TableBorder.Simple)
             .AddColumn("Status")
             .AddColumn("Location")
             .AddColumn("Target")
             .AddColumn("Message");
 
-        foreach (var location in locations)
+        if (interactive)
         {
-            var result = await CheckLocationAsync(location, httpClient, cancellationToken);
-            var icon = result.Status switch
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Checking locations...", async ctx =>
+                {
+                    foreach (var location in locations)
+                    {
+                        ctx.Status($"Checking [dim]{Markup.Escape(location.Name)}[/]...");
+                        var result = await CheckLocationAsync(location, httpClient, cancellationToken);
+                        var icon = result.Status switch
+                        {
+                            HealthStatus.Healthy => "[green]✓[/]",
+                            HealthStatus.Warning => "[yellow]⚠[/]",
+                            _ => "[red]✗[/]"
+                        };
+                        healthyCount += result.Status == HealthStatus.Healthy ? 1 : 0;
+                        warningCount += result.Status == HealthStatus.Warning ? 1 : 0;
+                        errorCount += result.Status == HealthStatus.Error ? 1 : 0;
+                        table.AddRow(icon, Markup.Escape(location.Name), Markup.Escape(result.Target), Markup.Escape(result.Message));
+                    }
+                });
+        }
+        else
+        {
+            foreach (var location in locations)
             {
-                HealthStatus.Healthy => "[green]✓[/]",
-                HealthStatus.Warning => "[yellow]⚠[/]",
-                _ => "[red]✗[/]"
-            };
-
-            healthyCount += result.Status == HealthStatus.Healthy ? 1 : 0;
-            warningCount += result.Status == HealthStatus.Warning ? 1 : 0;
-            errorCount += result.Status == HealthStatus.Error ? 1 : 0;
-            table.AddRow(icon, Markup.Escape(location.Name), Markup.Escape(result.Target), Markup.Escape(result.Message));
+                var result = await CheckLocationAsync(location, httpClient, cancellationToken);
+                var icon = result.Status switch
+                {
+                    HealthStatus.Healthy => "[green]✓[/]",
+                    HealthStatus.Warning => "[yellow]⚠[/]",
+                    _ => "[red]✗[/]"
+                };
+                healthyCount += result.Status == HealthStatus.Healthy ? 1 : 0;
+                warningCount += result.Status == HealthStatus.Warning ? 1 : 0;
+                errorCount += result.Status == HealthStatus.Error ? 1 : 0;
+                table.AddRow(icon, Markup.Escape(location.Name), Markup.Escape(result.Target), Markup.Escape(result.Message));
+            }
         }
 
         AnsiConsole.Write(table);
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine($"Results: [green]{healthyCount} healthy[/], [yellow]{warningCount} warning[/], [red]{errorCount} error[/]");
+
+        // Summary Rule with colour-coded result
+        var summaryColor = errorCount > 0 ? "red" : warningCount > 0 ? "yellow" : "green";
+        var summaryIcon = errorCount > 0 ? "✗" : warningCount > 0 ? "⚠" : "✓";
+        AnsiConsole.Write(new Rule(
+            $"[{summaryColor}]{summaryIcon}[/] [green]{healthyCount} healthy[/]  [yellow]{warningCount} warning[/]  [red]{errorCount} error[/]")
+        { Justification = Justify.Left });
+
         if (verbose)
             AnsiConsole.MarkupLine($"[dim]Loaded from: {Markup.Escape(configPath)}[/]");
 

--- a/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
@@ -117,19 +117,19 @@ internal sealed class GatewayCommand
 
         if (!File.Exists(gatewayDll))
         {
-            AnsiConsole.MarkupLine($"[red]Error:[/] Release build not found at: [dim]{Markup.Escape(gatewayDll)}[/]");
+            AnsiConsole.MarkupLine($"[red]✗[/] Release build not found at: [dim]{Markup.Escape(gatewayDll)}[/]");
             return 1;
         }
 
         var configPath = Path.Combine(home, "config.json");
         if (!File.Exists(configPath))
         {
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found \u2014 creating default config...");
+            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found — creating default config...");
             var init = new InitCommand();
             var initResult = await init.ExecuteAsync(force: false, verbose, cancellationToken);
             if (initResult != 0)
                 return initResult;
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] Configure your gateway via the WebUI at the root URL.");
+            AnsiConsole.MarkupLine("[dim]Configure your gateway via the WebUI at the root URL.[/]");
             AnsiConsole.WriteLine();
         }
 
@@ -143,23 +143,60 @@ internal sealed class GatewayCommand
             HomePath: home
         );
 
-        var result = await _processManager.StartAsync(options, cancellationToken);
+        GatewayStartResult result;
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+
+        if (interactive)
+        {
+            GatewayStartResult capturedResult = default!;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Starting gateway...", async ctx =>
+                {
+                    capturedResult = await _processManager.StartAsync(options, cancellationToken);
+                });
+            result = capturedResult;
+        }
+        else
+        {
+            result = await _processManager.StartAsync(options, cancellationToken);
+        }
 
         if (result.Success && result.Pid.HasValue)
         {
             var logsPath = Path.Combine(home, "logs", "gateway.log");
-
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[green]\u2713[/] Gateway started (PID [yellow]{result.Pid.Value}[/])");
-            AnsiConsole.MarkupLine($"  URL:  [green]{Markup.Escape(gatewayUrl)}[/]");
-            AnsiConsole.MarkupLine($"  Logs: [dim]{Markup.Escape(logsPath)}[/]");
-            AnsiConsole.MarkupLine($"  Stop: [dim]botnexus gateway stop[/]");
+
+            if (interactive)
+            {
+                var content =
+                    $"[green]✓[/] Running  [dim]PID:[/] [yellow]{result.Pid.Value}[/]\n\n" +
+                    $"[dim]URL:[/]   [green]{Markup.Escape(gatewayUrl)}[/]\n" +
+                    $"[dim]Logs:[/]  [dim]{Markup.Escape(logsPath)}[/]\n" +
+                    $"[dim]Stop:[/]  [dim]botnexus gateway stop[/]";
+                var panel = new Panel(content)
+                {
+                    Border = BoxBorder.Rounded,
+                    Header = new PanelHeader("[bold blue] BotNexus Gateway [/]"),
+                    Padding = new Padding(1, 0)
+                };
+                AnsiConsole.Write(panel);
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[green]✓[/] Gateway started (PID [yellow]{result.Pid.Value}[/])");
+                AnsiConsole.MarkupLine($"  URL:  [green]{Markup.Escape(gatewayUrl)}[/]");
+                AnsiConsole.MarkupLine($"  Logs: [dim]{Markup.Escape(logsPath)}[/]");
+                AnsiConsole.MarkupLine($"  Stop: [dim]botnexus gateway stop[/]");
+            }
+
             AnsiConsole.WriteLine();
             return 0;
         }
         else
         {
-            AnsiConsole.MarkupLine($"[red]\u2717[/] Failed to start gateway: {Markup.Escape(result.Message ?? "Unknown error")}");
+            AnsiConsole.MarkupLine($"[red]✗[/] Failed to start gateway: {Markup.Escape(result.Message ?? "Unknown error")}");
             return 1;
         }
     }
@@ -174,25 +211,25 @@ internal sealed class GatewayCommand
 
         if (!File.Exists(gatewayDll))
         {
-            AnsiConsole.MarkupLine($"[red]Error:[/] Release build not found at: [dim]{Markup.Escape(gatewayDll)}[/]");
+            AnsiConsole.MarkupLine($"[red]✗[/] Release build not found at: [dim]{Markup.Escape(gatewayDll)}[/]");
             return 1;
         }
 
         var configPath = Path.Combine(home, "config.json");
         if (!File.Exists(configPath))
         {
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found \u2014 creating default config...");
+            AnsiConsole.MarkupLine("[blue][[gateway]][/] No configuration found — creating default config...");
             var init = new InitCommand();
             var initResult = await init.ExecuteAsync(force: false, verbose, cancellationToken);
             if (initResult != 0)
                 return initResult;
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] Configure your gateway via the WebUI at the root URL.");
+            AnsiConsole.MarkupLine("[dim]Configure your gateway via the WebUI at the root URL.[/]");
             AnsiConsole.WriteLine();
         }
 
         if (!ServeCommand.IsPortAvailable(port))
         {
-            AnsiConsole.MarkupLine($"[red]Error:[/] Port [green]{port}[/] is already in use.");
+            AnsiConsole.MarkupLine($"[red]✗[/] Port [yellow]{port}[/] is already in use.");
             return 1;
         }
 
@@ -204,11 +241,11 @@ internal sealed class GatewayCommand
         while (true)
         {
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("[blue][[gateway]][/] Starting Gateway (attached mode)");
-            AnsiConsole.MarkupLine($"   URL:         [green]{Markup.Escape(gatewayUrl)}[/]");
-            AnsiConsole.MarkupLine("   Environment: [dim]Development[/]");
+            AnsiConsole.Write(new Rule("[bold blue]BotNexus Gateway[/]") { Justification = Justify.Left });
+            AnsiConsole.MarkupLine($"  [dim]URL:[/]         [green]{Markup.Escape(gatewayUrl)}[/]");
+            AnsiConsole.MarkupLine("  [dim]Environment:[/] Development");
+            AnsiConsole.MarkupLine("  Press [yellow]Ctrl+C[/] to stop the gateway.");
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("Press [yellow]Ctrl+C[/] to stop the gateway.");
 
             var psi = new System.Diagnostics.ProcessStartInfo
             {
@@ -227,7 +264,7 @@ internal sealed class GatewayCommand
             lastExitCode = process.ExitCode;
 
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[blue][[gateway]][/] Gateway exited (code [yellow]{lastExitCode}[/]).");
+            AnsiConsole.MarkupLine($"[dim]Gateway exited (code [yellow]{lastExitCode}[/]).[/]");
 
             if (cancellationToken.IsCancellationRequested)
                 break;
@@ -241,66 +278,144 @@ internal sealed class GatewayCommand
 
     private async Task<int> StopAsync(string home, bool verbose, CancellationToken cancellationToken)
     {
-        var result = await _processManager.StopAsync(home, cancellationToken);
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+        GatewayStopResult result;
+
+        if (interactive)
+        {
+            GatewayStopResult capturedResult = default!;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Stopping gateway...", async ctx =>
+                {
+                    capturedResult = await _processManager.StopAsync(home, cancellationToken);
+                });
+            result = capturedResult;
+        }
+        else
+        {
+            result = await _processManager.StopAsync(home, cancellationToken);
+        }
 
         if (result.Success)
         {
-            AnsiConsole.MarkupLine($"[green]\u2713[/] {Markup.Escape(result.Message ?? "Gateway stopped")}");
+            AnsiConsole.MarkupLine($"[green]✓[/] {Markup.Escape(result.Message ?? "Gateway stopped")}");
             return 0;
         }
         else
         {
-            AnsiConsole.MarkupLine($"[red]\u2717[/] {Markup.Escape(result.Message ?? "Failed to stop gateway")}");
+            AnsiConsole.MarkupLine($"[red]✗[/] {Markup.Escape(result.Message ?? "Failed to stop gateway")}");
             return 1;
         }
     }
 
     private async Task<int> StatusAsync(string home, bool verbose, CancellationToken cancellationToken)
     {
-        var status = await _processManager.GetStatusAsync(home, cancellationToken);
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+        GatewayStatus status;
+
+        if (interactive)
+        {
+            GatewayStatus capturedStatus = default!;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Checking gateway status...", async ctx =>
+                {
+                    capturedStatus = await _processManager.GetStatusAsync(home, cancellationToken);
+                });
+            status = capturedStatus;
+        }
+        else
+        {
+            status = await _processManager.GetStatusAsync(home, cancellationToken);
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(new Rule("[bold blue]Gateway Status[/]") { Justification = Justify.Left });
 
         switch (status.State)
         {
             case GatewayState.Running when status.Pid.HasValue:
-                AnsiConsole.MarkupLine($"[green]\u25cf[/] Gateway is running");
-                AnsiConsole.MarkupLine($"  PID:    [yellow]{status.Pid.Value}[/]");
-                if (status.Uptime.HasValue)
+                if (interactive)
                 {
-                    AnsiConsole.MarkupLine($"  Uptime: [dim]{FormatUptime(status.Uptime.Value)}[/]");
+                    var content = $"[green]● Running[/]\n\n" +
+                        $"[dim]PID:[/]    [yellow]{status.Pid.Value}[/]\n" +
+                        (status.Uptime.HasValue ? $"[dim]Uptime:[/] [dim]{FormatUptime(status.Uptime.Value)}[/]" : string.Empty);
+                    AnsiConsole.Write(new Panel(content.TrimEnd())
+                    {
+                        Border = BoxBorder.Rounded,
+                        Padding = new Padding(1, 0)
+                    });
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[green]●[/] Gateway is running");
+                    AnsiConsole.MarkupLine($"  PID:    [yellow]{status.Pid.Value}[/]");
+                    if (status.Uptime.HasValue)
+                        AnsiConsole.MarkupLine($"  Uptime: [dim]{FormatUptime(status.Uptime.Value)}[/]");
                 }
                 return 0;
 
             case GatewayState.NotRunning:
-                AnsiConsole.MarkupLine("[dim]\u25cf[/] Gateway is not running");
-                if (verbose && !string.IsNullOrWhiteSpace(status.Message))
+                if (interactive)
                 {
-                    AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(status.Message)}[/]");
+                    AnsiConsole.Write(new Panel("[dim]● Not running[/]")
+                    {
+                        Border = BoxBorder.Rounded,
+                        Padding = new Padding(1, 0)
+                    });
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[dim]● Gateway is not running[/]");
+                    if (verbose && !string.IsNullOrWhiteSpace(status.Message))
+                        AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(status.Message)}[/]");
                 }
                 return 0;
 
             case GatewayState.Unknown:
-                AnsiConsole.MarkupLine($"[yellow]\u25cf[/] Gateway state is unknown");
-                if (!string.IsNullOrWhiteSpace(status.Message))
-                {
-                    AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(status.Message)}[/]");
-                }
-                return 1;
-
             default:
-                AnsiConsole.MarkupLine("[yellow]\u25cf[/] Gateway state is unknown");
+                AnsiConsole.MarkupLine($"[yellow]●[/] Gateway state is unknown");
+                if (!string.IsNullOrWhiteSpace(status.Message))
+                    AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(status.Message)}[/]");
                 return 1;
         }
     }
 
     private async Task<int> RestartAsync(string repoRoot, string home, int port, bool verbose, CancellationToken cancellationToken)
     {
-        AnsiConsole.MarkupLine("[blue][[gateway]][/] Stopping gateway...");
-        await StopAsync(home, verbose, cancellationToken);
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+
+        // Stop
+        GatewayStopResult stopResult;
+        if (interactive)
+        {
+            GatewayStopResult capturedStop = default!;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Stopping gateway...", async ctx =>
+                {
+                    capturedStop = await _processManager.StopAsync(home, cancellationToken);
+                });
+            stopResult = capturedStop;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[blue][[gateway]][/] Stopping gateway...");
+            stopResult = await _processManager.StopAsync(home, cancellationToken);
+        }
+
+        if (stopResult.Success)
+            AnsiConsole.MarkupLine("[green]✓[/] Gateway stopped");
+        else
+            AnsiConsole.MarkupLine($"[yellow]⚠[/] Stop result: {Markup.Escape(stopResult.Message ?? "unknown")}");
 
         await Task.Delay(1000, cancellationToken);
 
-        AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[blue][[gateway]][/] Starting gateway...");
+        // Start
         return await StartAsync(repoRoot, home, port, attached: false, verbose, cancellationToken);
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -41,9 +41,15 @@ internal sealed class InitCommand
 
         if (File.Exists(configPath) && !force)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning:[/] Config already exists at [dim]{Markup.Escape(configPath)}[/]. Use [green]--force[/] to overwrite.");
-            AnsiConsole.MarkupLine($"BotNexus home: [dim]{Markup.Escape(homePath)}[/]");
+            AnsiConsole.MarkupLine($"[yellow]⚠[/] Config already exists at [dim]{Markup.Escape(configPath)}[/]. Use [green]--force[/] to overwrite.");
+            AnsiConsole.MarkupLine($"  Home: [dim]{Markup.Escape(homePath)}[/]");
             return 0;
+        }
+
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+        if (interactive)
+        {
+            AnsiConsole.Write(new FigletText("BotNexus").Color(Color.Blue));
         }
 
         var defaultConfig = new PlatformConfig
@@ -75,12 +81,35 @@ internal sealed class InitCommand
         };
 
         await WriteConfigAsync(defaultConfig, configPath, cancellationToken);
-        AnsiConsole.MarkupLine($"[green]\u2713[/] Initialized BotNexus home at: [dim]{Markup.Escape(homePath)}[/]");
-        AnsiConsole.MarkupLine($"[green]\u2713[/] Created config: [dim]{Markup.Escape(configPath)}[/]");
-        AnsiConsole.MarkupLine("\nNext steps:");
-        AnsiConsole.MarkupLine("  [green]botnexus provider setup[/]");
-        AnsiConsole.MarkupLine("  [green]botnexus validate[/]");
-        AnsiConsole.MarkupLine("  [green]botnexus agent list[/]");
+
+        var interactive2 = AnsiConsole.Profile.Capabilities.Interactive;
+        if (interactive2)
+        {
+            var panel = new Panel(
+                $"[green]\u2713[/] Initialized BotNexus home\n\n" +
+                $"[dim]Home:[/]   [dim]{Markup.Escape(homePath)}[/]\n" +
+                $"[dim]Config:[/] [dim]{Markup.Escape(configPath)}[/]\n\n" +
+                "[bold]Next steps:[/]\n" +
+                "  [green]botnexus provider setup[/]\n" +
+                "  [green]botnexus validate[/]\n" +
+                "  [green]botnexus agent list[/]")
+            {
+                Border = BoxBorder.Rounded,
+                Header = new PanelHeader("[bold blue] BotNexus Init [/]"),
+                Padding = new Padding(1, 0)
+            };
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(panel);
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[green]\u2713[/] Initialized BotNexus home at: [dim]{Markup.Escape(homePath)}[/]");
+            AnsiConsole.MarkupLine($"[green]\u2713[/] Created config: [dim]{Markup.Escape(configPath)}[/]");
+            AnsiConsole.MarkupLine("\nNext steps:");
+            AnsiConsole.MarkupLine("  [green]botnexus provider setup[/]");
+            AnsiConsole.MarkupLine("  [green]botnexus validate[/]");
+            AnsiConsole.MarkupLine("  [green]botnexus agent list[/]");
+        }
 
         if (verbose)
             AnsiConsole.WriteLine(JsonSerializer.Serialize(defaultConfig, CreateWriteJsonOptions()));

--- a/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
@@ -87,12 +87,12 @@ internal sealed class ServeCommand
         var configPath = Path.Combine(home, "config.json");
         if (!File.Exists(configPath))
         {
-            AnsiConsole.MarkupLine("[blue][[serve]][/] No configuration found \u2014 creating default config...");
+            AnsiConsole.MarkupLine("[blue][[serve]][/] No configuration found — creating default config...");
             var init = new InitCommand();
             var initResult = await init.ExecuteAsync(force: false, verbose, cancellationToken);
             if (initResult != 0)
                 return initResult;
-            AnsiConsole.MarkupLine("[blue][[serve]][/] Configure your gateway via the WebUI at the root URL.");
+            AnsiConsole.MarkupLine("[dim]Configure your gateway via the WebUI at the root URL.[/]");
             AnsiConsole.WriteLine();
         }
 
@@ -110,11 +110,11 @@ internal sealed class ServeCommand
         while (true)
         {
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("[blue][[serve]][/] Starting Gateway");
-            AnsiConsole.MarkupLine($"   URL:         [green]{Markup.Escape(gatewayUrl)}[/]");
-            AnsiConsole.MarkupLine("   Environment: [dim]Development[/]");
+            AnsiConsole.Write(new Rule("[bold blue]BotNexus Gateway[/]") { Justification = Justify.Left });
+            AnsiConsole.MarkupLine($"  [dim]URL:[/]         [green]{Markup.Escape(gatewayUrl)}[/]");
+            AnsiConsole.MarkupLine("  [dim]Environment:[/] Development");
+            AnsiConsole.MarkupLine("  Press [yellow]Ctrl+C[/] to stop the gateway.");
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("Press [yellow]Ctrl+C[/] to stop the gateway.");
 
             var psi = new ProcessStartInfo
             {
@@ -133,7 +133,7 @@ internal sealed class ServeCommand
             lastExitCode = process.ExitCode;
 
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[blue][[serve]][/] Gateway exited (code [yellow]{lastExitCode}[/]).");
+            AnsiConsole.MarkupLine($"[dim]Gateway exited (code [yellow]{lastExitCode}[/]).[/]");
 
             if (cancellationToken.IsCancellationRequested)
                 break;
@@ -168,9 +168,9 @@ internal sealed class ServeCommand
         var probeUrl = $"http://localhost:{port}";
 
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[blue][[serve]][/] Starting Probe");
-        AnsiConsole.MarkupLine($"   URL:         [green]{Markup.Escape(probeUrl)}[/]");
-        AnsiConsole.MarkupLine($"   Gateway:     [dim]{Markup.Escape(gatewayUrl)}[/]");
+        AnsiConsole.Write(new Rule("[bold blue]BotNexus Probe[/]") { Justification = Justify.Left });
+        AnsiConsole.MarkupLine($"  [dim]URL:[/]     [green]{Markup.Escape(probeUrl)}[/]");
+        AnsiConsole.MarkupLine($"  [dim]Gateway:[/] [dim]{Markup.Escape(gatewayUrl)}[/]");
         AnsiConsole.WriteLine();
 
         var psi = new ProcessStartInfo
@@ -186,8 +186,84 @@ internal sealed class ServeCommand
             ?? throw new InvalidOperationException("Failed to start Probe process.");
 
         await process.WaitForExitAsync(cancellationToken);
-        AnsiConsole.MarkupLine($"[blue][[serve]][/] Probe exited (code [yellow]{process.ExitCode}[/]).");
+        AnsiConsole.MarkupLine($"[dim]Probe exited (code [yellow]{process.ExitCode}[/]).[/]");
         return process.ExitCode;
+    }
+
+    /// <summary>
+    /// Deploys built extensions silently (no per-extension output) and returns the count deployed.
+    /// Used when a spinner is active so output doesn't interleave.
+    /// </summary>
+    public static int DeployExtensionsSilent(string repoRoot, string home, bool verbose)
+    {
+        var count = 0;
+        var extensionsRoot = Path.Combine(repoRoot, "src", "extensions");
+        if (!Directory.Exists(extensionsRoot))
+            return 0;
+
+        var destRoot = Path.Combine(home, "extensions");
+        var projects = Directory.GetFiles(extensionsRoot, "*.csproj", SearchOption.AllDirectories);
+        var deployedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var project in projects)
+        {
+            var projectDir = Path.GetDirectoryName(project)!;
+            var projectName = Path.GetFileNameWithoutExtension(project);
+            var manifestPath = Path.Combine(projectDir, "botnexus-extension.json");
+            if (!File.Exists(manifestPath))
+                continue;
+
+            string? extId;
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(manifestPath));
+                extId = doc.RootElement.GetProperty("id").GetString();
+            }
+            catch { continue; }
+
+            if (string.IsNullOrWhiteSpace(extId))
+                continue;
+
+            deployedIds.Add(extId);
+            var srcDir = Path.Combine(projectDir, "bin", "Release");
+            if (!Directory.Exists(srcDir))
+                continue;
+
+            var tfmDir = Directory.GetDirectories(srcDir)
+                .Where(d => Path.GetFileName(d).StartsWith("net", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(d => d)
+                .FirstOrDefault();
+            if (tfmDir is null)
+                continue;
+
+            var extDest = Path.Combine(destRoot, extId);
+            Directory.CreateDirectory(extDest);
+            foreach (var file in Directory.GetFiles(tfmDir, "*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(tfmDir, file);
+                var destFile = Path.Combine(extDest, relativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
+                File.Copy(file, destFile, overwrite: true);
+            }
+            File.Copy(manifestPath, Path.Combine(extDest, "botnexus-extension.json"), overwrite: true);
+            count++;
+        }
+
+        // Clean stale extensions
+        if (Directory.Exists(destRoot))
+        {
+            foreach (var dir in Directory.GetDirectories(destRoot))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (!deployedIds.Contains(dirName))
+                {
+                    try { Directory.Delete(dir, recursive: true); }
+                    catch { /* locked — leave it */ }
+                }
+            }
+        }
+
+        return count;
     }
 
     /// <summary>
@@ -298,7 +374,7 @@ internal sealed class ServeCommand
             }
         }
 
-        AnsiConsole.MarkupLine($"[blue][[deploy]][/] [green]{deployed}[/] extension(s) deployed to [dim]{Markup.Escape(destRoot)}[/]");
+        AnsiConsole.MarkupLine($"[green]✓[/] {deployed} extension(s) deployed to [dim]{Markup.Escape(destRoot)}[/]");
     }
 
     /// <summary>
@@ -308,7 +384,7 @@ internal sealed class ServeCommand
     public static async Task<bool> WaitForRestartOrQuitAsync(int seconds, CancellationToken cancellationToken)
     {
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine($"[blue][[restart]][/] Gateway will restart in [yellow]{seconds}[/] seconds. Press [yellow]q[/] to quit.");
+        AnsiConsole.MarkupLine($"[blue]Restarting[/] in [yellow]{seconds}s[/] — press [yellow]q[/] to quit.");
 
         for (var i = seconds; i > 0; i--)
         {

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -61,75 +61,166 @@ internal class UpdateCommand
     /// </summary>
     protected virtual async Task<int> RunPreStopStepsAsync(string repoRoot, string home, bool verbose, CancellationToken cancellationToken)
     {
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+
         // Step 1: git pull
-        AnsiConsole.MarkupLine("[blue][[update]][/] Checking for updates...");
+        string beforeSha;
+        string afterSha;
+        int pullResult;
+        int commitCount;
 
-        var beforeSha = GetCommitSha(repoRoot);
-
-        var pullResult = await RunGitPullAsync(repoRoot, verbose, cancellationToken);
-        if (pullResult != 0)
+        if (interactive)
         {
-            AnsiConsole.MarkupLine("[red][[update]][/] \u2717 git pull failed. Check network or repo path.");
-            return pullResult;
-        }
+            string capturedBeforeSha = string.Empty;
+            string capturedAfterSha = string.Empty;
+            int capturedCount = 0;
+            int capturedPullResult = 0;
 
-        var afterSha = GetCommitSha(repoRoot);
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Checking for updates...", async ctx =>
+                {
+                    capturedBeforeSha = GetCommitSha(repoRoot);
+                    capturedPullResult = await RunGitPullAsync(repoRoot, verbose, cancellationToken);
+                    if (capturedPullResult == 0)
+                    {
+                        capturedAfterSha = GetCommitSha(repoRoot);
+                        if (capturedBeforeSha != capturedAfterSha)
+                            capturedCount = await CountCommitsBetweenAsync(repoRoot, capturedBeforeSha, capturedAfterSha, cancellationToken);
+                    }
+                });
 
-        if (beforeSha == afterSha)
-        {
-            AnsiConsole.MarkupLine($"[blue][[update]][/] Already up to date ([dim]{Markup.Escape(Short(beforeSha))}[/]). Restarting gateway with current build...");
+            beforeSha = capturedBeforeSha;
+            afterSha = capturedAfterSha;
+            pullResult = capturedPullResult;
+            commitCount = capturedCount;
         }
         else
         {
-            var count = await CountCommitsBetweenAsync(repoRoot, beforeSha, afterSha, cancellationToken);
-            var countStr = count > 0 ? $"{count} new commit(s)" : "new commit(s)";
-            AnsiConsole.MarkupLine($"[blue][[update]][/] [green]\u2713[/] Pulled {countStr}: [dim]{Markup.Escape(Short(beforeSha))}[/] \u2192 [dim]{Markup.Escape(Short(afterSha))}[/]");
+            AnsiConsole.MarkupLine("[blue][[update]][/] Checking for updates...");
+            beforeSha = GetCommitSha(repoRoot);
+            pullResult = await RunGitPullAsync(repoRoot, verbose, cancellationToken);
+            afterSha = pullResult == 0 ? GetCommitSha(repoRoot) : string.Empty;
+            commitCount = 0;
+            if (pullResult == 0 && beforeSha != afterSha)
+                commitCount = await CountCommitsBetweenAsync(repoRoot, beforeSha, afterSha, cancellationToken);
+        }
+
+        if (pullResult != 0)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] git pull failed. Check network or repo path.");
+            return pullResult;
+        }
+
+        if (beforeSha == afterSha)
+        {
+            AnsiConsole.MarkupLine($"[green]✓[/] Already up to date ([dim]{Markup.Escape(Short(beforeSha))}[/])");
+        }
+        else
+        {
+            var countStr = commitCount > 0 ? $"{commitCount} new commit(s)" : "new commit(s)";
+            AnsiConsole.MarkupLine($"[green]✓[/] Pulled {countStr}: [dim]{Markup.Escape(Short(beforeSha))}[/] → [dim]{Markup.Escape(Short(afterSha))}[/]");
         }
 
         // Step 2: Build
-        AnsiConsole.MarkupLine("[blue][[update]][/] Building...");
-        var buildResult = await BuildCommand.BuildSolutionAsync(repoRoot, verbose, cancellationToken);
+        int buildResult;
+        if (interactive && !verbose)
+        {
+            int capturedBuild = 0;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Star)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Building...", async ctx =>
+                {
+                    capturedBuild = await BuildCommand.BuildSolutionAsync(repoRoot, verbose, cancellationToken);
+                });
+            buildResult = capturedBuild;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[blue][[update]][/] Building...");
+            buildResult = await BuildCommand.BuildSolutionAsync(repoRoot, verbose, cancellationToken);
+        }
+
         if (buildResult != 0)
         {
-            AnsiConsole.MarkupLine("[red][[update]][/] \u2717 Build failed.");
+            AnsiConsole.MarkupLine("[red]✗[/] Build failed.");
             return buildResult;
         }
-        AnsiConsole.MarkupLine("[blue][[update]][/] [green]\u2713[/] Build succeeded");
+        AnsiConsole.MarkupLine("[green]✓[/] Build succeeded");
 
         // Step 3: Deploy extensions
-        AnsiConsole.MarkupLine("[blue][[update]][/] Deploying extensions...");
-        ServeCommand.DeployExtensions(repoRoot, home, verbose);
-        AnsiConsole.MarkupLine("[blue][[update]][/] [green]\u2713[/] Extensions deployed");
+        int deployed = 0;
+        if (interactive)
+        {
+            int capturedDeployed = 0;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Deploying extensions...", async ctx =>
+                {
+                    capturedDeployed = ServeCommand.DeployExtensionsSilent(repoRoot, home, verbose);
+                    await Task.CompletedTask;
+                });
+            deployed = capturedDeployed;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[blue][[update]][/] Deploying extensions...");
+            deployed = ServeCommand.DeployExtensionsSilent(repoRoot, home, verbose);
+        }
+        AnsiConsole.MarkupLine($"[green]✓[/] {deployed} extension(s) deployed");
 
         return 0;
     }
 
     private async Task<int> RunRestartAsync(string home, int port, string repoRoot, CancellationToken cancellationToken)
     {
-        AnsiConsole.MarkupLine("[blue][[update]][/] Restarting gateway...");
-        var stopResult = await _processManager.StopAsync(home, cancellationToken);
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+
+        // Stop gateway
+        GatewayStopResult stopResult;
+        if (interactive)
+        {
+            GatewayStopResult capturedStop = default!;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Stopping gateway...", async ctx =>
+                {
+                    capturedStop = await _processManager.StopAsync(home, cancellationToken);
+                });
+            stopResult = capturedStop;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[blue][[update]][/] Stopping gateway...");
+            stopResult = await _processManager.StopAsync(home, cancellationToken);
+        }
+
         if (!stopResult.Success)
         {
-            AnsiConsole.MarkupLine($"[red][[update]][/] \u2717 Failed to stop gateway: {Markup.Escape(stopResult.Message ?? "Unknown")}");
-            AnsiConsole.MarkupLine("[yellow][[update]][/] Tip: try 'botnexus gateway stop' manually first.");
+            AnsiConsole.MarkupLine($"[red]✗[/] Failed to stop gateway: {Markup.Escape(stopResult.Message ?? "Unknown")}");
+            AnsiConsole.MarkupLine("[yellow]⚠[/] Tip: try [dim]botnexus gateway stop[/] manually first.");
             return 1;
         }
+        AnsiConsole.MarkupLine("[green]✓[/] Gateway stopped");
 
         await Task.Delay(1000, cancellationToken);
 
-        // Step 4b: Verify the port is actually free before starting new gateway
+        // Verify port is free
         if (!IsPortAvailable(port))
         {
-            AnsiConsole.MarkupLine($"[red][[update]][/] \u2717 Port {port} is still in use after stopping gateway.");
-            AnsiConsole.MarkupLine("[yellow][[update]][/] Tip: try 'botnexus gateway stop' manually or kill the process on that port.");
+            AnsiConsole.MarkupLine($"[red]✗[/] Port {port} is still in use after stopping gateway.");
+            AnsiConsole.MarkupLine("[yellow]⚠[/] Tip: try [dim]botnexus gateway stop[/] manually or kill the process on that port.");
             return 1;
         }
 
-        // Step 5: Start new gateway
         var gatewayDll = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Gateway.Api", "bin", "Release", "net10.0", "BotNexus.Gateway.Api.dll");
         if (!File.Exists(gatewayDll))
         {
-            AnsiConsole.MarkupLine($"[red][[update]][/] \u2717 Gateway binary not found: [dim]{Markup.Escape(gatewayDll)}[/]");
+            AnsiConsole.MarkupLine($"[red]✗[/] Gateway binary not found: [dim]{Markup.Escape(gatewayDll)}[/]");
             return 1;
         }
 
@@ -141,16 +232,53 @@ internal class UpdateCommand
             HomePath: home
         );
 
-        var startResult = await _processManager.StartAsync(options, cancellationToken);
+        // Start gateway
+        GatewayStartResult startResult;
+        if (interactive)
+        {
+            GatewayStartResult capturedStart = default!;
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("blue"))
+                .StartAsync("Starting gateway...", async ctx =>
+                {
+                    capturedStart = await _processManager.StartAsync(options, cancellationToken);
+                });
+            startResult = capturedStart;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[blue][[update]][/] Starting gateway...");
+            startResult = await _processManager.StartAsync(options, cancellationToken);
+        }
+
         if (startResult.Success && startResult.Pid.HasValue)
         {
-            AnsiConsole.MarkupLine($"[blue][[update]][/] [green]\u2713[/] Gateway restarted (PID [yellow]{startResult.Pid.Value}[/])");
-            AnsiConsole.MarkupLine($"  URL:  [green]{Markup.Escape(gatewayUrl)}[/]");
+            AnsiConsole.MarkupLine($"[green]✓[/] Gateway started (PID [yellow]{startResult.Pid.Value}[/])");
+
+            if (interactive)
+            {
+                var panel = new Panel(
+                    $"[green]Update complete![/]\n\n" +
+                    $"[dim]URL:[/]  [green]{Markup.Escape(gatewayUrl)}[/]\n" +
+                    $"[dim]PID:[/]  [yellow]{startResult.Pid.Value}[/]")
+                {
+                    Border = BoxBorder.Rounded,
+                    Header = new PanelHeader("[bold blue] BotNexus Gateway [/]"),
+                    Padding = new Padding(1, 0)
+                };
+                AnsiConsole.WriteLine();
+                AnsiConsole.Write(panel);
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"  URL:  [green]{Markup.Escape(gatewayUrl)}[/]");
+            }
             return 0;
         }
         else
         {
-            AnsiConsole.MarkupLine($"[red][[update]][/] \u2717 Failed to start gateway: {Markup.Escape(startResult.Message ?? "Unknown error")}");
+            AnsiConsole.MarkupLine($"[red]✗[/] Failed to start gateway: {Markup.Escape(startResult.Message ?? "Unknown error")}");
             return 1;
         }
     }
@@ -177,7 +305,7 @@ internal class UpdateCommand
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[red][[update]][/] git pull error: {Markup.Escape(ex.Message)}");
+            AnsiConsole.MarkupLine($"[red]✗[/] git pull error: {Markup.Escape(ex.Message)}");
             return 1;
         }
     }


### PR DESCRIPTION
Upgrades all CLI commands from plain `[blue][[tag]][/]` text to proper Spectre.Console visuals.

## Changes

| Command | What's new |
|---|---|
| `update` | Spinner per step (pull/stop/build/deploy/start); final success in a Rounded Panel |
| `gateway start` | Spinner during start; success Panel with PID, URL, logs path, stop hint |
| `gateway stop` | Spinner during stop |
| `gateway status` | Spinner while checking; result in Rounded Panel (running) with green ● / dim ● indicator |
| `gateway restart` | Spinner for stop + delegates to start |
| `build` | Interactive mode suppresses per-line noise; summary Table (result/projects/warnings/time) on completion |
| `serve` | Rule divider for startup banner; `DeployExtensionsSilent` under spinner to avoid interleaved output |
| `doctor` | Status spinner with per-location updates; Rounded border table; colour-coded Rule summary |
| `init` | FigletText splash + Rounded Panel with home path, config path, next steps |

## Behaviour rules
- All spinners gate on `AnsiConsole.Profile.Capabilities.Interactive` — falls back to plain MarkupLine in CI/pipes
- FigletText only on `init` — not spammed on every command
- Verbose mode shows more detail, not less
- 64/64 CLI tests pass