### PR TITLE
feat(gateway): inject memory prompt guidance from config

### DIFF
--- a/docs/botnexus-config.schema.json
+++ b/docs/botnexus-config.schema.json
@@ -792,6 +792,14 @@
         "indexing": {
           "type": "string"
         },
+        "promptInjection": {
+          "type": "string",
+          "enum": [
+            "full",
+            "summary",
+            "none"
+          ]
+        },
         "search": {
           "oneOf": [
             {

--- a/src/domain/BotNexus.Domain/Gateway/Models/MemoryAgentConfig.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/MemoryAgentConfig.cs
@@ -24,6 +24,11 @@ public sealed class MemoryAgentConfig
     /// Gets or sets the search.
     /// </summary>
     public MemorySearchAgentConfig? Search { get; set; }
+
+    /// <summary>
+    /// Gets or sets prompt-memory injection mode: <c>full</c>, <c>summary</c>, or <c>none</c>.
+    /// </summary>
+    public string? PromptInjection { get; set; } = "full";
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
@@ -168,6 +168,7 @@ public sealed class ConfigController : ControllerBase
         var agentMemObj = GetNestedObject(rawElement, "memory");
         sources["memory.enabled"] = ResolveBoolSource("enabled", defaults?.Memory?.Enabled, agent.Memory?.Enabled, agentMemObj, agent.Memory is null);
         sources["memory.indexing"] = ResolveStringSource("indexing", defaults?.Memory?.Indexing, agent.Memory?.Indexing, agentMemObj, agent.Memory is null);
+        sources["memory.promptInjection"] = ResolveStringSource("promptInjection", defaults?.Memory?.PromptInjection, agent.Memory?.PromptInjection, agentMemObj, agent.Memory is null);
 
         // heartbeat.*
         var agentHbObj = GetNestedObject(rawElement, "heartbeat");

--- a/src/gateway/BotNexus.Gateway.Prompts/ContextFileOrdering.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ContextFileOrdering.cs
@@ -38,7 +38,8 @@ public static class ContextFileOrdering
     /// <param name="pathValue">The path value.</param>
     /// <returns>The is dynamic result.</returns>
     public static bool IsDynamic(string pathValue) =>
-        string.Equals(GetBasename(pathValue), "heartbeat.md", StringComparison.Ordinal);
+        string.Equals(GetBasename(pathValue), "heartbeat.md", StringComparison.Ordinal) ||
+        IsDailyMemoryNote(pathValue);
 
     /// <summary>
     /// Executes normalize path.

--- a/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
@@ -43,12 +43,16 @@ public sealed record SystemPromptParams
     public string? OwnerIdentity { get; init; }
     public bool ReasoningTagHint { get; init; }
     public string? ReasoningLevel { get; init; }
+    public string? MemoryPromptInjection { get; init; }
 }
 
 public static class SystemPromptBuilder
 {
     private const string SilentReplyToken = "NO_REPLY";
     private const string SystemPromptCacheBoundary = "\n<!-- BOTNEXUS_CACHE_BOUNDARY -->\n";
+    private const string MemoryPromptInjectionFull = "full";
+    private const string MemoryPromptInjectionSummary = "summary";
+    private const string MemoryPromptInjectionNone = "none";
 
         public static string Build(SystemPromptParams @params)
     {
@@ -109,7 +113,10 @@ public static class SystemPromptBuilder
             .Add(new LambdaPromptSection(30, static context => buildOverridablePromptSection(null, buildExecutionBiasSection(GetGatewayData(context).IsMinimal))))
             .Add(new LambdaPromptSection(40, BuildSafetyAndCliSection))
             .Add(new LambdaPromptSection(50, static context => buildSkillsSection(GetGatewayData(context).Parameters.SkillsPrompt, GetGatewayData(context).ReadToolName)))
-            .Add(new LambdaPromptSection(60, static context => buildMemorySection(GetGatewayData(context).IsMinimal, GetGatewayData(context).NormalizedTools)))
+            .Add(new LambdaPromptSection(60, static context => buildMemorySection(
+                GetGatewayData(context).IsMinimal,
+                GetGatewayData(context).Parameters.MemoryPromptInjection,
+                GetGatewayData(context).NormalizedTools)))
             .Add(new LambdaPromptSection(70, BuildSelfUpdateSection, static context => GetGatewayData(context).HasGateway && !GetGatewayData(context).IsMinimal))
             .Add(new LambdaPromptSection(80, BuildModelAliasesSection))
             .Add(new LambdaPromptSection(90, BuildWorkspaceSection))
@@ -196,12 +203,40 @@ public static class SystemPromptBuilder
 
     public static IReadOnlyList<string> buildMemorySection(bool isMinimal, IReadOnlySet<string> availableTools)
     {
-        _ = availableTools;
+        return buildMemorySection(isMinimal, null, availableTools);
+    }
+
+    public static IReadOnlyList<string> buildMemorySection(bool isMinimal, string? promptInjectionMode, IReadOnlySet<string> availableTools)
+    {
         if (isMinimal)
             return [];
 
-        // TODO: Memory plugin prompt injection not yet implemented.
-        return [];
+        var mode = NormalizeMemoryPromptInjection(promptInjectionMode);
+        if (string.Equals(mode, MemoryPromptInjectionNone, StringComparison.Ordinal))
+            return [];
+
+        if (string.Equals(mode, MemoryPromptInjectionSummary, StringComparison.Ordinal))
+        {
+            return
+            [
+                "## Memory",
+                "Memory context is a snapshot loaded at session start and does not auto-refresh during this turn.",
+                BuildMemoryWriteGuidance(availableTools),
+                "Durable memory writes become available in future sessions after persistence.",
+                ""
+            ];
+        }
+
+        return
+        [
+            "## Memory",
+            "Memory context in this prompt is frozen at session start; do not assume memory files changed unless a new session starts.",
+            BuildMemoryWriteGuidance(availableTools),
+            "Use `MEMORY.md` as long-lived consolidated context and `memory/YYYY-MM-DD.md` as append-only daily notes.",
+            "Do not rewrite prior memory notes in-place during normal turns; append durable updates instead.",
+            "Durable memory writes appear in subsequent sessions after persistence and prompt rebuild.",
+            ""
+        ];
     }
 
     public static IReadOnlyList<string> buildUserIdentitySection(string? ownerLine, bool isMinimal)
@@ -622,6 +657,22 @@ public static class SystemPromptBuilder
     private static IReadOnlyList<string> NormalizePromptCapabilityIds(IEnumerable<string> capabilities)
         => PromptText.NormalizeCapabilityIds(capabilities);
 
+    private static string NormalizeMemoryPromptInjection(string? promptInjectionMode)
+    {
+        if (string.IsNullOrWhiteSpace(promptInjectionMode))
+            return MemoryPromptInjectionFull;
+
+        var normalized = promptInjectionMode.Trim().ToLowerInvariant();
+        return normalized is MemoryPromptInjectionSummary or MemoryPromptInjectionNone
+            ? normalized
+            : MemoryPromptInjectionFull;
+    }
+
+    private static string BuildMemoryWriteGuidance(IReadOnlySet<string> availableTools) =>
+        availableTools.Contains("memory_save")
+            ? "Use `memory_save` for durable memory writes."
+            : "Use the runtime's memory-write capability for durable memory writes when available.";
+
     private static bool IsDynamicContextFile(string pathValue) =>
         ContextFileOrdering.IsDynamic(pathValue);
 
@@ -631,4 +682,3 @@ public static class SystemPromptBuilder
     private static string GetContextFileBasename(string pathValue)
         => ContextFileOrdering.GetBasename(pathValue);
 }
-

--- a/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
@@ -11,8 +11,11 @@ namespace BotNexus.Gateway.Agents;
 public sealed class WorkspaceContextBuilder : IContextBuilder
 {
     private const string BootstrapFileName = "BOOTSTRAP.md";
+    private const string MemoryFileName = "MEMORY.md";
+    private const string MemoryPromptInjectionNone = "none";
+    private const string MemoryPromptInjectionFull = "full";
     private static readonly string[] DefaultPromptFiles =
-        ["AGENTS.md", "SOUL.md", "TOOLS.md", "BOOTSTRAP.md", "IDENTITY.md", "USER.md", "MEMORY.md"];
+        ["AGENTS.md", "SOUL.md", "TOOLS.md", "BOOTSTRAP.md", "IDENTITY.md", "USER.md", MemoryFileName];
     private readonly IAgentWorkspaceManager _workspaceManager;
     private readonly IFileSystem _fileSystem;
     private readonly IHookDispatcher? _hookDispatcher;
@@ -38,12 +41,16 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
         ArgumentNullException.ThrowIfNull(descriptor);
 
         var workspacePath = ResolveWorkspaceDirectory(_workspaceManager.GetWorkspacePath(descriptor.AgentId));
-        var promptFiles = ResolvePromptFiles(descriptor);
+        var memoryPromptInjection = ResolveMemoryPromptInjection(descriptor.Memory?.PromptInjection);
+        var promptFiles = ResolvePromptFiles(descriptor, includeMemoryFile: !IsMemoryPromptInjectionNone(memoryPromptInjection));
         var contextFiles = (await LoadContextFilesAsync(_fileSystem, workspacePath, promptFiles, cancellationToken)).ToList();
         if (descriptor.SystemPromptFiles.Count == 0 && string.IsNullOrWhiteSpace(descriptor.SystemPromptFile))
         {
-            var recentMemoryFiles = await LoadRecentDailyMemoryFilesAsync(_fileSystem, workspacePath, descriptor.Memory?.Path, cancellationToken);
-            contextFiles.AddRange(recentMemoryFiles);
+            if (!IsMemoryPromptInjectionNone(memoryPromptInjection))
+            {
+                var recentMemoryFiles = await LoadRecentDailyMemoryFilesAsync(_fileSystem, workspacePath, descriptor.Memory?.Path, cancellationToken);
+                contextFiles.AddRange(recentMemoryFiles);
+            }
         }
 
         var prompt = SystemPromptBuilder.Build(new SystemPromptParams
@@ -63,6 +70,7 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
             HeartbeatPrompt = descriptor.Heartbeat?.Enabled == true
                 ? descriptor.Heartbeat.Prompt ?? "Read HEARTBEAT.md if it exists and execute any pending tasks. If nothing needs attention, reply HEARTBEAT_OK."
                 : null,
+            MemoryPromptInjection = memoryPromptInjection,
             PromptMode = PromptMode.Full
         });
 
@@ -123,16 +131,39 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
         catch (UnauthorizedAccessException) { }
     }
 
-    private static IReadOnlyList<string> ResolvePromptFiles(AgentDescriptor descriptor)
+    private static IReadOnlyList<string> ResolvePromptFiles(AgentDescriptor descriptor, bool includeMemoryFile)
     {
         if (descriptor.SystemPromptFiles.Count > 0)
-            return descriptor.SystemPromptFiles;
+            return FilterMemoryFiles(descriptor.SystemPromptFiles, includeMemoryFile);
 
         if (!string.IsNullOrWhiteSpace(descriptor.SystemPromptFile))
-            return [descriptor.SystemPromptFile];
+            return includeMemoryFile || !IsMemoryPromptFile(descriptor.SystemPromptFile) ? [descriptor.SystemPromptFile] : [];
 
-        return DefaultPromptFiles;
+        return includeMemoryFile ? DefaultPromptFiles : FilterMemoryFiles(DefaultPromptFiles, includeMemoryFile);
     }
+
+    private static IReadOnlyList<string> FilterMemoryFiles(IReadOnlyList<string> promptFiles, bool includeMemoryFile)
+    {
+        if (includeMemoryFile)
+            return promptFiles;
+
+        return promptFiles.Where(static file => !IsMemoryPromptFile(file)).ToList();
+    }
+
+    private static bool IsMemoryPromptFile(string? promptFile) =>
+        !string.IsNullOrWhiteSpace(promptFile) &&
+        Path.GetFileName(promptFile).Equals(MemoryFileName, StringComparison.OrdinalIgnoreCase);
+
+    private static string ResolveMemoryPromptInjection(string? promptInjection)
+    {
+        if (string.IsNullOrWhiteSpace(promptInjection))
+            return MemoryPromptInjectionFull;
+
+        return promptInjection.Trim();
+    }
+
+    private static bool IsMemoryPromptInjectionNone(string promptInjection) =>
+        promptInjection.Equals(MemoryPromptInjectionNone, StringComparison.OrdinalIgnoreCase);
 
     private static async Task<IReadOnlyList<ContextFile>> LoadRecentDailyMemoryFilesAsync(
         IFileSystem fileSystem,

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -123,6 +123,7 @@ public static class AgentConfigMerger
             Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentMemObj),
             Path = PickNullableString("path", defaults.Path, agent.Path, agentMemObj),
             Indexing = PickString("indexing", defaults.Indexing, agent.Indexing, agentMemObj),
+            PromptInjection = PickString("promptInjection", defaults.PromptInjection, agent.PromptInjection, agentMemObj),
             Search = MergeMemorySearch(defaults.Search, agent.Search, agentMemObj),
         };
     }
