### PR TITLE
fix(webtool): add structured logging to web search — diagnose 400 errors

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/Search/CopilotMcpSearchProvider.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/Search/CopilotMcpSearchProvider.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using BotNexus.Extensions.Mcp;
@@ -17,6 +18,7 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
     private readonly Func<CancellationToken, Task<string?>> _copilotApiKeyResolver;
     private readonly HttpClient _httpClient;
     private readonly string _endpoint;
+    private readonly ILogger<CopilotMcpSearchProvider> _logger;
     private readonly SemaphoreSlim _clientGate = new(1, 1);
     private McpClient? _client;
     private bool _disposed;
@@ -24,11 +26,13 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
     public CopilotMcpSearchProvider(
         Func<CancellationToken, Task<string?>> copilotApiKeyResolver,
         HttpClient httpClient,
-        string? endpoint = null)
+        string? endpoint = null,
+        ILogger<CopilotMcpSearchProvider>? logger = null)
     {
         _copilotApiKeyResolver = copilotApiKeyResolver;
         _httpClient = httpClient;
         _endpoint = string.IsNullOrWhiteSpace(endpoint) ? DefaultEndpoint : endpoint;
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<CopilotMcpSearchProvider>.Instance;
     }
 
     public async Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
@@ -39,6 +43,7 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
 
     private async Task<IReadOnlyList<SearchResult>> SearchWithRetryAsync(string query, int maxResults, bool isRetry, CancellationToken ct)
     {
+        _logger.LogInformation("CopilotMcpSearch: querying endpoint={Endpoint} query={Query} isRetry={IsRetry}", _endpoint, query, isRetry);
         var client = await GetOrCreateClientAsync(ct).ConfigureAwait(false);
         var arguments = JsonSerializer.SerializeToElement(new { query });
 
@@ -49,7 +54,7 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
         }
         catch (McpException ex) when (!isRetry)
         {
-            // Token may have rotated — invalidate cached client and retry once
+            _logger.LogWarning(ex, "CopilotMcpSearch: MCP error on first attempt, invalidating client and retrying. Error={Error}", ex.Message);
             await InvalidateClientAsync().ConfigureAwait(false);
             if (ex.Message.Contains("401", StringComparison.Ordinal) ||
                 ex.Message.Contains("400", StringComparison.Ordinal) ||
@@ -63,7 +68,7 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
         }
         catch (HttpRequestException ex) when (!isRetry && (ex.StatusCode == System.Net.HttpStatusCode.BadRequest || ex.StatusCode == System.Net.HttpStatusCode.Unauthorized))
         {
-            // Token rotation — invalidate and retry once
+            _logger.LogWarning(ex, "CopilotMcpSearch: HTTP {Status} on first attempt, invalidating client and retrying", ex.StatusCode);
             await InvalidateClientAsync().ConfigureAwait(false);
             return await SearchWithRetryAsync(query, maxResults, isRetry: true, ct).ConfigureAwait(false);
         }
@@ -78,10 +83,14 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
                     .Where(static text => !string.IsNullOrWhiteSpace(text)));
 
             var detail = string.IsNullOrWhiteSpace(errorText) ? "no additional details." : errorText;
+            _logger.LogError("CopilotMcpSearch: tool returned error: {Detail}", detail);
             throw new InvalidOperationException($"Copilot MCP web_search returned an error: {detail}");
         }
 
-        return ParseResults(callResult.Content, maxResults);
+        _logger.LogDebug("CopilotMcpSearch: raw response contentItems={Count}", callResult.Content.Count);
+        var parsed = ParseResults(callResult.Content, maxResults);
+        _logger.LogInformation("CopilotMcpSearch: parsed {ResultCount} results for query={Query}", parsed.Count, query);
+        return parsed;
     }
 
     public async ValueTask DisposeAsync()
@@ -126,9 +135,14 @@ internal sealed class CopilotMcpSearchProvider : ISearchProvider, IAsyncDisposab
             if (_client is not null)
                 return _client;
 
+            _logger.LogDebug("CopilotMcpSearch: resolving Copilot API token");
             var apiKey = await _copilotApiKeyResolver(ct).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                _logger.LogError("CopilotMcpSearch: no Copilot token available");
                 throw new InvalidOperationException("Copilot token unavailable. Sign in again to refresh authentication.");
