### PR TITLE
fix: route steering to active session and conversation

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -82,7 +82,7 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
-            var result = await _hub.SteerAsync(agentId, agent.ActiveConversationSessionId!, content);
+            var result = await _hub.SteerAsync(agentId, agent.ActiveConversationSessionId!, content, agent.ActiveConversationId);
             _store.RegisterSession(agentId, result.SessionId, result.ChannelType);
             await RefreshConversationsForAgentAsync(agentId);
         }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayHubConnection.cs
@@ -128,8 +128,8 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     }
 
     /// <summary>Steer an in-progress agent response.</summary>
-    public async Task<SendMessageResult> SteerAsync(string agentId, string sessionId, string content)
-        => await _connection!.InvokeAsync<SendMessageResult>("Steer", agentId, sessionId, content);
+    public async Task<SendMessageResult> SteerAsync(string agentId, string sessionId, string content, string? conversationId)
+        => await _connection!.InvokeAsync<SendMessageResult>("Steer", agentId, sessionId, content, conversationId);
 
     /// <summary>Send a follow-up message into an existing session.</summary>
     public async Task FollowUpAsync(string agentId, string sessionId, string content)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -336,7 +336,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <param name="sessionId">The session id.</param>
     /// <param name="content">The content.</param>
     /// <returns>The steer result.</returns>
-    public async Task<SendMessageResult> Steer(AgentId agentId, SessionId sessionId, string content)
+    public async Task<SendMessageResult> Steer(AgentId agentId, SessionId sessionId, string content, string? conversationId)
     {
         var typedAgentId = NormalizeAgentId(agentId);
         var typedSessionId = NormalizeSessionId(sessionId);
@@ -348,6 +348,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         await SubscribeInternalAsync(typedSessionId);
 
         var connectionId = Context.ConnectionId;
+        var normalizedConversationId = string.IsNullOrWhiteSpace(conversationId) ? null : conversationId.Trim();
+
         _ = SafeDispatchAsync(
             () => _dispatcher.DispatchAsync(
                 new InboundMessage
@@ -358,6 +360,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                     SessionId = typedSessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
+                    ConversationId = normalizedConversationId,
                     Metadata = new Dictionary<string, object?>
                     {
                         ["messageType"] = "steer",

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -339,13 +339,13 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     public async Task<SendMessageResult> Steer(AgentId agentId, SessionId sessionId, string content)
     {
         var typedAgentId = NormalizeAgentId(agentId);
+        var typedSessionId = NormalizeSessionId(sessionId);
         var typedChannelType = ChannelKey.From("signalr");
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
 
-        // Resolve the actual session that will handle this steer — may differ from the
-        // requested sessionId if the old session was sealed and the router created a new one.
-        var session = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType);
-        await SubscribeInternalAsync(session.SessionId);
+        // Steering must target the caller-provided session so the control message
+        // reaches the active conversation the user is currently steering.
+        await SubscribeInternalAsync(typedSessionId);
 
         var connectionId = Context.ConnectionId;
         _ = SafeDispatchAsync(
@@ -355,7 +355,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                     ChannelType = typedChannelType,
                     SenderId = connectionId,
                     ChannelAddress = ChannelAddress.From(typedAgentId.Value),
-                    SessionId = session.SessionId.Value,
+                    SessionId = typedSessionId.Value,
                     TargetAgentId = typedAgentId.Value,
                     Content = content,
                     Metadata = new Dictionary<string, object?>
@@ -366,9 +366,9 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 },
                 CancellationToken.None),
             typedAgentId,
-            session.SessionId);
+            typedSessionId);
 
-        return new SendMessageResult(session.SessionId.Value, typedAgentId.Value, typedChannelType.Value);
+        return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
+++ b/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
@@ -62,28 +62,65 @@ public sealed class AgentPromptAction : ICronAction
 
     private static bool IsInQuietHours(QuietHoursConfig config, string timezoneId)
     {
+        var tz = ResolveTimeZone(timezoneId);
+        var localNow = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz);
+        var currentTime = localNow.TimeOfDay;
+
+        if (!TimeSpan.TryParse(config.Start, out var start) ||
+            !TimeSpan.TryParse(config.End, out var end))
+            return false;
+
+        if (start <= end)
+            return currentTime >= start && currentTime < end;
+
+        return currentTime >= start || currentTime < end;
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(string timezoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timezoneId) ||
+            timezoneId.Equals("UTC", StringComparison.OrdinalIgnoreCase))
+            return TimeZoneInfo.Utc;
+
         try
         {
-            var tz = TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
-            var localNow = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz);
-            var currentTime = localNow.TimeOfDay;
-
-            if (!TimeSpan.TryParse(config.Start, out var start) ||
-                !TimeSpan.TryParse(config.End, out var end))
-                return false;
-
-            if (start <= end)
-                return currentTime >= start && currentTime < end;
-
-            return currentTime >= start || currentTime < end;
+            return TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
         }
         catch (TimeZoneNotFoundException)
         {
-            return false;
         }
         catch (InvalidTimeZoneException)
         {
-            return false;
         }
