### PR TITLE
fix: archive old cron conversation cleanup ids

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -37,3 +37,4 @@
 - Extension-loading hosts need dispatcher fallback for lazy hub activation.
 - `GetOrCreateDefaultAsync` retired — use ListAsync for discovery, SaveAsync for state transitions.
 - Phase 2 dispatch layer: `IConversationDispatcher` owns inbound resolution/session binding; Hub/Host become pure transport relays.
+- Old cron sidebar IDs (`cron-session:{sessionId}`) can outlive conversation links; cleanup should still return 204, sealing any existing session while leaving history intact.

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -24,3 +24,8 @@
 4. **Component-level CSS state** — data attributes or classes for active state via component lifecycle
 
 **Test Philosophy:** Manual browser testing for scroll/layout UX; bUnit for component lifecycle; Playwright for E2E.
+
+## Learnings
+
+### 2026-05-11 — Cron Virtual Session Cleanup Must Route Through Session Deletion
+Virtual cron conversation projections (`cron-session:{sessionId}`) are UI-only constructs backed by session data, not real conversation records. Cleanup must call `DELETE /api/sessions/{sessionId}` — not `DELETE /api/conversations/{virtualId}` — or the backend returns 404. Stale orphans with no `ActiveSessionId` should be cleaned up locally without any API call. The `file.exe` URL prefix in browser dev-tools console logs was a display artifact, not a real REST base URL issue.

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -27,5 +27,5 @@
 
 ## Learnings
 
-### 2026-05-11 — Cron Virtual Session Cleanup Must Route Through Session Deletion
-Virtual cron conversation projections (`cron-session:{sessionId}`) are UI-only constructs backed by session data, not real conversation records. Cleanup must call `DELETE /api/sessions/{sessionId}` — not `DELETE /api/conversations/{virtualId}` — or the backend returns 404. Stale orphans with no `ActiveSessionId` should be cleaned up locally without any API call. The `file.exe` URL prefix in browser dev-tools console logs was a display artifact, not a real REST base URL issue.
+### 2026-05-11 — Cron Virtual Session Cleanup Must Route Through Conversation Archive
+Virtual cron conversation projections (`cron-session:{sessionId}`) should be cleaned up via `DELETE /api/conversations/{conversationId}` (ArchiveConversationAsync), NOT `DELETE /api/sessions/{sessionId}`. The backend handles `cron-session:` prefixed IDs idempotently — returns 204 even when no backing session exists. This preserves session records/history while hiding the conversation from the sidebar. The prior approach of calling session delete was incorrect as it permanently destroyed session data. Stale orphans (no ActiveSessionId) also route through conversation archive since the backend handles them gracefully.

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -40,4 +40,5 @@
 - Coverage gap: no gateway-level tests verify graceful degradation when extensions are absent or fail load.
 - CLI update regression coverage must assert pull failures short-circuit before stop/start.
 - Sub-agent wake delivery tests should assert both dispatch metadata and stream-event channel capabilities.
-- Legacy cron cleanup regressions should include fallback coverage: if DELETE /api/conversations/{cron-session-id} fails for old projections, Blazor must fall back to session cleanup and remove the row without console failure.
+- [CORRECTED] Legacy cron cleanup regressions must assert Blazor uses DELETE /api/conversations/{cron-session-id} (archive path only) and never falls back to session deletion; gateway must preserve/seal session history for linked/orphan projections.
+

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -40,3 +40,4 @@
 - Coverage gap: no gateway-level tests verify graceful degradation when extensions are absent or fail load.
 - CLI update regression coverage must assert pull failures short-circuit before stop/start.
 - Sub-agent wake delivery tests should assert both dispatch metadata and stream-event channel capabilities.
+- Legacy cron cleanup regressions should include fallback coverage: if DELETE /api/conversations/{cron-session-id} fails for old projections, Blazor must fall back to session cleanup and remove the row without console failure.

