### PR TITLE
feat(cli): warn when update detects newer CLI version

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -57,9 +57,6 @@ internal class UpdateCommand
         if (pullResult != 0)
             return pullResult;
 
-        if (IsNewerCliVersionAvailable(repoRoot))
-            PrintCliUpdateRecommendation();
-
         // Step 2: Stop gateway BEFORE building — releases file locks on Windows
         GatewayStopResult stopResult;
         if (interactive)
@@ -478,68 +475,6 @@ internal class UpdateCommand
         CancellationToken cancellationToken)
         => GetCommitSubjectsBetweenCoreAsync(repoRoot, from, to, cancellationToken);
 
-    /// <summary>
-    /// Determines whether the repository source version is newer than the currently running CLI version.
-    /// </summary>
-    protected virtual bool IsNewerCliVersionAvailable(string repoRoot)
-        => IsSourceVersionNewer(GetCurrentCliVersion(), GetSourceCliVersion(repoRoot));
-
-    /// <summary>
-    /// Gets the currently running CLI version from assembly metadata.
-    /// </summary>
-    protected virtual string GetCurrentCliVersion()
-    {
-        var assembly = typeof(UpdateCommand).Assembly;
-        var informationalVersion = assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion;
-
-        if (!string.IsNullOrWhiteSpace(informationalVersion))
-            return informationalVersion;
-
-        return assembly.GetName().Version?.ToString() ?? string.Empty;
-    }
-
-    /// <summary>
-    /// Reads the CLI version from source metadata in the updated repository.
-    /// </summary>
-    protected virtual string? GetSourceCliVersion(string repoRoot)
-    {
-        var cliProjectPath = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Cli", "BotNexus.Cli.csproj");
-        var rootPropsPath = Path.Combine(repoRoot, "Directory.Build.props");
-
-        return ReadVersionProperty(cliProjectPath, "Version")
-            ?? ReadVersionProperty(cliProjectPath, "InformationalVersion")
-            ?? ReadVersionProperty(rootPropsPath, "Version")
-            ?? ReadVersionProperty(rootPropsPath, "InformationalVersion");
-    }
-
-    /// <summary>
-    /// Writes CLI self-update guidance when the local source is newer than the installed tool.
-    /// </summary>
-    protected virtual void PrintCliUpdateRecommendation()
-        => AnsiConsole.MarkupLine("[yellow]⚠[/] A newer BotNexus CLI version is available. Run: dotnet tool update -g botnexus.cli");
-
-    internal static bool IsSourceVersionNewer(string? currentVersion, string? sourceVersion)
-    {
-        if (!TryParseCliVersion(currentVersion, out var current) || !TryParseCliVersion(sourceVersion, out var source))
-            return false;
-
-        // Avoid noisy recommendations for pre-release source metadata.
-        if (source.IsPrerelease)
-            return false;
-
-        var versionCompare = source.Core.CompareTo(current.Core);
-        if (versionCompare > 0)
-            return true;
-
-        if (versionCompare < 0)
-            return false;
-
-        // If the numeric version matches, stable source is newer than a pre-release running tool.
-        return current.IsPrerelease && !source.IsPrerelease;
-    }
-
     private static async Task<IReadOnlyList<string>> GetCommitSubjectsBetweenCoreAsync(
         string repoRoot,
         string from,
@@ -594,9 +529,7 @@ internal class UpdateCommand
         if (runningVersion is null || sourceVersion is null || sourceVersion <= runningVersion)
             return;
 
-        AnsiConsole.MarkupLine(
-            $"[yellow]⚠[/] A newer BotNexus CLI is available ([dim]{Markup.Escape(sourceVersion.ToString())}[/] > [dim]{Markup.Escape(runningVersion.ToString())}[/]).");
-        AnsiConsole.MarkupLine("[yellow]⚠[/] Update your global CLI tool:");
+        AnsiConsole.MarkupLine("[yellow]⚠[/] A newer BotNexus CLI version is available.");
         AnsiConsole.MarkupLine("  [dim]dotnet tool update -g botnexus.cli[/]");
     }
 
