### PR TITLE
fix: enforce warnings as errors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,9 @@
 # Copilot Instructions — BotNexus
 
+## Build Warnings
+
+**All compiler warnings must be fixed before tasks are complete.** Warnings will be treated as errors via `TreatWarningsAsErrors=true` in `Directory.Build.props`. Do not ignore, suppress, or work around warnings — fix the underlying issue (nullable checks, async/await, unused code, etc.).
+
 ## Git Workflow
 
 - **Worktrees are allowed when explicitly requested.** If a user asks you to create or use a worktree, do so. Otherwise, work directly on the current branch without creating a worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ Design specs and bug specs live in `docs/planning/`. Each item is a folder conta
    - User interactions (clicks, input)
    - Edge cases (loading, error, empty lists)
 
+### Test Warnings
+
+**Fix all compiler warnings in tests, including nullable and async warnings.** Do not use `#nullable disable`, `#pragma warning disable`, or null-forgiving operators (`!`) to silence warnings — fix the underlying code:
+- Nullable warnings: Add proper null checks or use required initializers
+- Async warnings: Await all `Task` results or mark unused values with `_ = await`
+- Do not use `Task.Run(...).Wait()` or `task.Result` — these hide warnings and can deadlock
+
+All test warnings will be treated as test failures once warnings-as-errors is enabled.
+
 ## Git Workflow
 
 **Worktrees may be used for independent branches when requested.** When a user asks for a worktree, use it. Do not create a worktree automatically without explicit user request.
@@ -98,6 +107,10 @@ dotnet build BotNexus.slnx --nologo --tl:off
 ```
 
 Build the full solution before running tests to avoid stale assembly issues (e.g., CLI integration tests depend on `BotNexus.Cli.dll` being built).
+
+### Build Warnings
+
+**All compiler warnings must be treated as build failures and fixed before a task is complete.** Do not ship code with compiler warnings. This is enforced centrally via `TreatWarningsAsErrors=true` in `Directory.Build.props` once implementation lands. Fix warnings during development rather than ignoring them later.
 
 ## MSBuild Conventions
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors Condition="'$(IsTestProject)' != 'true'">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Version>0.1.9</Version>
     <InformationalVersion>0.1.9</InformationalVersion>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors Condition="'$(IsTestProject)' != 'true'">true</TreatWarningsAsErrors>
     <Version>0.1.9</Version>
     <InformationalVersion>0.1.9</InformationalVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,13 +37,13 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.0-preview.3.25171.6" />
 
     <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
 
     <!-- Logging -->
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/ToolExecutor.cs
@@ -324,7 +324,7 @@ internal static class ToolExecutor
                 requested = TimeSpan.FromMilliseconds(ms);
             }
 
-            if (requested.HasValue && requested.Value > toolTimeout.Value)
+            if (requested.HasValue && toolTimeout.HasValue && requested.Value > toolTimeout.Value)
             {
                 // Agent explicitly requested a longer timeout — honour it with a 10s buffer
                 // so the tool's own timeout fires before the safety cap.

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/AgentInteractionService.cs
@@ -280,7 +280,15 @@ public sealed class AgentInteractionService : IAgentInteractionService
             if (agent.ActiveConversationId == conversationId)
             {
                 var next = agent.Conversations.Keys.FirstOrDefault();
-                _store.SetActiveConversation(agentId, next);
+                if (next is not null)
+                {
+                    _store.SetActiveConversation(agentId, next);
+                }
+                else
+                {
+                    agent.ActiveConversationId = null;
+                    _store.NotifyChanged();
+                }
             }
             else
             {
@@ -488,7 +496,15 @@ public sealed class AgentInteractionService : IAgentInteractionService
                     .ThenByDescending(c => c.UpdatedAt)
                     .Select(c => c.ConversationId)
                     .FirstOrDefault();
-                _store.SetActiveConversation(agentId, nextConversationId);
+                if (nextConversationId is not null)
+                {
+                    _store.SetActiveConversation(agentId, nextConversationId);
+                }
+                else
+                {
+                    agent.ActiveConversationId = null;
+                    _store.NotifyChanged();
+                }
             }
         }
         catch (Exception ex)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Services/GatewayEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
@@ -491,7 +492,10 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
     // ── Helpers ────────────────────────────────────────────────────────────
 
-    private bool ResolveAgent(string? sessionId, out string? agentId, out AgentState? agent)
+    private bool ResolveAgent(
+        string? sessionId,
+        [NotNullWhen(true)] out string? agentId,
+        [NotNullWhen(true)] out AgentState? agent)
     {
         agentId = null;
         agent = null;

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -43,7 +43,7 @@ public sealed class ConversationsController : ControllerBase
         [FromQuery] string? agentId,
         CancellationToken cancellationToken)
     {
-        AgentId? parsedAgentId = string.IsNullOrWhiteSpace(agentId) ? null : AgentId.From(agentId);
+        AgentId? parsedAgentId = string.IsNullOrWhiteSpace(agentId) ? (AgentId?)null : AgentId.From(agentId);
         var summaries = await _conversations.GetSummariesAsync(parsedAgentId, cancellationToken);
         return Ok(summaries);
     }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/GatewayController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/GatewayController.cs
@@ -6,21 +6,10 @@ namespace BotNexus.Gateway.Api.Controllers;
 /// <summary>
 /// Gateway lifecycle management endpoints.
 /// </summary>
-/// <summary>
-/// Represents gateway controller.
-/// </summary>
 [ApiController]
 [Route("api/gateway")]
 public sealed class GatewayController(IHostApplicationLifetime lifetime) : ControllerBase
 {
-    /// <summary>
-    /// Initiates a graceful shutdown of the gateway process.
-    /// The process supervisor (systemd, Docker, dev-loop script, etc.) is expected to restart it.
-    /// </summary>
-    /// <summary>
-    /// Executes shutdown.
-    /// </summary>
-    /// <returns>The shutdown result.</returns>
     /// <summary>Returns runtime and build information about the running gateway.</summary>
     [HttpGet("info")]
     public IActionResult Info() => Ok(new
@@ -32,6 +21,10 @@ public sealed class GatewayController(IHostApplicationLifetime lifetime) : Contr
         version       = GatewayBuildInfo.Version
     });
 
+    /// <summary>
+    /// Initiates a graceful shutdown so the process supervisor can restart the gateway cleanly.
+    /// </summary>
+    /// <returns>A shutdown acknowledgement payload.</returns>
     [HttpPost("shutdown")]
     public IActionResult Shutdown()
     {

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -33,6 +33,7 @@ public sealed class CronTrigger(
     /// <param name="agentId">The agent id.</param>
     /// <param name="prompt">The prompt.</param>
     /// <param name="ct">The ct.</param>
+    /// <param name="request">Optional trigger metadata such as cron job, conversation, and model override.</param>
     /// <returns>The create session async result.</returns>
     public async Task<SessionId> CreateSessionAsync(
         AgentId agentId,

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
@@ -38,6 +38,7 @@ public sealed class SoulTrigger(
     /// <param name="agentId">The agent id.</param>
     /// <param name="prompt">The prompt.</param>
     /// <param name="ct">The ct.</param>
+    /// <param name="request">Optional trigger metadata such as cron job and model override.</param>
     /// <returns>The create session async result.</returns>
     public async Task<SessionId> CreateSessionAsync(
         AgentId agentId,

--- a/src/gateway/BotNexus.Gateway/Agents/FileAgentWorkspaceManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/FileAgentWorkspaceManager.cs
@@ -124,7 +124,7 @@ public sealed class FileAgentWorkspaceManager : IAgentWorkspaceManager
             return (memoryRoot, overrideFullPath);
         }
 
-        return (overrideFullPath, defaultTargetPath: null);
+        return (overrideFullPath, DefaultTargetPath: null);
     }
 
     private string ResolveMemoryPath(string memoryRoot, string? defaultTargetPath, string? filePath)

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -123,7 +123,7 @@ public static class AgentConfigMerger
             Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentMemObj),
             Path = PickNullableString("path", defaults.Path, agent.Path, agentMemObj),
             Indexing = PickString("indexing", defaults.Indexing, agent.Indexing, agentMemObj),
-            PromptInjection = PickString("promptInjection", defaults.PromptInjection, agent.PromptInjection, agentMemObj),
+            PromptInjection = PickNullableString("promptInjection", defaults.PromptInjection, agent.PromptInjection, agentMemObj),
             Search = MergeMemorySearch(defaults.Search, agent.Search, agentMemObj),
         };
     }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -147,5 +147,6 @@ This uses `Directory.Build.targets` to strip all test project inputs when `SkipT
 - **xUnit** — all test projects use xUnit with `[Fact]` and `[Theory]`
 - **NSubstitute** — for mocking (where needed)
 - **No test skipping** — don't skip or disable tests to make the suite pass
