### PR TITLE
docs(squad): preserve gateway conversations session log

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -184,3 +184,39 @@
 - Foundation for Farnsworth's clean fix (58d03d13)
 
 **Learning:** Strict rejection protocol ensures architectural rigor — rejected work delegates to fresh implementer, prevents scope drift from remediation.
+---
+
+## 2026-05-07 — Conversation Project Extraction: Implementation
+
+**Status:** ✅ Complete (Leela design → Bender implementation → Hermes QA → Nibbler consistency → PR merged)  
+**Session:** Conversation project refactor orchestration  
+**Coordination:** With Leela (design), Hermes (QA), Nibbler (consistency)  
+
+**Your Role:** Runtime Developer. Implemented Leela's architectural decision.
+
+**Deliverables:**
+- Created `src\gateway\BotNexus.Gateway.Conversations` project structure
+- Created `tests\BotNexus.Gateway.Conversations.Tests` test project
+- Moved 4 runtime classes from Gateway.Sessions/Gateway:
+  - InMemoryConversationStore
+  - FileConversationStore
+  - SqliteConversationStore
+  - DefaultConversationRouter
+- Moved 7 conversation-focused test files from Gateway.Tests
+- Updated all namespaces to `BotNexus.Gateway.Conversations`
+- Updated project references in solution
+- Updated DI wiring in `GatewayServiceCollectionExtensions`
+- Added shared `TestOptionsMonitor` to new test project via linked compile include
+
+**Validation:**
+- Full solution build: ✅ Green (0 errors)
+- Targeted validation passed: Leela's verification checklist complete
+- Test count: BotNexus.Gateway.Conversations.Tests 66/66 passing
+- No circular project dependencies
+- Dependency graph correct
+
+**Commit:** `1aca5967` (implementation complete)
+
+**PR:** https://github.com/sytone/botnexus/pull/178
+
+---

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -123,3 +123,29 @@
 **Outcomes:**
 - Wave 1 memory alignment validated and approved
 - Three non-blocking conditions (C1–C3) carried to Wave 2 backlog
+## 2026-05-07 — Conversation Project Extraction: QA & Validation
+
+**Status:** ✅ Complete (Test validation passed, approved for merge)  
+**Session:** Conversation project refactor orchestration  
+**Coordination:** With Leela (design), Bender (implementation), Nibbler (consistency)  
+
+**Your Role:** Quality Assurance. Test validation and coverage verification.
+
+**Test Validation Results:**
+- **BotNexus.Gateway.Conversations.Tests:** 66/66 passing ✅
+- **BotNexus.Gateway.ConversationTests:** 9/9 passing ✅
+- **Focused Gateway conversation coverage:** 62/62 passing ✅
+
+**Scope Verification:**
+- Confirmed all 7 conversation-focused test files moved from Gateway.Tests to new project ✅
+- Confirmed store/router unit tests correctly isolated ✅
+- No test regressions in moved behavior ✅
+
+**Notes:**
+- SqliteSessionStoreConversationIdTests file-lock failures observed (outside moved scope, pre-existing issue)
+- Test naming conventions respected (Method_Condition_ExpectedBehavior)
+- All assertions aligned with Leela's design contracts
+
+**Status:** Approved for code review and merge
+
+---

--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -7,6 +7,31 @@
 
 ## Core Context
 
