### PR TITLE
refactor(gateway): conversation-first routing — ConversationId on InboundMessage

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -55,6 +55,7 @@
     <Project Path="tests/BotNexus.CodingAgent.Tests/BotNexus.CodingAgent.Tests.csproj" />
     <Project Path="tests/BotNexus.Cron.Tests/BotNexus.Cron.Tests.csproj" />
     <Project Path="tests/BotNexus.Extensions.WebTools.Tests/BotNexus.Extensions.WebTools.Tests.csproj" />
+    <Project Path="tests/BotNexus.Gateway.ConversationTests/BotNexus.Gateway.ConversationTests.csproj" />
     <Project Path="tests/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj" />
     <Project Path="tests/BotNexus.Sessions.Common.Tests/BotNexus.Sessions.Common.Tests.csproj" />
     <Project Path="tests/BotNexus.Skills.Tests/BotNexus.Skills.Tests.csproj" />

--- a/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
@@ -57,6 +57,13 @@ public sealed record InboundMessage
     /// Used by fan-out to exclude the originating binding from echo.
     /// </summary>
     public string? BindingId { get; init; }
+
+    /// <summary>
+    /// When set, routes directly to this conversation, bypassing binding lookup.
+    /// Used by portal clients that know which conversation they are viewing.
+    /// This avoids the thread-binding hack that caused duplicate bindings and double fan-out.
+    /// </summary>
+    public string? ConversationId { get; init; }
 }
 
 /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -59,11 +59,9 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
-            // For default conversations use null conversationId so the router uses the null-thread
-            // binding (signalr, agentId, null). Passing the conversationId for a default conversation
-            // causes a duplicate thread binding to be added, leading to double fan-out delivery.
-            var routingConvId = conv.IsDefault ? null : convIdNow;
-            var result = await _hub.SendMessageAsync(agentId, agent.ChannelType ?? "signalr", content, routingConvId);
+            // Always pass the conversation ID — the router handles direct lookup without binding scan.
+            // Removed the IsDefault special-case that previously caused duplicate thread bindings and double fan-out.
+            var result = await _hub.SendMessageAsync(agentId, agent.ChannelType ?? "signalr", content, convIdNow);
             _store.RegisterSession(agentId, result.SessionId, result.ChannelType);
 
             // Refresh conversation so ActiveSessionId is current

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
@@ -120,12 +120,11 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     public async Task<SubscribeAllResult> SubscribeAllAsync()
         => await _connection!.InvokeAsync<SubscribeAllResult>("SubscribeAll");
 
-    /// <summary>Send a message to the specified agent.</summary>
+    /// <summary>Send a message to the specified agent, optionally targeting a specific conversation.</summary>
     public async Task<SendMessageResult> SendMessageAsync(string agentId, string channelType, string content, string? conversationId = null)
     {
-        if (!string.IsNullOrWhiteSpace(conversationId))
-            return await _connection!.InvokeAsync<SendMessageResult>("SendMessageToConversation", agentId, channelType, content, conversationId);
-        return await _connection!.InvokeAsync<SendMessageResult>("SendMessage", agentId, channelType, content);
+        // Hub.SendMessage now accepts an optional conversationId — no separate SendMessageToConversation method.
+        return await _connection!.InvokeAsync<SendMessageResult>("SendMessage", agentId, channelType, content, conversationId);
     }
 
     /// <summary>Steer an in-progress agent response.</summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -35,7 +35,6 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     private readonly ISessionCompactor _compactor;
     private readonly ISessionWarmupService _warmup;
     private readonly IConversationRouter _conversationRouter;
-    private readonly IConversationStore _conversationStore;
     private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
     private readonly ILogger<GatewayHub> _logger;
 
@@ -48,7 +47,6 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         ISessionCompactor compactor,
         ISessionWarmupService warmup,
         IConversationRouter conversationRouter,
-        IConversationStore conversationStore,
         IOptionsMonitor<CompactionOptions> compactionOptions,
         ILogger<GatewayHub> logger)
     {
@@ -60,7 +58,6 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         _compactor = compactor;
         _warmup = warmup;
         _conversationRouter = conversationRouter;
-        _conversationStore = conversationStore;
         _compactionOptions = compactionOptions;
         _logger = logger;
     }
@@ -165,25 +162,16 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             Context.ConnectionAborted);
 
     /// <summary>
-    /// Executes send message.
-    /// </summary>
-    /// <param name="agentId">The agent id.</param>
-    /// <param name="channelType">The channel type.</param>
-    /// <param name="content">The content.</param>
-    /// <returns>The send message result.</returns>
-    public Task<SendMessageResult> SendMessage(AgentId agentId, ChannelKey channelType, string content)
-        => SendMessageCore(agentId, channelType, content, null);
-
-    /// <summary>
-    /// Sends a message routing into a specific conversation by ID.
-    /// Use this overload from portal clients that track the active conversation.
+    /// Sends a message to an agent, optionally routing into a specific conversation.
+    /// When conversationId is provided, the router looks up the conversation directly
+    /// without a binding scan. When null, routes via the default (agentId, channelType) binding.
     /// </summary>
     /// <param name="agentId">The target agent.</param>
     /// <param name="channelType">The channel type.</param>
     /// <param name="content">The message content.</param>
-    /// <param name="conversationId">Explicit conversation ID to route into.</param>
+    /// <param name="conversationId">Optional explicit conversation ID. When set, routes directly to that conversation.</param>
     /// <returns>The send message result.</returns>
-    public Task<SendMessageResult> SendMessageToConversation(AgentId agentId, ChannelKey channelType, string content, string conversationId)
+    public Task<SendMessageResult> SendMessage(AgentId agentId, ChannelKey channelType, string content, string? conversationId = null)
         => SendMessageCore(agentId, channelType, content, conversationId);
 
     private async Task<SendMessageResult> SendMessageCore(AgentId agentId, ChannelKey channelType, string content, string? conversationId)
@@ -192,9 +180,9 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var typedChannelType = NormalizeChannelKey(channelType);
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
 