+
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timezoneId, out var ianaTimeZone))
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(ianaTimeZone);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(timezoneId, out var windowsTimeZone))
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(windowsTimeZone);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        return TimeZoneInfo.Utc;
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -159,4 +159,64 @@ public sealed class AgentInteractionServiceTests
         var messages = agent.Conversations["conv-1"].Messages;
         Assert.Equal(5, messages.Count);
     }
+
+    // ── Steering tests ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SteerAsync_skips_when_agent_has_no_session()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        // No SessionId, no ActiveConversationSessionId
+        Assert.Null(agent.ActiveConversationSessionId);
+
+        await _service.SteerAsync("agent-1", "redirect me");
+
+        // No local message should be appended because SteerAsync bails early
+        Assert.Null(agent.ActiveConversationId);
+    }
+
+    [Fact]
+    public async Task SteerAsync_appends_steering_prefix_to_local_messages()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.SessionId = "sess-1";
+        agent.ActiveConversationId = "conv-1";
+        agent.Conversations["conv-1"] = new ConversationState
+        {
+            ConversationId = "conv-1",
+            Title = "Test conv",
+            ActiveSessionId = "sess-1"
+        };
+
+        // SteerAsync will fail on the hub call (no connection) and append an error,
+        // but the user steering message should be appended first.
+        await _service.SteerAsync("agent-1", "redirect me");
+
+        var conv = agent.Conversations["conv-1"];
+        Assert.True(conv.Messages.Count >= 1);
+        Assert.Equal("User", conv.Messages[0].Role);
+        Assert.Equal("🔀 redirect me", conv.Messages[0].Content);
+    }
+
+    [Fact]
+    public async Task SteerAsync_appends_error_on_hub_failure()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.SessionId = "sess-1";
+        agent.ActiveConversationId = "conv-1";
+        agent.Conversations["conv-1"] = new ConversationState
+        {
+            ConversationId = "conv-1",
+            Title = "Test conv",
+            ActiveSessionId = "sess-1"
+        };
+
+        await _service.SteerAsync("agent-1", "redirect me");
+
+        var conv = agent.Conversations["conv-1"];
+        // First message is the user steering, second is the error
+        Assert.Equal(2, conv.Messages.Count);
+        Assert.Equal("Error", conv.Messages[1].Role);
+        Assert.Contains("Steer failed", conv.Messages[1].Content);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -564,9 +564,11 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         const string sessionId = "steer-session";
-        await connection.InvokeAsync("Steer", TestAgentId, sessionId, "course correction", cts.Token);
+        var result = await connection.InvokeAsync<JsonElement>("Steer", TestAgentId, sessionId, "course correction", cts.Token);
 
         dispatcher.Messages.ShouldHaveSingleItem();
+        result.GetProperty("sessionId").GetString().ShouldBe(sessionId);
+        dispatcher.Messages[0].SessionId.ShouldBe(sessionId);
         dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
         dispatcher.Messages[0].Metadata["control"].ShouldBe("steer");
     }
@@ -941,4 +943,3 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }
-

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -564,11 +564,38 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         const string sessionId = "steer-session";
-        var result = await connection.InvokeAsync<JsonElement>("Steer", TestAgentId, sessionId, "course correction", cts.Token);
+        string? conversationId = null;
+        var result = await connection.InvokeAsync<JsonElement>("Steer", TestAgentId, sessionId, "course correction", conversationId, cts.Token);
 
         dispatcher.Messages.ShouldHaveSingleItem();
         result.GetProperty("sessionId").GetString().ShouldBe(sessionId);
         dispatcher.Messages[0].SessionId.ShouldBe(sessionId);