+## 2026-05-07 — Conversation Project Extraction: Architectural Design Review
+
+**Status:** ✅ Complete (Design Approved, Implementation Complete)  
+**Session:** Conversation project refactor orchestration  
+**Coordination:** With Bender (implementation), Hermes (QA), Nibbler (consistency)  
+
+**Your Role:** Lead Architect. Reran architecture review from fresh baseline, produced comprehensive design decision.
+
+**Decision:** Extract 3 conversation stores (InMemory, File, Sqlite) + DefaultConversationRouter from Gateway.Sessions/Gateway into dedicated BotNexus.Gateway.Conversations project. Keep contracts in Gateway.Contracts (dependency inversion), domain models in Domain. New test project: BotNexus.Gateway.Conversations.Tests.
+
+**Key Architectural Decisions:**
+- **Dependency graph:** Domain ← Contracts ← Gateway.Conversations ← Gateway (host)
+- **No circular deps:** Gateway.Conversations and Gateway.Sessions are siblings
+- **Contracts stay:** IConversationStore/IConversationRouter remain in Gateway.Contracts
+- **Domain stays:** Conversation models remain in Domain
+- **DI root unchanged:** GatewayServiceCollectionExtensions continues concrete registration
+
+**Risk Mitigation Table:** Documented 6 risks (all LOW-MEDIUM, all mitigated including SQLite coupling, shared database file, DI registration, namespace break, router interface dependency, test helper sharing).
+
+**Verification Checklist Provided:** Build, tests, namespace validation, project references, circular dependency checks.
+
+**Commit:** `d8552f1f` (design decision)
+
+---
+
 **Phases 1-7A Complete. Full Design Review Complete. Phase 12 Extension-Commands Design Review Complete (Grade: B+).** Build green (0 errors), 276 tests passing (up from 264), Full Review grade A-. Core systems operational:
 - Agent registry, supervisor, cross-agent calling with recursion guard + depth limits + timeout
 - WebSocket (with reconnect replay + sequence IDs), TUI (with steering), Telegram channel adapters

--- a/.squad/agents/nibbler/history.md
+++ b/.squad/agents/nibbler/history.md
@@ -112,3 +112,36 @@
 - Planning spec drift documented and flagged for post-merge planning-spec update (optional, non-blocking)
 - Active docs (workspace-and-memory.md) corrected
 - No consistency issues blocking Wave 1 merge
+---
+
+## 2026-05-07 — Conversation Project Extraction: Consistency Review
+
+**Status:** ✅ Complete (Post-work consistency review approved, ready for merge)  
+**Session:** Conversation project refactor orchestration  
+**Coordination:** With Leela (design), Bender (implementation), Hermes (QA)  
+
+**Your Role:** Consistency Reviewer. Scanned for stale references and documentation updates.
+
+**Stale References Found & Fixed:**
+1. **README.md** (top-level) — Updated project architecture section to reference new BotNexus.Gateway.Conversations project
+2. **src\gateway\README.md** — Updated gateway project structure docs to include Conversations project boundary
+3. **docs\planning\feature-conversation-topics\design-review.md** — Updated active planning docs to reflect new project layout
+
+**Consistency Verified ✅:**
+- Project structure matches docs ✅
+- Namespace alignment (BotNexus.Gateway.Conversations) consistent across code, comments, and docs ✅
+- No orphaned references to old conversation store locations ✅
+- Test project creation/location documented correctly ✅
+
+**Non-Blocking Future Cleanup (noted but not in scope):**
+- Heavy test references in shared test helpers
+- Shared test helper linking patterns (low priority, can batch with future refactors)
+
+**Commit:** `ef58f4f3` (consistency fixes)
+
+**Overall Grade: Good**
+- 3 documentation stale reference issues found and fixed
+- Code-to-docs alignment verified
+- Ready for PR merge
+
+---

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,76 @@
 
 ## Active Decisions
 