--- a/.squad/decisions/inbox/fry-old-cron-cleanup-404.md
+++ b/.squad/decisions/inbox/fry-old-cron-cleanup-404.md
@@ -1,0 +1,30 @@
+# Fry Decision: Virtual Cron Cleanup Routes Through Session Deletion
+
+**Date:** 2026-05-11
+**Author:** Fry (Web Dev)
+**Scope:** BlazorClient — AgentInteractionService
+**Status:** Implemented
+
+## Context
+
+Deleting old cron conversations from the sidebar returned 404 because `ArchiveConversationAsync` sent `DELETE /api/conversations/{virtualId}` using the UI-only virtual key (e.g. `cron-session:cron:20260509002033:...`). These IDs don't exist as real conversations — they're projections created by `MergeVirtualCronSessions` from session summaries.
+
+## Decision
+
+- Virtual cron sessions now route cleanup to `DELETE /api/sessions/{ActiveSessionId}` via the existing `DeleteSessionAsync` REST method.
+- Stale orphan projections (where `ActiveSessionId` is null) are cleaned up locally without any API call — the virtual row is simply removed from the sidebar.
+- A legacy fallback also attempts session deletion when a non-virtual conversation archive returns failure and the conversation ID matches the `cron-session:` pattern.
+- Normal (non-virtual) conversations continue using `DELETE /api/conversations/{id}` unchanged.
+
+## Test Coverage
+
+- `ArchiveConversationAsync_ForVirtualCronConversation_DeletesSessionAndRemovesConversation` — verifies session deletion routing
+- `ArchiveConversationAsync_ForVirtualCronWithColonsInId_DeletesCorrectSession` — verifies URL encoding of colon-heavy IDs
+- `ArchiveConversationAsync_ForStaleOrphanCronWithNoSession_RemovesLocallyWithoutApiCall` — verifies orphan cleanup
+- `ArchiveConversationAsync_ForNormalConversation_StillUsesConversationArchive` — regression guard
+- `GatewayRestClientTests` — new tests verify encoded session IDs and 404 handling
+
+## Impact
+
+- **Bender:** Backend also added gateway-side handling for legacy `cron-session:` IDs as a safety net.
+- **Hermes:** Old test replaced with 4 new tests covering the routing, encoding, orphan, and regression scenarios.

--- a/.squad/decisions/inbox/fry-preserve-session-cleanup-ui.md
+++ b/.squad/decisions/inbox/fry-preserve-session-cleanup-ui.md
@@ -1,0 +1,30 @@
+# Decision: Cron Conversation Cleanup Preserves Session Records
+
+**Author:** Fry (Web Dev)
+**Date:** 2026-05-11
+**Scope:** BlazorClient UI + API contract
+**Status:** Implemented
+
+## Context
+
+The prior implementation routed virtual cron conversation cleanup through `DELETE /api/sessions/{sessionId}`, which permanently deletes session records and history. This was a data-loss regression — users expected "close/archive" semantics that hide conversations while preserving underlying session data.
+
+## Decision
+
+- Virtual cron conversation cleanup now routes through `DELETE /api/conversations/{conversationId}` (the same `ArchiveConversationAsync` path used for regular conversations).
+- The conversation ID sent to the backend is the full `cron-session:{sessionId}` string, URL-encoded.
+- Backend returns 204 idempotently for `cron-session:` prefixed IDs even when no backing session exists (handles stale orphans).
+- `DeleteSessionAsync` removed from `IGatewayRestClient` — it was added solely for this cleanup path and has no other UI use.
+- Stale orphans (no `ActiveSessionId`) still call the conversations endpoint rather than being cleaned up locally-only, since the backend handles them gracefully.
+
+## Rationale
+
+1. **Session preservation** — Sessions contain execution history that must survive conversation cleanup.
+2. **Unified cleanup path** — All conversation types (regular, cron, legacy projections) use the same API.
+3. **Idempotent backend** — No need for client-side branching logic; backend handles all cron-session: variants.
+4. **Reduced surface area** — Removing DeleteSessionAsync from the UI client prevents accidental session destruction.
+
+## Impact
+
+- **Bender:** Backend already returns 204 for cron-session: archives. No changes needed.
+- **Hermes:** Tests rewritten to assert conversations endpoint is called (not sessions) and that session delete is never invoked.

--- a/.squad/decisions/inbox/hermes-no-session-delete-regression.md
+++ b/.squad/decisions/inbox/hermes-no-session-delete-regression.md
@@ -1,0 +1,22 @@
+# Hermes Decision Inbox — No Session Delete Regression Guard
+
+- **Date:** 2026-05-11
+- **Author:** Hermes (QA)
+- **Scope:** Blazor cron virtual cleanup + Gateway virtual cron archive contract
+
+## Recommendation
+
+Lock regression coverage to this invariant:
+
+1. **Blazor client (`AgentInteractionService`)** must always route cron virtual cleanup via `ArchiveConversationAsync` (`DELETE /api/conversations/{cron-session-id}`) and must never call `DeleteSessionAsync`.
+2. **Gateway (`ConversationsController`)** must continue returning **204 No Content** for `cron-session:{sessionId}` in linked, orphan, and missing-session cases, while sealing/preserving existing session records when present.
+
+## Why this matters
+
+Session deletion breaks conversation history guarantees and can remove persisted records users expect to retain. Archive-path cleanup keeps sidebar cleanup behavior while preserving history for reopen and audit scenarios.
+
+## Evidence
+
+- `tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs`
+- `tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs`
+- `tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs`

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/Abstractions/IGatewayRestClient.cs
@@ -54,9 +54,6 @@ public interface IGatewayRestClient
     /// <summary>DELETE /api/conversations/{conversationId} — soft delete (archive).</summary>
     Task<bool> ArchiveConversationAsync(string conversationId, CancellationToken ct = default);
 
