### PR TITLE
docs: enforce worktree policy for all changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,15 @@
 
 ## Git Workflow
 
-- **Worktrees are allowed when explicitly requested.** If a user asks you to create or use a worktree, do so. Otherwise, work directly on the current branch without creating a worktree.
+- **All file modifications and commits must happen in a dedicated worktree, never directly on `main`.** Create a worktree for every task. Keep the local `main` branch clean and always aligned to `origin/main`.
+- **If local changes appear on `main`**, stop work immediately, create a worktree for the branch containing those changes, then continue:
+  ```bash
+  git worktree add ../botnexus-temp -b <type>/<issue>-<slug>
+  cd ../botnexus-temp
+  git cherry-pick <commits> # move changes from main, or reset main and reset worktree to origin/main
+  cd ../botnexus && git reset --hard origin/main
+  ```
+- Then delete the temporary worktree after merging/pushing the PR.
 
 ## Dev Environment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,23 +82,34 @@ All test warnings will be treated as test failures once warnings-as-errors is en
 
 ## Git Workflow
 
-**Worktrees may be used for independent branches when requested.** When a user asks for a worktree, use it. Do not create a worktree automatically without explicit user request.
+**All file modifications and commits must happen in a dedicated worktree, never directly on `main`.** This is mandatory for all agents and developers. Local `main` must remain clean and aligned to `origin/main`.
 
-```bash
-# Create a worktree for new work (N = GitHub issue number)
-git worktree add ../botnexus-wt-N -b <type>/N-<short-slug>
+### Worktree Policy
 
-# Work in the worktree — main repo always stays on main
-cd ../botnexus-wt-N
+- **Every task requires a dedicated worktree.** Create one at the start of work:
+  ```bash
+  git worktree add ../botnexus-wt-N -b <type>/N-<short-slug>
+  cd ../botnexus-wt-N
+  ```
 
-# Clean up after PR merges
-git worktree remove ../botnexus-wt-N
-```
+- **Local `main` must always be clean.** After a worktree is merged and the PR closes:
+  ```bash
+  git worktree remove ../botnexus-wt-N
+  cd ../botnexus && git checkout main && git pull origin main
+  ```
 
-- `~/projects/botnexus` — always on `main`
-- `../botnexus-wt-N` — dedicated worktree per issue/PR
-- Branch naming: `<type>/<issue-number>-<short-slug>` (e.g. `fix/64-history-first-load`)
+- **If you find local changes on `main`:** Move them to a worktree immediately before continuing work:
+  1. `git worktree add ../botnexus-recover -b <type>/<recovery-slug>`
+  2. Cherry-pick or push the changes to the worktree
+  3. `git reset --hard origin/main` on the main repo
+  4. Continue work in the worktree, then merge via PR
+
+### Branch & PR Conventions
+
+- `../botnexus-wt-N` — dedicated worktree per issue/PR (N = GitHub issue number)
+- Branch naming: `<type>/<issue-number>-<short-slug>` (e.g. `fix/64-history-first-load`, `feat/128-gateway-plugins`)
 - PRs always target `main`; never branch off a feature branch
+- `~/projects/botnexus` — always on `main`, clean and synced to `origin/main`
 
 ## Build
 


### PR DESCRIPTION
## Summary

Updates .github/copilot-instructions.md and AGENTS.md to enforce a strict worktree-only policy for all file modifications.

## Changes

- **Requires all file modifications and commits to happen in dedicated worktrees** — agents and developers must never edit files directly on the local main branch.
- **Prohibits committing directly on local main** — main is a read-only tracking branch used only for pulling upstream changes.
- **Documents recovery steps** when changes accidentally appear on main (stash, create worktree, apply).
- Updates both instruction files to make the policy explicit and actionable.

## Testing

Documentation-only change; no code modified. Tests were not run unless the pre-commit hook already executed during commit.