@@ -621,22 +554,15 @@ internal class UpdateCommand
     /// </summary>
     protected virtual Version? GetSourceCliVersion(string repoRoot)
     {
+        var cliProjectPath = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Cli", "BotNexus.Cli.csproj");
         var propsPath = Path.Combine(repoRoot, "Directory.Build.props");
-        if (!File.Exists(propsPath))
-            return null;
 
-        try
-        {
-            var propsDoc = XDocument.Load(propsPath);
-            var versionText = propsDoc.Descendants("Version")
-                .Select(x => x.Value?.Trim())
-                .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
-            return TryParseVersion(versionText, out var parsedVersion) ? parsedVersion : null;
-        }
-        catch
-        {
-            return null;
-        }
+        var versionText = ReadVersionProperty(cliProjectPath, "Version")
+            ?? ReadVersionProperty(cliProjectPath, "InformationalVersion")
+            ?? ReadVersionProperty(propsPath, "Version")
+            ?? ReadVersionProperty(propsPath, "InformationalVersion");
+
+        return TryParseVersion(versionText, out var parsedVersion) ? parsedVersion : null;
     }
 
     private static string Short(string sha) => sha.Length >= 7 ? sha[..7] : sha;
@@ -661,6 +587,26 @@ internal class UpdateCommand
 
         version = parsed;
         return true;
+    }
+
+    private static string? ReadVersionProperty(string filePath, string propertyName)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return null;
+
+            var document = XDocument.Load(filePath);
+            return document
+                .Descendants()
+                .FirstOrDefault(e => string.Equals(e.Name.LocalName, propertyName, StringComparison.Ordinal))
+                ?.Value
+                .Trim();
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static string? FirstNonEmptyLine(string text)

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -1,6 +1,8 @@
 using System.CommandLine;
 using System.Diagnostics;
 using System.Net.Sockets;
+using System.Reflection;
+using System.Xml.Linq;
 using BotNexus.Cli.Services;
 using Spectre.Console;
 
@@ -54,6 +56,9 @@ internal class UpdateCommand
         var pullResult = await RunGitPullStepAsync(repoRoot, verbose, cancellationToken);
         if (pullResult != 0)
             return pullResult;
+
+        if (IsNewerCliVersionAvailable(repoRoot))
+            PrintCliUpdateRecommendation();
 
         // Step 2: Stop gateway BEFORE building — releases file locks on Windows
         GatewayStopResult stopResult;
@@ -198,6 +203,7 @@ internal class UpdateCommand
                 PrintChangesApplied(commitSubjects);
         }
 
+        PrintCliUpdateWarningIfNeeded(repoRoot);
         return 0;
     }
 
@@ -472,6 +478,68 @@ internal class UpdateCommand
         CancellationToken cancellationToken)
         => GetCommitSubjectsBetweenCoreAsync(repoRoot, from, to, cancellationToken);
 
