### PR TITLE
fix(cli): correct update step order — pull → stop → build → deploy → start

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/_Imports.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/_Imports.razor
@@ -10,3 +10,4 @@
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components.Config

--- a/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
+++ b/src/gateway/BotNexus.Cli/Commands/BuildOutputStreamer.cs
@@ -52,8 +52,31 @@ internal static partial class BuildOutputStreamer
         var stdoutTask = ReadStreamAsync(process.StandardOutput, state, suppressLive ? false : verbose, isError: false);
         var stderrTask = ReadStreamAsync(process.StandardError, state, suppressLive ? false : verbose, isError: true);
 
+        // Monitor for locked files and kill the build immediately if detected.
+        // MSBuild retries 10 times per file — without this we'd wait minutes.
+        var lockedFileMonitor = Task.Run(async () =>
+        {
+            while (!process.HasExited)
+            {
+                if (state.HasLockedFiles)
+                {
+                    try { process.Kill(entireProcessTree: true); } catch { }
+                    return;
+                }
+                await Task.Delay(100, CancellationToken.None);
+            }
+        }, CancellationToken.None);
+
         await Task.WhenAll(stdoutTask, stderrTask);
         await process.WaitForExitAsync(cancellationToken);
+
+        if (state.HasLockedFiles)
+        {
+            AnsiConsole.MarkupLine("[red][[build]][/] [red]✗[/] Build aborted — file locks detected.");
+            AnsiConsole.MarkupLine("[yellow][[build]][/] The gateway must be fully stopped before building on Windows.");
+            AnsiConsole.MarkupLine("[yellow][[build]][/] Run [dim]botnexus gateway stop[/] and wait a few seconds, then retry.");
+            return 1;
+        }
 
         RenderSummary(state, process.ExitCode, interactive);
         return process.ExitCode;
@@ -103,6 +126,19 @@ internal static partial class BuildOutputStreamer
             state.ProjectsBuilt++;
             var projectName = arrowMatch.Groups[1].Value;
             AnsiConsole.MarkupLine($"[blue][[build]][/] [green]\u2713[/] {Markup.Escape(projectName)}");
+            return;
+        }
+
+        // Locked file detection: MSB3027 means the gateway is still running and holding DLL locks
+        if (trimmed.Contains("MSB3027", StringComparison.Ordinal) || trimmed.Contains("MSB3021", StringComparison.Ordinal))
+        {
+            if (!state.HasLockedFiles)
+            {
+                state.HasLockedFiles = true;
+                AnsiConsole.MarkupLine("[red][[build]][/] [red]✗[/] File locked — the gateway is still running.");
+                AnsiConsole.MarkupLine("[yellow][[build]][/] Run [dim]botnexus gateway stop[/] first, then retry.");
+            }
+            state.ErrorCount++;
             return;
         }
 
@@ -261,6 +297,7 @@ internal static partial class BuildOutputStreamer
         public int ProjectsBuilt;
         public int WarningCount;
         public int ErrorCount;
+        public bool HasLockedFiles;
         public string? Elapsed;
         public bool RestoreShown;
         public List<DiagnosticEntry> Diagnostics { get; } = [];

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -49,12 +49,12 @@ internal class UpdateCommand
     {
         var interactive = AnsiConsole.Profile.Capabilities.Interactive;
 
-        // Step 1: git pull
-        var pullResult = await RunPreStopStepsAsync(repoRoot, home, verbose, cancellationToken);
+        // Step 1: git pull (safe to do while gateway is running)
+        var pullResult = await RunGitPullStepAsync(repoRoot, verbose, cancellationToken);
         if (pullResult != 0)
             return pullResult;
 
-        // Step 2: Stop gateway BEFORE building to release file locks on Windows
+        // Step 2: Stop gateway BEFORE building — releases file locks on Windows
         GatewayStopResult stopResult;
         if (interactive)
         {
@@ -75,22 +75,40 @@ internal class UpdateCommand
         }
 
         if (!stopResult.Success)
-            AnsiConsole.MarkupLine($"[yellow]⚠[/] Could not stop gateway ({Markup.Escape(stopResult.Message ?? "not running")}). Continuing anyway.");
+            AnsiConsole.MarkupLine($"[yellow]\u26a0[/] Could not stop gateway ({Markup.Escape(stopResult.Message ?? "not running")}). Continuing anyway.");
         else
-            AnsiConsole.MarkupLine("[green]✓[/] Gateway stopped");
+            AnsiConsole.MarkupLine("[green]\u2713[/] Gateway stopped");
 
-        // Small grace period for file handles to release on Windows
-        await Task.Delay(500, cancellationToken);
+        // Wait for the port to be free — confirms the process has fully released file locks.
+        // On Windows this can take several seconds after the process exits.
+        if (interactive)
+        {
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(Style.Parse("dim"))
+                .StartAsync("Waiting for gateway to release file handles...", async ctx =>
+                {
+                    await WaitForPortFreeAsync(port, cancellationToken);
+                });
+        }
+        else
+        {
+            await WaitForPortFreeAsync(port, cancellationToken);
+        }
 
-        // Steps 3–5: build, deploy, start
+        // Steps 3 & 4: Build and deploy (gateway is now stopped, no file locks)
+        var buildResult = await RunBuildAndDeployAsync(repoRoot, home, verbose, cancellationToken);
+        if (buildResult != 0)
+            return buildResult;
+
+        // Step 5: Start
         return await RunRestartAsync(home, port, repoRoot, cancellationToken);
     }
 
     /// <summary>
