### PR TITLE
fix(blazor): guard chat enter interop after refresh

### DIFF
--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -32,3 +32,6 @@ Virtual cron conversation projections (`cron-session:{sessionId}`) should be cle
 
 ### 2026-05-11 — PortalLoadService Must Not Abort on Stale Cron History 404
 When loading initial history during portal startup, virtual cron-session projections must use `GetSessionHistoryAsync` (session endpoint), not `GetHistoryAsync` (conversation endpoint). If a stale cron projection returns 404, it must be removed and the service must retry with the next conversation — never allow a single 404 to abort `InitializeAsync` for all agents/conversations. The fix uses a `while` loop with fallback and catches `HttpRequestException` with 404 status specifically.
+
+### 2026-07-29 — JS Interop Must Guard Against Non-DOM ElementReference
+Blazor's `ElementReference` for conditionally-rendered elements (e.g., `@if (!IsReadOnly)`) serialises as a truthy non-element object when the element is absent. JS helpers receiving ElementReferences must check `typeof element.addEventListener === 'function'` (not just `!element`) before using DOM APIs. The Blazor side should also skip the JS call entirely when the element is known to be absent, and reset any binding flags when the element may have been destroyed and recreated (e.g., read-only → interactive transitions).

--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -42,4 +42,4 @@
 - Sub-agent wake delivery tests should assert both dispatch metadata and stream-event channel capabilities.
 - [CORRECTED] Legacy cron cleanup regressions must assert Blazor uses DELETE /api/conversations/{cron-session-id} (archive path only) and never falls back to session deletion; gateway must preserve/seal session history for linked/orphan projections.
 - Portal startup regressions must protect initial history load from stale `cron-session:*` 404s by removing orphan projections and continuing to load other conversations.
-
+- ChatPanel hard-refresh coverage must treat stale `ActiveConversationId` values (including removed `cron-session:*`) as empty-state render paths and assert JS interop bind safety (`preventEnterSubmit` only for interactive views with valid ElementReference semantics).

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -8,7 +8,7 @@
         <div class="chat-header-left">
             <div class="chat-title-stack">
                 <h3>@DisplayName</h3>
-                @if (ActiveConversationId is not null)
+                @if (HasActiveConversation)
                 {
                     <div class="conversation-title-row">
                         @if (_editingTitle)
@@ -110,7 +110,7 @@
             </div>
         }
 
