### PR TITLE
feat(portal): multi-conversation support — route SendMessageToConversation via threadId

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -35,6 +35,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     private readonly ISessionCompactor _compactor;
     private readonly ISessionWarmupService _warmup;
     private readonly IConversationRouter _conversationRouter;
+    private readonly IConversationStore _conversationStore;
     private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
     private readonly ILogger<GatewayHub> _logger;
 
@@ -47,6 +48,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         ISessionCompactor compactor,
         ISessionWarmupService warmup,
         IConversationRouter conversationRouter,
+        IConversationStore conversationStore,
         IOptionsMonitor<CompactionOptions> compactionOptions,
         ILogger<GatewayHub> logger)
     {
@@ -58,6 +60,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         _compactor = compactor;
         _warmup = warmup;
         _conversationRouter = conversationRouter;
+        _conversationStore = conversationStore;
         _compactionOptions = compactionOptions;
         _logger = logger;
     }
@@ -199,7 +202,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             typedAgentId, typedChannelType, session.SessionId, connectionId, content.Length > 50 ? content[..50] + "..." : content);
 
         _ = SafeDispatchAsync(
-            () => DispatchMessageAsync(typedAgentId, session.SessionId, content, "message", connectionId),
+            () => DispatchMessageAsync(typedAgentId, session.SessionId, content, "message", connectionId,
+                threadId: string.IsNullOrWhiteSpace(conversationId) ? null : conversationId),
             typedAgentId,
             session.SessionId);
 
@@ -260,13 +264,14 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             session.ChannelType?.Value);
     }
 
