### PR TITLE
fix(portal): duplicate messages on default conversation; history not loading

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -59,7 +59,11 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
-            var result = await _hub.SendMessageAsync(agentId, agent.ChannelType ?? "signalr", content, convIdNow);
+            // For default conversations use null conversationId so the router uses the null-thread
+            // binding (signalr, agentId, null). Passing the conversationId for a default conversation
+            // causes a duplicate thread binding to be added, leading to double fan-out delivery.
+            var routingConvId = conv.IsDefault ? null : convIdNow;
+            var result = await _hub.SendMessageAsync(agentId, agent.ChannelType ?? "signalr", content, routingConvId);
             _store.RegisterSession(agentId, result.SessionId, result.ChannelType);
 
             // Refresh conversation so ActiveSessionId is current
@@ -363,11 +367,8 @@ public sealed class AgentInteractionService : IAgentInteractionService
         if (agent is null) return;
         var conv = agent.Conversations.GetValueOrDefault(conversationId);
         if (conv is null || conv.IsLoadingHistory) return;
-        if (conv.Messages.Count > 0)
-        {
-            conv.HistoryLoaded = true;
-            return;
-        }
+        if (conv.HistoryLoaded)
+            return; // Already loaded from server — don't reload
 
         // Cache hit: render immediately, then fall through to refresh from server
         if (_featureFlags?.ConversationHistoryCache == true && _cache is not null)


### PR DESCRIPTION
Two bugs introduced by the multi-conversation/portal UX work.

## Bug 1 — First message received twice by agent

`SendMessageToConversation` with the default conversation ID caused `ResolveOrCreateSessionByConversationAsync` to add a thread binding `(signalr, agentId, conversationId)`. The conversation already had `(signalr, agentId, null)`. Fan-out then delivered the response to both bindings — agent received the message twice, portal saw the response twice.

**Fix:** `AgentInteractionService.SendMessageAsync` passes `null` conversationId for `IsDefault` conversations, using the null-thread routing path which has no duplicate binding.

## Bug 2 — History not loading after message exchange

`LoadConversationHistoryAsync` short-circuited when `conv.Messages.Count > 0`, marking history as loaded without querying the server. After in-session messages accumulated (user message + streaming response), switching conversations and back would skip the server history load — earlier sessions' messages were never shown.

**Fix:** Gate the short-circuit on `conv.HistoryLoaded` (already fetched from server) instead of `Messages.Count` (may only have the current in-session exchange).