### PR TITLE
fix(cron): surface scheduled runs and model overrides

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -298,7 +298,7 @@ private bool IsStreaming =>
         Agent?.ActiveConversationId is string activeConvId
             ? Store.GetStreamState(activeConvId).IsStreaming
             : false; // no active conversation = not streaming
-    private bool IsReadOnly => Agent?.IsReadOnly ?? false;
+    private bool IsReadOnly => (Agent?.IsReadOnly ?? false) || (ActiveConversation?.IsVirtualSession ?? false);
     private bool IsConnected => Agent?.IsConnected ?? false;
     private bool ShowThinking => Agent?.ShowThinking ?? true;
     private bool ShowTools => Agent?.ShowTools ?? true;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/CronConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/CronConfigPanel.razor
@@ -1,24 +1,25 @@
 @using System.Text.Json.Nodes
 
-@{ var cron = GetObject(Config, "cron"); }
+@{ var cron = GetObjectCaseInsensitive(Config, "cron"); }
 
-<BoolField Label="Enabled" Value="@GetBool(cron, "enabled")" ValueChanged="@(v => SetNestedBool("cron", "enabled", v))" />
-<NumberField Label="Tick Interval (seconds)" Value="@GetNullableInt(cron, "tickIntervalSeconds")" ValueChanged="@(v => SetNestedNum("cron", "tickIntervalSeconds", v))" />
+<BoolField Label="Enabled" Value="@GetBoolCaseInsensitive(cron, "enabled")" ValueChanged="@(v => SetNestedBoolCaseInsensitive("cron", "enabled", v))" />
+<NumberField Label="Tick Interval (seconds)" Value="@GetNullableInt(cron, "tickIntervalSeconds")" ValueChanged="@(v => SetNestedNumCaseInsensitive("cron", "tickIntervalSeconds", v))" />
 
-<DictionarySection Title="Jobs" SectionPath="cron.jobs" Entries="@GetDict(cron, "jobs")"
-                   OnAddEntry="@((string key) => AddNestedDictEntry("cron", "jobs", key))"
-                   OnDeleteEntry="@((string key) => DeleteNestedDictEntry("cron", "jobs", key))">
+<DictionarySection Title="Jobs" SectionPath="cron.jobs" Entries="@GetDictCaseInsensitive(cron, "jobs")"
+                   OnAddEntry="@((string key) => AddNestedDictEntryCaseInsensitive("cron", "jobs", key))"
+                   OnDeleteEntry="@((string key) => DeleteNestedDictEntryCaseInsensitive("cron", "jobs", key))">
     <EntryTemplate Context="entry">
-        <TextField Label="Job Name" Value="@GetStr(entry.Value, "name")" ValueChanged="@(v => SetCronJobField(entry.Key, "name", v))" />
-        <TextField Label="Schedule (cron)" Value="@GetStr(entry.Value, "schedule")" ValueChanged="@(v => SetCronJobField(entry.Key, "schedule", v))" />
-        <SelectField Label="Action Type" Value="@GetStr(entry.Value, "actionType")" ValueChanged="@(v => SetCronJobField(entry.Key, "actionType", v))"
-                     Options="@(new[] { "agent-chat", "webhook", "shell" })" />
-        <TextField Label="Agent ID" Value="@GetStr(entry.Value, "agentId")" ValueChanged="@(v => SetCronJobField(entry.Key, "agentId", v))" />
-        <TextField Label="Message" Value="@GetStr(entry.Value, "message")" ValueChanged="@(v => SetCronJobField(entry.Key, "message", v))" />
-        <TextField Label="Webhook URL" Value="@GetStr(entry.Value, "webhookUrl")" ValueChanged="@(v => SetCronJobField(entry.Key, "webhookUrl", v))" />
-        <TextField Label="Shell Command" Value="@GetStr(entry.Value, "shellCommand")" ValueChanged="@(v => SetCronJobField(entry.Key, "shellCommand", v))" />
-        <BoolField Label="Enabled" Value="@GetBool(entry.Value, "enabled")" ValueChanged="@(v => SetCronJobBool(entry.Key, "enabled", v))" />
-        <TextField Label="Created By" Value="@GetStr(entry.Value, "createdBy")" ValueChanged="@(v => SetCronJobField(entry.Key, "createdBy", v))" />
+        <TextField Label="Job Name" Value="@GetStrCaseInsensitive(entry.Value, "name")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "name", v))" />
+        <TextField Label="Schedule (cron)" Value="@GetStrCaseInsensitive(entry.Value, "schedule")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "schedule", v))" />
+        <SelectField Label="Action Type" Value="@GetStrCaseInsensitive(entry.Value, "actionType")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "actionType", v))"
+                     Options="@(new[] { "agent-prompt", "agent-chat", "webhook", "shell" })" />
+        <TextField Label="Agent ID" Value="@GetStrCaseInsensitive(entry.Value, "agentId")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "agentId", v))" />
+        <TextField Label="Target Model" Value="@GetCronModel(entry.Value)" ValueChanged="@(v => SetCronModel(entry.Key, v))" />
+        <TextField Label="Message" Value="@GetStrCaseInsensitive(entry.Value, "message")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "message", v))" />
+        <TextField Label="Webhook URL" Value="@GetStrCaseInsensitive(entry.Value, "webhookUrl")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "webhookUrl", v))" />
+        <TextField Label="Shell Command" Value="@GetStrCaseInsensitive(entry.Value, "shellCommand")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "shellCommand", v))" />
+        <BoolField Label="Enabled" Value="@GetBoolCaseInsensitive(entry.Value, "enabled")" ValueChanged="@(v => SetCronJobBoolCaseInsensitive(entry.Key, "enabled", v))" />
+        <TextField Label="Created By" Value="@GetStrCaseInsensitive(entry.Value, "createdBy")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "createdBy", v))" />
     </EntryTemplate>
 </DictionarySection>
 
@@ -28,18 +29,33 @@
 
     private void MarkDirty() => OnChanged.InvokeAsync();
 
-    private static JsonObject? GetObject(JsonObject? parent, string key) => parent?[key] as JsonObject;
-
-    private static string GetStr(JsonObject? obj, string key)
+    private static JsonObject? GetObjectCaseInsensitive(JsonObject? parent, string key)
     {
-        var node = obj?[key];
+        if (parent is null) return null;
+        if (parent[key] is JsonObject exact) return exact;
+        var matched = parent.FirstOrDefault(kv => string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase));
+        return matched.Value as JsonObject;
+    }
+
+    private static string? ResolveKey(JsonObject? obj, string key)
+    {
+        if (obj is null) return null;
+        if (obj.ContainsKey(key)) return key;
+        return obj.FirstOrDefault(kv => string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase)).Key;
+    }
+
+    private static string GetStrCaseInsensitive(JsonObject? obj, string key)
+    {
+        var resolvedKey = ResolveKey(obj, key);
+        var node = resolvedKey is null ? null : obj?[resolvedKey];
         if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
         return "";
     }
 
