### PR TITLE
chore: remove personal identifiers from tests, source and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Some docs have a YAML front-matter header indicating ownership:
 ```yaml
 ---
 owner: human          # human | ai | shared
-author: Jon Bullen
+author: BotNexus Team
 ai-policy: minimal    # minimal | collaborative | open
 ---
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -253,7 +253,7 @@ Content-Type: application/json
 **Side Effects:**
 - Config is backed up to `config.json.bak`
 - Agent workspace is bootstrapped with template files (SOUL.md, IDENTITY.md, etc.)
-- Agent name is normalized to lowercase with dashes (e.g., "My Agent" → "my-agent")
+- Agent name is normalized to lowercase with dashes (e.g., "My Agent" → my-agent")
 
 **Error Responses:**
 - `400 Bad Request` — Invalid configuration or duplicate agent name
@@ -836,7 +836,7 @@ X-Api-Key: your-api-key
 ```json
 {
   "input": "/skills list",
-  "agentId": "nova",
+  "agentId": "my-agent",
   "sessionId": "sess-123abc"
 }
 ```
@@ -854,7 +854,7 @@ Content-Type: application/json
 
 {
   "input": "/skills list",
-  "agentId": "nova",
+  "agentId": "my-agent",
   "sessionId": "sess-123abc"
 }
 ```
@@ -862,14 +862,14 @@ Content-Type: application/json
 **Response:** 200 OK
 ```json
 {
-  "title": "📚 Skills for nova",
+  "title": "📚 Skills for my-agent",
   "body": "Loaded (3):\n  ado-work-management          Unified ADO work management...\n  m365-communication           Microsoft 365 communication...\n  reference-bank               Shared reference data...\n\nAvailable (8):\n  calendar-interaction         Calendar management...\n  datetime-helper              Date/time utilities...\n  ...\n\nConfig: max 20 loaded, ~25K token budget, ~10.5K used",
   "isError": false
 }
 ```
 
 **Response Fields:**
-- `title` (string) — Display title for the result block (e.g., "📚 Skills for nova")
+- `title` (string) — Display title for the result block (e.g., "📚 Skills for my-agent")
 - `body` (string) — Result content (plain text, rendered in a preformatted block)
 - `isError` (boolean) — True if the command execution failed. When true, the client should render the body as an error message
 
@@ -883,7 +883,7 @@ Content-Type: application/json
 
 {
   "input": "/skills info ado-work-management",
-  "agentId": "nova",
+  "agentId": "my-agent",
   "sessionId": "sess-123abc"
 }
 ```
@@ -907,7 +907,7 @@ Content-Type: application/json
 
 {
   "input": "/skills add nonexistent-skill",
-  "agentId": "nova",
+  "agentId": "my-agent",
   "sessionId": "sess-123abc"
 }
 ```

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -1,6 +1,6 @@
 ---
 owner: human
-author: Jon Bullen
+author: BotNexus Team
 ai-policy: minimal
 # AI agents: this document is human-owned. Do not rewrite, restructure,
 # or remove content. Minor fixes (typos, broken links) are OK.

--- a/docs/development/workspace-and-memory.md
+++ b/docs/development/workspace-and-memory.md
@@ -171,7 +171,7 @@ Lead/Architect for BotNexus platform. You own architectural decisions, code revi
 # User
 
 ## About
-Jon Bullen, Product Owner and Technical Lead for BotNexus.
+BotNexus Team.
 
 ## Working Preferences
 - Prefer written communication and documentation over sync meetings
@@ -878,7 +878,7 @@ System prompt assembled at session start for "leela" agent:
 
 - Agent: leela
 - Platform: Windows 10.0 (Build 22621)
-- Workspace: C:\Users\jonbullen\.botnexus\agents\leela
+- Workspace: C:\Users\username\.botnexus\agents\leela
 - Time (UTC): 2026-04-02T15:30:45.1234567+00:00
 
 ### Guidelines
@@ -905,7 +905,7 @@ Lead/Architect for the engineering team. You own architectural decisions...
 ## USER.md
 
 ## About
-Jon Bullen, Product Owner and Technical Lead for BotNexus.
+BotNexus Team.
 
 ## Working Preferences
 - Prefer written communication and documentation over sync meetings

