### PR TITLE
feat(blazor-client): support URL-routed portal state

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -55,7 +55,7 @@
 
             @* Nav links *@
             <nav class="sidebar-nav">
-                <a href="" class="sidebar-nav-item @NavClass("")" @onclick="OnNavClick">💬 Chat</a>
+                <a href="chat" class="sidebar-nav-item @NavClass("")" @onclick="OnNavClick">💬 Chat</a>
 
                 @* Scrollable agent/conversation section *@
                 <div class="sidebar-scroll-region">
@@ -362,7 +362,7 @@
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
         var relative = Nav.ToBaseRelativePath(e.Location).TrimEnd('/');
-        if (relative == "")
+        if (relative == "" || relative.Equals("chat", StringComparison.OrdinalIgnoreCase))
         {
             _ = InvokeAsync(async () =>
             {
@@ -375,6 +375,15 @@
     private string NavClass(string page)
     {
         var uri = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
+        if (string.IsNullOrEmpty(page))
+        {
+            return uri == "" ||
+                uri.Equals("chat", StringComparison.OrdinalIgnoreCase) ||
+                uri.StartsWith("chat/", StringComparison.OrdinalIgnoreCase)
+                ? "active"
+                : "";
+        }
+
         return string.Equals(uri, page, StringComparison.OrdinalIgnoreCase) ? "active" : "";
     }
 
@@ -403,6 +412,8 @@
                 if (agent.ActiveConversationId is not null)
                     await Interaction.SelectConversationAsync(agentId, agent.ActiveConversationId);
             }
+
+            NavigateToChat(agentId, Store.GetAgent(agentId)?.ActiveConversationId);
             Store.NotifyChanged();
 
             if (_isMobile)
@@ -463,15 +474,29 @@
     private async Task SelectConversationAsync(string agentId, string conversationId)
     {
         await Interaction.SelectConversationAsync(agentId, conversationId);
+        NavigateToChat(agentId, conversationId);
         if (_isMobile)
             _sidebarOpen = false;
     }
 
     private async Task CreateConversationAsync(string agentId)
     {
-        await Interaction.CreateConversationAsync(agentId);
+        var conversationId = await Interaction.CreateConversationAsync(agentId);
+        NavigateToChat(agentId, conversationId);
         if (_isMobile)
             _sidebarOpen = false;
+    }
+
+    private void NavigateToChat(string agentId, string? conversationId = null)
+    {
+        var encodedAgentId = Uri.EscapeDataString(agentId);
+        var target = string.IsNullOrWhiteSpace(conversationId)
+            ? $"chat/{encodedAgentId}"
+            : $"chat/{encodedAgentId}/{Uri.EscapeDataString(conversationId)}";
+
+        var current = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
+        if (!string.Equals(current, target, StringComparison.OrdinalIgnoreCase))
+            Nav.NavigateTo(target);
     }
 
     private async Task ArchiveConversationAsync(string agentId, string conversationId, string title, bool isVirtualSession)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
@@ -105,13 +105,19 @@ else
         if (!Store.Agents.ContainsKey(routeAgentId))
         {
             if (Store.ActiveAgentId is null && Store.Agents.Keys.FirstOrDefault() is { } fallback)
+            {
                 Store.ActiveAgentId = fallback;
+                Store.NotifyChanged();
+            }
 
             return;
         }
 
         if (!string.Equals(Store.ActiveAgentId, routeAgentId, StringComparison.Ordinal))
+        {
             Store.ActiveAgentId = routeAgentId;
+            Store.NotifyChanged();
+        }
 
         if (routeConversationId is null)
         {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
@@ -1,6 +1,10 @@
 @page "/"
+@page "/chat"
+@page "/chat/{AgentId}"
+@page "/chat/{AgentId}/{ConversationId}"
 @inject IClientStateStore Store
 @inject IPortalLoadService PortalLoad
+@inject IAgentInteractionService Interaction
 @inject NavigationManager Nav
 @implements IDisposable
 
@@ -37,10 +41,19 @@ else
 }
 
 @code {
+    [Parameter] public string? AgentId { get; set; }
+    [Parameter] public string? ConversationId { get; set; }
+    private string? _appliedRouteKey;
+
     protected override void OnInitialized()
     {
         PortalLoad.OnReadyChanged += HandleReadyChanged;
         Store.OnChanged += HandleStateChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await ApplyRouteSelectionAsync();
     }
 
     protected override async Task OnInitializedAsync()
@@ -58,10 +71,63 @@ else
                 Console.Error.WriteLine($"Portal initialization failed: {ex.Message}");
             }
         }
+
+        await ApplyRouteSelectionAsync();
     }
 