-        var session = string.IsNullOrWhiteSpace(conversationId)
-            ? await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType)
-            : await ResolveOrCreateSessionByConversationAsync(typedAgentId, typedChannelType, conversationId);
+        // Always resolve via the simple binding path (agentId as address, null thread).
+        // The ConversationId on the dispatched message will direct the router to the right conversation.
+        var session = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType);
         await SubscribeInternalAsync(session.SessionId);
 
         var connectionId = Context.ConnectionId;
@@ -202,8 +190,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             typedAgentId, typedChannelType, session.SessionId, connectionId, content.Length > 50 ? content[..50] + "..." : content);
 
         _ = SafeDispatchAsync(
-            () => DispatchMessageAsync(typedAgentId, session.SessionId, content, "message", connectionId,
-                threadId: string.IsNullOrWhiteSpace(conversationId) ? null : conversationId),
+            () => DispatchMessageAsync(typedAgentId, session.SessionId, content, "message", connectionId, conversationId),
             typedAgentId,
             session.SessionId);
 
@@ -264,14 +251,15 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             session.ChannelType?.Value);
     }
 
-    private Task DispatchMessageAsync(AgentId typedAgentId, SessionId typedSessionId, string content, string messageType, string senderId, string? threadId = null)
+    private Task DispatchMessageAsync(AgentId typedAgentId, SessionId typedSessionId, string content,
+        string messageType, string senderId, string? conversationId = null)
         => _dispatcher.DispatchAsync(
             new InboundMessage
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
                 ChannelAddress = typedAgentId.Value, // stable per-agent address — one portal conversation per agent
-                ThreadId = threadId, // non-null for secondary conversations; null targets the default portal conversation
+                ConversationId = conversationId, // router uses this to find the right conversation directly
                 SessionId = typedSessionId.Value,
                 TargetAgentId = typedAgentId.Value,
                 Content = content,
@@ -590,70 +578,6 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             Context.ConnectionAborted);
     }
 
-    private async Task<GatewaySession> ResolveOrCreateSessionByConversationAsync(AgentId agentId, ChannelKey channelType, string conversationId)
-    {
-        var routingResult = await _conversationRouter.ResolveInboundByConversationAsync(
-            ConversationId.From(conversationId),
-            agentId,
-            channelType,
-            Context.ConnectionId,
-            Context.ConnectionAborted);
-
-        var session = await _sessions.GetOrCreateAsync(routingResult.SessionId, agentId, Context.ConnectionAborted);
-
-        var needsSave = false;
-        if (session.Status == SessionStatus.Expired)
-        {
-            session.Status = SessionStatus.Active;
-            session.ExpiresAt = null;
-            needsSave = true;
-        }
-
-        if (!session.ChannelType.HasValue || !ChannelMatches(session.ChannelType.Value, channelType))
-        {
-            session.ChannelType = channelType;
-            needsSave = true;
-        }
-
-        if (!session.SessionType.Equals(SessionType.UserAgent))
-        {
-            session.SessionType = SessionType.UserAgent;
-            needsSave = true;
-        }
-
-        if (session.Participants.Count == 0)
-        {
-            session.Participants.Add(new SessionParticipant { Type = ParticipantType.User, Id = Context.ConnectionId });
-            needsSave = true;
-        }
-
-        if (needsSave)
-            await _sessions.SaveAsync(session, Context.ConnectionAborted);
-
-        // Ensure the conversation has a (signalr, agentId, conversationId) binding so that
-        // future ResolveInboundAsync calls with ThreadId=conversationId route here correctly.
-        var conversation = routingResult.Conversation;
-        var hasThreadBinding = conversation.ChannelBindings.Any(b =>
-            b.ChannelType == channelType &&
-            string.Equals(b.ChannelAddress, agentId.Value, StringComparison.Ordinal) &&
-            string.Equals(b.ThreadId, conversationId, StringComparison.Ordinal));
-
-        if (!hasThreadBinding)
-        {
-            conversation.ChannelBindings.Add(new ChannelBinding
-            {
-                ChannelType = channelType,
-                ChannelAddress = agentId.Value,
-                ThreadId = conversationId,
-                Mode = BindingMode.Interactive
-            });
-            conversation.UpdatedAt = DateTimeOffset.UtcNow;
-            await _conversationStore.SaveAsync(conversation, Context.ConnectionAborted);
-        }
-
-        return session;
-    }
-
     private async Task<GatewaySession> ResolveOrCreateSessionAsync(AgentId agentId, ChannelKey channelType)
     {
         // Conversation-first routing: resolve/create via IConversationRouter.
@@ -665,6 +589,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             channelType,
             channelAddress,
             threadId: null,
+            conversationId: null,
             Context.ConnectionAborted);
 
         var session = await _sessions.GetOrCreateAsync(routingResult.SessionId, agentId, Context.ConnectionAborted);

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -11,7 +11,8 @@ public interface IConversationRouter
 {
     /// <summary>
     /// Resolves or creates the conversation for an inbound message.
-    /// Uses (AgentId, ChannelType, ChannelAddress, ThreadId?) as the lookup key.
+    /// Uses (AgentId, ChannelType, ChannelAddress, ThreadId?) as the lookup key when conversationId is null.
+    /// When conversationId is provided, routes directly to that conversation, bypassing binding lookup.
     /// Every channel gets its own conversation on first contact regardless of address.
     /// Stamps Session.ConversationId when creating/resolving sessions.
     /// </summary>
@@ -20,18 +21,7 @@ public interface IConversationRouter
         ChannelKey channelType,
         string channelAddress,
         string? threadId,
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Resolves the conversation and session for an inbound message using an explicit conversation ID.
-    /// Use this when the client specifies which conversation a message belongs to (e.g. portal multi-conversation).
-    /// Creates a new session for the conversation if it has none active.
-    /// </summary>
-    Task<ConversationRoutingResult> ResolveInboundByConversationAsync(
-        ConversationId conversationId,
-        AgentId agentId,
-        ChannelKey channelType,
-        string channelAddress,
+        string? conversationId = null,
         CancellationToken ct = default);
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -34,8 +34,34 @@ public sealed class DefaultConversationRouter : IConversationRouter
         ChannelKey channelType,
         string channelAddress,
         string? threadId,
+        string? conversationId = null,
         CancellationToken ct = default)
     {
+        // When the caller knows the exact conversation (e.g. portal with active conversation tab),
+        // skip binding lookup entirely. This is the fast path that eliminates the thread-binding hack.
+        if (conversationId is not null)
+        {
+            var convId = ConversationId.From(conversationId);
+            var direct = await _conversationStore.GetAsync(convId, ct);
+            if (direct is null)
+            {
+                _logger.LogWarning(
+                    "ResolveInbound: explicit conversationId {ConversationId} not found — falling back to binding lookup",
+                    conversationId);
+                // Fall through to binding lookup below
+            }
+            else
+            {
+                var (directSessionId, directIsNew, changed) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
+                if (changed)
+                {
+                    direct.UpdatedAt = DateTimeOffset.UtcNow;
+                    await _conversationStore.SaveAsync(direct, ct);
+                }
+                return new ConversationRoutingResult(direct, directSessionId, directIsNew);
+            }
+        }
+
         // 1. Try to find an existing conversation by binding
         var conversation = await _conversationStore.ResolveByBindingAsync(
             agentId, channelType, channelAddress, threadId, ct);
@@ -89,35 +115,6 @@ public sealed class DefaultConversationRouter : IConversationRouter
                 string.Equals(b.ThreadId, threadId, StringComparison.Ordinal));
 
         return new ConversationRoutingResult(conversation, sessionId, isNewSession, originatingBinding);
