### PR TITLE
fix(cron): stable per-job conversation — all runs share one conversation

### DIFF
--- a/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
+++ b/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
@@ -61,7 +61,8 @@ public sealed class AgentPromptAction : ICronAction
                 new InternalTriggerRequest
                 {
                     CronJobId = context.Job.Id,
-                    ModelOverride = context.Job.Model
+                    ModelOverride = context.Job.Model,
+                    ConversationId = context.Job.ConversationId
                 })
             .ConfigureAwait(false);
 

--- a/src/gateway/BotNexus.Cron/CronJob.cs
+++ b/src/gateway/BotNexus.Cron/CronJob.cs
@@ -21,5 +21,11 @@ public sealed record CronJob
     public DateTimeOffset? NextRunAt { get; init; }
     public string? LastRunStatus { get; init; }
     public string? LastRunError { get; init; }
+    /// <summary>
+    /// Optional explicit conversation to route all runs of this job into.
+    /// When set, every run is linked to this conversation regardless of routing.
+    /// When null, a stable per-job conversation is created automatically using the job ID.
+    /// </summary>
+    public string? ConversationId { get; init; }
     public IReadOnlyDictionary<string, object?>? Metadata { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -42,6 +42,7 @@ public sealed class CronTrigger(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
 
+        // Each cron run gets a fresh session ID so history entries are cleanly separated by run.
         var sessionId = BuildCronSessionId(request?.CronJobId);
         var session = await sessions.GetOrCreateAsync(sessionId, agentId, ct).ConfigureAwait(false);
         session.ChannelType ??= ChannelKey.From(Type.Value);
@@ -59,10 +60,25 @@ public sealed class CronTrigger(
         else
             session.Metadata["cronJobId"] = request!.CronJobId;
 
-        var conversation = await conversations.GetOrCreateDefaultAsync(agentId, ct).ConfigureAwait(false);
+        // Resolve the conversation for this run:
+        // 1. Explicit ConversationId on the job — always use that conversation
+        // 2. Otherwise find/create a stable per-job conversation keyed by job ID
+        //    so every run of the same job lands in the same conversation.
+        Conversation conversation;
+        if (!string.IsNullOrWhiteSpace(request?.ConversationId))
+        {
+            conversation = await conversations.GetAsync(ConversationId.From(request.ConversationId), ct).ConfigureAwait(false)
+                ?? await GetOrCreateCronConversationAsync(agentId, request.CronJobId, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            conversation = await GetOrCreateCronConversationAsync(agentId, request?.CronJobId, ct).ConfigureAwait(false);
+        }
+
         if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
             session.Session.ConversationId = conversation.ConversationId;
 
+        // Update the conversation's active session to this run so history loads the latest.
         if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
         {
             conversation.ActiveSessionId = sessionId;
@@ -87,6 +103,40 @@ public sealed class CronTrigger(
             request?.ModelOverride);
 
         return sessionId;
+    }
+
+    /// <summary>
+    /// Finds or creates a stable conversation for a cron job.
+    /// All runs of the same job land in the same conversation.
+    /// The conversation is identified by its title "cron:{jobId}" or "cron:unnamed" for jobs without an ID.
+    /// </summary>
+    private async Task<Conversation> GetOrCreateCronConversationAsync(AgentId agentId, string? jobId, CancellationToken ct)
+    {
+        var title = string.IsNullOrWhiteSpace(jobId)
+            ? $"cron:{agentId.Value}"
+            : $"cron:{SanitizeSessionIdPart(jobId) ?? agentId.Value}";
+
+        // Try to find an existing conversation with this title.
+        var existing = await conversations.ListAsync(agentId, ct).ConfigureAwait(false);
+        var match = existing?.FirstOrDefault(c =>
+            string.Equals(c.Title, title, StringComparison.Ordinal) &&
+            c.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active);
+
+        if (match is not null)
+            return match;
+
+        // Create a new stable conversation for this job.
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = title,
+            IsDefault = false
+        };
+        await conversations.CreateAsync(conversation, ct).ConfigureAwait(false);
+        logger.LogInformation("CronTrigger: created conversation '{Title}' ({ConversationId}) for job '{JobId}'.",
+            title, conversation.ConversationId, jobId);
+        return conversation;
     }
 
     private static SessionId BuildCronSessionId(string? jobId)

--- a/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
@@ -42,4 +42,10 @@ public sealed record InternalTriggerRequest
     /// Supports either "model-id" (current provider) or "provider/model-id".
     /// </summary>
     public string? ModelOverride { get; init; }
+
+    /// <summary>
+    /// Optional explicit conversation ID to route this trigger run into.
+    /// When null, the trigger determines the conversation (e.g. per-job stable conversation for cron).
+    /// </summary>
+    public string? ConversationId { get; init; }
 }

--- a/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTests.cs
@@ -125,4 +125,49 @@ public sealed class AgentPromptActionTests
             TriggerType = CronTriggerType.Scheduled,
             Services = services
         };
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesConversationId_WhenJobHasConversationId()
+    {
+        // Verify that CronJob.ConversationId flows through to InternalTriggerRequest.ConversationId
+        var action = new AgentPromptAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        InternalTriggerRequest? capturedRequest = null;
+
+        trigger.SetupGet(value => value.Type).Returns(TriggerType.Cron);
+        trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .Callback<AgentId, string, CancellationToken, InternalTriggerRequest?>((_, _, _, request) => capturedRequest = request)
+            .ReturnsAsync(SessionId.From("cron:job-pinned:run-1"));
+
+        registry.Setup(value => value.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+        var services = BuildServices(trigger.Object, registry.Object);
+
+        var context = new CronExecutionContext
+        {
+            Job = new CronJob
+            {
+                Id = "job-pinned",
+                Name = "Pinned conversation job",
+                Schedule = "*/1 * * * *",
+                ActionType = "agent-prompt",
+                AgentId = "agent-a",
+                Message = "Run in pinned conversation",
+                ConversationId = "conv-explicit-123",
+                CreatedAt = DateTimeOffset.UtcNow,
+                Enabled = true
+            },
+            RunId = "run-1",
+            TriggeredAt = DateTimeOffset.UtcNow,
+            TriggerType = CronTriggerType.Scheduled,
+            Services = services
+        };
+
+        await action.ExecuteAsync(context);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest!.ConversationId.ShouldBe("conv-explicit-123");
+        capturedRequest.CronJobId.ShouldBe("job-pinned");
+    }
+
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -21,130 +21,207 @@ public sealed class CronTriggerTests
     }
 
     [Fact]
-    public async Task CreateSessionAsync_CreatesCronSession_WithCronTriggerType()
+    public async Task CreateSessionAsync_FirstRun_CreatesPerJobConversation()
     {
-        var sessionStore = new Mock<ISessionStore>();
-        var conversationStore = new Mock<IConversationStore>();
-        var supervisor = new Mock<IAgentSupervisor>();
-        var handle = new Mock<IAgentHandle>();
-        GatewaySession? savedSession = null;
-        Conversation? savedConversation = null;
-        var conversation = new Conversation
-        {
-            ConversationId = ConversationId.From("conv-default"),
-            AgentId = AgentId.From("agent-a"),
-            Title = "Default",
-            IsDefault = true,
-            Status = ConversationStatus.Active,
-            CreatedAt = DateTimeOffset.UtcNow,
-            UpdatedAt = DateTimeOffset.UtcNow
-        };
+        // Arrange: no existing conversations
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        Conversation? createdConversation = null;
 
-        handle.SetupGet(h => h.AgentId).Returns(AgentId.From("agent-a"));
-        handle.SetupGet(h => h.SessionId).Returns(SessionId.From("session-a"));
-        handle.SetupGet(h => h.IsRunning).Returns(true);
-        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentResponse { Content = "cron-response" });
-
-        sessionStore
-            .Setup(s => s.GetOrCreateAsync(It.IsAny<SessionId>(), AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
-            .Returns<SessionId, AgentId, CancellationToken>((sessionId, agentId, _) => Task.FromResult(new GatewaySession
-            {
-                SessionId = sessionId,
-                AgentId = agentId
-            }));
-        sessionStore
-            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
-            .Callback<GatewaySession, CancellationToken>((session, _) => savedSession = session)
-            .Returns(Task.CompletedTask);
         conversationStore
-            .Setup(value => value.GetOrCreateDefaultAsync(AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(conversation);
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation>());
         conversationStore
-            .Setup(value => value.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
-            .Callback<Conversation, CancellationToken>((conv, _) => savedConversation = conv)
-            .Returns(Task.CompletedTask);
-        supervisor
-            .Setup(s => s.GetOrCreateAsync(AgentId.From("agent-a"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(handle.Object);
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Callback<Conversation, CancellationToken>((c, _) => createdConversation = c)
+            .Returns<Conversation, CancellationToken>((c, _) => Task.FromResult(c));
 
         var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        // Act
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
-            "Run scheduled task",
-            request: new InternalTriggerRequest
-            {
-                CronJobId = "job-1",
-                ModelOverride = "openai/gpt-4.1"
-            });
+            "Scheduled task",
+            request: new InternalTriggerRequest { CronJobId = "job-1", ModelOverride = "openai/gpt-4.1" });
 
-        trigger.Type.ShouldBe(TriggerType.Cron);
+        // Assert: conversation created with stable per-job title
+        createdConversation.ShouldNotBeNull();
+        createdConversation!.Title.ShouldBe("cron:job-1");
+        createdConversation.AgentId.ShouldBe(AgentId.From("agent-a"));
+        createdConversation.IsDefault.ShouldBeFalse();
+        conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // Session ID in expected format
         sessionId.Value.ShouldStartWith("cron:job-1:");
-        savedSession.ShouldNotBeNull();
-        savedSession!.SessionType.ShouldBe(SessionType.Cron);
-        savedSession.ChannelType.ShouldBe(ChannelKey.From("cron"));
-        savedSession.CallerId.ShouldBe("cron:agent-a");
-        savedSession.Metadata["cronJobId"].ShouldBe("job-1");
-        savedSession.Metadata["modelOverride"].ShouldBe("openai/gpt-4.1");
-        savedSession.Session.ConversationId.ShouldBe(conversation.ConversationId);
-        savedSession.History.Where(e => e.Role == MessageRole.User && e.Content == "Run scheduled task").ShouldHaveSingleItem();
-        savedSession.History.Where(e => e.Role == MessageRole.Assistant && e.Content == "cron-response").ShouldHaveSingleItem();
-        savedConversation.ShouldNotBeNull();
-        savedConversation!.ActiveSessionId.ShouldBe(sessionId);
 
-        supervisor.Verify(
-            s => s.GetOrCreateAsync(AgentId.From("agent-a"), sessionId, It.IsAny<CancellationToken>()),
-            Times.Once);
+        // Session metadata stamped correctly
+        sessionStore.Verify(s => s.SaveAsync(
+            It.Is<GatewaySession>(gs =>
+                gs.SessionType == SessionType.Cron &&
+                gs.ChannelType == ChannelKey.From("cron") &&
+                gs.Metadata.ContainsKey("cronJobId") &&
+                gs.Metadata["cronJobId"] != null &&
+                gs.Metadata["cronJobId"]!.ToString() == "job-1"),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     [Fact]
-    public async Task CreateSessionAsync_CreatesDistinctSessions_PerRun()
+    public async Task CreateSessionAsync_SecondRun_ReusesExistingJobConversation()
     {
-        var sessionStore = new Mock<ISessionStore>();
-        var conversationStore = new Mock<IConversationStore>();
-        var supervisor = new Mock<IAgentSupervisor>();
-        var handle = new Mock<IAgentHandle>();
-        var conversation = new Conversation
+        // Arrange: conversation for this job already exists
+        var existingConversation = new Conversation
         {
-            ConversationId = ConversationId.From("conv-default"),
+            ConversationId = ConversationId.From("conv-job-1"),
             AgentId = AgentId.From("agent-a"),
-            Title = "Default",
-            IsDefault = true,
+            Title = "cron:job-1",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation> { existingConversation });
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        // Act
+        var sessionId = await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Scheduled task run 2",
+            request: new InternalTriggerRequest { CronJobId = "job-1" });
+
+        // Assert: no new conversation created — existing one reused
+        conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Existing conversation updated to point to new session
+        conversationStore.Verify(s => s.SaveAsync(
+            It.Is<Conversation>(c => c.ConversationId == ConversationId.From("conv-job-1")),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Fresh session ID per run
+        sessionId.Value.ShouldStartWith("cron:job-1:");
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_ExplicitConversationId_BypassesJobConversationLookup()
+    {
+        // Arrange: job pinned to a specific existing conversation
+        var pinnedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-pinned"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "My custom conversation",
+            IsDefault = false,
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
         };
 
-        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentResponse { Content = "cron-response" });
-        sessionStore
-            .Setup(s => s.GetOrCreateAsync(It.IsAny<SessionId>(), AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
-            .Returns<SessionId, AgentId, CancellationToken>((sessionId, agentId, _) => Task.FromResult(new GatewaySession
-            {
-                SessionId = sessionId,
-                AgentId = agentId
-            }));
-        sessionStore
-            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+
         conversationStore
-            .Setup(value => value.GetOrCreateDefaultAsync(AgentId.From("agent-a"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(conversation);
-        conversationStore
-            .Setup(value => value.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        supervisor
-            .Setup(s => s.GetOrCreateAsync(AgentId.From("agent-a"), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(handle.Object);
+            .Setup(s => s.GetAsync(ConversationId.From("conv-pinned"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pinnedConversation);
 
         var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
 
-        var first = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 1", request: new InternalTriggerRequest { CronJobId = "job-1" });
-        await Task.Delay(10);
-        var second = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 2", request: new InternalTriggerRequest { CronJobId = "job-1" });
+        // Act
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Pinned task",
+            request: new InternalTriggerRequest { CronJobId = "job-2", ConversationId = "conv-pinned" });
 
+        // Assert: no ListAsync (bypassed), no CreateAsync
+        conversationStore.Verify(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()), Times.Never);
+        conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Pinned conversation updated
+        conversationStore.Verify(s => s.SaveAsync(
+            It.Is<Conversation>(c => c.ConversationId == ConversationId.From("conv-pinned")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_EachRun_GetsDistinctSessionId()
+    {
+        var jobConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-job"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "cron:job-1",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        var listCallCount = 0;
+
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                listCallCount++;
+                return listCallCount == 1
+                    ? new List<Conversation>()
+                    : new List<Conversation> { jobConversation };
+            });
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Returns<Conversation, CancellationToken>((c, _) =>
+            {
+                jobConversation = c with { ConversationId = c.ConversationId };
+                return Task.FromResult(c);
+            });
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        var first = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 1",
+            request: new InternalTriggerRequest { CronJobId = "job-1" });
+        var second = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 2",
+            request: new InternalTriggerRequest { CronJobId = "job-1" });
+
+        // Different session IDs per run
         first.ShouldNotBe(second);
         first.Value.ShouldStartWith("cron:job-1:");
         second.Value.ShouldStartWith("cron:job-1:");
+
+        // First run created the conversation, second reused it
+        conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static (Mock<ISessionStore>, Mock<IConversationStore>, Mock<IAgentSupervisor>) BuildStandardMocks()
+    {
+        var sessionStore = new Mock<ISessionStore>();
+        var conversationStore = new Mock<IConversationStore>();
+        var supervisor = new Mock<IAgentSupervisor>();
+        var handle = new Mock<IAgentHandle>();
+
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "cron-response" });
+
+        sessionStore
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<SessionId>(), It.IsAny<AgentId>(), It.IsAny<CancellationToken>()))
+            .Returns<SessionId, AgentId, CancellationToken>((sid, aid, _) =>
+                Task.FromResult(new GatewaySession { SessionId = sid, AgentId = aid }));
+        sessionStore
+            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        conversationStore
+            .Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        return (sessionStore, conversationStore, supervisor);
     }
 }


### PR DESCRIPTION
Each cron job now has a stable conversation that all its runs land in.

## Problem

Cron runs were either all going to the agent's default conversation (mixing heartbeats and named jobs), or creating new conversations per run depending on routing.

## Fix

**`CronTrigger.GetOrCreateCronConversationAsync`** — finds or creates a stable conversation titled `cron:{jobId}` on first run and reuses it for all subsequent runs.

Each run still gets a **new `SessionId`** (clean execution history per run), but all sessions link to the same conversation — so the portal shows one conversation per job with all historical runs as sessions.

**Optional explicit conversation** — add `conversationId` to the cron job config to pin all runs to a specific conversation (e.g. the agent's default conversation or any other).

## Behaviour

| Scenario | Conversation |
|---|---|
| Cron job `heartbeat:my-agent` runs | `cron:heartbeat-my-agent` (stable) |
| Same job runs again | Same conversation, new session |
| Job with explicit `conversationId` set | That conversation |
| Job without ID | `cron:{agentId}` |