-    /// <summary>DELETE /api/sessions/{sessionId} — closes/removes a session.</summary>
-    Task<bool> DeleteSessionAsync(string sessionId, CancellationToken ct = default);
-
     /// <summary>Current API base URL (set via Configure). Null if not yet configured.</summary>
     string? ApiBaseUrl { get; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -260,18 +260,11 @@ public sealed class AgentInteractionService : IAgentInteractionService
             if (_featureFlags?.ConversationHistoryCache == true && _cache is not null)
                 await _cache.InvalidateAsync(conversationId);
 
-            // Virtual cron sessions are projections from session data, not real conversations.
-            // Route cleanup to DELETE /api/sessions/{sessionId} instead of conversations.
-            var isVirtualCron = conversation.IsVirtualSession &&
-                                string.Equals(conversation.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase);
-            var success = isVirtualCron
-                ? await DeleteVirtualCronSessionAsync(conversation)
-                : await _restClient.ArchiveConversationAsync(conversationId);
-
-            // Older UI projections may surface legacy cron-session IDs without virtual flags.
-            // If archive returns 404/false, fall back to session cleanup using the encoded session ID.
-            if (!success && TryResolveLegacyCronSessionId(conversation, out var legacySessionId))
-                success = await _restClient.DeleteSessionAsync(legacySessionId);
+            // All conversation cleanup — including virtual cron projections — routes through
+            // DELETE /api/conversations/{conversationId}. The backend handles cron-session: IDs
+            // idempotently (returns 204 even if no backing session exists), preserving session
+            // records while hiding the conversation from the sidebar.
+            var success = await _restClient.ArchiveConversationAsync(conversationId);
 
             if (!success)
             {
@@ -612,41 +605,7 @@ public sealed class AgentInteractionService : IAgentInteractionService
         _ => role
     };
 
-    /// <summary>
-    /// Deletes the backing session for a virtual cron conversation projection.
-    /// Returns false if the session ID is missing (stale orphan).
-    /// </summary>
-    private async Task<bool> DeleteVirtualCronSessionAsync(ConversationState conversation)
-    {
-        if (string.IsNullOrEmpty(conversation.ActiveSessionId))
-        {
-            // Stale orphan — no backing session to delete. Treat as success
-            // so the virtual row is removed from the sidebar.
-            return true;
-        }
 
-        return await _restClient.DeleteSessionAsync(conversation.ActiveSessionId);
-    }
-
-    private static bool TryResolveLegacyCronSessionId(ConversationState conversation, out string sessionId)
-    {
-        if (!string.IsNullOrWhiteSpace(conversation.ActiveSessionId))
-        {
-            sessionId = conversation.ActiveSessionId;
-            return true;
-        }
-
-        const string prefix = "cron-session:";
-        if (conversation.ConversationId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-            conversation.ConversationId.Length > prefix.Length)
-        {
-            sessionId = conversation.ConversationId[prefix.Length..];
-            return true;
-        }
-
-        sessionId = string.Empty;
-        return false;
-    }
 
     private static void MergeVirtualCronSessions(AgentState agent, IReadOnlyList<SessionSummary> sessions)
     {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -260,7 +260,19 @@ public sealed class AgentInteractionService : IAgentInteractionService
             if (_featureFlags?.ConversationHistoryCache == true && _cache is not null)
                 await _cache.InvalidateAsync(conversationId);
 
-            var success = await _restClient.ArchiveConversationAsync(conversationId);
+            // Virtual cron sessions are projections from session data, not real conversations.
+            // Route cleanup to DELETE /api/sessions/{sessionId} instead of conversations.
+            var isVirtualCron = conversation.IsVirtualSession &&
+                                string.Equals(conversation.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase);
+            var success = isVirtualCron
+                ? await DeleteVirtualCronSessionAsync(conversation)
+                : await _restClient.ArchiveConversationAsync(conversationId);
+
+            // Older UI projections may surface legacy cron-session IDs without virtual flags.
+            // If archive returns 404/false, fall back to session cleanup using the encoded session ID.
+            if (!success && TryResolveLegacyCronSessionId(conversation, out var legacySessionId))
+                success = await _restClient.DeleteSessionAsync(legacySessionId);
+
             if (!success)
             {
                 Console.Error.WriteLine($"AgentInteractionService: Conversation cleanup returned failure for {conversationId}");
@@ -599,6 +611,42 @@ public sealed class AgentInteractionService : IAgentInteractionService
         "system" => "System",
         _ => role
     };
+
+    /// <summary>
+    /// Deletes the backing session for a virtual cron conversation projection.
+    /// Returns false if the session ID is missing (stale orphan).
+    /// </summary>
+    private async Task<bool> DeleteVirtualCronSessionAsync(ConversationState conversation)
+    {
+        if (string.IsNullOrEmpty(conversation.ActiveSessionId))
+        {
+            // Stale orphan — no backing session to delete. Treat as success
+            // so the virtual row is removed from the sidebar.
+            return true;
+        }
+
+        return await _restClient.DeleteSessionAsync(conversation.ActiveSessionId);
+    }
+
+    private static bool TryResolveLegacyCronSessionId(ConversationState conversation, out string sessionId)
+    {
+        if (!string.IsNullOrWhiteSpace(conversation.ActiveSessionId))
+        {
+            sessionId = conversation.ActiveSessionId;
+            return true;
+        }
+
+        const string prefix = "cron-session:";
+        if (conversation.ConversationId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+            conversation.ConversationId.Length > prefix.Length)
+        {
+            sessionId = conversation.ConversationId[prefix.Length..];
+            return true;
+        }
+
+        sessionId = string.Empty;
+        return false;
+    }
 
     private static void MergeVirtualCronSessions(AgentState agent, IReadOnlyList<SessionSummary> sessions)
     {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayRestClient.cs
@@ -140,13 +140,4 @@ public sealed class GatewayRestClient : IGatewayRestClient
             $"{_apiBaseUrl}conversations/{Uri.EscapeDataString(conversationId)}", ct);
         return response.IsSuccessStatusCode;
     }
-
-    /// <inheritdoc />
-    public async Task<bool> DeleteSessionAsync(string sessionId, CancellationToken ct = default)
-    {
-        EnsureConfigured();
-        var response = await _http.DeleteAsync(
-            $"{_apiBaseUrl}sessions/{Uri.EscapeDataString(sessionId)}", ct);
-        return response.IsSuccessStatusCode;
-    }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -4,6 +4,8 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SessionId = BotNexus.Domain.Primitives.SessionId;
+using SessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
 namespace BotNexus.Gateway.Api.Controllers;
 
@@ -319,21 +321,36 @@ public sealed class ConversationsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Archive(string conversationId, CancellationToken cancellationToken)
     {
+        SessionId? virtualCronSessionId = null;
         var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
-        if (conversation is null) return NotFound();
-
-        if (conversation.ActiveSessionId is { } activeSessionId)
+        if (conversation is null && TryParseVirtualCronConversationId(conversationId, out var virtualSessionId))
         {
-            var session = await _sessions.GetAsync(activeSessionId, cancellationToken);
-            if (session is not null)
+            virtualCronSessionId = virtualSessionId;
+            var virtualSession = await _sessions.GetAsync(virtualSessionId, cancellationToken);
+            if (virtualSession is null)
+                return NoContent();
+
+            if (virtualSession.Session.ConversationId is { } linkedConversationId)
+                conversation = await _conversations.GetAsync(linkedConversationId, cancellationToken);
+
+            if (conversation is null)
             {
-                session.Status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                await _sessions.SaveAsync(session, cancellationToken);
+                await SealSessionAsync(virtualSessionId, cancellationToken);
+                return NoContent();
             }
         }
 
-        await _conversations.ArchiveAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+
+        if (virtualCronSessionId.HasValue)
+            await SealSessionAsync(virtualCronSessionId.Value, cancellationToken);
+
+        if (conversation.ActiveSessionId is { } activeSessionId)
+            if (!virtualCronSessionId.HasValue || virtualCronSessionId.Value != activeSessionId)
+                await SealSessionAsync(activeSessionId, cancellationToken);
+
+        await _conversations.ArchiveAsync(conversation.ConversationId, cancellationToken);
         return NoContent();
     }
 
@@ -359,5 +376,30 @@ public sealed class ConversationsController : ControllerBase
         ThreadingMode: b.ThreadingMode.ToString(),
         DisplayPrefix: b.DisplayPrefix,
         BoundAt: b.BoundAt);
