### PR TITLE
refactor(domain): ChannelAddress and ThreadId strong types; fix StaleChannelConnectionException

### DIFF
--- a/docs/architecture/gateway-flow.md
+++ b/docs/architecture/gateway-flow.md
@@ -146,32 +146,24 @@ sequenceDiagram
 
 ---
 
-## String Smell — Remaining Issues
+## Strong Types — Status
 
-The following fields are still plain `string` but should be strong types in a future refactor.
-**Do not change these yet** — too many callsites across extensions and tests.
+All channel-addressing fields have been migrated to strong types (completed in PR #171/#172/#173).
 
-### Pending strong types
-
-| Field / Parameter | Should become | Affected types |
+| Field / Parameter | Type | Notes |
 |---|---|---|
-| `ChannelBinding.ChannelAddress` | `ChannelAddress` | `ChannelBinding`, `InboundMessage`, `OutboundMessage`, `IConversationRouter` |
-| `ChannelBinding.ThreadId` | `ThreadId` | `ChannelBinding`, `InboundMessage`, `OutboundMessage`, `IConversationRouter` |
-| `InboundMessage.SenderId` | `SenderId` (already exists as a type — wire up) | `InboundMessage` |
+| `ChannelBinding.ChannelAddress` | `ChannelAddress` | Value type; `ChannelAddress.Empty` for addressless channels (e.g. portal SignalR) |
+| `ChannelBinding.ThreadId` | `ThreadId?` | Nullable; `ThreadId.FromNullable()` for optional thread context |
+| `InboundMessage.ChannelAddress` | `ChannelAddress` | Required on all inbound messages |
+| `InboundMessage.ThreadId` | `ThreadId?` | Nullable thread context |
+| `OutboundMessage.ChannelAddress` | `ChannelAddress` | Required on all outbound messages |
+| `OutboundMessage.ThreadId` | `ThreadId?` | Nullable thread context |
+| `StaleChannelConnectionException.ConversationId` | `ConversationId` | Was `string` — now strong type |
 
-### Swap-risk: adjacent string parameters
+### Remaining string boundaries
 
-Methods where two or more adjacent parameters are plain `string` and could be silently swapped by a caller:
-
-| Method | Adjacent string params | Risk |
+| Field | Location | Note |
 |---|---|---|
-| `IConversationRouter.ResolveInboundAsync` | `string channelAddress, string? threadId` | Caller could swap address and threadId — both are strings, no compile error |
-| `IConversationRouter.MuteBindingByAddressAsync` | `ChannelKey channelType, string channelAddress` | `channelAddress` is adjacent to `channelType` (which is a strong `ChannelKey`) — lower risk but worth noting |
-| `ChannelBinding` constructor / init | `ChannelAddress`, `ThreadId` as plain strings | Any code building a `ChannelBinding` with positional-style init could swap the two |
-| `StaleChannelConnectionException` constructor | `BindingId bindingId` (now strong), `string conversationId` | `conversationId` is still a string — misuse is unlikely but `ConversationId` strong type exists |
-
-**Recommended next steps:**
-1. File issue: introduce `ChannelAddress` record struct (similar to `ChannelKey`)
-2. File issue: introduce `ThreadId` record struct
-3. Wire existing `SenderId` primitive to `InboundMessage.SenderId`
-4. Update `StaleChannelConnectionException.ConversationId` to `ConversationId` strong type
+| `InboundMessage.SenderId` | `InboundMessage` | Could become `SenderId` strong type (already exists) — not yet wired |
+| `CrossWorldRelayRequest.ChannelAddress` | DTO | Intentionally string for HTTP wire format |
+| Streaming `conversationId` | `IStreamEventChannelAdapter` | Channel-specific encoding; strong type would need format changes |

--- a/src/domain/BotNexus.Domain/Gateway/Models/ChannelBinding.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/ChannelBinding.cs
@@ -13,11 +13,11 @@ public sealed record ChannelBinding
     /// <summary>Gets or sets the channel type for this binding.</summary>
     public ChannelKey ChannelType { get; set; }
 
-    /// <summary>Gets or sets the channel-specific address (e.g. chat id, phone number).</summary>
-    public string ChannelAddress { get; set; } = string.Empty;
+    /// <summary>Gets or sets the channel-specific address (e.g. chat id, phone number). Use <see cref="ChannelAddress.Empty"/> for addressless channels.</summary>
+    public ChannelAddress ChannelAddress { get; set; } = ChannelAddress.Empty;
 
-    /// <summary>Gets or sets the native thread or topic id within the channel, if applicable.</summary>
-    public string? ThreadId { get; set; }
+    /// <summary>Gets or sets the native thread or topic id within the channel, if applicable. Null for channels without thread support.</summary>
+    public ThreadId? ThreadId { get; set; }
 
     /// <summary>Gets or sets the binding mode controlling message fan-out participation.</summary>
     public BindingMode Mode { get; set; } = BindingMode.Interactive;

--- a/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
@@ -17,7 +17,7 @@ public sealed record InboundMessage
     /// Conversation identifier within the channel (e.g., chat ID, thread ID).
     /// Combined with <see cref="ChannelType"/> to derive a session key.
     /// </summary>
-    public required string ChannelAddress { get; init; }
+    public required ChannelAddress ChannelAddress { get; init; }
 
     /// <summary>The message text content.</summary>
     public required string Content { get; init; }
@@ -50,7 +50,7 @@ public sealed record InboundMessage
     /// For Telegram group topics, Signal threads, Teams threads, etc.
     /// When non-null, used to route into a thread-specific conversation binding.
     /// </summary>
-    public string? ThreadId { get; init; }
+    public ThreadId? ThreadId { get; init; }
 
     /// <summary>
     /// The channel binding ID this message arrived on, if known.
@@ -75,7 +75,7 @@ public sealed record OutboundMessage
     public required ChannelKey ChannelType { get; init; }
 
     /// <summary>Target conversation identifier within the channel.</summary>
-    public required string ChannelAddress { get; init; }
+    public required ChannelAddress ChannelAddress { get; init; }
 
     /// <summary>The message content.</summary>
     public required string Content { get; init; }
@@ -88,7 +88,7 @@ public sealed record OutboundMessage
     /// When non-null, adapters should deliver the message into the specified thread
     /// (e.g. Telegram <c>message_thread_id</c>, Teams thread id).
     /// </summary>
-    public string? ThreadId { get; init; }
+    public ThreadId? ThreadId { get; init; }
 
     /// <summary>
     /// Stable identifier of the channel binding that this message is being sent to.

--- a/src/domain/BotNexus.Domain/Primitives/ChannelAddress.cs
+++ b/src/domain/BotNexus.Domain/Primitives/ChannelAddress.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Serialization;
+
+namespace BotNexus.Domain.Primitives;
+
+[JsonConverter(typeof(ChannelAddressJsonConverter))]
+/// <summary>
+/// Strongly-typed channel address, preventing accidental confusion with <c>ThreadId</c>,
+/// <c>BindingId</c>, or other adjacent string parameters.
+/// </summary>
+public readonly record struct ChannelAddress : IComparable<ChannelAddress>
+{
+    /// <summary>Gets the raw string value of this channel address.</summary>
+    public string Value { get; }
+
+    private ChannelAddress(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ChannelAddress"/> from a string value.
+    /// </summary>
+    /// <param name="value">The raw channel address string. Must not be null.</param>
+    public static ChannelAddress From(string value) =>
+        new(value ?? throw new ArgumentNullException(nameof(value)));
+
+    /// <summary>
+    /// Empty channel address — used for addressless channels (e.g. portal SignalR
+    /// where the address is derived from the agent identity at routing time).
+    /// </summary>
+    public static ChannelAddress Empty => new(string.Empty);
+
+    /// <summary>Gets a value indicating whether this address is empty.</summary>
+    public bool IsEmpty => string.IsNullOrEmpty(Value);
+
+    // No implicit conversions — use .Value or .From() explicitly to keep the boundary visible.
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <inheritdoc />
+    public int CompareTo(ChannelAddress other) =>
+        string.Compare(Value, other.Value, StringComparison.Ordinal);
+}

--- a/src/domain/BotNexus.Domain/Primitives/ThreadId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/ThreadId.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Serialization;
+
+namespace BotNexus.Domain.Primitives;
+
+[JsonConverter(typeof(ThreadIdJsonConverter))]
+/// <summary>
+/// Strongly-typed thread/topic identifier within a channel, preventing accidental confusion
+/// with <c>ChannelAddress</c> or other adjacent string parameters.
+/// </summary>
+public readonly record struct ThreadId : IComparable<ThreadId>
+{
+    /// <summary>Gets the raw string value of this thread identifier.</summary>
+    public string Value { get; }
+
+    private ThreadId(string value) => Value = value;
+
+    /// <summary>
+    /// Creates a <see cref="ThreadId"/> from a string value.
+    /// </summary>
+    /// <param name="value">The raw thread id string. Must not be null or empty.</param>
+    public static ThreadId From(string value) =>
+        new(value ?? throw new ArgumentNullException(nameof(value)));
+
+    /// <summary>
+    /// Creates a nullable <see cref="ThreadId"/> — returns <c>null</c> when the input is null or empty,
+    /// which models the absence of a thread context on channels that don't support forum topics.
+    /// </summary>
+    public static ThreadId? FromNullable(string? value) =>
+        string.IsNullOrEmpty(value) ? null : From(value);
+
+    // No implicit conversions — use .Value or .From() explicitly to keep the boundary visible.
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <inheritdoc />
+    public int CompareTo(ThreadId other) =>
+        string.Compare(Value, other.Value, StringComparison.Ordinal);
+}

--- a/src/domain/BotNexus.Domain/Serialization/ChannelAddressJsonConverter.cs
+++ b/src/domain/BotNexus.Domain/Serialization/ChannelAddressJsonConverter.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.Serialization;
+
+/// <summary>
+/// JSON converter that serialises/deserialises <see cref="ChannelAddress"/> as a plain string.
+/// An empty string round-trips to <see cref="ChannelAddress.Empty"/>.
+/// </summary>
+public sealed class ChannelAddressJsonConverter : JsonConverter<ChannelAddress>
+{
+    /// <inheritdoc />
+    public override ChannelAddress Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException("ChannelAddress must be a string.");
+
+        return ChannelAddress.From(reader.GetString() ?? string.Empty);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ChannelAddress value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.Value);
+}

--- a/src/domain/BotNexus.Domain/Serialization/ThreadIdJsonConverter.cs
+++ b/src/domain/BotNexus.Domain/Serialization/ThreadIdJsonConverter.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.Serialization;
+
+/// <summary>
+/// JSON converter that serialises/deserialises <see cref="ThreadId"/> as a plain string.
+/// </summary>
+public sealed class ThreadIdJsonConverter : JsonConverter<ThreadId>
+{
+    /// <inheritdoc />
+    public override ThreadId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException("ThreadId must be a string.");
+
+        return ThreadId.From(reader.GetString() ?? string.Empty);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ThreadId value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.Value);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -9,6 +9,7 @@ using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
 using ParticipantType = BotNexus.Domain.Primitives.ParticipantType;
 using SessionId = BotNexus.Domain.Primitives.SessionId;
 using ConversationId = BotNexus.Domain.Primitives.ConversationId;
+using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
@@ -234,7 +235,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
-                    ChannelAddress = typedAgentId.Value, // stable per-agent address — one portal conversation per agent
+                    ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
                     SessionId = session.SessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
@@ -258,7 +259,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
-                ChannelAddress = typedAgentId.Value, // stable per-agent address — one portal conversation per agent
+                ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
                 ConversationId = conversationId, // router uses this to find the right conversation directly
                 SessionId = typedSessionId.Value,
                 TargetAgentId = typedAgentId.Value,
@@ -345,7 +346,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = typedChannelType,
                     SenderId = connectionId,
-                    ChannelAddress = typedAgentId.Value,
+                    ChannelAddress = ChannelAddress.From(typedAgentId.Value),
                     SessionId = session.SessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
@@ -506,7 +507,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 // Pass null to search all agents' conversations for bindings keyed to this connection.
                 agentId: null,
                 ChannelKey.From("signalr"),
-                Context.ConnectionId,
+                ChannelAddress.From(Context.ConnectionId),
                 Context.ConnectionAborted);
         }
         catch (Exception ex)