-    private void HandleReadyChanged() => InvokeAsync(StateHasChanged);
-    private void HandleStateChanged() => InvokeAsync(StateHasChanged);
+    private void HandleReadyChanged() =>
+        _ = InvokeAsync(async () =>
+        {
+            await ApplyRouteSelectionAsync();
+            StateHasChanged();
+        });
+
+    private void HandleStateChanged() =>
+        _ = InvokeAsync(async () =>
+        {
+            await ApplyRouteSelectionAsync();
+            StateHasChanged();
+        });
+
+    private async Task ApplyRouteSelectionAsync()
+    {
+        if (!PortalLoad.IsReady || string.IsNullOrWhiteSpace(AgentId))
+            return;
+
+        var routeAgentId = Uri.UnescapeDataString(AgentId);
+        var routeConversationId = string.IsNullOrWhiteSpace(ConversationId)
+            ? null
+            : Uri.UnescapeDataString(ConversationId);
+        var routeKey = $"{routeAgentId}|{routeConversationId ?? ""}";
+        if (string.Equals(_appliedRouteKey, routeKey, StringComparison.Ordinal))
+            return;
+
+        if (!Store.Agents.ContainsKey(routeAgentId))
+        {
+            if (Store.ActiveAgentId is null && Store.Agents.Keys.FirstOrDefault() is { } fallback)
+                Store.ActiveAgentId = fallback;
+
+            return;
+        }
+
+        if (!string.Equals(Store.ActiveAgentId, routeAgentId, StringComparison.Ordinal))
+            Store.ActiveAgentId = routeAgentId;
+
+        if (routeConversationId is null)
+        {
+            _appliedRouteKey = routeKey;
+            return;
+        }
+
+        var agent = Store.GetAgent(routeAgentId);
+        if (agent is null || !agent.Conversations.ContainsKey(routeConversationId))
+            return;
+
+        if (!string.Equals(agent.ActiveConversationId, routeConversationId, StringComparison.Ordinal))
+            await Interaction.SelectConversationAsync(routeAgentId, routeConversationId);
+
+        _appliedRouteKey = routeKey;
+    }
 
     public void Dispose()
     {

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
@@ -206,6 +206,31 @@ public sealed class HomePageTests : IDisposable
     }
 
     [Fact]
+    public void Direct_route_to_chat_agent_only_notifies_layout_subscribers_on_agent_restore()
+    {
+        _portalLoad.IsReady.Returns(true);
+        _store.ActiveAgentId.Returns("agent-1");
+
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-1"] = new() { AgentId = "agent-1", DisplayName = "Alpha" },
+            ["agent-2"] = new() { AgentId = "agent-2", DisplayName = "Beta" }
+        };
+
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        _ctx.Render<Home>(p => p.Add(c => c.AgentId, "agent-2"));
+
+        Assert.Equal("agent-2", _store.ActiveAgentId);
+        _store.Received(1).NotifyChanged();
+    }
+
+    [Fact]
     public void Direct_route_decodes_url_encoded_agent_and_conversation_ids()
     {
         _portalLoad.IsReady.Returns(true);
@@ -278,6 +303,45 @@ public sealed class HomePageTests : IDisposable
             .Add(c => c.ConversationId, "missing-conversation"));
 
         Assert.Equal("agent-1", _store.ActiveAgentId);
+        _interaction.DidNotReceive().SelectConversationAsync(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void Direct_route_with_missing_agent_sets_fallback_and_notifies_when_active_agent_is_empty()
+    {
+        _portalLoad.IsReady.Returns(true);
+        _store.ActiveAgentId.Returns((string?)null);
+
+        var fallbackAgent = new AgentState
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alpha",
+            ActiveConversationId = "known-conversation"
+        };
+        fallbackAgent.Conversations["known-conversation"] = new ConversationState
+        {
+            ConversationId = "known-conversation",
+            Title = "Known"
+        };
+
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-1"] = fallbackAgent
+        };
+
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        _ctx.Render<Home>(p => p
+            .Add(c => c.AgentId, "missing-agent")
+            .Add(c => c.ConversationId, "missing-conversation"));
+
+        Assert.Equal("agent-1", _store.ActiveAgentId);
+        _store.Received(1).NotifyChanged();
         _interaction.DidNotReceive().SelectConversationAsync(Arg.Any<string>(), Arg.Any<string>());
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
@@ -11,20 +11,25 @@ public sealed class HomePageTests : IDisposable
     private readonly BunitContext _ctx = new();
     private readonly IClientStateStore _store;
     private readonly IPortalLoadService _portalLoad;