-    /// Runs git pull, build, and extension deploy steps before the gateway restart.
-    /// Protected virtual so tests can override it to skip real git/build operations.
+    /// Runs git pull. Protected virtual so tests can override it.
     /// </summary>
-    protected virtual async Task<int> RunPreStopStepsAsync(string repoRoot, string home, bool verbose, CancellationToken cancellationToken)
+    protected virtual async Task<int> RunGitPullStepAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
     {
         var interactive = AnsiConsole.Profile.Capabilities.Interactive;
 
@@ -154,7 +172,18 @@ internal class UpdateCommand
             AnsiConsole.MarkupLine($"[green]✓[/] Pulled {countStr}: [dim]{Markup.Escape(Short(beforeSha))}[/] → [dim]{Markup.Escape(Short(afterSha))}[/]");
         }
 
-        // Step 2: Build
+        return 0;
+    }
+
+    /// <summary>
+    /// Runs build and deploy steps. Called after the gateway has been stopped.
+    /// Protected virtual so tests can override it.
+    /// </summary>
+    protected virtual async Task<int> RunBuildAndDeployAsync(string repoRoot, string home, bool verbose, CancellationToken cancellationToken)
+    {
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive;
+
+        // Build
         int buildResult;
         if (interactive && !verbose)
         {
@@ -181,7 +210,7 @@ internal class UpdateCommand
         }
         AnsiConsole.MarkupLine("[green]✓[/] Build succeeded");
 
-        // Step 3: Deploy extensions
+        // Deploy extensions
         int deployed = 0;
         if (interactive)
         {
@@ -367,6 +396,22 @@ internal class UpdateCommand
     /// Checks if a TCP port is available for binding. Mirrors ServeCommand.IsPortAvailable.
     /// Used to verify the port is free before starting the new gateway process.
     /// </summary>
+    /// <summary>
+    /// Waits until the given port is available (process released it) or timeout elapses.
+    /// Polls every 250ms for up to 15 seconds.
+    /// </summary>
+    private static async Task WaitForPortFreeAsync(int port, CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline && !cancellationToken.IsCancellationRequested)
+        {
+            if (IsPortAvailable(port))
+                return;
+            await Task.Delay(250, cancellationToken);
+        }
+        // If still not free, proceed anyway — build may still succeed if it's a different process
+    }
+
     internal static bool IsPortAvailable(int port)
     {
         try

--- a/tests/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -14,7 +14,11 @@ public class UpdateCommandTests
     private sealed class NoOpPreStopUpdateCommand(IGatewayProcessManager processManager)
         : UpdateCommand(processManager)
     {
-        protected override Task<int> RunPreStopStepsAsync(
+        protected override Task<int> RunGitPullStepAsync(
+            string repoRoot, bool verbose, CancellationToken cancellationToken)
+            => Task.FromResult(0);
+
+        protected override Task<int> RunBuildAndDeployAsync(
             string repoRoot, string home, bool verbose, CancellationToken cancellationToken)
             => Task.FromResult(0);
     }


### PR DESCRIPTION
Build and deploy were still happening before the gateway was stopped. The #151 fix moved stop into `ExecuteAsync` but the build and deploy remained inside `RunPreStopStepsAsync` which is called first.

**Wrong (0.1.5):** pull+build+deploy → stop → start

**Fixed:** pull → stop → build → deploy → start

Split `RunPreStopStepsAsync` into:
- `RunGitPullStepAsync` — git pull only (safe while gateway runs)  
- `RunBuildAndDeployAsync` — build + deploy (called after stop)

All Spectre.Console spinners and visual polish intact. 64/64 CLI tests pass.