+
+    private async Task SealSessionAsync(SessionId sessionId, CancellationToken cancellationToken)
+    {
+        var session = await _sessions.GetAsync(sessionId, cancellationToken);
+        if (session is null || session.Status == SessionStatus.Sealed)
+            return;
+
+        session.Status = SessionStatus.Sealed;
+        session.UpdatedAt = DateTimeOffset.UtcNow;
+        await _sessions.SaveAsync(session, cancellationToken);
+    }
+
+    private static bool TryParseVirtualCronConversationId(string conversationId, out SessionId sessionId)
+    {
+        const string prefix = "cron-session:";
+        if (conversationId.StartsWith(prefix, StringComparison.Ordinal) &&
+            conversationId.Length > prefix.Length)
+        {
+            sessionId = SessionId.From(conversationId[prefix.Length..]);
+            return true;
+        }
+
+        sessionId = default;
+        return false;
+    }
 
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -236,7 +236,7 @@ public sealed class AgentInteractionServiceTests
     }
 
     [Fact]
-    public async Task ArchiveConversationAsync_ForVirtualCronConversation_ArchivesConversationAndRemovesConversation()
+    public async Task ArchiveConversationAsync_ForVirtualCronConversation_DeletesSessionAndRemovesConversation()
     {
         var agent = _store.GetAgent("agent-1")!;
         agent.Conversations["conv-1"] = new ConversationState
@@ -258,15 +258,119 @@ public sealed class AgentInteractionServiceTests
         };
         _store.SetActiveConversation("agent-1", "cron-session:cron:job-1:run");
 