+    private readonly IAgentInteractionService _interaction;
 
     public HomePageTests()
     {
         _store = Substitute.For<IClientStateStore>();
         _portalLoad = Substitute.For<IPortalLoadService>();
+        _interaction = Substitute.For<IAgentInteractionService>();
 
         _portalLoad.IsReady.Returns(false);
         _portalLoad.IsLoading.Returns(true);
         _portalLoad.LoadError.Returns((string?)null);
+        _portalLoad.InitializeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
         _store.Agents.Returns(new Dictionary<string, AgentState>().AsReadOnly());
         _store.ActiveAgentId.Returns((string?)null);
+        _store.GetStreamState(Arg.Any<string>()).Returns(new ConversationStreamState());
 
         _ctx.Services.AddSingleton(_store);
         _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(_interaction);
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -141,5 +146,138 @@ public sealed class HomePageTests : IDisposable
 
         var wrapper = cut.Find(".chat-panel-wrapper");
         Assert.Contains("active", wrapper.ClassList);
+    }
+
+    [Fact]
+    public void Applies_agent_route_when_portal_becomes_ready()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-1"] = new() { AgentId = "agent-1", DisplayName = "Alpha" },
+            ["agent-2"] = new() { AgentId = "agent-2", DisplayName = "Beta" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+        _portalLoad.IsReady.Returns(false, true);
+        _portalLoad.IsLoading.Returns(true, false);
+
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        _ctx.Render<Home>(p => p.Add(c => c.AgentId, "agent-2"));
+
+        _portalLoad.OnReadyChanged += Raise.Event<Action>();
+
+        Assert.Equal("agent-2", _store.ActiveAgentId);
+    }
+
+    [Fact]
+    public void Direct_route_to_chat_agent_and_conversation_selects_conversation_when_available()
+    {
+        _portalLoad.IsReady.Returns(true);
+
+        var targetAgent = new AgentState
+        {
+            AgentId = "agent-2",
+            DisplayName = "Beta",
+            ActiveConversationId = "c-1"
+        };
+        targetAgent.Conversations["c-1"] = new ConversationState { ConversationId = "c-1", Title = "One" };
+        targetAgent.Conversations["c-2"] = new ConversationState { ConversationId = "c-2", Title = "Two" };
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-2"] = targetAgent
+        };
+
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        _ctx.Render<Home>(p => p
+            .Add(c => c.AgentId, "agent-2")
+            .Add(c => c.ConversationId, "c-2"));
+
+        Assert.Equal("agent-2", _store.ActiveAgentId);
+        _interaction.Received(1).SelectConversationAsync("agent-2", "c-2");
+    }
+
+    [Fact]
+    public void Direct_route_decodes_url_encoded_agent_and_conversation_ids()
+    {
+        _portalLoad.IsReady.Returns(true);
+
+        const string decodedAgentId = "agent/encoded";
+        const string decodedConversationId = "conv/encoded id";
+        var encodedAgentId = Uri.EscapeDataString(decodedAgentId);
+        var encodedConversationId = Uri.EscapeDataString(decodedConversationId);
+
+        var targetAgent = new AgentState
+        {
+            AgentId = decodedAgentId,
+            DisplayName = "Encoded Agent",
+            ActiveConversationId = "fallback"
+        };
+        targetAgent.Conversations[decodedConversationId] = new ConversationState
+        {
+            ConversationId = decodedConversationId,
+            Title = "Encoded Conversation"
+        };
+        var agents = new Dictionary<string, AgentState> { [decodedAgentId] = targetAgent };
+
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        _ctx.Render<Home>(p => p
+            .Add(c => c.AgentId, encodedAgentId)
+            .Add(c => c.ConversationId, encodedConversationId));
+
+        Assert.Equal(decodedAgentId, _store.ActiveAgentId);
+        _interaction.Received(1).SelectConversationAsync(decodedAgentId, decodedConversationId);
+    }
+
+    [Fact]
+    public void Direct_route_with_stale_ids_falls_back_without_crashing()
+    {
+        _portalLoad.IsReady.Returns(true);
+        _store.ActiveAgentId = "agent-1";
+
+        var knownAgent = new AgentState
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alpha",
+            ActiveConversationId = "known-conversation"
+        };
+        knownAgent.Conversations["known-conversation"] = new ConversationState
+        {
+            ConversationId = "known-conversation",
+            Title = "Known"
+        };
+
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["agent-1"] = knownAgent
+        };
+
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.GetAgent(Arg.Any<string>()).Returns(ci =>
+            agents.GetValueOrDefault(ci.ArgAt<string>(0)));
+
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.Services.AddSingleton(new HttpClient());
+
+        _ctx.Render<Home>(p => p
+            .Add(c => c.AgentId, "missing-agent")
+            .Add(c => c.ConversationId, "missing-conversation"));
+
+        Assert.Equal("agent-1", _store.ActiveAgentId);
+        _interaction.DidNotReceive().SelectConversationAsync(Arg.Any<string>(), Arg.Any<string>());
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -401,6 +402,91 @@ public sealed class MainLayoutTests : IDisposable
 
         var scrollContainer = cut.Find(".conversation-list-scroll");
         Assert.Equal(40, scrollContainer.QuerySelectorAll(".conversation-list-item-btn").Length);