-    private static bool GetBool(JsonObject? obj, string key)
+    private static bool GetBoolCaseInsensitive(JsonObject? obj, string key)
     {
-        if (obj?[key] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        var resolvedKey = ResolveKey(obj, key);
+        if (resolvedKey is not null && obj?[resolvedKey] is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
         return false;
     }
 
@@ -49,15 +65,16 @@
         return null;
     }
 
-    private static Dictionary<string, JsonObject?> GetDict(JsonObject? obj, string key)
+    private static Dictionary<string, JsonObject?> GetDictCaseInsensitive(JsonObject? obj, string key)
     {
-        if (obj?[key] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
+        var resolvedKey = ResolveKey(obj, key);
+        if (resolvedKey is not null && obj?[resolvedKey] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
         return new();
     }
 
     private void SetNestedBool(string section, string key, bool value)
     {
-        EnsureObject(section);
+        EnsureObjectCaseInsensitive(section);
         var obj = Config![section] as JsonObject;
         if (obj is null) return;
         obj[key] = value;
@@ -66,58 +83,121 @@
 
     private void SetNestedNum(string section, string key, int? value)
     {
-        EnsureObject(section);
+        EnsureObjectCaseInsensitive(section);
         var obj = Config![section] as JsonObject;
         if (obj is null) return;
         obj[key] = value.HasValue ? JsonValue.Create(value.Value) : null;
         MarkDirty();
     }
 
-    private void SetCronJobField(string jobKey, string field, string? value)
+    private void SetNestedBoolCaseInsensitive(string section, string key, bool value)
     {
-        var cron = Config?["cron"] as JsonObject;
-        var jobs = cron?["jobs"] as JsonObject;
-        var job = jobs?[jobKey] as JsonObject;
-        if (job is null) return;
-        job[field] = string.IsNullOrEmpty(value) ? null : value;
+        EnsureObjectCaseInsensitive(section);
+        var sectionKey = ResolveKey(Config, section) ?? section;
+        var obj = Config?[sectionKey] as JsonObject;
+        if (obj is null) return;
+        var resolvedKey = ResolveKey(obj, key) ?? key;
+        obj[resolvedKey] = value;
         MarkDirty();
     }
 
-    private void SetCronJobBool(string jobKey, string field, bool value)
+    private void SetNestedNumCaseInsensitive(string section, string key, int? value)
     {
-        var cron = Config?["cron"] as JsonObject;
-        var jobs = cron?["jobs"] as JsonObject;
-        var job = jobs?[jobKey] as JsonObject;
-        if (job is null) return;
-        job[field] = value;
+        EnsureObjectCaseInsensitive(section);
+        var sectionKey = ResolveKey(Config, section) ?? section;
+        var obj = Config?[sectionKey] as JsonObject;
+        if (obj is null) return;
+        var resolvedKey = ResolveKey(obj, key) ?? key;
+        obj[resolvedKey] = value.HasValue ? JsonValue.Create(value.Value) : null;
         MarkDirty();
     }
 
-    private void AddNestedDictEntry(string section, string dict, string key)
+    private void SetCronJobFieldCaseInsensitive(string jobKey, string field, string? value)
+    {
+        var cron = GetObjectCaseInsensitive(Config, "cron");
+        var jobs = GetObjectCaseInsensitive(cron, "jobs");
+        var job = jobs?[jobKey] as JsonObject;
+        if (job is null) return;
+        var key = ResolveKey(job, field) ?? field;
+        job[key] = string.IsNullOrEmpty(value) ? null : value;
+        MarkDirty();
+    }
+
+    private void SetCronJobBoolCaseInsensitive(string jobKey, string field, bool value)
+    {
+        var cron = GetObjectCaseInsensitive(Config, "cron");
+        var jobs = GetObjectCaseInsensitive(cron, "jobs");
+        var job = jobs?[jobKey] as JsonObject;
+        if (job is null) return;
+        var key = ResolveKey(job, field) ?? field;
+        job[key] = value;
+        MarkDirty();
+    }
+
+    private void AddNestedDictEntryCaseInsensitive(string section, string dict, string key)
     {
         if (Config is null || string.IsNullOrWhiteSpace(key)) return;
-        EnsureObject(section);
-        var parent = Config[section] as JsonObject;
+        EnsureObjectCaseInsensitive(section);
+        var sectionKey = ResolveKey(Config, section) ?? section;
+        var parent = Config[sectionKey] as JsonObject;
         if (parent is null) return;
-        if (parent[dict] is not JsonObject dictObj) { dictObj = new JsonObject(); parent[dict] = dictObj; }
+        var dictKey = ResolveKey(parent, dict) ?? dict;
+        if (parent[dictKey] is not JsonObject dictObj) { dictObj = new JsonObject(); parent[dictKey] = dictObj; }
         dictObj[key] = new JsonObject();
         MarkDirty();
         StateHasChanged();
     }
 
-    private void DeleteNestedDictEntry(string section, string dict, string key)
+    private void DeleteNestedDictEntryCaseInsensitive(string section, string dict, string key)
     {
-        var parent = Config?[section] as JsonObject;
-        var dictObj = parent?[dict] as JsonObject;
+        var parent = GetObjectCaseInsensitive(Config, section);
+        var dictObj = GetObjectCaseInsensitive(parent, dict);
         if (dictObj is null) return;
         dictObj.Remove(key);
         MarkDirty();
         StateHasChanged();
     }
 
-    private void EnsureObject(string key)
+    private void EnsureObjectCaseInsensitive(string key)
     {
         if (Config is null) return;
-        if (Config[key] is not JsonObject) Config[key] = new JsonObject();
+        var resolvedKey = ResolveKey(Config, key) ?? key;
+        if (Config[resolvedKey] is not JsonObject) Config[resolvedKey] = new JsonObject();
+    }
+
+    private static string GetCronModel(JsonObject? job)
+    {
+        var model = GetStrCaseInsensitive(job, "model");
+        if (!string.IsNullOrWhiteSpace(model))
+            return model;
+
+        var metadata = ResolveKey(job, "metadata") is { } metadataKey
+            ? job?[metadataKey] as JsonObject
+            : null;
+
+        return GetStrCaseInsensitive(metadata, "model");
+    }
+
+    private void SetCronModel(string jobKey, string? value)
+    {
+        var cron = GetObjectCaseInsensitive(Config, "cron");
+        var jobs = GetObjectCaseInsensitive(cron, "jobs");
+        var job = jobs?[jobKey] as JsonObject;
+        if (job is null) return;
+
+        var modelKey = ResolveKey(job, "model") ?? "model";
+        job[modelKey] = string.IsNullOrWhiteSpace(value) ? null : value;
+
+        if (ResolveKey(job, "metadata") is { } metadataKeyName
+            && job[metadataKeyName] is JsonObject metadata)
+        {
+            if (ResolveKey(metadata, "model") is { } metadataModelKey)
+                metadata.Remove(metadataModelKey);
+
+            if (metadata.Count == 0)
+                job[metadataKeyName] = null;
+        }
+
+        MarkDirty();
     }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -116,6 +116,10 @@
                                                 {
                                                     <span class="conversation-default-badge">Default</span>
                                                 }
+                                                @if (conversation.IsVirtualSession)
+                                                {
+                                                    <span class="conversation-default-badge">Cron</span>
+                                                }
                                             </span>
 
                                             <span class="conversation-list-item-meta">
@@ -130,7 +134,7 @@
                                                 </span>
                                             </span>
                                         </button>
-                                        @if (!conversation.IsDefault)
+                                        @if (!conversation.IsDefault && !conversation.IsVirtualSession)
                                         {
                                             <button class="conversation-archive-btn"
                                                     title="Archive conversation"
@@ -281,6 +285,9 @@
             if (PortalLoad.IsReady)
                 await LoadGatewayInfoAsync();
 
+            if (Store.ActiveAgentId is { Length: > 0 } activeAgentId)
+                await Interaction.RefreshConversationsAsync(activeAgentId);
+
             StateHasChanged();
         }
     }
@@ -375,6 +382,7 @@
         var agentId = e.Value?.ToString();
         if (!string.IsNullOrEmpty(agentId))
         {
+            await Interaction.RefreshConversationsAsync(agentId);
             Store.ActiveAgentId = agentId;
             if (Store.GetAgent(agentId) is { } agent)
             {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IAgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IAgentInteractionService.cs
@@ -18,6 +18,7 @@ public interface IAgentInteractionService
     Task RenameConversationAsync(string agentId, string? conversationId, string newTitle);
     Task ArchiveConversationAsync(string agentId, string conversationId);
     Task RefreshAgentsAsync();
+    Task RefreshConversationsAsync(string agentId);
     Task ViewSubAgentAsync(SubAgentInfo subAgent);
     void ClearLocalMessages(string agentId);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IClientStateStore.cs
@@ -183,6 +183,12 @@ public sealed class ConversationState
     /// <summary>When the conversation was last updated.</summary>
     public DateTimeOffset UpdatedAt { get; set; }
 
+    /// <summary>True when this is a virtual read-only session row (for example, cron).</summary>
+    public bool IsVirtualSession { get; set; }
+
+    /// <summary>Virtual session kind label (for example, "cron"). Null for normal conversations.</summary>
+    public string? VirtualSessionKind { get; set; }
+
     // ── History flags ────────────────────────────────────────────────────────
 
     /// <summary>Whether the latest page of history has been loaded.</summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IGatewayRestClient.cs
@@ -28,6 +28,18 @@ public interface IGatewayRestClient
         string conversationId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>GET /api/sessions?agentId={agentId}</summary>
+    Task<IReadOnlyList<SessionSummary>> GetSessionsAsync(
+        string? agentId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>GET /api/sessions/{sessionId}/history?limit={limit}&amp;offset={offset}</summary>
+    Task<SessionHistoryResponseDto?> GetSessionHistoryAsync(
+        string sessionId,
+        int limit = 50,
+        int offset = 0,
+        CancellationToken cancellationToken = default);
+
     /// <summary>POST /api/conversations</summary>
     Task<ConversationResponseDto?> CreateConversationAsync(
         CreateConversationRequestDto request,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -313,6 +313,11 @@ public sealed class AgentInteractionService : IAgentInteractionService
         }
     }
 
+    public async Task RefreshConversationsAsync(string agentId)
+    {
+        await RefreshConversationsForAgentAsync(agentId);
+    }
+
     public async Task ViewSubAgentAsync(SubAgentInfo subAgent)
     {
         var subAgentId = subAgent.SubAgentId;
@@ -387,6 +392,32 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
+            if (conv.IsVirtualSession && conv.ActiveSessionId is { Length: > 0 } sessionId)
+            {
+                const int virtualHistoryLimit = 200;
+                var sessionResponse = await _restClient.GetSessionHistoryAsync(sessionId, limit: virtualHistoryLimit);
+                conv.Messages.Clear();
+                if (sessionResponse?.Entries is { Count: > 0 })
+                {
+                    foreach (var entry in sessionResponse.Entries)
+                    {
+                        var role = MapRole(entry.Role ?? "system");
+                        conv.Messages.Add(new ChatMessage(role, entry.Content ?? string.Empty, entry.Timestamp)
+                        {
+                            ToolName = entry.ToolName,
+                            ToolCallId = entry.ToolCallId,
+                            ToolArgs = entry.ToolArgs,
+                            ToolIsError = entry.ToolIsError,
+                            IsToolCall = entry.ToolName is not null,
+                            ToolResult = entry.ToolName is not null ? entry.Content : null
+                        });
+                    }
+                }
+
+                conv.HistoryLoaded = true;
+                return;
+            }
+
             const int historyLimit = 200;
             var response = await _restClient.GetHistoryAsync(conversationId, limit: historyLimit);
 
@@ -512,8 +543,21 @@ public sealed class AgentInteractionService : IAgentInteractionService
     {
         try
         {
-            var list = await _restClient.GetConversationsAsync(agentId);
+            var listTask = _restClient.GetConversationsAsync(agentId);
+            var sessionsTask = _restClient.GetSessionsAsync(agentId);
+            await Task.WhenAll(listTask, sessionsTask);
+
+            var list = listTask.Result;
             _store.SeedConversations(agentId, list);
+
+            var agent = _store.GetAgent(agentId);
+            if (agent is not null)
+                MergeVirtualCronSessions(agent, sessionsTask.Result);
+
+            foreach (var session in sessionsTask.Result)
+                _store.RegisterSession(session.AgentId, session.SessionId, session.ChannelType, session.SessionType);
+
+            _store.NotifyChanged();
         }
         catch (Exception ex)
         {
@@ -552,4 +596,48 @@ public sealed class AgentInteractionService : IAgentInteractionService
         "system" => "System",
         _ => role
     };
+
+    private static void MergeVirtualCronSessions(AgentState agent, IReadOnlyList<SessionSummary> sessions)
+    {
+        var cronSessions = sessions
+            .Where(s => string.Equals(s.SessionType, "cron", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(s => $"cron-session:{s.SessionId}", s => s, StringComparer.Ordinal);
+
+        foreach (var key in agent.Conversations
+                     .Where(kv => kv.Value.IsVirtualSession &&
+                                  string.Equals(kv.Value.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase) &&
+                                  !cronSessions.ContainsKey(kv.Key))
+                     .Select(kv => kv.Key)
+                     .ToList())
+        {
+            agent.Conversations.Remove(key);
+        }
+
+        foreach (var (conversationId, session) in cronSessions)
+        {
+            var title = $"Cron · {session.SessionId[..Math.Min(8, session.SessionId.Length)]}";
+            if (agent.Conversations.TryGetValue(conversationId, out var existing))
+            {
+                existing.Title = title;
+                existing.ActiveSessionId = session.SessionId;
+                existing.Status = session.Status ?? "Active";
+                existing.UpdatedAt = session.UpdatedAt ?? existing.UpdatedAt;
+                existing.IsVirtualSession = true;
+                existing.VirtualSessionKind = "cron";
+                continue;
+            }
+
+            agent.Conversations[conversationId] = new ConversationState
+            {
+                ConversationId = conversationId,
+                Title = title,
+                Status = session.Status ?? "Active",
+                ActiveSessionId = session.SessionId,
+                CreatedAt = session.CreatedAt ?? DateTimeOffset.UtcNow,
+                UpdatedAt = session.UpdatedAt ?? DateTimeOffset.UtcNow,
+                IsVirtualSession = true,
+                VirtualSessionKind = "cron"
+            };
+        }
+    }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateStore.cs
@@ -91,8 +91,13 @@ public sealed class ClientStateStore : IClientStateStore
 
         // Remove conversations no longer in the list
         var incomingIds = incoming.Select(d => d.ConversationId).ToHashSet();
-        foreach (var id in agent.Conversations.Keys.Where(k => !incomingIds.Contains(k)).ToList())
+        foreach (var id in agent.Conversations
+                     .Where(kv => !incomingIds.Contains(kv.Key) && !kv.Value.IsVirtualSession)
+                     .Select(kv => kv.Key)
+                     .ToList())
+        {
             agent.Conversations.Remove(id);
+        }
 
         // Auto-select a conversation if none is selected
         if (agent.ActiveConversationId is null && agent.Conversations.Count > 0)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ConversationContracts.cs
@@ -82,3 +82,33 @@ public sealed class ConversationHistoryEntryDto
     [JsonPropertyName("reason")]
     public string? Reason { get; init; }
 }
+
+public sealed record SessionHistoryResponseDto(
+    [property: JsonPropertyName("offset")] int Offset,
+    [property: JsonPropertyName("limit")] int Limit,
+    [property: JsonPropertyName("totalCount")] int TotalCount,
+    [property: JsonPropertyName("entries")] IReadOnlyList<SessionHistoryEntryDto> Entries);
+
+public sealed class SessionHistoryEntryDto
+{
+    [JsonPropertyName("role")]
+    public string? Role { get; init; }
+
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; init; }
+
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; init; }
+
+    [JsonPropertyName("toolArgs")]
+    public string? ToolArgs { get; init; }
+
+    [JsonPropertyName("toolIsError")]
+    public bool ToolIsError { get; init; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayRestClient.cs
@@ -72,6 +72,34 @@ public sealed class GatewayRestClient : IGatewayRestClient
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<SessionSummary>> GetSessionsAsync(
+        string? agentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        var query = string.IsNullOrWhiteSpace(agentId)
+            ? string.Empty
+            : $"?agentId={Uri.EscapeDataString(agentId)}";
+        var result = await _http.GetFromJsonAsync<List<SessionSummary>>(
+            $"{_apiBaseUrl}sessions{query}",
+            cancellationToken);
+        return result as IReadOnlyList<SessionSummary> ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<SessionHistoryResponseDto?> GetSessionHistoryAsync(
+        string sessionId,
+        int limit = 50,
+        int offset = 0,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        return await _http.GetFromJsonAsync<SessionHistoryResponseDto>(
+            $"{_apiBaseUrl}sessions/{Uri.EscapeDataString(sessionId)}/history?limit={limit}&offset={offset}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<ConversationResponseDto?> CreateConversationAsync(
         CreateConversationRequestDto request,
         CancellationToken cancellationToken = default)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/HubContracts.cs
@@ -98,6 +98,7 @@ public sealed record SessionSummary(
     [property: JsonPropertyName("sessionId")] string SessionId,
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("channelType")] string? ChannelType,
+    [property: JsonPropertyName("sessionType")] string? SessionType,
     [property: JsonPropertyName("status")] string? Status,
     [property: JsonPropertyName("messageCount")] int MessageCount,
     [property: JsonPropertyName("isInteractive")] bool IsInteractive = true,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/PortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/PortalLoadService.cs
@@ -59,6 +59,34 @@ public sealed class PortalLoadService : IPortalLoadService
             });
             await Task.WhenAll(conversationTasks);
 
+            var sessions = await _restClient.GetSessionsAsync(cancellationToken: cancellationToken);
+            foreach (var session in sessions)
+                _store.RegisterSession(session.AgentId, session.SessionId, session.ChannelType, session.SessionType);
+
+            foreach (var group in sessions
+                         .Where(s => string.Equals(s.SessionType, "cron", StringComparison.OrdinalIgnoreCase))
+                         .GroupBy(s => s.AgentId))
+            {
+                var agent = _store.GetAgent(group.Key);
+                if (agent is null) continue;
+
+                foreach (var session in group)
+                {
+                    var conversationId = $"cron-session:{session.SessionId}";
+                    agent.Conversations[conversationId] = new ConversationState
+                    {
+                        ConversationId = conversationId,
+                        Title = $"Cron · {session.SessionId[..Math.Min(8, session.SessionId.Length)]}",
+                        Status = session.Status ?? "Active",
+                        ActiveSessionId = session.SessionId,
+                        CreatedAt = session.CreatedAt ?? DateTimeOffset.UtcNow,
+                        UpdatedAt = session.UpdatedAt ?? DateTimeOffset.UtcNow,
+                        IsVirtualSession = true,
+                        VirtualSessionKind = "cron"
+                    };
+                }
+            }
+
             var selectedAgentId = agents.OrderBy(a => a.DisplayName).FirstOrDefault()?.AgentId;
             if (selectedAgentId is not null)
             {

--- a/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
+++ b/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
@@ -54,7 +54,15 @@ public sealed class AgentPromptAction : ICronAction
                     : "Cron internal trigger is not registered.");
 
         var sessionId = await trigger
-            .CreateSessionAsync(AgentId.From(agentId), message, cancellationToken)
+            .CreateSessionAsync(
+                AgentId.From(agentId),
+                message,
+                cancellationToken,
+                new InternalTriggerRequest
+                {
+                    CronJobId = context.Job.Id,
+                    ModelOverride = context.Job.Model
+                })
             .ConfigureAwait(false);
 
         context.RecordSessionId(sessionId);

--- a/src/gateway/BotNexus.Cron/ActionStubs/WebhookActionStub.cs
+++ b/src/gateway/BotNexus.Cron/ActionStubs/WebhookActionStub.cs
@@ -5,5 +5,6 @@ public sealed class WebhookAction : ICronAction
     public string ActionType => "webhook";
 
     public Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
+        => throw new NotSupportedException(
+            "Cron webhook actions are not implemented yet. Job execution failed intentionally instead of succeeding silently.");
 }

--- a/src/gateway/BotNexus.Cron/CronJob.cs
+++ b/src/gateway/BotNexus.Cron/CronJob.cs
@@ -8,6 +8,7 @@ public sealed record CronJob
     public required string ActionType { get; init; }
     public string? AgentId { get; init; }
     public string? Message { get; init; }
+    public string? Model { get; init; }
     public string? WebhookUrl { get; init; }
     public string? ShellCommand { get; init; }
     public bool Enabled { get; init; } = true;

--- a/src/gateway/BotNexus.Cron/CronOptions.cs
+++ b/src/gateway/BotNexus.Cron/CronOptions.cs
@@ -18,6 +18,7 @@ public sealed record ConfiguredCronJob
     public string? ActionType { get; init; }
     public string? AgentId { get; init; }
     public string? Message { get; init; }
+    public string? Model { get; init; }
     public string? WebhookUrl { get; init; }
     public string? ShellCommand { get; init; }
     public bool Enabled { get; init; } = true;

--- a/src/gateway/BotNexus.Cron/CronScheduler.cs
+++ b/src/gateway/BotNexus.Cron/CronScheduler.cs
@@ -109,7 +109,7 @@ public sealed class CronScheduler(
     private async Task<CronRun> RunActionAsync(CronJob job, CronTriggerType triggerType, DateTimeOffset triggeredAt, CancellationToken ct)
     {
         var run = await _cronStore.RecordRunStartAsync(job.Id, ct).ConfigureAwait(false);
-        var action = ResolveAction(job.ActionType);
+        var action = ResolveAction(NormalizeActionType(job.ActionType));
 
         try
         {
@@ -205,6 +205,28 @@ public sealed class CronScheduler(
                 string.IsNullOrWhiteSpace(configuredJob.Schedule) ||
                 string.IsNullOrWhiteSpace(configuredJob.ActionType))
             {
+                _logger.LogWarning(
+                    "Skipping configured cron job '{JobId}' due to missing required fields (schedule/actionType).",
+                    jobId);
+                continue;
+            }
+
+            var normalizedActionType = NormalizeActionType(configuredJob.ActionType);
+            if (!_actions.ContainsKey(normalizedActionType))
+            {
+                _logger.LogWarning(
+                    "Skipping configured cron job '{JobId}' because action type '{ActionType}' is not registered.",
+                    jobId,
+                    configuredJob.ActionType);
+                continue;
+            }
+
+            if (string.Equals(normalizedActionType, "agent-prompt", StringComparison.OrdinalIgnoreCase)
+                && (string.IsNullOrWhiteSpace(configuredJob.AgentId) || string.IsNullOrWhiteSpace(configuredJob.Message)))
+            {
+                _logger.LogWarning(
+                    "Skipping configured cron job '{JobId}' because agent-prompt jobs require both agentId and message.",
+                    jobId);
                 continue;
             }
 
@@ -216,9 +238,10 @@ public sealed class CronScheduler(
                     Id = jobId,
                     Name = configuredJob.Name ?? jobId,
                     Schedule = configuredJob.Schedule,
-                    ActionType = configuredJob.ActionType,
+                    ActionType = normalizedActionType,
                     AgentId = configuredJob.AgentId,
                     Message = configuredJob.Message,
+                    Model = configuredJob.Model,
                     WebhookUrl = configuredJob.WebhookUrl,
                     ShellCommand = configuredJob.ShellCommand,
                     Enabled = configuredJob.Enabled,
@@ -236,9 +259,10 @@ public sealed class CronScheduler(
             {
                 Name = configuredJob.Name ?? existing.Name,
                 Schedule = configuredJob.Schedule,
-                ActionType = configuredJob.ActionType,
+                ActionType = normalizedActionType,
                 AgentId = configuredJob.AgentId,
                 Message = configuredJob.Message,
+                Model = configuredJob.Model,
                 WebhookUrl = configuredJob.WebhookUrl,
                 ShellCommand = configuredJob.ShellCommand,
                 Enabled = configuredJob.Enabled,
@@ -250,5 +274,13 @@ public sealed class CronScheduler(
 
             await _cronStore.UpdateAsync(merged, ct).ConfigureAwait(false);
         }
+    }
+
+    private static string NormalizeActionType(string? actionType)
+    {
+        if (string.Equals(actionType, "agent-chat", StringComparison.OrdinalIgnoreCase))
+            return "agent-prompt";
+
+        return actionType?.Trim() ?? string.Empty;
     }
 }

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -14,7 +14,10 @@ public static class CronServiceCollectionExtensions
         services.TryAddSingleton<ICronStore>(sp =>
         {
             var rootPath = ResolveRootPath(sp);
-            return new SqliteCronStore(Path.Combine(rootPath, "cron.sqlite"), new FileSystem());
+            return new SqliteCronStore(
+                Path.Combine(rootPath, "cron.sqlite"),
+                new FileSystem(),
+                sp.GetService<Microsoft.Extensions.Logging.ILogger<SqliteCronStore>>());
         });
         services.TryAddSingleton<HeartbeatCronProvisioner>();
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<HeartbeatCronProvisioner>());

--- a/src/gateway/BotNexus.Cron/SqliteCronStore.cs
+++ b/src/gateway/BotNexus.Cron/SqliteCronStore.cs
@@ -1,14 +1,17 @@
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BotNexus.Cron;
 
-public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = null) : ICronStore
+public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = null, ILogger<SqliteCronStore>? logger = null) : ICronStore
 {
     private readonly string _dbPath = dbPath;
     private readonly string _connectionString = $"Data Source={dbPath};Mode=ReadWriteCreate";
     private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystem();
+    private readonly ILogger<SqliteCronStore> _logger = logger ?? NullLogger<SqliteCronStore>.Instance;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private bool _initialized;
 
@@ -43,6 +46,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
                     action_type TEXT NOT NULL,
                     agent_id TEXT NULL,
                     message TEXT NULL,
+                    model TEXT NULL,
                     webhook_url TEXT NULL,
                     shell_command TEXT NULL,
                     enabled INTEGER NOT NULL DEFAULT 1,
@@ -92,6 +96,14 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             try { await migrateSystem.ExecuteNonQueryAsync(ct).ConfigureAwait(false); }
             catch (SqliteException) { /* column already exists */ }
 
+            // Migrate existing databases: add model column if missing.
+            await using var migrateModel = connection.CreateCommand();
+            migrateModel.CommandText = """
+                ALTER TABLE cron_jobs ADD COLUMN model TEXT NULL;
+                """;
+            try { await migrateModel.ExecuteNonQueryAsync(ct).ConfigureAwait(false); }
+            catch (SqliteException) { /* column already exists */ }
+
             _initialized = true;
         }
         finally
@@ -120,16 +132,22 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             await using var command = connection.CreateCommand();
             command.CommandText = """
                 INSERT INTO cron_jobs (
-                    id, name, schedule, action_type, agent_id, message, webhook_url, shell_command,
+                    id, name, schedule, action_type, agent_id, message, model, webhook_url, shell_command,
                     enabled, system, time_zone, created_by, created_at, last_run_at, next_run_at, last_run_status, last_run_error, metadata_json
                 )
                 VALUES (
-                    $id, $name, $schedule, $actionType, $agentId, $message, $webhookUrl, $shellCommand,
+                    $id, $name, $schedule, $actionType, $agentId, $message, $model, $webhookUrl, $shellCommand,
                     $enabled, $system, $timeZone, $createdBy, $createdAt, $lastRunAt, $nextRunAt, $lastRunStatus, $lastRunError, $metadataJson
                 )
                 """;
             BindJob(command, created);
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Created cron job '{JobId}' (action={ActionType}, enabled={Enabled}, createdBy={CreatedBy}).",
+                created.Id,
+                created.ActionType,
+                created.Enabled,
+                created.CreatedBy);
             return created;
         }
         finally
@@ -147,7 +165,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         await connection.OpenAsync(ct).ConfigureAwait(false);
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, name, schedule, action_type, agent_id, message, webhook_url, shell_command,
+            SELECT id, name, schedule, action_type, agent_id, message, model, webhook_url, shell_command,
                    enabled, system, time_zone, created_by, created_at, last_run_at, next_run_at, last_run_status, last_run_error, metadata_json
             FROM cron_jobs
             WHERE id = $id
@@ -168,7 +186,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         await connection.OpenAsync(ct).ConfigureAwait(false);
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, name, schedule, action_type, agent_id, message, webhook_url, shell_command,
+            SELECT id, name, schedule, action_type, agent_id, message, model, webhook_url, shell_command,
                    enabled, system, time_zone, created_by, created_at, last_run_at, next_run_at, last_run_status, last_run_error, metadata_json
             FROM cron_jobs
             WHERE $agentId IS NULL OR agent_id = $agentId
@@ -197,11 +215,11 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             await using var command = connection.CreateCommand();
             command.CommandText = """
                 INSERT INTO cron_jobs (
-                    id, name, schedule, action_type, agent_id, message, webhook_url, shell_command,
+                    id, name, schedule, action_type, agent_id, message, model, webhook_url, shell_command,
                     enabled, system, time_zone, created_by, created_at, last_run_at, next_run_at, last_run_status, last_run_error, metadata_json
                 )
                 VALUES (
-                    $id, $name, $schedule, $actionType, $agentId, $message, $webhookUrl, $shellCommand,
+                    $id, $name, $schedule, $actionType, $agentId, $message, $model, $webhookUrl, $shellCommand,
                     $enabled, $system, $timeZone, $createdBy, $createdAt, $lastRunAt, $nextRunAt, $lastRunStatus, $lastRunError, $metadataJson
                 )
                 ON CONFLICT(id) DO UPDATE SET
@@ -210,6 +228,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
                     action_type = excluded.action_type,
                     agent_id = excluded.agent_id,
                     message = excluded.message,
+                    model = excluded.model,
                     webhook_url = excluded.webhook_url,
                     shell_command = excluded.shell_command,
                     enabled = excluded.enabled,
@@ -225,6 +244,11 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
                 """;
             BindJob(command, job);
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Updated cron job '{JobId}' (action={ActionType}, enabled={Enabled}).",
+                job.Id,
+                job.ActionType,
+                job.Enabled);
             return job;
         }
         finally
@@ -253,6 +277,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             deleteJob.CommandText = "DELETE FROM cron_jobs WHERE id = $jobId";
             deleteJob.Parameters.AddWithValue("$jobId", jobId);
             await deleteJob.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation("Deleted cron job '{JobId}'.", jobId);
         }
         finally
         {
@@ -390,6 +415,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         command.Parameters.AddWithValue("$actionType", job.ActionType);
         command.Parameters.AddWithValue("$agentId", (object?)job.AgentId ?? DBNull.Value);
         command.Parameters.AddWithValue("$message", (object?)job.Message ?? DBNull.Value);
+        command.Parameters.AddWithValue("$model", (object?)job.Model ?? DBNull.Value);
         command.Parameters.AddWithValue("$webhookUrl", (object?)job.WebhookUrl ?? DBNull.Value);
         command.Parameters.AddWithValue("$shellCommand", (object?)job.ShellCommand ?? DBNull.Value);
         command.Parameters.AddWithValue("$enabled", job.Enabled ? 1 : 0);
@@ -406,7 +432,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
 
     private static CronJob ReadJob(SqliteDataReader reader)
     {
-        var metadataJson = reader.IsDBNull(17) ? null : reader.GetString(17);
+        var metadataJson = reader.IsDBNull(18) ? null : reader.GetString(18);
         return new CronJob
         {
             Id = reader.GetString(0),
@@ -415,17 +441,18 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             ActionType = reader.GetString(3),
             AgentId = reader.IsDBNull(4) ? null : reader.GetString(4),
             Message = reader.IsDBNull(5) ? null : reader.GetString(5),
-            WebhookUrl = reader.IsDBNull(6) ? null : reader.GetString(6),
-            ShellCommand = reader.IsDBNull(7) ? null : reader.GetString(7),
-            Enabled = !reader.IsDBNull(8) && reader.GetInt32(8) != 0,
-            System = !reader.IsDBNull(9) && reader.GetInt32(9) != 0,
-            TimeZone = reader.IsDBNull(10) ? null : reader.GetString(10),
-            CreatedBy = reader.IsDBNull(11) ? null : reader.GetString(11),
-            CreatedAt = ParseDate(reader.GetString(12)),
-            LastRunAt = reader.IsDBNull(13) ? null : ParseDate(reader.GetString(13)),
-            NextRunAt = reader.IsDBNull(14) ? null : ParseDate(reader.GetString(14)),
-            LastRunStatus = reader.IsDBNull(15) ? null : reader.GetString(15),
-            LastRunError = reader.IsDBNull(16) ? null : reader.GetString(16),
+            Model = reader.IsDBNull(6) ? null : reader.GetString(6),
+            WebhookUrl = reader.IsDBNull(7) ? null : reader.GetString(7),
+            ShellCommand = reader.IsDBNull(8) ? null : reader.GetString(8),
+            Enabled = !reader.IsDBNull(9) && reader.GetInt32(9) != 0,
+            System = !reader.IsDBNull(10) && reader.GetInt32(10) != 0,
+            TimeZone = reader.IsDBNull(11) ? null : reader.GetString(11),
+            CreatedBy = reader.IsDBNull(12) ? null : reader.GetString(12),
+            CreatedAt = ParseDate(reader.GetString(13)),
+            LastRunAt = reader.IsDBNull(14) ? null : ParseDate(reader.GetString(14)),
+            NextRunAt = reader.IsDBNull(15) ? null : ParseDate(reader.GetString(15)),
+            LastRunStatus = reader.IsDBNull(16) ? null : reader.GetString(16),
+            LastRunError = reader.IsDBNull(17) ? null : reader.GetString(17),
             Metadata = DeserializeMetadata(metadataJson)
         };
     }

--- a/src/gateway/BotNexus.Cron/Tools/CronTool.cs
+++ b/src/gateway/BotNexus.Cron/Tools/CronTool.cs
@@ -36,6 +36,7 @@ public sealed class CronTool(
                 "timeZone": { "type": "string", "description": "IANA timezone name for the schedule (e.g. 'America/Los_Angeles', 'Europe/London', 'Asia/Tokyo'). When set, the cron expression is interpreted in this timezone (including DST adjustments). Defaults to UTC if omitted." },
                 "agentId": { "type": "string", "description": "Target agent (for create, defaults to calling agent)." },
                 "message": { "type": "string", "description": "Prompt message (for create/update)." },
+                "model": { "type": "string", "description": "Optional model override for agent-prompt jobs. Supports model-id or provider/model-id." },
                 "enabled": { "type": "boolean", "description": "Whether the job is enabled." }
               },
               "required": ["action"]
@@ -62,6 +63,7 @@ public sealed class CronTool(
         CopyString(arguments, prepared, "timeZone");
         CopyString(arguments, prepared, "agentId");
         CopyString(arguments, prepared, "message");
+        CopyString(arguments, prepared, "model");
 
         if (arguments.TryGetValue("enabled", out var enabled) && enabled is not null)
             prepared["enabled"] = ReadBool(enabled, "enabled");
@@ -122,6 +124,7 @@ public sealed class CronTool(
             ActionType = "agent-prompt",
             AgentId = ReadString(arguments, "agentId") ?? _agentId,
             Message = ReadString(arguments, "message"),
+            Model = ReadString(arguments, "model"),
             Enabled = arguments.TryGetValue("enabled", out var enabled) && enabled is bool boolEnabled ? boolEnabled : true,
             TimeZone = timeZone,
             CreatedBy = _agentId,
@@ -150,6 +153,7 @@ public sealed class CronTool(
             Schedule = newSchedule,
             TimeZone = newTimeZone,
             Message = ReadString(arguments, "message") ?? existing.Message,
+            Model = ReadString(arguments, "model") ?? existing.Model,
             AgentId = ReadString(arguments, "agentId") ?? existing.AgentId,
             Enabled = arguments.TryGetValue("enabled", out var enabled) && enabled is bool boolEnabled ? boolEnabled : existing.Enabled
         };

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CronController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CronController.cs
@@ -1,5 +1,6 @@
 using BotNexus.Cron;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Api.Controllers;
 
@@ -11,7 +12,11 @@ namespace BotNexus.Gateway.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-public sealed class CronController(ICronStore store, CronScheduler scheduler) : ControllerBase
+public sealed class CronController(
+    ICronStore store,
+    CronScheduler scheduler,
+    IOptionsMonitor<CronOptions> cronOptions,
+    ILogger<CronController> logger) : ControllerBase
 {
     /// <summary>Lists cron jobs.</summary>
     /// <summary>
@@ -21,7 +26,47 @@ public sealed class CronController(ICronStore store, CronScheduler scheduler) : 
     /// <returns>The list result.</returns>
     [HttpGet]
     public async Task<ActionResult<IReadOnlyList<CronJob>>> List(CancellationToken cancellationToken)
-        => Ok(await store.ListAsync(ct: cancellationToken));
+    {
+        var persisted = await store.ListAsync(ct: cancellationToken);
+        var merged = persisted.ToDictionary(job => job.Id, StringComparer.OrdinalIgnoreCase);
+        var configuredJobs = cronOptions.CurrentValue?.Jobs;
+        if (configuredJobs is not null)
+        {
+            foreach (var (jobId, configured) in configuredJobs)
+            {
+                if (merged.ContainsKey(jobId))
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(jobId)
+                    || string.IsNullOrWhiteSpace(configured.Schedule)
+                    || string.IsNullOrWhiteSpace(configured.ActionType))
+                {
+                    continue;
+                }
+
+                merged[jobId] = new CronJob
+                {
+                    Id = jobId,
+                    Name = configured.Name ?? jobId,
+                    Schedule = configured.Schedule,
+                    ActionType = NormalizeActionType(configured.ActionType),
+                    AgentId = configured.AgentId,
+                    Message = configured.Message,
+                    Model = configured.Model,
+                    WebhookUrl = configured.WebhookUrl,
+                    ShellCommand = configured.ShellCommand,
+                    Enabled = configured.Enabled,
+                    System = configured.System,
+                    TimeZone = configured.TimeZone,
+                    CreatedBy = configured.CreatedBy,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    Metadata = configured.Metadata
+                };
+            }
+        }
+
+        return Ok(merged.Values.OrderByDescending(job => job.CreatedAt).ToList());
+    }
 
     /// <summary>Gets a cron job by identifier.</summary>
     /// <summary>
@@ -50,10 +95,12 @@ public sealed class CronController(ICronStore store, CronScheduler scheduler) : 
         var toCreate = request with
         {
             Id = string.IsNullOrWhiteSpace(request.Id) ? Guid.NewGuid().ToString("N") : request.Id,
+            ActionType = NormalizeActionType(request.ActionType),
             CreatedAt = request.CreatedAt == default ? DateTimeOffset.UtcNow : request.CreatedAt
         };
 
         var created = await store.CreateAsync(toCreate, cancellationToken);
+        logger.LogInformation("Cron job created via API: {JobId} ({ActionType})", created.Id, created.ActionType);
         return CreatedAtAction(nameof(Get), new { jobId = created.Id }, created);
     }
 
@@ -75,10 +122,13 @@ public sealed class CronController(ICronStore store, CronScheduler scheduler) : 
         var updated = request with
         {
             Id = jobId,
+            ActionType = NormalizeActionType(request.ActionType),
             CreatedAt = existing.CreatedAt
         };
 
-        return Ok(await store.UpdateAsync(updated, cancellationToken));
+        var saved = await store.UpdateAsync(updated, cancellationToken);
+        logger.LogInformation("Cron job updated via API: {JobId} ({ActionType})", saved.Id, saved.ActionType);
+        return Ok(saved);
     }
 
     /// <summary>Deletes a cron job.</summary>
@@ -92,6 +142,7 @@ public sealed class CronController(ICronStore store, CronScheduler scheduler) : 
     public async Task<IActionResult> Delete(string jobId, CancellationToken cancellationToken)
     {
         await store.DeleteAsync(jobId, cancellationToken);
+        logger.LogInformation("Cron job deleted via API: {JobId}", jobId);
         return NoContent();
     }
 
@@ -129,5 +180,13 @@ public sealed class CronController(ICronStore store, CronScheduler scheduler) : 
             return NotFound();
 
         return Ok(await store.GetRunHistoryAsync(jobId, limit, cancellationToken));
+    }
+
+    private static string NormalizeActionType(string? actionType)
+    {
+        if (string.Equals(actionType, "agent-chat", StringComparison.OrdinalIgnoreCase))
+            return "agent-prompt";
+
+        return actionType?.Trim() ?? string.Empty;
     }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -99,6 +99,7 @@ builder.Services.Configure<CronOptions>(options =>
                 ActionType = pair.Value.ActionType,
                 AgentId = pair.Value.AgentId,
                 Message = pair.Value.Message,
+                Model = ResolveCronModel(pair.Value),
                 WebhookUrl = pair.Value.WebhookUrl,
                 ShellCommand = pair.Value.ShellCommand,
                 Enabled = pair.Value.Enabled,
@@ -107,6 +108,24 @@ builder.Services.Configure<CronOptions>(options =>
             },
             StringComparer.OrdinalIgnoreCase);
 });
+
+static string? ResolveCronModel(CronJobConfig config)
+{
+    if (!string.IsNullOrWhiteSpace(config.Model))
+        return config.Model;
+
+    if (config.Metadata is null)
+        return null;
+
+    var metadataModel = config.Metadata
+        .FirstOrDefault(pair => string.Equals(pair.Key, "model", StringComparison.OrdinalIgnoreCase))
+        .Value;
+
+    return string.IsNullOrWhiteSpace(metadataModel)
+        ? null
+        : metadataModel;
+}
+
 builder.Services.AddExtensionLoading();
 builder.Services.AddSignalR();
 builder.Services.AddBotNexusGatewayApi();

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -1,4 +1,5 @@
 using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Triggers;
@@ -12,6 +13,7 @@ namespace BotNexus.Gateway.Api.Triggers;
 /// </summary>
 public sealed class CronTrigger(
     IAgentSupervisor supervisor,
+    IConversationStore conversations,
     ISessionStore sessions,
     ILogger<CronTrigger> logger) : IInternalTrigger
 {
@@ -32,16 +34,44 @@ public sealed class CronTrigger(
     /// <param name="prompt">The prompt.</param>
     /// <param name="ct">The ct.</param>
     /// <returns>The create session async result.</returns>
-    public async Task<SessionId> CreateSessionAsync(AgentId agentId, string prompt, CancellationToken ct = default)
+    public async Task<SessionId> CreateSessionAsync(
+        AgentId agentId,
+        string prompt,
+        CancellationToken ct = default,
+        InternalTriggerRequest? request = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
 
-        var sessionId = SessionId.From($"cron:{DateTimeOffset.UtcNow:yyyyMMddHHmmss}:{Guid.NewGuid():N}");
+        var sessionId = BuildCronSessionId(request?.CronJobId);
         var session = await sessions.GetOrCreateAsync(sessionId, agentId, ct).ConfigureAwait(false);
         session.ChannelType ??= ChannelKey.From(Type.Value);
         session.CallerId ??= $"{Type.Value}:{agentId.Value}";
         session.SessionType = SessionType.Cron;
+        session.Metadata["triggerType"] = Type.Value;
+
+        if (string.IsNullOrWhiteSpace(request?.ModelOverride))
+            session.Metadata.Remove("modelOverride");
+        else
+            session.Metadata["modelOverride"] = request!.ModelOverride;
+
+        if (string.IsNullOrWhiteSpace(request?.CronJobId))
+            session.Metadata.Remove("cronJobId");
+        else
+            session.Metadata["cronJobId"] = request!.CronJobId;
+
+        var conversation = await conversations.GetOrCreateDefaultAsync(agentId, ct).ConfigureAwait(false);
+        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
+            session.Session.ConversationId = conversation.ConversationId;
+
+        if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
+        {
+            conversation.ActiveSessionId = sessionId;
+            conversation.UpdatedAt = DateTimeOffset.UtcNow;
+            await conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
+        }
+
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = prompt });
+        await sessions.SaveAsync(session, ct).ConfigureAwait(false);
 
         var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);
         var response = await handle.PromptAsync(prompt, ct).ConfigureAwait(false);
@@ -50,10 +80,46 @@ public sealed class CronTrigger(
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);
 
         logger.LogInformation(
-            "Cron trigger created session '{SessionId}' for agent '{AgentId}'.",
+            "Cron trigger created session '{SessionId}' for agent '{AgentId}' (jobId: {JobId}, model: {ModelOverride}).",
             sessionId,
-            agentId);
+            agentId,
+            request?.CronJobId,
+            request?.ModelOverride);
 
         return sessionId;