-        _restClient.ArchiveConversationAsync("cron-session:cron:job-1:run", Arg.Any<CancellationToken>())
+        _restClient.DeleteSessionAsync("cron:job-1:run", Arg.Any<CancellationToken>())
             .Returns(true);
 
         await _service.ArchiveConversationAsync("agent-1", "cron-session:cron:job-1:run");
 
-        await _restClient.Received(1).ArchiveConversationAsync("cron-session:cron:job-1:run", Arg.Any<CancellationToken>());
-        await _restClient.DidNotReceive().DeleteSessionAsync("cron:job-1:run", Arg.Any<CancellationToken>());
+        // Should route through session deletion, not conversation archive
+        await _restClient.Received(1).DeleteSessionAsync("cron:job-1:run", Arg.Any<CancellationToken>());
+        await _restClient.DidNotReceive().ArchiveConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         agent.Conversations.ContainsKey("cron-session:cron:job-1:run").ShouldBeFalse();
         agent.ActiveConversationId.ShouldBe("conv-1");
+    }
+
+    [Fact]
+    public async Task ArchiveConversationAsync_ForVirtualCronWithColonsInId_DeletesCorrectSession()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        const string sessionId = "cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54";
+        var cronKey = $"cron-session:{sessionId}";
+
+        agent.Conversations[cronKey] = new ConversationState
+        {
+            ConversationId = cronKey,
+            Title = "Cron · cron:202",
+            IsVirtualSession = true,
+            VirtualSessionKind = "cron",
+            ActiveSessionId = sessionId,
+            HistoryLoaded = true
+        };
+        _store.SetActiveConversation("agent-1", cronKey);
+
+        _restClient.DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await _service.ArchiveConversationAsync("agent-1", cronKey);
+
+        await _restClient.Received(1).DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>());
+        await _restClient.DidNotReceive().ArchiveConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        agent.Conversations.ContainsKey(cronKey).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ArchiveConversationAsync_ForStaleOrphanCronWithNoSession_RemovesLocallyWithoutApiCall()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        const string cronKey = "cron-session:cron:stale:orphan";
+        agent.Conversations[cronKey] = new ConversationState
+        {
+            ConversationId = cronKey,
+            Title = "Cron · stale",
+            IsVirtualSession = true,
+            VirtualSessionKind = "cron",
+            ActiveSessionId = null, // stale — no backing session
+            HistoryLoaded = false
+        };
+
+        await _service.ArchiveConversationAsync("agent-1", cronKey);
+
+        // No REST calls should be made for stale orphans
+        await _restClient.DidNotReceive().ArchiveConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _restClient.DidNotReceive().DeleteSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        agent.Conversations.ContainsKey(cronKey).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54")]
+    [InlineData("cron:20260510001608:c7fe67628e3142a1894974d22bb998a8")]
+    public async Task ArchiveConversationAsync_ForLegacyCronProjection_WhenArchiveFails_FallsBackToSessionCleanup(string sessionId)
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var cronKey = $"cron-session:{sessionId}";
+        agent.Conversations[cronKey] = new ConversationState
+        {
+            ConversationId = cronKey,
+            Title = "Legacy cron projection",
+            IsDefault = false,
+            // Legacy projection: no virtual flags and no active session linkage in local state.
+            ActiveSessionId = null,
+            HistoryLoaded = false
+        };
+
+        _restClient.ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>())
+            .Returns(false);
+        _restClient.DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await _service.ArchiveConversationAsync("agent-1", cronKey);
+
+        await _restClient.Received(1).ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>());
+        await _restClient.Received(1).DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>());
+        agent.Conversations.ContainsKey(cronKey).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ArchiveConversationAsync_ForNormalConversation_StillUsesConversationArchive()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.Conversations["conv-normal"] = new ConversationState
+        {
+            ConversationId = "conv-normal",
+            Title = "Normal conversation",
+            IsDefault = false,
+            HistoryLoaded = true
+        };
+        _store.SetActiveConversation("agent-1", "conv-normal");
+
+        _restClient.ArchiveConversationAsync("conv-normal", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await _service.ArchiveConversationAsync("agent-1", "conv-normal");
+
+        await _restClient.Received(1).ArchiveConversationAsync("conv-normal", Arg.Any<CancellationToken>());
+        await _restClient.DidNotReceive().DeleteSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        agent.Conversations.ContainsKey("conv-normal").ShouldBeFalse();
     }
 
     // ── Steering tests ────────────────────────────────────────────────────

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -236,7 +236,7 @@ public sealed class AgentInteractionServiceTests
     }
 
     [Fact]