-    }
-
-    /// <inheritdoc />
-    public async Task<ConversationRoutingResult> ResolveInboundByConversationAsync(
-        ConversationId conversationId,
-        AgentId agentId,
-        ChannelKey channelType,
-        string channelAddress,
-        CancellationToken ct = default)
-    {
-        var conversation = await _conversationStore.GetAsync(conversationId, ct);
-        if (conversation is null)
-        {
-            _logger.LogWarning(
-                "ResolveInboundByConversation: conversation {ConversationId} not found — falling back to default routing",
-                conversationId);
-            return await ResolveInboundAsync(agentId, channelType, channelAddress, null, ct);
-        }
-
-        // Resolve or create session for this conversation
-        var (sessionId, isNewSession, changed) = await ResolveOrCreateSessionAsync(conversation, agentId, ct);
-
-        if (changed)
-        {
-            conversation.UpdatedAt = DateTimeOffset.UtcNow;
-            await _conversationStore.SaveAsync(conversation, ct);
-        }
-
-        return new ConversationRoutingResult(conversation, sessionId, isNewSession);
     }
 
     /// <inheritdoc />

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -265,6 +265,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     message.ChannelType,
                     message.ChannelAddress ?? string.Empty,
                     threadId: message.ThreadId,
+                    conversationId: message.ConversationId,
                     cancellationToken);
                 sessionId = routingResult.SessionId.Value;
                 resolvedConversationId = routingResult.Conversation.ConversationId;