+    }
+
+    [Fact]
+    public void Direct_route_to_chat_marks_chat_section_active()
+    {
+        var nav = _ctx.Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("http://localhost/chat");
+
+        var cut = RenderLayout();
+
+        var chatLink = cut.Find("a[href='chat']");
+        Assert.Contains("active", chatLink.ClassName);
+    }
+
+    [Fact]
+    public void Hard_refresh_on_configuration_path_marks_configuration_section_active()
+    {
+        var nav = _ctx.Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("http://localhost/configuration");
+
+        var cut = RenderLayout();
+
+        var configLink = cut.Find("a[href='configuration']");
+        Assert.Contains("active", configLink.ClassName);
+    }
+
+    [Fact]
+    public void In_app_agent_selection_updates_url_with_agent_route()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "Default", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+
+        var nav = _ctx.Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("http://localhost/chat");
+
+        var cut = RenderLayout();
+        cut.Find(".agent-dropdown-select").Change("a-1");
+
+        cut.WaitForAssertion(() =>
+            Assert.EndsWith("/chat/a-1/c-1", nav.Uri));
+    }
+
+    [Fact]
+    public void In_app_conversation_selection_updates_url_with_conversation_route()
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", [
+            new ConversationSummaryDto("c-1", "a-1", "First", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("c-2", "a-1", "Second", false, "Active", null, 0, DateTimeOffset.UtcNow.AddMinutes(1), DateTimeOffset.UtcNow.AddMinutes(1))
+        ]);
+        _store.ActiveAgentId = "a-1";
+
+        var nav = _ctx.Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("http://localhost/chat/a-1/c-1");
+
+        var cut = RenderLayout();
+        cut.FindAll(".conversation-list-item-btn")
+            .First(btn => btn.TextContent.Contains("Second", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+            Assert.EndsWith("/chat/a-1/c-2", nav.Uri));
+    }
+
+    [Fact]
+    public void In_app_selection_url_encodes_agent_and_conversation_ids()
+    {
+        const string agentId = "agent/x";
+        const string conversationId = "conv/1 with space";
+        _store.SeedAgents([new AgentSummary(agentId, "Encoded Agent")]);
+        _store.SeedConversations(agentId, [
+            new ConversationSummaryDto(conversationId, agentId, "Encoded Conversation", true, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+
+        var nav = _ctx.Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("http://localhost/chat");
+
+        var cut = RenderLayout();
+        cut.Find(".agent-dropdown-select").Change(agentId);
+
+        var expectedSuffix = $"/chat/{Uri.EscapeDataString(agentId)}/{Uri.EscapeDataString(conversationId)}";
+        cut.WaitForAssertion(() =>
+            Assert.EndsWith(expectedSuffix, nav.Uri));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add deep-link routes for chat, chat agent, and chat conversation state
- keep browser URLs in sync when users switch agents or conversations
- restore route-selected chat state after hard refresh with safe fallback for stale IDs
- add Blazor regression tests for direct routes, config activation, URL encoding, stale IDs, and route-driven notifications

## Validation
- dotnet test tests\extensions\BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests\BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj --nologo --tl:off
- dotnet build BotNexus.slnx --nologo --tl:off
- dotnet test BotNexus.slnx --nologo --tl:off