+        dispatcher.Messages[0].ConversationId.ShouldBeNull();
+        dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
+        dispatcher.Messages[0].Metadata["control"].ShouldBe("steer");
+    }
+
+    [Fact]
+    public async Task Hub_Steer_SetsConversationIdWhenProvided()
+    {
+        var dispatcher = new RecordingDispatcher();
+        await using var factory = CreateTestFactory(services =>
+        {
+            services.RemoveAll<IChannelDispatcher>();
+            services.AddSingleton<IChannelDispatcher>(dispatcher);
+        });
+        using var cts = CreateTimeout();
+        await RegisterAgentAsync(factory, cts.Token);
+
+        await using var connection = await CreateStartedConnection(factory, cts.Token);
+        const string sessionId = "steer-session";
+        const string conversationId = "conv-42";
+        var result = await connection.InvokeAsync<JsonElement>("Steer", TestAgentId, sessionId, "course correction", conversationId, cts.Token);
+
+        dispatcher.Messages.ShouldHaveSingleItem();
+        result.GetProperty("sessionId").GetString().ShouldBe(sessionId);
+        dispatcher.Messages[0].SessionId.ShouldBe(sessionId);
+        dispatcher.Messages[0].ConversationId.ShouldBe("conv-42");
         dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
         dispatcher.Messages[0].Metadata["control"].ShouldBe("steer");
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -366,13 +366,32 @@ public sealed class SignalRHubTests
 
         var hub = CreateHub(dispatcher: dispatcher.Object, connectionId: "conn-1");
 
-        var result = await hub.Steer("agent-a", requestedSessionId, "nudge");
+        var result = await hub.Steer("agent-a", requestedSessionId, "nudge", null);
 
         result.SessionId.ShouldBe(requestedSessionId);
         dispatched.ShouldNotBeNull();
         dispatched!.SessionId.ShouldBe(requestedSessionId);
+        dispatched.ConversationId.ShouldBeNull();
         dispatched.Metadata["messageType"].ShouldBe("steer");
         dispatched.Metadata["control"].ShouldBe("steer");
+    }
+
+    [Fact]
+    public async Task GatewayHub_Steer_SetsConversationIdOnDispatchedMessage()
+    {
+        InboundMessage? dispatched = null;
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(value => value.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched = m)
+            .Returns(Task.CompletedTask);
+
+        var hub = CreateHub(dispatcher: dispatcher.Object, connectionId: "conn-1");
+
+        var result = await hub.Steer("agent-a", "sess-1", "nudge", "conv-42");
+
+        dispatched.ShouldNotBeNull();
+        dispatched!.ConversationId.ShouldBe("conv-42");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -354,6 +354,28 @@ public sealed class SignalRHubTests
     }
 
     [Fact]
+    public async Task GatewayHub_Steer_UsesRequestedSessionId()
+    {
+        const string requestedSessionId = "session-steer-target";
+        InboundMessage? dispatched = null;
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(value => value.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched = m)
+            .Returns(Task.CompletedTask);
+
+        var hub = CreateHub(dispatcher: dispatcher.Object, connectionId: "conn-1");
+
+        var result = await hub.Steer("agent-a", requestedSessionId, "nudge");
+
+        result.SessionId.ShouldBe(requestedSessionId);
+        dispatched.ShouldNotBeNull();
+        dispatched!.SessionId.ShouldBe(requestedSessionId);
+        dispatched.Metadata["messageType"].ShouldBe("steer");
+        dispatched.Metadata["control"].ShouldBe("steer");
+    }
+
+    [Fact]
     public async Task ResetSession_ArchivesInsteadOfDeleting()
     {
         var caller = new Mock<IGatewayHubClient>();


### PR DESCRIPTION
## Summary
- Route steering to the caller-requested session instead of re-resolving through default conversation routing.
- Propagate `conversationId` through the Blazor SignalR client and Gateway hub steering path so fall-through processing stays in the active conversation.
- Add regression coverage for session ID and conversation ID propagation in steering.

## Live Debug Evidence
- The user-provided steering text was persisted in `sessions.db` but logged as falling through because the agent was not running.
- The hub ignored caller session/conversation context, allowing steering fall-through to route through default bindings and appear accepted without affecting the active Quill conversation.

## Validation
- `dotnet test BotNexus.slnx --nologo --tl:off`