--- a/tests/BotNexus.Gateway.ConversationTests/BotNexus.Gateway.ConversationTests.csproj
+++ b/tests/BotNexus.Gateway.ConversationTests/BotNexus.Gateway.ConversationTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\gateway\BotNexus.Gateway\BotNexus.Gateway.csproj" />
+    <ProjectReference Include="..\..\src\gateway\BotNexus.Gateway.Sessions\BotNexus.Gateway.Sessions.csproj" />
+    <ProjectReference Include="..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/BotNexus.Gateway.ConversationTests/ConversationRoutingScenarios.cs
+++ b/tests/BotNexus.Gateway.ConversationTests/ConversationRoutingScenarios.cs
@@ -1,0 +1,332 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Routing;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+
+namespace BotNexus.Gateway.ConversationTests;
+
+/// <summary>
+/// End-to-end conversation routing scenarios using real in-memory stores and a real
+/// <see cref="DefaultConversationRouter"/>. No network, no external process.
+///
+/// These tests validate the conversation-first routing model introduced by the
+/// refactor/conversation-first-routing branch:
+///  - InboundMessage.ConversationId bypasses binding lookup (direct routing)
+///  - Binding lookup (channelType, channelAddress, threadId) is the fallback
+///  - No duplicate bindings, no double fan-out from portal secondary conversations
+/// </summary>
+public sealed class ConversationRoutingScenarios
+{
+    private static AgentId Agent(string id = "agent1") => AgentId.From(id);
+    private static ChannelKey Telegram() => ChannelKey.From("telegram");
+    private static ChannelKey SignalR() => ChannelKey.From("signalr");
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 1: Single channel, single conversation — Telegram DM always same conv
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario1_TelegramDm_AlwaysRoutesToSameConversation()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // Act — two messages from the same Telegram chat ID
+        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-123", null);
+        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-123", null);
+
+        // Assert — same conversation, same session
+        result1.Conversation.ConversationId.ShouldBe(result2.Conversation.ConversationId,
+            "repeated messages from same Telegram DM must route to same conversation");
+        result2.IsNewSession.ShouldBeFalse("session must be reused on second message");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 2: Portal default conversation — null conversationId → default
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario2_Portal_NullConversationId_RoutesToDefaultConversation()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // Act — portal sends with null conversationId (binding lookup path)
+        var result1 = await router.ResolveInboundAsync(agentId, SignalR(), "agent1", null);
+        var result2 = await router.ResolveInboundAsync(agentId, SignalR(), "agent1", null);
+
+        // Assert — same conversation on both calls (binding found on second call)
+        result1.Conversation.ConversationId.ShouldBe(result2.Conversation.ConversationId,
+            "null conversationId should resolve to the same portal conversation each time");
+        result2.IsNewSession.ShouldBeFalse("session must be reused");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 3: Portal secondary conversation — explicit conversationId → direct
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario3_Portal_ExplicitConversationId_RoutesDirectlyNoDuplicateBindings()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // Pre-create a secondary conversation (as the portal API would)
+        var secondaryConv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "Secondary"
+        };
+        await convStore.SaveAsync(secondaryConv);
+
+        // Act — portal sends with explicit conversationId (direct routing path)
+        var result = await router.ResolveInboundAsync(
+            agentId, SignalR(), "agent1", null,
+            conversationId: secondaryConv.ConversationId.Value);
+
+        // Assert — routes to the correct conversation with NO new binding added
+        result.Conversation.ConversationId.ShouldBe(secondaryConv.ConversationId,
+            "explicit conversationId must route directly to that conversation");
+
+        // The critical invariant: no duplicate thread binding was added
+        // (old design added a binding with ThreadId=conversationId, causing double fan-out)
+        var conv = await convStore.GetAsync(secondaryConv.ConversationId);
+        conv.ShouldNotBeNull();
+        conv!.ChannelBindings.Count.ShouldBe(0,
+            "direct conversationId routing must NOT add a binding — no binding hack");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 4: Cross-channel fan-out — Telegram + portal bound to same conversation
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario4_CrossChannelFanOut_BothBindingsReceiveOutbound()
+    {
+        // Arrange — a conversation with both Telegram and SignalR bindings
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // First contact via Telegram creates the conversation with a Telegram binding
+        var result = await router.ResolveInboundAsync(agentId, Telegram(), "chat-789", null);
+        var conversationId = result.Conversation.ConversationId;
+
+        // Attach a SignalR binding (simulates portal joining the same conversation)
+        var conv = await convStore.GetAsync(conversationId);
+        conv!.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = SignalR(),
+            ChannelAddress = "conn-abc",
+            Mode = BindingMode.Interactive
+        });
+        await convStore.SaveAsync(conv);
+
+        // Act — get outbound bindings for fan-out
+        var sessionId = result.SessionId;
+        var outbound = await router.GetOutboundBindingsAsync(sessionId, originatingBindingId: null);
+
+        // Assert — both bindings are available for fan-out
+        outbound.Count.ShouldBe(2,
+            "cross-channel fan-out should include both Telegram and SignalR bindings");
+        outbound.ShouldContain(b => b.ChannelType == Telegram());
+        outbound.ShouldContain(b => b.ChannelType == SignalR());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 5: Session reuse after expiry — expired session is reactivated
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario5_ExpiredSession_IsReusedNotReplaced()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // First message creates session
+        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-exp", null);
+        var originalSessionId = result1.SessionId;
+
+        // Expire the session
+        var session = await sessionStore.GetAsync(originalSessionId);
+        session!.Status = Abstractions.Models.SessionStatus.Expired;
+        await sessionStore.SaveAsync(session);
+
+        // Act — second message should reuse the expired session (not create a new one)
+        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-exp", null);
+
+        // Assert — same session reused (GatewayHost reactivates expired sessions)
+        result2.SessionId.ShouldBe(originalSessionId,
+            "expired sessions must be reused — GatewayHost handles reactivation, not the router");
+        result2.IsNewSession.ShouldBeFalse();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 6: Session sealed → new session is created
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario6_SealedSession_TriggersNewSessionCreation()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // First message creates session
+        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-seal", null);
+        var originalSessionId = result1.SessionId;
+
+        // Seal the session (simulates an explicit reset/archive)
+        var session = await sessionStore.GetAsync(originalSessionId);
+        session!.Status = Abstractions.Models.SessionStatus.Sealed;
+        await sessionStore.SaveAsync(session);
+
+        // Act — next message must create a new session
+        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-seal", null);
+
+        // Assert
+        result2.SessionId.ShouldNotBe(originalSessionId,
+            "sealed session must trigger new session creation");
+        result2.IsNewSession.ShouldBeTrue();
+
+        // Same conversation — session is replaced but conversation is preserved
+        result2.Conversation.ConversationId.ShouldBe(result1.Conversation.ConversationId,
+            "conversation must be preserved even after session replacement");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 7: Multiple agents, same channel — separate conversations
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario7_TwoAgents_SameTelegramBot_GetSeparateConversations()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var routerA = CreateRouter(convStore, sessionStore);
+        var routerB = CreateRouter(convStore, sessionStore);
+        var agentA = Agent("agent-a");
+        var agentB = Agent("agent-b");
+
+        // Act — same Telegram chat ID sends to both agents
+        var resultA = await routerA.ResolveInboundAsync(agentA, Telegram(), "shared-chat", null);
+        var resultB = await routerB.ResolveInboundAsync(agentB, Telegram(), "shared-chat", null);
+
+        // Assert — each agent gets its own conversation
+        resultA.Conversation.ConversationId.ShouldNotBe(resultB.Conversation.ConversationId,
+            "different agents on same channel must have separate conversations");
+        resultA.Conversation.AgentId.ShouldBe(agentA);
+        resultB.Conversation.AgentId.ShouldBe(agentB);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 8: Thread isolation — different forum topics are separate conversations
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario8_DifferentThreadIds_GetSeparateConversations()
+    {
+        // Arrange
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // Act — same group chat but different topics
+        var result42 = await router.ResolveInboundAsync(agentId, Telegram(), "group-1", threadId: "42");
+        var result99 = await router.ResolveInboundAsync(agentId, Telegram(), "group-1", threadId: "99");
+
+        // Assert — thread isolation: different topics → different conversations
+        result42.Conversation.ConversationId.ShouldNotBe(result99.Conversation.ConversationId,
+            "Telegram forum topics 42 and 99 must route to separate conversations");
+
+        // Verify bindings have correct thread IDs
+        result42.OriginatingBinding.ShouldNotBeNull();
+        result42.OriginatingBinding!.ThreadId.ShouldBe("42");
+        result99.OriginatingBinding.ShouldNotBeNull();
+        result99.OriginatingBinding!.ThreadId.ShouldBe("99");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Scenario 9: ConversationId routing bypasses binding lookup entirely
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Scenario9_ExplicitConversationId_SkipsBindingLookup()
+    {
+        // Arrange — two separate conversations for the same agent
+        var convStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(convStore, sessionStore);
+        var agentId = Agent();
+
+        // Create conversation A via binding lookup
+        var resultA = await router.ResolveInboundAsync(agentId, SignalR(), "agent1", null);
+        var convAId = resultA.Conversation.ConversationId;
+
+        // Create conversation B via API (no binding)
+        var convB = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "Conversation B"
+        };
+        await convStore.SaveAsync(convB);
+
+        // Act — send to conversation B by explicit ID
+        // Note: (SignalR, "agent1", null) binding points to conversation A,
+        // but we override with conversationId=B
+        var resultB = await router.ResolveInboundAsync(
+            agentId, SignalR(), "agent1", null,
+            conversationId: convB.ConversationId.Value);
+
+        // Assert — routed to conversation B, not A
+        resultB.Conversation.ConversationId.ShouldBe(convB.ConversationId,
+            "explicit conversationId must bypass binding lookup and route directly");
+        resultB.Conversation.ConversationId.ShouldNotBe(convAId,
+            "must NOT fall back to the binding-matched conversation A");
+
+        // Conversation A's binding is untouched — no duplicate bindings
+        var updatedConvA = await convStore.GetAsync(convAId);
+        updatedConvA.ShouldNotBeNull();
+        // Conversation A still has only the original binding
+        updatedConvA!.ChannelBindings.Count.ShouldBe(1);
+        updatedConvA.ChannelBindings[0].ChannelType.ShouldBe(SignalR());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    private static DefaultConversationRouter CreateRouter(
+        IConversationStore convStore,
+        ISessionStore sessionStore)
+        => new(convStore, sessionStore, NullLogger<DefaultConversationRouter>.Instance);
+}

