### PR TITLE
[Gateway] Wire tool timeout config into runtime (#24)

### DIFF
--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -383,3 +383,17 @@
 **Next Step:** Implement 4 new tests + fix 4 pre-existing failures before merge.
 
 ---
+## 2026-05-07 — Issue #24 timeout regression test pass (Hermes)
+
+- Added failing Gateway regression tests for missing timeout configuration plumbing:
+  - `InProcessIsolationStrategyTests.CreateAsync_WhenDescriptorSpecifiesToolTimeout_PropagatesToAgentOptions`
+  - `PlatformConfigAgentSourceTests.LoadAsync_WithAgentToolTimeoutSeconds_PreservesTimeoutForRuntimeWiring`
+  - `PlatformConfigAgentSourceTests.LoadAsync_WithDefaultsToolTimeoutSeconds_InheritsTimeoutWhenAgentOmitsOverride`
+- Added passing AgentCore regression test for structured timeout end-event emission:
+  - `ToolExecutorTimeoutTests.HangingTool_EmitsToolExecutionEndEvent_AsError`
+- Verified existing timeout recovery coverage remains in place:
+  - `ToolExecutorTimeoutTests.HangingTool_TimesOut_ReturnsErrorResult`
+  - `ToolExecutorTimeoutTests.AfterTimeout_NextToolCallSucceeds`
+- Outcome: AgentCore timeout behavior passes; gateway timeout config wiring tests fail (expected, highlights issue #24 gap).
+
+---

--- a/.squad/decisions/inbox/hermes-issue-24-tests.md
+++ b/.squad/decisions/inbox/hermes-issue-24-tests.md
@@ -1,0 +1,12 @@
+# Hermes Decision — Issue 24 test strategy
+
+Date: 2026-05-07
+
+## Decision
+For issue #24, QA will lock in three regression contracts before runtime implementation:
+1. Platform config must preserve per-agent and defaults-level `ToolTimeoutSeconds` for descriptor/runtime wiring.
+2. In-process agent creation must propagate configured timeout into `AgentOptions.ToolTimeout`.
+3. AgentCore timeout behavior keeps passing contracts for structured timeout error + continued execution after timeout.
+
+## Rationale
+The runtime timeout behavior is partially implemented in AgentCore, but gateway config-to-runtime wiring is currently missing. These tests separate already-working behavior from missing plumbing so implementation can land safely without regressing existing timeout handling.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,7 @@ Default settings for all agents. Individual agents can override any property.
 | `Temperature` | double? | null | Randomness (0.0=deterministic, 1.0=creative). If unset, provider decides |
 | `MaxToolIterations` | int | 40 | Max tool call loops in a single agent cycle |
 | `MaxRepeatedToolCalls` | int | 2 | Max times the same tool can be called with identical arguments (loop detection) |
+| `ToolTimeoutSeconds` | int? | null | Per-tool execution timeout in seconds. When set, overrides the runtime default (120s). Propagated to all agents that don't set their own |
 | `Timezone` | string | `UTC` | Default timezone for agent operations (IANA format) |
 | `Named` | dict | `{}` | Per-agent customizations (see AgentConfig below) |
 
@@ -245,6 +246,7 @@ Override any default for a specific agent:
 | `MaxRepeatedToolCalls` | int | Override default repeated tool call limit (loop detection) |
 | `Timezone` | string | Override default timezone |
 | `EnableMemory` | bool | Enable persistent memory for this agent |
+| `ToolTimeoutSeconds` | int? | Per-tool execution timeout in seconds. Overrides the defaults-level value for this agent. When null, inherits from AgentDefaults |
 | `DisallowedTools` | list | Tool names to exclude for this agent (e.g., `["shell", "filesystem"]`) — see [Internal Tools](#internal-tools) |
 | `McpServers` | list | MCP servers enabled for this agent (see [MCP Servers](#mcp-servers)) |
 | `Skills` | list | Named skill references (plugin extension names) |

--- a/docs/planning/bug-tool-execution-timeout/design-spec.md
+++ b/docs/planning/bug-tool-execution-timeout/design-spec.md
@@ -3,14 +3,14 @@ id: bug-tool-execution-timeout
 title: "No Tool Execution Timeout or Stuck-Turn Recovery"
 type: bug
 priority: critical
-status: draft
+status: in-progress
 created: 2026-04-20
 tags: [tools, timeout, resilience, session-recovery, agent-lifecycle]
 ---
 
 # Bug: No Tool Execution Timeout or Stuck-Turn Recovery
 
-**Status:** draft
+**Status:** in-progress
 **Priority:** critical
 **Created:** 2026-04-20
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
@@ -10,12 +10,13 @@ namespace BotNexus.Gateway.Abstractions.Sessions;
 /// <remarks>
 /// <para>Built-in implementations:</para>
 /// <list type="bullet">
-///   <item><b>InMemorySessionStore</b> — Fast, non-durable. For development and testing.</item>
-///   <item><b>FileSessionStore</b> — JSONL file-backed. For single-instance deployments.
-///   Inspired by the archive's <c>SessionManager</c> (JSONL with .meta.json sidecar).</item>
+///   <item><b>InMemorySessionStore</b> — Non-durable, in-process. For development and testing.</item>
+///   <item><b>FileSessionStore</b> — File-backed with JSONL history + JSON metadata sidecar. For single-instance deployments.</item>
+///   <item><b>SqliteSessionStore</b> — SQLite database-backed, production-ready. Features indexed queries,
+///   WAL mode for concurrency, and per-session locking.</item>
 /// </list>
 /// <para>
-/// Future implementations could use SQLite, Redis, PostgreSQL, etc.
+/// Future implementations could use Redis, PostgreSQL, or other backends.
 /// All implementations must be thread-safe.
 /// </para>
 /// </remarks>

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -50,6 +50,7 @@ public static class AgentConfigMerger
             SubAgents = agent.SubAgents,
             IsolationStrategy = agent.IsolationStrategy,
             MaxConcurrentSessions = agent.MaxConcurrentSessions,
+            ToolTimeoutSeconds = MergeToolTimeoutSeconds(defaults.ToolTimeoutSeconds, agent.ToolTimeoutSeconds, agentObj),
             Metadata = agent.Metadata,
             IsolationOptions = agent.IsolationOptions,
             Enabled = agent.Enabled,
@@ -80,6 +81,17 @@ public static class AgentConfigMerger
             return agent;
 
         // No agent override — inherit defaults
+        return agent ?? defaults;
+    }
+
+    private static int? MergeToolTimeoutSeconds(
+        int? defaults,
+        int? agent,
+        JsonElement? agentObj)
+    {
+        if (agentObj is not null && agentObj.Value.TryGetProperty("toolTimeoutSeconds", out _))
+            return agent;
+
         return agent ?? defaults;
     }
 

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentDefaultsConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentDefaultsConfig.cs
@@ -11,6 +11,11 @@ public sealed class AgentDefaultsConfig
     /// <summary>Default tool IDs inherited by agents that do not explicitly set their own toolIds.</summary>
     public List<string>? ToolIds { get; set; }
 
+    /// <summary>
+    /// Default per-tool timeout (seconds) inherited by agents that do not explicitly set their own timeout.
+    /// </summary>
+    public int? ToolTimeoutSeconds { get; set; }
+
     /// <summary>Default memory configuration inherited by agents.</summary>
     public MemoryAgentConfig? Memory { get; set; }
 

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -356,6 +356,8 @@ public sealed class AgentDefinitionConfig
     public string? SystemPromptFile { get; set; }
     /// <summary>Tool identifiers this agent has access to.</summary>
     public List<string>? ToolIds { get; set; }
+    /// <summary>Per-tool timeout in seconds for runtime tool execution safety caps.</summary>
+    public int? ToolTimeoutSeconds { get; set; }
     /// <summary>Agent IDs this agent can call as sub-agents.</summary>
     public List<string>? SubAgents { get; set; }
     /// <summary>Isolation strategy name (e.g. 'in-process').</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -59,7 +59,7 @@ public sealed class PlatformConfigAgentSource(
         if (agents is null || agents.Count == 0)
             return descriptors;
 
-        var agentDefaults = platformConfig.AgentDefaults;
+        var agentDefaults = platformConfig.AgentDefaults ?? ExtractInlineAgentDefaults(agents);
         var agentRawElements = platformConfig.AgentRawElements;
 
         foreach (var (agentId, agentConfig) in agents)
@@ -78,6 +78,9 @@ public sealed class PlatformConfigAgentSource(
             if (agentRawElements is not null && agentRawElements.TryGetValue(agentId, out var rawEl))
                 rawElement = rawEl;
             var effectiveConfig = AgentConfigMerger.Merge(agentDefaults, agentConfig, rawElement);
+            var metadata = new Dictionary<string, object?>(ConvertObject(effectiveConfig.Metadata), StringComparer.OrdinalIgnoreCase);
+            if (effectiveConfig.ToolTimeoutSeconds is int toolTimeoutSeconds)
+                metadata["toolTimeoutSeconds"] = toolTimeoutSeconds;
 
             var descriptor = new AgentDescriptor
             {
@@ -95,7 +98,7 @@ public sealed class PlatformConfigAgentSource(
                     ? "in-process"
                     : effectiveConfig.IsolationStrategy,
                 MaxConcurrentSessions = effectiveConfig.MaxConcurrentSessions ?? 0,
-                Metadata = ConvertObject(effectiveConfig.Metadata),
+                Metadata = metadata,
                 IsolationOptions = ConvertObject(effectiveConfig.IsolationOptions),
                 Memory = CloneMemoryConfig(effectiveConfig.Memory),
                 Soul = CloneSoulConfig(effectiveConfig.Soul),
@@ -122,6 +125,26 @@ public sealed class PlatformConfigAgentSource(
         }
 
         return descriptors;
+    }
+
+    private static AgentDefaultsConfig? ExtractInlineAgentDefaults(IReadOnlyDictionary<string, AgentDefinitionConfig> agents)
+    {
+        foreach (var (agentId, config) in agents)
+        {
+            if (!string.Equals(agentId, "defaults", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return new AgentDefaultsConfig
+            {
+                ToolIds = config.ToolIds,
+                ToolTimeoutSeconds = config.ToolTimeoutSeconds,
+                Memory = config.Memory,
+                Heartbeat = config.Heartbeat,
+                FileAccess = config.FileAccess
+            };
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<string> ResolveSystemPromptFiles(AgentDefinitionConfig agentConfig)

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Linq;
+using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core;
 using BotNexus.Agent.Core.Configuration;
@@ -295,7 +296,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             GenerationSettings: new SimpleStreamOptions(),
             SteeringMode: QueueMode.All,
             FollowUpMode: QueueMode.All,
-            SessionId: context.SessionId);
+            SessionId: context.SessionId,
+            ToolTimeout: ResolveToolTimeout(descriptor));
 
         var agent = new BotNexus.Agent.Core.Agent(options);
         IAgentHandle handle = new InProcessAgentHandle(
@@ -331,6 +333,45 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             string value when bool.TryParse(value, out var parsed) => parsed,
             _ => false
         };
+    }
+
+    private TimeSpan? ResolveToolTimeout(AgentDescriptor descriptor)
+    {
+        if (!descriptor.Metadata.TryGetValue("toolTimeoutSeconds", out var raw) || raw is null)
+            return null;
+
+        if (TryConvertPositiveSeconds(raw, out var seconds))
+        {
+            _logger.LogDebug("Applying tool timeout for '{AgentId}': {ToolTimeoutSeconds}s", descriptor.AgentId, seconds);
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        _logger.LogWarning(
+            "Ignoring invalid tool timeout metadata for '{AgentId}'. Expected positive seconds but got '{ToolTimeoutSecondsRaw}'.",
+            descriptor.AgentId,
+            raw);
+        return null;
+    }
+
+    private static bool TryConvertPositiveSeconds(object raw, out int seconds)
+    {
+        seconds = 0;
+        var parsed = raw switch
+        {
+            int value => value,
+            long value when value <= int.MaxValue => (int)value,
+            double value when value <= int.MaxValue && value == Math.Truncate(value) => (int)value,
+            string value when int.TryParse(value, out var parsedValue) => parsedValue,
+            JsonElement { ValueKind: JsonValueKind.Number } jsonNumber when jsonNumber.TryGetInt32(out var parsedValue) => parsedValue,
+            JsonElement { ValueKind: JsonValueKind.String } jsonString when int.TryParse(jsonString.GetString(), out var parsedValue) => parsedValue,
+            _ => -1
+        };
+
+        if (parsed <= 0)
+            return false;
+
+        seconds = parsed;
+        return true;
     }
 
     private static (SessionAccessLevel level, IReadOnlyList<string>? allowedAgents) ResolveSessionAccess(AgentDescriptor descriptor)

--- a/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
+++ b/tests/BotNexus.AgentCore.Tests/Loop/ToolExecutorTimeoutTests.cs
@@ -131,6 +131,37 @@ public sealed class ToolExecutorTimeoutTests
         results[0].Result.Content[0].Value.ShouldContain("timed out");
     }
 
+    [Fact]
+    public async Task HangingTool_EmitsToolExecutionEndEvent_AsError()
+    {
+        var tool = CreateTool("hang", async ct =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
+        });
+
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(100));
+        var context = new AgentContext(null, [], [tool]);
+        var assistant = CreateAssistant("tc-event", "hang");
+        var events = new List<AgentEvent>();
+
+        _ = await ToolExecutor.ExecuteAsync(
+            context,
+            assistant,
+            config,
+            evt =>
+            {
+                events.Add(evt);
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        var timeoutEnd = events.OfType<ToolExecutionEndEvent>().ShouldHaveSingleItem();
+        timeoutEnd.ToolName.ShouldBe("hang");
+        timeoutEnd.IsError.ShouldBeTrue();
+        timeoutEnd.Result.Content[0].Value.ShouldContain("timed out");
+    }
+
     private static AssistantAgentMessage CreateAssistant(string id, string toolName)
     {
         return new AssistantAgentMessage(

--- a/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -16,6 +16,7 @@ using BotNexus.Tools;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Core.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions;
@@ -229,6 +230,26 @@ public sealed class InProcessIsolationStrategyTests
         tools.ShouldContain(t => string.Equals(t.Name, "read", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task CreateAsync_WhenDescriptorSpecifiesToolTimeout_PropagatesToAgentOptions()
+    {
+        var strategy = CreateStrategyWithRegisteredModel();
+        var descriptor = CreateDescriptor() with
+        {
+            Metadata = new Dictionary<string, object?>
+            {
+                ["toolTimeoutSeconds"] = 7
+            }
+        };
+
+        var handle = await strategy.CreateAsync(
+            descriptor,
+            new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-timeout") });
+
+        var options = GetAgentOptions(handle);
+        options.ToolTimeout.ShouldBe(TimeSpan.FromSeconds(7));
+    }
+
     private static InProcessIsolationStrategy CreateStrategyWithRegisteredModel(
         IReadOnlyList<IAgentToolContributor>? contributors = null)
     {
@@ -285,6 +306,18 @@ public sealed class InProcessIsolationStrategyTests
         var agent = agentField!.GetValue(handle) as BotNexus.Agent.Core.Agent;
         agent.ShouldNotBeNull();
         return agent!.State.Tools;
+    }
+
+    private static AgentOptions GetAgentOptions(IAgentHandle handle)
+    {
+        var agentField = handle.GetType().GetField("_agent", BindingFlags.Instance | BindingFlags.NonPublic);
+        agentField.ShouldNotBeNull();
+        var agent = agentField!.GetValue(handle) as BotNexus.Agent.Core.Agent;
+        agent.ShouldNotBeNull();
+
+        var optionsField = typeof(BotNexus.Agent.Core.Agent).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
+        optionsField.ShouldNotBeNull();
+        return optionsField!.GetValue(agent).ShouldBeOfType<AgentOptions>();
     }
 
     private sealed class PassthroughContextBuilder : IContextBuilder

--- a/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -807,6 +807,86 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
         descriptor.ToolIds.ShouldBe(["read", "write"]);
     }
 
+    [Fact]
+    public async Task LoadAsync_WithAgentToolTimeoutSeconds_PreservesTimeoutForRuntimeWiring()
+    {
+        var config = JsonSerializer.Deserialize<PlatformConfig>(
+            """
+            {
+              "Agents": {
+                "assistant": {
+                  "Provider": "copilot",
+                  "Model": "gpt-4.1",
+                  "Enabled": true,
+                  "ToolTimeoutSeconds": 9
+                }
+              }
+            }
+            """)!;
+
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        ReadToolTimeoutSeconds(descriptor).ShouldBe(9);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithDefaultsToolTimeoutSeconds_InheritsTimeoutWhenAgentOmitsOverride()
+    {
+        var config = JsonSerializer.Deserialize<PlatformConfig>(
+            """
+            {
+              "Agents": {
+                "defaults": {
+                  "ToolTimeoutSeconds": 11
+                },
+                "assistant": {
+                  "Provider": "copilot",
+                  "Model": "gpt-4.1",
+                  "Enabled": true
+                }
+              }
+            }
+            """)!;
+
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        ReadToolTimeoutSeconds(descriptor).ShouldBe(11);
+    }
+
+    private static int? ReadToolTimeoutSeconds(AgentDescriptor descriptor)
+    {
+        var timeoutProperty = descriptor.GetType().GetProperty("ToolTimeoutSeconds", BindingFlags.Public | BindingFlags.Instance);
+        if (timeoutProperty?.GetValue(descriptor) is int seconds)
+        {
+            return seconds;
+        }
+
+        if (!descriptor.Metadata.TryGetValue("toolTimeoutSeconds", out var raw) || raw is null)
+        {
+            return null;
+        }
+
+        return raw switch
+        {
+            int value => value,
+            long value => checked((int)value),
+            JsonElement { ValueKind: JsonValueKind.Number } jsonNumber when jsonNumber.TryGetInt32(out var value) => value,
+            JsonElement { ValueKind: JsonValueKind.String } jsonString when int.TryParse(jsonString.GetString(), out var value) => value,
+            string value when int.TryParse(value, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
     private sealed class StubLocationResolver(IReadOnlyDictionary<string, string> paths) : ILocationResolver
     {
         private readonly IReadOnlyDictionary<string, string> _paths = paths;


### PR DESCRIPTION
Closes #24

## What changed
- Added regression tests for tool timeout behavior and gateway config timeout wiring.
- Wired `toolTimeoutSeconds` from `agents.defaults` and per-agent config into runtime `AgentOptions.ToolTimeout`.
- Preserved existing tool timeout structured error behavior and added diagnostics for invalid runtime timeout metadata.
- Updated configuration docs for `ToolTimeoutSeconds` and restored the session store documentation fix.

## Validation
- `BotNexus.AgentCore.Tests` filtered `ToolExecutorTimeoutTests`: 9 passed.
- `BotNexus.Gateway.Tests` filtered issue #24 coverage: 4 passed.
- Full build was green during implementation.
- Full solution tests still have unrelated baseline failures noted by QA: snapshot/session-store and MCP robustness failures outside the #24 touched files.