@@ -314,6 +315,7 @@ public static class AgentConfigMerger
         Enabled = src.Enabled,
         Path = src.Path,
         Indexing = src.Indexing,
+        PromptInjection = src.PromptInjection,
         Search = src.Search is null ? null : CloneMemorySearch(src.Search),
     };
 

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -168,6 +168,7 @@ public sealed class PlatformConfigAgentSource(
             Enabled = memoryConfig.Enabled,
             Path = memoryConfig.Path,
             Indexing = memoryConfig.Indexing,
+            PromptInjection = memoryConfig.PromptInjection,
             Search = memoryConfig.Search is null
                 ? null
                 : new MemorySearchAgentConfig

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
@@ -482,6 +482,12 @@ public static class PlatformConfigLoader
                 errors.Add($"agents.{agentId}.provider is required (example: 'copilot').");
             if (string.IsNullOrWhiteSpace(agentConfig.Model))
                 errors.Add($"agents.{agentId}.model is required (example: 'gpt-4.1').");
+
+            if (!string.IsNullOrWhiteSpace(agentConfig.Memory?.PromptInjection) &&
+                !IsValidMemoryPromptInjection(agentConfig.Memory.PromptInjection))
+            {
+                errors.Add($"agents.{agentId}.memory.promptInjection must be one of: full, summary, none.");
+            }
         }
     }
 