+- **No warning suppression** — fix nullable and async warnings instead of using `#nullable disable` or `#pragma warning disable`
 - **Isolation** — tests must not depend on external services or user config
 - **Naming** — `MethodUnderTest_Scenario_ExpectedResult`

--- a/tests/BotNexus.CodingAgent.Tests/Hooks/SafetyHooksTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Hooks/SafetyHooksTests.cs
@@ -38,8 +38,11 @@ public sealed class SafetyHooksTests : IDisposable
         var result = await _hooks.ValidateAsync(context, _config);
 
         result.ShouldNotBeNull();
-        result!.Block.ShouldBeTrue();
-        result.Reason.ShouldContain("Unsafe path");
+        var blockedResult = result ?? throw new InvalidOperationException("Expected blocked result.");
+        blockedResult.Block.ShouldBeTrue();
+        blockedResult.Reason.ShouldNotBeNull();
+        var reason = blockedResult.Reason ?? throw new InvalidOperationException("Expected rejection reason.");
+        reason.ShouldContain("Unsafe path");
     }
 
     [Fact]
@@ -53,8 +56,11 @@ public sealed class SafetyHooksTests : IDisposable
         var result = await _hooks.ValidateAsync(context, _config);
 
         result.ShouldNotBeNull();
-        result!.Block.ShouldBeTrue();
-        result.Reason.ShouldContain("dangerous command pattern");
+        var blockedResult = result ?? throw new InvalidOperationException("Expected blocked result.");
+        blockedResult.Block.ShouldBeTrue();
+        blockedResult.Reason.ShouldNotBeNull();
+        var reason = blockedResult.Reason ?? throw new InvalidOperationException("Expected rejection reason.");
+        reason.ShouldContain("dangerous command pattern");
     }
 
     [Fact]

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,7 +6,6 @@
          This sets BOTNEXUS_HOME to a temp path so tests never touch ~/.botnexus -->
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)test.runsettings</RunSettingsFilePath>
     <IsPackable>false</IsPackable>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,6 +6,7 @@
          This sets BOTNEXUS_HOME to a temp path so tests never touch ~/.botnexus -->
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)test.runsettings</RunSettingsFilePath>
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
@@ -159,11 +159,10 @@ public sealed class ProbeRound3BlazorTests : IDisposable
     public void GatewayConfigPanel_ChangingListenUrl_InvokesOnChangedCallback()
     {
         var config = new JsonObject { ["gateway"] = new JsonObject { ["listenUrl"] = "http://localhost:5005" } };
-        var callbackFired = false;
 
         var cut = _ctx.Render<GatewayConfigPanel>(p => p
             .Add(c => c.Config, config)
-            .Add(c => c.OnChanged, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, () => callbackFired = true)));
+            .Add(c => c.OnChanged, Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, static () => { })));
 
         // Trigger ValueChanged on the Listen URL TextField
         // The TextField renders an input; fire change on the first input

--- a/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpExtensionConfigTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpExtensionConfigTests.cs
@@ -30,15 +30,20 @@ public class McpExtensionConfigTests
         var config = JsonSerializer.Deserialize<McpExtensionConfig>(json);
 
         config.ShouldNotBeNull();
-        config!.Servers.Count().ShouldBe(2);
-        config.ToolPrefix.ShouldBeTrue();
+        var extensionConfig = config ?? throw new InvalidOperationException("Expected MCP config.");
+        extensionConfig.Servers.Count().ShouldBe(2);
+        extensionConfig.ToolPrefix.ShouldBeTrue();
 
-        config.Servers["github"].Command.ShouldBe("npx");
-        config.Servers["github"].Args.ShouldContain("-y");
-        config.Servers["github"].Env.ShouldContainKey("GITHUB_TOKEN");
+        extensionConfig.Servers["github"].Command.ShouldBe("npx");
+        extensionConfig.Servers["github"].Args.ShouldNotBeNull();
+        var githubArgs = extensionConfig.Servers["github"].Args ?? throw new InvalidOperationException("Expected github args.");
+        githubArgs.ShouldContain("-y");
+        extensionConfig.Servers["github"].Env.ShouldNotBeNull();
+        var githubEnv = extensionConfig.Servers["github"].Env ?? throw new InvalidOperationException("Expected github env.");
+        githubEnv.ShouldContainKey("GITHUB_TOKEN");
 
-        config.Servers["filesystem"].Command.ShouldBe("node");
-        config.Servers["filesystem"].WorkingDirectory.ShouldBe("/opt/mcp");
+        extensionConfig.Servers["filesystem"].Command.ShouldBe("node");
+        extensionConfig.Servers["filesystem"].WorkingDirectory.ShouldBe("/opt/mcp");
     }
 
     [Fact]
@@ -74,8 +79,10 @@ public class McpExtensionConfigTests
 
         var config = JsonSerializer.Deserialize<McpExtensionConfig>(json);
 
-        config!.Servers["slow-server"].InitTimeoutMs.ShouldBe(60_000);
-        config.Servers["slow-server"].CallTimeoutMs.ShouldBe(120_000);
+        config.ShouldNotBeNull();
+        var extensionConfig = config ?? throw new InvalidOperationException("Expected MCP config.");
+        extensionConfig.Servers["slow-server"].InitTimeoutMs.ShouldBe(60_000);
+        extensionConfig.Servers["slow-server"].CallTimeoutMs.ShouldBe(120_000);
     }
 
     [Fact]