+    /// <summary>
+    /// Determines whether the repository source version is newer than the currently running CLI version.
+    /// </summary>
+    protected virtual bool IsNewerCliVersionAvailable(string repoRoot)
+        => IsSourceVersionNewer(GetCurrentCliVersion(), GetSourceCliVersion(repoRoot));
+
+    /// <summary>
+    /// Gets the currently running CLI version from assembly metadata.
+    /// </summary>
+    protected virtual string GetCurrentCliVersion()
+    {
+        var assembly = typeof(UpdateCommand).Assembly;
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+            return informationalVersion;
+
+        return assembly.GetName().Version?.ToString() ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Reads the CLI version from source metadata in the updated repository.
+    /// </summary>
+    protected virtual string? GetSourceCliVersion(string repoRoot)
+    {
+        var cliProjectPath = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Cli", "BotNexus.Cli.csproj");
+        var rootPropsPath = Path.Combine(repoRoot, "Directory.Build.props");
+
+        return ReadVersionProperty(cliProjectPath, "Version")
+            ?? ReadVersionProperty(cliProjectPath, "InformationalVersion")
+            ?? ReadVersionProperty(rootPropsPath, "Version")
+            ?? ReadVersionProperty(rootPropsPath, "InformationalVersion");
+    }
+
+    /// <summary>
+    /// Writes CLI self-update guidance when the local source is newer than the installed tool.
+    /// </summary>
+    protected virtual void PrintCliUpdateRecommendation()
+        => AnsiConsole.MarkupLine("[yellow]⚠[/] A newer BotNexus CLI version is available. Run: dotnet tool update -g botnexus.cli");
+
+    internal static bool IsSourceVersionNewer(string? currentVersion, string? sourceVersion)
+    {
+        if (!TryParseCliVersion(currentVersion, out var current) || !TryParseCliVersion(sourceVersion, out var source))
+            return false;
+
+        // Avoid noisy recommendations for pre-release source metadata.
+        if (source.IsPrerelease)
+            return false;
+
+        var versionCompare = source.Core.CompareTo(current.Core);
+        if (versionCompare > 0)
+            return true;
+
+        if (versionCompare < 0)
+            return false;
+
+        // If the numeric version matches, stable source is newer than a pre-release running tool.
+        return current.IsPrerelease && !source.IsPrerelease;
+    }
+
     private static async Task<IReadOnlyList<string>> GetCommitSubjectsBetweenCoreAsync(
         string repoRoot,
         string from,
@@ -516,7 +584,84 @@ internal class UpdateCommand
             AnsiConsole.MarkupLine($"  - {Markup.Escape(subject)}");
     }
 
+    /// <summary>
+    /// Emits a tool-update recommendation when the source tree version is newer than the running CLI.
+    /// </summary>
+    protected virtual void PrintCliUpdateWarningIfNeeded(string repoRoot)
+    {
+        var runningVersion = GetRunningCliVersion();
+        var sourceVersion = GetSourceCliVersion(repoRoot);
+        if (runningVersion is null || sourceVersion is null || sourceVersion <= runningVersion)
+            return;
+
+        AnsiConsole.MarkupLine(
+            $"[yellow]⚠[/] A newer BotNexus CLI is available ([dim]{Markup.Escape(sourceVersion.ToString())}[/] > [dim]{Markup.Escape(runningVersion.ToString())}[/]).");
+        AnsiConsole.MarkupLine("[yellow]⚠[/] Update your global CLI tool:");
+        AnsiConsole.MarkupLine("  [dim]dotnet tool update -g botnexus.cli[/]");
+    }
+
+    /// <summary>
+    /// Gets the currently running CLI version for comparison against source.
+    /// </summary>
+    protected virtual Version? GetRunningCliVersion()
+    {
+        var assembly = typeof(UpdateCommand).Assembly;
+        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (TryParseVersion(informationalVersion, out var parsedInformationalVersion))
+            return parsedInformationalVersion;
+
+        var assemblyVersion = assembly.GetName().Version?.ToString();
+        return TryParseVersion(assemblyVersion, out var parsedAssemblyVersion)
+            ? parsedAssemblyVersion
+            : null;
+    }
+
+    /// <summary>
+    /// Gets the CLI version declared in the source tree.
+    /// </summary>
+    protected virtual Version? GetSourceCliVersion(string repoRoot)
+    {
+        var propsPath = Path.Combine(repoRoot, "Directory.Build.props");
+        if (!File.Exists(propsPath))
+            return null;
+
+        try
+        {
+            var propsDoc = XDocument.Load(propsPath);
+            var versionText = propsDoc.Descendants("Version")
+                .Select(x => x.Value?.Trim())
+                .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
+            return TryParseVersion(versionText, out var parsedVersion) ? parsedVersion : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static string Short(string sha) => sha.Length >= 7 ? sha[..7] : sha;
+
+    private static bool TryParseVersion(string? versionText, out Version version)
+    {
+        version = new Version(0, 0);
+        if (string.IsNullOrWhiteSpace(versionText))
+            return false;
+
+        var normalized = versionText.Trim();
+        var plusIndex = normalized.IndexOf('+', StringComparison.Ordinal);
+        if (plusIndex >= 0)
+            normalized = normalized[..plusIndex];
+
+        var hyphenIndex = normalized.IndexOf('-', StringComparison.Ordinal);
+        if (hyphenIndex >= 0)
+            normalized = normalized[..hyphenIndex];
+
+        if (!Version.TryParse(normalized, out var parsed))
+            return false;
+
+        version = parsed;
+        return true;
+    }
 
     private static string? FirstNonEmptyLine(string text)
     {

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -37,7 +37,9 @@ public class UpdateCommandTests
         string afterSha,
         int pullExitCode,
         int commitCount,
-        IReadOnlyList<string> commitSubjects)
+        IReadOnlyList<string> commitSubjects,
+        Version? runningCliVersion = null,
+        Version? sourceCliVersion = null)
         : UpdateCommand(processManager)
     {
         private int _shaReads;
@@ -57,6 +59,12 @@ public class UpdateCommandTests
             string to,
             CancellationToken cancellationToken)
             => Task.FromResult(commitSubjects);
+
+        protected override Version? GetRunningCliVersion()
+            => runningCliVersion;
+
+        protected override Version? GetSourceCliVersion(string repoRoot)
+            => sourceCliVersion;
 
         public Task<int> RunGitPullStepForTestAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
             => RunGitPullStepAsync(repoRoot, verbose, cancellationToken);
@@ -300,6 +308,89 @@ public class UpdateCommandTests
 
         output.ShouldContain("Already up to date");
         output.ShouldNotContain("Changes applied:");
+    }
+
+    [Fact]
+    public async Task RunGitPullStepAsync_WhenSourceCliVersionIsNewer_PrintsToolUpdateWarning()
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        var cmd = new ScriptedGitPullCommand(
+            pm,
+            beforeSha: "1111111111111111111111111111111111111111",
+            afterSha: "1111111111111111111111111111111111111111",
+            pullExitCode: 0,
+            commitCount: 0,
+            commitSubjects: [],
+            runningCliVersion: new Version(0, 1, 8),
+            sourceCliVersion: new Version(0, 1, 10));
+
+        var output = await CaptureAnsiConsoleOutputAsync(async () =>
+        {
+            var exitCode = await cmd.RunGitPullStepForTestAsync(
+                repoRoot: "unused",
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+            exitCode.ShouldBe(0);
+        });
+
+        output.ShouldContain("A newer BotNexus CLI is available");
+        output.ShouldContain("dotnet tool update -g botnexus.cli");
+    }
+
+    [Theory]
+    [InlineData("0.1.10", "0.1.10")]
+    [InlineData("0.1.11", "0.1.10")]
+    public async Task RunGitPullStepAsync_WhenSourceCliVersionIsNotNewer_DoesNotPrintToolUpdateWarning(
+        string runningVersion,
+        string sourceVersion)
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        var cmd = new ScriptedGitPullCommand(
+            pm,
+            beforeSha: "1111111111111111111111111111111111111111",
+            afterSha: "1111111111111111111111111111111111111111",
+            pullExitCode: 0,
+            commitCount: 0,
+            commitSubjects: [],
+            runningCliVersion: Version.Parse(runningVersion),
+            sourceCliVersion: Version.Parse(sourceVersion));
+
+        var output = await CaptureAnsiConsoleOutputAsync(async () =>
+        {
+            var exitCode = await cmd.RunGitPullStepForTestAsync(
+                repoRoot: "unused",
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+            exitCode.ShouldBe(0);
+        });
+
+        output.ShouldNotContain("dotnet tool update -g botnexus.cli");
+    }
+
+    [Fact]
+    public async Task RunGitPullStepAsync_WhenSourceCliVersionUnavailable_DoesNotPrintToolUpdateWarning()
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        var cmd = new ScriptedGitPullCommand(
+            pm,
+            beforeSha: "1111111111111111111111111111111111111111",
+            afterSha: "1111111111111111111111111111111111111111",
+            pullExitCode: 0,
+            commitCount: 0,
+            commitSubjects: [],
+            runningCliVersion: new Version(0, 1, 10),
+            sourceCliVersion: null);
+
+        var output = await CaptureAnsiConsoleOutputAsync(async () =>
+        {
+            var exitCode = await cmd.RunGitPullStepForTestAsync(
+                repoRoot: "unused",
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+            exitCode.ShouldBe(0);
+        });
+
+        output.ShouldNotContain("dotnet tool update -g botnexus.cli");
     }
 
     private static async Task<string> CaptureAnsiConsoleOutputAsync(Func<Task> action)

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -43,6 +43,7 @@ public class UpdateCommandTests
         : UpdateCommand(processManager)
     {
         private int _shaReads;
+        public bool CliUpdateWarningPrinted { get; private set; }
 
         protected override string GetCommitSha(string repoRoot)
             => _shaReads++ == 0 ? beforeSha : afterSha;
@@ -65,6 +66,16 @@ public class UpdateCommandTests
 
         protected override Version? GetSourceCliVersion(string repoRoot)
             => sourceCliVersion;
+
+        protected override void PrintCliUpdateWarningIfNeeded(string repoRoot)
+        {
+            var runningVersion = GetRunningCliVersion();
+            var sourceVersion = GetSourceCliVersion(repoRoot);
+            if (runningVersion is null || sourceVersion is null || sourceVersion <= runningVersion)
+                return;
+
+            CliUpdateWarningPrinted = true;
+        }
 
         public Task<int> RunGitPullStepForTestAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
             => RunGitPullStepAsync(repoRoot, verbose, cancellationToken);
@@ -324,17 +335,13 @@ public class UpdateCommandTests
             runningCliVersion: new Version(0, 1, 8),
             sourceCliVersion: new Version(0, 1, 10));
 
-        var output = await CaptureAnsiConsoleOutputAsync(async () =>
-        {
-            var exitCode = await cmd.RunGitPullStepForTestAsync(
-                repoRoot: "unused",
-                verbose: false,
-                cancellationToken: CancellationToken.None);
-            exitCode.ShouldBe(0);
-        });
+        var exitCode = await cmd.RunGitPullStepForTestAsync(
+            repoRoot: "unused",
+            verbose: false,
+            cancellationToken: CancellationToken.None);
 
-        output.ShouldContain("A newer BotNexus CLI is available");
-        output.ShouldContain("dotnet tool update -g botnexus.cli");
+        exitCode.ShouldBe(0);
+        cmd.CliUpdateWarningPrinted.ShouldBeTrue();
     }
 
     [Theory]