@@ -508,6 +514,12 @@ public static class PlatformConfigLoader
             // indexing must be non-empty if explicitly set to something other than default
             if (defaults.Memory.Indexing is not null && string.IsNullOrWhiteSpace(defaults.Memory.Indexing))
                 errors.Add($"{prefix}.memory.indexing must be a non-empty string if specified.");
+
+            if (!string.IsNullOrWhiteSpace(defaults.Memory.PromptInjection) &&
+                !IsValidMemoryPromptInjection(defaults.Memory.PromptInjection))
+            {
+                errors.Add($"{prefix}.memory.promptInjection must be one of: full, summary, none.");
+            }
         }
 
         // heartbeat
@@ -537,6 +549,11 @@ public static class PlatformConfigLoader
                 errors.Add($"{fieldPath}[{i}] must be a non-empty string.");
         }
     }
+
+    private static bool IsValidMemoryPromptInjection(string value) =>
+        value.Equals("full", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("summary", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("none", StringComparison.OrdinalIgnoreCase);
 
     private static void ValidateApiKeys(Dictionary<string, ApiKeyConfig>? apiKeys, List<string> errors)
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SystemPromptBuilderSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SystemPromptBuilderSnapshotTests.cs
@@ -7,6 +7,74 @@ namespace BotNexus.Gateway.Tests.Agents;
 public sealed class SystemPromptBuilderSnapshotTests
 {
     [Fact]
+    public void BuildMemorySection_FullPromptInjection_EmitsBehavioralGuidance()
+    {
+        var lines = InvokeBuildMemorySection(isMinimal: false, "full");
+
+        lines.ShouldNotBeEmpty();
+        var text = string.Join('\n', lines).ToLowerInvariant();
+        text.ShouldContain("memory");
+    }
+
+    [Fact]
+    public void BuildMemorySection_SummaryPromptInjection_EmitsConciseGuidanceOnly()
+    {
+        var full = InvokeBuildMemorySection(isMinimal: false, "full");
+        var summary = InvokeBuildMemorySection(isMinimal: false, "summary");
+
+        summary.ShouldNotBeEmpty();
+        summary.Count.ShouldBeLessThan(full.Count);
+    }
+
+    [Fact]
+    public void BuildMemorySection_NonePromptInjection_ReturnsNoMemorySection()
+    {
+        var lines = InvokeBuildMemorySection(isMinimal: false, "none");
+        lines.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildMemorySection_MinimalPromptMode_ReturnsNoMemorySection()
+    {
+        var lines = InvokeBuildMemorySection(isMinimal: true, "full");
+        lines.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ContextFileOrdering_DailyMemoryNotes_RenderAfterCacheBoundary()
+    {
+        var prompt = SystemPromptBuilder.Build(new SystemPromptParams
+        {
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "repo", "workspace"),
+            ToolNames = ["read"],
+            PromptMode = PromptMode.Full,
+            ContextFiles =
+            [
+                new ContextFile("AGENTS.md", "Agent instructions"),
+                new ContextFile("MEMORY.md", "Long-term memory summary"),
+                new ContextFile("memory/2026-05-07.md", "Older daily note"),
+                new ContextFile("memory/2026-05-08.md", "Latest daily note")
+            ],
+            Runtime = new RuntimeInfo
+            {
+                AgentId = "agent-a",
+                Channel = "signalr"
+            }
+        });
+
+        var cacheBoundaryIndex = prompt.IndexOf("<!-- BOTNEXUS_CACHE_BOUNDARY -->", StringComparison.Ordinal);
+        var memorySummaryIndex = prompt.IndexOf("## MEMORY.md", StringComparison.Ordinal);
+        var olderDailyIndex = prompt.IndexOf("## memory/2026-05-07.md", StringComparison.Ordinal);
+        var newerDailyIndex = prompt.IndexOf("## memory/2026-05-08.md", StringComparison.Ordinal);
+
+        cacheBoundaryIndex.ShouldBeGreaterThanOrEqualTo(0);
+        memorySummaryIndex.ShouldBeGreaterThanOrEqualTo(0);
+        olderDailyIndex.ShouldBeGreaterThan(cacheBoundaryIndex);
+        newerDailyIndex.ShouldBeGreaterThan(cacheBoundaryIndex);
+        memorySummaryIndex.ShouldBeLessThan(cacheBoundaryIndex);
+    }
+
+    [Fact]
     public void Build_FullMode_MatchesSnapshot()
     {
         var prompt = SystemPromptBuilder.Build(new SystemPromptParams
@@ -153,5 +221,49 @@ public sealed class SystemPromptBuilderSnapshotTests
         }
 
         throw new InvalidOperationException("Could not locate BotNexus.slnx from test base directory.");
+    }
+
+    private static IReadOnlyList<string> InvokeBuildMemorySection(bool isMinimal, string promptInjection)
+    {
+        var availableTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "memory_save", "memory_search" };
+        var methods = typeof(SystemPromptBuilder)
+            .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Where(method => string.Equals(method.Name, "buildMemorySection", StringComparison.Ordinal))
+            .ToList();
+        methods.ShouldNotBeEmpty("SystemPromptBuilder.buildMemorySection should exist.");
+
+        var threeArgMethod = methods.SingleOrDefault(method =>
+        {
+            var parameters = method.GetParameters();
+            return parameters.Length == 3 &&
+                   parameters[0].ParameterType == typeof(bool) &&
+                   parameters[1].ParameterType == typeof(string) &&
+                   typeof(IReadOnlySet<string>).IsAssignableFrom(parameters[2].ParameterType);
+        });
+        if (threeArgMethod is not null)
+        {
+            var result = threeArgMethod.Invoke(null, [isMinimal, promptInjection, availableTools]);
+            result.ShouldNotBeNull();
+            return (IReadOnlyList<string>)result!;
+        }
+
+        var twoArgMethod = methods.SingleOrDefault(method =>
+        {
+            var parameters = method.GetParameters();
+            return parameters.Length == 2 &&
+                   parameters[0].ParameterType == typeof(bool) &&
+                   typeof(IReadOnlySet<string>).IsAssignableFrom(parameters[1].ParameterType);
+        });
+
+        if (twoArgMethod is not null)
+        {
+            if (!string.Equals(promptInjection, "full", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("SystemPromptBuilder.buildMemorySection must support memory.promptInjection (full/summary/none).");
+            var result = twoArgMethod.Invoke(null, [isMinimal, availableTools]);
+            result.ShouldNotBeNull();
+            return (IReadOnlyList<string>)result!;
+        }
+
+        throw new InvalidOperationException("No supported SystemPromptBuilder.buildMemorySection overload found.");
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs
@@ -10,6 +10,13 @@ namespace BotNexus.Gateway.Tests.Configuration;
 /// </summary>
 public sealed class AgentConfigMergerTests
 {
+    [Fact]
+    public void MemoryAgentConfig_DefaultPromptInjection_IsFull()
+    {
+        var memory = new MemoryAgentConfig();
+        GetPromptInjection(memory).ShouldBe("full");
+    }
+
     // -------------------------------------------------------------------------
     // Memory merge — full inherit (scenario 3)
     // -------------------------------------------------------------------------
@@ -90,6 +97,51 @@ public sealed class AgentConfigMergerTests
         result.Memory.ShouldNotBeNull();
         result.Memory!.Indexing.ShouldBe("manual");        // agent override wins
         result.Memory.Enabled.ShouldBeTrue();              // inherited from defaults
+    }
+
+    [Fact]
+    public void Merge_AgentOmitsMemoryPromptInjection_InheritsDefaults()
+    {
+        var defaultsMemory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" };
+        SetPromptInjection(defaultsMemory, "full");
+        var defaults = new AgentDefaultsConfig
+        {
+            Memory = defaultsMemory
+        };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            Memory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" }
+        };
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","memory":{"enabled":true}}""").RootElement;
+
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        result.Memory.ShouldNotBeNull();
+        GetPromptInjection(result.Memory!).ShouldBe("full");
+    }
+
+    [Fact]
+    public void Merge_AgentOverridesMemoryPromptInjection_UsesAgentValue()
+    {
+        var defaultsMemory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" };
+        SetPromptInjection(defaultsMemory, "full");
+        var agentMemory = new MemoryAgentConfig { Enabled = true, Indexing = "auto" };
+        SetPromptInjection(agentMemory, "summary");
+        var defaults = new AgentDefaultsConfig { Memory = defaultsMemory };
+        var agent = new AgentDefinitionConfig
+        {
+            Provider = "copilot",
+            Model = "gpt-4.1",
+            Memory = agentMemory
+        };
+        var raw = JsonDocument.Parse("""{"provider":"copilot","model":"gpt-4.1","memory":{"promptInjection":"summary"}}""").RootElement;
+
+        var result = AgentConfigMerger.Merge(defaults, agent, raw);
+
+        result.Memory.ShouldNotBeNull();
+        GetPromptInjection(result.Memory!).ShouldBe("summary");
     }
 
     // -------------------------------------------------------------------------
@@ -333,6 +385,7 @@ public sealed class AgentConfigMergerTests
     public void MergeMemory_DefaultsOnlyNoAgentKey_ReturnsCloneOfDefaults()
     {
         var defaults = new MemoryAgentConfig { Enabled = true, Indexing = "auto" };
+        SetPromptInjection(defaults, "full");
         var agentObj = JsonDocument.Parse("""{"provider":"copilot"}""").RootElement;
 
         var result = AgentConfigMerger.MergeMemory(defaults, null, agentObj);
@@ -340,6 +393,7 @@ public sealed class AgentConfigMergerTests
         result.ShouldNotBeNull();
         result!.Enabled.ShouldBeTrue();
         result.Indexing.ShouldBe("auto");
+        GetPromptInjection(result).ShouldBe("full");
         result.ShouldNotBeSameAs(defaults);  // must be a clone
     }
 
@@ -354,5 +408,19 @@ public sealed class AgentConfigMergerTests
         result.ShouldNotBeNull();
         result!.Enabled.ShouldBeTrue();
         result.IntervalMinutes.ShouldBe(15);
+    }
+
+    private static void SetPromptInjection(MemoryAgentConfig config, string value)
+    {
+        var property = typeof(MemoryAgentConfig).GetProperty("PromptInjection");
+        property.ShouldNotBeNull("MemoryAgentConfig.PromptInjection should exist for memory prompt-injection merge behavior.");
+        property!.SetValue(config, value);
+    }
+
+    private static string GetPromptInjection(MemoryAgentConfig config)
+    {
+        var property = typeof(MemoryAgentConfig).GetProperty("PromptInjection");
+        property.ShouldNotBeNull("MemoryAgentConfig.PromptInjection should exist for memory prompt-injection merge behavior.");
+        return property!.GetValue(config)?.ToString() ?? string.Empty;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -1664,6 +1665,67 @@ public sealed class PlatformConfigValidationTests
             });
     }
 
+    [Theory]
+    [InlineData("full")]
+    [InlineData("summary")]
+    [InlineData("none")]
+    public async Task Validate_MemoryPromptInjection_AllowsSupportedValues(string promptInjection)
+    {
+        await WithConfigFileAsync(
+            $$"""
+            {
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1",
+                  "memory": {
+                    "enabled": true,
+                    "promptInjection": "{{promptInjection}}"
+                  }
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                var memory = config.Agents!["assistant"].Memory.ShouldNotBeNull();
+                GetPromptInjection(memory).ShouldBe(promptInjection);
+            });
+    }
+
+    [Fact]
+    public async Task Validate_MemoryPromptInjection_InvalidValue_ThrowsValidationError()
+    {
+        await WithConfigFileAsync(
+            """
+            {
+              "providers": {
+                "copilot": { "apiKey": "provider-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1",
+                  "memory": {
+                    "enabled": true,
+                    "promptInjection": "verbose"
+                  }
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var ex = await Should.ThrowAsync<OptionsValidationException>(() => PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: true));
+                ex.Failures.ShouldContain("agents.assistant.memory.promptInjection must be one of: full, summary, none.");
+            });
+    }
+
     private static Task WithProviderConfigAsync(string providerKey, string providerJson, Action<PlatformConfig> assertConfig)
         => WithConfigFileAsync(
             $$"""
@@ -1708,5 +1770,12 @@ public sealed class PlatformConfigValidationTests
     {
         var exception = Record.Exception(() => JsonSerializer.Serialize(config));
         exception.ShouldBeNull();
+    }
+
+    private static string GetPromptInjection(MemoryAgentConfig config)
+    {
+        var property = typeof(MemoryAgentConfig).GetProperty("PromptInjection");
+        property.ShouldNotBeNull("MemoryAgentConfig.PromptInjection should exist for memory prompt-injection validation.");
+        return property!.GetValue(config)?.ToString() ?? string.Empty;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/EffectiveAgentConfigEndpointTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/EffectiveAgentConfigEndpointTests.cs
@@ -190,6 +190,67 @@ public sealed class EffectiveAgentConfigEndpointTests : IDisposable
         payload.Sources.ShouldContainKeyAndValue("memory.enabled", "agent");
     }
 
+    [Fact]
+    public async Task GetEffectiveAgentConfig_AgentInheritsMemoryPromptInjection_SourceIsInherited()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "memory": {
+                "enabled": true,
+                "promptInjection": "full"
+              }
+            },
+            "bot-inherits-prompt-injection": {
+              "displayName": "Inheritor",
+              "model": "gpt-4o",
+              "memory": { "enabled": true }
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-inherits-prompt-injection");
+
+        payload.Sources.ShouldContainKeyAndValue("memory.promptInjection", "inherited");
+    }
+
+    [Fact]
+    public async Task GetEffectiveAgentConfig_AgentOverridesMemoryPromptInjection_SourceIsAgent()
+    {
+        var path = WriteConfig("""
+        {
+          "agents": {
+            "defaults": {
+              "memory": {
+                "enabled": true,
+                "promptInjection": "full"
+              }
+            },
+            "bot-overrides-prompt-injection": {
+              "displayName": "Overrider",
+              "model": "gpt-4o",
+              "memory": {
+                "enabled": true,
+                "promptInjection": "summary"
+              }
+            }
+          }
+        }
+        """);
+
+        await using var factory = CreateFactory(path);
+        using var client = factory.CreateClient();
+
+        var payload = await GetEffective(client, "bot-overrides-prompt-injection");
+
+        payload.Sources.ShouldContainKeyAndValue("memory.promptInjection", "agent");
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     //  Scenario 5 — Unknown agentId → 404
     // ──────────────────────────────────────────────────────────────────────

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -786,6 +786,37 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadAsync_WithMemoryEnabledAndPromptInjectionOmitted_DefaultsPromptInjectionToFull()
+    {
+        var config = JsonSerializer.Deserialize<PlatformConfig>(
+            """
+            {
+              "Agents": {
+                "assistant": {
+                  "Provider": "copilot",
+                  "Model": "gpt-4.1",
+                  "Enabled": true,
+                  "Memory": {
+                    "Enabled": true,
+                    "Indexing": "auto"
+                  }
+                }
+              }
+            }
+            """)!;
+
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.Memory.ShouldNotBeNull();
+        GetPromptInjection(descriptor.Memory!).ShouldBe("full");
+    }
+
+    [Fact]
     public async Task LoadAsync_WithAgentMemoryPathOverride_MapsPathOnDescriptorMemoryConfig()
     {
         var config = JsonSerializer.Deserialize<PlatformConfig>(
@@ -877,6 +908,13 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
         var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
 
         ReadToolTimeoutSeconds(descriptor).ShouldBe(9);
+    }
+
+    private static string GetPromptInjection(MemoryAgentConfig config)
+    {
+        var property = typeof(MemoryAgentConfig).GetProperty("PromptInjection");
+        property.ShouldNotBeNull("MemoryAgentConfig.PromptInjection should exist for memory prompt-injection behavior.");
+        return property!.GetValue(config)?.ToString() ?? string.Empty;
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
@@ -51,6 +51,12 @@ Constraints: never read more than one skill up front; only read after selecting.
 ## Available Skills
 - skill-a
 - skill-b
+## Memory
+Memory context in this prompt is frozen at session start; do not assume memory files changed unless a new session starts.
+Use the runtime's memory-write capability for durable memory writes when available.
+Use `MEMORY.md` as long-lived consolidated context and `memory/YYYY-MM-DD.md` as append-only daily notes.
+Do not rewrite prior memory notes in-place during normal turns; append durable updates instead.
+Durable memory writes appear in subsequent sessions after persistence and prompt rebuild.
 ## BotNexus Self-Update
 Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.
 Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.
@@ -63,12 +69,12 @@ Prefer aliases when specifying model overrides; full provider/model is also acce
 - smart => gpt-5
 If you need the current date, time, or day of week, run session_status (📊 session_status).
 ## Workspace
-Your working directory is: C:\Users\jobullen\AppData\Local\Temp\repo\workspace
+Your working directory is: <workspace>
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 Note one
 Note two
 ## Documentation
-BotNexus docs: C:\Users\jobullen\AppData\Local\Temp\repo\docs
+BotNexus docs: <docs-path>
 Mirror: https://docs.botnexus.ai
 Source: https://github.com/botnexus/botnexus
 Community: https://discord.com/invite/clawd

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
@@ -41,7 +41,7 @@ Constraints: never read more than one skill up front; only read after selecting.
 - skill-a
 If you need the current date, time, or day of week, run session_status (📊 session_status).
 ## Workspace
-Your working directory is: C:\Users\jobullen\AppData\Local\Temp\repo\workspace
+Your working directory is: <workspace>
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 Minimal note
 ## Current Date & Time

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
@@ -37,8 +37,14 @@ To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway stop
 - botnexus gateway restart
 If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output.
+## Memory
+Memory context in this prompt is frozen at session start; do not assume memory files changed unless a new session starts.
+Use the runtime's memory-write capability for durable memory writes when available.
+Use `MEMORY.md` as long-lived consolidated context and `memory/YYYY-MM-DD.md` as append-only daily notes.
+Do not rewrite prior memory notes in-place during normal turns; append durable updates instead.
+Durable memory writes appear in subsequent sessions after persistence and prompt rebuild.
 ## Workspace
-Your working directory is: C:\Users\jobullen\AppData\Local\Temp\repo\workspace
+Your working directory is: <workspace>
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.

--- a/tests/gateway/BotNexus.Gateway.Tests/WorkspaceContextBuilderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/WorkspaceContextBuilderTests.cs
@@ -147,6 +147,87 @@ public sealed class WorkspaceContextBuilderTests
     }
 
     [Fact]
+    public async Task BuildSystemPromptAsync_DefaultPrompt_WithMemoryPromptInjectionNone_SkipsMemorySummaryAndRecentDailyFiles()
+    {
+        var todayFileName = $"{DateTime.Now:yyyy-MM-dd}.md";
+        var yesterdayFileName = $"{DateTime.Now.AddDays(-1):yyyy-MM-dd}.md";
+        var workspacePath = CreateWorkspace(
+            ("AGENTS.md", "AGENTS"),
+            ("SOUL.md", "SOUL"),
+            ("TOOLS.md", "TOOLS"),
+            ("BOOTSTRAP.md", "BOOTSTRAP"),
+            ("IDENTITY.md", "IDENTITY"),
+            ("USER.md", "USER"),
+            ("MEMORY.md", "LONG-TERM MEMORY"),
+            (Path.Combine("memory", todayFileName), "TODAY MEMORY ENTRY"),
+            (Path.Combine("memory", yesterdayFileName), "YESTERDAY MEMORY ENTRY"));
+        try
+        {
+            var manager = new StubWorkspaceManager(workspacePath);
+            var builder = new WorkspaceContextBuilder(manager, _fileSystem);
+            var memoryConfig = new MemoryAgentConfig { Enabled = true };
+            SetPromptInjection(memoryConfig, "none");
+
+            var result = await builder.BuildSystemPromptAsync(new AgentDescriptor
+            {
+                AgentId = BotNexus.Domain.Primitives.AgentId.From("farnsworth"),
+                DisplayName = "Farnsworth",
+                ModelId = "test-model",
+                ApiProvider = "test-provider",
+                Memory = memoryConfig
+            });
+
+            result.ShouldContain("AGENTS");
+            result.ShouldNotContain("LONG-TERM MEMORY");
+            result.ShouldNotContain("TODAY MEMORY ENTRY");
+            result.ShouldNotContain("YESTERDAY MEMORY ENTRY");
+        }
+        finally
+        {
+            _fileSystem.Directory.Delete(Path.GetDirectoryName(workspacePath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task BuildSystemPromptAsync_DefaultPrompt_WithMemoryEnabledAndPromptInjectionOmitted_PreservesFullMemoryBehavior()
+    {
+        var todayFileName = $"{DateTime.Now:yyyy-MM-dd}.md";
+        var yesterdayFileName = $"{DateTime.Now.AddDays(-1):yyyy-MM-dd}.md";
+        var workspacePath = CreateWorkspace(
+            ("AGENTS.md", "AGENTS"),
+            ("SOUL.md", "SOUL"),
+            ("TOOLS.md", "TOOLS"),
+            ("BOOTSTRAP.md", "BOOTSTRAP"),
+            ("IDENTITY.md", "IDENTITY"),
+            ("USER.md", "USER"),
+            ("MEMORY.md", "LONG-TERM MEMORY"),
+            (Path.Combine("memory", todayFileName), "TODAY MEMORY ENTRY"),
+            (Path.Combine("memory", yesterdayFileName), "YESTERDAY MEMORY ENTRY"));
+        try
+        {
+            var manager = new StubWorkspaceManager(workspacePath);
+            var builder = new WorkspaceContextBuilder(manager, _fileSystem);
+
+            var result = await builder.BuildSystemPromptAsync(new AgentDescriptor
+            {
+                AgentId = BotNexus.Domain.Primitives.AgentId.From("farnsworth"),
+                DisplayName = "Farnsworth",
+                ModelId = "test-model",
+                ApiProvider = "test-provider",
+                Memory = new MemoryAgentConfig { Enabled = true }
+            });
+
+            result.ShouldContain("LONG-TERM MEMORY");
+            result.ShouldContain("TODAY MEMORY ENTRY");
+            result.ShouldContain("YESTERDAY MEMORY ENTRY");
+        }
+        finally
+        {
+            _fileSystem.Directory.Delete(Path.GetDirectoryName(workspacePath)!, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task BuildSystemPromptAsync_DefaultPrompt_LoadsRecentDailyMemoryFilesFromOverridePathInDeterministicOrder()
     {
         var todayFileName = $"{DateTime.Now:yyyy-MM-dd}.md";
@@ -280,5 +361,12 @@ public sealed class WorkspaceContextBuilderTests
         }
 
         return workspacePath;
+    }
+
+    private static void SetPromptInjection(MemoryAgentConfig config, string mode)
+    {
+        var property = typeof(MemoryAgentConfig).GetProperty("PromptInjection");
+        property.ShouldNotBeNull("MemoryAgentConfig.PromptInjection should exist for memory prompt-injection behavior.");
+        property!.SetValue(config, mode);
     }
 }


### PR DESCRIPTION
## Summary
- Add `memory.promptInjection` config with `full`, `summary`, and `none` modes.
- Generate memory behavior guidance from `SystemPromptBuilder` instead of relying on duplicated AGENTS.md instructions.
- Gate workspace memory context loading for `none` mode and classify daily memory notes as dynamic context below the cache boundary.
- Update schema, validation, effective-config provenance, snapshots, and regression coverage.

## Validation
- Targeted gateway prompt/config tests: 124 passed
- `dotnet build BotNexus.slnx --nologo --tl:off`
- `dotnet test BotNexus.slnx --nologo --tl:off`