@@ -97,10 +104,13 @@ public class McpExtensionConfigTests
         var config = JsonSerializer.Deserialize<McpExtensionConfig>(json);
 
         config.ShouldNotBeNull();
-        config!.Servers["remote"].Url.ShouldBe("http://localhost:3000/mcp");
-        config.Servers["remote"].Headers.ShouldContainKey("Authorization");
-        config.Servers["remote"].Headers!["Authorization"].ShouldBe("Bearer my-token");
-        config.Servers["remote"].Command.ShouldBeNull();
+        var extensionConfig = config ?? throw new InvalidOperationException("Expected MCP config.");
+        extensionConfig.Servers["remote"].Url.ShouldBe("http://localhost:3000/mcp");
+        extensionConfig.Servers["remote"].Headers.ShouldNotBeNull();
+        var headers = extensionConfig.Servers["remote"].Headers ?? throw new InvalidOperationException("Expected headers.");
+        headers.ShouldContainKey("Authorization");
+        headers["Authorization"].ShouldBe("Bearer my-token");
+        extensionConfig.Servers["remote"].Command.ShouldBeNull();
     }
 
     [Fact]
@@ -123,11 +133,12 @@ public class McpExtensionConfigTests
         var config = JsonSerializer.Deserialize<McpExtensionConfig>(json);
 
         config.ShouldNotBeNull();
-        config!.Servers.Count().ShouldBe(2);
-        config.Servers["local"].Command.ShouldBe("npx");
-        config.Servers["local"].Url.ShouldBeNull();
-        config.Servers["remote"].Url.ShouldBe("http://remote-host:8080/mcp");
-        config.Servers["remote"].Command.ShouldBeNull();
+        var extensionConfig = config ?? throw new InvalidOperationException("Expected MCP config.");
+        extensionConfig.Servers.Count().ShouldBe(2);
+        extensionConfig.Servers["local"].Command.ShouldBe("npx");
+        extensionConfig.Servers["local"].Url.ShouldBeNull();
+        extensionConfig.Servers["remote"].Url.ShouldBe("http://remote-host:8080/mcp");
+        extensionConfig.Servers["remote"].Command.ShouldBeNull();
     }
 
     [Fact]
@@ -221,7 +232,9 @@ public class McpExtensionConfigTests
 
         var config = JsonSerializer.Deserialize<McpExtensionConfig>(json);
 
-        config!.ToolPrefix.ShouldBeFalse();
+        config.ShouldNotBeNull();
+        var extensionConfig = config ?? throw new InvalidOperationException("Expected MCP config.");
+        extensionConfig.ToolPrefix.ShouldBeFalse();
     }
 
     [Fact]
@@ -244,9 +257,13 @@ public class McpExtensionConfigTests
 
         var config = JsonSerializer.Deserialize<McpExtensionConfig>(json);
 
-        config!.Servers["srv"].Env.Count().ShouldBe(3);
-        config.Servers["srv"].Env!["TOKEN"].ShouldBe("${env:MY_TOKEN}");
-        config.Servers["srv"].Env!["API_KEY"].ShouldBe("${env:API_KEY:-default-key}");
-        config.Servers["srv"].Env!["PLAIN"].ShouldBe("literal-value");
+        config.ShouldNotBeNull();
+        var extensionConfig = config ?? throw new InvalidOperationException("Expected MCP config.");
+        extensionConfig.Servers["srv"].Env.ShouldNotBeNull();
+        var env = extensionConfig.Servers["srv"].Env ?? throw new InvalidOperationException("Expected env values.");
+        env.Count().ShouldBe(3);
+        env["TOKEN"].ShouldBe("${env:MY_TOKEN}");
+        env["API_KEY"].ShouldBe("${env:API_KEY:-default-key}");
+        env["PLAIN"].ShouldBe("literal-value");
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpSecurityTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpSecurityTests.cs
@@ -142,8 +142,11 @@ public sealed class McpSecurityTests
         var result = await handler.HandleAsync(evt);
 
         result.ShouldNotBeNull();
-        result!.Denied.ShouldBeTrue();
-        result.DenyReason.ShouldContain("github_search_repositories");
+        var deniedResult = result ?? throw new InvalidOperationException("Expected denied result.");
+        deniedResult.Denied.ShouldBeTrue();
+        deniedResult.DenyReason.ShouldNotBeNull();
+        var denyReason = deniedResult.DenyReason ?? throw new InvalidOperationException("Expected deny reason.");
+        denyReason.ShouldContain("github_search_repositories");
     }
 
     // -- IsMcpTool detection --

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/Search/TavilySearchProviderTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/Search/TavilySearchProviderTests.cs
@@ -79,6 +79,8 @@ public class TavilySearchProviderTests
 
         results.ShouldBeEmpty();
         handler.Requests.ShouldHaveSingleItem();
-        handler.Requests[0].Body.ShouldContain("\"api_key\"");
+        var requestBody = handler.Requests[0].Body;
+        requestBody.ShouldNotBeNull();
+        requestBody.ShouldContain("\"api_key\"");
     }
 }

--- a/tests/gateway/BotNexus.Cli.Tests/Services/GatewayProcessManagerTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Services/GatewayProcessManagerTests.cs
@@ -44,7 +44,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
 
         result.Success.ShouldBeFalse();
         result.Pid.ShouldBe(currentPid);
-        result.Message.ShouldContain("already running");
+        result.Message.ShouldNotBeNull();
+        var message = result.Message ?? throw new InvalidOperationException("Expected status message.");
+        message.ShouldContain("already running");
     }
 
     [Fact]
@@ -82,7 +84,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
         var result = await _manager.StopAsync(_testPidDirectory);
 
         result.Success.ShouldBeTrue();
-        result.Message.ShouldContain("not running");
+        result.Message.ShouldNotBeNull();
+        var message = result.Message ?? throw new InvalidOperationException("Expected status message.");
+        message.ShouldContain("not running");
     }
 
     [Fact]
@@ -94,7 +98,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
         var result = await _manager.StopAsync(_testPidDirectory);
 
         result.Success.ShouldBeTrue();
-        result.Message.ShouldContain("stale PID");
+        result.Message.ShouldNotBeNull();
+        var message = result.Message ?? throw new InvalidOperationException("Expected status message.");
+        message.ShouldContain("stale PID");
 
         // PID file should be cleaned up
         var pidFilePath = GetPidFilePath();
@@ -124,7 +130,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
             var result = await _manager.StopAsync(_testPidDirectory);
 
             result.Success.ShouldBeTrue();
-            result.Message.ShouldContain("stopped");
+            result.Message.ShouldNotBeNull();
+            var message = result.Message ?? throw new InvalidOperationException("Expected status message.");
+            message.ShouldContain("stopped");
 
             // PID file should be deleted
             var pidFilePath = GetPidFilePath();
@@ -155,7 +163,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
         status.State.ShouldBe(GatewayState.NotRunning);
         status.Pid.ShouldBeNull();
         status.Uptime.ShouldBeNull();