+            }
+            _logger.LogDebug("CopilotMcpSearch: initialising MCP client at {Endpoint}", _endpoint);
 
             var headers = new Dictionary<string, string>(StringComparer.Ordinal)
             {

--- a/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
@@ -4,6 +4,7 @@ using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Extensions.WebTools.Search;
 using BotNexus.Agent.Providers.Core.Models;
+using Microsoft.Extensions.Logging;
 
 namespace BotNexus.Extensions.WebTools;
 
@@ -18,6 +19,8 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
     private readonly bool _ownsHttpClient;
     private readonly Func<CancellationToken, Task<string?>>? _copilotApiKeyResolver;
     private readonly string? _copilotApiEndpoint;
+    private readonly ILogger<WebSearchTool> _logger;
+    private readonly ILoggerFactory? _loggerFactory;
     private readonly object _providerGate = new();
     private ISearchProvider? _provider;
     private bool _disposed;
@@ -26,11 +29,15 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
         WebSearchConfig config,
         HttpClient? httpClient = null,
         Func<CancellationToken, Task<string?>>? copilotApiKeyResolver = null,
-        string? copilotApiEndpoint = null)
+        string? copilotApiEndpoint = null,
+        ILogger<WebSearchTool>? logger = null,
+        ILoggerFactory? loggerFactory = null)
     {
         _config = config;
         _copilotApiKeyResolver = copilotApiKeyResolver;
         _copilotApiEndpoint = copilotApiEndpoint;
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<WebSearchTool>.Instance;
+        _loggerFactory = loggerFactory;
 
         if (httpClient is not null)
         {
@@ -100,6 +107,7 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
 
         var query = (string)arguments["query"]!;
         var providerName = _config.Provider.ToLowerInvariant();
+        _logger.LogInformation("WebSearch executing: provider={Provider} query={Query} maxResults={MaxResults}", providerName, query, _config.MaxResults);
         var isCopilot = string.Equals(providerName, "copilot", StringComparison.Ordinal);
         var apiKey = string.Empty;
 
@@ -125,6 +133,7 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
         {
             var results = await provider.SearchAsync(query, _config.MaxResults, cancellationToken)
                 .ConfigureAwait(false);
+            _logger.LogInformation("WebSearch completed: provider={Provider} query={Query} resultCount={Count}", providerName, query, results.Count);
 
             if (results.Count == 0)
             {
@@ -152,6 +161,7 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
         }
         catch (HttpRequestException ex)
         {
+            _logger.LogError(ex, "WebSearch HTTP error: provider={Provider} query={Query} status={Status}", providerName, query, ex.StatusCode);
             return TextResult($"Search API error: {ex.Message}");
         }
         catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -177,7 +187,8 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
                 "tavily" when !string.IsNullOrWhiteSpace(apiKey) => new TavilySearchProvider(_httpClient, apiKey),
                 "bing" when !string.IsNullOrWhiteSpace(apiKey) => new BingSearchProvider(_httpClient, apiKey),
                 "copilot" when _copilotApiKeyResolver is not null =>
-                    new CopilotMcpSearchProvider(_copilotApiKeyResolver, _httpClient, _copilotApiEndpoint),
+                    new CopilotMcpSearchProvider(_copilotApiKeyResolver, _httpClient, _copilotApiEndpoint,
+                        _loggerFactory?.CreateLogger<CopilotMcpSearchProvider>()),
                 _ => null
             };
         }

--- a/src/extensions/BotNexus.Extensions.WebTools/WebToolsContributor.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebToolsContributor.cs
@@ -1,6 +1,7 @@
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging;
 
 namespace BotNexus.Extensions.WebTools;
 
@@ -9,6 +10,13 @@ namespace BotNexus.Extensions.WebTools;
 /// </summary>
 public sealed class WebToolsContributor : IAgentToolContributor
 {
+    private readonly ILoggerFactory? _loggerFactory;
+
+    public WebToolsContributor(ILoggerFactory? loggerFactory = null)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
     /// <inheritdoc />
     public Task<AgentToolContribution> ContributeAsync(
         AgentToolContributionContext context,
@@ -40,7 +48,8 @@ public sealed class WebToolsContributor : IAgentToolContributor
                     copilotApiKeyResolver: useCopilotProvider
                         ? ct => context.GetProviderApiKeyAsync(context.Descriptor.ApiProvider, ct)
                         : null,
-                    copilotApiEndpoint: copilotApiEndpoint));
+                    copilotApiEndpoint: copilotApiEndpoint,
+                    logger: _loggerFactory?.CreateLogger<WebSearchTool>()));
             }
         }
 


### PR DESCRIPTION
Adds structured logging throughout the web search path so failures are visible in logs instead of surfacing as silent 'Search API error: ...' messages.

## What's logged now
- `Information`: query start (provider, query, maxResults), completion (result count)
- `Warning`: retry triggered with HTTP status code
- `Error`: HTTP errors with status code, provider errors, missing Copilot token
- `Debug`: token resolution, MCP client initialisation, raw response item count

## Example log output
```
[INF] WebSearch executing: provider=copilot query="current weather" maxResults=5
[INF] CopilotMcpSearch: querying endpoint=https://api.githubcopilot.com/mcp query="current weather" isRetry=False
[DBG] CopilotMcpSearch: resolving Copilot API token
[DBG] CopilotMcpSearch: initialising MCP client at https://api.githubcopilot.com/mcp
[WRN] CopilotMcpSearch: HTTP BadRequest on first attempt, invalidating client and retrying
[INF] CopilotMcpSearch: querying endpoint=... isRetry=True
```