--- a/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -57,7 +57,7 @@ public sealed class GatewayHostBindingRoutingTests
         convRouter
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
-                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -130,7 +130,7 @@ public sealed class GatewayHostBindingRoutingTests
         convRouter
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
-                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -215,7 +215,7 @@ public sealed class GatewayHostBindingRoutingTests
         convRouter
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
-                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))

--- a/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
@@ -98,7 +98,8 @@ public sealed class ThreadIdRoutingTests
             Agent(),
             message.ChannelType,
             message.ChannelAddress,
-            message.ThreadId);
+            message.ThreadId,
+            conversationId: null);
 
         capturingRouter.CapturedThreadId.ShouldBe("topic-55");
     }
@@ -113,18 +114,13 @@ internal sealed class CapturingConversationRouter : IConversationRouter
 
     public Task<ConversationRoutingResult> ResolveInboundAsync(
         AgentId agentId, ChannelKey channelType, string channelAddress,
-        string? threadId, CancellationToken ct = default)
+        string? threadId, string? conversationId = null, CancellationToken ct = default)
     {
         CapturedThreadId = threadId;
         var conv = new Conversation { AgentId = agentId };
         var sessionId = SessionId.Create();
         return Task.FromResult(new ConversationRoutingResult(conv, sessionId, true));
     }
-
-    public Task<ConversationRoutingResult> ResolveInboundByConversationAsync(
-        ConversationId conversationId, AgentId agentId, ChannelKey channelType,
-        string channelAddress, CancellationToken ct = default)
-        => throw new NotImplementedException();
 
     public Task<IReadOnlyList<ChannelBinding>> GetOutboundBindingsAsync(
         SessionId sessionId, string originatingChannelAddress, CancellationToken ct = default)

--- a/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -124,7 +124,7 @@ public sealed class FanOutStaleBindingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
 
         // Return the stale binding for fan-out
@@ -190,7 +190,7 @@ public sealed class FanOutStaleBindingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
 
         // Empty list = already muted / no fan-out targets

--- a/tests/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -891,6 +891,7 @@ public sealed class GatewayHostTests
                 It.IsAny<BotNexus.Domain.Primitives.ChannelKey>(),
                 It.IsAny<string>(),
                 It.IsAny<string?>(),
+                It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BotNexus.Gateway.Abstractions.Conversations.ConversationRoutingResult(
                 conversation, expectedSessionId, false));
@@ -913,6 +914,7 @@ public sealed class GatewayHostTests
             It.IsAny<BotNexus.Domain.Primitives.AgentId>(),
             It.IsAny<BotNexus.Domain.Primitives.ChannelKey>(),
             It.IsAny<string>(),
+            It.IsAny<string?>(),
             It.IsAny<string?>(),
             It.IsAny<CancellationToken>()), Times.AtLeastOnce, "IConversationRouter.ResolveInboundAsync must be called");
 

--- a/tests/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
@@ -72,8 +72,8 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
         });
 
         // Act - Send messages concurrently
-        var slowResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-slow", "signalr", "test-slow", cts.Token);
-        var fastResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-fast", "signalr", "test-fast", cts.Token);
+        var slowResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-slow", "signalr", "test-slow", (string?)null, cts.Token);
+        var fastResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-fast", "signalr", "test-fast", (string?)null, cts.Token);
 
         var slowSessionId = slowResult.GetProperty("sessionId").GetString();
         var fastSessionId = fastResult.GetProperty("sessionId").GetString();
@@ -135,9 +135,9 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
         });
 
         // Act - Send messages to all 3 agents concurrently
-        var slowResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-slow", "signalr", "test", cts.Token);
-        var mediumResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-medium", "signalr", "test", cts.Token);
-        var fastResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-fast", "signalr", "test", cts.Token);
+        var slowResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-slow", "signalr", "test", (string?)null, cts.Token);
+        var mediumResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-medium", "signalr", "test", (string?)null, cts.Token);
+        var fastResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-fast", "signalr", "test", (string?)null, cts.Token);
 
         var slowSessionId = slowResult.GetProperty("sessionId").GetString()!;
         var mediumSessionId = mediumResult.GetProperty("sessionId").GetString()!;
@@ -197,12 +197,12 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
         });
 
         // Act
-        var resultA = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-a", "signalr", "start processing", cts.Token);
+        var resultA = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-a", "signalr", "start processing", (string?)null, cts.Token);
         
         // Wait 100ms to ensure agent-a is processing
         await Task.Delay(100, cts.Token);
         
-        var resultB = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-b", "signalr", "quick response", cts.Token);
+        var resultB = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-b", "signalr", "quick response", (string?)null, cts.Token);
 
         var sessionA = resultA.GetProperty("sessionId").GetString()!;
         var sessionB = resultB.GetProperty("sessionId").GetString()!;
@@ -259,7 +259,7 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
         });
 
         // Act - Send first message
-        var firstResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-reset", "signalr", "first message", cts.Token);
+        var firstResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-reset", "signalr", "first message", (string?)null, cts.Token);
         var firstSessionId = firstResult.GetProperty("sessionId").GetString()!;
 
         // Wait for first response
@@ -270,7 +270,7 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
         await connection.InvokeAsync("ResetSession", "agent-reset", firstSessionId, cts.Token);
 
         // Send second message to same agent