-        status.Message.ShouldContain("No PID file");
+        status.Message.ShouldNotBeNull();
+        var message = status.Message ?? throw new InvalidOperationException("Expected status message.");
+        message.ShouldContain("No PID file");
     }
 
     [Fact]
@@ -169,7 +179,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
         status.State.ShouldBe(GatewayState.NotRunning);
         status.Pid.ShouldBeNull();
         status.Uptime.ShouldBeNull();
-        status.Message.ShouldContain("stale PID");
+        status.Message.ShouldNotBeNull();
+        var message = status.Message ?? throw new InvalidOperationException("Expected status message.");
+        message.ShouldContain("stale PID");
 
         // PID file should be cleaned up
         var pidFilePath = GetPidFilePath();
@@ -207,7 +219,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
                 status.State.ShouldBe(GatewayState.Running);
                 status.Pid.ShouldBe(process.Id);
                 status.Uptime.ShouldNotBeNull();
-                status.Message.ShouldContain("Running");
+                status.Message.ShouldNotBeNull();
+                var message = status.Message ?? throw new InvalidOperationException("Expected status message.");
+                message.ShouldContain("Running");
             }
             else
             {
@@ -246,7 +260,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
         status.State.ShouldBe(GatewayState.Running);
         status.Pid.ShouldBe(currentProcess.Id);
         status.Uptime.ShouldNotBeNull();
-        status.Message.ShouldContain("Running");
+        status.Message.ShouldNotBeNull();
+        var runningMessage = status.Message ?? throw new InvalidOperationException("Expected status message.");
+        runningMessage.ShouldContain("Running");
     }
 
     [Fact]
@@ -298,7 +314,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
 
             // Process reported as still running (override returned false) — MUST return failure.
             result.Success.ShouldBeFalse();
-            result.Message.ShouldContain("did not exit");
+            result.Message.ShouldNotBeNull();
+            var message = result.Message ?? throw new InvalidOperationException("Expected status message.");
+            message.ShouldContain("did not exit");
         }
         finally
         {
@@ -358,7 +376,9 @@ public sealed class GatewayProcessManagerTests : IDisposable
             var result = await _manager.StopAsync(altTarget);
 
             result.Success.ShouldBeTrue();
-            result.Message.ShouldContain("stale PID");
+            result.Message.ShouldNotBeNull();
+            var message = result.Message ?? throw new InvalidOperationException("Expected status message.");
+            message.ShouldContain("stale PID");
             File.Exists(altPidPath).ShouldBeFalse();
 
             // Default target should be unaffected

--- a/tests/gateway/BotNexus.Cli.Tests/Services/GatewayProcessTypesTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Services/GatewayProcessTypesTests.cs
@@ -95,7 +95,9 @@ public sealed class GatewayProcessTypesTests
         status.State.ShouldBe(GatewayState.Running);
         status.Pid.ShouldBe(12345);
         status.Uptime.ShouldBe(uptime);
-        status.Message.ShouldContain("Running");
+        status.Message.ShouldNotBeNull();
+        var message = status.Message ?? throw new InvalidOperationException("Expected status message.");
+        message.ShouldContain("Running");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
@@ -99,6 +99,7 @@ public sealed class CronSchedulerTests
         run.Error.ShouldBe("boom");
         var updated = await context.Store.GetAsync("job-1");
         updated!.LastRunStatus.ShouldBe("error");
+        updated.LastRunError.ShouldNotBeNull();
         updated.LastRunError.ShouldContain("boom");
         var history = await context.Store.GetRunHistoryAsync("job-1");
         var entry = history.ShouldHaveSingleItem();

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs
@@ -20,7 +20,11 @@ public sealed class AgentsControllerTests
 
         var result = controller.List();
 
-        ((result.Result as OkObjectResult)?.Value as IReadOnlyList<AgentDescriptor>).Count().ShouldBe(1);
+        var okResult = result.Result.ShouldBeOfType<OkObjectResult>();
+        var agents = okResult.Value.ShouldBeAssignableTo<IReadOnlyList<AgentDescriptor>>();
+        agents.ShouldNotBeNull();
+        var registeredAgents = agents ?? throw new InvalidOperationException("Expected agent list.");
+        registeredAgents.Count.ShouldBe(1);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -107,8 +107,12 @@ public sealed class TelegramChannelAdapterTests
 
         var messageCalls = calls.Where(c => c.MethodName == "sendMessage").ToList();
         messageCalls.Count().ShouldBe(2);
-        messageCalls[0].Text.Length.ShouldBe(4096);
-        messageCalls[1].Text.Length.ShouldBe(904);
+        messageCalls[0].Text.ShouldNotBeNull();
+        messageCalls[1].Text.ShouldNotBeNull();
+        var firstText = messageCalls[0].Text ?? throw new InvalidOperationException("Expected first message text.");
+        var secondText = messageCalls[1].Text ?? throw new InvalidOperationException("Expected second message text.");
+        firstText.Length.ShouldBe(4096);
+        secondText.Length.ShouldBe(904);
     }
 
     [Fact]
@@ -316,8 +320,11 @@ public sealed class TelegramChannelAdapterTests
 
         calls.Count(c => c.MethodName == "sendMessage").ShouldBe(1);
         calls.Count(c => c.MethodName == "editMessageText").ShouldBeGreaterThan(0);
-        calls.Where(c => c.MethodName == "editMessageText").Last().Text.ShouldContain(new string('a', 101));
-        calls.Where(c => c.MethodName == "editMessageText").Last().Text.ShouldContain(new string('b', 101));
+        var lastEditCall = calls.Where(c => c.MethodName == "editMessageText").Last();
+        lastEditCall.Text.ShouldNotBeNull();
+        var lastEditText = lastEditCall.Text ?? throw new InvalidOperationException("Expected edited message text.");
+        lastEditText.ShouldContain(new string('a', 101));
+        lastEditText.ShouldContain(new string('b', 101));
     }
 
     [Fact]
@@ -532,7 +539,9 @@ public sealed class TelegramChannelAdapterTests
         await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCalls.Count.ShouldBe(1);
-        sendCalls[0].Text.ShouldContain("first");
+        sendCalls[0].Text.ShouldNotBeNull();
+        var firstErrorText = sendCalls[0].Text ?? throw new InvalidOperationException("Expected error message text.");
+        firstErrorText.ShouldContain("first");
     }
 
     [Fact]
@@ -1185,4 +1194,3 @@ public sealed class TelegramChannelAdapterTests
         }
     }
 }
-

--- a/tests/gateway/BotNexus.Gateway.Tests/Cli/AgentCommandsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Cli/AgentCommandsTests.cs
@@ -34,8 +34,10 @@ public sealed class AgentCommandsTests
         var config = await fixture.LoadConfigAsync();
 
         result.ExitCode.ShouldBe(0);
-        config.Agents.ShouldContainKey("reviewer");
-        config.Agents!["reviewer"].Model.ShouldBe("gpt-5");
+        config.Agents.ShouldNotBeNull();
+        var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+        agents.ShouldContainKey("reviewer");
+        agents["reviewer"].Model.ShouldBe("gpt-5");
     }
 
     [Fact]