-    public async Task ArchiveConversationAsync_ForVirtualCronConversation_DeletesSessionAndRemovesConversation()
+    public async Task ArchiveConversationAsync_ForVirtualCronConversation_ArchivesConversationNotSession()
     {
         var agent = _store.GetAgent("agent-1")!;
         agent.Conversations["conv-1"] = new ConversationState
@@ -258,20 +258,19 @@ public sealed class AgentInteractionServiceTests
         };
         _store.SetActiveConversation("agent-1", "cron-session:cron:job-1:run");
 
-        _restClient.DeleteSessionAsync("cron:job-1:run", Arg.Any<CancellationToken>())
+        _restClient.ArchiveConversationAsync("cron-session:cron:job-1:run", Arg.Any<CancellationToken>())
             .Returns(true);
 
         await _service.ArchiveConversationAsync("agent-1", "cron-session:cron:job-1:run");
 
-        // Should route through session deletion, not conversation archive
-        await _restClient.Received(1).DeleteSessionAsync("cron:job-1:run", Arg.Any<CancellationToken>());
-        await _restClient.DidNotReceive().ArchiveConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Must route through conversation archive (not session deletion) to preserve session records
+        await _restClient.Received(1).ArchiveConversationAsync("cron-session:cron:job-1:run", Arg.Any<CancellationToken>());
         agent.Conversations.ContainsKey("cron-session:cron:job-1:run").ShouldBeFalse();
         agent.ActiveConversationId.ShouldBe("conv-1");
     }
 
     [Fact]
-    public async Task ArchiveConversationAsync_ForVirtualCronWithColonsInId_DeletesCorrectSession()
+    public async Task ArchiveConversationAsync_ForVirtualCronWithColonsInId_ArchivesWithEncodedConversationId()
     {
         var agent = _store.GetAgent("agent-1")!;
         const string sessionId = "cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54";
@@ -288,18 +287,18 @@ public sealed class AgentInteractionServiceTests
         };
         _store.SetActiveConversation("agent-1", cronKey);
 
-        _restClient.DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>())
+        _restClient.ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>())
             .Returns(true);
 
         await _service.ArchiveConversationAsync("agent-1", cronKey);
 
-        await _restClient.Received(1).DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>());
-        await _restClient.DidNotReceive().ArchiveConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Calls conversations endpoint with full cron-session:... ID, not sessions endpoint
+        await _restClient.Received(1).ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>());
         agent.Conversations.ContainsKey(cronKey).ShouldBeFalse();
     }
 
     [Fact]
-    public async Task ArchiveConversationAsync_ForStaleOrphanCronWithNoSession_RemovesLocallyWithoutApiCall()
+    public async Task ArchiveConversationAsync_ForStaleOrphanCron_CallsConversationArchive()
     {
         var agent = _store.GetAgent("agent-1")!;
         const string cronKey = "cron-session:cron:stale:orphan";
@@ -313,18 +312,21 @@ public sealed class AgentInteractionServiceTests
             HistoryLoaded = false
         };
 
+        // Backend returns 204 for cron-session: IDs with missing backing sessions
+        _restClient.ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>())
+            .Returns(true);
+
         await _service.ArchiveConversationAsync("agent-1", cronKey);
 
-        // No REST calls should be made for stale orphans
-        await _restClient.DidNotReceive().ArchiveConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _restClient.DidNotReceive().DeleteSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Stale orphans still call the conversations endpoint (backend handles idempotently)
+        await _restClient.Received(1).ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>());
         agent.Conversations.ContainsKey(cronKey).ShouldBeFalse();
     }
 
     [Theory]
     [InlineData("cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54")]
     [InlineData("cron:20260510001608:c7fe67628e3142a1894974d22bb998a8")]
