### PR TITLE
fix(gateway): Steer returns session ID so portal tracks new session on fallthrough

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -80,7 +80,9 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
-            await _hub.SteerAsync(agentId, agent.ActiveConversationSessionId!, content);
+            var result = await _hub.SteerAsync(agentId, agent.ActiveConversationSessionId!, content);
+            _store.RegisterSession(agentId, result.SessionId, result.ChannelType);
+            await RefreshConversationsForAgentAsync(agentId);
         }
         catch (Exception ex)
         {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
@@ -125,8 +125,8 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     }
 
     /// <summary>Steer an in-progress agent response.</summary>
-    public async Task SteerAsync(string agentId, string sessionId, string content)
-        => await _connection!.InvokeAsync("Steer", agentId, sessionId, content);
+    public async Task<SendMessageResult> SteerAsync(string agentId, string sessionId, string content)
+        => await _connection!.InvokeAsync<SendMessageResult>("Steer", agentId, sessionId, content);
 
     /// <summary>Send a follow-up message into an existing session.</summary>
     public async Task FollowUpAsync(string agentId, string sessionId, string content)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -339,20 +339,26 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <param name="sessionId">The session id.</param>
     /// <param name="content">The content.</param>
     /// <returns>The steer result.</returns>
-    public Task Steer(AgentId agentId, SessionId sessionId, string content)
+    public async Task<SendMessageResult> Steer(AgentId agentId, SessionId sessionId, string content)
     {
         var typedAgentId = NormalizeAgentId(agentId);
-        var typedSessionId = NormalizeSessionId(sessionId);
-        var connectionId = Context.ConnectionId;
+        var typedChannelType = ChannelKey.From("signalr");
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
+
+        // Resolve the actual session that will handle this steer — may differ from the
+        // requested sessionId if the old session was sealed and the router created a new one.
+        var session = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType);
+        await SubscribeInternalAsync(session.SessionId);
+
+        var connectionId = Context.ConnectionId;
         _ = SafeDispatchAsync(
             () => _dispatcher.DispatchAsync(
                 new InboundMessage
                 {
-                    ChannelType = ChannelKey.From("signalr"),
+                    ChannelType = typedChannelType,
                     SenderId = connectionId,
-                    ChannelAddress = typedAgentId.Value, // stable per-agent address — one portal conversation per agent
-                    SessionId = typedSessionId.Value,
+                    ChannelAddress = typedAgentId.Value,
+                    SessionId = session.SessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
                     Metadata = new Dictionary<string, object?>
@@ -363,8 +369,9 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 },
                 CancellationToken.None),
             typedAgentId,
-            typedSessionId);
-        return Task.CompletedTask;
+            session.SessionId);
+
+        return new SendMessageResult(session.SessionId.Value, typedAgentId.Value, typedChannelType.Value);
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -260,10 +260,13 @@ public sealed class DefaultConversationRouter : IConversationRouter
         if (conversation.ActiveSessionId.HasValue)
         {
             var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
-            if (existingSession is { Status: not SessionStatus.Sealed and not SessionStatus.Expired })
+            if (existingSession is { Status: not SessionStatus.Sealed })
             {
+                // Reuse Active AND Expired sessions — GatewayHost reactivates Expired sessions.
+                // Only Sealed sessions (explicit reset/archive) should trigger a new session.
                 sessionId = conversation.ActiveSessionId.Value;
-                _logger.LogDebug("Reusing active session {SessionId} for conversation {ConversationId}", sessionId, conversation.ConversationId);
+                _logger.LogDebug("Reusing {Status} session {SessionId} for conversation {ConversationId}",
+                    existingSession.Status, sessionId, conversation.ConversationId);
             }
             else
             {


### PR DESCRIPTION
Closes #163

## Problem

When a steering message fell through to normal processing (agent not running), the gateway created a new session if the old one was sealed. `Steer()` returned void so the portal never knew — it kept showing the old session ID and sending subsequent messages to the wrong session.

## Fix

`GatewayHub.Steer()` now resolves/creates the session before dispatching (same pattern as `SendMessage`) and returns `SendMessageResult`. The portal registers the returned session ID and refreshes conversations, so it always stays in sync with the actual active session.

## Flow after fix
```
Steer sent (portal has session 896ab)
  → Hub resolves session → old 896ab is sealed → new session f8d885 created
  → Hub returns SendMessageResult { SessionId = f8d885 }
  → Portal registers f8d885, refreshes conversations
  → Header now shows f8d885 ✓
```