+    }
+
+    private static SessionId BuildCronSessionId(string? jobId)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmss");
+        var suffix = Guid.NewGuid().ToString("N");
+        var safeJobId = SanitizeSessionIdPart(jobId);
+        return string.IsNullOrWhiteSpace(safeJobId)
+            ? SessionId.From($"cron:{timestamp}:{suffix}")
+            : SessionId.From($"cron:{safeJobId}:{timestamp}:{suffix}");
+    }
+
+    private static string? SanitizeSessionIdPart(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        Span<char> buffer = stackalloc char[Math.Min(40, value.Length)];
+        var length = 0;
+        foreach (var ch in value)
+        {
+            if (length >= buffer.Length)
+                break;
+
+            if (char.IsLetterOrDigit(ch) || ch is '-' or '_')
+            {
+                buffer[length++] = ch;
+                continue;
+            }
+
+            buffer[length++] = '-';
+        }
+
+        return new string(buffer[..length]).Trim('-');
     }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
@@ -39,7 +39,11 @@ public sealed class SoulTrigger(
     /// <param name="prompt">The prompt.</param>
     /// <param name="ct">The ct.</param>
     /// <returns>The create session async result.</returns>
-    public async Task<SessionId> CreateSessionAsync(AgentId agentId, string prompt, CancellationToken ct = default)
+    public async Task<SessionId> CreateSessionAsync(
+        AgentId agentId,
+        string prompt,
+        CancellationToken ct = default,
+        InternalTriggerRequest? request = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
 
@@ -54,7 +58,18 @@ public sealed class SoulTrigger(
         var session = await sessions.GetOrCreateAsync(sessionId, agentId, ct).ConfigureAwait(false);
         InitializeSoulSession(session, agentId, soulDate);
 
+        if (string.IsNullOrWhiteSpace(request?.ModelOverride))
+            session.Metadata.Remove("modelOverride");
+        else
+            session.Metadata["modelOverride"] = request!.ModelOverride;
+
+        if (string.IsNullOrWhiteSpace(request?.CronJobId))
+            session.Metadata.Remove("cronJobId");
+        else
+            session.Metadata["cronJobId"] = request!.CronJobId;
+
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = prompt });
+        await sessions.SaveAsync(session, ct).ConfigureAwait(false);
         var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);
         var response = await handle.PromptAsync(prompt, ct).ConfigureAwait(false);
         session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = response.Content });