-    public async Task ArchiveConversationAsync_ForLegacyCronProjection_WhenArchiveFails_FallsBackToSessionCleanup(string sessionId)
+    public async Task ArchiveConversationAsync_ForLegacyCronProjection_UsesConversationArchive(string sessionId)
     {
         var agent = _store.GetAgent("agent-1")!;
         var cronKey = $"cron-session:{sessionId}";
@@ -339,14 +341,12 @@ public sealed class AgentInteractionServiceTests
         };
 
         _restClient.ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>())
-            .Returns(false);
-        _restClient.DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>())
             .Returns(true);
 
         await _service.ArchiveConversationAsync("agent-1", cronKey);
 
+        // Legacy projections now route through conversation archive (backend returns 204 for virtual cron IDs)
         await _restClient.Received(1).ArchiveConversationAsync(cronKey, Arg.Any<CancellationToken>());
-        await _restClient.Received(1).DeleteSessionAsync(sessionId, Arg.Any<CancellationToken>());
         agent.Conversations.ContainsKey(cronKey).ShouldBeFalse();
     }
 
@@ -369,7 +369,6 @@ public sealed class AgentInteractionServiceTests
         await _service.ArchiveConversationAsync("agent-1", "conv-normal");
 
         await _restClient.Received(1).ArchiveConversationAsync("conv-normal", Arg.Any<CancellationToken>());
-        await _restClient.DidNotReceive().DeleteSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         agent.Conversations.ContainsKey("conv-normal").ShouldBeFalse();
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs
@@ -135,6 +135,31 @@ public sealed class GatewayRestClientTests
     }
 
     [Fact]
+    public async Task DeleteSessionAsync_encodes_colons_in_cron_session_id()
+    {
+        var (client, handler) = CreateClient();
+        const string sessionId = "cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54";
+        handler.SetResponse(Uri.EscapeDataString(sessionId), "{}");
+
+        var success = await client.DeleteSessionAsync(sessionId);
+
+        success.ShouldBeTrue();
+        handler.LastRequestUrl.ShouldContain("/api/sessions/");
+        handler.LastRequestUrl.ShouldContain(Uri.EscapeDataString(sessionId));
+    }
+
+    [Fact]
+    public async Task DeleteSessionAsync_returns_false_on_404()
+    {
+        var (client, _) = CreateClient();
+        // No response registered — handler returns 404
+
+        var success = await client.DeleteSessionAsync("cron:nonexistent:id");
+
+        success.ShouldBeFalse();
+    }
+
+    [Fact]
     public void Configure_not_called_throws_on_request()
     {
         var client = new GatewayRestClient(new HttpClient());

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs
@@ -123,40 +123,17 @@ public sealed class GatewayRestClientTests
     }
 
     [Fact]