+### 2026-05-06T18:12:51-07:00: User Directive — Conversation Project Extraction
+
+**By:** Sytone (via Copilot)  
+**What:** Conversation stores and code related to conversations should be in the gateway conversation namespace. Keep this clean and better abstracted by creating `src\gateway\BotNexus.Gateway.Conversations` and moving conversation store/object tests into `tests\BotNexus.Gateway.Conversations.Tests`.  
+**Why:** User request — captured for team memory
+
+---
+
+### Conversation Project Extraction — Architectural Design Review
+
+**Decision Date:** 2026-05-06  
+**Decided By:** Leela (Lead/Architect)  
+**Status:** Approved
+
+**Context:** User directive: conversation stores and related code currently live in `BotNexus.Gateway.Sessions` alongside session stores. They should be extracted to a dedicated `BotNexus.Gateway.Conversations` project to improve separation of concerns and make conversation lifecycle independently testable.
+
+**Decision:** Extract 3 conversation stores (InMemory, File, Sqlite) + DefaultConversationRouter from Gateway.Sessions/Gateway into new BotNexus.Gateway.Conversations. Keep contracts in Gateway.Contracts, domain models in Domain. Dependency direction preserved.
+
+**Key points:**
+- **New project:** `BotNexus.Gateway.Conversations` with namespace `BotNexus.Gateway.Conversations`
+- **What moves:** InMemoryConversationStore, FileConversationStore, SqliteConversationStore, DefaultConversationRouter
+- **What stays:** IConversationStore/IConversationRouter (in Contracts), Domain models, API layer, DI root
+- **Project references:** Gateway.Conversations → Gateway.Contracts, Domain (no circular deps with Gateway.Sessions)
+- **Tests:** 7 conversation-focused tests move from Gateway.Tests → new test project
+
+**Rationale:**
+1. Separation of concerns — conversation lifecycle independent of session stores
+2. Dependency inversion — contracts stay at abstraction layer
+3. Clear ownership — conversations project owns its stores and router
+4. Bounded risk — no architectural changes, single-file DI update
+
+**Risks (all mitigated):**
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| SQLite coupling in SqliteSessionStore | MEDIUM | Takes IConversationStore interface; DI container resolves it. No compile-time coupling. |
+| Shared SQLite database file | MEDIUM | Independent tables and schemas. Runtime config concern, no code change. |
+| DI registration uses concrete types | LOW | Composition root already references Gateway.Sessions. Normal pattern. |
+| Namespace change | LOW | All consumers reference interface via Contracts/DI. Single file update. |
+| DefaultConversationRouter depends on ISessionStore | LOW | Takes interface from Contracts. No project coupling. |
+| Test helper sharing | LOW | Check at implementation; extract or duplicate if needed. |
+
+---
+
+### Bender Decision: Conversation Project Refactor Implementation
+
+**Date:** 2026-05-06  
+**Status:** Implemented
+
+Implemented Leela's boundary decision by extracting conversation runtime code into `BotNexus.Gateway.Conversations` and moving conversation store/router tests into `BotNexus.Gateway.Conversations.Tests`.
+
+**Completed:**
+- Created `src\gateway\BotNexus.Gateway.Conversations` project
+- Created `tests\BotNexus.Gateway.Conversations.Tests` test project
+- Moved 4 runtime classes: InMemoryConversationStore, FileConversationStore, SqliteConversationStore, DefaultConversationRouter
+- Moved 7 conversation-focused test files
+- Updated all namespaces and project references
+- Updated DI wiring in GatewayServiceCollectionExtensions
+- Added shared TestOptionsMonitor to new test project via linked compile
+- Full solution build succeeded
+- BotNexus.Gateway.Conversations.Tests: 66/66 passing
+
+**Key callouts:**
+- GatewayServiceCollectionExtensions remains composition root with concrete registration
+- BotNexus.Gateway.Tests keeps integration/API/E2E-adjacent tests
+- Targeted validation passed (Leela checklist)
+
+**PR:** https://github.com/sytone/botnexus/pull/178
+
+---
+
 ### Leela Design Review: bug-blazor-autoscroll (2026-04-20)
 
 **Decision Date:** 2026-04-20  


### PR DESCRIPTION
## Summary
- Preserves the post-merge Squad bookkeeping from the gateway conversations work on a clean branch from latest `main`.
- Contains only Squad history/decision updates from the local `refactor/gateway-conversations` tail commit.

## Notes
- The exact original `refactor/gateway-conversations` branch head was also pushed to GitHub as a safety net.