### PR TITLE
fix(agent): enable tool execution timeout — defaults to 120s

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/GatewayOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/GatewayOptions.cs
@@ -41,4 +41,13 @@ public sealed class GatewayOptions
     /// Options controlling the built-in file watcher tool.
     /// </summary>
     public FileWatcherToolOptions FileWatcherTool { get; set; } = new();
+
+    /// <summary>
+    /// Per-tool execution timeout in seconds. When a tool call exceeds this duration
+    /// it is cancelled and the agent receives an error result. Defaults to 120 seconds.
+    /// Set to 0 to disable (not recommended for production).
+    /// Can be overridden per-tool via <c>DefaultTimeout</c> on the tool itself,
+    /// or per-call via a <c>timeout</c> argument in the tool invocation.
+    /// </summary>
+    public int ToolTimeoutSeconds { get; set; } = 120;
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -161,6 +161,9 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         tools.Add(new FileWatcherTool(fileWatcherToolOptions, pathValidator));
 
         var subAgentOptions = _serviceProvider.GetService<IOptions<GatewayOptions>>()?.Value.SubAgents;
+        var gatewayOptions = _serviceProvider.GetService<IOptions<GatewayOptions>>()?.Value;
+        var toolTimeoutSeconds = gatewayOptions?.ToolTimeoutSeconds ?? 120;
+        var toolTimeout = toolTimeoutSeconds > 0 ? TimeSpan.FromSeconds(toolTimeoutSeconds) : (TimeSpan?)null;
         var subAgentManager = _serviceProvider.GetService<ISubAgentManager>();
         var isSubAgentSession = context.SessionId.IsSubAgent;
         if (subAgentManager is not null &&
@@ -295,7 +298,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             GenerationSettings: new SimpleStreamOptions(),
             SteeringMode: QueueMode.All,
             FollowUpMode: QueueMode.All,
-            SessionId: context.SessionId);
+            SessionId: context.SessionId,
+            ToolTimeout: toolTimeout);
 
         var agent = new BotNexus.Agent.Core.Agent(options);
         IAgentHandle handle = new InProcessAgentHandle(


### PR DESCRIPTION
Closes #24

## Problem

`ToolTimeout` was plumbed through `ToolExecutor` and `AgentOptions` but never set. `InProcessIsolationStrategy` always constructed `AgentOptions` with `ToolTimeout = null` — meaning no timeout. A hung tool call blocked the agent permanently.

## Fix

- Added `ToolTimeoutSeconds` (default: 120) to `GatewayOptions`
- `InProcessIsolationStrategy` reads it and passes `TimeSpan.FromSeconds(toolTimeoutSeconds)` as `ToolTimeout` to `AgentOptions`
- `ToolTimeoutSeconds = 0` disables the timeout (not recommended)

## Config

```json
{
  "gateway": {
    "toolTimeoutSeconds": 120
  }
}
```

## Precedence (unchanged)

Per-tool `DefaultTimeout` and per-call `timeout`/`timeoutMs` arguments still override the gateway default. The gateway value acts as a safety cap.