### PR TITLE
fix(portal): archived conversations reappear on message; sidebar not scrollable

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -57,6 +57,8 @@
             <nav class="sidebar-nav">
                 <a href="" class="sidebar-nav-item @NavClass("")" @onclick="OnNavClick">💬 Chat</a>
 
+                @* Scrollable agent/conversation section *@
+                <div class="sidebar-scroll-region">
                 @* Agent dropdown + session list nested under Chat *@
                 @if (Store.Agents.Count > 0)
                 {
@@ -160,6 +162,8 @@
                         </div>
                     }
                 }
+
+                </div>@* end sidebar-scroll-region *@
 
                 <a href="configuration" class="sidebar-nav-item @NavClass("configuration")" @onclick="OnNavClick">⚙️ Configuration</a>
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -1674,6 +1674,18 @@ details[open] > .thinking-summary::before {
     padding: 0.5rem 0.75rem;
     gap: 2px;
     border-bottom: 1px solid var(--border);
+    flex: 1;
+    min-height: 0; /* allow flex child to shrink below content size */
+    overflow: hidden;
+}
+
+/* Scrollable region within sidebar nav — contains agent dropdown + conversations */
+.sidebar-scroll-region {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 .sidebar-nav-item {

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
@@ -348,6 +348,7 @@ public sealed class SqliteConversationStore : IConversationStore
                     COUNT(b.binding_id)
                 FROM conversations c
                 LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
+                WHERE c.status = 'Active'
                 GROUP BY c.id, c.agent_id, c.title, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at
                 ORDER BY c.updated_at DESC
                 """
@@ -364,7 +365,7 @@ public sealed class SqliteConversationStore : IConversationStore
                     COUNT(b.binding_id)
                 FROM conversations c
                 LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
-                WHERE c.agent_id = $agentId
+                WHERE c.agent_id = $agentId AND c.status = 'Active'
                 GROUP BY c.id, c.agent_id, c.title, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at
                 ORDER BY c.updated_at DESC
                 """;


### PR DESCRIPTION
Two bugs from latest release.

## Bug 1 — Archived conversations reappear

`SqliteConversationStore.GetSummariesAsync` returned ALL conversations including Archived. Sending a message triggers `RefreshConversationsForAgentAsync` which re-seeds all conversations — archived ones came back.

**Fix:** Added `WHERE c.status = 'Active'` to both queries in `GetSummariesAsync`. `InMemoryConversationStore` already had this filter.

## Bug 2 — Sidebar not scrollable

The sidebar `<nav>` had no overflow handling. As the conversation list grew it expanded, pushing the Configuration and Agents links below the viewport.

**Fix:**
- `.sidebar-nav` gets `flex: 1; min-height: 0; overflow: hidden`
- Scrollable section (agent dropdown + conversations) wrapped in `.sidebar-scroll-region` with `flex: 1; overflow-y: auto`
- Configuration and Agents links sit outside the scroll region — always visible