--- a/docs/extension-development.md
+++ b/docs/extension-development.md
@@ -1074,7 +1074,7 @@ Extension defaults are defined in the `gateway.extensions.defaults` section of `
     }
   },
   "agents": {
-    "nova": {
+    "my-agent": {
       "extensions": {
         "botnexus-skills": { "maxLoadedSkills": 30 }
       }
@@ -1090,7 +1090,7 @@ Extension defaults are defined in the `gateway.extensions.defaults` section of `
 ```json
 {
   "agents": {
-    "nova": {
+    "my-agent": {
       "extensions": {
         "botnexus-skills": { "enabled": true, "maxLoadedSkills": 20 },
         "botnexus-exec": { "enabled": true }
@@ -1118,7 +1118,7 @@ Extension defaults are defined in the `gateway.extensions.defaults` section of `
     }
   },
   "agents": {
-    "nova": {
+    "my-agent": {
       "extensions": {
         "botnexus-skills": { "maxLoadedSkills": 30 }
       }

--- a/docs/features/sub-agent-spawning.md
+++ b/docs/features/sub-agent-spawning.md
@@ -82,7 +82,7 @@ Sub-agent spawning extends the existing BotNexus session infrastructure. Sub-age
 ### Parent–Child Session Model
 
 ```text
-Parent Session (agent: nova, model: claude-opus-4.6)
+Parent Session (agent: my-agent, model: claude-opus-4.6)
   │
   ├── Sub-Agent Session (model: gpt-4.1)
   │     task: "Research compaction strategies..."

--- a/docs/planning/feature-conversation-topics/design-spec.md
+++ b/docs/planning/feature-conversation-topics/design-spec.md
@@ -125,7 +125,7 @@ public sealed record ChannelBinding
 {
     public string BindingId { get; set; } = Guid.NewGuid().ToString("N");
     public ChannelKey ChannelType { get; set; }
-    public string ExternalAddress { get; set; } = string.Empty; // e.g. telegram:5067802539
+    public string ExternalAddress { get; set; } = string.Empty; // e.g. telegram:1234567890
     public BindingMode Mode { get; set; } = BindingMode.Interactive;
     public ThreadingMode ThreadingMode { get; set; } = ThreadingMode.Single;
     public string? ThreadId { get; set; } // native thread/topic id when ThreadingMode = NativeThread
@@ -482,7 +482,7 @@ Current design assumes a single effective user per agent/channel context.
 
 ## Design Decisions
 
-The following were decided by Jon Bullen on 2026-04-27:
+The following were decided by BotNexus Team on 2026-04-27:
 
 1. **Name: `Conversation`** — More natural. Humans have conversations across any channel — in person, on the phone, via text.
 

--- a/docs/planning/feature-conversation-topics/research.md
+++ b/docs/planning/feature-conversation-topics/research.md
@@ -196,7 +196,7 @@ Agent
 ## Open Questions
 
 1. **Naming** — should the new container be `Conversation`, `Conversation`, or `Thread` (not chosen)?
-2. **Binding granularity** — is channel binding per provider (`telegram`) or per channel identity (`telegram chat 5067802539`)?
+2. **Binding granularity** — is channel binding per provider (`telegram`) or per channel identity (`telegram chat 1234567890`)?
 3. **Fan-out policy** — should all agent replies go to all bound channels by default, or should bindings support notification-only vs interactive modes?
 4. **Topic creation policy** — should every agent always have exactly one default topic at first boot, or only once first contacted?
 5. **Portal semantics** — when the user clicks "new conversation", does that create a new topic immediately or lazily on first message?

--- a/docs/planning/improvement-skills-path-resolution/design-spec.md
+++ b/docs/planning/improvement-skills-path-resolution/design-spec.md
@@ -50,16 +50,16 @@ Provides persistent, shared reference data storage for skills...
 
 ```
 ## Skill: reference-bank
-**Path:** C:\Users\jobullen\.botnexus\skills\reference-bank\
+**Path:** C:\Users\username\.botnexus\skills\reference-bank\
 
 # Reference Bank
 Provides persistent, shared reference data storage for skills...
 ```
 
 With the base path, the agent can:
-- `read("C:\Users\jobullen\.botnexus\skills\reference-bank\scripts\Resolve-UserDataRoot.ps1")`
-- `exec("powershell", "-File", "C:\Users\jobullen\.botnexus\skills\reference-bank\scripts\Sync-AdoFeatures.ps1")`
-- `ls("C:\Users\jobullen\.botnexus\skills\reference-bank\references\")`
+- `read("C:\Users\username\.botnexus\skills\reference-bank\scripts\Resolve-UserDataRoot.ps1")`
+- `exec("powershell", "-File", "C:\Users\username\.botnexus\skills\reference-bank\scripts\Sync-AdoFeatures.ps1")`
+- `ls("C:\Users\username\.botnexus\skills\reference-bank\references\")`
 
 Without it, the agent is blind to the skill's file tree.
 
@@ -93,9 +93,9 @@ When listing loaded skills, also show their base paths:
 ```
 ## Loaded Skills
 - **ado-work-management**: Unified ADO work management...
-  Path: C:\Users\jobullen\.botnexus\skills\ado-work-management\
+  Path: C:\Users\username\.botnexus\skills\ado-work-management\
 - **reference-bank**: Shared reference data...
-  Path: C:\Users\jobullen\.botnexus\skills\reference-bank\
+  Path: C:\Users\username\.botnexus\skills\reference-bank\
 ```
 
 Available (not-yet-loaded) skills don't need paths in the list — the agent can get the path when it loads.
@@ -106,7 +106,7 @@ For richer context, include a brief file listing alongside the path:
 
 ```
 ## Skill: ado-work-management
-**Path:** C:\Users\jobullen\.botnexus\skills\ado-work-management\
+**Path:** C:\Users\username\.botnexus\skills\ado-work-management\
 **Files:** SKILL.md, scripts/Sync-AdoFeatures.ps1, references/features.md, references/epics.md, workflows/daily.md
 ```
 

--- a/docs/planning/polyglot-extensions-prd.md
+++ b/docs/planning/polyglot-extensions-prd.md
@@ -1,6 +1,6 @@
 # PRD: Polyglot Extension System
 
-**Author:** Jon Bullen
+**Author:** BotNexus Team
 **Date:** 2026-04-08
 **Status:** Draft
 **Area:** Extension System / Platform Architecture

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -219,7 +219,7 @@ Controls which file paths agents can access via file tools (`read`, `write`, `ed
 ```json
 {
   "agents": {
-    "nova": {
+    "my-agent": {
       "fileAccess": {
         "allowedReadPaths": ["Q:/repos/botnexus"],
         "allowedWritePaths": ["Q:/repos/botnexus/docs/planning"],
@@ -409,9 +409,9 @@ Uses long polling by default (no public URL required). For webhook mode, add `"w
   "channels": {
     "telegram": {
       "bots": {
-        "larry-bot": {
+        "my-bot": {
           "botToken": "111:AAA...",
-          "agentId": "larry",
+          "agentId": "my-agent",
           "allowedChatIds": [123456789]
         },
         "assistant-bot": {

--- a/docs/user-guide/conversations.md
+++ b/docs/user-guide/conversations.md
@@ -125,13 +125,13 @@ If you want two agents to collaborate, you use one of:
 - **Shared memory** — agents can read from shared memory files/databases if configured, but this is outside the conversation model.
 
 ```
-Agent: larry          Agent: assistant
+Agent: my-agent          Agent: assistant
 │                     │
 Conversation A        Conversation B
-(Jon ↔ larry)         (Jon ↔ assistant)
+(User ↔ my-agent)         (Jon ↔ assistant)
 ```
 
-These are independent. A message sent to larry does not reach assistant.
+These are independent. A message sent to my-agent does not reach assistant.
 
 ---
 

--- a/tests/BotNexus.ConversationTests/ConversationBindingTests.cs
+++ b/tests/BotNexus.ConversationTests/ConversationBindingTests.cs
@@ -20,7 +20,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
 
         var convId = await CreateConversationAsync();
         var response = await fixture.Conversations.AddBindingAsync(
-            convId, "telegram", "5067802539", "Single");
+            convId, "telegram", "1234567890", "Single");
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
 
         var json = await response.Content.ReadAsStringAsync();
@@ -34,7 +34,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
         bidStr.ShouldNotContain("-");
 
         doc.GetProperty("channelType").GetString().ShouldBe("telegram");
-        doc.GetProperty("channelAddress").GetString().ShouldBe("5067802539");
+        doc.GetProperty("channelAddress").GetString().ShouldBe("1234567890");
 
         doc.TryGetProperty("threadId", out var threadId).ShouldBeTrue();
         threadId.ValueKind.ShouldBe(JsonValueKind.Null);
@@ -49,7 +49,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
         Skip.If(!fixture.IsAvailable, "Dev gateway not running at localhost:5006");
 
         var response = await fixture.Conversations.AddBindingAsync(
-            "c_doesnotexist", "telegram", "5067802539", "Single");
+            "c_doesnotexist", "telegram", "1234567890", "Single");
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
 
@@ -88,7 +88,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
 
         var convId = await CreateConversationAsync();
         var addResponse = await fixture.Conversations.AddBindingAsync(
-            convId, "telegram", "5067802539", "Single");
+            convId, "telegram", "1234567890", "Single");
         addResponse.StatusCode.ShouldBe(HttpStatusCode.Created);
         var bindingId = JsonDocument.Parse(await addResponse.Content.ReadAsStringAsync())
             .RootElement.GetProperty("bindingId").GetString()!;
@@ -104,7 +104,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
         var binding = bindings.EnumerateArray().First();
         binding.GetProperty("bindingId").GetString().ShouldBe(bindingId);
         binding.GetProperty("channelType").GetString().ShouldBe("telegram");
-        binding.GetProperty("channelAddress").GetString().ShouldBe("5067802539");
+        binding.GetProperty("channelAddress").GetString().ShouldBe("1234567890");
     }
 
     [SkippableFact]
@@ -118,7 +118,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
         var convId = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync())
             .RootElement.GetProperty("conversationId").GetString()!;
 
-        var addResponse = await fixture.Conversations.AddBindingAsync(convId, "telegram", "5067802539", "Single");
+        var addResponse = await fixture.Conversations.AddBindingAsync(convId, "telegram", "1234567890", "Single");
         addResponse.StatusCode.ShouldBe(HttpStatusCode.Created);
 
         var listResponse = await fixture.Conversations.GetConversationsAsync(agentId);
@@ -140,7 +140,7 @@ public class ConversationBindingTests(LiveGatewayFixture fixture, ITestOutputHel
 
         var convId = await CreateConversationAsync();
         var addResponse = await fixture.Conversations.AddBindingAsync(
-            convId, "telegram", "5067802539", "Single");
+            convId, "telegram", "1234567890", "Single");
         addResponse.StatusCode.ShouldBe(HttpStatusCode.Created);
         var bindingId = JsonDocument.Parse(await addResponse.Content.ReadAsStringAsync())
             .RootElement.GetProperty("bindingId").GetString()!;

--- a/tests/BotNexus.Domain.Tests/CrossWorldAgentReferenceTests.cs
+++ b/tests/BotNexus.Domain.Tests/CrossWorldAgentReferenceTests.cs
@@ -8,18 +8,18 @@ public sealed class CrossWorldAgentReferenceTests
     [Fact]
     public void TryParse_WithQualifiedAgentId_ReturnsWorldAndAgent()
     {
-        var parsed = CrossWorldAgentReference.TryParse(AgentId.From("world-b:leela"), out var reference);
+        var parsed = CrossWorldAgentReference.TryParse(AgentId.From("world-b:agent-c"), out var reference);
 
         parsed.ShouldBeTrue();
         reference.ShouldNotBeNull();
         reference!.WorldId.ShouldBe("world-b");
-        reference.AgentId.ShouldBe(AgentId.From("leela"));
+        reference.AgentId.ShouldBe(AgentId.From("agent-c"));
     }
 
     [Fact]
     public void TryParse_WithLocalAgentId_ReturnsFalse()
     {
-        var parsed = CrossWorldAgentReference.TryParse(AgentId.From("leela"), out var reference);
+        var parsed = CrossWorldAgentReference.TryParse(AgentId.From("agent-c"), out var reference);
 
         parsed.ShouldBeFalse();
         reference.ShouldBeNull();

--- a/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -21,9 +21,9 @@ public sealed class AgentExchangeServiceTests
     [Fact]
     public async Task ConverseAsync_SingleTurn_CreatesSealedAgentAgentSessionVisibleToBothAgents()
     {
-        var initiator = AgentId.From("nova");
-        var target = AgentId.From("leela");
-        var registry = CreateRegistry(initiator, target, ["leela"]);
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
         var sessionStore = new InMemorySessionStore();
 
         var handle = new Mock<IAgentHandle>();
@@ -57,8 +57,8 @@ public sealed class AgentExchangeServiceTests
         session.ShouldNotBeNull();
         session!.SessionType.ShouldBe(SessionType.AgentAgent);
         session.Status.ShouldBe(GatewaySessionStatus.Sealed);
-        session.Participants.Where(p => p.Type == ParticipantType.Agent && p.Id == "nova" && p.Role == "initiator").ShouldHaveSingleItem();
-        session.Participants.Where(p => p.Type == ParticipantType.Agent && p.Id == "leela" && p.Role == "target").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.Type == ParticipantType.Agent && p.Id == "test-agent" && p.Role == "initiator").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.Type == ParticipantType.Agent && p.Id == "agent-c" && p.Role == "target").ShouldHaveSingleItem();
 
         var initiatorExistence = await sessionStore.GetExistenceAsync(initiator, new ExistenceQuery());
         var targetExistence = await sessionStore.GetExistenceAsync(target, new ExistenceQuery());
@@ -69,8 +69,8 @@ public sealed class AgentExchangeServiceTests
     [Fact]
     public async Task ConverseAsync_WhenTargetNotAllowed_ThrowsUnauthorizedAccessException()
     {
-        var initiator = AgentId.From("nova");
-        var target = AgentId.From("leela");
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
         var registry = CreateRegistry(initiator, target, []);
         var service = new AgentExchangeService(
             registry.Object,
@@ -92,9 +92,9 @@ public sealed class AgentExchangeServiceTests
     [Fact]
     public async Task ConverseAsync_WhenCycleDetected_ThrowsInvalidOperationException()
     {
-        var initiator = AgentId.From("nova");
-        var target = AgentId.From("leela");
-        var registry = CreateRegistry(initiator, target, ["leela"]);
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
         var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
@@ -107,7 +107,7 @@ public sealed class AgentExchangeServiceTests
             InitiatorId = initiator,
             TargetId = target,
             Message = "hello",
-            CallChain = [AgentId.From("nova"), AgentId.From("leela")]
+            CallChain = [AgentId.From("test-agent"), AgentId.From("agent-c")]
         });
 
         (await action.ShouldThrowAsync<InvalidOperationException>())
@@ -117,9 +117,9 @@ public sealed class AgentExchangeServiceTests
     [Fact]
     public async Task ConverseAsync_WhenDepthExceeded_ThrowsInvalidOperationException()
     {
-        var initiator = AgentId.From("nova");
-        var target = AgentId.From("leela");
-        var registry = CreateRegistry(initiator, target, ["leela"]);
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
         var service = new AgentExchangeService(
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
@@ -132,7 +132,7 @@ public sealed class AgentExchangeServiceTests
             InitiatorId = initiator,
             TargetId = target,
             Message = "hello",
-            CallChain = [AgentId.From("alpha"), AgentId.From("nova")]
+            CallChain = [AgentId.From("alpha"), AgentId.From("test-agent")]
         });
 
         (await action.ShouldThrowAsync<InvalidOperationException>())
@@ -142,9 +142,9 @@ public sealed class AgentExchangeServiceTests
     [Fact]
     public async Task ConverseAsync_CrossWorldTarget_CreatesCrossWorldSessionAndRelaysMessage()
     {
-        var initiator = AgentId.From("nova");
-        var target = AgentId.From("world-b:leela");
-        var registry = CreateRegistry(initiator, AgentId.From("leela"), ["world-b:leela"]);
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("world-b:agent-c");
+        var registry = CreateRegistry(initiator, AgentId.From("agent-c"), ["world-b:agent-c"]);
         registry.Setup(r => r.Contains(target)).Returns(false);
         var sessionStore = new InMemorySessionStore();
 
@@ -184,7 +184,7 @@ public sealed class AgentExchangeServiceTests
                         {
                             TargetWorldId = "world-b",
                             AllowOutbound = true,
-                            AllowedAgents = ["nova"]
+                            AllowedAgents = ["test-agent"]
                         }
                     ],
                     CrossWorld = new CrossWorldFederationConfig
@@ -216,8 +216,8 @@ public sealed class AgentExchangeServiceTests
         var session = await sessionStore.GetAsync(result.SessionId);
         session.ShouldNotBeNull();
         session!.ChannelType.ShouldBe(ChannelKey.From("cross-world"));
-        session.Participants.Where(p => p.Id == "nova" && p.WorldId == "world-a").ShouldHaveSingleItem();
-        session.Participants.Where(p => p.Id == "leela" && p.WorldId == "world-b").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.Id == "test-agent" && p.WorldId == "world-a").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.Id == "agent-c" && p.WorldId == "world-b").ShouldHaveSingleItem();
 
         capturedRequest.ShouldNotBeNull();
         capturedRequest!.Headers.TryGetValues("X-Cross-World-Key", out var keys).ShouldBeTrue();
@@ -227,9 +227,9 @@ public sealed class AgentExchangeServiceTests
     [Fact]
     public async Task ConverseAsync_CrossWorldTargetWithoutOutboundPermission_ThrowsUnauthorizedAccessException()
     {
-        var initiator = AgentId.From("nova");
-        var target = AgentId.From("world-b:leela");
-        var registry = CreateRegistry(initiator, AgentId.From("leela"), ["world-b:leela"]);
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("world-b:agent-c");
+        var registry = CreateRegistry(initiator, AgentId.From("agent-c"), ["world-b:agent-c"]);
         registry.Setup(r => r.Contains(target)).Returns(false);
 
         var service = new AgentExchangeService(
@@ -248,7 +248,7 @@ public sealed class AgentExchangeServiceTests
                         {
                             TargetWorldId = "world-b",
                             AllowOutbound = false,
-                            AllowedAgents = ["nova"]
+                            AllowedAgents = ["test-agent"]
                         }
                     ],
                     CrossWorld = new CrossWorldFederationConfig

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -617,7 +617,7 @@ public sealed class TelegramChannelAdapterTests
         var adapter = CreateAdapter(new TelegramGatewayOptions
         {
             BotToken = "token",
-            AgentId = "larry",
+            AgentId = "agent-b",
             PollingTimeoutSeconds = 1,
             AllowedChatIds = { 42 }
         }, handler);
@@ -631,7 +631,7 @@ public sealed class TelegramChannelAdapterTests
         var message = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await adapter.StopAsync(CancellationToken.None);
 
-        message.TargetAgentId.ShouldBe("larry");
+        message.TargetAgentId.ShouldBe("agent-b");
         message.ChannelAddress.ShouldBe("42");
         message.Content.ShouldBe("hello");
     }

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramMultiBotTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramMultiBotTests.cs
@@ -61,7 +61,7 @@ public sealed class TelegramMultiBotTests
                 ["larry-bot"] = new TelegramBotConfig
                 {
                     BotToken = "token-larry",
-                    AgentId = "larry",
+                    AgentId = "agent-b",
                     AllowedChatIds = { 101 },
                     PollingTimeoutSeconds = 1
                 },
@@ -97,7 +97,7 @@ public sealed class TelegramMultiBotTests
         await twoMessagesSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await adapter.StopAsync(CancellationToken.None);
 
-        dispatchedMessages.ShouldContain(m => m.TargetAgentId == "larry" && m.Content == "hello from bot1");
+        dispatchedMessages.ShouldContain(m => m.TargetAgentId == "agent-b" && m.Content == "hello from bot1");
         dispatchedMessages.ShouldContain(m => m.TargetAgentId == "assistant" && m.Content == "hello from bot2");
     }
 

--- a/tests/BotNexus.Gateway.Tests/Commands/BuiltInCommandContributorTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Commands/BuiltInCommandContributorTests.cs
@@ -68,7 +68,7 @@ public sealed class BuiltInCommandContributorTests
         [
             new AgentDescriptor
             {
-                AgentId = AgentId.From("nova"),
+                AgentId = AgentId.From("test-agent"),
                 DisplayName = "Nova",
                 ModelId = "claude-sonnet-4.5",
                 ApiProvider = "copilot"
@@ -78,7 +78,7 @@ public sealed class BuiltInCommandContributorTests
         var result = await InvokeExecuteAsync(contributor, "/agents", "/agents");
 
         result.IsError.ShouldBeFalse();
-        result.Body.ToLowerInvariant().ShouldContain("nova");
+        result.Body.ToLowerInvariant().ShouldContain("test-agent");
     }
 
     [Fact]

--- a/tests/BotNexus.Gateway.Tests/Commands/CommandsControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Commands/CommandsControllerTests.cs
@@ -100,7 +100,7 @@ public sealed class CommandsControllerTests
                       ?? throw new InvalidOperationException($"Could not create {requestType.Name}.");
 
         SetPropertyIfPresent(requestType, request, "Input", input);
-        SetPropertyIfPresent(requestType, request, "AgentId", "nova");
+        SetPropertyIfPresent(requestType, request, "AgentId", "test-agent");
         SetPropertyIfPresent(requestType, request, "SessionId", "session-1");
         return request;
     }

--- a/tests/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
@@ -359,7 +359,7 @@ public sealed class PlatformConfigValidationTests
                     "botnexus-mcp": { "enabled": true, "servers": ["filesystem"] }
                   },
                   "metadata": {
-                    "owner": "jon",
+                    "owner": "test-user",
                     "priority": 1
                   }
                 }
@@ -386,7 +386,7 @@ public sealed class PlatformConfigValidationTests
                 agent.Extensions.ShouldContainKey("botnexus-mcp");
                 agent.Extensions!["botnexus-mcp"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
                 agent.Metadata.ShouldNotBeNull();
-                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("jon");
+                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("test-user");
                 SerializeShouldNotThrow(config);
             });
 
@@ -1578,7 +1578,7 @@ public sealed class PlatformConfigValidationTests
                   "provider": "copilot",
                   "model": "gpt-4.1",
                   "metadata": {
-                    "owner": "jon",
+                    "owner": "test-user",
                     "tags": ["core", "test"]
                   },
                   "isolationOptions": {
@@ -1602,7 +1602,7 @@ public sealed class PlatformConfigValidationTests
 
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
                 config.Gateway!.Extensions!.Defaults!["botnexus-skills"].GetProperty("paths")[0].GetString().ShouldBe("skills");
-                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("jon");
+                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("test-user");
                 agent.IsolationOptions!.Value.GetProperty("timeout").GetInt32().ShouldBe(30);
                 agent.Extensions!["botnexus-exec"].GetProperty("shell").GetString().ShouldBe("bash");
                 SerializeShouldNotThrow(config);

--- a/tests/BotNexus.Gateway.Tests/Configuration/SchemaValidationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Configuration/SchemaValidationTests.cs
@@ -215,11 +215,11 @@ public sealed class SchemaValidationTests
                   },
                   "providers": { "copilot": { "enabled": true, "apiKey": "test" } },
                   "agents": {
-                    "larry": {
+                    "agent-b": {
                       "provider": "copilot",
                       "model": "gpt-4.1",
                       "extensions": { "botnexus-mcp": { "enabled": true } },
-                      "metadata": { "owner": "jon" },
+                      "metadata": { "owner": "test-user" },
                       "isolationOptions": { "timeout": 30 }
                     }
                   }
@@ -232,8 +232,8 @@ public sealed class SchemaValidationTests
             errors.ShouldBeEmpty();
             config.Gateway?.Extensions?.Defaults.ShouldNotBeNull();
             config.Gateway!.Extensions!.Defaults!.ShouldContainKey("botnexus-skills");
-            config.Agents!["larry"].Extensions.ShouldNotBeNull();
-            config.Agents["larry"].Extensions!.ShouldContainKey("botnexus-mcp");
+            config.Agents!["agent-b"].Extensions.ShouldNotBeNull();
+            config.Agents["agent-b"].Extensions!.ShouldContainKey("botnexus-mcp");
         }
         finally
         {

--- a/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -28,7 +28,7 @@ public sealed class CrossWorldFederationControllerTests
                     {
                         TargetWorldId = "world-a",
                         AllowInbound = true,
-                        AllowedAgents = ["leela"]
+                        AllowedAgents = ["agent-c"]
                     }
                 ],
                 CrossWorld = new CrossWorldFederationConfig
@@ -44,12 +44,12 @@ public sealed class CrossWorldFederationControllerTests
         };
 
         var registry = new Mock<IAgentRegistry>();
-        registry.Setup(r => r.Contains(AgentId.From("leela"))).Returns(true);
+        registry.Setup(r => r.Contains(AgentId.From("agent-c"))).Returns(true);
         var handle = new Mock<IAgentHandle>();
         handle.Setup(h => h.PromptAsync("Hello from world-a", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentResponse { Content = "Hello back from world-b" });
         var supervisor = new Mock<IAgentSupervisor>();
-        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From("leela"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From("agent-c"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
         var sessions = new InMemorySessionStore();
         var platformConfigMonitor = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
@@ -72,8 +72,8 @@ public sealed class CrossWorldFederationControllerTests
             new CrossWorldRelayRequest
             {
                 SourceWorldId = "world-a",
-                SourceAgentId = "nova",
-                TargetAgentId = "leela",
+                SourceAgentId = "test-agent",
+                TargetAgentId = "agent-c",
                 Message = "Hello from world-a",
                 ChannelAddress = "nova::cross::leela::abc123"
             },
@@ -87,8 +87,8 @@ public sealed class CrossWorldFederationControllerTests
         var savedSession = await sessions.GetAsync(SessionId.From(payload.SessionId));
         savedSession.ShouldNotBeNull();
         savedSession!.ChannelType.ShouldBe(ChannelKey.From("cross-world"));
-        savedSession.Participants.Where(p => p.Id == "nova" && p.WorldId == "world-a").ShouldHaveSingleItem();
-        savedSession.Participants.Where(p => p.Id == "leela" && p.WorldId == "world-b").ShouldHaveSingleItem();
+        savedSession.Participants.Where(p => p.Id == "test-agent" && p.WorldId == "world-a").ShouldHaveSingleItem();
+        savedSession.Participants.Where(p => p.Id == "agent-c" && p.WorldId == "world-b").ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public sealed class CrossWorldFederationControllerTests
                     {
                         TargetWorldId = "world-a",
                         AllowInbound = true,
-                        AllowedAgents = ["leela"]
+                        AllowedAgents = ["agent-c"]
                     }
                 ],
                 CrossWorld = new CrossWorldFederationConfig
@@ -120,7 +120,7 @@ public sealed class CrossWorldFederationControllerTests
         };
 
         var registry = new Mock<IAgentRegistry>();
-        registry.Setup(r => r.Contains(AgentId.From("leela"))).Returns(true);
+        registry.Setup(r => r.Contains(AgentId.From("agent-c"))).Returns(true);
         var platformConfigMonitor2 = new StaticOptionsMonitor<PlatformConfig>(platformConfig);
         var controller = new CrossWorldFederationController(
             registry.Object,
@@ -140,8 +140,8 @@ public sealed class CrossWorldFederationControllerTests
             new CrossWorldRelayRequest
             {
                 SourceWorldId = "world-a",
-                SourceAgentId = "nova",
-                TargetAgentId = "leela",
+                SourceAgentId = "test-agent",
+                TargetAgentId = "agent-c",
                 Message = "hello",
                 ChannelAddress = "c-1"
             },

--- a/tests/BotNexus.Gateway.Tests/FileAgentConfigurationWriterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FileAgentConfigurationWriterTests.cs
@@ -24,21 +24,21 @@ public sealed class FileAgentConfigurationWriterTests : IDisposable
     public async Task SaveAsync_WritesConfigAndCreatesWorkspace()
     {
         var writer = new FileAgentConfigurationWriter(_configDirectory, _home, _fileSystem);
-        var descriptor = CreateDescriptor("nova");
+        var descriptor = CreateDescriptor("test-agent");
 
         await writer.SaveAsync(descriptor);
 
-        var configPath = Path.Combine(_configDirectory, "nova.json");
+        var configPath = Path.Combine(_configDirectory, "test-agent.json");
         _fileSystem.File.Exists(configPath).ShouldBeTrue();
-        _fileSystem.Directory.Exists(Path.Combine(_home.AgentsPath, "nova")).ShouldBeTrue();
-        _fileSystem.File.Exists(Path.Combine(_home.AgentsPath, "nova", "workspace", "SOUL.md")).ShouldBeTrue();
+        _fileSystem.Directory.Exists(Path.Combine(_home.AgentsPath, "test-agent")).ShouldBeTrue();
+        _fileSystem.File.Exists(Path.Combine(_home.AgentsPath, "test-agent", "workspace", "SOUL.md")).ShouldBeTrue();
     }
 
     [Fact]
     public async Task SaveAsync_UsesCamelCaseAndOmitsNulls()
     {
         var writer = new FileAgentConfigurationWriter(_configDirectory, _home, _fileSystem);
-        var descriptor = CreateDescriptor("nova") with
+        var descriptor = CreateDescriptor("test-agent") with
         {
             Description = null,
             SystemPromptFile = null,
@@ -48,8 +48,8 @@ public sealed class FileAgentConfigurationWriterTests : IDisposable
 
         await writer.SaveAsync(descriptor);
 
-        var json = await _fileSystem.File.ReadAllTextAsync(Path.Combine(_configDirectory, "nova.json"));
-        json.ShouldContain("\"agentId\": \"nova\"");
+        var json = await _fileSystem.File.ReadAllTextAsync(Path.Combine(_configDirectory, "test-agent.json"));
+        json.ShouldContain("\"agentId\": \"test-agent\"");
         json.ShouldContain("\"subAgentIds\": [");
         json.ShouldContain("\"toolIds\": [");
         json.ShouldNotContain("\"description\"");
@@ -60,17 +60,17 @@ public sealed class FileAgentConfigurationWriterTests : IDisposable
     public async Task DeleteAsync_RemovesConfigFile()
     {
         var writer = new FileAgentConfigurationWriter(_configDirectory, _home, _fileSystem);
-        await writer.SaveAsync(CreateDescriptor("nova"));
+        await writer.SaveAsync(CreateDescriptor("test-agent"));
 
-        await writer.DeleteAsync("nova");
+        await writer.DeleteAsync("test-agent");
 
-        _fileSystem.File.Exists(Path.Combine(_configDirectory, "nova.json")).ShouldBeFalse();
+        _fileSystem.File.Exists(Path.Combine(_configDirectory, "test-agent.json")).ShouldBeFalse();
     }
 
     [Fact]
     public async Task SaveAsync_PreservesRoundTripCompatibilityWithSource()
     {
-        var descriptor = CreateDescriptor("nova") with
+        var descriptor = CreateDescriptor("test-agent") with
         {
             Metadata = new Dictionary<string, object?> { ["owner"] = "gateway" },
             IsolationOptions = new Dictionary<string, object?> { ["timeoutMs"] = 1000 }

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigAgentWriterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigAgentWriterTests.cs
@@ -24,7 +24,7 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
     public async Task SaveAsync_WritesAgentIntoConfigAndCreatesWorkspace()
     {
         var writer = new PlatformConfigAgentWriter(_configPath, _home, _fileSystem);
-        var descriptor = CreateDescriptor("nova") with
+        var descriptor = CreateDescriptor("test-agent") with
         {
             AllowedModelIds = ["claude-sonnet-4.5"],
             ToolIds = ["read"],
@@ -36,11 +36,11 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
         await writer.SaveAsync(descriptor);
 
         var root = await ReadConfigAsync();
-        var agent = root["agents"]!["nova"]!;
+        var agent = root["agents"]!["test-agent"]!;
 
         agent["provider"]!.GetValue<string>().ShouldBe("github-copilot");
         agent["model"]!.GetValue<string>().ShouldBe("claude-sonnet-4.5");
-        agent["displayName"]!.GetValue<string>().ShouldBe("nova");
+        agent["displayName"]!.GetValue<string>().ShouldBe("test-agent");
         agent["enabled"]!.GetValue<bool>().ShouldBeTrue();
         agent["allowedModels"]!.AsArray().ShouldHaveSingleItem()!.GetValue<string>().ShouldBe("claude-sonnet-4.5");
         agent["toolIds"]!.AsArray().ShouldHaveSingleItem()!.GetValue<string>().ShouldBe("read");
@@ -48,8 +48,8 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
         agent["metadata"]!["owner"]!.GetValue<string>().ShouldBe("gateway");
         agent["isolationOptions"]!["timeoutMs"]!.GetValue<int>().ShouldBe(1000);
 
-        _fileSystem.Directory.Exists(Path.Combine(_home.AgentsPath, "nova")).ShouldBeTrue();
-        _fileSystem.File.Exists(Path.Combine(_home.AgentsPath, "nova", "workspace", "SOUL.md")).ShouldBeTrue();
+        _fileSystem.Directory.Exists(Path.Combine(_home.AgentsPath, "test-agent")).ShouldBeTrue();
+        _fileSystem.File.Exists(Path.Combine(_home.AgentsPath, "test-agent", "workspace", "SOUL.md")).ShouldBeTrue();
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
               "version": 1,
               "customRootField": "preserve-me",
               "agents": {
-                "nova": {
+                "test-agent": {
                   "customAgentField": "keep"
                 }
               }
@@ -68,7 +68,7 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
             """);
 
         var writer = new PlatformConfigAgentWriter(_configPath, _home, _fileSystem);
-        await writer.SaveAsync(CreateDescriptor("nova") with
+        await writer.SaveAsync(CreateDescriptor("test-agent") with
         {
             Description = null,
             SystemPromptFile = null,
@@ -79,7 +79,7 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
         });
 
         var root = await ReadConfigAsync();
-        var agent = root["agents"]!["nova"]!;
+        var agent = root["agents"]!["test-agent"]!;
 
         root["customRootField"]!.GetValue<string>().ShouldBe("preserve-me");
         agent["customAgentField"]!.GetValue<string>().ShouldBe("keep");
@@ -97,17 +97,17 @@ public sealed class PlatformConfigAgentWriterTests : IDisposable
         await _fileSystem.File.WriteAllTextAsync(_configPath, """
             {
               "agents": {
-                "nova": { "provider": "github-copilot", "model": "gpt-4.1" },
+                "test-agent": { "provider": "github-copilot", "model": "gpt-4.1" },
                 "other": { "provider": "openai", "model": "gpt-4.1" }
               }
             }
             """);
 
         var writer = new PlatformConfigAgentWriter(_configPath, _home, _fileSystem);
-        await writer.DeleteAsync("nova");
+        await writer.DeleteAsync("test-agent");
 
         var root = await ReadConfigAsync();
-        root["agents"]!["nova"].ShouldBeNull();
+        root["agents"]!["test-agent"].ShouldBeNull();
         root["agents"]!["other"].ShouldNotBeNull();
     }
 

--- a/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
@@ -262,7 +262,7 @@ public sealed class SqliteConversationStoreTests
         await seedStore.CreateAsync(new Conversation
         {
             ConversationId = convId,
-            AgentId = Agent("nova"),
+            AgentId = Agent("test-agent"),
             Title = "signalr:nova",
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,

--- a/tests/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Tools/AgentConverseToolTests.cs
@@ -15,7 +15,7 @@ public sealed class AgentConverseToolTests
     [Fact]
     public void Tool_HasExpectedNameAndLabel()
     {
-        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), "nova", "session-1");
+        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), "test-agent", "session-1");
         tool.Name.ShouldBe("agent_converse");
         tool.Label.ShouldBe("Agent Converse");
     }
@@ -23,7 +23,7 @@ public sealed class AgentConverseToolTests
     [Fact]
     public async Task PrepareArgumentsAsync_WhenRequiredArgsMissing_Throws()
     {
-        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), "nova", "session-1");
+        var tool = new AgentConverseTool(Mock.Of<IAgentExchangeService>(), new InMemorySessionStore(), "test-agent", "session-1");
 
         Func<Task> action = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?>());
 
@@ -47,19 +47,19 @@ public sealed class AgentConverseToolTests
             });
 
         var store = new InMemorySessionStore();
-        var session = await store.GetOrCreateAsync("session-1", "nova");
-        session.Metadata["callChain"] = new[] { "alpha", "nova" };
+        var session = await store.GetOrCreateAsync("session-1", "test-agent");
+        session.Metadata["callChain"] = new[] { "alpha", "test-agent" };
         await store.SaveAsync(session);
 
-        var tool = new AgentConverseTool(service.Object, store, "nova", "session-1");
+        var tool = new AgentConverseTool(service.Object, store, "test-agent", "session-1");
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
-            ["agentId"] = "leela",
+            ["agentId"] = "agent-c",
             ["message"] = "Review this plan"
         });
 
         captured.ShouldNotBeNull();
-        captured!.CallChain.Select(id => id.Value).ShouldBe(new[] { "alpha", "nova" });
+        captured!.CallChain.Select(id => id.Value).ShouldBe(new[] { "alpha", "test-agent" });
     }
 
     [Fact]
@@ -79,16 +79,16 @@ public sealed class AgentConverseToolTests
             });
 
         var store = new InMemorySessionStore();
-        var tool = new AgentConverseTool(service.Object, store, "nova", "session-1");
+        var tool = new AgentConverseTool(service.Object, store, "test-agent", "session-1");
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
-            ["agentId"] = "leela",
+            ["agentId"] = "agent-c",
             ["message"] = "Review this plan",
             ["maxTurns"] = 3
         });
 
         captured.ShouldNotBeNull();
-        captured!.CallChain.ShouldHaveSingleItem().Value.ShouldBe("nova");
+        captured!.CallChain.ShouldHaveSingleItem().Value.ShouldBe("test-agent");
         captured.MaxTurns.ShouldBe(3);
         ReadText(result).ShouldContain("\"sessionId\"");
     }

--- a/tests/BotNexus.Skills.Tests/SkillsCommandContributorTests.cs
+++ b/tests/BotNexus.Skills.Tests/SkillsCommandContributorTests.cs
@@ -231,7 +231,7 @@ public sealed class SkillsCommandContributorTests
             RawInput = $"/skills {subCommand} {string.Join(" ", arguments)}".Trim(),
             SubCommand = subCommand,
             Arguments = arguments,
-            AgentId = "nova",
+            AgentId = "test-agent",
             SessionId = "session-1",
             HomeDirectory = @"Q:\repos\botnexus",
             ResolveSessionTool = name => string.Equals(name, "skills", StringComparison.OrdinalIgnoreCase) ? skillTool : null


### PR DESCRIPTION
Removes personal names, agent IDs, user IDs and paths from all source code, tests and live documentation.

## Replacements

### Tests (14 files)
- `"nova"` → `"test-agent"`
- `"larry"` → `"agent-b"`
- `"leela"` → `"agent-c"`
- `"owner": "jon"` → `"owner": "test-user"`
- `5067802539` → `1234567890`

### Live docs (10 files)
- Agent ID examples: `nova`, `larry` → `my-agent`, `assistant`
- Author fields: `Jon Bullen` → `BotNexus Team`
- Paths: `C:\\Users\\jobullen\\` → `C:\\Users\\username\\`
- User ID: `5067802539` → `1234567890`

## Not touched
- `docs/archive/` — historical
- `docs/planning/archived/` — historical  
- `CHANGELOG.md` / `docs/releases/` — release history
- `.squad/` — internal squad files