@@ -80,7 +82,9 @@ public sealed class AgentCommandsTests
         var config = await fixture.LoadConfigAsync();
 
         result.ExitCode.ShouldBe(0);
-        config.Agents.ShouldNotContainKey("reviewer");
+        config.Agents.ShouldNotBeNull();
+        var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+        agents.ShouldNotContainKey("reviewer");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Cli/InitCommandTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Cli/InitCommandTests.cs
@@ -21,8 +21,10 @@ public sealed class InitCommandTests
         Directory.Exists(Path.Combine(fixture.RootPath, "agents")).ShouldBeTrue();
 
         var config = await fixture.LoadConfigAsync();
-        config.Agents.ShouldContainKey("assistant");
-        config.Agents!["assistant"].Provider.ShouldBe("github-copilot");
+        config.Agents.ShouldNotBeNull();
+        var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+        agents.ShouldContainKey("assistant");
+        agents["assistant"].Provider.ShouldBe("github-copilot");
     }
 
     [Fact]
@@ -48,7 +50,9 @@ public sealed class InitCommandTests
 
         result.ExitCode.ShouldBe(0);
         config.Gateway?.ListenUrl.ShouldBe("http://0.0.0.0:5005");
-        config.Agents.ShouldContainKey("assistant");
+        config.Agents.ShouldNotBeNull();
+        var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+        agents.ShouldContainKey("assistant");
     }
 
     // -------------------------------------------------------------------------
@@ -89,4 +93,3 @@ public sealed class InitCommandTests
         enabledEl.GetBoolean().ShouldBeTrue();
     }
 }
-

--- a/tests/gateway/BotNexus.Gateway.Tests/Cli/LocationsCommandsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Cli/LocationsCommandsTests.cs
@@ -51,7 +51,11 @@ public sealed class LocationsCommandsTests
         addResult.ExitCode.ShouldBe(0);
         updateResult.ExitCode.ShouldBe(0);
         deleteResult.ExitCode.ShouldBe(0);
-        config.Gateway?.Locations.ShouldNotContainKey("repo");
+        config.Gateway.ShouldNotBeNull();
+        var gateway = config.Gateway ?? throw new InvalidOperationException("Expected gateway config.");
+        gateway.Locations.ShouldNotBeNull();
+        var locations = gateway.Locations ?? throw new InvalidOperationException("Expected locations.");
+        locations.ShouldNotContainKey("repo");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/AgentConfigMergerTests.cs
@@ -235,8 +235,11 @@ public sealed class AgentConfigMergerTests
 
         // Assert
         result.FileAccess.ShouldNotBeNull();
-        result.FileAccess!.AllowedReadPaths.ShouldBe(["/agent/read"]);  // replaced, not union
-        result.FileAccess.AllowedReadPaths.ShouldNotContain("/defaults/read1");
+        var fileAccess = result.FileAccess ?? throw new InvalidOperationException("Expected file access policy.");
+        fileAccess.AllowedReadPaths.ShouldNotBeNull();
+        var allowedReadPaths = fileAccess.AllowedReadPaths ?? throw new InvalidOperationException("Expected read paths.");
+        allowedReadPaths.ShouldBe(["/agent/read"]);  // replaced, not union
+        allowedReadPaths.ShouldNotContain("/defaults/read1");
     }
 
     // -------------------------------------------------------------------------
@@ -321,7 +324,8 @@ public sealed class AgentConfigMergerTests
 
         // Assert
         result.ToolIds.ShouldBe(["tool-c"]);      // replaced entirely
-        result.ToolIds.ShouldNotContain("tool-a");
+        var toolIds = result.ToolIds ?? throw new InvalidOperationException("Expected tool IDs.");
+        toolIds.ShouldNotContain("tool-a");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/LocationRegistryConfigurationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/LocationRegistryConfigurationTests.cs
@@ -32,10 +32,15 @@ public sealed class LocationRegistryConfigurationTests
         });
 
         config.ShouldNotBeNull();
-        config!.Gateway!.Locations.ShouldContainKey("repo-root");
-        config.Gateway.Locations!["repo-root"].Path.ShouldBe("Q:\\repos\\botnexus");
-        config.Gateway.Locations!["repo-root"].Description.ShouldBe("Repository root");
-        config.Gateway.Locations!["gateway-api"].Endpoint.ShouldBe("https://example.test");
+        var platformConfig = config ?? throw new InvalidOperationException("Expected config.");
+        platformConfig.Gateway.ShouldNotBeNull();
+        var gateway = platformConfig.Gateway ?? throw new InvalidOperationException("Expected gateway config.");
+        gateway.Locations.ShouldNotBeNull();
+        var locations = gateway.Locations ?? throw new InvalidOperationException("Expected locations.");
+        locations.ShouldContainKey("repo-root");
+        locations["repo-root"].Path.ShouldBe("Q:\\repos\\botnexus");
+        locations["repo-root"].Description.ShouldBe("Repository root");
+        locations["gateway-api"].Endpoint.ShouldBe("https://example.test");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigValidationTests.cs
@@ -33,8 +33,12 @@ public sealed class PlatformConfigValidationTests
 
                 errors.ShouldBeEmpty();
                 config.Version.ShouldBe(1);
-                config.Agents.ShouldContainKey("assistant");
-                config.Providers.ShouldContainKey("copilot");
+                config.Agents.ShouldNotBeNull();
+                var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+                agents.ShouldContainKey("assistant");
+                config.Providers.ShouldNotBeNull();
+                var providers = config.Providers ?? throw new InvalidOperationException("Expected providers config.");
+                providers.ShouldContainKey("copilot");
             });
 
     [Fact]
@@ -83,9 +87,15 @@ public sealed class PlatformConfigValidationTests
 
                 errors.ShouldBeEmpty();
                 config.Gateway.ShouldNotBeNull();
-                config.Gateway!.SessionStore!.Type.ShouldBe("InMemory");
-                config.Gateway.Extensions!.Defaults!.ShouldContainKey("botnexus-skills");
-                config.Gateway.Extensions.Defaults["botnexus-skills"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
+                var gateway = config.Gateway ?? throw new InvalidOperationException("Expected gateway config.");
+                gateway.SessionStore.ShouldNotBeNull();
+                gateway.SessionStore.Type.ShouldBe("InMemory");
+                gateway.Extensions.ShouldNotBeNull();
+                var extensions = gateway.Extensions ?? throw new InvalidOperationException("Expected gateway extensions.");
+                extensions.Defaults.ShouldNotBeNull();
+                var defaults = extensions.Defaults ?? throw new InvalidOperationException("Expected extension defaults.");
+                defaults.ShouldContainKey("botnexus-skills");
+                defaults["botnexus-skills"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
                 SerializeShouldNotThrow(config);
             });
 
@@ -371,7 +381,9 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 var errors = PlatformConfigLoader.Validate(config);
-                var agent = config.Agents!["assistant"];
+                config.Agents.ShouldNotBeNull();
+                var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+                var agent = agents["assistant"];
 
                 errors.ShouldBeEmpty();
                 agent.DisplayName.ShouldBe("Assistant");
