### PR TITLE
docs(architecture): gateway flow diagrams; refactor(domain): BindingId strong type

### DIFF
--- a/docs/architecture/gateway-flow.md
+++ b/docs/architecture/gateway-flow.md
@@ -1,0 +1,177 @@
+---
+owner: ai
+author: Hermes
+ai-policy: open
+---
+
+# Gateway Flow Diagrams
+
+Architectural diagrams for the BotNexus gateway message processing pipeline.
+Focus: gateway core. Channel-specific details (Telegram, SignalR) are deliberately omitted.
+
+---
+
+## Diagram 1 — Inbound Message Flow
+
+```mermaid
+sequenceDiagram
+    participant CA as Channel Adapter
+    participant GH as GatewayHost
+    participant CR as ConversationRouter
+    participant SS as SessionStore
+    participant AS as AgentSupervisor
+    participant A as Agent
+
+    CA->>GH: dispatcher.DispatchAsync(InboundMessage)
+
+    alt message has explicit ConversationId
+        GH->>CR: ResolveInboundByConversationAsync(conversationId, ...)
+    else route by channel key
+        GH->>CR: ResolveInboundAsync(agentId, channelType, channelAddress, threadId)
+    end
+
+    CR->>CR: Resolve or create Conversation
+    CR->>SS: GetOrCreate Session
+    note over CR,SS: Reuse Active/Expired session<br/>Create new only if Sealed or absent
+    CR-->>GH: ConversationRoutingResult(conversation, sessionId, originatingBinding)
+
+    GH->>GH: Stamp BindingId on message from originatingBinding
+    GH->>SS: GetOrCreateAsync(sessionId, agentId)
+    GH->>AS: GetOrCreateAsync(agentId, sessionId)
+    AS-->>GH: IAgentHandle
+
+    alt streaming supported
+        GH->>A: StreamAsync(prompt)
+        A-->>GH: IAsyncEnumerable<AgentResponse>
+    else
+        GH->>A: PromptAsync(prompt)
+        A-->>GH: AgentResponse
+    end
+
+    GH->>CA: adapter.SendAsync(OutboundMessage) [direct reply]
+    GH->>SS: session.AddEntry(assistant response)
+    GH->>GH: FanOutAsync(message, sessionId)
+    note over GH: Fan-out to all non-originating<br/>Interactive/NotifyOnly bindings
+```
+
+---
+
+## Diagram 2 — Conversation & Session Resolution
+
+```mermaid
+flowchart TD
+    A([InboundMessage arrives]) --> B{ConversationId\non message?}
+
+    B -- Yes --> C[Direct lookup by ConversationId]
+    B -- No  --> D[Lookup by channelType + channelAddress + threadId]
+
+    C --> E{Conversation\nfound?}
+    D --> E
+
+    E -- No  --> F[Create new Conversation + ChannelBinding]
+    E -- Yes --> G[Use existing Conversation]
+    F --> G
+
+    G --> H{ActiveSessionId\npresent?}
+
+    H -- No  --> I[Create new Session]
+    H -- Yes --> J{Session\nstatus?}
+
+    J -- Sealed --> I
+    J -- Active  --> K[Reuse session as-is]
+    J -- Expired --> L[Reactivate: set status back to Active]
+
+    I --> M([Return ConversationRoutingResult])
+    K --> M
+    L --> M
+```
+
+---
+
+## Diagram 3 — Outbound Fan-out
+
+```mermaid
+sequenceDiagram
+    participant GH as GatewayHost
+    participant CR as ConversationRouter
+    participant CM as ChannelManager
+    participant CA as Channel Adapter
+
+    GH->>CR: GetOutboundBindingsAsync(sessionId, originatingBindingId)
+    note over CR: Excludes originating binding<br/>Returns Interactive + NotifyOnly only<br/>(Muted bindings filtered out)
+    CR-->>GH: [ChannelBinding, ...]
+
+    loop for each binding
+        GH->>CM: ResolveChannelAdapter(binding.ChannelType)
+        CM-->>GH: IChannelAdapter (or null → skip)
+
+        GH->>CA: SendAsync(OutboundMessage with binding fields)
+
+        alt StaleChannelConnectionException
+            CA--xGH: throws StaleChannelConnectionException
+            GH->>CR: MuteBindingAsync(conversationId, binding.BindingId)
+            note over GH: Self-heal: demote dead binding<br/>to Muted so future fan-outs skip it
+        end
+    end
+```
+
+---
+
+## Diagram 4 — Channel Extension Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant EL as Extension Loader
+    participant CM as ChannelManager
+    participant CA as Channel Adapter
+    participant D  as IChannelDispatcher
+    participant GH as GatewayHost
+
+    note over EL: Startup
+    EL->>CM: Register IChannelAdapter via IAgentToolContributor
+    CM->>CA: StartAsync(IChannelDispatcher)
+    note over CA: Adapter now listening on its channel
+
+    note over CA,GH: Inbound path
+    CA->>D: dispatcher.DispatchAsync(InboundMessage)
+    D->>GH: DispatchAsync(message)
+
+    note over GH,CA: Outbound path
+    GH->>CA: adapter.SendAsync(OutboundMessage)
+
+    note over EL: Shutdown
+    EL->>CA: StopAsync()
+    note over CA: Adapter stops listening
+```
+
+---
+
+## String Smell — Remaining Issues
+
+The following fields are still plain `string` but should be strong types in a future refactor.
+**Do not change these yet** — too many callsites across extensions and tests.
+
+### Pending strong types
+
+| Field / Parameter | Should become | Affected types |
+|---|---|---|
+| `ChannelBinding.ChannelAddress` | `ChannelAddress` | `ChannelBinding`, `InboundMessage`, `OutboundMessage`, `IConversationRouter` |
+| `ChannelBinding.ThreadId` | `ThreadId` | `ChannelBinding`, `InboundMessage`, `OutboundMessage`, `IConversationRouter` |
+| `InboundMessage.SenderId` | `SenderId` (already exists as a type — wire up) | `InboundMessage` |
+
+### Swap-risk: adjacent string parameters
+
+Methods where two or more adjacent parameters are plain `string` and could be silently swapped by a caller:
+
+| Method | Adjacent string params | Risk |
+|---|---|---|
+| `IConversationRouter.ResolveInboundAsync` | `string channelAddress, string? threadId` | Caller could swap address and threadId — both are strings, no compile error |
+| `IConversationRouter.MuteBindingByAddressAsync` | `ChannelKey channelType, string channelAddress` | `channelAddress` is adjacent to `channelType` (which is a strong `ChannelKey`) — lower risk but worth noting |
+| `ChannelBinding` constructor / init | `ChannelAddress`, `ThreadId` as plain strings | Any code building a `ChannelBinding` with positional-style init could swap the two |
+| `StaleChannelConnectionException` constructor | `BindingId bindingId` (now strong), `string conversationId` | `conversationId` is still a string — misuse is unlikely but `ConversationId` strong type exists |
+
+**Recommended next steps:**
+1. File issue: introduce `ChannelAddress` record struct (similar to `ChannelKey`)
+2. File issue: introduce `ThreadId` record struct
+3. Wire existing `SenderId` primitive to `InboundMessage.SenderId`
+4. Update `StaleChannelConnectionException.ConversationId` to `ConversationId` strong type

--- a/src/domain/BotNexus.Domain/Gateway/Models/ChannelBinding.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/ChannelBinding.cs
@@ -8,7 +8,7 @@ namespace BotNexus.Gateway.Abstractions.Models;
 public sealed record ChannelBinding
 {
     /// <summary>Gets or sets the unique binding identifier.</summary>
-    public string BindingId { get; set; } = Guid.NewGuid().ToString("N");
+    public BindingId BindingId { get; set; } = BindingId.Create();
 
     /// <summary>Gets or sets the channel type for this binding.</summary>
     public ChannelKey ChannelType { get; set; }

--- a/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
@@ -56,7 +56,7 @@ public sealed record InboundMessage
     /// The channel binding ID this message arrived on, if known.
     /// Used by fan-out to exclude the originating binding from echo.
     /// </summary>
-    public string? BindingId { get; init; }
+    public BindingId? BindingId { get; init; }
 
     /// <summary>
     /// When set, routes directly to this conversation, bypassing binding lookup.
@@ -94,7 +94,7 @@ public sealed record OutboundMessage
     /// Stable identifier of the channel binding that this message is being sent to.
     /// Populated during fan-out to allow adapters and logging to correlate delivery.
     /// </summary>
-    public string? BindingId { get; init; }
+    public BindingId? BindingId { get; init; }
 
     /// <summary>
     /// Optional display prefix prepended to outbound content when

--- a/src/domain/BotNexus.Domain/Primitives/BindingId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/BindingId.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Serialization;
+
+namespace BotNexus.Domain.Primitives;
+
+[JsonConverter(typeof(BindingIdJsonConverter))]
+/// <summary>
+/// Strongly-typed identifier for a <c>ChannelBinding</c>, preventing accidental confusion
+/// with <c>ChannelAddress</c>, <c>ThreadId</c>, or other adjacent string parameters.
+/// </summary>
+public readonly record struct BindingId : IComparable<BindingId>
+{
+    /// <summary>Gets the raw string value of this binding identifier.</summary>
+    public string Value { get; }
+
+    private BindingId(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="BindingId"/> from an existing string value.
+    /// </summary>
+    /// <param name="value">The raw identifier string. Must not be null or whitespace.</param>
+    public static BindingId From(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentException("BindingId cannot be empty", nameof(value))
+            : new(value.Trim());
+
+    /// <summary>
+    /// Creates a new unique <see cref="BindingId"/> using a GUID.
+    /// </summary>
+    public static BindingId Create() => new(Guid.NewGuid().ToString("N"));
+
+    /// <summary>Explicit conversion from <see cref="BindingId"/> to <see cref="string"/>. Use <see cref="Value"/> or <see cref="ToString"/> instead.</summary>
+    public static explicit operator string(BindingId id) => id.Value;
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <inheritdoc />
+    public int CompareTo(BindingId other) => string.Compare(Value, other.Value, StringComparison.Ordinal);
+}

--- a/src/domain/BotNexus.Domain/Serialization/BindingIdJsonConverter.cs
+++ b/src/domain/BotNexus.Domain/Serialization/BindingIdJsonConverter.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.Serialization;
+
+/// <summary>
+/// JSON converter that serialises/deserialises <see cref="BindingId"/> as a plain string,
+/// matching the on-wire format used by <see cref="SessionIdJsonConverter"/>.
+/// </summary>
+public sealed class BindingIdJsonConverter : JsonConverter<BindingId>
+{
+    /// <inheritdoc />
+    public override BindingId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException("BindingId must be a string.");
+
+        return BindingId.From(reader.GetString() ?? string.Empty);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, BindingId value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.Value);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/StaleSignalRConnectionException.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/StaleSignalRConnectionException.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Channels;
 
 namespace BotNexus.Extensions.Channels.SignalR;
@@ -12,7 +13,7 @@ public sealed class StaleSignalRConnectionException : StaleChannelConnectionExce
     /// <summary>
     /// Initialises a new instance describing a stale SignalR connection for a specific binding.
     /// </summary>
-    public StaleSignalRConnectionException(string bindingId, string conversationId, Exception? inner = null)
+    public StaleSignalRConnectionException(BindingId bindingId, string conversationId, Exception? inner = null)
         : base(bindingId, conversationId, inner)
     {
     }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -155,7 +155,7 @@ public sealed class ConversationsController : ControllerBase
 
         var binding = new ChannelBinding
         {
-            BindingId = Guid.NewGuid().ToString("N"),
+            BindingId = BindingId.Create(),
             ChannelType = ChannelKey.From(request.ChannelType),
             ChannelAddress = request.ChannelAddress ?? string.Empty,
             ThreadId = request.ThreadId,
@@ -192,7 +192,7 @@ public sealed class ConversationsController : ControllerBase
             return NotFound();
 
         var binding = conversation.ChannelBindings.FirstOrDefault(b =>
-            string.Equals(b.BindingId, bindingId, StringComparison.Ordinal));
+            string.Equals(b.BindingId.Value, bindingId, StringComparison.Ordinal));
         if (binding is null)
             return NotFound();
 
@@ -317,7 +317,7 @@ public sealed class ConversationsController : ControllerBase
         UpdatedAt: c.UpdatedAt);
 
     private static BindingResponse ToBindingResponse(ChannelBinding b) => new(
-        BindingId: b.BindingId,
+        BindingId: b.BindingId.Value,
         ChannelType: b.ChannelType.Value,
         ChannelAddress: b.ChannelAddress,
         ThreadId: b.ThreadId,

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/StaleChannelConnectionException.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/StaleChannelConnectionException.cs
@@ -1,3 +1,5 @@
+using BotNexus.Domain.Primitives;
+
 namespace BotNexus.Gateway.Abstractions.Channels;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace BotNexus.Gateway.Abstractions.Channels;
 public class StaleChannelConnectionException : Exception
 {
     /// <summary>Gets the binding ID whose underlying connection is gone.</summary>
-    public string BindingId { get; }
+    public BindingId BindingId { get; }
 
     /// <summary>Gets the conversation ID the binding belongs to.</summary>
     public string ConversationId { get; }
@@ -18,7 +20,7 @@ public class StaleChannelConnectionException : Exception
     /// <summary>
     /// Initialises a new instance describing a stale connection for a specific binding.
     /// </summary>
-    public StaleChannelConnectionException(string bindingId, string conversationId, Exception? inner = null)
+    public StaleChannelConnectionException(BindingId bindingId, string conversationId, Exception? inner = null)
         : base($"Channel send failed — connection for binding {bindingId} in conversation {conversationId} is gone.", inner)
     {
         BindingId = bindingId;

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -31,7 +31,7 @@ public interface IConversationRouter
     /// </summary>
     Task<IReadOnlyList<ChannelBinding>> GetOutboundBindingsAsync(
         SessionId sessionId,
-        string? originatingBindingId,
+        BindingId? originatingBindingId,
         CancellationToken ct = default);
 
     /// <summary>
@@ -41,7 +41,7 @@ public interface IConversationRouter
     /// <param name="bindingId">The binding to move.</param>
     /// <param name="targetConversationId">The conversation that should own the binding after the call.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task ReattachBindingAsync(string bindingId, ConversationId targetConversationId, CancellationToken ct = default);
+    Task ReattachBindingAsync(BindingId bindingId, ConversationId targetConversationId, CancellationToken ct = default);
 
     /// <summary>
     /// Demotes a channel binding to <see cref="BindingMode.Muted"/> so it no longer receives fan-out.
@@ -50,7 +50,7 @@ public interface IConversationRouter
     /// <param name="conversationId">The conversation that owns the binding.</param>
     /// <param name="bindingId">The binding to silence.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task MuteBindingAsync(ConversationId conversationId, string bindingId, CancellationToken ct = default);
+    Task MuteBindingAsync(ConversationId conversationId, BindingId bindingId, CancellationToken ct = default);
 
     /// <summary>
     /// Finds and mutes the binding associated with the given channel type and address.

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
@@ -529,7 +529,7 @@ public sealed class SqliteConversationStore : IConversationStore
         {
             bindings.Add(new ChannelBinding
             {
-                BindingId = reader.GetString(0),
+                BindingId = BindingId.From(reader.GetString(0)),
                 ChannelType = ChannelKey.From(reader.GetString(1)),
                 ChannelAddress = reader.GetString(2),
                 ThreadId = reader.IsDBNull(3) ? null : reader.GetString(3),
@@ -594,7 +594,7 @@ public sealed class SqliteConversationStore : IConversationStore
                 INSERT INTO conversation_bindings (binding_id, conversation_id, channel_type, channel_address, thread_id, mode, threading_mode, display_prefix, bound_at, last_inbound_at, last_outbound_at)
                 VALUES ($bindingId, $conversationId, $channelType, $channelAddress, $threadId, $mode, $threadingMode, $displayPrefix, $boundAt, $lastInboundAt, $lastOutboundAt)
                 """;
-            bindingCommand.Parameters.AddWithValue("$bindingId", binding.BindingId);
+            bindingCommand.Parameters.AddWithValue("$bindingId", binding.BindingId.Value);
             bindingCommand.Parameters.AddWithValue("$conversationId", conversation.ConversationId.Value);
             bindingCommand.Parameters.AddWithValue("$channelType", binding.ChannelType.Value);
             bindingCommand.Parameters.AddWithValue("$channelAddress", binding.ChannelAddress);

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -120,7 +120,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
     /// <inheritdoc />
     public async Task<IReadOnlyList<ChannelBinding>> GetOutboundBindingsAsync(
         SessionId sessionId,
-        string? originatingBindingId,
+        BindingId? originatingBindingId,
         CancellationToken ct = default)
     {
         // 1. Resolve the session to get ConversationId
@@ -148,12 +148,12 @@ public sealed class DefaultConversationRouter : IConversationRouter
         // 2. Filter bindings: not muted, not the originating binding
         return conversation.ChannelBindings
             .Where(b => b.Mode != BindingMode.Muted)
-            .Where(b => originatingBindingId is null || !string.Equals(b.BindingId, originatingBindingId, StringComparison.Ordinal))
+            .Where(b => originatingBindingId is null || b.BindingId != originatingBindingId.Value)
             .ToList();
     }
 
     /// <inheritdoc />
-    public async Task MuteBindingAsync(ConversationId conversationId, string bindingId, CancellationToken ct = default)
+    public async Task MuteBindingAsync(ConversationId conversationId, BindingId bindingId, CancellationToken ct = default)
     {
         var conversation = await _conversationStore.GetAsync(conversationId, ct);
         if (conversation is null)
@@ -163,7 +163,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
         }
 
         var binding = conversation.ChannelBindings.FirstOrDefault(b =>
-            string.Equals(b.BindingId, bindingId, StringComparison.Ordinal));
+            string.Equals(b.BindingId.Value, bindingId.Value, StringComparison.Ordinal));
 
         if (binding is null)
         {
@@ -202,7 +202,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
     }
 
     /// <inheritdoc />
-    public async Task ReattachBindingAsync(string bindingId, ConversationId targetConversationId, CancellationToken ct = default)
+    public async Task ReattachBindingAsync(BindingId bindingId, ConversationId targetConversationId, CancellationToken ct = default)
     {
         var target = await _conversationStore.GetAsync(targetConversationId, ct);
         if (target is null)
@@ -216,7 +216,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
         foreach (var source in conversations)
         {
             var binding = source.ChannelBindings.FirstOrDefault(b =>
-                string.Equals(b.BindingId, bindingId, StringComparison.Ordinal));
+                string.Equals(b.BindingId.Value, bindingId.Value, StringComparison.Ordinal));
 
             if (binding is null)
                 continue;

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using System.Net;
 using System.Text;
 using System.Text.Json;

--- a/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -230,8 +230,8 @@ public sealed class DefaultConversationRouterTests
 
         // Create conversation with two bindings — each with an explicit BindingId
         var conversation = await conversationStore.GetOrCreateDefaultAsync(agentId);
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = "binding-tg", ChannelType = Channel("telegram"), ChannelAddress = "chat-A", Mode = BindingMode.Interactive });
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = "binding-sr", ChannelType = Channel("signalr"), ChannelAddress = "conn-B", Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-tg"), ChannelType = Channel("telegram"), ChannelAddress = "chat-A", Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-sr"), ChannelType = Channel("signalr"), ChannelAddress = "conn-B", Mode = BindingMode.Interactive });
         await conversationStore.SaveAsync(conversation);
 
         var sessionId = SessionId.Create();
@@ -241,7 +241,7 @@ public sealed class DefaultConversationRouterTests
 
         var router = CreateRouter(conversationStore, sessionStore);
         // Exclude by BindingId, not ChannelAddress
-        var bindings = await router.GetOutboundBindingsAsync(sessionId, "binding-tg");
+        var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("binding-tg"));
 
         bindings.ShouldNotBeNull();
         bindings.Count.ShouldBe(1);
@@ -256,9 +256,9 @@ public sealed class DefaultConversationRouterTests
         var agentId = Agent();
 
         var conversation = await conversationStore.GetOrCreateDefaultAsync(agentId);
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = "binding-orig", ChannelType = Channel("telegram"), ChannelAddress = "originator", Mode = BindingMode.Interactive });
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = "binding-muted", ChannelType = Channel("signalr"), ChannelAddress = "muted-chan", Mode = BindingMode.Muted });
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = "binding-active", ChannelType = Channel("slack"), ChannelAddress = "active-chan", Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-orig"), ChannelType = Channel("telegram"), ChannelAddress = "originator", Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-muted"), ChannelType = Channel("signalr"), ChannelAddress = "muted-chan", Mode = BindingMode.Muted });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-active"), ChannelType = Channel("slack"), ChannelAddress = "active-chan", Mode = BindingMode.Interactive });
         await conversationStore.SaveAsync(conversation);
 
         var sessionId = SessionId.Create();
@@ -267,7 +267,7 @@ public sealed class DefaultConversationRouterTests
         await sessionStore.SaveAsync(session);
 
         var router = CreateRouter(conversationStore, sessionStore);
-        var bindings = await router.GetOutboundBindingsAsync(sessionId, "binding-orig");
+        var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("binding-orig"));
 
         bindings.ShouldNotContain(b => b.Mode == BindingMode.Muted);
         bindings.Count.ShouldBe(1);
@@ -281,7 +281,7 @@ public sealed class DefaultConversationRouterTests
         var sessionId = SessionId.Create();
 
         // Session does not exist in store
-        var bindings = await router.GetOutboundBindingsAsync(sessionId, "anything");
+        var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("anything"));
 
         bindings.ShouldNotBeNull();
         bindings.Count.ShouldBe(0);
@@ -305,7 +305,7 @@ public sealed class DefaultConversationRouterTests
         await sessionStore.SaveAsync(session);
 
         var router = CreateRouter(conversationStore, sessionStore);
-        var bindings = await router.GetOutboundBindingsAsync(sessionId, "src");
+        var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("src"));
 
         bindings.ShouldContain(b => b.ChannelAddress == "notify-only-chan" && b.Mode == BindingMode.NotifyOnly);
     }

--- a/tests/BotNexus.Gateway.Tests/Conversations/FanOutBindingAwareTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/FanOutBindingAwareTests.cs
@@ -28,14 +28,14 @@ public sealed class FanOutBindingAwareTests
         var conversation = await conversationStore.GetOrCreateDefaultAsync(agentId);
         conversation.ChannelBindings.Add(new ChannelBinding
         {
-            BindingId = "binding-src",
+            BindingId = BindingId.From("binding-src"),
             ChannelType = Channel("signalr"),
             ChannelAddress = "conn-origin",
             Mode = BindingMode.Interactive
         });
         conversation.ChannelBindings.Add(new ChannelBinding
         {
-            BindingId = "binding-tg",
+            BindingId = BindingId.From("binding-tg"),
             ChannelType = Channel("telegram"),
             ChannelAddress = "chat-999",
             ThreadId = "topic-77",
@@ -49,7 +49,7 @@ public sealed class FanOutBindingAwareTests
         await sessionStore.SaveAsync(session);
 
         var router = new DefaultConversationRouter(conversationStore, sessionStore, NullLogger<DefaultConversationRouter>.Instance);
-        var bindings = await router.GetOutboundBindingsAsync(sessionId, "binding-src");
+        var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("binding-src"));
 
         // The telegram binding with ThreadId should be included
         bindings.Count.ShouldBe(1);
@@ -69,6 +69,6 @@ public sealed class FanOutBindingAwareTests
         };
 
         outbound.ThreadId.ShouldBe("topic-77");
-        outbound.BindingId.ShouldBe("binding-tg");
+        outbound.BindingId?.Value.ShouldBe("binding-tg");
     }
 }

--- a/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -32,7 +32,7 @@ public sealed class GatewayHostBindingRoutingTests
     {
         var binding = new ChannelBinding
         {
-            BindingId = "bind-tg-1",
+            BindingId = BindingId.From("bind-tg-1"),
             ChannelType = ChannelKey.From("telegram"),
             ChannelAddress = "chat-100",
             ThreadId = "topic-42",
@@ -60,7 +60,7 @@ public sealed class GatewayHostBindingRoutingTests
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
-            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
         var handle = CreatePromptHandle(AgentIdStr, SessionIdStr, "response text");
@@ -93,7 +93,7 @@ public sealed class GatewayHostBindingRoutingTests
 
         capturedOutbound.ShouldNotBeNull("adapter.SendAsync should have been called for non-streaming path");
         capturedOutbound!.ThreadId.ShouldBe("topic-42", "ThreadId from originating binding must be stamped on direct send");
-        capturedOutbound.BindingId.ShouldBe("bind-tg-1", "BindingId from originating binding must be stamped on direct send");
+        capturedOutbound.BindingId?.Value.ShouldBe("bind-tg-1", "BindingId from originating binding must be stamped on direct send");
         capturedOutbound.DisplayPrefix.ShouldBe("[Bot]", "DisplayPrefix from originating binding must be stamped on direct send");
     }
 
@@ -106,7 +106,7 @@ public sealed class GatewayHostBindingRoutingTests
     {
         var binding = new ChannelBinding
         {
-            BindingId = "bind-tg-2",
+            BindingId = BindingId.From("bind-tg-2"),
             ChannelType = ChannelKey.From("telegram"),
             ChannelAddress = "chat-200",
             ThreadId = "topic-99",
@@ -133,7 +133,7 @@ public sealed class GatewayHostBindingRoutingTests
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
-            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
         var handle = new Mock<IAgentHandle>();
@@ -190,7 +190,7 @@ public sealed class GatewayHostBindingRoutingTests
     {
         var binding = new ChannelBinding
         {
-            BindingId = "bind-origin",
+            BindingId = BindingId.From("bind-origin"),
             ChannelType = ChannelKey.From("telegram"),
             ChannelAddress = "chat-300",
             ThreadId = null,
@@ -210,7 +210,7 @@ public sealed class GatewayHostBindingRoutingTests
             false,
             OriginatingBinding: binding);
 
-        string? capturedOriginatingBindingId = null;
+        BindingId? capturedOriginatingBindingId = null;
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
@@ -218,8 +218,8 @@ public sealed class GatewayHostBindingRoutingTests
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
-            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Callback<SessionId, string?, CancellationToken>((_, bindId, _) => capturedOriginatingBindingId = bindId)
+            .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
+            .Callback<SessionId, BindingId?, CancellationToken>((_, bindId, _) => capturedOriginatingBindingId = bindId)
             .ReturnsAsync([]);
 
         var handle = CreatePromptHandle(AgentIdStr, SessionIdStr, "ok");
@@ -245,7 +245,8 @@ public sealed class GatewayHostBindingRoutingTests
             Metadata = new Dictionary<string, object?>()
         });
 
-        capturedOriginatingBindingId.ShouldBe("bind-origin",
+        capturedOriginatingBindingId.ShouldNotBeNull();
+        capturedOriginatingBindingId.Value.Value.ShouldBe("bind-origin",
             "The originating BindingId from the resolved binding must be passed to GetOutboundBindingsAsync for fan-out exclusion");
     }
 

--- a/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -236,8 +237,8 @@ public sealed class MultiChannelFanOutTests
             ActiveSessionId = BotNexus.Domain.Primitives.SessionId.From("legacy-session"),
             ChannelBindings =
             [
-                new ChannelBinding { BindingId = "sig", ChannelType = ChannelKey.From("signalr"), ChannelAddress = "chat-1" },
-                new ChannelBinding { BindingId = "tel", ChannelType = ChannelKey.From("telegram"), ChannelAddress = "chat-100" }
+                new ChannelBinding { BindingId = BindingId.From("sig"), ChannelType = ChannelKey.From("signalr"), ChannelAddress = "chat-1" },
+                new ChannelBinding { BindingId = BindingId.From("tel"), ChannelType = ChannelKey.From("telegram"), ChannelAddress = "chat-100" }
             ]
         };
         await harness.Conversations.CreateAsync(conversation);

--- a/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
@@ -123,15 +123,15 @@ internal sealed class CapturingConversationRouter : IConversationRouter
     }
 
     public Task<IReadOnlyList<ChannelBinding>> GetOutboundBindingsAsync(
-        SessionId sessionId, string originatingChannelAddress, CancellationToken ct = default)
+        SessionId sessionId, BindingId? originatingChannelAddress, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<ChannelBinding>>([]);
 
-    public Task MuteBindingAsync(ConversationId conversationId, string bindingId, CancellationToken ct = default)
+    public Task MuteBindingAsync(ConversationId conversationId, BindingId bindingId, CancellationToken ct = default)
         => Task.CompletedTask;
 
     public Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default)
         => Task.CompletedTask;
 
-    public Task ReattachBindingAsync(string bindingId, ConversationId targetConversationId, CancellationToken ct = default)
+    public Task ReattachBindingAsync(BindingId bindingId, ConversationId targetConversationId, CancellationToken ct = default)
         => Task.CompletedTask;
 }

--- a/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -71,7 +71,7 @@ public sealed class FanOutStaleBindingTests
         const string agentId = "agent-a";
         const string sessionId = "session-1";
         const string convId = "conv-fanout-stale";
-        const string bindingId = "binding-signalr-1";
+        var bindingId = BindingId.From("binding-signalr-1");
 
         var router = new Mock<IMessageRouter>();
         router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
@@ -129,7 +129,7 @@ public sealed class FanOutStaleBindingTests
 
         // Return the stale binding for fan-out
         convRouter
-            .Setup(r => r.GetOutboundBindingsAsync(SessionId.From(sessionId), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetOutboundBindingsAsync(SessionId.From(sessionId), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([staleBinding]);
 
         convRouter
@@ -195,7 +195,7 @@ public sealed class FanOutStaleBindingTests
 
         // Empty list = already muted / no fan-out targets
         convRouter
-            .Setup(r => r.GetOutboundBindingsAsync(SessionId.From(sessionId), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetOutboundBindingsAsync(SessionId.From(sessionId), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
         await using var host = CreateHost(supervisor.Object, router.Object, sessions, channelManager.Object, convRouter.Object);

--- a/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
@@ -300,7 +300,7 @@ public sealed class SqliteConversationStoreTests
     private static ChannelBinding CreateBinding(string channelType, string channelAddress, string? threadId = null)
         => new()
         {
-            BindingId = Guid.NewGuid().ToString("N"),
+            BindingId = BindingId.Create(),
             ChannelType = ChannelKey.From(channelType),
             ChannelAddress = channelAddress,
             ThreadId = threadId,


### PR DESCRIPTION
Two things in one branch.

## 1. Gateway flow diagrams — `docs/architecture/gateway-flow.md`

Four Mermaid diagrams:

1. **Inbound message flow** — channel adapter → GatewayHost → ConversationRouter → SessionStore → Agent → direct send + fan-out
2. **Conversation & session resolution** — ConversationId direct lookup vs binding lookup; session reuse/sealed/expired decision tree  
3. **Outbound fan-out** — GetOutboundBindings, per-binding send, StaleChannelConnectionException → MuteBinding self-heal
4. **Channel extension lifecycle** — startup registration, StartAsync, inbound dispatch, outbound send, shutdown

Also documents remaining string-primitive smell and swap-risk methods.

## 2. BindingId strong type

`BindingId` value type introduced in `BotNexus.Domain.Primitives`.

**Used on:**
- `ChannelBinding.BindingId` (was `string`)
- `InboundMessage.BindingId` / `OutboundMessage.BindingId` (was `string?`)
- `IConversationRouter.GetOutboundBindingsAsync`, `MuteBindingAsync`, `ReattachBindingAsync`
- `StaleChannelConnectionException` / `StaleSignalRConnectionException`
- All callers updated

**No implicit string→BindingId conversion** (would confuse Moq). Use `BindingId.From(str)` or `BindingId.Create()` explicitly.

## Remaining string smell (documented, not changed yet)

| Field | Risk |
|---|---|
| `ChannelAddress` | Too many callsites — follow-up issue |
| `ThreadId` | Same — follow-up issue |
| `ResolveInboundAsync(agentId, channelType, channelAddress, threadId)` | Two adjacent strings — swap risk |