### PR TITLE
fix: keep sub-agent output in originating conversation

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -22,7 +22,14 @@
                         }
                         else
                         {
-                            <span class="conversation-title editable" @onclick="StartEditTitle" title="Click to rename">@ActiveConversationTitle</span>
+                            @if (IsReadOnly)
+                            {
+                                <span class="conversation-title">@ActiveConversationTitle</span>
+                            }
+                            else
+                            {
+                                <span class="conversation-title editable" @onclick="StartEditTitle" title="Click to rename">@ActiveConversationTitle</span>
+                            }
                             @if (ActiveConversation?.IsDefault == true)
                             {
                                 <span class="conversation-default-badge">Default</span>
@@ -50,12 +57,18 @@
             <button class="config-btn" @onclick="OpenConfig" title="Agent configuration">
                 ⚙
             </button>
-            <button class="new-chat-btn" @onclick="ConfirmNewSession" title="Start a new session in this conversation"
-                    disabled="@IsStreaming">
-                ↺ New session
-            </button>
+            @if (!IsReadOnly)
+            {
+                <button class="new-chat-btn" @onclick="ConfirmNewSession" title="Start a new session in this conversation"
+                        disabled="@IsStreaming">
+                    ↺ New session
+                </button>
+            }
         </div>
-        <SessionControls AgentId="@AgentId" />
+        @if (!IsReadOnly)
+        {
+            <SessionControls AgentId="@AgentId" />
+        }
     </header>
 
     @if (_showNewSessionConfirm)
@@ -340,6 +353,9 @@ private bool IsStreaming =>
 
     private void StartEditTitle()
     {
+        if (IsReadOnly)
+            return;
+
         _titleDraft = ActiveConversationTitle ?? "";
         _editingTitle = true;
         _ = InvokeAsync(async () =>
@@ -353,6 +369,13 @@ private bool IsStreaming =>
 
     private async Task SaveTitle()
     {
+        if (IsReadOnly)
+        {
+            _editingTitle = false;
+            StateHasChanged();
+            return;
+        }
+
         _editingTitle = false;
         var draft = _titleDraft.Trim();
         if (!string.IsNullOrWhiteSpace(draft) && draft != ActiveConversationTitle)
@@ -481,11 +504,20 @@ private bool IsStreaming =>
             await _configPanel.Open();
     }
 
-    private void ConfirmNewSession() => _showNewSessionConfirm = true;
+    private void ConfirmNewSession()
+    {
+        if (IsReadOnly)
+            return;
+
+        _showNewSessionConfirm = true;
+    }
     private void CancelNewSession() => _showNewSessionConfirm = false;
 
     private async Task DoNewSession()
     {
+        if (IsReadOnly)
+            return;
+
         _showNewSessionConfirm = false;
         await Interaction.ResetSessionAsync(AgentId);
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -84,12 +84,15 @@
                         <div class="agent-conversation-list">
                             <div class="agent-conversation-list-header">
                                 <span class="agent-conversation-list-title">Conversations</span>
-                                <button class="conversation-new-btn"
-                                        @onclick="() => CreateConversationAsync(activeAgent.AgentId)"
-                                        title="Start a new conversation">
-                                    <span class="conversation-new-btn-icon">+</span>
-                                    <span class="conversation-new-btn-label">New</span>
-                                </button>
+                                @if (!activeAgent.IsReadOnly)
+                                {
+                                    <button class="conversation-new-btn"
+                                            @onclick="() => CreateConversationAsync(activeAgent.AgentId)"
+                                            title="Start a new conversation">
+                                        <span class="conversation-new-btn-icon">+</span>
+                                        <span class="conversation-new-btn-label">New</span>
+                                    </button>
+                                }
                             </div>
 
                             @if (activeAgent.IsLoadingConversations)
@@ -117,9 +120,9 @@
                                                 {
                                                     <span class="conversation-default-badge">Default</span>
                                                 }
-                                                @if (conversation.IsVirtualSession)
+                                                @if (GetVirtualConversationBadge(conversation) is { } badge)
                                                 {
-                                                    <span class="conversation-default-badge">Cron</span>
+                                                    <span class="conversation-default-badge">@badge</span>
                                                 }
                                             </span>
 
@@ -135,7 +138,7 @@
                                                 </span>
                                             </span>
                                         </button>
-                                        @if (!conversation.IsDefault)
+                                        @if (!conversation.IsDefault && !activeAgent.IsReadOnly)
                                         {
                                             <button class="conversation-archive-btn"
                                                     title="@(conversation.IsVirtualSession ? "Close conversation — reopens on next trigger" : "Archive conversation")"
@@ -153,11 +156,12 @@
                                 .Where(s => s.Status is "Running" or "Completed"))
                             {
                                 <div class="agent-session-item @(IsSubAgentActive(sub) ? "active" : "")"
-                                     @onclick="() => ViewSubAgentAsync(sub)"
-                                     style="cursor: pointer;"
-                                     title="@sub.Task">
+                                      @onclick="() => ViewSubAgentAsync(sub)"
+                                      style="cursor: pointer;"
+                                      title="@($"{sub.Task} (read-only)")">
                                     <span>@SubAgentIcon(sub.Status)</span>
                                     <span>@(sub.Name ?? sub.SubAgentId[..Math.Min(8, sub.SubAgentId.Length)])</span>
+                                    <span class="conversation-default-badge">Read-only</span>
                                     @if (sub.Archetype is not null)
                                     {
                                         <span class="sub-agent-archetype">@sub.Archetype</span>
@@ -411,8 +415,35 @@
     };
 
     private static bool IsUserFacingConversation(ConversationState conversation)
-        => !(conversation.IsVirtualSession &&
-             string.Equals(conversation.VirtualSessionKind, "internal", StringComparison.OrdinalIgnoreCase));
+    {
+        // Current contracts expose only conversationId + virtual kind. To hide internal runtime
+        // threads safely we filter known internal IDs ("internal:*") and internal virtual kinds.
+        // Backend contract needed for full fidelity: explicit conversation visibility
+        // (e.g., user-facing | inspectable-readonly | internal-hidden).
+        if (conversation.ConversationId.StartsWith("internal:", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (conversation.IsVirtualSession &&
+            string.Equals(conversation.VirtualSessionKind, "internal", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string? GetVirtualConversationBadge(ConversationState conversation)
+    {
+        if (!conversation.IsVirtualSession)
+            return null;
+
+        return conversation.VirtualSessionKind?.ToLowerInvariant() switch
+        {
+            "cron" => "Cron",
+            "subagent" => "Read-only",
+            _ => "Virtual"
+        };
+    }
 
     private async Task ViewSubAgentAsync(SubAgentInfo sub)
     {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -103,6 +103,7 @@
                             else
                             {
                                 @foreach (var conversation in activeAgent.Conversations.Values
+                                    .Where(IsUserFacingConversation)
                                     .OrderByDescending(c => c.IsDefault)
                                     .ThenByDescending(c => c.UpdatedAt))
                                 {
@@ -408,6 +409,10 @@
         "Completed" => "✅",
         _           => "🤖"
     };
+
+    private static bool IsUserFacingConversation(ConversationState conversation)
+        => !(conversation.IsVirtualSession &&
+             string.Equals(conversation.VirtualSessionKind, "internal", StringComparison.OrdinalIgnoreCase));
 
     private async Task ViewSubAgentAsync(SubAgentInfo sub)
     {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -614,8 +614,6 @@ public sealed class AgentInteractionService : IAgentInteractionService
         _ => role
     };
 
-
-
     private static void MergeVirtualCronSessions(AgentState agent, IReadOnlyList<SessionSummary> sessions)
     {
         var cronSessions = sessions

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -485,24 +485,29 @@ public sealed class AgentInteractionService : IAgentInteractionService
     private async Task LoadSubAgentHistoryAsync(string subAgentId)
     {
         // Sub-agents use session history endpoint, not conversation history
-        // For now create a stub conversation to hold messages
         var agent = _store.GetAgent(subAgentId);
         if (agent is null) return;
 
         // Create a virtual conversation for the sub-agent session
-        const string convId = "subagent-session";
-        if (!agent.Conversations.ContainsKey(convId))
+        var convId = $"subagent-session:{subAgentId}";
+        if (!agent.Conversations.TryGetValue(convId, out var conv))
         {
-            agent.Conversations[convId] = new ConversationState
+            conv = new ConversationState
             {
                 ConversationId = convId,
                 Title = "Sub-agent session",
+                Status = "Active",
+                ActiveSessionId = subAgentId,
+                IsVirtualSession = true,
+                VirtualSessionKind = "subagent",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
                 HistoryLoaded = false
             };
-            agent.ActiveConversationId = convId;
+            agent.Conversations[convId] = conv;
         }
 
-        var conv = agent.Conversations[convId];
+        agent.ActiveConversationId = convId;
         if (conv.HistoryLoaded || conv.IsLoadingHistory) return;
 
         conv.IsLoadingHistory = true;
@@ -510,11 +515,12 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         try
         {
-            // Use session history endpoint
-            var response = await _restClient.GetHistoryAsync(subAgentId, limit: 50);
+            // Use session history endpoint for sub-agent session transcripts.
+            var response = await _restClient.GetSessionHistoryAsync(subAgentId, limit: 50);
+            conv.Messages.Clear();
             if (response?.Entries is { Count: > 0 })
             {
-                foreach (var entry in response.Entries.Where(e => e.Kind != "boundary"))
+                foreach (var entry in response.Entries)
                 {
                     conv.Messages.Add(new ChatMessage(
                         MapRole(entry.Role ?? "system"),
@@ -523,6 +529,9 @@ public sealed class AgentInteractionService : IAgentInteractionService
                     {
                         ToolName = entry.ToolName,
                         ToolCallId = entry.ToolCallId,
+                        ToolArgs = entry.ToolArgs,
+                        ToolIsError = entry.ToolIsError,
+                        ToolResult = entry.ToolName is not null ? entry.Content : null,
                         IsToolCall = entry.ToolName is not null
                     });
                 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateModels.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/ClientStateModels.cs
@@ -32,6 +32,9 @@ public sealed class SubAgentInfo
     /// <summary>The task assigned to this sub-agent.</summary>
     public string Task { get; set; } = "";
 
+    /// <summary>The parent conversation where this sub-agent was started.</summary>
+    public string? OriginConversationId { get; set; }
+
     /// <summary>Current status: Running, Completed, Failed, Killed.</summary>
     public string Status { get; set; } = "Running";
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
@@ -310,13 +310,14 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
     public void HandleSubAgentSpawned(SubAgentEventPayload payload)
     {
         if (!ResolveAgent(payload.SessionId, out var agentId, out var agent)) return;
-        var convId = agent!.ActiveConversationId;
+        var convId = ResolveConversationId(agentId!, agent!, payload.SessionId);
 
         agent.SubAgents[payload.SubAgentId] = new SubAgentInfo
         {
             SubAgentId = payload.SubAgentId,
             Name = payload.Name,
             Task = payload.Task,
+            OriginConversationId = convId,
             Status = "Running",
             StartedAt = payload.StartedAt,
             Model = payload.Model,
@@ -338,8 +339,8 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
     public void HandleSubAgentCompleted(SubAgentEventPayload payload)
     {
-        if (!ResolveAgent(payload.SessionId, out var _, out var agent)) return;
-        var convId = agent!.ActiveConversationId;
+        if (!ResolveAgent(payload.SessionId, out var agentId, out var agent)) return;
+        var convId = ResolveSubAgentConversationId(agentId!, agent!, payload);
 
         if (agent.SubAgents.TryGetValue(payload.SubAgentId, out var sub))
         {
@@ -361,8 +362,8 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
     public void HandleSubAgentFailed(SubAgentEventPayload payload)
     {
-        if (!ResolveAgent(payload.SessionId, out var _, out var agent)) return;
-        var convId = agent!.ActiveConversationId;
+        if (!ResolveAgent(payload.SessionId, out var agentId, out var agent)) return;
+        var convId = ResolveSubAgentConversationId(agentId!, agent!, payload);
 
         if (agent.SubAgents.TryGetValue(payload.SubAgentId, out var sub))
         {
@@ -384,8 +385,8 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
     public void HandleSubAgentKilled(SubAgentEventPayload payload)
     {
-        if (!ResolveAgent(payload.SessionId, out var _, out var agent)) return;
-        var convId = agent!.ActiveConversationId;
+        if (!ResolveAgent(payload.SessionId, out var agentId, out var agent)) return;
+        var convId = ResolveSubAgentConversationId(agentId!, agent!, payload);
 
         if (agent.SubAgents.TryGetValue(payload.SubAgentId, out var sub))
         {
@@ -505,6 +506,20 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         if (_store.TryResolveConversationBySession(agentId, sessionId, out var convId))
             return convId;
         return agent.ActiveConversationId;
+    }
+
+    private string? ResolveSubAgentConversationId(string agentId, AgentState agent, SubAgentEventPayload payload)
+    {
+        if (agent.SubAgents.TryGetValue(payload.SubAgentId, out var subAgent) &&
+            !string.IsNullOrWhiteSpace(subAgent.OriginConversationId))
+        {
+            return subAgent.OriginConversationId;
+        }
+
+        if (_store.TryResolveConversationBySession(agentId, payload.SessionId, out var convId))
+            return convId;
+
+        return null;
     }
 
     // ── Hub event wiring (called when hub reconnects) ─────────────────────

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentWorkspaceManager.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentWorkspaceManager.cs
@@ -54,4 +54,11 @@ public interface IAgentWorkspaceManager
     /// <param name="agentName">The agent identifier.</param>
     /// <returns>The workspace directory path.</returns>
     string GetWorkspacePath(string agentName);
+
+    /// <summary>
+    /// Removes an agent-owned temporary workspace when it is safe to do so.
+    /// </summary>
+    /// <param name="agentName">The agent identifier.</param>
+    /// <returns><c>true</c> when the workspace was removed or did not exist; otherwise <c>false</c>.</returns>
+    bool TryCleanupWorkspace(string agentName) => false;
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -21,6 +21,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
     private readonly IAgentRegistry _registry;
     private readonly IActivityBroadcaster _activity;
     private readonly IChannelDispatcher _dispatcher;
+    private readonly IAgentWorkspaceManager? _workspaceManager;
     private readonly IOptionsMonitor<GatewayOptions> _options;
     private readonly ILogger<DefaultSubAgentManager> _logger;
     private readonly ConcurrentDictionary<string, SubAgentInfo> _subAgents = new(StringComparer.OrdinalIgnoreCase);
@@ -36,12 +37,14 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         IActivityBroadcaster activity,
         IChannelDispatcher dispatcher,
         IOptionsMonitor<GatewayOptions> options,
-        ILogger<DefaultSubAgentManager> logger)
+        ILogger<DefaultSubAgentManager> logger,
+        IAgentWorkspaceManager? workspaceManager = null)
     {
         _supervisor = supervisor;
         _registry = registry;
         _activity = activity;
         _dispatcher = dispatcher;
+        _workspaceManager = workspaceManager;
         _options = options;
         _logger = logger;
     }
@@ -179,11 +182,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             timeoutCts.Dispose();
         }
 
-        if (_childAgentIds.TryGetValue(subAgentId, out var childAgentId))
-        {
-            await _supervisor.StopAsync(childAgentId, info.ChildSessionId, ct);
-            _registry.Unregister(childAgentId);
-        }
+        await CleanupChildAgentAsync(subAgentId, info.ChildSessionId, ct);
 
         if (!TryUpdateSubAgent(
             subAgentId,
@@ -331,8 +330,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         }
         finally
         {
-            if (_childAgentIds.TryGetValue(subAgentId, out var childAgentId))
-                _registry.Unregister(childAgentId);
+            await CleanupChildAgentAsync(subAgentId, updated.ChildSessionId, CancellationToken.None);
         }
     }
 
@@ -446,6 +444,49 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
                 "Failed to publish sub-agent lifecycle event '{EventName}' for sub-agent '{SubAgentId}'.",
                 eventName,
                 info.SubAgentId);
+        }
+    }
+
+    private async Task CleanupChildAgentAsync(string subAgentId, SessionId childSessionId, CancellationToken ct)
+    {
+        if (!_childAgentIds.TryRemove(subAgentId, out var childAgentId))
+            return;
+
+        try
+        {
+            await _supervisor.StopAsync(childAgentId, childSessionId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed stopping child agent '{ChildAgentId}' for sub-agent '{SubAgentId}'.",
+                childAgentId,
+                subAgentId);
+        }
+        finally
+        {
+            _registry.Unregister(childAgentId);
+        }
+
+        if (_workspaceManager is null)
+            return;
+
+        try
+        {
+            if (_workspaceManager.TryCleanupWorkspace(childAgentId.Value))
+            {
+                _logger.LogDebug(
+                    "Cleaned up temporary workspace for child agent '{ChildAgentId}'.",
+                    childAgentId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed cleaning temporary workspace for child agent '{ChildAgentId}'.",
+                childAgentId);
         }
     }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/FileAgentWorkspaceManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/FileAgentWorkspaceManager.cs
@@ -7,6 +7,8 @@ namespace BotNexus.Gateway.Agents;
 public sealed class FileAgentWorkspaceManager : IAgentWorkspaceManager
 {
     private const string MemoryDirectoryName = "memory";
+    private const string SubAgentMarker = "--subagent--";
+    private const string SubAgentWorkspaceDirectoryName = "botnexus-subagent-workspaces";
     private readonly BotNexusHome _botNexusHome;
     private readonly IFileSystem _fileSystem;
 
@@ -62,7 +64,35 @@ public sealed class FileAgentWorkspaceManager : IAgentWorkspaceManager
     public string GetWorkspacePath(string agentName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
-        return Path.Combine(_botNexusHome.GetAgentDirectory(agentName.Trim()), "workspace");
+        var normalizedAgentName = agentName.Trim();
+        if (IsSubAgentAgentName(normalizedAgentName))
+            return _fileSystem.Path.Combine(GetSubAgentWorkspaceRoot(), SanitizePathSegment(normalizedAgentName), "workspace");
+
+        return Path.Combine(_botNexusHome.GetAgentDirectory(normalizedAgentName), "workspace");
+    }
+
+    public bool TryCleanupWorkspace(string agentName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
+
+        var normalizedAgentName = agentName.Trim();
+        if (!IsSubAgentAgentName(normalizedAgentName))
+            return false;
+
+        var workspacePath = GetWorkspacePath(normalizedAgentName);
+        var workspaceRoot = _fileSystem.Path.GetDirectoryName(workspacePath);
+        if (string.IsNullOrWhiteSpace(workspaceRoot))
+            return false;
+
+        var tempRoot = _fileSystem.Path.GetFullPath(GetSubAgentWorkspaceRoot());
+        var workspaceRootFullPath = _fileSystem.Path.GetFullPath(workspaceRoot);
+        if (!IsWithinRoot(tempRoot, workspaceRootFullPath))
+            return false;
+
+        if (_fileSystem.Directory.Exists(workspaceRootFullPath))
+            _fileSystem.Directory.Delete(workspaceRootFullPath, recursive: true);
+
+        return true;
     }
 
     private async Task<string> ReadFileOrEmptyAsync(string path, CancellationToken cancellationToken)
@@ -120,12 +150,33 @@ public sealed class FileAgentWorkspaceManager : IAgentWorkspaceManager
 
     private void EnsureWithinRoot(string root, string path, string parameterName, string message)
     {
-        var prefix = root.TrimEnd(_fileSystem.Path.DirectorySeparatorChar, _fileSystem.Path.AltDirectorySeparatorChar)
-            + _fileSystem.Path.DirectorySeparatorChar;
-        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-            !path.Equals(root, StringComparison.OrdinalIgnoreCase))
+        if (!IsWithinRoot(root, path))
         {
             throw new ArgumentException(message, parameterName);
         }
+    }
+
+    private bool IsWithinRoot(string root, string path)
+    {
+        var prefix = root.TrimEnd(_fileSystem.Path.DirectorySeparatorChar, _fileSystem.Path.AltDirectorySeparatorChar)
+            + _fileSystem.Path.DirectorySeparatorChar;
+        return path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+               path.Equals(root, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsSubAgentAgentName(string agentName)
+        => agentName.Contains(SubAgentMarker, StringComparison.OrdinalIgnoreCase);
+
+    private string GetSubAgentWorkspaceRoot()
+        => _fileSystem.Path.Combine(_fileSystem.Path.GetTempPath(), SubAgentWorkspaceDirectoryName);
+
+    private static string SanitizePathSegment(string value)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var sanitized = value;
+        foreach (var ch in invalidCharacters)
+            sanitized = sanitized.Replace(ch, '_');
+
+        return sanitized;
     }
 }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -266,15 +266,19 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 DisplayPrefix: null);
             ConversationSessionResolution? resolution = null;
             var isInternalWakeMessage =
-                message.ChannelType.Equals(ChannelKey.From("internal")) &&
-                !string.IsNullOrWhiteSpace(message.SessionId);
+                message.ChannelType.Equals(ChannelKey.From("internal"));
 
             if (isInternalWakeMessage)
             {
                 // Internal sub-agent wake-ups target an already-known parent session.
                 // Routing them through conversation resolution creates synthetic internal
                 // conversations and can misroute the user-visible response stream.
-                sessionId = message.SessionId!;
+                var internalTargetSessionId = !string.IsNullOrWhiteSpace(message.SessionId)
+                    ? message.SessionId
+                    : message.ChannelAddress.Value;
+
+                if (!string.IsNullOrWhiteSpace(internalTargetSessionId))
+                    sessionId = internalTargetSessionId;
             }
             else if (_conversationDispatcher is not null)
             {

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -265,7 +265,18 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 message.BindingId,
                 DisplayPrefix: null);
             ConversationSessionResolution? resolution = null;
-            if (_conversationDispatcher is not null)
+            var isInternalWakeMessage =
+                message.ChannelType.Equals(ChannelKey.From("internal")) &&
+                !string.IsNullOrWhiteSpace(message.SessionId);
+
+            if (isInternalWakeMessage)
+            {
+                // Internal sub-agent wake-ups target an already-known parent session.
+                // Routing them through conversation resolution creates synthetic internal
+                // conversations and can misroute the user-visible response stream.
+                sessionId = message.SessionId!;
+            }
+            else if (_conversationDispatcher is not null)
             {
                 var dispatchResult = await _conversationDispatcher.DispatchAsync(
                     InboundMessageContext.FromInboundMessage(AgentId.From(agentId), message),

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -269,6 +269,45 @@ public sealed class AgentInteractionServiceTests
         agent.ActiveConversationId.ShouldBe("conv-1");
     }
 
+    [Fact]
+    public async Task ViewSubAgentAsync_loads_session_history_into_read_only_virtual_conversation()
+    {
+        _restClient.GetSessionHistoryAsync("sub-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new SessionHistoryResponseDto(
+                0,
+                50,
+                1,
+                [
+                    new SessionHistoryEntryDto
+                    {
+                        Role = "assistant",
+                        Content = "sub-agent result",
+                        Timestamp = DateTimeOffset.UtcNow
+                    }
+                ]));
+
+        await _service.ViewSubAgentAsync(new SubAgentInfo
+        {
+            SubAgentId = "sub-1",
+            Name = "Scout",
+            Task = "Inspect repository"
+        });
+
+        await _restClient.Received(1).GetSessionHistoryAsync("sub-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _restClient.DidNotReceive().GetHistoryAsync("sub-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+        var subAgent = _store.GetAgent("sub-1");
+        Assert.NotNull(subAgent);
+        Assert.Equal("agent-subagent", subAgent.SessionType);
+        Assert.Equal("subagent-session:sub-1", subAgent.ActiveConversationId);
+
+        var conversation = subAgent.Conversations["subagent-session:sub-1"];
+        Assert.True(conversation.IsVirtualSession);
+        Assert.Equal("subagent", conversation.VirtualSessionKind);
+        Assert.Single(conversation.Messages);
+        Assert.Equal("sub-agent result", conversation.Messages[0].Content);
+    }
+
     // ── Steering tests ────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -142,6 +142,27 @@ public sealed class ChatPanelTests : IDisposable
     }
 
     [Fact]
+    public void Read_only_sub_agent_view_hides_interactive_controls()
+    {
+        CreateAndSeedAgent("sub-1", "Sub Agent", isConnected: true);
+        _store.SeedConversations("sub-1", [MakeConvDto("subagent-session:sub-1", "sub-1", "Sub-agent session")]);
+        _store.SetActiveConversation("sub-1", "subagent-session:sub-1");
+
+        var agent = _store.GetAgent("sub-1")!;
+        agent.SessionType = "agent-subagent";
+        var conversation = agent.Conversations["subagent-session:sub-1"];
+        conversation.IsVirtualSession = true;
+        conversation.VirtualSessionKind = "subagent";
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "sub-1"));
+
+        cut.Find(".read-only-banner");
+        Assert.Empty(cut.FindAll(".chat-input"));
+        Assert.Empty(cut.FindAll(".new-chat-btn"));
+        Assert.Empty(cut.FindAll(".conversation-title.editable"));
+    }
+
+    [Fact]
     public void Renders_user_message_with_user_css_class()
     {
         CreateAndSeedAgent("agent-1", isConnected: true);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -281,4 +281,104 @@ public sealed class GatewayEventHandlerTests
         Assert.Contains(conversationOneMessages, content => content.Contains("Sub-agent completed", StringComparison.Ordinal));
         Assert.DoesNotContain(conversationTwoMessages, content => content.Contains("Sub-agent completed", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public void HandleSubAgentFailed_routes_failure_to_originating_conversation_when_active_switches()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.Conversations["conv-2"] = new ConversationState
+        {
+            ConversationId = "conv-2",
+            Title = "Conversation 2",
+            ActiveSessionId = "sess-2"
+        };
+        _store.RegisterSession("agent-1", "sess-2");
+
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _handler.HandleSubAgentSpawned(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-2",
+            Name: "Hermes worker",
+            Task: "Run checks",
+            Model: "gpt-5-mini",
+            Archetype: "general-purpose",
+            Status: "Running",
+            StartedAt: DateTimeOffset.UtcNow,
+            CompletedAt: null,
+            TurnsUsed: 0,
+            ResultSummary: null,
+            TimedOut: false));
+
+        _store.SetActiveConversation("agent-1", "conv-2");
+
+        _handler.HandleSubAgentFailed(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-2",
+            Name: "Hermes worker",
+            Task: "Run checks",
+            Model: "gpt-5-mini",
+            Archetype: "general-purpose",
+            Status: "Failed",
+            StartedAt: DateTimeOffset.UtcNow.AddMinutes(-1),
+            CompletedAt: DateTimeOffset.UtcNow,
+            TurnsUsed: 1,
+            ResultSummary: "Tool call failed",
+            TimedOut: false));
+
+        var conversationOneMessages = agent.Conversations["conv-1"].Messages.Select(m => m.Content).ToList();
+        var conversationTwoMessages = agent.Conversations["conv-2"].Messages.Select(m => m.Content).ToList();
+
+        Assert.Contains(conversationOneMessages, content => content.Contains("Sub-agent failed", StringComparison.Ordinal));
+        Assert.DoesNotContain(conversationTwoMessages, content => content.Contains("Sub-agent failed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void HandleSubAgentKilled_routes_killed_notice_to_originating_conversation_when_active_switches()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.Conversations["conv-2"] = new ConversationState
+        {
+            ConversationId = "conv-2",
+            Title = "Conversation 2",
+            ActiveSessionId = "sess-2"
+        };
+        _store.RegisterSession("agent-1", "sess-2");
+
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _handler.HandleSubAgentSpawned(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-3",
+            Name: "Hermes worker",
+            Task: "Run checks",
+            Model: "gpt-5-mini",
+            Archetype: "general-purpose",
+            Status: "Running",
+            StartedAt: DateTimeOffset.UtcNow,
+            CompletedAt: null,
+            TurnsUsed: 0,
+            ResultSummary: null,
+            TimedOut: false));
+
+        _store.SetActiveConversation("agent-1", "conv-2");
+
+        _handler.HandleSubAgentKilled(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-3",
+            Name: "Hermes worker",
+            Task: "Run checks",
+            Model: "gpt-5-mini",
+            Archetype: "general-purpose",
+            Status: "Killed",
+            StartedAt: DateTimeOffset.UtcNow.AddMinutes(-1),
+            CompletedAt: DateTimeOffset.UtcNow,
+            TurnsUsed: 1,
+            ResultSummary: null,
+            TimedOut: false));
+
+        var conversationOneMessages = agent.Conversations["conv-1"].Messages.Select(m => m.Content).ToList();
+        var conversationTwoMessages = agent.Conversations["conv-2"].Messages.Select(m => m.Content).ToList();
+
+        Assert.Contains(conversationOneMessages, content => content.Contains("Sub-agent killed", StringComparison.Ordinal));
+        Assert.DoesNotContain(conversationTwoMessages, content => content.Contains("Sub-agent killed", StringComparison.Ordinal));
+    }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -231,4 +231,54 @@ public sealed class GatewayEventHandlerTests
         Assert.Equal("System", msg.Role);
         Assert.Contains("↳ Steering queued", msg.Content);
     }
+
+    [Fact]
+    public void HandleSubAgentCompleted_routes_completion_to_originating_conversation_when_active_switches()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.Conversations["conv-2"] = new ConversationState
+        {
+            ConversationId = "conv-2",
+            Title = "Conversation 2",
+            ActiveSessionId = "sess-2"
+        };
+        _store.RegisterSession("agent-1", "sess-2");
+
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _handler.HandleSubAgentSpawned(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-1",
+            Name: "Hermes worker",
+            Task: "Run checks",
+            Model: "gpt-5-mini",
+            Archetype: "general-purpose",
+            Status: "Running",
+            StartedAt: DateTimeOffset.UtcNow,
+            CompletedAt: null,
+            TurnsUsed: 0,
+            ResultSummary: null,
+            TimedOut: false));
+
+        _store.SetActiveConversation("agent-1", "conv-2");
+
+        _handler.HandleSubAgentCompleted(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-1",
+            Name: "Hermes worker",
+            Task: "Run checks",
+            Model: "gpt-5-mini",
+            Archetype: "general-purpose",
+            Status: "Completed",
+            StartedAt: DateTimeOffset.UtcNow.AddMinutes(-1),
+            CompletedAt: DateTimeOffset.UtcNow,
+            TurnsUsed: 1,
+            ResultSummary: "All green",
+            TimedOut: false));
+
+        var conversationOneMessages = agent.Conversations["conv-1"].Messages.Select(m => m.Content).ToList();
+        var conversationTwoMessages = agent.Conversations["conv-2"].Messages.Select(m => m.Content).ToList();
+
+        Assert.Contains(conversationOneMessages, content => content.Contains("Sub-agent completed", StringComparison.Ordinal));
+        Assert.DoesNotContain(conversationTwoMessages, content => content.Contains("Sub-agent completed", StringComparison.Ordinal));
+    }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -233,6 +233,35 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
+    public void Internal_prefix_conversation_is_hidden_from_user_conversation_list()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "General", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("internal:sub-1", "a-1", "Internal routing thread", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        Assert.Contains("General", cut.Markup);
+        Assert.DoesNotContain("Internal routing thread", cut.Markup);
+    }
+
+    [Fact]
+    public void Read_only_agent_hides_new_conversation_button()
+    {
+        _store.SeedAgents([new AgentSummary("sub-1", "Subagent")]);
+        _store.SeedConversations("sub-1", []);
+        _store.ActiveAgentId = "sub-1";
+        _store.GetAgent("sub-1")!.SessionType = "agent-subagent";
+
+        var cut = RenderLayout();
+
+        Assert.Empty(cut.FindAll(".conversation-new-btn"));
+    }
+
+    [Fact]
     public void Non_default_conversation_shows_archive_button()
     {
         _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -249,6 +249,46 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
+    public void Internal_conversations_are_not_rendered_as_selectable_conversation_rows()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "General", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("internal:sub-1", "a-1", "Internal routing thread", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        Assert.Single(cut.FindAll(".conversation-list-item-btn"));
+    }
+
+    [Fact]
+    public void Clicking_sub_agent_row_routes_to_read_only_sub_agent_view()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "General", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+        _store.GetAgent("a-1")!.SubAgents["sub-1"] = new SubAgentInfo
+        {
+            SubAgentId = "sub-1",
+            Name = "Scout",
+            Task = "Inspect repository",
+            Status = "Running",
+            StartedAt = DateTimeOffset.UtcNow
+        };
+
+        var cut = RenderLayout();
+
+        cut.Find(".agent-session-item").Click();
+
+        _interaction.Received(1).ViewSubAgentAsync(
+            Arg.Is<SubAgentInfo>(s => s.SubAgentId == "sub-1"));
+    }
+
+    [Fact]
     public void Read_only_agent_hides_new_conversation_button()
     {
         _store.SeedAgents([new AgentSummary("sub-1", "Subagent")]);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -213,6 +213,26 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
+    public void Virtual_internal_conversation_is_hidden_from_user_conversation_list()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "General", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("c-2", "a-1", "Internal sub-agent", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var internalConversation = _store.GetAgent("a-1")!.Conversations["c-2"];
+        internalConversation.IsVirtualSession = true;
+        internalConversation.VirtualSessionKind = "internal";
+
+        var cut = RenderLayout();
+
+        Assert.Contains("General", cut.Markup);
+        Assert.DoesNotContain("Internal sub-agent", cut.Markup);
+    }
+
+    [Fact]
     public void Non_default_conversation_shows_archive_button()
     {
         _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -110,24 +110,129 @@ public sealed class SubAgentIntegrationTests
         subAgentToolNames.ShouldNotContain("manage_subagent");
     }
 
+    [Fact]
+    public async Task SpawnCompletion_StopsChildHandleAndCleansWorkspace()
+    {
+        var registry = CreateRegistry();
+        var childHandle = new Mock<IAgentHandle>();
+        childHandle.SetupGet(h => h.AgentId).Returns("parent-agent");
+        childHandle.SetupGet(h => h.SessionId).Returns("child-session");
+        childHandle.SetupGet(h => h.IsRunning).Returns(true);
+        childHandle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+
+        var supervisor = CreateSupervisor(childHandle.Object);
+        supervisor.Setup(s => s.StopAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var workspaceManager = new Mock<IAgentWorkspaceManager>();
+        workspaceManager.Setup(w => w.TryCleanupWorkspace(It.IsAny<string>())).Returns(true);
+
+        var manager = CreateManager(supervisor.Object, registry.Object, workspaceManager: workspaceManager.Object);
+        var spawned = await manager.SpawnAsync(CreateSpawnRequest());
+
+        await Task.Delay(100);
+        var completed = await manager.GetAsync(spawned.SubAgentId);
+
+        completed.ShouldNotBeNull();
+        completed!.Status.ShouldBe(SubAgentStatus.Completed);
+        supervisor.Verify(s => s.StopAsync(
+                It.IsAny<BotNexus.Domain.Primitives.AgentId>(),
+                completed.ChildSessionId,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        workspaceManager.Verify(w => w.TryCleanupWorkspace(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SpawnFailure_CleansWorkspace()
+    {
+        var registry = CreateRegistry();
+        var supervisor = CreateSupervisor(CreateFailingHandle().Object);
+        supervisor.Setup(s => s.StopAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var workspaceManager = new Mock<IAgentWorkspaceManager>();
+        workspaceManager.Setup(w => w.TryCleanupWorkspace(It.IsAny<string>())).Returns(true);
+
+        var manager = CreateManager(supervisor.Object, registry.Object, workspaceManager: workspaceManager.Object);
+        var spawned = await manager.SpawnAsync(CreateSpawnRequest());
+
+        await WaitUntilAsync(
+            async () => (await manager.GetAsync(spawned.SubAgentId))?.Status == SubAgentStatus.Failed,
+            TimeSpan.FromSeconds(2));
+        await WaitUntilAsync(
+            () => Task.FromResult(workspaceManager.Invocations.Count > 0),
+            TimeSpan.FromSeconds(2));
+
+        workspaceManager.Verify(w => w.TryCleanupWorkspace(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SpawnTimeout_CleansWorkspace()
+    {
+        var registry = CreateRegistry();
+        var supervisor = CreateSupervisor(CreateHangingHandle().Object);
+        supervisor.Setup(s => s.StopAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var workspaceManager = new Mock<IAgentWorkspaceManager>();
+        workspaceManager.Setup(w => w.TryCleanupWorkspace(It.IsAny<string>())).Returns(true);
+
+        var manager = CreateManager(supervisor.Object, registry.Object, workspaceManager: workspaceManager.Object);
+        var spawned = await manager.SpawnAsync(CreateSpawnRequest(timeoutSeconds: 1));
+
+        await WaitUntilAsync(
+            async () => (await manager.GetAsync(spawned.SubAgentId))?.Status == SubAgentStatus.TimedOut,
+            TimeSpan.FromSeconds(3));
+        await WaitUntilAsync(
+            () => Task.FromResult(workspaceManager.Invocations.Count > 0),
+            TimeSpan.FromSeconds(2));
+
+        workspaceManager.Verify(w => w.TryCleanupWorkspace(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Kill_CleansWorkspace()
+    {
+        var registry = CreateRegistry();
+        var supervisor = CreateSupervisor(CreateHangingHandle().Object);
+        supervisor.Setup(s => s.StopAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var workspaceManager = new Mock<IAgentWorkspaceManager>();
+        workspaceManager.Setup(w => w.TryCleanupWorkspace(It.IsAny<string>())).Returns(true);
+
+        var manager = CreateManager(supervisor.Object, registry.Object, workspaceManager: workspaceManager.Object);
+        var spawned = await manager.SpawnAsync(CreateSpawnRequest());
+
+        var killed = await manager.KillAsync(spawned.SubAgentId, spawned.ParentSessionId);
+
+        killed.ShouldBeTrue();
+        workspaceManager.Verify(w => w.TryCleanupWorkspace(It.IsAny<string>()), Times.Once);
+    }
+
     private static DefaultSubAgentManager CreateManager(
         IAgentSupervisor supervisor,
         IAgentRegistry registry,
-        GatewayOptions? options = null)
+        GatewayOptions? options = null,
+        IAgentWorkspaceManager? workspaceManager = null)
         => new(
             supervisor,
             registry,
             new Mock<IActivityBroadcaster>().Object,
             new Mock<IChannelDispatcher>().Object,
             new TestOptionsMonitor<GatewayOptions>(options ?? new GatewayOptions()),
-            NullLogger<DefaultSubAgentManager>.Instance);
+            NullLogger<DefaultSubAgentManager>.Instance,
+            workspaceManager);
 
-    private static SubAgentSpawnRequest CreateSpawnRequest()
+    private static SubAgentSpawnRequest CreateSpawnRequest(int timeoutSeconds = 600)
         => new()
         {
             ParentAgentId = BotNexus.Domain.Primitives.AgentId.From("parent-agent"),
             ParentSessionId = BotNexus.Domain.Primitives.SessionId.From("parent-session"),
-            Task = "Investigate flaky test"
+            Task = "Investigate flaky test",
+            TimeoutSeconds = timeoutSeconds
         };
 
     private static Mock<IAgentRegistry> CreateRegistry()
@@ -170,6 +275,31 @@ public sealed class SubAgentIntegrationTests
                 return new AgentResponse { Content = "never" };
             });
         return handle;
+    }
+
+    private static Mock<IAgentHandle> CreateFailingHandle()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("parent-agent");
+        handle.SetupGet(h => h.SessionId).Returns("child-session");
+        handle.SetupGet(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        return handle;
+    }
+
+    private static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await condition())
+                return;
+
+            await Task.Delay(25);
+        }
+
+        throw new TimeoutException("Condition was not met before timeout.");
     }
 
     private static InProcessIsolationStrategy CreateStrategy()

--- a/tests/gateway/BotNexus.Gateway.Tests/FileAgentWorkspaceManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileAgentWorkspaceManagerTests.cs
@@ -96,6 +96,32 @@ public sealed class FileAgentWorkspaceManagerTests : IDisposable
         content.ShouldContain("override entry");
     }
 
+    [Fact]
+    public void GetWorkspacePath_ForSubAgent_UsesTempWorkspaceRoot()
+    {
+        var subAgentName = "farnsworth--subagent--general--abc123";
+
+        var workspacePath = _workspaceManager.GetWorkspacePath(subAgentName);
+        var normalizedHome = Path.GetFullPath(_homePath);
+
+        workspacePath.Replace('\\', '/').ShouldContain("botnexus-subagent-workspaces");
+        Path.GetFullPath(workspacePath).StartsWith(normalizedHome, StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryCleanupWorkspace_ForSubAgent_RemovesOwnedTempWorkspace()
+    {
+        var subAgentName = "farnsworth--subagent--general--cleanup";
+        var workspacePath = _workspaceManager.GetWorkspacePath(subAgentName);
+        _fileSystem.Directory.CreateDirectory(workspacePath);
+        _fileSystem.File.WriteAllText(Path.Combine(workspacePath, "scratch.txt"), "test");
+
+        var cleaned = _workspaceManager.TryCleanupWorkspace(subAgentName);
+
+        cleaned.ShouldBeTrue();
+        _fileSystem.Directory.Exists(Path.GetDirectoryName(workspacePath)!).ShouldBeFalse();
+    }
+
     public void Dispose()
     {
         SqliteConnection.ClearAllPools();

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -647,6 +647,60 @@ public sealed class GatewayHostTests
     }
 
     [Fact]
+    public async Task DispatchAsync_InternalWakeMessage_WithoutSessionId_UsesChannelAddressAndBypassesConversationDispatcher()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        var handle = CreatePromptHandle("agent-a", "parent-session", "wake-ack");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("parent-session"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        var parentSession = await sessions.GetOrCreateAsync(
+            BotNexus.Domain.Primitives.SessionId.From("parent-session"),
+            BotNexus.Domain.Primitives.AgentId.From("agent-a"));
+        parentSession.Session.ConversationId = BotNexus.Domain.Primitives.ConversationId.From("conv-parent");
+        await sessions.SaveAsync(parentSession);
+
+        var conversationDispatcher = new Mock<IConversationDispatcher>();
+
+        await using var host = CreateHost(
+            supervisor.Object,
+            router.Object,
+            sessions,
+            new RecordingActivityBroadcaster(),
+            CreateChannelManager(),
+            conversationDispatcher: conversationDispatcher.Object);
+
+        await host.DispatchAsync(new InboundMessage
+        {
+            ChannelType = BotNexus.Domain.Primitives.ChannelKey.From("internal"),
+            SenderId = "subagent:test",
+            ChannelAddress = ChannelAddress.From("parent-session"),
+            TargetAgentId = "agent-a",
+            Content = "subagent completion wake-up",
+            Metadata = new Dictionary<string, object?> { ["messageType"] = "subagent-completion" }
+        });
+
+        conversationDispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<InboundMessageContext>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        supervisor.Verify(
+            s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("parent-session"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task GatewayHost_AutoCompaction_TriggersWhenAboveThreshold()
     {
         var router = new Mock<IMessageRouter>();

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -587,6 +587,66 @@ public sealed class GatewayHostTests
     }
 
     [Fact]
+    public async Task DispatchAsync_InternalWakeMessage_WithSessionId_BypassesConversationDispatcher()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        var handle = CreatePromptHandle("agent-a", "parent-session", "wake-ack");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("parent-session"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var sessions = new InMemorySessionStore();
+        var parentSession = await sessions.GetOrCreateAsync(
+            BotNexus.Domain.Primitives.SessionId.From("parent-session"),
+            BotNexus.Domain.Primitives.AgentId.From("agent-a"));
+        parentSession.Session.ConversationId = BotNexus.Domain.Primitives.ConversationId.From("conv-parent");
+        await sessions.SaveAsync(parentSession);
+
+        var conversationDispatcher = new Mock<IConversationDispatcher>();
+
+        await using var host = CreateHost(
+            supervisor.Object,
+            router.Object,
+            sessions,
+            new RecordingActivityBroadcaster(),
+            CreateChannelManager(),
+            conversationDispatcher: conversationDispatcher.Object);
+
+        await host.DispatchAsync(new InboundMessage
+        {
+            ChannelType = BotNexus.Domain.Primitives.ChannelKey.From("internal"),
+            SenderId = "subagent:test",
+            ChannelAddress = ChannelAddress.From("parent-session"),
+            SessionId = "parent-session",
+            TargetAgentId = "agent-a",
+            Content = "subagent completion wake-up",
+            Metadata = new Dictionary<string, object?> { ["messageType"] = "subagent-completion" }
+        });
+
+        conversationDispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<InboundMessageContext>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        supervisor.Verify(
+            s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("parent-session"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var reloaded = await sessions.GetAsync(BotNexus.Domain.Primitives.SessionId.From("parent-session"));
+        reloaded.ShouldNotBeNull();
+        reloaded!.History.Count.ShouldBe(2);
+        reloaded.Session.ConversationId.ShouldBe(BotNexus.Domain.Primitives.ConversationId.From("conv-parent"));
+    }
+
+    [Fact]
     public async Task GatewayHost_AutoCompaction_TriggersWhenAboveThreshold()
     {
         var router = new Mock<IMessageRouter>();


### PR DESCRIPTION
## Summary

Fixes internal wake messages creating and routing through `internal:` conversations, which caused sub-agent output to appear in hidden/wrong conversations instead of the one the user was looking at.

## Changes

- **Routes sub-agent lifecycle and final output back to the originating (default) conversation** instead of letting internal wakeup messages spawn separate `internal:` threads.
- **Gateway keeps internal wakeups on the parent session**, preventing them from leaking into user-visible conversation state.
- **Sub-agent run views remain visible as read-only inspection views** while `internal:` runtime threads are hidden from the normal conversation list.
- **Sub-agent workspaces are moved to temporary isolated locations** and cleaned up automatically on completion, failure, timeout, or kill.
- **Regression test coverage** added for routing correctness, read-only UI behaviour, internal conversation filtering, and workspace cleanup.

## Validation

```shell
dotnet test BotNexus.slnx --nologo --tl:off
```