@@ -384,10 +396,13 @@ public sealed class PlatformConfigValidationTests
                 agent.Heartbeat.ShouldNotBeNull();
                 agent.SessionAccess.ShouldNotBeNull();
                 agent.FileAccess.ShouldNotBeNull();
-                agent.Extensions.ShouldContainKey("botnexus-mcp");
-                agent.Extensions!["botnexus-mcp"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
+                agent.Extensions.ShouldNotBeNull();
+                var agentExtensions = agent.Extensions ?? throw new InvalidOperationException("Expected agent extensions.");
+                agentExtensions.ShouldContainKey("botnexus-mcp");
+                agentExtensions["botnexus-mcp"].GetProperty("enabled").GetBoolean().ShouldBeTrue();
                 agent.Metadata.ShouldNotBeNull();
-                agent.Metadata!.Value.GetProperty("owner").GetString().ShouldBe("test-user");
+                var metadata = agent.Metadata ?? throw new InvalidOperationException("Expected metadata.");
+                metadata.GetProperty("owner").GetString().ShouldBe("test-user");
                 SerializeShouldNotThrow(config);
             });
 
@@ -428,10 +443,15 @@ public sealed class PlatformConfigValidationTests
 
                 errors.ShouldBeEmpty();
                 config.AgentDefaults.ShouldNotBeNull();
-                config.AgentDefaults!.ToolIds.ShouldBe(["read", "write"]);
-                config.Agents.ShouldContainKey("assistant");
-                config.Agents.ShouldNotContainKey("defaults");
-                config.AgentRawElements.ShouldContainKey("assistant");
+                var agentDefaults = config.AgentDefaults ?? throw new InvalidOperationException("Expected agent defaults.");
+                agentDefaults.ToolIds.ShouldBe(["read", "write"]);
+                config.Agents.ShouldNotBeNull();
+                var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+                agents.ShouldContainKey("assistant");
+                agents.ShouldNotContainKey("defaults");
+                config.AgentRawElements.ShouldNotBeNull();
+                var rawElements = config.AgentRawElements ?? throw new InvalidOperationException("Expected agent raw elements.");
+                rawElements.ShouldContainKey("assistant");
             });
 
     [Fact]
@@ -563,12 +583,18 @@ public sealed class PlatformConfigValidationTests
             async configPath =>
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
-                var agent = config.Agents!["assistant"];
+                config.Agents.ShouldNotBeNull();
+                var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+                var agent = agents["assistant"];
 
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                agent.Extensions.ShouldContainKey("botnexus-exec");
-                agent.Extensions!["botnexus-exec"].GetProperty("limits").GetProperty("timeout").GetInt32().ShouldBe(30);
-                agent.Metadata!.Value.GetProperty("team").GetProperty("name").GetString().ShouldBe("platform");
+                agent.Extensions.ShouldNotBeNull();
+                var extensions = agent.Extensions ?? throw new InvalidOperationException("Expected agent extensions.");
+                extensions.ShouldContainKey("botnexus-exec");
+                extensions["botnexus-exec"].GetProperty("limits").GetProperty("timeout").GetInt32().ShouldBe(30);
+                agent.Metadata.ShouldNotBeNull();
+                var metadata = agent.Metadata ?? throw new InvalidOperationException("Expected metadata.");
+                metadata.GetProperty("team").GetProperty("name").GetString().ShouldBe("platform");
                 SerializeShouldNotThrow(config);
             });
 
@@ -711,7 +737,9 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Channels.ShouldContainKey("telegram");
+                config.Channels.ShouldNotBeNull();
+                var channels = config.Channels ?? throw new InvalidOperationException("Expected channels.");
+                channels.ShouldContainKey("telegram");
             });
 
     [Fact]
@@ -753,7 +781,9 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Channels.ShouldContainKey("telegram");
+                config.Channels.ShouldNotBeNull();
+                var channels = config.Channels ?? throw new InvalidOperationException("Expected channels.");
+                channels.ShouldContainKey("telegram");
             });
 
     [Fact]
@@ -783,7 +813,9 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Channels.ShouldContainKey("telegram");
+                config.Channels.ShouldNotBeNull();
+                var channels = config.Channels ?? throw new InvalidOperationException("Expected channels.");
+                channels.ShouldContainKey("telegram");
             });
 
     [Fact]
@@ -872,9 +904,15 @@ public sealed class PlatformConfigValidationTests
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
 
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Gateway!.Extensions!.Defaults.ShouldContainKey("botnexus-skills");
-                config.Gateway.Extensions.Defaults.ShouldContainKey("botnexus-exec");
-                config.Gateway.Extensions.Defaults["botnexus-exec"].GetProperty("timeout").GetInt32().ShouldBe(30);
+                config.Gateway.ShouldNotBeNull();
+                var gateway = config.Gateway ?? throw new InvalidOperationException("Expected gateway config.");
+                gateway.Extensions.ShouldNotBeNull();
+                var extensions = gateway.Extensions ?? throw new InvalidOperationException("Expected gateway extensions.");
+                extensions.Defaults.ShouldNotBeNull();
+                var defaults = extensions.Defaults ?? throw new InvalidOperationException("Expected extension defaults.");
+                defaults.ShouldContainKey("botnexus-skills");
+                defaults.ShouldContainKey("botnexus-exec");
+                defaults["botnexus-exec"].GetProperty("timeout").GetInt32().ShouldBe(30);
                 SerializeShouldNotThrow(config);
             });
 
@@ -966,7 +1004,11 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Cron!.Jobs.ShouldContainKey("daily-summary");
+                config.Cron.ShouldNotBeNull();
+                var cron = config.Cron ?? throw new InvalidOperationException("Expected cron config.");
+                cron.Jobs.ShouldNotBeNull();
+                var jobs = cron.Jobs ?? throw new InvalidOperationException("Expected cron jobs.");
+                jobs.ShouldContainKey("daily-summary");
             });
 
     [Fact]
@@ -1027,8 +1069,12 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Cron!.Jobs.ShouldContainKey("daily-summary");
-                var job = config.Cron.Jobs["daily-summary"];
+                config.Cron.ShouldNotBeNull();
+                var cron = config.Cron ?? throw new InvalidOperationException("Expected cron config.");
+                cron.Jobs.ShouldNotBeNull();
+                var jobs = cron.Jobs ?? throw new InvalidOperationException("Expected cron jobs.");
+                jobs.ShouldContainKey("daily-summary");
+                var job = jobs["daily-summary"];
                 job.ActionType.ShouldBe("agent-chat");
                 job.Model.ShouldBe("openai/gpt-4.1");
             });
@@ -1298,8 +1344,12 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Gateway!.ApiKeys!.ShouldContainKey("tenant-a");
-                config.Gateway.ApiKeys["tenant-a"].AllowedAgents.ShouldBe(["assistant"]);
+                config.Gateway.ShouldNotBeNull();
+                var gateway = config.Gateway ?? throw new InvalidOperationException("Expected gateway config.");
+                gateway.ApiKeys.ShouldNotBeNull();
+                var apiKeys = gateway.ApiKeys ?? throw new InvalidOperationException("Expected API keys.");
+                apiKeys.ShouldContainKey("tenant-a");
+                apiKeys["tenant-a"].AllowedAgents.ShouldBe(["assistant"]);
             });
 
     [Fact]