-        var secondResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-reset", "signalr", "second message", cts.Token);
+        var secondResult = await connection.InvokeAsync<JsonElement>("SendMessage", "agent-reset", "signalr", "second message", (string?)null, cts.Token);
         var secondSessionId = secondResult.GetProperty("sessionId").GetString()!;
 
         // Assert - Should create new session and respond
@@ -326,7 +326,7 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
         // Act - Start all agents concurrently
         var sendTasks = agentIds.Select(async agentId =>
         {
-            var result = await connection.InvokeAsync<JsonElement>("SendMessage", agentId, "signalr", "concurrent start", cts.Token);
+            var result = await connection.InvokeAsync<JsonElement>("SendMessage", agentId, "signalr", "concurrent start", (string?)null, cts.Token);
             return (AgentId: agentId, SessionId: result.GetProperty("sessionId").GetString()!);
         });
 

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
@@ -63,17 +63,18 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         var result = await connection.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "routed message", conversationId, cts.Token);
+            "SendMessage", TestAgentId, "signalr", "routed message", conversationId, cts.Token);
 
         var sessionId = result.GetProperty("sessionId").GetString();
         sessionId.ShouldNotBeNullOrWhiteSpace();
 
-        // Verify the session has the conversationId stamped
-        var sessionStore = factory.Services.GetRequiredService<ISessionStore>();
-        var session = await sessionStore.GetAsync(SessionId.From(sessionId!), cts.Token);
-        session.ShouldNotBeNull();
-        session!.Session.ConversationId.ShouldNotBeNull("session should have conversationId stamped after SendMessageToConversation");
-        session.Session.ConversationId!.Value.Value.ShouldBe(conversationId);
+        // With conversation-first routing: the dispatched InboundMessage carries the ConversationId.
+        // GatewayHost uses it to route to the correct conversation.
+        // The hub returns the default portal session; the ConversationId on the dispatched message
+        // is what routes correctly — verify the dispatcher received it.
+        dispatcher.Messages.ShouldHaveSingleItem();
+        dispatcher.Messages[0].ConversationId.ShouldBe(conversationId,
+            "InboundMessage.ConversationId must carry the target conversationId for direct routing");
     }
 
     // ── Two messages to same conversation: both sessions link to same conversationId ──
@@ -100,25 +101,16 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
         await using var conn1 = await CreateStartedConnection(factory, cts.Token);
         await using var conn2 = await CreateStartedConnection(factory, cts.Token);
 
-        var result1 = await conn1.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "message one", conversationId, cts.Token);
-        var result2 = await conn2.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "message two", conversationId, cts.Token);
+        await conn1.InvokeAsync<JsonElement>(
+            "SendMessage", TestAgentId, "signalr", "message one", conversationId, cts.Token);
+        await conn2.InvokeAsync<JsonElement>(
+            "SendMessage", TestAgentId, "signalr", "message two", conversationId, cts.Token);
 
-        var sessionId1 = result1.GetProperty("sessionId").GetString()!;
-        var sessionId2 = result2.GetProperty("sessionId").GetString()!;
-
-        var sessionStore = factory.Services.GetRequiredService<ISessionStore>();
-        var s1 = await sessionStore.GetAsync(SessionId.From(sessionId1), cts.Token);
-        var s2 = await sessionStore.GetAsync(SessionId.From(sessionId2), cts.Token);
-
-        s1.ShouldNotBeNull();
-        s2.ShouldNotBeNull();
-        s1!.Session.ConversationId.ShouldNotBeNull();
-        s2!.Session.ConversationId.ShouldNotBeNull();
-        s1.Session.ConversationId!.Value.Value.ShouldBe(conversationId);
-        s2.Session.ConversationId!.Value.Value.ShouldBe(conversationId,
-            "both messages to same conversation should produce sessions linking to the same conversationId");
+        // With conversation-first routing, both dispatched InboundMessages carry the same ConversationId.
+        // No duplicate thread bindings, no double fan-out.
+        dispatcher.Messages.Count.ShouldBe(2);
+        dispatcher.Messages.ShouldAllBe(m => m.ConversationId == conversationId,
+            "both messages to same conversation should carry the correct ConversationId for routing");
     }
 
     // ── SendMessage without conversationId creates default conversation with conversationId ──
@@ -136,7 +128,7 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
         await RegisterAgentAsync(factory, cts.Token);
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        var result = await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "hello", cts.Token);
+        var result = await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "hello", (string?)null, cts.Token);
 
         var sessionId = result.GetProperty("sessionId").GetString()!;
 
@@ -171,7 +163,7 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         var msgResult = await connection.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "before reset", conversationId, cts.Token);
+            "SendMessage", TestAgentId, "signalr", "before reset", conversationId, cts.Token);
         var originalSessionId = msgResult.GetProperty("sessionId").GetString()!;
 
         // Reset the session
@@ -180,19 +172,17 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
         await connection.InvokeAsync("ResetSession", TestAgentId, originalSessionId, cts.Token);
         await resetDone.Task.WaitAsync(cts.Token);
 
-        // Send again — should route to same conversation and create a new session
+        // Send again to the same conversation — still routes via ConversationId
         var msg2Result = await connection.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "after reset", conversationId, cts.Token);
+            "SendMessage", TestAgentId, "signalr", "after reset", conversationId, cts.Token);
         var newSessionId = msg2Result.GetProperty("sessionId").GetString()!;
 
         newSessionId.ShouldNotBe(originalSessionId, "after reset, a new session should be created");
 
-        var sessionStore = factory.Services.GetRequiredService<ISessionStore>();
-        var newSession = await sessionStore.GetAsync(SessionId.From(newSessionId), cts.Token);
-        newSession.ShouldNotBeNull();
-        newSession!.Session.ConversationId.ShouldNotBeNull();
-        newSession.Session.ConversationId!.Value.Value.ShouldBe(conversationId,
-            "new session after ResetSession should still be linked to the same conversation");
+        // The dispatched messages should both carry the target conversationId
+        dispatcher.Messages.Count.ShouldBe(2);
+        dispatcher.Messages.ShouldAllBe(m => m.ConversationId == conversationId,
+            "after reset, sending to same conversationId should still dispatch with the correct ConversationId");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -258,7 +258,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         await RegisterAgentAsync(factory, cts.Token);
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        var result = await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "hello", cts.Token);
+        var result = await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "hello", (string?)null, cts.Token);
         var sessionId = result.GetProperty("sessionId").GetString();
         sessionId.ShouldNotBeNullOrWhiteSpace();
 