-    private Task DispatchMessageAsync(AgentId typedAgentId, SessionId typedSessionId, string content, string messageType, string senderId)
+    private Task DispatchMessageAsync(AgentId typedAgentId, SessionId typedSessionId, string content, string messageType, string senderId, string? threadId = null)
         => _dispatcher.DispatchAsync(
             new InboundMessage
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
                 ChannelAddress = typedAgentId.Value, // stable per-agent address — one portal conversation per agent
+                ThreadId = threadId, // non-null for secondary conversations; null targets the default portal conversation
                 SessionId = typedSessionId.Value,
                 TargetAgentId = typedAgentId.Value,
                 Content = content,
@@ -617,6 +622,27 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
         if (needsSave)
             await _sessions.SaveAsync(session, Context.ConnectionAborted);
+
+        // Ensure the conversation has a (signalr, agentId, conversationId) binding so that
+        // future ResolveInboundAsync calls with ThreadId=conversationId route here correctly.
+        var conversation = routingResult.Conversation;
+        var hasThreadBinding = conversation.ChannelBindings.Any(b =>
+            b.ChannelType == channelType &&
+            string.Equals(b.ChannelAddress, agentId.Value, StringComparison.Ordinal) &&
+            string.Equals(b.ThreadId, conversationId, StringComparison.Ordinal));
+
+        if (!hasThreadBinding)
+        {
+            conversation.ChannelBindings.Add(new ChannelBinding
+            {
+                ChannelType = channelType,
+                ChannelAddress = agentId.Value,
+                ThreadId = conversationId,
+                Mode = BindingMode.Interactive
+            });
+            conversation.UpdatedAt = DateTimeOffset.UtcNow;
+            await _conversationStore.SaveAsync(conversation, Context.ConnectionAborted);
+        }
 
         return session;
     }

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Gateway.Api;
+using BotNexus.Extensions.Channels.SignalR;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Tests.Helpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace BotNexus.Gateway.Tests.Integration;
+
+/// <summary>
+/// Tests verifying that GatewayHub correctly passes conversationId as ThreadId on
+/// the dispatched InboundMessage, enabling the conversation router to route to the
+/// correct conversation rather than always falling back to the default portal conversation.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("IntegrationTests")]
+public sealed class SignalRThreadRoutingTests : IAsyncDisposable
+{
+    private const string TestAgentId = "thread-routing-agent";
+
+    /// <summary>
+    /// When SendMessageToConversation is called with a specific conversationId, the
+    /// dispatched InboundMessage.ThreadId must equal that conversationId so the router
+    /// can distinguish secondary conversations from the default one.
+    /// </summary>
+    [Fact]
+    public async Task SignalRHub_SendMessageToConversation_RoutesToCorrectConversation()
+    {
+        var dispatcher = new RecordingDispatcher();
+        await using var factory = CreateTestFactory(services =>
+        {
+            services.RemoveAll<IChannelDispatcher>();
+            services.AddSingleton<IChannelDispatcher>(dispatcher);
+        });
+        using var cts = CreateTimeout();
+        await RegisterAgentAsync(factory, cts.Token);
+
+        // Create two distinct conversations for the same agent
+        using var client = factory.CreateClient();
+        var conv1Id = await CreateConversationAsync(client, "Conversation Alpha", cts.Token);
+        var conv2Id = await CreateConversationAsync(client, "Conversation Beta", cts.Token);
+
+        await using var connection = await CreateStartedConnection(factory, cts.Token);
+
+        // Send to first conversation
+        var result1 = await connection.InvokeAsync<JsonElement>(
+            "SendMessageToConversation", TestAgentId, "signalr", "message to alpha", conv1Id, cts.Token);
+        var sessionId1 = result1.GetProperty("sessionId").GetString()!;
+
+        // Send to second conversation
+        var result2 = await connection.InvokeAsync<JsonElement>(
+            "SendMessageToConversation", TestAgentId, "signalr", "message to beta", conv2Id, cts.Token);
+        var sessionId2 = result2.GetProperty("sessionId").GetString()!;
+
+        // The sessions should be different — each conversation has its own session
+        sessionId1.ShouldNotBe(sessionId2,
+            "messages to different conversations should route to different sessions");
+
+        // The dispatched messages should carry the correct threadId
+        dispatcher.Messages.Count.ShouldBe(2);
+
+        var msg1 = dispatcher.Messages.FirstOrDefault(m => m.Content == "message to alpha");
+        var msg2 = dispatcher.Messages.FirstOrDefault(m => m.Content == "message to beta");
+
+        msg1.ShouldNotBeNull();
+        msg2.ShouldNotBeNull();
+
+        msg1!.ThreadId.ShouldBe(conv1Id,
+            "InboundMessage.ThreadId for conv1 message should be the conversationId");
+        msg2!.ThreadId.ShouldBe(conv2Id,
+            "InboundMessage.ThreadId for conv2 message should be the conversationId");
+    }
+
+    /// <summary>
+    /// When SendMessage (no conversationId) is called, the dispatched InboundMessage.ThreadId
+    /// must be null so the router resolves the default (signalr, agentId, null) conversation.
+    /// </summary>
+    [Fact]
+    public async Task SignalRHub_SendMessage_DefaultConversation_UsesNullThread()
+    {
+        var dispatcher = new RecordingDispatcher();
+        await using var factory = CreateTestFactory(services =>
+        {
+            services.RemoveAll<IChannelDispatcher>();
+            services.AddSingleton<IChannelDispatcher>(dispatcher);
+        });
+        using var cts = CreateTimeout();
+        await RegisterAgentAsync(factory, cts.Token);
+
+        await using var connection = await CreateStartedConnection(factory, cts.Token);
+
+        await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "default hello", cts.Token);
+
+        var dispatched = dispatcher.Messages.ShouldHaveSingleItem();
+        dispatched.ThreadId.ShouldBeNull(
+            "SendMessage without conversationId must dispatch with ThreadId=null to target the default portal conversation");
+        dispatched.ChannelAddress.ShouldBe(TestAgentId);
+    }
+
+    /// <summary>
+    /// When a new conversation is created via POST /api/conversations and a message is sent
+    /// to it, the agent processes it in a different session than the default conversation session.
+    /// </summary>
+    [Fact]
+    public async Task SignalRHub_NewConversation_GetsItsOwnSession()
+    {
+        var dispatcher = new RecordingDispatcher();
+        await using var factory = CreateTestFactory(services =>
+        {
+            services.RemoveAll<IChannelDispatcher>();
+            services.AddSingleton<IChannelDispatcher>(dispatcher);
+        });
+        using var cts = CreateTimeout();
+        await RegisterAgentAsync(factory, cts.Token);
+
+        using var client = factory.CreateClient();
+
+        await using var connection = await CreateStartedConnection(factory, cts.Token);
+
+        // First send to the default conversation to establish it
+        var defaultResult = await connection.InvokeAsync<JsonElement>(
+            "SendMessage", TestAgentId, "signalr", "default message", cts.Token);
+        var defaultSessionId = defaultResult.GetProperty("sessionId").GetString()!;
+
+        // Create a new conversation via the API
+        var newConvId = await CreateConversationAsync(client, "Brand New Conversation", cts.Token);
+
+        // Send to the new conversation
+        var newResult = await connection.InvokeAsync<JsonElement>(
+            "SendMessageToConversation", TestAgentId, "signalr", "new conv message", newConvId, cts.Token);
+        var newSessionId = newResult.GetProperty("sessionId").GetString()!;
+
+        newSessionId.ShouldNotBe(defaultSessionId,
+            "a new conversation created via API must get its own distinct session, separate from the default portal conversation session");
+
+        // And the dispatched message for the new conversation should carry the conversationId as threadId
+        var newMsg = dispatcher.Messages.LastOrDefault();
+        newMsg.ShouldNotBeNull();
+        newMsg!.ThreadId.ShouldBe(newConvId,
+            "the new conversation's message should be dispatched with ThreadId=conversationId");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static async Task<string> CreateConversationAsync(HttpClient client, string title, CancellationToken ct)
+    {
+        var resp = await client.PostAsJsonAsync("/api/conversations",
+            new { agentId = TestAgentId, title }, ct);
+        resp.StatusCode.ShouldBeOneOf(HttpStatusCode.Created, HttpStatusCode.OK);
+        var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct)).RootElement;
+        return doc.GetProperty("conversationId").GetString()!;
+    }
+
+    private static WebApplicationFactory<Program> CreateTestFactory(Action<IServiceCollection>? configureServices = null)
+        => new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.UseUrls("http://127.0.0.1:0");
+                builder.ConfigureServices(services =>
+                {
+                    var hostedServices = services
+                        .Where(d => d.ServiceType == typeof(IHostedService))
+                        .ToList();
+                    foreach (var descriptor in hostedServices)
+                        services.Remove(descriptor);
+
+                    services.RemoveAll<IAgentConfigurationWriter>();
+                    services.AddSingleton<IAgentConfigurationWriter, NoOpAgentConfigurationWriter>();
+
+                    services.AddSignalRChannelForTests();
+
+                    services.Replace(ServiceDescriptor.Singleton<ISessionStore, InMemorySessionStore>());
+                    services.Replace(ServiceDescriptor.Singleton<IConversationStore, InMemoryConversationStore>());
+
+                    configureServices?.Invoke(services);
+                });
+            });
+
+    private static HubConnection CreateHubConnection(WebApplicationFactory<Program> factory)
+    {
+        var server = factory.Server;
+        var handler = server.CreateHandler();
+        return new HubConnectionBuilder()
+            .WithUrl("http://localhost/hub/gateway", options =>
+            {
+                options.HttpMessageHandlerFactory = _ => handler;
+                options.Transports = HttpTransportType.LongPolling;
+            })
+            .Build();
+    }
+
+    private static async Task<HubConnection> CreateStartedConnection(WebApplicationFactory<Program> factory, CancellationToken cancellationToken)
+    {
+        var connection = CreateHubConnection(factory);
+        await connection.StartAsync(CancellationToken.None);
+        return connection;
+    }
+
+    private static async Task RegisterAgentAsync(WebApplicationFactory<Program> factory, CancellationToken cancellationToken)
+    {
+        using var client = factory.CreateClient();
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From(TestAgentId),
+            DisplayName = "Thread Routing Test Agent",
+            ModelId = "gpt-4.1",
+            ApiProvider = "copilot",
+            IsolationStrategy = "in-process"
+        };
+        var response = await client.PostAsJsonAsync("/api/agents", descriptor, CancellationToken.None);
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.Created, HttpStatusCode.Conflict);
+    }
+
+    private static CancellationTokenSource CreateTimeout()
+        => new(TimeSpan.FromSeconds(20));
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private sealed class RecordingDispatcher : IChannelDispatcher
+    {
+        private readonly List<InboundMessage> _messages = [];
+
+        public IReadOnlyList<InboundMessage> Messages
+        {
+            get { lock (_messages) { return _messages.ToList(); } }
+        }
+
+        public Task DispatchAsync(InboundMessage message, CancellationToken cancellationToken = default)
+        {
+            lock (_messages) { _messages.Add(message); }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -176,6 +176,7 @@ public sealed class SignalRHubTests
             Mock.Of<ISessionCompactor>(),
             Mock.Of<ISessionWarmupService>(),
             router,
+            conversationStore,
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance)
         {
@@ -193,6 +194,7 @@ public sealed class SignalRHubTests
             Mock.Of<ISessionCompactor>(),
             Mock.Of<ISessionWarmupService>(),
             router,
+            conversationStore,
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance)
         {
@@ -354,11 +356,13 @@ public sealed class SignalRHubTests
         ISessionWarmupService? warmup = null,
         IOptionsMonitor<CompactionOptions>? compactionOptions = null,
         IConversationRouter? conversationRouter = null,
+        IConversationStore? conversationStore = null,
         string connectionId = "conn-test")
     {
         var sessionStore = sessions ?? new InMemorySessionStore();
+        var convStore = conversationStore ?? new InMemoryConversationStore();
         var router = conversationRouter ?? new DefaultConversationRouter(
-            new InMemoryConversationStore(),
+            convStore,
             sessionStore,
             NullLogger<DefaultConversationRouter>.Instance);
 
@@ -371,6 +375,7 @@ public sealed class SignalRHubTests
             compactor ?? Mock.Of<ISessionCompactor>(),
             warmup ?? Mock.Of<ISessionWarmupService>(),
             router,
+            convStore,
             compactionOptions ?? new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance)
         {


### PR DESCRIPTION
Enables the portal "+" button to create independent conversations that messages actually route to correctly.

## Problem

`SendMessageToConversation(agentId, channelType, content, conversationId)` was dispatching with `ThreadId = null`. The conversation router resolved `(signalr, agentId, null)` — always the default conversation — ignoring the specified one.

## Fix

### Routing model
| Portal context | channelType | channelAddress | threadId | Routes to |
|---|---|---|---|---|
| Default conversation | signalr | agentId | null | Default portal conversation |
| Secondary conversation | signalr | agentId | conversationId | That specific conversation |

### `GatewayHub` changes
- `DispatchMessageAsync` — added `threadId` parameter, set on `InboundMessage.ThreadId`
- `SendMessageCore` — passes `conversationId` as `threadId` when non-null
- `ResolveOrCreateSessionByConversationAsync` — ensures a `(signalr, agentId, conversationId)` binding exists on the conversation; persists it so the router can find it by threadId on subsequent messages
- Constructor — injects `IConversationStore` for binding persistence

## Tests (3 new, all green)
- `SignalRHub_SendMessageToConversation_RoutesToCorrectConversation`
- `SignalRHub_SendMessage_DefaultConversation_UsesNullThread`
- `SignalRHub_NewConversation_GetsItsOwnSession`

1220/1220 Gateway tests pass including MultiAgentConcurrencyTests.