@@ -1497,7 +1547,13 @@ public sealed class PlatformConfigValidationTests
             {
                 var config = await PlatformConfigLoader.LoadAsync(configPath, validateOnLoad: false);
                 PlatformConfigLoader.Validate(config).ShouldBeEmpty();
-                config.Gateway!.CrossWorld!.Peers.ShouldContainKey("world-b");
+                config.Gateway.ShouldNotBeNull();
+                var gateway = config.Gateway ?? throw new InvalidOperationException("Expected gateway config.");
+                gateway.CrossWorld.ShouldNotBeNull();
+                var crossWorld = gateway.CrossWorld ?? throw new InvalidOperationException("Expected cross-world settings.");
+                crossWorld.Peers.ShouldNotBeNull();
+                var peers = crossWorld.Peers ?? throw new InvalidOperationException("Expected cross-world peers.");
+                peers.ShouldContainKey("world-b");
             });
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/SchemaValidationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/SchemaValidationTests.cs
@@ -154,8 +154,10 @@ public sealed class SchemaValidationTests
             var errors = PlatformConfigLoader.Validate(config);
 
             config.Gateway?.ListenUrl.ShouldBe("http://localhost:5005");
-            config.Providers.ShouldContainKey("copilot");
-            config.Providers!["copilot"].ApiKey.ShouldBe("provider-key");
+            config.Providers.ShouldNotBeNull();
+            var providers = config.Providers ?? throw new InvalidOperationException("Expected providers.");
+            providers.ShouldContainKey("copilot");
+            providers["copilot"].ApiKey.ShouldBe("provider-key");
             errors.ShouldNotBeNull();
         }
         finally
@@ -243,5 +245,4 @@ public sealed class SchemaValidationTests
     }
 
 }
-
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionLoaderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionLoaderTests.cs
@@ -109,11 +109,15 @@ public sealed class ExtensionLoaderTests : IDisposable
         result.RegisteredServices.ShouldContain(service => service.StartsWith("IChannelAdapter->", StringComparison.Ordinal));
         var descriptor = services.Single(d => d.ServiceType == typeof(IChannelAdapter));
         descriptor.ImplementationType.ShouldNotBeNull();
-        descriptor.ImplementationType!.FullName.ShouldContain("TelegramChannelAdapter");
+        var implementationType = descriptor.ImplementationType ?? throw new InvalidOperationException("Expected implementation type.");
+        implementationType.FullName.ShouldNotBeNull();
+        var fullName = implementationType.FullName ?? throw new InvalidOperationException("Expected implementation full name.");
+        fullName.ShouldContain("TelegramChannelAdapter");
 
-        var loadContext = AssemblyLoadContext.GetLoadContext(descriptor.ImplementationType.Assembly);
+        var loadContext = AssemblyLoadContext.GetLoadContext(implementationType.Assembly);
         loadContext.ShouldNotBeNull();
-        loadContext!.IsCollectible.ShouldBeTrue();
+        var context = loadContext ?? throw new InvalidOperationException("Expected load context.");
+        context.IsCollectible.ShouldBeTrue();
         loadContext.ShouldNotBe(AssemblyLoadContext.Default);
 
         loader.GetLoaded().Where(x => x.ExtensionId == "telegram-extension").ShouldHaveSingleItem();

--- a/tests/gateway/BotNexus.Gateway.Tests/FileAgentWorkspaceManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileAgentWorkspaceManagerTests.cs
@@ -25,9 +25,15 @@ public sealed class FileAgentWorkspaceManagerTests : IDisposable
         var workspace = await _workspaceManager.LoadWorkspaceAsync("farnsworth");
 
         workspace.AgentName.ShouldBe("farnsworth");
-        workspace.Soul.ShouldContain("# Soul");
-        workspace.Identity.ShouldContain("# Identity");
-        workspace.User.ShouldContain("# User");
+        workspace.Soul.ShouldNotBeNull();
+        workspace.Identity.ShouldNotBeNull();
+        workspace.User.ShouldNotBeNull();
+        var soul = workspace.Soul ?? throw new InvalidOperationException("Expected soul content.");
+        var identity = workspace.Identity ?? throw new InvalidOperationException("Expected identity content.");
+        var user = workspace.User ?? throw new InvalidOperationException("Expected user content.");
+        soul.ShouldContain("# Soul");
+        identity.ShouldContain("# Identity");
+        user.ShouldContain("# User");
         workspace.Memory.ShouldBeEmpty();
 
         var workspacePath = _workspaceManager.GetWorkspacePath("farnsworth");
@@ -67,12 +73,12 @@ public sealed class FileAgentWorkspaceManagerTests : IDisposable
 
         overload.ShouldNotBeNull("Wave 1 requires memory_save(file_path, content) support.");
 
-        var task = (Task?)overload!.Invoke(
+        var invocationResult = overload!.Invoke(
             _workspaceManager,
             ["farnsworth", @"memory\handoff.md", "first handoff entry", CancellationToken.None]);
-
-        task.ShouldNotBeNull();
-        await task!;
+        invocationResult.ShouldNotBeNull();
+        var task = invocationResult as Task ?? throw new InvalidOperationException("Expected async task.");
+        await task;
 
         var handoffPath = Path.Combine(_workspaceManager.GetWorkspacePath("farnsworth"), "memory", "handoff.md");
         var content = await _fileSystem.File.ReadAllTextAsync(handoffPath);

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
@@ -72,7 +72,10 @@ public sealed class GatewayStartupAndConfigurationTests
 
             health.GetProperty("status").GetString().ShouldBe("ok");
             validationResponse.GetProperty("isValid").GetBoolean().ShouldBeFalse();
-            validationResponse.GetProperty("errors")[0].GetString().ShouldContain("Config file not found");
+            var firstError = validationResponse.GetProperty("errors")[0].GetString();
+            firstError.ShouldNotBeNull();
+            var errorText = firstError ?? throw new InvalidOperationException("Expected validation error text.");
+            errorText.ShouldContain("Config file not found");
         });
     }
 
@@ -96,9 +99,11 @@ public sealed class GatewayStartupAndConfigurationTests
         {
             var config = PlatformConfigLoader.Load(configPath, validateOnLoad: false);
 
-            config.Providers.ShouldContainKey("github-copilot");
-            config.Providers!["github-copilot"].ApiKey.ShouldBe("auth:copilot");
-            config.Providers["github-copilot"].BaseUrl.ShouldBe("https://api.githubcopilot.com");
+            config.Providers.ShouldNotBeNull();
+            var providers = config.Providers ?? throw new InvalidOperationException("Expected providers.");
+            providers.ShouldContainKey("github-copilot");
+            providers["github-copilot"].ApiKey.ShouldBe("auth:copilot");
+            providers["github-copilot"].BaseUrl.ShouldBe("https://api.githubcopilot.com");
             return Task.CompletedTask;
         });
     }
@@ -373,4 +378,3 @@ public sealed class GatewayStartupAndConfigurationTests
         }
     }
 }