--- a/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
@@ -20,5 +20,26 @@ public interface IInternalTrigger
     /// <summary>
     /// Creates and executes a session for this trigger source.
     /// </summary>
-    Task<SessionId> CreateSessionAsync(AgentId agentId, string prompt, CancellationToken ct = default);
+    Task<SessionId> CreateSessionAsync(
+        AgentId agentId,
+        string prompt,
+        CancellationToken ct = default,
+        InternalTriggerRequest? request = null);
+}
+
+/// <summary>
+/// Optional trigger request options supplied by internal schedulers and background workflows.
+/// </summary>
+public sealed record InternalTriggerRequest
+{
+    /// <summary>
+    /// Optional cron job identifier used for traceability and session-id composition.
+    /// </summary>
+    public string? CronJobId { get; init; }
+
+    /// <summary>
+    /// Optional model override for this trigger execution.
+    /// Supports either "model-id" (current provider) or "provider/model-id".
+    /// </summary>
+    public string? ModelOverride { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultAgentSupervisor.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultAgentSupervisor.cs
@@ -43,8 +43,10 @@ public sealed class DefaultAgentSupervisor : IAgentSupervisor, IAgentHandleInspe
         activity?.SetTag("botnexus.session.id", sessionId);
         activity?.SetTag("botnexus.correlation.id", System.Diagnostics.Activity.Current?.TraceId.ToString());
 
-        var descriptor = _registry.Get(agentId)
+        var baseDescriptor = _registry.Get(agentId)
             ?? throw new KeyNotFoundException($"Agent '{agentId}' is not registered.");
+        var existingSession = await _sessionStore.GetAsync(sessionId, cancellationToken);
+        var descriptor = ResolveDescriptorForSession(baseDescriptor, existingSession);
         var key = AgentSessionKey.From(agentId, sessionId);
         Task<(AgentInstance Instance, IAgentHandle Handle, AgentDescriptor Descriptor)> creationTask;
         TaskCompletionSource<(AgentInstance Instance, IAgentHandle Handle, AgentDescriptor Descriptor)>? creationCompletion = null;
@@ -88,7 +90,7 @@ public sealed class DefaultAgentSupervisor : IAgentSupervisor, IAgentHandleInspe
 
         try
         {
-            var created = await CreateEntryAsync(descriptor, sessionId, key, cancellationToken);
+            var created = await CreateEntryAsync(descriptor, sessionId, key, existingSession, cancellationToken);
             lock (_sync)
             {
                 _pendingCreates.Remove(key);
@@ -202,6 +204,7 @@ public sealed class DefaultAgentSupervisor : IAgentSupervisor, IAgentHandleInspe
         AgentDescriptor descriptor,
         SessionId sessionId,
         AgentSessionKey key,
+        GatewaySession? existingSession,
         CancellationToken cancellationToken)
     {
         var descriptorErrors = AgentDescriptorValidator.Validate(descriptor, _strategies.Keys);
@@ -218,7 +221,6 @@ public sealed class DefaultAgentSupervisor : IAgentSupervisor, IAgentHandleInspe
         }
 
         IReadOnlyList<SessionEntry> priorHistory = [];
-        var existingSession = await _sessionStore.GetAsync(sessionId, cancellationToken);
         if (existingSession?.History.Count > 0)
         {
             priorHistory = existingSession.History;
@@ -243,6 +245,62 @@ public sealed class DefaultAgentSupervisor : IAgentSupervisor, IAgentHandleInspe
         };
 
         return (instance, handle, descriptor);
+    }
+
+    private AgentDescriptor ResolveDescriptorForSession(AgentDescriptor descriptor, GatewaySession? session)
+    {
+        if (session is null
+            || !TryGetMetadataString(session, "modelOverride", out var rawOverride)
+            || string.IsNullOrWhiteSpace(rawOverride))
+        {
+            return descriptor;
+        }
+
+        var trimmed = rawOverride.Trim();
+        var provider = descriptor.ApiProvider;
+        var model = trimmed;
+        var separator = trimmed.IndexOf('/');
+        if (separator > 0 && separator < trimmed.Length - 1)
+        {
+            provider = trimmed[..separator];
+            model = trimmed[(separator + 1)..];
+        }
+
+        if (descriptor.AllowedModelIds.Count > 0
+            && !descriptor.AllowedModelIds.Contains(model, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Session '{session.SessionId}' requested model '{model}', but it is not allowed for agent '{descriptor.AgentId}'.");
+        }
+
+        if (string.Equals(provider, descriptor.ApiProvider, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(model, descriptor.ModelId, StringComparison.OrdinalIgnoreCase))
+        {
+            return descriptor;
+        }
+
+        _logger.LogInformation(
+            "Applying per-session model override for agent '{AgentId}' session '{SessionId}': {Provider}/{Model}",
+            descriptor.AgentId,
+            session.SessionId,
+            provider,
+            model);
+
+        return descriptor with
+        {
+            ApiProvider = provider,
+            ModelId = model
+        };
+    }
+
+    private static bool TryGetMetadataString(GatewaySession session, string key, out string value)
+    {
+        value = string.Empty;
+        if (!session.Metadata.TryGetValue(key, out var raw) || raw is null)
+            return false;
+
+        value = raw.ToString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
     }
 
     private async Task DisposeHandleAsync(IAgentHandle handle)

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -301,6 +301,9 @@ public sealed class CronJobConfig
     /// <summary>Prompt message for agent prompt jobs.</summary>
     public string? Message { get; set; }
 
+    /// <summary>Optional model override for agent prompt jobs.</summary>
+    public string? Model { get; set; }
+
     /// <summary>Webhook destination URL for webhook jobs.</summary>
     public string? WebhookUrl { get; set; }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -160,6 +160,81 @@ public sealed class AgentInteractionServiceTests
         Assert.Equal(5, messages.Count);
     }
 
+    [Fact]
+    public async Task RefreshConversationsAsync_AddsVirtualCronConversationRows()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        _restClient.GetConversationsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns([
+                new ConversationSummaryDto(
+                    "conv-1",
+                    "agent-1",
+                    "General",
+                    false,
+                    "Active",
+                    null,
+                    0,
+                    DateTimeOffset.UtcNow.AddHours(-1),
+                    DateTimeOffset.UtcNow.AddMinutes(-5))
+            ]);
+        _restClient.GetSessionsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns([
+                new SessionSummary(
+                    "cron:job-1:20260508010101:abc123",
+                    "agent-1",
+                    "cron",
+                    "cron",
+                    "Active",
+                    2,
+                    false,
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    DateTimeOffset.UtcNow.AddMinutes(-1))
+            ]);
+
+        await _service.RefreshConversationsAsync("agent-1");
+
+        var cronConversation = agent.Conversations["cron-session:cron:job-1:20260508010101:abc123"];
+        Assert.True(cronConversation.IsVirtualSession);
+        Assert.Equal("cron", cronConversation.VirtualSessionKind);
+        Assert.Equal("cron:job-1:20260508010101:abc123", cronConversation.ActiveSessionId);
+    }
+
+    [Fact]
+    public async Task SelectConversation_ForVirtualCronConversation_LoadsSessionHistory()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.Conversations["cron-session:cron:job-1:run"] = new ConversationState
+        {
+            ConversationId = "cron-session:cron:job-1:run",
+            Title = "Cron session",
+            IsVirtualSession = true,
+            VirtualSessionKind = "cron",
+            ActiveSessionId = "cron:job-1:run",
+            HistoryLoaded = false
+        };
+
+        _restClient.GetSessionHistoryAsync("cron:job-1:run", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new SessionHistoryResponseDto(
+                0,
+                200,
+                1,
+                [
+                    new SessionHistoryEntryDto
+                    {
+                        Role = "assistant",
+                        Content = "Cron execution complete",
+                        Timestamp = DateTimeOffset.UtcNow
+                    }
+                ]));
+
+        await _service.SelectConversationAsync("agent-1", "cron-session:cron:job-1:run");
+
+        await _restClient.Received(1).GetSessionHistoryAsync("cron:job-1:run", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        var messages = agent.Conversations["cron-session:cron:job-1:run"].Messages;
+        Assert.Single(messages);
+        Assert.Equal("Cron execution complete", messages[0].Content);
+    }
+
     // ── Steering tests ────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -193,6 +193,24 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
+    public void Virtual_cron_conversation_shows_badge_and_hides_archive_button()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "General", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+        var conv = _store.GetAgent("a-1")!.Conversations["c-1"];
+        conv.IsVirtualSession = true;
+        conv.VirtualSessionKind = "cron";
+
+        var cut = RenderLayout();
+
+        Assert.Contains("Cron", cut.Markup);
+        Assert.Empty(cut.FindAll(".conversation-archive-btn"));
+    }
+
+    [Fact]
     public void Switching_agent_triggers_history_load_for_active_conversation()
     {
         // Arrange: two agents, each with a default conversation auto-selected via SeedConversations

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
@@ -198,6 +198,71 @@ public sealed class ProbeRound3BlazorTests : IDisposable
     }
 
     [Fact]
+    public void CronConfigPanel_ReadsMixedCaseConfig_AndShowsAgentPromptOption()
+    {
+        var config = new JsonObject
+        {
+            ["Cron"] = new JsonObject
+            {
+                ["Enabled"] = true,
+                ["Jobs"] = new JsonObject
+                {
+                    ["daily-summary"] = new JsonObject
+                    {
+                        ["Name"] = "Daily summary",
+                        ["Schedule"] = "0 9 * * *",
+                        ["ActionType"] = "agent-chat",
+                        ["AgentId"] = "assistant",
+                        ["Message"] = "Summarize"
+                    }
+                }
+            }
+        };
+
+        var cut = _ctx.Render<CronConfigPanel>(p => p
+            .Add(c => c.Config, config)
+            .Add(c => c.OnChanged, Microsoft.AspNetCore.Components.EventCallback.Empty));
+
+        Assert.Contains("Daily summary", cut.Markup);
+        Assert.Contains("agent-prompt", cut.Markup);
+    }
+
+    [Fact]
+    public void CronConfigPanel_ModelMetadataField_PreservesMetadataModelValue()
+    {
+        var config = new JsonObject
+        {
+            ["cron"] = new JsonObject
+            {
+                ["jobs"] = new JsonObject
+                {
+                    ["daily-summary"] = new JsonObject
+                    {
+                        ["name"] = "Daily summary",
+                        ["schedule"] = "0 9 * * *",
+                        ["actionType"] = "agent-prompt",
+                        ["metadata"] = new JsonObject
+                        {
+                            ["model"] = "openai/gpt-4.1"
+                        }
+                    }
+                }
+            }
+        };
+
+        var cut = _ctx.Render<CronConfigPanel>(p => p
+            .Add(c => c.Config, config)
+            .Add(c => c.OnChanged, Microsoft.AspNetCore.Components.EventCallback.Empty));
+
+        cut.Markup.ShouldNotBeNullOrWhiteSpace();
+        var model = ((config["cron"] as JsonObject)?["jobs"] as JsonObject)?["daily-summary"]?
+            .AsObject()["metadata"]?
+            .AsObject()["model"]?
+            .GetValue<string>();
+        model.ShouldBe("openai/gpt-4.1");
+    }
+
+    [Fact]
     public void ProvidersConfigPanel_WithExistingProvider_RendersProviderEntry()
     {
         var providerEntry = new JsonObject

--- a/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTests.cs
@@ -1,4 +1,6 @@
 using BotNexus.Cron.Actions;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Triggers;
 using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,28 +15,35 @@ public sealed class AgentPromptActionTests
     {
         var action = new AgentPromptAction();
         var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
         AgentId capturedAgentId = default;
         string? capturedPrompt = null;
+        InternalTriggerRequest? capturedRequest = null;
         var createdSession = SessionId.From("cron:job-1:run-1");
 
         trigger.SetupGet(value => value.Type).Returns(TriggerType.Cron);
-        trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<AgentId, string, CancellationToken>((agentId, prompt, _) =>
+        trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .Callback<AgentId, string, CancellationToken, InternalTriggerRequest?>((agentId, prompt, _, request) =>
             {
                 capturedAgentId = agentId;
                 capturedPrompt = prompt;
+                capturedRequest = request;
             })
             .ReturnsAsync(createdSession);
 
-        var services = BuildServices(trigger.Object);
-        var context = CreateContext(services);
+        registry.Setup(value => value.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+        var services = BuildServices(trigger.Object, registry.Object);
+        var context = CreateContext(services, model: "openai/gpt-4.1");
 
         await action.ExecuteAsync(context);
 
         capturedAgentId.ShouldBe(AgentId.From("agent-a"));
         capturedPrompt.ShouldBe("Ping from cron");
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest!.CronJobId.ShouldBe("job-1");
+        capturedRequest.ModelOverride.ShouldBe("openai/gpt-4.1");
         context.SessionId.ShouldBe(createdSession.Value);
-        trigger.Verify(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        trigger.Verify(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
     }
 
     [Fact]
@@ -49,12 +58,53 @@ public sealed class AgentPromptActionTests
         ex.Message.ShouldContain("Cron internal trigger is not registered");
     }
 
-    private static IServiceProvider BuildServices(IInternalTrigger trigger)
+    [Fact]
+    public async Task ExecuteAsync_SoulAgent_UsesSoulTrigger()
+    {
+        var action = new AgentPromptAction();
+        var cronTrigger = new Mock<IInternalTrigger>();
+        var soulTrigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("agent-a"),
+            DisplayName = "Agent A",
+            ModelId = "gpt-4.1",
+            ApiProvider = "copilot",
+            Soul = new SoulAgentConfig { Enabled = true }
+        };
+
+        registry.Setup(value => value.Get(AgentId.From("agent-a"))).Returns(descriptor);
+        cronTrigger.SetupGet(value => value.Type).Returns(TriggerType.Cron);
+        soulTrigger.SetupGet(value => value.Type).Returns(TriggerType.Soul);
+        soulTrigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(SessionId.From("soul:agent-a:2026-05-08"));
+
+        var services = BuildServices(cronTrigger.Object, soulTrigger.Object, registry.Object);
+        var context = CreateContext(services);
+
+        await action.ExecuteAsync(context);
+
+        soulTrigger.Verify(value =>
+            value.CreateSessionAsync(AgentId.From("agent-a"), "Ping from cron", It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
+        cronTrigger.Verify(value =>
+            value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Never);
+    }
+
+    private static IServiceProvider BuildServices(IInternalTrigger trigger, IAgentRegistry? registry = null)
         => new ServiceCollection()
             .AddSingleton<IInternalTrigger>(trigger)
+            .AddSingleton(registry ?? Mock.Of<IAgentRegistry>())
             .BuildServiceProvider();
 
-    private static CronExecutionContext CreateContext(IServiceProvider services)
+    private static IServiceProvider BuildServices(IInternalTrigger trigger1, IInternalTrigger trigger2, IAgentRegistry registry)
+        => new ServiceCollection()
+            .AddSingleton<IInternalTrigger>(trigger1)
+            .AddSingleton<IInternalTrigger>(trigger2)
+            .AddSingleton(registry)
+            .BuildServiceProvider();
+
+    private static CronExecutionContext CreateContext(IServiceProvider services, string? model = null)
         => new()
         {
             Job = new CronJob
@@ -65,6 +115,7 @@ public sealed class AgentPromptActionTests
                 ActionType = "agent-prompt",
                 AgentId = "agent-a",
                 Message = "Ping from cron",
+                Model = model,
                 CreatedBy = "tester",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Enabled = true

--- a/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
@@ -1,7 +1,10 @@
 using System.Reflection;
+using BotNexus.Cron.Actions;
 using BotNexus.Cron.Tests.TestInfrastructure;
+using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace BotNexus.Cron.Tests;
@@ -65,6 +68,23 @@ public sealed class CronSchedulerTests
     }
 
     [Fact]
+    public async Task Scheduler_RecordsRunSessionId_WhenActionCreatesSession()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var action = new SessionRecordingAction("test-action", "cron:job-1:session-1");
+        var job = CronStoreTestContext.CreateJob("job-1", actionType: "test-action");
+        await context.Store.CreateAsync(job);
+        var scheduler = CreateScheduler(context.Store, [action]);
+
+        var run = await scheduler.RunNowAsync("job-1");
+
+        run.Status.ShouldBe("ok");
+        run.SessionId.ShouldBe("cron:job-1:session-1");
+        var history = await context.Store.GetRunHistoryAsync("job-1");
+        history.ShouldHaveSingleItem().SessionId.ShouldBe("cron:job-1:session-1");
+    }
+
+    [Fact]
     public async Task Scheduler_RecordsErrorOnFailure()
     {
         await using var context = await CronStoreTestContext.CreateAsync();
@@ -84,6 +104,26 @@ public sealed class CronSchedulerTests
         var entry = history.ShouldHaveSingleItem();
         entry.Status.ShouldBe("error");
         entry.Error.ShouldBe("boom");
+    }
+
+    [Fact]
+    public async Task Scheduler_WebhookAction_RecordsError_NotSilentSuccess()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1", actionType: "webhook") with
+        {
+            WebhookUrl = "https://example.test/hook"
+        };
+        await context.Store.CreateAsync(job);
+        var scheduler = CreateScheduler(context.Store, [new WebhookAction()]);
+
+        var run = await scheduler.RunNowAsync("job-1");
+
+        run.Status.ShouldBe("error");
+        run.Error.ShouldNotBeNull();
+        run.Error!.ToLowerInvariant().ShouldContain("not implemented");
+        var history = await context.Store.GetRunHistoryAsync("job-1");
+        history.ShouldHaveSingleItem().Status.ShouldBe("error");
     }
 
     [Fact]
@@ -414,6 +454,69 @@ public sealed class CronSchedulerTests
     }
 
     [Fact]
+    public async Task Scheduler_SyncConfiguredJobs_NormalizesAgentChatAndPersistsModel()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var logger = new ListLogger<CronScheduler>();
+        var options = new CronOptions
+        {
+            Jobs = new Dictionary<string, ConfiguredCronJob>
+            {
+                ["config-job"] = new()
+                {
+                    Name = "Config Prompt Job",
+                    Schedule = "*/5 * * * *",
+                    ActionType = "agent-chat",
+                    AgentId = "agent-a",
+                    Message = "hello",
+                    Model = "openai/gpt-4.1",
+                    Enabled = true
+                }
+            }
+        };
+        var scheduler = CreateScheduler(context.Store, [new RecordingAction("agent-prompt")], options, logger);
+
+        await InvokeSyncConfiguredJobsAsync(scheduler, options);
+
+        var stored = await context.Store.GetAsync("config-job");
+        stored.ShouldNotBeNull();
+        stored!.ActionType.ShouldBe("agent-prompt");
+        stored.Model.ShouldBe("openai/gpt-4.1");
+    }
+
+    [Fact]
+    public async Task Scheduler_SyncConfiguredJobs_InvalidJobs_AreSkippedWithWarnings()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var logger = new ListLogger<CronScheduler>();
+        var options = new CronOptions
+        {
+            Jobs = new Dictionary<string, ConfiguredCronJob>
+            {
+                ["missing-required"] = new()
+                {
+                    ActionType = "agent-prompt",
+                    AgentId = "agent-a"
+                },
+                ["unknown-action"] = new()
+                {
+                    Schedule = "*/5 * * * *",
+                    ActionType = "unknown",
+                    AgentId = "agent-a",
+                    Message = "test"
+                }
+            }
+        };
+        var scheduler = CreateScheduler(context.Store, [new RecordingAction("agent-prompt")], options, logger);
+
+        await InvokeSyncConfiguredJobsAsync(scheduler, options);
+
+        (await context.Store.ListAsync()).ShouldBeEmpty();
+        logger.Messages.ShouldContain(message => message.Contains("Skipping configured cron job 'missing-required'", StringComparison.Ordinal));
+        logger.Messages.ShouldContain(message => message.Contains("Skipping configured cron job 'unknown-action'", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Scheduler_CreateWithInvalidSchedule_SetsNullNextRunAt()
     {
         await using var context = await CronStoreTestContext.CreateAsync();
@@ -432,7 +535,11 @@ public sealed class CronSchedulerTests
         action.ExecutionCount.ShouldBe(0);
     }
 
-    private static CronScheduler CreateScheduler(ICronStore store, IEnumerable<ICronAction> actions)
+    private static CronScheduler CreateScheduler(
+        ICronStore store,
+        IEnumerable<ICronAction> actions,
+        CronOptions? options = null,
+        ILogger<CronScheduler>? logger = null)
     {
         var services = new ServiceCollection().BuildServiceProvider();
         var scopeFactory = services.GetRequiredService<IServiceScopeFactory>();
@@ -440,8 +547,8 @@ public sealed class CronSchedulerTests
             store,
             actions,
             scopeFactory,
-            new StaticOptionsMonitor<CronOptions>(new CronOptions { Enabled = true, TickIntervalSeconds = 1 }),
-            NullLogger<CronScheduler>.Instance);
+            new StaticOptionsMonitor<CronOptions>(options ?? new CronOptions { Enabled = true, TickIntervalSeconds = 1 }),
+            logger ?? NullLogger<CronScheduler>.Instance);
     }
 
     private static async Task InvokeProcessTickAsync(CronScheduler scheduler)
@@ -449,7 +556,16 @@ public sealed class CronSchedulerTests
         var method = typeof(CronScheduler).GetMethod("ProcessTickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
         method.ShouldNotBeNull();
         var task = method!.Invoke(scheduler, [CancellationToken.None]) as Task;
-        task.ShouldNotBeNull();
+        Assert.NotNull(task);
+        await task!;
+    }
+
+    private static async Task InvokeSyncConfiguredJobsAsync(CronScheduler scheduler, CronOptions options)
+    {
+        var method = typeof(CronScheduler).GetMethod("SyncConfiguredJobsAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        method.ShouldNotBeNull();
+        var task = method!.Invoke(scheduler, [options, CancellationToken.None]) as Task;
+        Assert.NotNull(task);
         await task!;
     }
 
@@ -473,10 +589,37 @@ public sealed class CronSchedulerTests
             => throw new InvalidOperationException(message);
     }
 
+    private sealed class SessionRecordingAction(string actionType, string sessionId) : ICronAction
+    {
+        public string ActionType => actionType;
+
+        public Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            context.RecordSessionId(SessionId.From(sessionId));
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class StaticOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
     {
         public T CurrentValue { get; } = currentValue;
         public T Get(string? name) => CurrentValue;
         public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
     }
 }

--- a/tests/gateway/BotNexus.Cron.Tests/CronToolTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronToolTests.cs
@@ -30,6 +30,27 @@ public sealed class CronToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_List_SurfacesModelField()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        store.Setup(value => value.ListAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                CreateJob("job-1", createdBy: "agent-a") with
+                {
+                    Model = "openai/gpt-4.1"
+                }
+            ]);
+        var tool = new CronTool(store.Object, scheduler, "agent-a");
+
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
+        var jobs = JsonSerializer.Deserialize<List<CronJobDto>>(ReadText(result), JsonOptions);
+
+        jobs.ShouldNotBeNull();
+        jobs!.ShouldHaveSingleItem().Model.ShouldBe("openai/gpt-4.1");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Create_CreatesJob()
     {
         var store = new Mock<ICronStore>();
@@ -45,13 +66,15 @@ public sealed class CronToolTests
             ["action"] = "create",
             ["name"] = "Daily summary",
             ["schedule"] = "*/5 * * * *",
-            ["message"] = "Summarize status"
+            ["message"] = "Summarize status",
+            ["model"] = "openai/gpt-4.1"
         });
 
         created.ShouldNotBeNull();
         created!.ActionType.ShouldBe("agent-prompt");
         created.CreatedBy.ShouldBe("agent-a");
         created.AgentId.ShouldBe("agent-a");