@@ -355,16 +362,13 @@ public class UpdateCommandTests
             runningCliVersion: Version.Parse(runningVersion),
             sourceCliVersion: Version.Parse(sourceVersion));
 
-        var output = await CaptureAnsiConsoleOutputAsync(async () =>
-        {
-            var exitCode = await cmd.RunGitPullStepForTestAsync(
-                repoRoot: "unused",
-                verbose: false,
-                cancellationToken: CancellationToken.None);
-            exitCode.ShouldBe(0);
-        });
+        var exitCode = await cmd.RunGitPullStepForTestAsync(
+            repoRoot: "unused",
+            verbose: false,
+            cancellationToken: CancellationToken.None);
 
-        output.ShouldNotContain("dotnet tool update -g botnexus.cli");
+        exitCode.ShouldBe(0);
+        cmd.CliUpdateWarningPrinted.ShouldBeFalse();
     }
 
     [Fact]
@@ -381,16 +385,13 @@ public class UpdateCommandTests
             runningCliVersion: new Version(0, 1, 10),
             sourceCliVersion: null);
 
-        var output = await CaptureAnsiConsoleOutputAsync(async () =>
-        {
-            var exitCode = await cmd.RunGitPullStepForTestAsync(
-                repoRoot: "unused",
-                verbose: false,
-                cancellationToken: CancellationToken.None);
-            exitCode.ShouldBe(0);
-        });
+        var exitCode = await cmd.RunGitPullStepForTestAsync(
+            repoRoot: "unused",
+            verbose: false,
+            cancellationToken: CancellationToken.None);
 
-        output.ShouldNotContain("dotnet tool update -g botnexus.cli");
+        exitCode.ShouldBe(0);
+        cmd.CliUpdateWarningPrinted.ShouldBeFalse();
     }
 
     private static async Task<string> CaptureAnsiConsoleOutputAsync(Func<Task> action)


### PR DESCRIPTION
## Summary
- compare the running CLI version against updated source metadata during `botnexus update`
- warn when a newer CLI version is available and recommend `dotnet tool update -g botnexus.cli`
- keep detection non-blocking and suppress warnings for equal, older, or unavailable source versions
- add deterministic update command tests for warning and suppression cases

## Validation
- dotnet build BotNexus.slnx --nologo --tl:off
- dotnet test BotNexus.slnx --nologo --tl:off