-

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigReloadTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigReloadTests.cs
@@ -80,12 +80,16 @@ public sealed class PlatformConfigReloadTests : IDisposable
         var config = sp.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue;
 
         // Assert
-        config.Agents.ShouldNotContainKey("defaults",
+        config.Agents.ShouldNotBeNull();
+        var agents = config.Agents ?? throw new InvalidOperationException("Expected agents config.");
+        agents.ShouldNotContainKey("defaults",
             "defaults pseudo-agent should be stripped after post-configure");
-        config.Agents.ShouldContainKey("myagent");
+        agents.ShouldContainKey("myagent");
         config.AgentDefaults.ShouldNotBeNull();
-        config.AgentDefaults!.ToolIds.ShouldNotBeNull();
-        config.AgentDefaults!.ToolIds!.ShouldContain("web-search");
+        var agentDefaults = config.AgentDefaults ?? throw new InvalidOperationException("Expected agent defaults.");
+        agentDefaults.ToolIds.ShouldNotBeNull();
+        var toolIds = agentDefaults.ToolIds ?? throw new InvalidOperationException("Expected default tool IDs.");
+        toolIds.ShouldContain("web-search");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs
@@ -52,10 +52,12 @@ public sealed class PlatformConfigurationTests
         config.Gateway?.ListenUrl.ShouldBe("http://localhost:18790");
         config.Gateway?.DefaultAgentId.ShouldBe("agent-a");
         config.Gateway?.LogLevel.ShouldBe("Debug");
-        config.Providers.ShouldContainKey("copilot");
-        config.Providers!["copilot"].ApiKey.ShouldBe("test-key");
-        config.Providers["copilot"].BaseUrl.ShouldBe("https://api.githubcopilot.com");
-        config.Providers["copilot"].DefaultModel.ShouldBe("gpt-4.1");
+        config.Providers.ShouldNotBeNull();
+        var providers = config.Providers ?? throw new InvalidOperationException("Expected providers.");
+        providers.ShouldContainKey("copilot");
+        providers["copilot"].ApiKey.ShouldBe("test-key");
+        providers["copilot"].BaseUrl.ShouldBe("https://api.githubcopilot.com");
+        providers["copilot"].DefaultModel.ShouldBe("gpt-4.1");
     }
 
     [Fact]
@@ -698,8 +700,10 @@ public sealed class PlatformConfigurationTests
         var reloaded = await PlatformConfigLoader.LoadAsync(fixture.ConfigPath, validateOnLoad: false);
 
         reloaded.Gateway?.LogLevel.ShouldBe("Warning");
-        reloaded.Providers.ShouldContainKey("copilot");
-        reloaded.Providers!["copilot"].ApiKey.ShouldBe("updated-key");
+        reloaded.Providers.ShouldNotBeNull();
+        var providers = reloaded.Providers ?? throw new InvalidOperationException("Expected providers.");
+        providers.ShouldContainKey("copilot");
+        providers["copilot"].ApiKey.ShouldBe("updated-key");
     }
 
     private sealed class PlatformConfigFixture : IDisposable

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/ListByChannelTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/ListByChannelTests.cs
@@ -76,10 +76,10 @@ public sealed class ListByChannelTests
             [typeof(BotNexus.Domain.Primitives.AgentId), typeof(ChannelKey), typeof(CancellationToken)]);
 
         method.ShouldNotBeNull("ListByChannelAsync must exist on session store implementations.");
-        var invocationResult = method!.Invoke(store, [BotNexus.Domain.Primitives.AgentId.From(agentId), channelType, CancellationToken.None]);
-        invocationResult.ShouldBeAssignableTo<Task>();
-
-        var task = (Task)invocationResult!;
+        var reflectionMethod = method ?? throw new InvalidOperationException("Expected ListByChannelAsync method.");
+        var invocationResult = reflectionMethod.Invoke(store, [BotNexus.Domain.Primitives.AgentId.From(agentId), channelType, CancellationToken.None]);
+        invocationResult.ShouldNotBeNull();
+        var task = invocationResult as Task ?? throw new InvalidOperationException("Expected task result.");
         await task;
 
         var resultProperty = task.GetType().GetProperty("Result");
@@ -89,4 +89,3 @@ public sealed class ListByChannelTests
         return sessions!;
     }
 }
-

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionsControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionsControllerTests.cs
@@ -446,7 +446,9 @@ public sealed class SessionsControllerTests
         var result = await controller.PatchMetadata("s1", patchDocument.RootElement.Clone(), CancellationToken.None);
 
         var payload = (result.Result as OkObjectResult)?.Value as Dictionary<string, object?>;
-        payload.ShouldContainKeyAndValue("theme", (object?)"dark");
+        payload.ShouldNotBeNull();
+        var metadata = payload ?? throw new InvalidOperationException("Expected metadata payload.");
+        metadata.ShouldContainKeyAndValue("theme", (object?)"dark");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/ToolPolicyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ToolPolicyTests.cs
@@ -187,8 +187,11 @@ public sealed class ToolPolicyTests
         var result = await handler.HandleAsync(evt);
 
         result.ShouldNotBeNull();
-        result!.Denied.ShouldBeTrue();
-        result.DenyReason.ShouldContain("exec");
+        var deniedResult = result ?? throw new InvalidOperationException("Expected denied result.");
+        deniedResult.Denied.ShouldBeTrue();
+        deniedResult.DenyReason.ShouldNotBeNull();
+        var denyReason = deniedResult.DenyReason ?? throw new InvalidOperationException("Expected deny reason.");
+        denyReason.ShouldContain("exec");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Updates/UpdateCheckServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Updates/UpdateCheckServiceTests.cs
@@ -116,7 +116,6 @@ public sealed class UpdateCheckServiceTests
     [Fact]
     public async Task CheckNowAsync_WhenGitHubReturnsNewerCommit_SetsIsUpdateAvailable()
     {
-        const string currentSha = "aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000";
         const string latestSha = "bbbb1111bbbb1111bbbb1111bbbb1111bbbb1111";
 
         var config = BuildConfig();


### PR DESCRIPTION
## Summary

Fixes build and test warning sources across the runtime, tests, and agent instructions, then locks the door so new warnings can't slip in.

### Changes

- **Warning fixes (gateway/API):** Resolved nullable reference and XML documentation warnings in gateway and API projects.
- **Warning fixes (tests):** Fixed nullable warnings in test assertion code.
- **OpenTelemetry package updates:** Updated vulnerable OpenTelemetry package versions to remove NU1902 (known-vulnerabilities) warnings.
- **Warnings-as-errors enforcement:** Enabled `TreatWarningsAsErrors=true` centrally in `Directory.Build.props` for **all** projects, including tests.
- **Agent instructions update:** Updated docs so warnings are treated as task-blocking failures and must not be suppressed or ignored.

### Validation

```shell
dotnet build BotNexus.slnx --nologo --tl:off
dotnet test BotNexus.slnx --nologo --tl:off --no-build -m:1
dotnet list BotNexus.slnx package --vulnerable --include-transitive
```

All three commands pass cleanly with zero warnings.