-        @if (ActiveConversationId is null && !IsLoadingConversations)
+        @if (!HasActiveConversation && !IsLoadingConversations)
         {
             <div class="chat-empty-state">
                 Select a conversation or start a new one.
@@ -306,6 +306,7 @@
 
     private string DisplayName => Agent?.DisplayName ?? AgentId;
     private string? ActiveConversationId => Agent?.ActiveConversationId;
+    private bool HasActiveConversation => ActiveConversation is not null;
     private string? ActiveConversationTitle => ActiveConversation?.Title;
 private bool IsStreaming =>
         Agent?.ActiveConversationId is string activeConvId
@@ -326,6 +327,7 @@ private bool IsStreaming =>
     private ElementReference _messagesContainer;
     private ElementReference _inputElement;
     private bool _enterPreventionBound;
+    private bool _wasReadOnly;
     private AgentConfigPanel? _configPanel;
     private bool _editingTitle;
     private string _titleDraft = "";
@@ -526,7 +528,12 @@ private bool IsStreaming =>
     {
         try
         {
-            if (!_enterPreventionBound)
+            // Reset enter-prevention binding when textarea is recreated (read-only → interactive)
+            if (_wasReadOnly && !IsReadOnly)
+                _enterPreventionBound = false;
+            _wasReadOnly = IsReadOnly;
+
+            if (!_enterPreventionBound && !IsReadOnly)
             {
                 await JS.InvokeVoidAsync("chatScroll.preventEnterSubmit", _inputElement);
                 _enterPreventionBound = true;
@@ -554,7 +561,7 @@ private bool IsStreaming =>
                 _forceScrollNext = true;
             _wasActive = isActive;
 
-            var currentConvId = ActiveConversationId;
+            var currentConvId = ActiveConversation?.ConversationId;
             var currentCount = Messages.Count;
             if (currentConvId != _lastActiveConversationId)
             {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/chat.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/chat.js
@@ -48,7 +48,7 @@ window.chatScroll = {
     },
 
     preventEnterSubmit: function (element) {
-        if (!element || element._preventEnterBound) return;
+        if (!element || typeof element.addEventListener !== 'function' || element._preventEnterBound) return;
         element.addEventListener('keydown', function (e) {
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -160,6 +161,66 @@ public sealed class ChatPanelTests : IDisposable
         Assert.Empty(cut.FindAll(".chat-input"));
         Assert.Empty(cut.FindAll(".new-chat-btn"));
         Assert.Empty(cut.FindAll(".conversation-title.editable"));
+    }
+
+    [Fact]
+    public void Stale_active_conversation_id_without_backing_conversation_shows_empty_state()
+    {
+        var agent = CreateAndSeedAgent("agent-1");
+        agent.ActiveConversationId = "missing-conversation";
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("Select a conversation", cut.Markup);
+    }
+
+    [Fact]
+    public void Stale_removed_cron_conversation_shows_empty_state_after_refresh()
+    {
+        var agent = CreateAndSeedAgent("agent-1");
+        agent.ActiveConversationId = "cron-session:removed-cron-session";
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Contains("Select a conversation", cut.Markup);
+    }
+
+    [Fact]
+    public void First_render_binds_prevent_enter_with_non_empty_element_reference()
+    {
+        CreateAndSeedAgent("agent-1");
+        _ctx.JSInterop.Mode = JSRuntimeMode.Strict;
+        _ctx.JSInterop.SetupVoid("chatScroll.preventEnterSubmit", _ => true);
+        _ctx.JSInterop.SetupVoid("chatScroll.forceScrollToBottom", _ => true);
+
+        _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var invocation = Assert.Single(_ctx.JSInterop.Invocations,
+            i => i.Identifier == "chatScroll.preventEnterSubmit");
+        var arg = Assert.IsType<ElementReference>(Assert.Single(invocation.Arguments));
+        Assert.False(string.IsNullOrWhiteSpace(arg.Id));
+    }
+
+    [Fact]
+    public void Read_only_sub_agent_view_does_not_bind_prevent_enter_submit()
+    {
+        CreateAndSeedAgent("sub-1", "Sub Agent", isConnected: true);
+        _store.SeedConversations("sub-1", [MakeConvDto("subagent-session:sub-1", "sub-1", "Sub-agent session")]);
+        _store.SetActiveConversation("sub-1", "subagent-session:sub-1");
+
+        var agent = _store.GetAgent("sub-1")!;
+        agent.SessionType = "agent-subagent";
+        var conversation = agent.Conversations["subagent-session:sub-1"];
+        conversation.IsVirtualSession = true;
+        conversation.VirtualSessionKind = "subagent";
+
+        _ctx.JSInterop.Mode = JSRuntimeMode.Strict;
+        _ctx.JSInterop.SetupVoid("chatScroll.forceScrollToBottom", _ => true);
+
+        _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "sub-1"));
+
+        Assert.DoesNotContain(_ctx.JSInterop.Invocations,
+            i => i.Identifier == "chatScroll.preventEnterSubmit");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Guard `chat.preventEnterSubmit` against null/non-DOM ElementReference values.
- Skip binding enter-prevention when `ChatPanel` is read-only and reset binding state when it becomes interactive again.
- Add ChatPanel regressions for stale/missing active conversation and removed cron-session hard-refresh states.

## Validation
- `dotnet build BotNexus.slnx --nologo --tl:off`
- `dotnet test BotNexus.slnx --nologo --tl:off`
- Focused code review: no blocking issues found