### PR TITLE
fix(crossworld): rename CrossWorldRelayRequest.ChannelAddress to ConversationId

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/CrossWorldRelayModels.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/CrossWorldRelayModels.cs
@@ -22,9 +22,10 @@ public sealed record CrossWorldRelayRequest
     /// </summary>
     public required string Message { get; init; }
     /// <summary>
-    /// Gets or sets the conversation id.
+    /// Gets or sets the conversation id that the message belongs to on the source world.
+    /// Used by the remote gateway to correlate the response back to the originating conversation.
     /// </summary>
-    public required string ChannelAddress { get; init; }
+    public required string ConversationId { get; init; }
     /// <summary>
     /// Gets or sets the source session id.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -83,7 +83,7 @@ public sealed class CrossWorldFederationController(
             WorldId = _localWorldId,
             Role = "target"
         });
-        session.Metadata["conversationId"] = request.ChannelAddress;
+        session.Metadata["conversationId"] = request.ConversationId;
         session.Metadata["sourceWorldId"] = request.SourceWorldId;
         session.Metadata["sourceSessionId"] = request.SourceSessionId;
         session.Status = GatewaySessionStatus.Active;

--- a/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
@@ -65,7 +65,7 @@ public sealed class CrossWorldChannelAdapter(
                 SourceAgentId = sourceAgentId,
                 TargetAgentId = targetAgentId,
                 Message = message.Content,
-                ChannelAddress = conversationId,
+                ConversationId = conversationId,
                 SourceSessionId = sourceSessionId,
                 RemoteSessionId = remoteSessionId
             }, options: JsonOptions)

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -212,7 +212,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
                     new OutboundMessage
                     {
                         ChannelType = ChannelKey.From("cross-world"),
-                        ChannelAddress = ChannelAddress.From(conversationId),
+                        ChannelAddress = ChannelAddress.From(peer.Endpoint ?? string.Empty), // target endpoint is the channel address
                         Content = message,
                         SessionId = sessionId.Value,
                         Metadata = new Dictionary<string, object?>

--- a/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -75,7 +75,7 @@ public sealed class CrossWorldFederationControllerTests
                 SourceAgentId = "test-agent",
                 TargetAgentId = "agent-c",
                 Message = "Hello from world-a",
-                ChannelAddress = "nova::cross::leela::abc123"
+                ConversationId = "nova::cross::leela::abc123"
             },
             CancellationToken.None);
 
@@ -143,7 +143,7 @@ public sealed class CrossWorldFederationControllerTests
                 SourceAgentId = "test-agent",
                 TargetAgentId = "agent-c",
                 Message = "hello",
-                ChannelAddress = "c-1"
+                ConversationId = "c-1"
             },
             CancellationToken.None);
 


### PR DESCRIPTION
Found during primitive type audit.

`CrossWorldRelayRequest` had a field named `ChannelAddress` that was documented as a conversation ID and used exclusively as one. This was a naming bug.

## Changes

- `CrossWorldRelayRequest.ChannelAddress` → `ConversationId` (string, API wire format unchanged — same position in JSON)
- `CrossWorldChannelAdapter`: passes `conversationId` metadata to the renamed field
- `CrossWorldFederationController`: reads `request.ConversationId` not `ChannelAddress`
- `AgentExchangeService`: `OutboundMessage.ChannelAddress` now uses `peer.Endpoint` (the actual channel address) — conversation ID stays in metadata where it belongs

No behaviour change — only naming and semantic correctness.