@@ -583,7 +584,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // Conversation-first routing: resolve/create via IConversationRouter.
         // Use agentId as the channel address so every connection from the same agent
         // routes to the same portal conversation, regardless of SignalR connection ID.
-        var channelAddress = agentId.Value;
+        var channelAddress = ChannelAddress.From(agentId.Value);
         var routingResult = await _conversationRouter.ResolveInboundAsync(
             agentId,
             channelType,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -44,11 +44,11 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
     {
         if (string.Equals(message.Content?.Trim(), NoReplySentinel, StringComparison.Ordinal))
         {
-            logger.LogDebug("Suppressed NO_REPLY message for session {SessionId}", message.SessionId ?? message.ChannelAddress);
+            logger.LogDebug("Suppressed NO_REPLY message for session {SessionId}", message.SessionId ?? message.ChannelAddress.Value);
             return Task.CompletedTask;
         }
 
-        var normalizedSessionId = NormalizeSessionId(message.SessionId ?? message.ChannelAddress);
+        var normalizedSessionId = NormalizeSessionId(message.SessionId ?? message.ChannelAddress.Value);
         return _hubContext.Clients.Group(GetSessionGroup(normalizedSessionId))
             .ContentDelta(new ContentDeltaPayload(normalizedSessionId, message.Content));
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/StaleSignalRConnectionException.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/StaleSignalRConnectionException.cs
@@ -13,7 +13,7 @@ public sealed class StaleSignalRConnectionException : StaleChannelConnectionExce
     /// <summary>
     /// Initialises a new instance describing a stale SignalR connection for a specific binding.
     /// </summary>
-    public StaleSignalRConnectionException(BindingId bindingId, string conversationId, Exception? inner = null)
+    public StaleSignalRConnectionException(BindingId bindingId, ConversationId conversationId, Exception? inner = null)
         : base(bindingId, conversationId, inner)
     {
     }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -150,12 +150,12 @@ public sealed class TelegramChannelAdapter(
         cancellationToken.ThrowIfCancellationRequested();
         EnsureBotsInitialized();
 
-        if (!TryParseChatId(message.ChannelAddress, out var chatId))
+        if (!TryParseChatId(message.ChannelAddress.Value, out var chatId))
         {
             _logger.LogWarning(
                 "{DisplayName} send requested with invalid conversation id '{ConversationId}'",
                 DisplayName,
-                message.ChannelAddress);
+                message.ChannelAddress.Value);
             return;
         }
 
@@ -164,7 +164,7 @@ public sealed class TelegramChannelAdapter(
         var formatted = BuildOutboundText(message.Content, message.Metadata, message.DisplayPrefix);
 
         int? threadId = null;
-        if (!string.IsNullOrEmpty(message.ThreadId) && int.TryParse(message.ThreadId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedThreadId))
+        if (!string.IsNullOrEmpty(message.ThreadId?.Value) && int.TryParse(message.ThreadId.Value.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedThreadId))
             threadId = parsedThreadId;
 
         foreach (var chunk in SplitMessage(formatted, Math.Max(1, runtime.Config.MaxMessageLength)))
@@ -347,11 +347,11 @@ public sealed class TelegramChannelAdapter(
         {
             ChannelType = ChannelType,
             SenderId = senderId,
-            ChannelAddress = chatIdText,
+            ChannelAddress = ChannelAddress.From(chatIdText),
             Content = message.Text,
             TargetAgentId = string.IsNullOrWhiteSpace(runtime.Config.AgentId) ? null : runtime.Config.AgentId,
             ThreadId = message.MessageThreadId.HasValue
-                ? message.MessageThreadId.Value.ToString(CultureInfo.InvariantCulture)
+                ? ThreadId.From(message.MessageThreadId.Value.ToString(CultureInfo.InvariantCulture))
                 : null,
             Metadata = new Dictionary<string, object?>
             {

--- a/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
@@ -90,7 +90,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
             _logger.LogDebug("{DisplayName} send requested while adapter is not running", DisplayName);
         }
 
-        return Console.Out.WriteLineAsync($"[{DisplayName}:{message.ChannelAddress}] {message.Content}");
+        return Console.Out.WriteLineAsync($"[{DisplayName}:{message.ChannelAddress.Value}] {message.Content}");
     }
 
     /// <summary>
@@ -193,7 +193,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
                 {
                     ChannelType = ChannelType,
                     SenderId = Environment.UserName,
-                    ChannelAddress = "console",
+                    ChannelAddress = ChannelAddress.From("console"),
                     SessionId = "tui-console",
                     Content = steerContent,
                     Metadata = new Dictionary<string, object?>
@@ -208,7 +208,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
             {
                 ChannelType = ChannelType,
                 SenderId = Environment.UserName,
-                ChannelAddress = "console",
+                ChannelAddress = ChannelAddress.From("console"),
                 SessionId = "tui-console",
                 Content = line
             }, cancellationToken);

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -157,8 +157,8 @@ public sealed class ConversationsController : ControllerBase
         {
             BindingId = BindingId.Create(),
             ChannelType = ChannelKey.From(request.ChannelType),
-            ChannelAddress = request.ChannelAddress ?? string.Empty,
-            ThreadId = request.ThreadId,
+            ChannelAddress = ChannelAddress.From(request.ChannelAddress ?? string.Empty),
+            ThreadId = ThreadId.FromNullable(request.ThreadId),
             Mode = bindingMode,
             ThreadingMode = threadingMode,
             DisplayPrefix = request.DisplayPrefix,
@@ -319,8 +319,8 @@ public sealed class ConversationsController : ControllerBase
     private static BindingResponse ToBindingResponse(ChannelBinding b) => new(
         BindingId: b.BindingId.Value,
         ChannelType: b.ChannelType.Value,
-        ChannelAddress: b.ChannelAddress,
-        ThreadId: b.ThreadId,
+        ChannelAddress: b.ChannelAddress.Value,
+        ThreadId: b.ThreadId?.Value,
         Mode: b.Mode.ToString(),
         ThreadingMode: b.ThreadingMode.ToString(),
         DisplayPrefix: b.DisplayPrefix,

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/StaleChannelConnectionException.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/StaleChannelConnectionException.cs
@@ -15,12 +15,12 @@ public class StaleChannelConnectionException : Exception
     public BindingId BindingId { get; }
 
     /// <summary>Gets the conversation ID the binding belongs to.</summary>
-    public string ConversationId { get; }
+    public ConversationId ConversationId { get; }
 
     /// <summary>
     /// Initialises a new instance describing a stale connection for a specific binding.
     /// </summary>
-    public StaleChannelConnectionException(BindingId bindingId, string conversationId, Exception? inner = null)
+    public StaleChannelConnectionException(BindingId bindingId, ConversationId conversationId, Exception? inner = null)
         : base($"Channel send failed — connection for binding {bindingId} in conversation {conversationId} is gone.", inner)
     {
         BindingId = bindingId;

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -19,8 +19,8 @@ public interface IConversationRouter
     Task<ConversationRoutingResult> ResolveInboundAsync(
         AgentId agentId,
         ChannelKey channelType,
-        string channelAddress,
-        string? threadId,
+        ChannelAddress channelAddress,
+        ThreadId? threadId,
         string? conversationId = null,
         CancellationToken ct = default);
 
@@ -60,7 +60,7 @@ public interface IConversationRouter
     /// <param name="channelType">The channel type (e.g. signalr).</param>
     /// <param name="channelAddress">The channel address (e.g. SignalR connection ID).</param>
     /// <param name="ct">Cancellation token.</param>
-    Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default);
+    Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
@@ -71,8 +71,8 @@ public interface IConversationStore
     Task<Conversation?> ResolveByBindingAsync(
         AgentId agentId,
         ChannelKey channelType,
-        string channelAddress,
-        string? threadId,
+        ChannelAddress channelAddress,
+        ThreadId? threadId,
         CancellationToken ct = default);
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway.Sessions/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileConversationStore.cs
@@ -127,8 +127,8 @@ public sealed class FileConversationStore : IConversationStore
     public async Task<Conversation?> ResolveByBindingAsync(
         AgentId agentId,
         ChannelKey channelType,
-        string channelAddress,
-        string? threadId,
+        ChannelAddress channelAddress,
+        ThreadId? threadId,
         CancellationToken ct = default)
     {
         await _lock.WaitAsync(ct).ConfigureAwait(false);
@@ -139,8 +139,8 @@ public sealed class FileConversationStore : IConversationStore
                 c.Status == ConversationStatus.Active &&
                 c.ChannelBindings.Any(b =>
                     b.ChannelType == channelType &&
-                    string.Equals(b.ChannelAddress, channelAddress, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(b.ThreadId, threadId, StringComparison.OrdinalIgnoreCase)));
+                    b.ChannelAddress == channelAddress &&
+                    b.ThreadId == threadId));
         }
         finally { _lock.Release(); }
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/InMemoryConversationStore.cs
@@ -80,8 +80,8 @@ public sealed class InMemoryConversationStore : IConversationStore
     public Task<Conversation?> ResolveByBindingAsync(
         AgentId agentId,
         ChannelKey channelType,
-        string channelAddress,
-        string? threadId,
+        ChannelAddress channelAddress,
+        ThreadId? threadId,
         CancellationToken ct = default)
     {
         var match = _conversations.Values.FirstOrDefault(c =>
@@ -89,8 +89,8 @@ public sealed class InMemoryConversationStore : IConversationStore
             c.Status == ConversationStatus.Active &&
             c.ChannelBindings.Any(b =>
                 b.ChannelType == channelType &&
-                string.Equals(b.ChannelAddress, channelAddress, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(b.ThreadId, threadId, StringComparison.OrdinalIgnoreCase)));
+                b.ChannelAddress == channelAddress &&
+                b.ThreadId == threadId));
 
         return Task.FromResult(match);
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteConversationStore.cs
@@ -279,16 +279,16 @@ public sealed class SqliteConversationStore : IConversationStore
     public async Task<Conversation?> ResolveByBindingAsync(
         AgentId agentId,
         ChannelKey channelType,
-        string channelAddress,
-        string? threadId,
+        ChannelAddress channelAddress,
+        ThreadId? threadId,
         CancellationToken ct = default)
     {
         using var activity = ActivitySource.StartActivity("conversation.resolve_by_binding", ActivityKind.Internal);
         activity?.SetTag("botnexus.agent.id", agentId.Value);
         activity?.SetTag("botnexus.channel.type", channelType.Value);
-        activity?.SetTag("botnexus.channel.address", channelAddress);
-        if (!string.IsNullOrWhiteSpace(threadId))
-            activity?.SetTag("botnexus.channel.thread_id", threadId);
+        activity?.SetTag("botnexus.channel.address", channelAddress.Value);
+        if (threadId is not null)
+            activity?.SetTag("botnexus.channel.thread_id", threadId.Value.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
         await using var connection = CreateConnection();
@@ -311,11 +311,11 @@ public sealed class SqliteConversationStore : IConversationStore
                 ORDER BY c.updated_at DESC
                 LIMIT 1
                 """;
-        command.Parameters.AddWithValue("$threadId", (object?)threadId ?? DBNull.Value);
+        command.Parameters.AddWithValue("$threadId", (object?)threadId?.Value ?? DBNull.Value);
         command.Parameters.AddWithValue("$agentId", agentId.Value);
         command.Parameters.AddWithValue("$status", ConversationStatus.Active.ToString());
         command.Parameters.AddWithValue("$channelType", channelType.Value);
-        command.Parameters.AddWithValue("$channelAddress", channelAddress);
+        command.Parameters.AddWithValue("$channelAddress", channelAddress.Value);
         var id = (string?)await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(id)
             ? null
@@ -531,8 +531,8 @@ public sealed class SqliteConversationStore : IConversationStore
             {
                 BindingId = BindingId.From(reader.GetString(0)),
                 ChannelType = ChannelKey.From(reader.GetString(1)),
-                ChannelAddress = reader.GetString(2),
-                ThreadId = reader.IsDBNull(3) ? null : reader.GetString(3),
+                ChannelAddress = ChannelAddress.From(reader.GetString(2)),
+                ThreadId = reader.IsDBNull(3) ? null : ThreadId.From(reader.GetString(3)),
                 Mode = ParseBindingMode(reader.GetString(4)),
                 ThreadingMode = ParseThreadingMode(reader.GetString(5)),
                 DisplayPrefix = reader.IsDBNull(6) ? null : reader.GetString(6),
@@ -597,8 +597,8 @@ public sealed class SqliteConversationStore : IConversationStore
             bindingCommand.Parameters.AddWithValue("$bindingId", binding.BindingId.Value);
             bindingCommand.Parameters.AddWithValue("$conversationId", conversation.ConversationId.Value);
             bindingCommand.Parameters.AddWithValue("$channelType", binding.ChannelType.Value);
-            bindingCommand.Parameters.AddWithValue("$channelAddress", binding.ChannelAddress);
-            bindingCommand.Parameters.AddWithValue("$threadId", (object?)binding.ThreadId ?? DBNull.Value);
+            bindingCommand.Parameters.AddWithValue("$channelAddress", binding.ChannelAddress.Value);
+            bindingCommand.Parameters.AddWithValue("$threadId", (object?)binding.ThreadId?.Value ?? DBNull.Value);
             bindingCommand.Parameters.AddWithValue("$mode", binding.Mode.ToString());
             bindingCommand.Parameters.AddWithValue("$threadingMode", binding.ThreadingMode.ToString());
             bindingCommand.Parameters.AddWithValue("$displayPrefix", (object?)binding.DisplayPrefix ?? DBNull.Value);

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -212,7 +212,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
                     new OutboundMessage
                     {
                         ChannelType = ChannelKey.From("cross-world"),
-                        ChannelAddress = conversationId,
+                        ChannelAddress = ChannelAddress.From(conversationId),
                         Content = message,
                         SessionId = sessionId.Value,
                         Metadata = new Dictionary<string, object?>

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -306,7 +306,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             {
                 ChannelType = ChannelKey.From("internal"),
                 SenderId = $"subagent:{subAgentId}",
-                ChannelAddress = updated.ParentSessionId,
+                ChannelAddress = ChannelAddress.From(updated.ParentSessionId.Value),
                 SessionId = updated.ParentSessionId,
                 TargetAgentId = parentAgentId,
                 Content = followUp,

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationRouter.cs
@@ -32,8 +32,8 @@ public sealed class DefaultConversationRouter : IConversationRouter
     public async Task<ConversationRoutingResult> ResolveInboundAsync(
         AgentId agentId,
         ChannelKey channelType,
-        string channelAddress,
-        string? threadId,
+        ChannelAddress channelAddress,
+        ThreadId? threadId,
         string? conversationId = null,
         CancellationToken ct = default)
     {
@@ -111,8 +111,8 @@ public sealed class DefaultConversationRouter : IConversationRouter
         var originatingBinding = conversation.ChannelBindings
             .FirstOrDefault(b =>
                 b.ChannelType == channelType &&
-                string.Equals(b.ChannelAddress, channelAddress, StringComparison.Ordinal) &&
-                string.Equals(b.ThreadId, threadId, StringComparison.Ordinal));
+                b.ChannelAddress == channelAddress &&
+                b.ThreadId == threadId);
 
         return new ConversationRoutingResult(conversation, sessionId, isNewSession, originatingBinding);
     }
@@ -181,14 +181,14 @@ public sealed class DefaultConversationRouter : IConversationRouter
     }
 
     /// <inheritdoc />
-    public async Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default)
+    public async Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
     {
         var conversations = await _conversationStore.ListAsync(agentId, ct);
         foreach (var conversation in conversations)
         {
             var binding = conversation.ChannelBindings.FirstOrDefault(b =>
                 b.ChannelType.Equals(channelType) &&
-                string.Equals(b.ChannelAddress, channelAddress, StringComparison.Ordinal) &&
+                b.ChannelAddress == channelAddress &&
                 b.Mode != BindingMode.Muted);
 
             if (binding is null)

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -263,7 +263,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 var routingResult = await _conversationRouter.ResolveInboundAsync(
                     AgentId.From(agentId),
                     message.ChannelType,
-                    message.ChannelAddress ?? string.Empty,
+                    message.ChannelAddress,
                     threadId: message.ThreadId,
                     conversationId: message.ConversationId,
                     cancellationToken);
@@ -419,7 +419,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                                 // so the adapter can split them apart (fixes #125).
                                 var streamConversationId = streamingBinding?.ThreadId is not null
                                     ? $"{message.ChannelAddress}:{streamingBinding.ThreadId}"
-                                    : message.ChannelAddress;
+                                    : message.ChannelAddress.Value;
 
                                 if (channel is IStreamEventChannelAdapter streamEventChannel)
                                     return new ValueTask(streamEventChannel.SendStreamEventAsync(streamConversationId, enriched, ct));

--- a/tests/BotNexus.Domain.Tests/InboundMessageContentPartsTests.cs
+++ b/tests/BotNexus.Domain.Tests/InboundMessageContentPartsTests.cs
@@ -64,7 +64,7 @@ public sealed class InboundMessageContentPartsTests
     {
         ChannelType = ChannelKey.From("signalr"),
         SenderId = "sender-1",
-        ChannelAddress = "conversation-1",
+        ChannelAddress = ChannelAddress.From("conversation-1"),
         Content = "hello"
     };
 }

--- a/tests/BotNexus.Gateway.ConversationTests/ConversationRoutingScenarios.cs
+++ b/tests/BotNexus.Gateway.ConversationTests/ConversationRoutingScenarios.cs
@@ -45,8 +45,8 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // Act — two messages from the same Telegram chat ID
-        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-123", null);
-        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-123", null);
+        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-123"), null);
+        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-123"), null);
 
         // Assert — same conversation, same session
         result1.Conversation.ConversationId.ShouldBe(result2.Conversation.ConversationId,
@@ -68,8 +68,8 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // Act — portal sends with null conversationId (binding lookup path)
-        var result1 = await router.ResolveInboundAsync(agentId, SignalR(), "agent1", null);
-        var result2 = await router.ResolveInboundAsync(agentId, SignalR(), "agent1", null);
+        var result1 = await router.ResolveInboundAsync(agentId, SignalR(), ChannelAddress.From("agent1"), null);
+        var result2 = await router.ResolveInboundAsync(agentId, SignalR(), ChannelAddress.From("agent1"), null);
 
         // Assert — same conversation on both calls (binding found on second call)
         result1.Conversation.ConversationId.ShouldBe(result2.Conversation.ConversationId,
@@ -101,7 +101,7 @@ public sealed class ConversationRoutingScenarios
 
         // Act — portal sends with explicit conversationId (direct routing path)
         var result = await router.ResolveInboundAsync(
-            agentId, SignalR(), "agent1", null,
+            agentId, SignalR(), ChannelAddress.From("agent1"), null,
             conversationId: secondaryConv.ConversationId.Value);
 
         // Assert — routes to the correct conversation with NO new binding added
@@ -130,7 +130,7 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // First contact via Telegram creates the conversation with a Telegram binding
-        var result = await router.ResolveInboundAsync(agentId, Telegram(), "chat-789", null);
+        var result = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-789"), null);
         var conversationId = result.Conversation.ConversationId;
 
         // Attach a SignalR binding (simulates portal joining the same conversation)
@@ -138,7 +138,7 @@ public sealed class ConversationRoutingScenarios
         conv!.ChannelBindings.Add(new ChannelBinding
         {
             ChannelType = SignalR(),
-            ChannelAddress = "conn-abc",
+            ChannelAddress = ChannelAddress.From("conn-abc"),
             Mode = BindingMode.Interactive
         });
         await convStore.SaveAsync(conv);
@@ -168,7 +168,7 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // First message creates session
-        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-exp", null);
+        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-exp"), null);
         var originalSessionId = result1.SessionId;
 
         // Expire the session
@@ -177,7 +177,7 @@ public sealed class ConversationRoutingScenarios
         await sessionStore.SaveAsync(session);
 
         // Act — second message should reuse the expired session (not create a new one)
-        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-exp", null);
+        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-exp"), null);
 
         // Assert — same session reused (GatewayHost reactivates expired sessions)
         result2.SessionId.ShouldBe(originalSessionId,
@@ -199,7 +199,7 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // First message creates session
-        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-seal", null);
+        var result1 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-seal"), null);
         var originalSessionId = result1.SessionId;
 
         // Seal the session (simulates an explicit reset/archive)
@@ -208,7 +208,7 @@ public sealed class ConversationRoutingScenarios
         await sessionStore.SaveAsync(session);
 
         // Act — next message must create a new session
-        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), "chat-seal", null);
+        var result2 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("chat-seal"), null);
 
         // Assert
         result2.SessionId.ShouldNotBe(originalSessionId,
@@ -236,8 +236,8 @@ public sealed class ConversationRoutingScenarios
         var agentB = Agent("agent-b");
 
         // Act — same Telegram chat ID sends to both agents
-        var resultA = await routerA.ResolveInboundAsync(agentA, Telegram(), "shared-chat", null);
-        var resultB = await routerB.ResolveInboundAsync(agentB, Telegram(), "shared-chat", null);
+        var resultA = await routerA.ResolveInboundAsync(agentA, Telegram(), ChannelAddress.From("shared-chat"), null);
+        var resultB = await routerB.ResolveInboundAsync(agentB, Telegram(), ChannelAddress.From("shared-chat"), null);
 
         // Assert — each agent gets its own conversation
         resultA.Conversation.ConversationId.ShouldNotBe(resultB.Conversation.ConversationId,
@@ -260,8 +260,8 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // Act — same group chat but different topics
-        var result42 = await router.ResolveInboundAsync(agentId, Telegram(), "group-1", threadId: "42");
-        var result99 = await router.ResolveInboundAsync(agentId, Telegram(), "group-1", threadId: "99");
+        var result42 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("group-1"), ThreadId.From("42"));
+        var result99 = await router.ResolveInboundAsync(agentId, Telegram(), ChannelAddress.From("group-1"), ThreadId.From("99"));
 
         // Assert — thread isolation: different topics → different conversations
         result42.Conversation.ConversationId.ShouldNotBe(result99.Conversation.ConversationId,
@@ -269,9 +269,9 @@ public sealed class ConversationRoutingScenarios
 
         // Verify bindings have correct thread IDs
         result42.OriginatingBinding.ShouldNotBeNull();
-        result42.OriginatingBinding!.ThreadId.ShouldBe("42");
+        result42.OriginatingBinding!.ThreadId.ShouldBe(ThreadId.From("42"));
         result99.OriginatingBinding.ShouldNotBeNull();
-        result99.OriginatingBinding!.ThreadId.ShouldBe("99");
+        result99.OriginatingBinding!.ThreadId.ShouldBe(ThreadId.From("99"));
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -288,7 +288,7 @@ public sealed class ConversationRoutingScenarios
         var agentId = Agent();
 
         // Create conversation A via binding lookup
-        var resultA = await router.ResolveInboundAsync(agentId, SignalR(), "agent1", null);
+        var resultA = await router.ResolveInboundAsync(agentId, SignalR(), ChannelAddress.From("agent1"), null);
         var convAId = resultA.Conversation.ConversationId;
 
         // Create conversation B via API (no binding)
@@ -304,7 +304,7 @@ public sealed class ConversationRoutingScenarios
         // Note: (SignalR, "agent1", null) binding points to conversation A,
         // but we override with conversationId=B
         var resultB = await router.ResolveInboundAsync(
-            agentId, SignalR(), "agent1", null,
+            agentId, SignalR(), ChannelAddress.From("agent1"), null,
             conversationId: convB.ConversationId.Value);
 
         // Assert — routed to conversation B, not A

--- a/tests/BotNexus.Gateway.Tests/Channels/InternalChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/InternalChannelAdapterTests.cs
@@ -34,7 +34,7 @@ public sealed class InternalChannelAdapterTests
         var outbound = new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ChannelAddress = "conversation-1",
+            ChannelAddress = ChannelAddress.From("conversation-1"),
             SessionId = "session-1",
             Content = "hello"
         };
@@ -45,7 +45,7 @@ public sealed class InternalChannelAdapterTests
             a => a.SendAsync(
                 It.Is<OutboundMessage>(m =>
                     m.ChannelType.Equals(ChannelKey.From("signalr")) &&
-                    m.ChannelAddress == "conversation-1" &&
+                    m.ChannelAddress == ChannelAddress.From("conversation-1") &&
                     m.SessionId == "session-1" &&
                     m.Content == "hello"),
                 CancellationToken.None),
@@ -72,7 +72,7 @@ public sealed class InternalChannelAdapterTests
         await sut.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ChannelAddress = "conversation-1",
+            ChannelAddress = ChannelAddress.From("conversation-1"),
             SessionId = "session-1",
             Content = "hello"
         }, CancellationToken.None);
@@ -99,7 +99,7 @@ public sealed class InternalChannelAdapterTests
         Func<Task> act = () => sut.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ChannelAddress = "conversation-1",
+            ChannelAddress = ChannelAddress.From("conversation-1"),
             SessionId = "session-1",
             Content = "hello"
         }, CancellationToken.None);
@@ -145,7 +145,7 @@ public sealed class InternalChannelAdapterTests
         await sut.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("internal"),
-            ChannelAddress = "conversation-1",
+            ChannelAddress = ChannelAddress.From("conversation-1"),
             SessionId = "session-1",
             Content = "hello"
         }, CancellationToken.None);

--- a/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -76,7 +76,7 @@ public sealed class TelegramChannelAdapterTests
         dispatcher.Invocations
             .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
             .Select(i => (InboundMessage)i.Arguments[0])
-            .Where(m => m.ChannelAddress == "42" && m.Content == "hello")
+            .Where(m => m.ChannelAddress == ChannelAddress.From("42") && m.Content == "hello")
             .ShouldHaveSingleItem();
     }
 
@@ -101,7 +101,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "42",
+            ChannelAddress = ChannelAddress.From("42"),
             Content = new string('a', 5000)
         });
 
@@ -132,7 +132,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "42",
+            ChannelAddress = ChannelAddress.From("42"),
             Content = "a < b && c > d"
         });
 
@@ -352,8 +352,8 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "42",
-            ThreadId = "1",
+            ChannelAddress = ChannelAddress.From("42"),
+            ThreadId = ThreadId.From("1"),
             Content = "general topic"
         });
 
@@ -382,8 +382,8 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "42",
-            ThreadId = "42",
+            ChannelAddress = ChannelAddress.From("42"),
+            ThreadId = ThreadId.From("42"),
             Content = "topic reply"
         });
 
@@ -451,7 +451,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "42",
+            ChannelAddress = ChannelAddress.From("42"),
             Content = "hello"
         });
 
@@ -490,7 +490,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "42",
+            ChannelAddress = ChannelAddress.From("42"),
             Content = "hello"
         });
 
@@ -579,7 +579,7 @@ public sealed class TelegramChannelAdapterTests
         Func<Task> act = () => adapter.SendAsync(new OutboundMessage
         {
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "99",
+            ChannelAddress = ChannelAddress.From("99"),
             Content = "blocked"
         });
 
@@ -633,7 +633,7 @@ public sealed class TelegramChannelAdapterTests
         await adapter.StopAsync(CancellationToken.None);
 
         message.TargetAgentId.ShouldBe("agent-b");
-        message.ChannelAddress.ShouldBe("42");
+        message.ChannelAddress.ShouldBe(ChannelAddress.From("42"));
         message.Content.ShouldBe("hello");
     }
 
@@ -687,7 +687,7 @@ public sealed class TelegramChannelAdapterTests
 
         // Adapter dispatches without BindingId — GatewayHost stamps it after routing
         message.BindingId.ShouldBeNull();
-        message.ChannelAddress.ShouldBe("42");
+        message.ChannelAddress.ShouldBe(ChannelAddress.From("42"));
     }
 
     // ── Security: AllowedUserIds ────────────────────────────────────────────

--- a/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -34,14 +34,14 @@ public sealed class DefaultConversationRouterTests
         var router = CreateRouter();
         var agentId = Agent();
 
-        var result = await router.ResolveInboundAsync(agentId, Channel(), "chat-123", null);
+        var result = await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-123"), null);
 
         result.ShouldNotBeNull();
         result.Conversation.ShouldNotBeNull();
         result.Conversation.AgentId.ShouldBe(agentId);
         result.Conversation.IsDefault.ShouldBeFalse(); // per-address conversation, not the default
         result.Conversation.ChannelBindings.ShouldHaveSingleItem();
-        result.Conversation.ChannelBindings[0].ChannelAddress.ShouldBe("chat-123");
+        result.Conversation.ChannelBindings[0].ChannelAddress.ShouldBe(ChannelAddress.From("chat-123"));
     }
 
     [Fact]
@@ -52,13 +52,13 @@ public sealed class DefaultConversationRouterTests
         var router = CreateRouter();
         var agentId = Agent();
 
-        var result = await router.ResolveInboundAsync(agentId, Channel(), "", null);
+        var result = await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From(""), null);
 
         result.ShouldNotBeNull();
         result.Conversation.ShouldNotBeNull();
         result.Conversation.AgentId.ShouldBe(agentId);
         result.Conversation.ChannelBindings.ShouldHaveSingleItem();
-        result.Conversation.ChannelBindings[0].ChannelAddress.ShouldBe("");
+        result.Conversation.ChannelBindings[0].ChannelAddress.ShouldBe(ChannelAddress.From(""));
     }
 
     [Fact]
@@ -74,12 +74,12 @@ public sealed class DefaultConversationRouterTests
         existing.ChannelBindings.Add(new ChannelBinding
         {
             ChannelType = channel,
-            ChannelAddress = address
+            ChannelAddress = ChannelAddress.From(address)
         });
         await conversationStore.SaveAsync(existing);
 
         var router = CreateRouter(conversationStore);
-        var result = await router.ResolveInboundAsync(agentId, channel, address, null);
+        var result = await router.ResolveInboundAsync(agentId, channel, ChannelAddress.From(address), null);
 
         result.Conversation.ConversationId.ShouldBe(existing.ConversationId);
     }
@@ -91,7 +91,7 @@ public sealed class DefaultConversationRouterTests
         var router = CreateRouter(sessionStore: sessionStore);
         var agentId = Agent();
 
-        var result = await router.ResolveInboundAsync(agentId, Channel(), "chat-999", null);
+        var result = await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-999"), null);
 
         var session = await sessionStore.GetAsync(result.SessionId);
         session.ShouldNotBeNull();
@@ -106,7 +106,7 @@ public sealed class DefaultConversationRouterTests
         var router = CreateRouter(conversationStore);
         var agentId = Agent();
 
-        var result = await router.ResolveInboundAsync(agentId, Channel(), "chat-777", null);
+        var result = await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-777"), null);
 
         var updated = await conversationStore.GetAsync(result.Conversation.ConversationId);
         updated.ShouldNotBeNull();
@@ -118,7 +118,7 @@ public sealed class DefaultConversationRouterTests
     {
         var router = CreateRouter();
 
-        var result = await router.ResolveInboundAsync(Agent(), Channel(), "new-chat", null);
+        var result = await router.ResolveInboundAsync(Agent(), Channel(), ChannelAddress.From("new-chat"), null);
 
         result.IsNewSession.ShouldBeTrue();
     }
@@ -130,8 +130,8 @@ public sealed class DefaultConversationRouterTests
         var router = CreateRouter();
         var agentId = Agent();
 
-        var result1 = await router.ResolveInboundAsync(agentId, Channel(), "chat-abc", null);
-        var result2 = await router.ResolveInboundAsync(agentId, Channel(), "chat-abc", null);
+        var result1 = await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-abc"), null);
+        var result2 = await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-abc"), null);
 
         result2.Conversation.ConversationId.ShouldBe(result1.Conversation.ConversationId);
         result2.SessionId.ShouldBe(result1.SessionId);
@@ -151,7 +151,7 @@ public sealed class DefaultConversationRouterTests
             conversationStore,
             new InMemorySessionStore(),
             NullLogger<DefaultConversationRouter>.Instance)
-            .ResolveInboundAsync(agentId, channel, "addr-src", null);
+            .ResolveInboundAsync(agentId, channel, ChannelAddress.From("addr-src"), null);
         var sourceConversationId = result.Conversation.ConversationId;
         var bindingId = result.Conversation.ChannelBindings[0].BindingId;
 
@@ -187,7 +187,7 @@ public sealed class DefaultConversationRouterTests
         var router = new DefaultConversationRouter(conversationStore, sessionStore, NullLogger<DefaultConversationRouter>.Instance);
 
         // Source: conversation A with a telegram binding
-        var inbound = await router.ResolveInboundAsync(agentId, Channel("telegram"), "addr-a", null);
+        var inbound = await router.ResolveInboundAsync(agentId, Channel("telegram"), ChannelAddress.From("addr-a"), null);
         var telegramBindingId = inbound.Conversation.ChannelBindings[0].BindingId;
         var sourceConvId = inbound.Conversation.ConversationId;
 
@@ -201,7 +201,7 @@ public sealed class DefaultConversationRouterTests
         targetConv.ChannelBindings.Add(new ChannelBinding
         {
             ChannelType = Channel("slack"),
-            ChannelAddress = "slack-channel",
+            ChannelAddress = ChannelAddress.From("slack-channel"),
             Mode = BindingMode.Interactive
         });
         await conversationStore.SaveAsync(targetConv);
@@ -216,7 +216,7 @@ public sealed class DefaultConversationRouterTests
         // Target conversation should now have both telegram and slack bindings
         var target = await conversationStore.GetAsync(targetConv.ConversationId);
         target!.ChannelBindings.ShouldContain(b => b.BindingId == telegramBindingId);
-        target.ChannelBindings.ShouldContain(b => b.ChannelAddress == "slack-channel");
+        target.ChannelBindings.ShouldContain(b => b.ChannelAddress == ChannelAddress.From("slack-channel"));
     }
 
     // ── GetOutboundBindingsAsync ───────────────────────────────────────────────
@@ -230,8 +230,8 @@ public sealed class DefaultConversationRouterTests
 
         // Create conversation with two bindings — each with an explicit BindingId
         var conversation = await conversationStore.GetOrCreateDefaultAsync(agentId);
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-tg"), ChannelType = Channel("telegram"), ChannelAddress = "chat-A", Mode = BindingMode.Interactive });
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-sr"), ChannelType = Channel("signalr"), ChannelAddress = "conn-B", Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-tg"), ChannelType = Channel("telegram"), ChannelAddress = ChannelAddress.From("chat-A"), Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-sr"), ChannelType = Channel("signalr"), ChannelAddress = ChannelAddress.From("conn-B"), Mode = BindingMode.Interactive });
         await conversationStore.SaveAsync(conversation);
 
         var sessionId = SessionId.Create();
@@ -245,7 +245,7 @@ public sealed class DefaultConversationRouterTests
 
         bindings.ShouldNotBeNull();
         bindings.Count.ShouldBe(1);
-        bindings[0].ChannelAddress.ShouldBe("conn-B");
+        bindings[0].ChannelAddress.ShouldBe(ChannelAddress.From("conn-B"));
     }
 
     [Fact]
@@ -256,9 +256,9 @@ public sealed class DefaultConversationRouterTests
         var agentId = Agent();
 
         var conversation = await conversationStore.GetOrCreateDefaultAsync(agentId);
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-orig"), ChannelType = Channel("telegram"), ChannelAddress = "originator", Mode = BindingMode.Interactive });
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-muted"), ChannelType = Channel("signalr"), ChannelAddress = "muted-chan", Mode = BindingMode.Muted });
-        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-active"), ChannelType = Channel("slack"), ChannelAddress = "active-chan", Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-orig"), ChannelType = Channel("telegram"), ChannelAddress = ChannelAddress.From("originator"), Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-muted"), ChannelType = Channel("signalr"), ChannelAddress = ChannelAddress.From("muted-chan"), Mode = BindingMode.Muted });
+        conversation.ChannelBindings.Add(new ChannelBinding { BindingId = BindingId.From("binding-active"), ChannelType = Channel("slack"), ChannelAddress = ChannelAddress.From("active-chan"), Mode = BindingMode.Interactive });
         await conversationStore.SaveAsync(conversation);
 
         var sessionId = SessionId.Create();
@@ -271,7 +271,7 @@ public sealed class DefaultConversationRouterTests
 
         bindings.ShouldNotContain(b => b.Mode == BindingMode.Muted);
         bindings.Count.ShouldBe(1);
-        bindings[0].ChannelAddress.ShouldBe("active-chan");
+        bindings[0].ChannelAddress.ShouldBe(ChannelAddress.From("active-chan"));
     }
 
     [Fact]
@@ -295,8 +295,8 @@ public sealed class DefaultConversationRouterTests
         var agentId = Agent();
 
         var conversation = await conversationStore.GetOrCreateDefaultAsync(agentId);
-        conversation.ChannelBindings.Add(new ChannelBinding { ChannelType = Channel("telegram"), ChannelAddress = "src", Mode = BindingMode.Interactive });
-        conversation.ChannelBindings.Add(new ChannelBinding { ChannelType = Channel("slack"), ChannelAddress = "notify-only-chan", Mode = BindingMode.NotifyOnly });
+        conversation.ChannelBindings.Add(new ChannelBinding { ChannelType = Channel("telegram"), ChannelAddress = ChannelAddress.From("src"), Mode = BindingMode.Interactive });
+        conversation.ChannelBindings.Add(new ChannelBinding { ChannelType = Channel("slack"), ChannelAddress = ChannelAddress.From("notify-only-chan"), Mode = BindingMode.NotifyOnly });
         await conversationStore.SaveAsync(conversation);
 
         var sessionId = SessionId.Create();
@@ -307,6 +307,6 @@ public sealed class DefaultConversationRouterTests
         var router = CreateRouter(conversationStore, sessionStore);
         var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("src"));
 
-        bindings.ShouldContain(b => b.ChannelAddress == "notify-only-chan" && b.Mode == BindingMode.NotifyOnly);
+        bindings.ShouldContain(b => b.ChannelAddress == ChannelAddress.From("notify-only-chan") && b.Mode == BindingMode.NotifyOnly);
     }
 }

--- a/tests/BotNexus.Gateway.Tests/Conversations/FanOutBindingAwareTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/FanOutBindingAwareTests.cs
@@ -30,15 +30,15 @@ public sealed class FanOutBindingAwareTests
         {
             BindingId = BindingId.From("binding-src"),
             ChannelType = Channel("signalr"),
-            ChannelAddress = "conn-origin",
+            ChannelAddress = ChannelAddress.From("conn-origin"),
             Mode = BindingMode.Interactive
         });
         conversation.ChannelBindings.Add(new ChannelBinding
         {
             BindingId = BindingId.From("binding-tg"),
             ChannelType = Channel("telegram"),
-            ChannelAddress = "chat-999",
-            ThreadId = "topic-77",
+            ChannelAddress = ChannelAddress.From("chat-999"),
+            ThreadId = ThreadId.From("topic-77"),
             Mode = BindingMode.Interactive
         });
         await conversationStore.SaveAsync(conversation);
@@ -54,8 +54,8 @@ public sealed class FanOutBindingAwareTests
         // The telegram binding with ThreadId should be included
         bindings.Count.ShouldBe(1);
         var tgBinding = bindings[0];
-        tgBinding.ChannelAddress.ShouldBe("chat-999");
-        tgBinding.ThreadId.ShouldBe("topic-77");
+        tgBinding.ChannelAddress.ShouldBe(ChannelAddress.From("chat-999"));
+        tgBinding.ThreadId.ShouldBe(ThreadId.From("topic-77"));
 
         // Build the outbound message as FanOutResponseAsync would
         var outbound = new OutboundMessage
@@ -68,7 +68,7 @@ public sealed class FanOutBindingAwareTests
             DisplayPrefix = tgBinding.DisplayPrefix
         };
 
-        outbound.ThreadId.ShouldBe("topic-77");
+        outbound.ThreadId.ShouldBe(ThreadId.From("topic-77"));
         outbound.BindingId?.Value.ShouldBe("binding-tg");
     }
 }

--- a/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -34,8 +34,8 @@ public sealed class GatewayHostBindingRoutingTests
         {
             BindingId = BindingId.From("bind-tg-1"),
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "chat-100",
-            ThreadId = "topic-42",
+            ChannelAddress = ChannelAddress.From("chat-100"),
+            ThreadId = ThreadId.From("topic-42"),
             DisplayPrefix = "[Bot]",
             Mode = BindingMode.Interactive
         };
@@ -56,8 +56,8 @@ public sealed class GatewayHostBindingRoutingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
-                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
@@ -85,14 +85,14 @@ public sealed class GatewayHostBindingRoutingTests
         {
             ChannelType = ChannelKey.From("telegram"),
             SenderId = "user-1",
-            ChannelAddress = "chat-100",
-            ThreadId = "topic-42",
+            ChannelAddress = ChannelAddress.From("chat-100"),
+            ThreadId = ThreadId.From("topic-42"),
             Content = "hello",
             Metadata = new Dictionary<string, object?>()
         });
 
         capturedOutbound.ShouldNotBeNull("adapter.SendAsync should have been called for non-streaming path");
-        capturedOutbound!.ThreadId.ShouldBe("topic-42", "ThreadId from originating binding must be stamped on direct send");
+        capturedOutbound!.ThreadId.ShouldBe(ThreadId.From("topic-42"), "ThreadId from originating binding must be stamped on direct send");
         capturedOutbound.BindingId?.Value.ShouldBe("bind-tg-1", "BindingId from originating binding must be stamped on direct send");
         capturedOutbound.DisplayPrefix.ShouldBe("[Bot]", "DisplayPrefix from originating binding must be stamped on direct send");
     }
@@ -108,8 +108,8 @@ public sealed class GatewayHostBindingRoutingTests
         {
             BindingId = BindingId.From("bind-tg-2"),
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "chat-200",
-            ThreadId = "topic-99",
+            ChannelAddress = ChannelAddress.From("chat-200"),
+            ThreadId = ThreadId.From("topic-99"),
             Mode = BindingMode.Interactive
         };
 
@@ -129,8 +129,8 @@ public sealed class GatewayHostBindingRoutingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
-                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
@@ -168,8 +168,8 @@ public sealed class GatewayHostBindingRoutingTests
         {
             ChannelType = ChannelKey.From("telegram"),
             SenderId = "user-1",
-            ChannelAddress = "chat-200",
-            ThreadId = "topic-99",
+            ChannelAddress = ChannelAddress.From("chat-200"),
+            ThreadId = ThreadId.From("topic-99"),
             Content = "hello",
             Metadata = new Dictionary<string, object?>()
         });
@@ -192,7 +192,7 @@ public sealed class GatewayHostBindingRoutingTests
         {
             BindingId = BindingId.From("bind-origin"),
             ChannelType = ChannelKey.From("telegram"),
-            ChannelAddress = "chat-300",
+            ChannelAddress = ChannelAddress.From("chat-300"),
             ThreadId = null,
             Mode = BindingMode.Interactive
         };
@@ -214,8 +214,8 @@ public sealed class GatewayHostBindingRoutingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(),
-                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
@@ -239,7 +239,7 @@ public sealed class GatewayHostBindingRoutingTests
         {
             ChannelType = ChannelKey.From("telegram"),
             SenderId = "user-1",
-            ChannelAddress = "chat-300",
+            ChannelAddress = ChannelAddress.From("chat-300"),
             ThreadId = null,
             Content = "hello",
             Metadata = new Dictionary<string, object?>()

--- a/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -61,9 +61,9 @@ public sealed class MultiChannelFanOutTests
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "signalr", "chat-1"));
 
         harness.SignalR.Messages.Count.ShouldBe(1);
-        harness.SignalR.Messages[0].ChannelAddress.ShouldBe("chat-1");
+        harness.SignalR.Messages[0].ChannelAddress.ShouldBe(ChannelAddress.From("chat-1"));
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ChannelAddress.ShouldBe("chat-100");
+        harness.Telegram.Messages[0].ChannelAddress.ShouldBe(ChannelAddress.From("chat-100"));
         harness.Tui.Messages.ShouldBeEmpty();
     }
 
@@ -77,9 +77,9 @@ public sealed class MultiChannelFanOutTests
         await harness.Host.DispatchAsync(harness.CreateMessage("hello", "telegram", "chat-100"));
 
         harness.SignalR.Messages.Count.ShouldBe(1);
-        harness.SignalR.Messages[0].ChannelAddress.ShouldBe("chat-1");
+        harness.SignalR.Messages[0].ChannelAddress.ShouldBe(ChannelAddress.From("chat-1"));
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ChannelAddress.ShouldBe("chat-100");
+        harness.Telegram.Messages[0].ChannelAddress.ShouldBe(ChannelAddress.From("chat-100"));
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public sealed class MultiChannelFanOutTests
         harness.ClearOutbound();
         await harness.Host.DispatchAsync(harness.CreateMessage("topic", "telegram", "100", threadId: "42"));
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ThreadId.ShouldBe("42"); // fix #126: ThreadId now correctly set on direct send
+        harness.Telegram.Messages[0].ThreadId.ShouldBe(ThreadId.From("42")); // fix #126: ThreadId now correctly set on direct send
 
         var conversations = await harness.Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName));
         conversations.Count.ShouldBe(2);
@@ -182,9 +182,9 @@ public sealed class MultiChannelFanOutTests
         await harness.Host.DispatchAsync(harness.CreateMessage("topic", "telegram", "100", threadId: "42"));
 
         harness.SignalR.Messages.Count.ShouldBe(1);
-        harness.SignalR.Messages[0].ThreadId.ShouldBe("42"); // fan-out carries thread
+        harness.SignalR.Messages[0].ThreadId.ShouldBe(ThreadId.From("42")); // fan-out carries thread
         harness.Telegram.Messages.Count.ShouldBe(1);
-        harness.Telegram.Messages[0].ThreadId.ShouldBe("42"); // fix #126: direct send now carries ThreadId
+        harness.Telegram.Messages[0].ThreadId.ShouldBe(ThreadId.From("42")); // fix #126: direct send now carries ThreadId
     }
 
     [Fact]
@@ -237,8 +237,8 @@ public sealed class MultiChannelFanOutTests
             ActiveSessionId = BotNexus.Domain.Primitives.SessionId.From("legacy-session"),
             ChannelBindings =
             [
-                new ChannelBinding { BindingId = BindingId.From("sig"), ChannelType = ChannelKey.From("signalr"), ChannelAddress = "chat-1" },
-                new ChannelBinding { BindingId = BindingId.From("tel"), ChannelType = ChannelKey.From("telegram"), ChannelAddress = "chat-100" }
+                new ChannelBinding { BindingId = BindingId.From("sig"), ChannelType = ChannelKey.From("signalr"), ChannelAddress = ChannelAddress.From("chat-1") },
+                new ChannelBinding { BindingId = BindingId.From("tel"), ChannelType = ChannelKey.From("telegram"), ChannelAddress = ChannelAddress.From("chat-100") }
             ]
         };
         await harness.Conversations.CreateAsync(conversation);
@@ -419,10 +419,10 @@ public sealed class MultiChannelFanOutTests
             {
                 ChannelType = ChannelKey.From(channelType),
                 SenderId = $"sender-{channelType}",
-                ChannelAddress = channelAddress,
+                ChannelAddress = ChannelAddress.From(channelAddress),
                 Content = content,
                 SessionId = sessionId,
-                ThreadId = threadId,
+                ThreadId = ThreadId.FromNullable(threadId),
                 Metadata = new Dictionary<string, object?>()
             };
 
@@ -459,7 +459,7 @@ public sealed class MultiChannelFanOutTests
                 conversation.ChannelBindings.Add(new ChannelBinding
                 {
                     ChannelType = ChannelKey.From(channelType),
-                    ChannelAddress = channelAddress,
+                    ChannelAddress = ChannelAddress.From(channelAddress),
                     Mode = BindingMode.Interactive
                 });
             }
@@ -470,8 +470,8 @@ public sealed class MultiChannelFanOutTests
             => Conversations.ListAsync(BotNexus.Domain.Primitives.AgentId.From(AgentName)).Result
                 .Single(c => c.ChannelBindings.Any(b =>
                     b.ChannelType == ChannelKey.From(channelType) &&
-                    b.ChannelAddress == channelAddress &&
-                    b.ThreadId == threadId));
+                    b.ChannelAddress == ChannelAddress.From(channelAddress) &&
+                    b.ThreadId == ThreadId.FromNullable(threadId)));
 
         public async Task AttachBindingToConversationAsync(string channelType, string channelAddress, BotNexus.Domain.Primitives.ConversationId conversationId, string? threadId = null)
         {
@@ -479,8 +479,8 @@ public sealed class MultiChannelFanOutTests
             conversation.ChannelBindings.Add(new ChannelBinding
             {
                 ChannelType = ChannelKey.From(channelType),
-                ChannelAddress = channelAddress,
-                ThreadId = threadId,
+                ChannelAddress = ChannelAddress.From(channelAddress),
+                ThreadId = ThreadId.FromNullable(threadId),
                 Mode = BindingMode.Interactive
             });
             await Conversations.SaveAsync(conversation);
@@ -491,8 +491,8 @@ public sealed class MultiChannelFanOutTests
             var conversation = GetConversationFor(channelType, channelAddress, threadId);
             var binding = conversation.ChannelBindings.Single(b =>
                 b.ChannelType == ChannelKey.From(channelType) &&
-                b.ChannelAddress == channelAddress &&
-                b.ThreadId == threadId);
+                b.ChannelAddress == ChannelAddress.From(channelAddress) &&
+                b.ThreadId == ThreadId.FromNullable(threadId));
             binding.Mode = mode;
             await Conversations.SaveAsync(conversation);
         }

--- a/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Conversations/ThreadIdRoutingTests.cs
@@ -36,10 +36,10 @@ public sealed class ThreadIdRoutingTests
         const string address = "group-chat-123";
 
         // Act: first message with no thread
-        var resultNoThread = await router.ResolveInboundAsync(agentId, channel, address, threadId: null);
+        var resultNoThread = await router.ResolveInboundAsync(agentId, channel, ChannelAddress.From(address), threadId: null);
 
         // Act: second message with a specific thread id
-        var resultWithThread = await router.ResolveInboundAsync(agentId, channel, address, threadId: "topic-42");
+        var resultWithThread = await router.ResolveInboundAsync(agentId, channel, ChannelAddress.From(address), threadId: ThreadId.From("topic-42"));
 
         // They should resolve to different conversations since thread identity differs
         resultWithThread.Conversation.ConversationId.ShouldNotBe(resultNoThread.Conversation.ConversationId);
@@ -56,8 +56,8 @@ public sealed class ThreadIdRoutingTests
         const string address = "group-chat-456";
         const string threadId = "topic-99";
 
-        var result1 = await router.ResolveInboundAsync(agentId, channel, address, threadId: threadId);
-        var result2 = await router.ResolveInboundAsync(agentId, channel, address, threadId: threadId);
+        var result1 = await router.ResolveInboundAsync(agentId, channel, ChannelAddress.From(address), threadId: ThreadId.From(threadId));
+        var result2 = await router.ResolveInboundAsync(agentId, channel, ChannelAddress.From(address), threadId: ThreadId.From(threadId));
 
         result2.Conversation.ConversationId.ShouldBe(result1.Conversation.ConversationId);
         result2.IsNewSession.ShouldBeFalse();
@@ -71,12 +71,12 @@ public sealed class ThreadIdRoutingTests
         {
             ChannelType = Channel(),
             SenderId = "user1",
-            ChannelAddress = "chat1",
+            ChannelAddress = ChannelAddress.From("chat1"),
             Content = "hello",
-            ThreadId = "thread-1"
+            ThreadId = ThreadId.From("thread-1")
         };
 
-        msg.ThreadId.ShouldBe("thread-1");
+        msg.ThreadId.ShouldBe(ThreadId.From("thread-1"));
     }
 
     [Fact]
@@ -89,9 +89,9 @@ public sealed class ThreadIdRoutingTests
         {
             ChannelType = Channel("telegram"),
             SenderId = "user1",
-            ChannelAddress = "chat-789",
+            ChannelAddress = ChannelAddress.From("chat-789"),
             Content = "hello",
-            ThreadId = "topic-55"
+            ThreadId = ThreadId.From("topic-55")
         };
 
         var result = await capturingRouter.ResolveInboundAsync(
@@ -101,7 +101,7 @@ public sealed class ThreadIdRoutingTests
             message.ThreadId,
             conversationId: null);
 
-        capturingRouter.CapturedThreadId.ShouldBe("topic-55");
+        capturingRouter.CapturedThreadId.ShouldBe(ThreadId.From("topic-55"));
     }
 }
 
@@ -110,11 +110,11 @@ public sealed class ThreadIdRoutingTests
 /// </summary>
 internal sealed class CapturingConversationRouter : IConversationRouter
 {
-    public string? CapturedThreadId { get; private set; }
+    public ThreadId? CapturedThreadId { get; private set; }
 
     public Task<ConversationRoutingResult> ResolveInboundAsync(
-        AgentId agentId, ChannelKey channelType, string channelAddress,
-        string? threadId, string? conversationId = null, CancellationToken ct = default)
+        AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress,
+        ThreadId? threadId, string? conversationId = null, CancellationToken ct = default)
     {
         CapturedThreadId = threadId;
         var conv = new Conversation { AgentId = agentId };
@@ -129,7 +129,7 @@ internal sealed class CapturingConversationRouter : IConversationRouter
     public Task MuteBindingAsync(ConversationId conversationId, BindingId bindingId, CancellationToken ct = default)
         => Task.CompletedTask;
 
-    public Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, string channelAddress, CancellationToken ct = default)
+    public Task MuteBindingByAddressAsync(AgentId? agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
         => Task.CompletedTask;
 
     public Task ReattachBindingAsync(BindingId bindingId, ConversationId targetConversationId, CancellationToken ct = default)

--- a/tests/BotNexus.Gateway.Tests/DefaultMessageRouterTests.cs
+++ b/tests/BotNexus.Gateway.Tests/DefaultMessageRouterTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
@@ -100,7 +101,7 @@ public sealed class DefaultMessageRouterTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "sender-1",
-            ChannelAddress = "conv-1",
+            ChannelAddress = ChannelAddress.From("conv-1"),
             Content = "hello",
             TargetAgentId = targetAgentId,
             SessionId = sessionId

--- a/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -39,7 +39,7 @@ public sealed class FanOutStaleBindingTests
         {
             ChannelType = channelType,
             SenderId = "sender-1",
-            ChannelAddress = conversationId,
+            ChannelAddress = ChannelAddress.From(conversationId),
             Content = content,
             SessionId = sessionId,
             Metadata = new Dictionary<string, object?>()
@@ -99,7 +99,7 @@ public sealed class FanOutStaleBindingTests
         signalrAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("signalr"));
         signalrAdapter
             .Setup(a => a.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new StaleSignalRConnectionException(bindingId, convId));
+            .ThrowsAsync(new StaleSignalRConnectionException(bindingId, ConversationId.From(convId)));
 
         var channelManager = new Mock<IChannelManager>();
         channelManager.SetupGet(m => m.Adapters).Returns([primaryAdapter.Object, signalrAdapter.Object]);
@@ -111,7 +111,7 @@ public sealed class FanOutStaleBindingTests
         {
             BindingId = bindingId,
             ChannelType = ChannelKey.From("signalr"),
-            ChannelAddress = "conn-dead-1",
+            ChannelAddress = ChannelAddress.From("conn-dead-1"),
             Mode = BindingMode.Interactive
         };
         var conversation = new Conversation
@@ -124,7 +124,7 @@ public sealed class FanOutStaleBindingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
 
         // Return the stale binding for fan-out
@@ -133,7 +133,7 @@ public sealed class FanOutStaleBindingTests
             .ReturnsAsync([staleBinding]);
 
         convRouter
-            .Setup(r => r.MuteBindingByAddressAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId?>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.MuteBindingByAddressAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId?>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         await using var host = CreateHost(supervisor.Object, router.Object, sessions, channelManager.Object, convRouter.Object);
@@ -190,7 +190,7 @@ public sealed class FanOutStaleBindingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
 
         // Empty list = already muted / no fan-out targets

--- a/tests/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1,3 +1,5 @@
+using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
+using ThreadId = BotNexus.Domain.Primitives.ThreadId;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
@@ -830,7 +832,7 @@ public sealed class GatewayHostTests
         {
             ChannelType = channelType,
             SenderId = "sender-1",
-            ChannelAddress = conversationId,
+            ChannelAddress = ChannelAddress.From(conversationId),
             Content = content,
             SessionId = sessionId,
             Metadata = metadata ?? new Dictionary<string, object?>()
@@ -889,8 +891,8 @@ public sealed class GatewayHostTests
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<BotNexus.Domain.Primitives.AgentId>(),
                 It.IsAny<BotNexus.Domain.Primitives.ChannelKey>(),
-                It.IsAny<string>(),
-                It.IsAny<string?>(),
+                It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(),
                 It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BotNexus.Gateway.Abstractions.Conversations.ConversationRoutingResult(
@@ -913,8 +915,8 @@ public sealed class GatewayHostTests
         convRouter.Verify(r => r.ResolveInboundAsync(
             It.IsAny<BotNexus.Domain.Primitives.AgentId>(),
             It.IsAny<BotNexus.Domain.Primitives.ChannelKey>(),
-            It.IsAny<string>(),
-            It.IsAny<string?>(),
+            It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
+            It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(),
             It.IsAny<string?>(),
             It.IsAny<CancellationToken>()), Times.AtLeastOnce, "IConversationRouter.ResolveInboundAsync must be called");
 

--- a/tests/BotNexus.Gateway.Tests/InMemoryConversationStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/InMemoryConversationStoreTests.cs
@@ -141,13 +141,13 @@ public sealed class InMemoryConversationStoreTests
                 new ChannelBinding
                 {
                     ChannelType = ChannelKey.From("telegram"),
-                    ChannelAddress = "12345"
+                    ChannelAddress = ChannelAddress.From("12345")
                 }
             ]
         };
         await store.CreateAsync(conv);
 
-        var result = await store.ResolveByBindingAsync(agentId, ChannelKey.From("telegram"), "12345", null);
+        var result = await store.ResolveByBindingAsync(agentId, ChannelKey.From("telegram"), ChannelAddress.From("12345"), null);
 
         result.ShouldNotBeNull();
         result!.ConversationId.ShouldBe(conv.ConversationId);
@@ -165,15 +165,15 @@ public sealed class InMemoryConversationStoreTests
                 new ChannelBinding
                 {
                     ChannelType = ChannelKey.From("teams"),
-                    ChannelAddress = "team-channel",
-                    ThreadId = "thread-42"
+                    ChannelAddress = ChannelAddress.From("team-channel"),
+                    ThreadId = ThreadId.From("thread-42")
                 }
             ]
         };
         await store.CreateAsync(conv);
 
-        var match = await store.ResolveByBindingAsync(agentId, ChannelKey.From("teams"), "team-channel", "thread-42");
-        var noMatch = await store.ResolveByBindingAsync(agentId, ChannelKey.From("teams"), "team-channel", "wrong-thread");
+        var match = await store.ResolveByBindingAsync(agentId, ChannelKey.From("teams"), ChannelAddress.From("team-channel"), ThreadId.From("thread-42"));
+        var noMatch = await store.ResolveByBindingAsync(agentId, ChannelKey.From("teams"), ChannelAddress.From("team-channel"), ThreadId.From("wrong-thread"));
 
         match.ShouldNotBeNull();
         noMatch.ShouldBeNull();
@@ -191,14 +191,14 @@ public sealed class InMemoryConversationStoreTests
                 new ChannelBinding
                 {
                     ChannelType = ChannelKey.From("telegram"),
-                    ChannelAddress = "99999"
+                    ChannelAddress = ChannelAddress.From("99999")
                 }
             ]
         };
         await store.CreateAsync(conv);
         await store.ArchiveAsync(conv.ConversationId);
 
-        var result = await store.ResolveByBindingAsync(agentId, ChannelKey.From("telegram"), "99999", null);
+        var result = await store.ResolveByBindingAsync(agentId, ChannelKey.From("telegram"), ChannelAddress.From("99999"), null);
         result.ShouldBeNull();
     }
 
@@ -209,7 +209,7 @@ public sealed class InMemoryConversationStoreTests
         var agentId = Agent("summary-agent");
         var conv = MakeConversation(agentId) with
         {
-            ChannelBindings = [new ChannelBinding { ChannelType = ChannelKey.From("telegram"), ChannelAddress = "1" }]
+            ChannelBindings = [new ChannelBinding { ChannelType = ChannelKey.From("telegram"), ChannelAddress = ChannelAddress.From("1") }]
         };
         await store.CreateAsync(conv);
 

--- a/tests/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
@@ -213,7 +213,7 @@ public sealed class CopilotIntegrationTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "integration-user",
-            ChannelAddress = "copilot-integration-conversation",
+            ChannelAddress = ChannelAddress.From("copilot-integration-conversation"),
             Content = content,
             SessionId = BotNexus.Domain.Primitives.SessionId.From("integration-session")
         };

--- a/tests/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
@@ -176,7 +176,7 @@ public sealed class Phase5IntegrationTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "phase5-tester",
-            ChannelAddress = "phase5-live-conv",
+            ChannelAddress = ChannelAddress.From("phase5-live-conv"),
             SessionId = BotNexus.Domain.Primitives.SessionId.From("phase5-live"),
             Content = "Reply with a short greeting."
         });

--- a/tests/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
+++ b/tests/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
@@ -114,7 +114,7 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
         var dispatched = dispatcher.Messages.ShouldHaveSingleItem();
         dispatched.ConversationId.ShouldBeNull(
             "SendMessage without conversationId must dispatch with ConversationId=null to use binding lookup");
-        dispatched.ChannelAddress.ShouldBe(TestAgentId);
+        dispatched.ChannelAddress.ShouldBe(ChannelAddress.From(TestAgentId));
     }
 
     /// <summary>

--- a/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
+++ b/tests/BotNexus.Gateway.Tests/SqliteConversationStoreTests.cs
@@ -29,7 +29,7 @@ public sealed class SqliteConversationStoreTests
         loaded!.Title.ShouldBe("First");
         loaded.ChannelBindings.Count.ShouldBe(1);
         loaded.ChannelBindings[0].ChannelType.ShouldBe(ChannelKey.From("telegram"));
-        loaded.ChannelBindings[0].ChannelAddress.ShouldBe("12345");
+        loaded.ChannelBindings[0].ChannelAddress.ShouldBe(ChannelAddress.From("12345"));
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public sealed class SqliteConversationStoreTests
         await store.CreateAsync(expected);
         await store.CreateAsync(CreateConversation(Agent("agent-a"), "Other", CreateBinding("telegram", "99999")));
 
-        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("telegram"), "12345", null);
+        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("telegram"), ChannelAddress.From("12345"), null);
 
         resolved.ShouldNotBeNull();
         resolved!.ConversationId.ShouldBe(expected.ConversationId);
@@ -116,7 +116,7 @@ public sealed class SqliteConversationStoreTests
         await store.CreateAsync(expected);
         await store.CreateAsync(CreateConversation(Agent("agent-a"), "Other", CreateBinding("teams", "channel-1", "thread-99")));
 
-        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", "thread-42");
+        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), ChannelAddress.From("channel-1"), ThreadId.From("thread-42"));
 
         resolved.ShouldNotBeNull();
         resolved!.ConversationId.ShouldBe(expected.ConversationId);
@@ -132,11 +132,11 @@ public sealed class SqliteConversationStoreTests
         await store.CreateAsync(expected);
 
         // Querying with null threadId should NOT match the thread-42 binding
-        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", null);
+        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), ChannelAddress.From("channel-1"), null);
         resolved.ShouldBeNull();
 
         // But querying with the actual thread-42 should match
-        var resolvedWithThread = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", "thread-42");
+        var resolvedWithThread = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), ChannelAddress.From("channel-1"), ThreadId.From("thread-42"));
         resolvedWithThread.ShouldNotBeNull();
         resolvedWithThread!.ConversationId.ShouldBe(expected.ConversationId);
     }
@@ -149,7 +149,7 @@ public sealed class SqliteConversationStoreTests
         var expected = CreateConversation(Agent("agent-a"), "Address", CreateBinding("teams", "channel-1", null));
         await store.CreateAsync(expected);
 
-        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), "channel-1", null);
+        var resolved = await fixture.CreateStore().ResolveByBindingAsync(Agent("agent-a"), ChannelKey.From("teams"), ChannelAddress.From("channel-1"), null);
 
         resolved.ShouldNotBeNull();
         resolved!.ConversationId.ShouldBe(expected.ConversationId);
@@ -188,7 +188,7 @@ public sealed class SqliteConversationStoreTests
         var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
         loaded.ShouldNotBeNull();
         loaded!.ChannelBindings.Count.ShouldBe(2);
-        loaded.ChannelBindings.Any(b => b.ChannelType == ChannelKey.From("teams") && b.ThreadId == "thread-1").ShouldBeTrue();
+        loaded.ChannelBindings.Any(b => b.ChannelType == ChannelKey.From("teams") && b.ThreadId == ThreadId.From("thread-1")).ShouldBeTrue();
     }
 
     [Fact]
@@ -302,8 +302,8 @@ public sealed class SqliteConversationStoreTests
         {
             BindingId = BindingId.Create(),
             ChannelType = ChannelKey.From(channelType),
-            ChannelAddress = channelAddress,
-            ThreadId = threadId,
+            ChannelAddress = ChannelAddress.From(channelAddress),
+            ThreadId = ThreadId.FromNullable(threadId),
             BoundAt = DateTimeOffset.UtcNow,
             Mode = BindingMode.Interactive,
             ThreadingMode = threadId is null ? ThreadingMode.Single : ThreadingMode.NativeThread

--- a/tests/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
+++ b/tests/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
@@ -181,7 +182,7 @@ public sealed class StreamingPipelineTests
         {
             ChannelType = ChannelKey.From("web"),
             SenderId = "sender-1",
-            ChannelAddress = "conv-1",
+            ChannelAddress = ChannelAddress.From("conv-1"),
             Content = content,
             SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1")
         };


### PR DESCRIPTION
Closes #171 Closes #172 Closes #173

Completes the domain primitive cleanup. After BindingId (#170), this eliminates the remaining adjacent-string swap risk in method signatures.

## New types

**`ChannelAddress`** — replaces `string` for channel addresses throughout
- `ChannelAddress.From(string)` — explicit construction
- `ChannelAddress.Empty` — for addressless channels (portal SignalR)
- `IsEmpty` property

**`ThreadId`** — replaces `string?` for thread/topic identifiers
- `ThreadId.From(string)` — non-nullable construction
- `ThreadId.FromNullable(string?)` — returns null when input is null/empty

## Fix

**`StaleChannelConnectionException.ConversationId`** — changed from `string` to `ConversationId` strong type. `StaleSignalRConnectionException` updated to match.

## Scope

41 files updated. No remaining `string channelAddress` or `string? threadId` in any method signature. Serialization boundaries (SQLite, JSON API DTOs) kept as string, converted at the boundary.

## Domain model is now fully typed

| Field | Before | After |
|---|---|---|
| BindingId | string | BindingId (#170) |
| ChannelAddress | string | ChannelAddress |
| ThreadId | string? | ThreadId? |
| ConversationId | string | ConversationId (existing) |
| AgentId | string | AgentId (existing) |
| SessionId | string | SessionId (existing) |