### PR TITLE
fix: stabilize cron conversations and sidebar scrolling

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -95,79 +95,81 @@
                                 }
                             </div>
 
-                            @if (activeAgent.IsLoadingConversations)
-                            {
-                                <div class="conversation-list-loading">Loading conversations…</div>
-                            }
-                            else if (activeAgent.Conversations.Count == 0)
-                            {
-                                <div class="conversation-list-empty">No conversations yet.</div>
-                            }
-                            else
-                            {
-                                @foreach (var conversation in activeAgent.Conversations.Values
-                                    .Where(IsUserFacingConversation)
-                                    .OrderByDescending(c => c.IsDefault)
-                                    .ThenByDescending(c => c.UpdatedAt))
+                            <div class="conversation-list-scroll">
+                                @if (activeAgent.IsLoadingConversations)
                                 {
-                                    <div class="conversation-list-item">
-                                        <button class="conversation-list-item-btn @(conversation.ConversationId == activeAgent.ActiveConversationId ? "active" : "")"
-                                                @onclick="() => SelectConversationAsync(activeAgent.AgentId, conversation.ConversationId)">
-                                            <span class="conversation-list-item-main">
-                                                <span class="conversation-list-item-title">@conversation.Title</span>
+                                    <div class="conversation-list-loading">Loading conversations…</div>
+                                }
+                                else if (activeAgent.Conversations.Count == 0)
+                                {
+                                    <div class="conversation-list-empty">No conversations yet.</div>
+                                }
+                                else
+                                {
+                                    @foreach (var conversation in activeAgent.Conversations.Values
+                                        .Where(IsUserFacingConversation)
+                                        .OrderByDescending(c => c.IsDefault)
+                                        .ThenByDescending(c => c.UpdatedAt))
+                                    {
+                                        <div class="conversation-list-item">
+                                            <button class="conversation-list-item-btn @(conversation.ConversationId == activeAgent.ActiveConversationId ? "active" : "")"
+                                                    @onclick="() => SelectConversationAsync(activeAgent.AgentId, conversation.ConversationId)">
+                                                <span class="conversation-list-item-main">
+                                                    <span class="conversation-list-item-title">@conversation.Title</span>
 
-                                                @if (conversation.IsDefault)
-                                                {
-                                                    <span class="conversation-default-badge">Default</span>
-                                                }
-                                                @if (GetVirtualConversationBadge(conversation) is { } badge)
-                                                {
-                                                    <span class="conversation-default-badge">@badge</span>
-                                                }
-                                            </span>
-
-                                            <span class="conversation-list-item-meta">
-                                                @if (conversation.UnreadCount > 0)
-                                                {
-                                                    <span class="conversation-unread-dot"
-                                                          aria-label="Unread messages"></span>
-                                                }
-
-                                                <span class="conversation-updated-at">
-                                                    @FormatConversationTimestamp(conversation.UpdatedAt)
+                                                    @if (conversation.IsDefault)
+                                                    {
+                                                        <span class="conversation-default-badge">Default</span>
+                                                    }
+                                                    @if (GetVirtualConversationBadge(conversation) is { } badge)
+                                                    {
+                                                        <span class="conversation-default-badge">@badge</span>
+                                                    }
                                                 </span>
-                                            </span>
-                                        </button>
-                                        @if (!conversation.IsDefault && !activeAgent.IsReadOnly)
-                                        {
-                                            <button class="conversation-archive-btn"
-                                                    title="@(conversation.IsVirtualSession ? "Close conversation — reopens on next trigger" : "Archive conversation")"
-                                                    @onclick:stopPropagation="true"
-                                                    @onclick="() => ArchiveConversationAsync(activeAgent.AgentId, conversation.ConversationId, conversation.Title, conversation.IsVirtualSession)">
-                                                @(conversation.IsVirtualSession ? "✕" : "🗑️")
+
+                                                <span class="conversation-list-item-meta">
+                                                    @if (conversation.UnreadCount > 0)
+                                                    {
+                                                        <span class="conversation-unread-dot"
+                                                              aria-label="Unread messages"></span>
+                                                    }
+
+                                                    <span class="conversation-updated-at">
+                                                        @FormatConversationTimestamp(conversation.UpdatedAt)
+                                                    </span>
+                                                </span>
                                             </button>
+                                            @if (!conversation.IsDefault && !activeAgent.IsReadOnly)
+                                            {
+                                                <button class="conversation-archive-btn"
+                                                        title="@(conversation.IsVirtualSession ? "Close conversation — reopens on next trigger" : "Archive conversation")"
+                                                        @onclick:stopPropagation="true"
+                                                        @onclick="() => ArchiveConversationAsync(activeAgent.AgentId, conversation.ConversationId, conversation.Title, conversation.IsVirtualSession)">
+                                                    @(conversation.IsVirtualSession ? "✕" : "🗑️")
+                                                </button>
+                                            }
+                                        </div>
+                                    }
+                                }
+
+                                @* Sub-agent sessions *@
+                                @foreach (var sub in activeAgent.SubAgents.Values
+                                    .Where(s => s.Status is "Running" or "Completed"))
+                                {
+                                    <div class="agent-session-item @(IsSubAgentActive(sub) ? "active" : "")"
+                                          @onclick="() => ViewSubAgentAsync(sub)"
+                                          style="cursor: pointer;"
+                                          title="@($"{sub.Task} (read-only)")">
+                                        <span>@SubAgentIcon(sub.Status)</span>
+                                        <span>@(sub.Name ?? sub.SubAgentId[..Math.Min(8, sub.SubAgentId.Length)])</span>
+                                        <span class="conversation-default-badge">Read-only</span>
+                                        @if (sub.Archetype is not null)
+                                        {
+                                            <span class="sub-agent-archetype">@sub.Archetype</span>
                                         }
                                     </div>
                                 }
-                            }
-
-                            @* Sub-agent sessions *@
-                            @foreach (var sub in activeAgent.SubAgents.Values
-                                .Where(s => s.Status is "Running" or "Completed"))
-                            {
-                                <div class="agent-session-item @(IsSubAgentActive(sub) ? "active" : "")"
-                                      @onclick="() => ViewSubAgentAsync(sub)"
-                                      style="cursor: pointer;"
-                                      title="@($"{sub.Task} (read-only)")">
-                                    <span>@SubAgentIcon(sub.Status)</span>
-                                    <span>@(sub.Name ?? sub.SubAgentId[..Math.Min(8, sub.SubAgentId.Length)])</span>
-                                    <span class="conversation-default-badge">Read-only</span>
-                                    @if (sub.Archetype is not null)
-                                    {
-                                        <span class="sub-agent-archetype">@sub.Archetype</span>
-                                    }
-                                </div>
-                            }
+                            </div>
                         </div>
                     }
                 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -632,8 +632,22 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
     private static void MergeVirtualCronSessions(AgentState agent, IReadOnlyList<SessionSummary> sessions)
     {
+        var stableCronConversationTitles = agent.Conversations.Values
+            .Where(conversation => !IsVirtualCronConversation(conversation))
+            .Select(conversation => conversation.Title)
+            .Where(title => !string.IsNullOrWhiteSpace(title) &&
+                            title.StartsWith("cron:", StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var cronSessions = sessions
             .Where(s => string.Equals(s.SessionType, "cron", StringComparison.OrdinalIgnoreCase))
+            .Where(s =>
+            {
+                if (!TryGetCronConversationTitleFromSessionId(s.SessionId, out var cronConversationTitle))
+                    return true;
+
+                return !stableCronConversationTitles.Contains(cronConversationTitle);
+            })
             .ToDictionary(s => $"cron-session:{s.SessionId}", s => s, StringComparer.Ordinal);
 
         foreach (var key in agent.Conversations
@@ -676,4 +690,21 @@ public sealed class AgentInteractionService : IAgentInteractionService
         => (conversation.IsVirtualSession &&
             string.Equals(conversation.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase))
            || conversation.ConversationId.StartsWith("cron-session:", StringComparison.Ordinal);
+
+    private static bool TryGetCronConversationTitleFromSessionId(string sessionId, out string title)
+    {
+        title = string.Empty;
+        if (string.IsNullOrWhiteSpace(sessionId) ||
+            !sessionId.StartsWith("cron:", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var segments = sessionId.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 4)
+            return false;
+
+        // Expected cron run format: cron:{jobId}:{yyyyMMddHHmmss}:{guid}
+        // Job ids are sanitized to [a-zA-Z0-9_-], so they do not contain ':'.
+        title = $"cron:{segments[1]}";
+        return true;
+    }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -1691,7 +1691,7 @@ details[open] > .thinking-summary::before {
 .sidebar-scroll-region {
     flex: 1;
     min-height: 0;
-    overflow-y: auto;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
 }
@@ -2463,7 +2463,18 @@ details[open] > .thinking-summary::before {
 .agent-conversation-list {
     display: flex;
     flex-direction: column;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
+}
+
+.conversation-list-scroll {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
 }
 
 .agent-conversation-list-header {

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -115,28 +115,128 @@ public sealed class CronTrigger(
         var title = string.IsNullOrWhiteSpace(jobId)
             ? $"cron:{agentId.Value}"
             : $"cron:{SanitizeSessionIdPart(jobId) ?? agentId.Value}";
+        var stableConversationId = BuildCronConversationId(agentId, jobId);
 
-        // Try to find an existing conversation with this title.
+        // Prefer deterministic lookup by stable conversation id.
+        var byStableId = await conversations.GetAsync(stableConversationId, ct).ConfigureAwait(false);
+        if (byStableId is not null)
+        {
+            if (byStableId.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Archived)
+            {
+                byStableId.Status = BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active;
+                byStableId.UpdatedAt = DateTimeOffset.UtcNow;
+                await conversations.SaveAsync(byStableId, ct).ConfigureAwait(false);
+            }
+
+            var conversationsForAgent = await conversations.ListAsync(agentId, ct).ConfigureAwait(false);
+            await NormalizeDuplicateCronConversationsAsync(agentId, title, byStableId, conversationsForAgent, ct).ConfigureAwait(false);
+            return byStableId;
+        }
+
+        // Backward-compatible lookup by title for legacy records created before stable IDs.
         var existing = await conversations.ListAsync(agentId, ct).ConfigureAwait(false);
-        var match = existing?.FirstOrDefault(c =>
-            string.Equals(c.Title, title, StringComparison.Ordinal) &&
-            c.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active);
+        var titleMatches = existing
+            .Where(c => string.Equals(c.Title, title, StringComparison.Ordinal))
+            .ToList();
 
-        if (match is not null)
-            return match;
+        var canonical = titleMatches
+            .Where(c => c.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active)
+            .OrderByDescending(c => c.UpdatedAt)
+            .FirstOrDefault()
+            ?? titleMatches.OrderByDescending(c => c.UpdatedAt).FirstOrDefault();
+
+        if (canonical is not null)
+        {
+            if (canonical.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Archived)
+            {
+                canonical.Status = BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active;
+                canonical.UpdatedAt = DateTimeOffset.UtcNow;
+                await conversations.SaveAsync(canonical, ct).ConfigureAwait(false);
+            }
+
+            await NormalizeDuplicateCronConversationsAsync(agentId, title, canonical, existing, ct).ConfigureAwait(false);
+            return canonical;
+        }
 
         // Create a new stable conversation for this job.
         var conversation = new Conversation
         {
-            ConversationId = ConversationId.Create(),
+            ConversationId = stableConversationId,
             AgentId = agentId,
             Title = title,
             IsDefault = false
         };
-        await conversations.CreateAsync(conversation, ct).ConfigureAwait(false);
-        logger.LogInformation("CronTrigger: created conversation '{Title}' ({ConversationId}) for job '{JobId}'.",
-            title, conversation.ConversationId, jobId);
-        return conversation;
+        try
+        {
+            await conversations.CreateAsync(conversation, ct).ConfigureAwait(false);
+            logger.LogInformation("CronTrigger: created conversation '{Title}' ({ConversationId}) for job '{JobId}'.",
+                title, conversation.ConversationId, jobId);
+            return conversation;
+        }
+        catch (Exception ex)
+        {
+            // If another concurrent run created it first, re-resolve and continue.
+            logger.LogDebug(ex, "CronTrigger: create race for conversation '{ConversationId}', retrying lookup.", stableConversationId);
+            var resolved = await conversations.GetAsync(stableConversationId, ct).ConfigureAwait(false);
+            if (resolved is not null)
+                return resolved;
+
+            var fallback = (await conversations.ListAsync(agentId, ct).ConfigureAwait(false))
+                .FirstOrDefault(c =>
+                    string.Equals(c.Title, title, StringComparison.Ordinal) &&
+                    c.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active);
+            if (fallback is not null)
+                return fallback;
+
+            throw;
+        }
+    }
+
+    private async Task NormalizeDuplicateCronConversationsAsync(
+        AgentId agentId,
+        string title,
+        Conversation canonical,
+        IReadOnlyList<Conversation> conversationsForAgent,
+        CancellationToken ct)
+    {
+        var duplicateActive = conversationsForAgent
+            .Where(c => c.Status == BotNexus.Gateway.Abstractions.Models.ConversationStatus.Active)
+            .Where(c => c.ConversationId != canonical.ConversationId)
+            .Where(c => string.Equals(c.Title, title, StringComparison.Ordinal))
+            .ToList();
+
+        if (duplicateActive.Count == 0)
+            return;
+
+        var agentSessions = await sessions.ListAsync(agentId, ct).ConfigureAwait(false);
+        foreach (var duplicate in duplicateActive)
+        {
+            foreach (var session in agentSessions.Where(s => s.Session.ConversationId == duplicate.ConversationId))
+            {
+                session.Session.ConversationId = canonical.ConversationId;
+                await sessions.SaveAsync(session, ct).ConfigureAwait(false);
+            }
+
+            await conversations.ArchiveAsync(duplicate.ConversationId, ct).ConfigureAwait(false);
+        }
+
+        var latestLinked = agentSessions
+            .Where(s => s.Session.ConversationId == canonical.ConversationId)
+            .OrderByDescending(s => s.UpdatedAt)
+            .FirstOrDefault();
+
+        if (latestLinked is not null && canonical.ActiveSessionId != latestLinked.SessionId)
+        {
+            canonical.ActiveSessionId = latestLinked.SessionId;
+            canonical.UpdatedAt = DateTimeOffset.UtcNow;
+            await conversations.SaveAsync(canonical, ct).ConfigureAwait(false);
+        }
+
+        logger.LogInformation(
+            "CronTrigger: normalized {DuplicateCount} duplicate conversation(s) for '{Title}' under canonical {ConversationId}.",
+            duplicateActive.Count,
+            title,
+            canonical.ConversationId);
     }
 
     private static SessionId BuildCronSessionId(string? jobId)
@@ -171,5 +271,12 @@ public sealed class CronTrigger(
         }
 
         return new string(buffer[..length]).Trim('-');
+    }
+
+    private static ConversationId BuildCronConversationId(AgentId agentId, string? jobId)
+    {
+        var safeAgentId = SanitizeSessionIdPart(agentId.Value) ?? "agent";
+        var safeJobId = SanitizeSessionIdPart(jobId) ?? safeAgentId;
+        return ConversationId.From($"cronconv:{safeAgentId}:{safeJobId}");
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -201,6 +201,57 @@ public sealed class AgentInteractionServiceTests
     }
 
     [Fact]
+    public async Task RefreshConversationsAsync_RepeatedCronRunsReuseSingleConversationKey()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        const string stableConversationId = "conv-cron-job-1";
+        const string firstRunSessionId = "cron:job-1:20260508010101:abc123";
+        const string secondRunSessionId = "cron:job-1:20260508020101:def456";
+
+        _restClient.GetConversationsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns([
+                new ConversationSummaryDto(
+                    stableConversationId,
+                    "agent-1",
+                    "cron:job-1",
+                    false,
+                    "Active",
+                    secondRunSessionId,
+                    0,
+                    DateTimeOffset.UtcNow.AddHours(-1),
+                    DateTimeOffset.UtcNow.AddMinutes(-1))
+            ]);
+        _restClient.GetSessionsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns([
+                new SessionSummary(
+                    firstRunSessionId,
+                    "agent-1",
+                    "cron",
+                    "cron",
+                    "Completed",
+                    12,
+                    false,
+                    DateTimeOffset.UtcNow.AddHours(-1),
+                    DateTimeOffset.UtcNow.AddMinutes(-10)),
+                new SessionSummary(
+                    secondRunSessionId,
+                    "agent-1",
+                    "cron",
+                    "cron",
+                    "Active",
+                    2,
+                    false,
+                    DateTimeOffset.UtcNow.AddMinutes(-3),
+                    DateTimeOffset.UtcNow.AddMinutes(-1))
+            ]);
+
+        await _service.RefreshConversationsAsync("agent-1");
+
+        Assert.True(agent.Conversations.ContainsKey(stableConversationId));
+        Assert.DoesNotContain(agent.Conversations.Keys, key => key.StartsWith("cron-session:", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task SelectConversation_ForVirtualCronConversation_LoadsSessionHistory()
     {
         var agent = _store.GetAgent("agent-1")!;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -363,6 +363,47 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
+    public void Conversation_list_scroll_container_wraps_conversation_rows()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Chat 1", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        var scrollContainer = cut.Find(".conversation-list-scroll");
+        Assert.Single(scrollContainer.QuerySelectorAll(".conversation-list-item-btn"));
+    }
+
+    [Fact]
+    public void Conversation_list_scroll_container_handles_many_conversations()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations(
+            "a-1",
+            Enumerable.Range(1, 40)
+                .Select(i => new ConversationSummaryDto(
+                    $"c-{i}",
+                    "a-1",
+                    $"Chat {i}",
+                    false,
+                    "Active",
+                    null,
+                    0,
+                    DateTimeOffset.UtcNow.AddMinutes(-i),
+                    DateTimeOffset.UtcNow.AddMinutes(-i)))
+                .ToList());
+        _store.ActiveAgentId = "a-1";
+
+        var cut = RenderLayout();
+
+        var scrollContainer = cut.Find(".conversation-list-scroll");
+        Assert.Equal(40, scrollContainer.QuerySelectorAll(".conversation-list-item-btn").Length);
+    }
+
+    [Fact]
     public void Switching_agent_triggers_history_load_for_active_conversation()
     {
         // Arrange: two agents, each with a default conversation auto-selected via SeedConversations

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -194,6 +194,102 @@ public sealed class CronTriggerTests
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task CreateSessionAsync_WhenCreateRaces_ReusesConversationCreatedByPeerRun()
+    {
+        var racedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("cronconv:agent-a:job-1"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "cron:job-1",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .SetupSequence(s => s.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation?)null)
+            .ReturnsAsync(racedConversation);
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation>());
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Duplicate id"));
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        var sessionId = await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Scheduled task",
+            request: new InternalTriggerRequest { CronJobId = "job-1" });
+
+        sessionId.Value.ShouldStartWith("cron:job-1:");
+        conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WhenDuplicateActiveJobConversationsExist_NormalizesToSingleConversation()
+    {
+        var canonical = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-job-1-new"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "cron:job-1",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            UpdatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+
+        var duplicate = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-job-1-old"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "cron:job-1",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        var legacySession = new GatewaySession
+        {
+            SessionId = SessionId.From("cron:job-1:legacy"),
+            AgentId = AgentId.From("agent-a"),
+            UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-10)
+        };
+        legacySession.Session.ConversationId = duplicate.ConversationId;
+
+        conversationStore
+            .Setup(s => s.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation?)null);
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation> { canonical, duplicate });
+        sessionStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GatewaySession> { legacySession });
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Scheduled task",
+            request: new InternalTriggerRequest { CronJobId = "job-1" });
+
+        conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+        conversationStore.Verify(s => s.ArchiveAsync(duplicate.ConversationId, It.IsAny<CancellationToken>()), Times.Once);
+        sessionStore.Verify(s => s.SaveAsync(
+            It.Is<GatewaySession>(gs => gs.SessionId == legacySession.SessionId &&
+                                        gs.Session.ConversationId == canonical.ConversationId),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static (Mock<ISessionStore>, Mock<IConversationStore>, Mock<IAgentSupervisor>) BuildStandardMocks()
@@ -216,6 +312,9 @@ public sealed class CronTriggerTests
 
         conversationStore
             .Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        conversationStore
+            .Setup(s => s.ArchiveAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         supervisor


### PR DESCRIPTION
## Summary

Fixes duplicate conversations for repeated runs of the same cron job and adds proper scrolling for long conversation lists in the sidebar.

## Changes

- **Deterministic cron conversation identity:** Cron jobs now use a stable, per-job conversation ID so repeated runs reuse the same conversation instead of creating duplicates.
- **Legacy duplicate normalization:** Existing duplicate `cron-session:*` conversations are detected and consolidated on startup.
- **Suppress duplicate UI projections:** Duplicate `cron-session:*` virtual rows are suppressed when a stable cron conversation already exists.
- **Sidebar scroll container:** The conversation and sub-agent lists in the sidebar now scroll within their available space instead of overflowing.
- **Regression coverage:** Added/updated tests for cron conversation reuse and sidebar structure.

## Validation

```
dotnet test BotNexus.slnx --nologo --tl:off
```