### PR TITLE
fix: hydrate latest Quill history after refresh

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -376,8 +376,17 @@
         if (!string.IsNullOrEmpty(agentId))
         {
             Store.ActiveAgentId = agentId;
-            if (Store.GetAgent(agentId) is { } agent && agent.UnreadCount > 0)
-                agent.UnreadCount = 0;
+            if (Store.GetAgent(agentId) is { } agent)
+            {
+                if (agent.UnreadCount > 0)
+                    agent.UnreadCount = 0;
+
+                // SeedConversations auto-selects a default conversation, but its
+                // history is only loaded for the very first agent during portal init.
+                // Trigger history loading now so the user sees messages immediately.
+                if (agent.ActiveConversationId is not null)
+                    await Interaction.SelectConversationAsync(agentId, agent.ActiveConversationId);
+            }
             Store.NotifyChanged();
 
             if (_isMobile)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -390,16 +390,6 @@ public sealed class AgentInteractionService : IAgentInteractionService
             const int historyLimit = 200;
             var response = await _restClient.GetHistoryAsync(conversationId, limit: historyLimit);
 
-            // The API returns entries in chronological order starting from offset 0.
-            // When totalCount exceeds the limit, the first page contains the oldest
-            // entries and the most recent messages are beyond the page boundary.
-            // Re-fetch from the tail so users see their latest conversation.
-            if (response is not null && response.TotalCount > historyLimit)
-            {
-                var tailOffset = response.TotalCount - historyLimit;
-                response = await _restClient.GetHistoryAsync(conversationId, limit: historyLimit, offset: tailOffset);
-            }
-
             if (response?.Entries is { Count: > 0 })
             {
                 // Replace any cache-rendered messages with fresh server data

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/PortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/PortalLoadService.cs
@@ -77,17 +77,6 @@ public sealed class PortalLoadService : IPortalLoadService
                     const int historyLimit = 200;
                     var history = await _restClient.GetHistoryAsync(selectedConversation.ConversationId, historyLimit, 0, cancellationToken);
 
-                    // The API returns entries in chronological order starting from offset.
-                    // When totalCount exceeds the limit, the first page contains the oldest
-                    // entries and the most recent messages are beyond the page boundary.
-                    // Re-fetch from the tail so users see their latest conversation.
-                    if (history is not null && history.TotalCount > historyLimit)
-                    {
-                        var tailOffset = history.TotalCount - historyLimit;
-                        history = await _restClient.GetHistoryAsync(
-                            selectedConversation.ConversationId, historyLimit, tailOffset, cancellationToken);
-                    }
-
                     if (history?.Entries is { Count: > 0 })
                     {
                         foreach (var entry in history.Entries)

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -85,10 +85,10 @@ public sealed class AgentInteractionServiceTests
         Assert.False(agent.Conversations["conv-1"].HistoryLoaded);
     }
 
-    // ── History tail-fetch tests ──────────────────────────────────────────
+    // ── Conversation history loading tests ────────────────────────────────
 
     [Fact]
-    public async Task SelectConversation_loads_history_from_tail_when_totalCount_exceeds_limit()
+    public async Task SelectConversation_uses_first_page_when_totalCount_exceeds_limit()
     {
         var agent = _store.GetAgent("agent-1")!;
         agent.Conversations["conv-1"] = new ConversationState
@@ -98,21 +98,9 @@ public sealed class AgentInteractionServiceTests
             HistoryLoaded = false
         };
 
-        // First call returns oldest 200 of 272 total
+        // API returns the newest entries on offset=0, even for long conversations.
         var firstPage = new ConversationHistoryResponseDto(
             "conv-1", TotalCount: 272, Offset: 0, Limit: 200,
-            Entries: Enumerable.Range(0, 200).Select(i => new ConversationHistoryEntryDto
-            {
-                Kind = "message",
-                SessionId = "s1",
-                Role = "user",
-                Content = $"old-{i}",
-                Timestamp = DateTimeOffset.UtcNow.AddMinutes(-300 + i)
-            }).ToList());
-
-        // Second call returns latest 200 from offset 72
-        var tailPage = new ConversationHistoryResponseDto(
-            "conv-1", TotalCount: 272, Offset: 72, Limit: 200,
             Entries: Enumerable.Range(72, 200).Select(i => new ConversationHistoryEntryDto
             {
                 Kind = "message",
@@ -124,16 +112,14 @@ public sealed class AgentInteractionServiceTests
 
         _restClient.GetHistoryAsync("conv-1", 200, 0, Arg.Any<CancellationToken>())
             .Returns(firstPage);
-        _restClient.GetHistoryAsync("conv-1", 200, 72, Arg.Any<CancellationToken>())
-            .Returns(tailPage);
 
         await _service.SelectConversationAsync("agent-1", "conv-1");
 
-        // Should have made two REST calls: first page + tail page
+        // Should only fetch once; a second call pages away from newest data.
         await _restClient.Received(1).GetHistoryAsync("conv-1", 200, 0, Arg.Any<CancellationToken>());
-        await _restClient.Received(1).GetHistoryAsync("conv-1", 200, 72, Arg.Any<CancellationToken>());
+        await _restClient.DidNotReceive().GetHistoryAsync("conv-1", 200, 72, Arg.Any<CancellationToken>());
 
-        // Messages should come from the tail page (most recent)
+        // Messages come directly from the first page (latest entries).
         var messages = agent.Conversations["conv-1"].Messages;
         Assert.Equal(200, messages.Count);
         Assert.Equal("msg-72", messages[0].Content);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -191,4 +191,30 @@ public sealed class MainLayoutTests : IDisposable
         var activeConv = cut.Find(".conversation-list-item-btn.active");
         Assert.NotNull(activeConv);
     }
+
+    [Fact]
+    public void Switching_agent_triggers_history_load_for_active_conversation()
+    {
+        // Arrange: two agents, each with a default conversation auto-selected via SeedConversations
+        _store.SeedAgents([
+            new AgentSummary("a-1", "Alpha"),
+            new AgentSummary("a-2", "Beta")
+        ]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Default", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.SeedConversations("a-2", [
+            new ConversationSummaryDto("c-2", "a-2", "Default", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        // Act: switch to agent a-2 via dropdown
+        var dropdown = cut.Find(".agent-dropdown-select");
+        dropdown.Change("a-2");
+
+        // Assert: SelectConversationAsync was called for Beta's auto-selected conversation
+        _interaction.Received(1).SelectConversationAsync("a-2", "c-2");
+    }
 }


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #187.
- Load the selected conversation history when switching agents after refresh, so Quill's selected conversation is hydrated immediately.
- Remove redundant Blazor tail repaging now that the Gateway history API returns the newest page at `offset=0`.

## Validation
- dotnet build BotNexus.slnx --nologo --tl:off
- dotnet test BotNexus.slnx --nologo --tl:off

## Notes
PR #187 had already merged before these live-debug fixes were pushed to its old branch, so this PR carries only the post-merge follow-up commits on a fresh branch from `main`.