+        created.Model.ShouldBe("openai/gpt-4.1");
         ReadText(result).ShouldContain("Daily summary");
     }
 
@@ -274,6 +297,34 @@ public sealed class CronToolTests
         saved!.NextRunAt.ShouldBeNull("invalid schedule should null out NextRunAt");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_Update_UpdatesModel()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        var existingJob = CreateJob("job-1", createdBy: "agent-a") with
+        {
+            Model = "copilot/gpt-4o-mini"
+        };
+        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingJob);
+        CronJob? saved = null;
+        store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
+            .Callback<CronJob, CancellationToken>((job, _) => saved = job)
+            .ReturnsAsync((CronJob job, CancellationToken _) => job);
+        var tool = new CronTool(store.Object, scheduler, "agent-a");
+
+        await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = "update",
+            ["jobId"] = "job-1",
+            ["model"] = "openai/gpt-4.1"
+        });
+
+        saved.ShouldNotBeNull();
+        saved!.Model.ShouldBe("openai/gpt-4.1");
+    }
+
     private static CronScheduler CreateScheduler()
     {
         var store = new Mock<ICronStore>().Object;
@@ -314,6 +365,7 @@ public sealed class CronToolTests
     private sealed class CronJobDto
     {
         public string Id { get; set; } = string.Empty;
+        public string? Model { get; set; }
     }
 
     private sealed class StaticOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>

--- a/tests/gateway/BotNexus.Cron.Tests/QuietHoursTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/QuietHoursTests.cs
@@ -35,7 +35,7 @@ public sealed class QuietHoursTests
 
         await action.ExecuteAsync(context);
 
-        trigger.Verify(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        trigger.Verify(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Never);
         context.SessionId.ShouldBeNull();
     }
 
@@ -55,7 +55,7 @@ public sealed class QuietHoursTests
         var sessionId = SessionId.From("cron:heartbeat:run-1");
 
         trigger.SetupGet(value => value.Type).Returns(TriggerType.Cron);
-        trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
             .ReturnsAsync(sessionId);
         registry.Setup(value => value.Get(AgentId.From("agent-a"))).Returns(descriptor);
 
@@ -67,7 +67,7 @@ public sealed class QuietHoursTests
 
         await action.ExecuteAsync(context);
 
-        trigger.Verify(value => value.CreateSessionAsync(AgentId.From("agent-a"), "Ping from heartbeat", It.IsAny<CancellationToken>()), Times.Once);
+        trigger.Verify(value => value.CreateSessionAsync(AgentId.From("agent-a"), "Ping from heartbeat", It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
         context.SessionId.ShouldBe(sessionId.Value);
     }
 

--- a/tests/gateway/BotNexus.Cron.Tests/SqliteCronStoreTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/SqliteCronStoreTests.cs
@@ -93,6 +93,22 @@ public sealed class SqliteCronStoreTests
     }
 
     [Fact]
+    public async Task CreateAsync_PersistsModelField()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1") with
+        {
+            Model = "openai/gpt-4.1"
+        };
+
+        await context.Store.CreateAsync(job);
+        var loaded = await context.Store.GetAsync("job-1");
+
+        loaded.ShouldNotBeNull();
+        loaded!.Model.ShouldBe("openai/gpt-4.1");
+    }
+
+    [Fact]
     public async Task DeleteAsync_RemovesJob()
     {
         await using var context = await CronStoreTestContext.CreateAsync();

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -1,5 +1,6 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -23,9 +24,21 @@ public sealed class CronTriggerTests
     public async Task CreateSessionAsync_CreatesCronSession_WithCronTriggerType()
     {
         var sessionStore = new Mock<ISessionStore>();
+        var conversationStore = new Mock<IConversationStore>();
         var supervisor = new Mock<IAgentSupervisor>();
         var handle = new Mock<IAgentHandle>();
         GatewaySession? savedSession = null;
+        Conversation? savedConversation = null;
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-default"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "Default",
+            IsDefault = true,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
 
         handle.SetupGet(h => h.AgentId).Returns(AgentId.From("agent-a"));
         handle.SetupGet(h => h.SessionId).Returns(SessionId.From("session-a"));
@@ -44,24 +57,94 @@ public sealed class CronTriggerTests
             .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
             .Callback<GatewaySession, CancellationToken>((session, _) => savedSession = session)
             .Returns(Task.CompletedTask);
+        conversationStore
+            .Setup(value => value.GetOrCreateDefaultAsync(AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+        conversationStore
+            .Setup(value => value.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Callback<Conversation, CancellationToken>((conv, _) => savedConversation = conv)
+            .Returns(Task.CompletedTask);
         supervisor
             .Setup(s => s.GetOrCreateAsync(AgentId.From("agent-a"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
 
-        var trigger = new CronTrigger(supervisor.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
-        var sessionId = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run scheduled task");
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+        var sessionId = await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Run scheduled task",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = "job-1",
+                ModelOverride = "openai/gpt-4.1"
+            });
 
         trigger.Type.ShouldBe(TriggerType.Cron);
-        sessionId.Value.ShouldStartWith("cron:");
+        sessionId.Value.ShouldStartWith("cron:job-1:");
         savedSession.ShouldNotBeNull();
         savedSession!.SessionType.ShouldBe(SessionType.Cron);
         savedSession.ChannelType.ShouldBe(ChannelKey.From("cron"));
         savedSession.CallerId.ShouldBe("cron:agent-a");
+        savedSession.Metadata["cronJobId"].ShouldBe("job-1");
+        savedSession.Metadata["modelOverride"].ShouldBe("openai/gpt-4.1");
+        savedSession.Session.ConversationId.ShouldBe(conversation.ConversationId);
         savedSession.History.Where(e => e.Role == MessageRole.User && e.Content == "Run scheduled task").ShouldHaveSingleItem();
         savedSession.History.Where(e => e.Role == MessageRole.Assistant && e.Content == "cron-response").ShouldHaveSingleItem();
+        savedConversation.ShouldNotBeNull();
+        savedConversation!.ActiveSessionId.ShouldBe(sessionId);
 
         supervisor.Verify(
             s => s.GetOrCreateAsync(AgentId.From("agent-a"), sessionId, It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_CreatesDistinctSessions_PerRun()
+    {
+        var sessionStore = new Mock<ISessionStore>();
+        var conversationStore = new Mock<IConversationStore>();
+        var supervisor = new Mock<IAgentSupervisor>();
+        var handle = new Mock<IAgentHandle>();
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-default"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "Default",
+            IsDefault = true,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "cron-response" });
+        sessionStore
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<SessionId>(), AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
+            .Returns<SessionId, AgentId, CancellationToken>((sessionId, agentId, _) => Task.FromResult(new GatewaySession
+            {
+                SessionId = sessionId,
+                AgentId = agentId
+            }));
+        sessionStore
+            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        conversationStore
+            .Setup(value => value.GetOrCreateDefaultAsync(AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conversation);
+        conversationStore
+            .Setup(value => value.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(AgentId.From("agent-a"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        var first = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 1", request: new InternalTriggerRequest { CronJobId = "job-1" });
+        await Task.Delay(10);
+        var second = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 2", request: new InternalTriggerRequest { CronJobId = "job-1" });
+
+        first.ShouldNotBe(second);
+        first.Value.ShouldStartWith("cron:job-1:");
+        second.Value.ShouldStartWith("cron:job-1:");
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/SoulTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/SoulTriggerTests.cs
@@ -134,7 +134,65 @@ public sealed class SoulTriggerTests
         todaySession.History.ShouldContain(entry => entry.Role == MessageRole.User && entry.Content == "new soul prompt");
         todaySession.History.ShouldContain(entry => entry.Role == MessageRole.Assistant && entry.Content == "Today response");
         sessions.Verify(s => s.SaveAsync(previousSession, It.IsAny<CancellationToken>()), Times.Once);
-        sessions.Verify(s => s.SaveAsync(todaySession, It.IsAny<CancellationToken>()), Times.Once);
+        sessions.Verify(s => s.SaveAsync(todaySession, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_SameDay_ReusesSoulSessionId()
+    {
+        var agentId = AgentId.From("agent-a");
+        var now = new DateTimeOffset(2026, 1, 10, 8, 0, 0, TimeSpan.Zero);
+        var soulDate = new DateOnly(2026, 1, 10);
+        var expectedSessionId = SessionId.ForSoul(agentId, soulDate);
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(agentId)).Returns(CreateDescriptor(agentId, new SoulAgentConfig
+        {
+            Timezone = "UTC",
+            DayBoundary = "06:00"
+        }));
+
+        var session = new GatewaySession
+        {
+            SessionId = expectedSessionId,
+            AgentId = agentId
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.ListAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        sessions.Setup(s => s.GetOrCreateAsync(expectedSessionId, agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "response" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(agentId, expectedSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var trigger = new SoulTrigger(
+            supervisor.Object,
+            registry.Object,
+            sessions.Object,
+            NullLogger<SoulTrigger>.Instance,
+            new FixedTimeProvider(now));
+
+        var first = await trigger.CreateSessionAsync(
+            agentId,
+            "first prompt",
+            request: new BotNexus.Gateway.Abstractions.Triggers.InternalTriggerRequest
+            {
+                CronJobId = "job-1",
+                ModelOverride = "openai/gpt-4.1"
+            });
+        var second = await trigger.CreateSessionAsync(agentId, "second prompt");
+
+        first.ShouldBe(expectedSessionId);
+        second.ShouldBe(expectedSessionId);
+        session.Metadata["soulDate"].ShouldBe("2026-01-10");
+        sessions.Verify(s => s.GetOrCreateAsync(expectedSessionId, agentId, It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     private static AgentDescriptor CreateDescriptor(AgentId agentId, SoulAgentConfig soul)

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
@@ -997,6 +997,43 @@ public sealed class PlatformConfigValidationTests
             });
 
     [Fact]
+    public Task Validate_CronJobWithModelAndAgentChat_BindsFields()
+        => WithConfigFileAsync(
+            """
+            {
+              "cron": {
+                "jobs": {
+                  "daily-summary": {
+                    "schedule": "0 9 * * *",
+                    "actionType": "agent-chat",
+                    "agentId": "assistant",
+                    "message": "Summarize the day",
+                    "model": "openai/gpt-4.1"
+                  }
+                }
+              },
+              "providers": {
+                "copilot": { "apiKey": "test-key" }
+              },
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """,
+            async configPath =>
+            {
+                var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
+                PlatformConfigLoader.Validate(config).ShouldBeEmpty();
+                config.Cron!.Jobs.ShouldContainKey("daily-summary");
+                var job = config.Cron.Jobs["daily-summary"];
+                job.ActionType.ShouldBe("agent-chat");
+                job.Model.ShouldBe("openai/gpt-4.1");
+            });
+
+    [Fact]
     public Task Validate_NoCronSection_NoErrors()
         => WithConfigFileAsync(
             """

--- a/tests/gateway/BotNexus.Gateway.Tests/CronControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CronControllerTests.cs
@@ -15,7 +15,7 @@ public sealed class CronControllerTests
         var store = new FakeCronStore();
         await store.CreateAsync(CreateJob("job-1"));
         await store.CreateAsync(CreateJob("job-2"));
-        var controller = CreateController(store, new RecordingAction());
+        var controller = CreateController(store, new RecordingAction(), new CronOptions());
 
         var result = await controller.List(CancellationToken.None);
 
@@ -29,7 +29,7 @@ public sealed class CronControllerTests
     {
         var store = new FakeCronStore();
         await store.CreateAsync(CreateJob("job-1"));
-        var controller = CreateController(store, new RecordingAction());
+        var controller = CreateController(store, new RecordingAction(), new CronOptions());
 
         var result = await controller.Get("job-1", CancellationToken.None);
 
@@ -42,7 +42,7 @@ public sealed class CronControllerTests
     public async Task Create_ReturnsCreated()
     {
         var store = new FakeCronStore();
-        var controller = CreateController(store, new RecordingAction());
+        var controller = CreateController(store, new RecordingAction(), new CronOptions());
         var request = CreateJob(string.Empty) with { Id = string.Empty };
 
         var result = await controller.Create(request, CancellationToken.None);
@@ -58,7 +58,7 @@ public sealed class CronControllerTests
     {
         var store = new FakeCronStore();
         await store.CreateAsync(CreateJob("job-1"));
-        var controller = CreateController(store, new RecordingAction());
+        var controller = CreateController(store, new RecordingAction(), new CronOptions());
 
         var result = await controller.Delete("job-1", CancellationToken.None);
 
@@ -72,7 +72,7 @@ public sealed class CronControllerTests
         var action = new RecordingAction();
         var store = new FakeCronStore();
         await store.CreateAsync(CreateJob("job-1", actionType: action.ActionType));
-        var controller = CreateController(store, action);
+        var controller = CreateController(store, action, new CronOptions());
 
         var result = await controller.Run("job-1", CancellationToken.None);
 
@@ -82,7 +82,58 @@ public sealed class CronControllerTests
         action.ExecutionCount.ShouldBe(1);
     }
 
-    private static CronController CreateController(FakeCronStore store, ICronAction action)
+    [Fact]
+    public async Task List_IncludesConfiguredJobs_AndNormalizesAgentChat()
+    {
+        var store = new FakeCronStore();
+        var options = new CronOptions
+        {
+            Jobs = new Dictionary<string, ConfiguredCronJob>
+            {
+                ["config-job"] = new()
+                {
+                    Name = "Configured Job",
+                    Schedule = "*/5 * * * *",
+                    ActionType = "agent-chat",
+                    AgentId = "agent-a",
+                    Message = "hello",
+                    Model = "openai/gpt-4.1",
+                    Enabled = true
+                }
+            }
+        };
+        var controller = CreateController(store, new RecordingAction(), options);
+
+        var result = await controller.List(CancellationToken.None);
+
+        var jobs = (result.Result as OkObjectResult)?.Value as IReadOnlyList<CronJob>;
+        jobs.ShouldNotBeNull();
+        var configured = jobs!.Single(job => job.Id == "config-job");
+        configured.ActionType.ShouldBe("agent-prompt");
+        configured.Model.ShouldBe("openai/gpt-4.1");
+    }
+
+    [Fact]
+    public async Task Create_NormalizesAgentChat_AndPersistsModel()
+    {
+        var store = new FakeCronStore();
+        var controller = CreateController(store, new RecordingAction(), new CronOptions());
+        var request = CreateJob(string.Empty) with
+        {
+            Id = string.Empty,
+            ActionType = "agent-chat",
+            Model = "openai/gpt-4.1"
+        };
+
+        var result = await controller.Create(request, CancellationToken.None);
+
+        var created = (result.Result as CreatedAtActionResult)?.Value as CronJob;
+        created.ShouldNotBeNull();
+        created!.ActionType.ShouldBe("agent-prompt");
+        created.Model.ShouldBe("openai/gpt-4.1");
+    }
+
+    private static CronController CreateController(FakeCronStore store, ICronAction action, CronOptions options)
     {
         var scheduler = new CronScheduler(
             store,
@@ -90,7 +141,7 @@ public sealed class CronControllerTests
             new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             new StaticOptionsMonitor<CronOptions>(new CronOptions()),
             NullLogger<CronScheduler>.Instance);
-        return new CronController(store, scheduler);
+        return new CronController(store, scheduler, new StaticOptionsMonitor<CronOptions>(options), NullLogger<CronController>.Instance);
     }
 
     private static CronJob CreateJob(string id, string actionType = "agent-prompt")


### PR DESCRIPTION
## Summary
- Show configured cron jobs in the portal and normalize legacy `agent-chat` cron actions to runtime `agent-prompt`.
- Add first-class cron `model` support across config/API/store/tool/runtime, with legacy `metadata.model` fallback.
- Link cron-triggered sessions to conversations so scheduled runs appear as read-only Cron rows in the portal.
- Improve cron observability: create/update/delete logging, invalid config warnings, job IDs in cron session IDs, and explicit webhook-not-implemented failures.
- Add regression coverage for backend cron behavior and Blazor cron/session surfacing.

## Validation
- Targeted cron tests: 57 passed
- Targeted gateway tests: 74 passed
- Targeted Blazor tests: 39 passed
- `dotnet build BotNexus.slnx --nologo --tl:off`
- `dotnet test BotNexus.slnx --nologo --tl:off`