-    public async Task DeleteSessionAsync_calls_delete_session_endpoint()
+    public async Task ArchiveConversationAsync_encodes_cron_session_colon_id()
     {
         var (client, handler) = CreateClient();
-        handler.SetResponse("/api/sessions/s1", "{}");
+        const string conversationId = "cron-session:cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54";
+        handler.SetResponse(Uri.EscapeDataString(conversationId), "{}");
 
-        var success = await client.DeleteSessionAsync("s1");
-
-        success.ShouldBeTrue();
-        handler.LastRequestUrl.ShouldContain("/api/sessions/s1");
-    }
-
-    [Fact]
-    public async Task DeleteSessionAsync_encodes_colons_in_cron_session_id()
-    {
-        var (client, handler) = CreateClient();
-        const string sessionId = "cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54";
-        handler.SetResponse(Uri.EscapeDataString(sessionId), "{}");
-
-        var success = await client.DeleteSessionAsync(sessionId);
+        var success = await client.ArchiveConversationAsync(conversationId);
 
         success.ShouldBeTrue();
-        handler.LastRequestUrl.ShouldContain("/api/sessions/");
-        handler.LastRequestUrl.ShouldContain(Uri.EscapeDataString(sessionId));
-    }
-
-    [Fact]
-    public async Task DeleteSessionAsync_returns_false_on_404()
-    {
-        var (client, _) = CreateClient();
-        // No response registered — handler returns 404
-
-        var success = await client.DeleteSessionAsync("cron:nonexistent:id");
-
-        success.ShouldBeFalse();
+        handler.LastRequestUrl.ShouldContain("/api/conversations/");
+        handler.LastRequestUrl.ShouldContain(Uri.EscapeDataString(conversationId));
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -107,6 +107,98 @@ public sealed class ConversationsControllerHistoryTests
         archivedConversation.ActiveSessionId.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task Archive_WithVirtualCronConversationId_SealsRequestedSession_AndDistinctActiveSession()
+    {
+        var conversationId = ConversationId.From("c_cron_cleanup_seals_requested_and_active");
+        var requestedSessionId = SessionId.From("cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54");
+        var activeSessionId = SessionId.From("cron:20260510001608:c7fe67628e3142a1894974d22bb998a8");
+        var virtualConversationId = $"cron-session:{requestedSessionId.Value}";
+        var sessions = new InMemorySessionStore();
+
+        var requestedSession = await sessions.GetOrCreateAsync(requestedSessionId, AgentId.From("assistant"));
+        requestedSession.Session.ConversationId = conversationId;
+        requestedSession.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "session-a-history",
+            Timestamp = DateTimeOffset.UtcNow
+        });
+        await sessions.SaveAsync(requestedSession);
+
+        var activeSession = await sessions.GetOrCreateAsync(activeSessionId, AgentId.From("assistant"));
+        activeSession.Session.ConversationId = conversationId;
+        activeSession.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "session-b-history",
+            Timestamp = DateTimeOffset.UtcNow
+        });
+        await sessions.SaveAsync(activeSession);
+
+        var conversationStore = new InMemoryConversationStore();
+        await conversationStore.CreateAsync(CreateConversation(conversationId, "assistant", activeSessionId));
+        var controller = new ConversationsController(conversationStore, sessions);
+
+        var archiveResult = await controller.Archive(virtualConversationId, CancellationToken.None);
+
+        archiveResult.ShouldBeOfType<NoContentResult>();
+
+        var sealedRequestedSession = await sessions.GetAsync(requestedSessionId);
+        sealedRequestedSession.ShouldNotBeNull();
+        sealedRequestedSession!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
+        sealedRequestedSession.History.ShouldContain(entry => entry.Content == "session-a-history");
+
+        var sealedActiveSession = await sessions.GetAsync(activeSessionId);
+        sealedActiveSession.ShouldNotBeNull();
+        sealedActiveSession!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
+        sealedActiveSession.History.ShouldContain(entry => entry.Content == "session-b-history");
+
+        var archivedConversation = await conversationStore.GetAsync(conversationId);
+        archivedConversation.ShouldNotBeNull();
+        archivedConversation!.Status.ShouldBe(ConversationStatus.Archived);
+        archivedConversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Archive_WithVirtualCronConversationId_WithoutLinkedConversation_SealsSession_AndReturnsNoContent()
+    {
+        var orphanSessionId = SessionId.From("cron:20260509002033:6f2f84a4f1634ff492a4fec212872c54");
+        var virtualConversationId = $"cron-session:{orphanSessionId.Value}";
+        var sessions = new InMemorySessionStore();
+        var orphanSession = await sessions.GetOrCreateAsync(orphanSessionId, AgentId.From("assistant"));
+        orphanSession.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "keep-history",
+            Timestamp = DateTimeOffset.UtcNow
+        });
+        await sessions.SaveAsync(orphanSession);
+
+        var controller = new ConversationsController(new InMemoryConversationStore(), sessions);
+
+        var archiveResult = await controller.Archive(virtualConversationId, CancellationToken.None);
+
+        archiveResult.ShouldBeOfType<NoContentResult>();
+        var sealedSession = await sessions.GetAsync(orphanSessionId);
+        sealedSession.ShouldNotBeNull();
+        sealedSession!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
+        sealedSession.History.ShouldContain(entry => entry.Content == "keep-history");
+    }
+
+    [Fact]
+    public async Task Archive_WithVirtualCronConversationId_WhenSessionMissing_ReturnsNoContent()
+    {
+        var sessions = new InMemorySessionStore();
+        var controller = new ConversationsController(new InMemoryConversationStore(), sessions);
+
+        var result = await controller.Archive(
+            "cron-session:cron:20260510001608:c7fe67628e3142a1894974d22bb998a8",
+            CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+    }
+
     private static Conversation CreateConversation(ConversationId conversationId, string agentId, SessionId? activeSessionId = null)
         => new()
         {


### PR DESCRIPTION
## Summary
- Fix old UI-visible `cron-session:cron:...` cleanup IDs returning 404.
- Resolve virtual cron cleanup through the conversation archive endpoint, preserving session records/history.
- Return idempotent success for stale/orphan cron-session projections while preserving 404 for invalid real conversation IDs.
- Add regressions for linked, orphan, missing, and UI cleanup paths, including guard coverage against `DELETE /api/sessions`.

## Validation
- `dotnet build BotNexus.slnx --nologo --tl:off`
- `dotnet test BotNexus.slnx --nologo --tl:off`
- Focused code review: no blocking issues found