@@ -282,7 +282,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         await RegisterAgentAsync(factory, cts.Token);
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        Func<Task> act = async () => await connection.InvokeCoreAsync("SendMessage", [TestAgentId, null, "no-session"], cts.Token);
+        Func<Task> act = async () => await connection.InvokeCoreAsync("SendMessage", [TestAgentId, null, "no-session", null], cts.Token);
 
         await act.ShouldThrowAsync<HubException>();
     }
@@ -302,7 +302,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         // Wave 2: conversation routing creates a new session for new channel addresses.
         // Seed sessions are no longer picked up by channel-type scan; a conversation binding is required.
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        await connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "latest", cts.Token);
+        await connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "latest", (string?)null, cts.Token);
 
         dispatcher.Messages.ShouldHaveSingleItem();
         dispatcher.Messages[0].TargetAgentId.ShouldBe(TestAgentId);
@@ -326,8 +326,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         // Rapid sends on different channel types each create/reuse their own conversation sessions.
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         await Task.WhenAll(
-            connection.InvokeAsync("SendMessage", TestAgentId, "signalr", "before-switch", cts.Token),
-            connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "after-switch", cts.Token));
+            connection.InvokeAsync("SendMessage", TestAgentId, "signalr", "before-switch", (string?)null, cts.Token),
+            connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "after-switch", (string?)null, cts.Token));
 
         dispatcher.Messages.ShouldContain(m => m.Content == "after-switch");
         dispatcher.Messages.ShouldContain(m => m.Content == "before-switch");
@@ -347,7 +347,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
         // Wave 2: conversation routing creates a session per conversation binding.
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        await connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "send-during-join", cts.Token);
+        await connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "send-during-join", (string?)null, cts.Token);
 
         dispatcher.Messages.ShouldHaveSingleItem();
         dispatcher.Messages[0].Content.ShouldBe("send-during-join");
@@ -368,7 +368,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
         // Wave 2: conversation routing creates sessions per conversation binding.
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        await connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "immediate-after-join", cts.Token);
+        await connection.InvokeAsync("SendMessage", TestAgentId, "telegram", "immediate-after-join", (string?)null, cts.Token);
 
         dispatcher.Messages.ShouldHaveSingleItem();
         dispatcher.Messages[0].Content.ShouldBe("immediate-after-join");
@@ -392,8 +392,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
         // Wave 2: conversation routing creates sessions per conversation binding.
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        await connection.InvokeAsync("SendMessage", agentA, "signalr", "message-for-a", cts.Token);
-        await connection.InvokeAsync("SendMessage", agentB, "signalr", "message-for-b", cts.Token);
+        await connection.InvokeAsync("SendMessage", agentA, "signalr", "message-for-a", (string?)null, cts.Token);
+        await connection.InvokeAsync("SendMessage", agentB, "signalr", "message-for-b", (string?)null, cts.Token);
 
         dispatcher.Messages.Count().ShouldBe(2);
         dispatcher.Messages.Where(m =>
@@ -421,8 +421,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
         // Wave 2: conversation routing creates sessions per conversation binding.
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        await connection.InvokeAsync("SendMessage", agentA, "signalr", "message-for-a", cts.Token);
-        await connection.InvokeAsync("SendMessage", agentB, "signalr", "message-for-b", cts.Token);
+        await connection.InvokeAsync("SendMessage", agentA, "signalr", "message-for-a", (string?)null, cts.Token);
+        await connection.InvokeAsync("SendMessage", agentB, "signalr", "message-for-b", (string?)null, cts.Token);
 
         dispatcher.Messages.Count().ShouldBe(2);
         dispatcher.Messages.Where(m =>
@@ -459,7 +459,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         await connection.InvokeAsync<JsonElement>("JoinSession", TestAgentId, sessionA, cts.Token);
         await connection.InvokeAsync("LeaveSession", sessionA, cts.Token);
 
-        var result = await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "after-leave", cts.Token);
+        var result = await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "after-leave", (string?)null, cts.Token);
 
         result.GetProperty("sessionId").GetString().ShouldNotBeNullOrWhiteSpace();
         dispatcher.Messages.ShouldHaveSingleItem();

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
@@ -62,19 +62,21 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
 
         // Send to first conversation
         var result1 = await connection.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "message to alpha", conv1Id, cts.Token);
+            "SendMessage", TestAgentId, "signalr", "message to alpha", conv1Id, cts.Token);
         var sessionId1 = result1.GetProperty("sessionId").GetString()!;
 
         // Send to second conversation
         var result2 = await connection.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "message to beta", conv2Id, cts.Token);
+            "SendMessage", TestAgentId, "signalr", "message to beta", conv2Id, cts.Token);
         var sessionId2 = result2.GetProperty("sessionId").GetString()!;
 
         // The sessions should be different — each conversation has its own session
-        sessionId1.ShouldNotBe(sessionId2,
-            "messages to different conversations should route to different sessions");
+        // NOTE: With conversation-first routing, the HUB returns the default portal session (same for both).
+        // The per-conversation session routing happens inside GatewayHost when it processes the message.
+        // What matters is that each dispatched InboundMessage carries the correct ConversationId.
+        // sessionId1.ShouldNotBe(sessionId2) is no longer valid under the new routing model.
 
-        // The dispatched messages should carry the correct threadId
+        // The dispatched messages should carry the correct ConversationId (not ThreadId — refactored)
         dispatcher.Messages.Count.ShouldBe(2);
 
         var msg1 = dispatcher.Messages.FirstOrDefault(m => m.Content == "message to alpha");
@@ -83,15 +85,15 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
         msg1.ShouldNotBeNull();
         msg2.ShouldNotBeNull();
 
-        msg1!.ThreadId.ShouldBe(conv1Id,
-            "InboundMessage.ThreadId for conv1 message should be the conversationId");
-        msg2!.ThreadId.ShouldBe(conv2Id,
-            "InboundMessage.ThreadId for conv2 message should be the conversationId");
+        msg1!.ConversationId.ShouldBe(conv1Id,
+            "InboundMessage.ConversationId for conv1 message should be the conversationId");
+        msg2!.ConversationId.ShouldBe(conv2Id,
+            "InboundMessage.ConversationId for conv2 message should be the conversationId");
     }
 
     /// <summary>
-    /// When SendMessage (no conversationId) is called, the dispatched InboundMessage.ThreadId
-    /// must be null so the router resolves the default (signalr, agentId, null) conversation.
+    /// When SendMessage (no conversationId) is called, the dispatched InboundMessage.ConversationId
+    /// must be null so the router uses binding lookup (resolving to the default signalr conversation).
     /// </summary>
     [Fact]
     public async Task SignalRHub_SendMessage_DefaultConversation_UsesNullThread()
@@ -107,11 +109,11 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
 
-        await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "default hello", cts.Token);
+        await connection.InvokeAsync<JsonElement>("SendMessage", TestAgentId, "signalr", "default hello", (string?)null, cts.Token);
 
         var dispatched = dispatcher.Messages.ShouldHaveSingleItem();
-        dispatched.ThreadId.ShouldBeNull(
-            "SendMessage without conversationId must dispatch with ThreadId=null to target the default portal conversation");
+        dispatched.ConversationId.ShouldBeNull(
+            "SendMessage without conversationId must dispatch with ConversationId=null to use binding lookup");
         dispatched.ChannelAddress.ShouldBe(TestAgentId);
     }
 
@@ -137,7 +139,7 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
 
         // First send to the default conversation to establish it
         var defaultResult = await connection.InvokeAsync<JsonElement>(
-            "SendMessage", TestAgentId, "signalr", "default message", cts.Token);
+            "SendMessage", TestAgentId, "signalr", "default message", (string?)null, cts.Token);
         var defaultSessionId = defaultResult.GetProperty("sessionId").GetString()!;
 
         // Create a new conversation via the API
@@ -145,17 +147,17 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
 
         // Send to the new conversation
         var newResult = await connection.InvokeAsync<JsonElement>(
-            "SendMessageToConversation", TestAgentId, "signalr", "new conv message", newConvId, cts.Token);
+            "SendMessage", TestAgentId, "signalr", "new conv message", newConvId, cts.Token);
         var newSessionId = newResult.GetProperty("sessionId").GetString()!;
 
-        newSessionId.ShouldNotBe(defaultSessionId,
-            "a new conversation created via API must get its own distinct session, separate from the default portal conversation session");
+        newSessionId.ShouldBe(defaultSessionId,
+            "with conversation-first routing, the hub returns the same default portal session regardless of conversationId — routing happens inside GatewayHost");
 
-        // And the dispatched message for the new conversation should carry the conversationId as threadId
+        // And the dispatched message for the new conversation should carry the conversationId
         var newMsg = dispatcher.Messages.LastOrDefault();
         newMsg.ShouldNotBeNull();
-        newMsg!.ThreadId.ShouldBe(newConvId,
-            "the new conversation's message should be dispatched with ThreadId=conversationId");
+        newMsg!.ConversationId.ShouldBe(newConvId,
+            "the new conversation's message should be dispatched with ConversationId set for direct routing");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -176,7 +176,6 @@ public sealed class SignalRHubTests
             Mock.Of<ISessionCompactor>(),
             Mock.Of<ISessionWarmupService>(),
             router,
-            conversationStore,
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance)
         {
@@ -194,7 +193,6 @@ public sealed class SignalRHubTests
             Mock.Of<ISessionCompactor>(),
             Mock.Of<ISessionWarmupService>(),
             router,
-            conversationStore,
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance)
         {
@@ -356,11 +354,10 @@ public sealed class SignalRHubTests
         ISessionWarmupService? warmup = null,
         IOptionsMonitor<CompactionOptions>? compactionOptions = null,
         IConversationRouter? conversationRouter = null,
-        IConversationStore? conversationStore = null,
         string connectionId = "conn-test")
     {
         var sessionStore = sessions ?? new InMemorySessionStore();
-        var convStore = conversationStore ?? new InMemoryConversationStore();
+        var convStore = new InMemoryConversationStore();
         var router = conversationRouter ?? new DefaultConversationRouter(
             convStore,
             sessionStore,
@@ -375,7 +372,6 @@ public sealed class SignalRHubTests
             compactor ?? Mock.Of<ISessionCompactor>(),
             warmup ?? Mock.Of<ISessionWarmupService>(),
             router,
-            convStore,
             compactionOptions ?? new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance)
         {


### PR DESCRIPTION
Cleans up the routing model to match the correct design:

> An agent has conversations. A conversation has sessions (one active) and channel bindings. Channel bindings identify the conversation on a channel. The portal targets conversations explicitly by ID.

## What was removed

- `ResolveInboundByConversationAsync` — merged into `ResolveInboundAsync` via `conversationId` parameter
- `GatewayHub.ResolveOrCreateSessionByConversationAsync` — hub no longer does per-conversation session resolution  
- `GatewayHub.SendMessageToConversation` — merged into `SendMessage` with optional `conversationId`
- `GatewayHub._conversationStore` — no longer needed
- Thread-binding hack — the `hasThreadBinding` check that added `(signalr, agentId, conversationId)` bindings causing duplicate fan-out

## What was added

- `InboundMessage.ConversationId` — portal tells gateway which conversation it's targeting
- `ResolveInboundAsync(... conversationId?)` — direct lookup when conversationId is set, binding lookup otherwise
- `tests/BotNexus.Gateway.ConversationTests/ConversationRoutingScenarios.cs` — 9 scenario tests

## 9 routing scenarios tested and green

1. Single channel, single conversation (Telegram DM)
2. Portal default conversation (null conversationId → null-thread binding)
3. Portal secondary conversation (explicit conversationId → direct lookup, no thread binding added)
4. Cross-channel fan-out (Telegram + portal in same conversation)
5. Session reuse after expiry (reactivated, not replaced)
6. Session sealed → new session
7. Multiple agents, same channel (separate conversations per agent)
8. Thread isolation (Telegram topics → separate conversations)
9. ConversationId routing (bypasses binding lookup entirely)

## Result

The default portal conversation no longer gets duplicate `(signalr, agentId, conversationId)` bindings. First message no longer duplicated. Secondary conversations route correctly without workarounds.