### PR TITLE
feat(channels): add Service Bus queue channel extension

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/BotNexus.Extensions.Channels.SignalR.BlazorClient.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Tui/BotNexus.Extensions.Channels.Tui.csproj" />
+    <Project Path="src/extensions/BotNexus.Extensions.Channels.ServiceBus/BotNexus.Extensions.Channels.ServiceBus.csproj" />
   </Folder>
   <Folder Name="/src/" />
   <Folder Name="/src/agent/">
@@ -69,6 +70,7 @@
     <Project Path="tests/extensions/BotNexus.Extensions.ProcessTool.Tests/BotNexus.Extensions.ProcessTool.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Skills.Tests/BotNexus.Extensions.Skills.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.WebTools.Tests/BotNexus.Extensions.WebTools.Tests.csproj" />
+    <Project Path="tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/gateway/">
     <Project Path="tests/gateway/BotNexus.Cli.Tests/BotNexus.Cli.Tests.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,9 @@
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 
+    <!-- Azure SDK -->
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.4" />
+
     <!-- Tools / utilities -->
     <PackageVersion Include="Cronos" Version="0.11.1" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/BotNexus.Extensions.Channels.ServiceBus.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/BotNexus.Extensions.Channels.ServiceBus.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Extensions.Channels.ServiceBus</RootNamespace>
+    <Description>Azure Service Bus queue channel adapter for BotNexus — inbound message receive and outbound reply dispatch.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>BotNexus.Extensions.Channels.ServiceBus.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="botnexus-extension.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/DefaultServiceBusAdapterClientFactory.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/DefaultServiceBusAdapterClientFactory.cs
@@ -1,0 +1,39 @@
+using Azure.Messaging.ServiceBus;
+
+namespace BotNexus.Extensions.Channels.ServiceBus;
+
+/// <summary>
+/// Production <see cref="IServiceBusAdapterClientFactory"/> implementation backed by a real
+/// <see cref="ServiceBusClient"/>. Created by <see cref="ServiceBusChannelAdapter"/> when no
+/// factory is injected via the constructor.
+/// </summary>
+internal sealed class DefaultServiceBusAdapterClientFactory : IServiceBusAdapterClientFactory, IAsyncDisposable
+{
+    private readonly ServiceBusClient _client;
+
+    internal DefaultServiceBusAdapterClientFactory(ServiceBusClient client) => _client = client;
+
+    /// <inheritdoc/>
+    public ServiceBusProcessor CreateProcessor(string queueName, ServiceBusProcessorOptions options)
+        => _client.CreateProcessor(queueName, options);
+
+    /// <inheritdoc/>
+    public IServiceBusSenderWrapper CreateSender(string queueName)
+        => new DefaultServiceBusSenderWrapper(_client.CreateSender(queueName));
+
+    /// <summary>Disposes the underlying <see cref="ServiceBusClient"/>.</summary>
+    public async ValueTask DisposeAsync() => await _client.DisposeAsync();
+}
+
+/// <summary>
+/// Production <see cref="IServiceBusSenderWrapper"/> backed by a real <see cref="ServiceBusSender"/>.
+/// </summary>
+internal sealed class DefaultServiceBusSenderWrapper(ServiceBusSender sender) : IServiceBusSenderWrapper
+{
+    /// <inheritdoc/>
+    public Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
+        => sender.SendMessageAsync(message, cancellationToken);
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync() => await sender.DisposeAsync();
+}

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/IServiceBusAdapterClientFactory.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/IServiceBusAdapterClientFactory.cs
@@ -1,0 +1,33 @@
+using Azure.Messaging.ServiceBus;
+
+namespace BotNexus.Extensions.Channels.ServiceBus;
+
+/// <summary>
+/// Abstraction over the sealed <see cref="ServiceBusSender"/> SDK type.
+/// Inject a test double to verify outbound message content and queue routing
+/// without a real Azure connection.
+/// </summary>
+public interface IServiceBusSenderWrapper : IAsyncDisposable
+{
+    /// <summary>Sends a single message to the Service Bus queue this sender targets.</summary>
+    Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Factory that creates the Service Bus processor and sender components used by
+/// <see cref="ServiceBusChannelAdapter"/>.
+/// </summary>
+/// <remarks>
+/// The default implementation wraps a real <see cref="ServiceBusClient"/> created from
+/// <see cref="ServiceBusChannelOptions.ConnectionString"/>. For managed-identity or custom
+/// credential scenarios, provide an alternative implementation via dependency injection
+/// before calling <c>AddBotNexusServiceBusChannel</c>.
+/// </remarks>
+public interface IServiceBusAdapterClientFactory
+{
+    /// <summary>Creates a processor that receives messages from <paramref name="queueName"/>.</summary>
+    ServiceBusProcessor CreateProcessor(string queueName, ServiceBusProcessorOptions options);
+
+    /// <summary>Creates a sender that targets <paramref name="queueName"/>.</summary>
+    IServiceBusSenderWrapper CreateSender(string queueName);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs
@@ -276,13 +276,26 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
         var requestKey = messageId ?? envelope.MessageId ?? Guid.NewGuid().ToString();
 
         // Store routing context keyed by request key.
-        _pendingReplies[requestKey] = new PendingReplyContext(replyTo, correlationId, conversationId);
-
-        // Also enqueue to the per-conversation FIFO queue so SendAsync can fall back to FIFO
-        // when OutboundMessage.Metadata does not carry MetaRequestKey (live gateway path).
-        _pendingQueue
-            .GetOrAdd(channelAddress.Value, _ => new ConcurrentQueue<string>())
-            .Enqueue(requestKey);
+        // TryAdd returns false when this requestKey is already present, which happens when
+        // Service Bus redelivers an abandoned message with the same MessageId. On retry we
+        // update the context (replyTo/correlationId may have changed) but must NOT add a
+        // second entry to _pendingQueue — the original entry is already there. A duplicate
+        // would leave a stale key in _pendingQueue after the first successful reply removes
+        // the context, which would cause the next FIFO-fallback lookup to pop the stale key,
+        // fail TryRemove, and misroute that reply to the default queue.
+        var pendingContext = new PendingReplyContext(replyTo, correlationId, conversationId);
+        if (_pendingReplies.TryAdd(requestKey, pendingContext))
+        {
+            // First arrival: register in the per-conversation FIFO queue for SendAsync fallback.
+            _pendingQueue
+                .GetOrAdd(channelAddress.Value, _ => new ConcurrentQueue<string>())
+                .Enqueue(requestKey);
+        }
+        else
+        {
+            // Retry/redelivery: overwrite context only, do not add a duplicate FIFO entry.
+            _pendingReplies[requestKey] = pendingContext;
+        }
 
         var metadata = new Dictionary<string, object?>
         {

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs
@@ -1,0 +1,370 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Extensions.Channels.ServiceBus;
+
+/// <summary>
+/// Azure Service Bus channel adapter.
+/// Receives JSON-enveloped messages from an inbound queue, routes them through the gateway,
+/// and sends agent replies to a reply queue (either the per-message <c>replyTo</c> queue
+/// or the configured <see cref="ServiceBusChannelOptions.DefaultReplyQueueName"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The adapter maintains an in-memory pending-reply index keyed by <see cref="ChannelAddress"/>
+/// (the conversation key). This allows the outbound path to recover the original
+/// <c>replyTo</c> and <c>correlationId</c> values even when the gateway does not propagate
+/// inbound metadata to <see cref="OutboundMessage.Metadata"/>.
+/// </para>
+/// <para>
+/// For managed-identity or custom credential scenarios, register your own
+/// <see cref="IServiceBusAdapterClientFactory"/> in DI before calling
+/// <see cref="ServiceBusServiceCollectionExtensions.AddBotNexusServiceBusChannel"/>.
+/// </para>
+/// </remarks>
+public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
+{
+    // Metadata keys stored in InboundMessage.Metadata for use by the outbound path.
+    internal const string MetaReplyTo = "servicebus.replyTo";
+    internal const string MetaCorrelationId = "servicebus.correlationId";
+    internal const string MetaConversationId = "servicebus.conversationId";
+    internal const string MetaAgentId = "servicebus.agentId";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly ILogger<ServiceBusChannelAdapter> _logger;
+    private readonly ServiceBusChannelOptions _options;
+
+    // Optional factory injected at construction time; null → create real factory in OnStartAsync.
+    private readonly IServiceBusAdapterClientFactory? _injectedFactory;
+
+    private IServiceBusAdapterClientFactory? _activeFactory;
+    private ServiceBusProcessor? _processor;
+
+    // Senders are cached per queue name so we don't create a new sender on every reply.
+    private readonly ConcurrentDictionary<string, IServiceBusSenderWrapper> _senders =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    // Per-conversation state stored when an inbound message arrives, consumed by SendAsync.
+    // Keyed by ChannelAddress.Value (conversationId or senderId).
+    private readonly ConcurrentDictionary<string, PendingReplyContext> _pendingReplies =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initialises the adapter. Pass a <paramref name="clientFactory"/> in tests to avoid
+    /// real Azure connections; leave it <c>null</c> in production (a factory is created from
+    /// <see cref="ServiceBusChannelOptions.ConnectionString"/> on first start).
+    /// </summary>
+    public ServiceBusChannelAdapter(
+        ILogger<ServiceBusChannelAdapter> logger,
+        IOptions<ServiceBusChannelOptions> optionsAccessor,
+        IServiceBusAdapterClientFactory? clientFactory = null)
+        : base(logger)
+    {
+        _logger = logger;
+        _options = optionsAccessor.Value;
+        _injectedFactory = clientFactory;
+        AllowList = [.. _options.AllowedSenderIds];
+    }
+
+    /// <inheritdoc/>
+    public override ChannelKey ChannelType => ChannelKey.From("servicebus");
+
+    /// <inheritdoc/>
+    public override string DisplayName => "Azure Service Bus";
+
+    /// <inheritdoc/>
+    public override bool SupportsStreaming => false;
+
+    /// <inheritdoc/>
+    public override bool SupportsSteering => false;
+
+    /// <inheritdoc/>
+    public override bool SupportsFollowUp => false;
+
+    /// <inheritdoc/>
+    public override bool SupportsThinkingDisplay => false;
+
+    /// <inheritdoc/>
+    public override bool SupportsToolDisplay => false;
+
+    /// <inheritdoc/>
+    protected override async Task OnStartAsync(CancellationToken cancellationToken)
+    {
+        _activeFactory = _injectedFactory ?? CreateDefaultFactory();
+
+        var processorOptions = new ServiceBusProcessorOptions
+        {
+            MaxConcurrentCalls = _options.MaxConcurrentCalls,
+            // Manual completion — we complete after successful dispatch, abandon on error.
+            AutoCompleteMessages = false,
+        };
+
+        _processor = _activeFactory.CreateProcessor(_options.InboundQueueName, processorOptions);
+        _processor.ProcessMessageAsync += OnProcessMessageAsync;
+        _processor.ProcessErrorAsync += OnProcessErrorAsync;
+
+        await _processor.StartProcessingAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "{DisplayName} adapter started; listening on queue '{QueueName}'",
+            DisplayName,
+            _options.InboundQueueName);
+    }
+
+    /// <inheritdoc/>
+    protected override async Task OnStopAsync(CancellationToken cancellationToken)
+    {
+        if (_processor is not null)
+        {
+            _processor.ProcessMessageAsync -= OnProcessMessageAsync;
+            _processor.ProcessErrorAsync -= OnProcessErrorAsync;
+
+            await _processor.StopProcessingAsync(cancellationToken);
+            await _processor.DisposeAsync();
+            _processor = null;
+        }
+
+        foreach (var sender in _senders.Values)
+            await sender.DisposeAsync();
+
+        _senders.Clear();
+        _pendingReplies.Clear();
+
+        if (_activeFactory is IAsyncDisposable disposable)
+            await disposable.DisposeAsync();
+
+        _activeFactory = null;
+
+        _logger.LogInformation("{DisplayName} adapter stopped", DisplayName);
+    }
+
+    /// <inheritdoc/>
+    public override async Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
+    {
+        var replyQueue = ResolveReplyQueue(message);
+        var (correlationId, conversationId) = ResolveReplyContext(message);
+
+        var envelope = new ServiceBusOutboundEnvelope
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            CorrelationId = correlationId,
+            AgentId = GetMetadataString(message.Metadata, MetaAgentId),
+            ConversationId = conversationId ?? message.ChannelAddress.Value,
+            SessionId = message.SessionId,
+            Content = message.Content,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+
+        var json = JsonSerializer.Serialize(envelope, JsonOptions);
+        var sbMessage = new ServiceBusMessage(json)
+        {
+            ContentType = "application/json",
+            MessageId = envelope.MessageId,
+        };
+
+        if (envelope.CorrelationId is not null)
+            sbMessage.CorrelationId = envelope.CorrelationId;
+
+        // Mirror key fields as application properties for server-side filtering.
+        if (envelope.AgentId is not null)
+            sbMessage.ApplicationProperties["agentId"] = envelope.AgentId;
+        if (envelope.ConversationId is not null)
+            sbMessage.ApplicationProperties["conversationId"] = envelope.ConversationId;
+        if (envelope.SessionId is not null)
+            sbMessage.ApplicationProperties["sessionId"] = envelope.SessionId;
+
+        var sender = GetOrCreateSender(replyQueue);
+        await sender.SendMessageAsync(sbMessage, cancellationToken);
+
+        // Release the pending-reply context once the reply has been sent.
+        _pendingReplies.TryRemove(message.ChannelAddress.Value, out _);
+
+        _logger.LogDebug(
+            "{DisplayName} reply sent to queue '{ReplyQueue}' (correlationId={CorrelationId})",
+            DisplayName,
+            replyQueue,
+            envelope.CorrelationId);
+    }
+
+    /// <summary>
+    /// Deserialises a raw Service Bus message body and dispatches it to the gateway pipeline.
+    /// Exposed as <c>internal</c> so unit tests can invoke the inbound path directly using
+    /// <see cref="Azure.Messaging.ServiceBus.ServiceBusModelFactory"/> messages, without
+    /// needing a live processor or real Azure connection.
+    /// </summary>
+    internal async Task HandleMessageBodyAsync(
+        string body,
+        IReadOnlyDictionary<string, object>? applicationProperties,
+        CancellationToken cancellationToken)
+    {
+        ServiceBusInboundEnvelope? envelope;
+
+        try
+        {
+            envelope = JsonSerializer.Deserialize<ServiceBusInboundEnvelope>(body, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "{DisplayName} failed to deserialise inbound message; message will be abandoned", DisplayName);
+            return;
+        }
+
+        if (envelope is null)
+        {
+            _logger.LogWarning("{DisplayName} received null envelope after deserialisation; message will be abandoned", DisplayName);
+            return;
+        }
+
+        var senderId = envelope.SenderId
+            ?? GetApplicationProperty(applicationProperties, "senderId")
+            ?? "unknown";
+
+        var conversationId = envelope.ConversationId
+            ?? GetApplicationProperty(applicationProperties, "conversationId");
+
+        // Use conversationId as the channel address when available; fall back to senderId.
+        // ChannelAddress is the session-routing key and must be stable across a conversation.
+        var channelAddress = ChannelAddress.From(conversationId ?? senderId);
+
+        var replyTo = envelope.ReplyTo
+            ?? GetApplicationProperty(applicationProperties, "replyTo");
+
+        var correlationId = envelope.CorrelationId
+            ?? GetApplicationProperty(applicationProperties, "correlationId");
+
+        // Store routing context so SendAsync can recover replyTo/correlationId even when
+        // the gateway does not propagate InboundMessage.Metadata to OutboundMessage.Metadata.
+        _pendingReplies[channelAddress.Value] = new PendingReplyContext(replyTo, correlationId, conversationId);
+
+        var metadata = new Dictionary<string, object?>
+        {
+            [MetaReplyTo] = replyTo,
+            [MetaCorrelationId] = correlationId,
+            [MetaConversationId] = conversationId,
+            [MetaAgentId] = envelope.AgentId ?? GetApplicationProperty(applicationProperties, "agentId"),
+        };
+
+        // Merge caller-supplied metadata, without overwriting the keys set above.
+        if (envelope.Metadata is not null)
+        {
+            foreach (var kvp in envelope.Metadata)
+                metadata.TryAdd(kvp.Key, kvp.Value);
+        }
+
+        var inbound = new InboundMessage
+        {
+            ChannelType = ChannelType,
+            SenderId = senderId,
+            ChannelAddress = channelAddress,
+            Content = envelope.Content,
+            TargetAgentId = envelope.AgentId ?? GetApplicationProperty(applicationProperties, "agentId"),
+            SessionId = envelope.SessionId ?? GetApplicationProperty(applicationProperties, "sessionId"),
+            ConversationId = conversationId,
+            Timestamp = envelope.Timestamp ?? DateTimeOffset.UtcNow,
+            Metadata = metadata,
+        };
+
+        await DispatchInboundAsync(inbound, cancellationToken);
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    private async Task OnProcessMessageAsync(ProcessMessageEventArgs args)
+    {
+        try
+        {
+            await HandleMessageBodyAsync(
+                args.Message.Body.ToString(),
+                args.Message.ApplicationProperties,
+                args.CancellationToken);
+
+            await args.CompleteMessageAsync(args.Message, args.CancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown is in progress — abandon so the message is retried on the next startup.
+            await args.AbandonMessageAsync(args.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "{DisplayName} unhandled error processing Service Bus message; message will be abandoned",
+                DisplayName);
+
+            await args.AbandonMessageAsync(args.Message);
+        }
+    }
+
+    private Task OnProcessErrorAsync(ProcessErrorEventArgs args)
+    {
+        _logger.LogError(
+            args.Exception,
+            "{DisplayName} Service Bus processor error (source={ErrorSource}, entity={EntityPath})",
+            DisplayName,
+            args.ErrorSource,
+            args.EntityPath);
+
+        return Task.CompletedTask;
+    }
+
+    private IServiceBusAdapterClientFactory CreateDefaultFactory()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.ConnectionString))
+            return new DefaultServiceBusAdapterClientFactory(new ServiceBusClient(_options.ConnectionString));
+
+        throw new InvalidOperationException(
+            $"{nameof(ServiceBusChannelOptions.ConnectionString)} must be set in '{nameof(ServiceBusChannelOptions)}'. " +
+            $"For managed-identity authentication, inject a custom {nameof(IServiceBusAdapterClientFactory)} via DI.");
+    }
+
+    private string ResolveReplyQueue(OutboundMessage message)
+    {
+        // 1. Metadata key (populated when the caller manually constructs OutboundMessage in tests)
+        if (GetMetadataString(message.Metadata, MetaReplyTo) is { Length: > 0 } metaQueue)
+            return metaQueue;
+
+        // 2. Pending-reply context (populated by HandleMessageBodyAsync in the live path)
+        if (_pendingReplies.TryGetValue(message.ChannelAddress.Value, out var ctx)
+            && ctx.ReplyTo is { Length: > 0 } pendingQueue)
+            return pendingQueue;
+
+        return _options.DefaultReplyQueueName;
+    }
+
+    private (string? CorrelationId, string? ConversationId) ResolveReplyContext(OutboundMessage message)
+    {
+        // Prefer values from pending-reply context (live gateway path), fall back to metadata.
+        if (_pendingReplies.TryGetValue(message.ChannelAddress.Value, out var ctx))
+            return (ctx.CorrelationId, ctx.ConversationId);
+
+        return (
+            GetMetadataString(message.Metadata, MetaCorrelationId),
+            GetMetadataString(message.Metadata, MetaConversationId));
+    }
+
+    private IServiceBusSenderWrapper GetOrCreateSender(string queueName)
+    {
+        if (_activeFactory is null)
+            throw new InvalidOperationException("Channel adapter has not been started. Call StartAsync before SendAsync.");
+
+        return _senders.GetOrAdd(queueName, q => _activeFactory.CreateSender(q));
+    }
+
+    private static string? GetMetadataString(IReadOnlyDictionary<string, object?> metadata, string key)
+        => metadata.TryGetValue(key, out var val) ? val?.ToString() : null;
+
+    private static string? GetApplicationProperty(IReadOnlyDictionary<string, object>? props, string key)
+        => props is not null && props.TryGetValue(key, out var val) ? val?.ToString() : null;
+
+    /// <summary>Routing context preserved between inbound receipt and outbound reply.</summary>
+    private sealed record PendingReplyContext(string? ReplyTo, string? CorrelationId, string? ConversationId);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs
@@ -18,10 +18,18 @@ namespace BotNexus.Extensions.Channels.ServiceBus;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The adapter maintains an in-memory pending-reply index keyed by <see cref="ChannelAddress"/>
-/// (the conversation key). This allows the outbound path to recover the original
-/// <c>replyTo</c> and <c>correlationId</c> values even when the gateway does not propagate
-/// inbound metadata to <see cref="OutboundMessage.Metadata"/>.
+/// The adapter maintains an in-memory pending-reply index keyed by a per-dispatch request key
+/// (the inbound Service Bus message ID, or a generated GUID when absent). This prevents reply
+/// context from being overwritten when <see cref="ServiceBusChannelOptions.MaxConcurrentCalls"/>
+/// is greater than one and two inbound messages for the same conversation are in-flight
+/// simultaneously.
+/// </para>
+/// <para>
+/// A secondary per-conversation FIFO queue maps each <see cref="ChannelAddress"/> to its
+/// pending request keys. When the gateway does not propagate <c>InboundMessage.Metadata</c>
+/// to <c>OutboundMessage.Metadata</c>, <see cref="SendAsync"/> dequeues the oldest context
+/// for that conversation address. When the outbound message does carry
+/// <see cref="MetaRequestKey"/>, the lookup is exact and order-independent.
 /// </para>
 /// <para>
 /// For managed-identity or custom credential scenarios, register your own
@@ -36,6 +44,14 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
     internal const string MetaCorrelationId = "servicebus.correlationId";
     internal const string MetaConversationId = "servicebus.conversationId";
     internal const string MetaAgentId = "servicebus.agentId";
+
+    /// <summary>
+    /// Per-dispatch unique key threaded through <c>InboundMessage.Metadata</c> so that
+    /// <see cref="SendAsync"/> can retrieve the exact <see cref="PendingReplyContext"/> for
+    /// this request when the outbound message carries it. Preferred over the FIFO fallback
+    /// when two in-flight requests share the same conversation address.
+    /// </summary>
+    internal const string MetaRequestKey = "servicebus.requestKey";
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -52,9 +68,16 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
     private readonly ConcurrentDictionary<string, IServiceBusSenderWrapper> _senders =
         new(StringComparer.OrdinalIgnoreCase);
 
-    // Per-conversation state stored when an inbound message arrives, consumed by SendAsync.
-    // Keyed by ChannelAddress.Value (conversationId or senderId).
+    // Pending-reply contexts keyed by per-dispatch request key (SB messageId or generated GUID).
+    // Using a unique key per dispatch prevents a second in-flight message for the same
+    // conversation from overwriting the first entry when MaxConcurrentCalls > 1.
     private readonly ConcurrentDictionary<string, PendingReplyContext> _pendingReplies =
+        new(StringComparer.Ordinal);
+
+    // Secondary index: conversation address → FIFO queue of request keys.
+    // Used by SendAsync as a fallback when OutboundMessage.Metadata does not carry
+    // MetaRequestKey (the live gateway path does not propagate InboundMessage.Metadata).
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _pendingQueue =
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
@@ -137,6 +160,7 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
 
         _senders.Clear();
         _pendingReplies.Clear();
+        _pendingQueue.Clear();
 
         if (_activeFactory is IAsyncDisposable disposable)
             await disposable.DisposeAsync();
@@ -149,12 +173,13 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
     /// <inheritdoc/>
     public override async Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
     {
-        var replyQueue = ResolveReplyQueue(message);
-        var (correlationId, conversationId) = ResolveReplyContext(message);
+        var pendingCtx = DequeuePendingReplyContext(message);
+        var replyQueue = ResolveReplyQueue(message, pendingCtx);
+        var (correlationId, conversationId) = ResolveReplyContext(message, pendingCtx);
 
         var envelope = new ServiceBusOutboundEnvelope
         {
-            MessageId = Guid.NewGuid().ToString(),
+            // MessageId is initialised to Guid.NewGuid() by the property initializer.
             CorrelationId = correlationId,
             AgentId = GetMetadataString(message.Metadata, MetaAgentId),
             ConversationId = conversationId ?? message.ChannelAddress.Value,
@@ -184,9 +209,6 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
         var sender = GetOrCreateSender(replyQueue);
         await sender.SendMessageAsync(sbMessage, cancellationToken);
 
-        // Release the pending-reply context once the reply has been sent.
-        _pendingReplies.TryRemove(message.ChannelAddress.Value, out _);
-
         _logger.LogDebug(
             "{DisplayName} reply sent to queue '{ReplyQueue}' (correlationId={CorrelationId})",
             DisplayName,
@@ -200,9 +222,17 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
     /// <see cref="Azure.Messaging.ServiceBus.ServiceBusModelFactory"/> messages, without
     /// needing a live processor or real Azure connection.
     /// </summary>
+    /// <param name="body">Raw JSON message body.</param>
+    /// <param name="applicationProperties">Optional Service Bus application properties used as
+    /// fallbacks when envelope fields are absent.</param>
+    /// <param name="messageId">The Service Bus message identifier, used as the per-dispatch
+    /// request key. When <c>null</c>, the envelope's own <c>messageId</c> field is tried first,
+    /// then a GUID is generated.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     internal async Task HandleMessageBodyAsync(
         string body,
         IReadOnlyDictionary<string, object>? applicationProperties,
+        string? messageId,
         CancellationToken cancellationToken)
     {
         ServiceBusInboundEnvelope? envelope;
@@ -240,12 +270,23 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
         var correlationId = envelope.CorrelationId
             ?? GetApplicationProperty(applicationProperties, "correlationId");
 
-        // Store routing context so SendAsync can recover replyTo/correlationId even when
-        // the gateway does not propagate InboundMessage.Metadata to OutboundMessage.Metadata.
-        _pendingReplies[channelAddress.Value] = new PendingReplyContext(replyTo, correlationId, conversationId);
+        // Generate a per-dispatch request key.  Using the SB messageId (or envelope messageId)
+        // means two concurrent inbound messages for the same conversation get distinct keys,
+        // so the second arrival cannot overwrite the first entry in _pendingReplies.
+        var requestKey = messageId ?? envelope.MessageId ?? Guid.NewGuid().ToString();
+
+        // Store routing context keyed by request key.
+        _pendingReplies[requestKey] = new PendingReplyContext(replyTo, correlationId, conversationId);
+
+        // Also enqueue to the per-conversation FIFO queue so SendAsync can fall back to FIFO
+        // when OutboundMessage.Metadata does not carry MetaRequestKey (live gateway path).
+        _pendingQueue
+            .GetOrAdd(channelAddress.Value, _ => new ConcurrentQueue<string>())
+            .Enqueue(requestKey);
 
         var metadata = new Dictionary<string, object?>
         {
+            [MetaRequestKey] = requestKey,
             [MetaReplyTo] = replyTo,
             [MetaCorrelationId] = correlationId,
             [MetaConversationId] = conversationId,
@@ -284,6 +325,7 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
             await HandleMessageBodyAsync(
                 args.Message.Body.ToString(),
                 args.Message.ApplicationProperties,
+                args.Message.MessageId,
                 args.CancellationToken);
 
             await args.CompleteMessageAsync(args.Message, args.CancellationToken);
@@ -326,25 +368,51 @@ public sealed class ServiceBusChannelAdapter : ChannelAdapterBase
             $"For managed-identity authentication, inject a custom {nameof(IServiceBusAdapterClientFactory)} via DI.");
     }
 
-    private string ResolveReplyQueue(OutboundMessage message)
+    /// <summary>
+    /// Resolves and atomically removes the pending reply context for the given outbound message.
+    /// Prefers an explicit <see cref="MetaRequestKey"/> in <paramref name="message"/> metadata;
+    /// falls back to dequeuing the oldest context for the conversation address.
+    /// </summary>
+    private PendingReplyContext? DequeuePendingReplyContext(OutboundMessage message)
+    {
+        // Explicit key: present when the outbound message carries MetaRequestKey (e.g., tests,
+        // or a future gateway path that propagates inbound metadata).
+        if (GetMetadataString(message.Metadata, MetaRequestKey) is { Length: > 0 } requestKey
+            && _pendingReplies.TryRemove(requestKey, out var explicit_ctx))
+        {
+            return explicit_ctx;
+        }
+
+        // Fallback: dequeue the oldest request key for this conversation.
+        // Relies on the gateway serialising per-session so FIFO order matches reply order.
+        if (_pendingQueue.TryGetValue(message.ChannelAddress.Value, out var queue)
+            && queue.TryDequeue(out var oldestKey)
+            && _pendingReplies.TryRemove(oldestKey, out var fallback_ctx))
+        {
+            return fallback_ctx;
+        }
+
+        return null;
+    }
+
+    private string ResolveReplyQueue(OutboundMessage message, PendingReplyContext? pendingCtx)
     {
         // 1. Metadata key (populated when the caller manually constructs OutboundMessage in tests)
         if (GetMetadataString(message.Metadata, MetaReplyTo) is { Length: > 0 } metaQueue)
             return metaQueue;
 
         // 2. Pending-reply context (populated by HandleMessageBodyAsync in the live path)
-        if (_pendingReplies.TryGetValue(message.ChannelAddress.Value, out var ctx)
-            && ctx.ReplyTo is { Length: > 0 } pendingQueue)
+        if (pendingCtx?.ReplyTo is { Length: > 0 } pendingQueue)
             return pendingQueue;
 
         return _options.DefaultReplyQueueName;
     }
 
-    private (string? CorrelationId, string? ConversationId) ResolveReplyContext(OutboundMessage message)
+    private (string? CorrelationId, string? ConversationId) ResolveReplyContext(OutboundMessage message, PendingReplyContext? pendingCtx)
     {
         // Prefer values from pending-reply context (live gateway path), fall back to metadata.
-        if (_pendingReplies.TryGetValue(message.ChannelAddress.Value, out var ctx))
-            return (ctx.CorrelationId, ctx.ConversationId);
+        if (pendingCtx is not null)
+            return (pendingCtx.CorrelationId, pendingCtx.ConversationId);
 
         return (
             GetMetadataString(message.Metadata, MetaCorrelationId),

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelOptions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelOptions.cs
@@ -1,0 +1,41 @@
+namespace BotNexus.Extensions.Channels.ServiceBus;
+
+/// <summary>
+/// Configuration options for the Azure Service Bus channel adapter.
+/// Bind under the <c>channels:servicebus</c> configuration key, or configure via the
+/// <c>AddBotNexusServiceBusChannel</c> delegate overload.
+/// </summary>
+public sealed class ServiceBusChannelOptions
+{
+    /// <summary>
+    /// Service Bus connection string (e.g., from the Azure portal Shared Access Policy).
+    /// Use this for simple deployments. For managed-identity auth, inject a custom
+    /// <see cref="IServiceBusAdapterClientFactory"/> instead.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Name of the Service Bus queue the adapter listens on for inbound messages.
+    /// </summary>
+    public string InboundQueueName { get; set; } = "botnexus-inbound";
+
+    /// <summary>
+    /// Default queue to send outbound replies to when the inbound envelope does not
+    /// specify a <c>replyTo</c> queue name.
+    /// </summary>
+    public string DefaultReplyQueueName { get; set; } = "botnexus-outbound";
+
+    /// <summary>
+    /// Maximum number of messages processed concurrently by the Service Bus processor.
+    /// Increasing this value allows parallel agent requests but requires each agent
+    /// to be capable of concurrent operation.
+    /// </summary>
+    public int MaxConcurrentCalls { get; set; } = 1;
+
+    /// <summary>
+    /// Allow-list of sender IDs permitted to dispatch messages into the gateway.
+    /// When non-empty, messages from senders not in this list are silently dropped.
+    /// An empty list permits all senders.
+    /// </summary>
+    public ICollection<string> AllowedSenderIds { get; } = [];
+}

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusEnvelope.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusEnvelope.cs
@@ -1,0 +1,114 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Extensions.Channels.ServiceBus;
+
+/// <summary>
+/// JSON envelope expected in the body of inbound Service Bus messages.
+/// All fields map 1-to-1 to <see cref="BotNexus.Gateway.Abstractions.Models.InboundMessage"/> fields.
+/// </summary>
+public sealed class ServiceBusInboundEnvelope
+{
+    /// <summary>Client-assigned message identifier, used for idempotency and tracing.</summary>
+    [JsonPropertyName("messageId")]
+    public string? MessageId { get; set; }
+
+    /// <summary>
+    /// Correlation identifier linking this request to its reply.
+    /// Preserved in the outbound reply envelope so the caller can match responses.
+    /// </summary>
+    [JsonPropertyName("correlationId")]
+    public string? CorrelationId { get; set; }
+
+    /// <summary>Target agent identifier; maps to <c>InboundMessage.TargetAgentId</c>.</summary>
+    [JsonPropertyName("agentId")]
+    public string? AgentId { get; set; }
+
+    /// <summary>
+    /// Conversation identifier used to resume or group messages in the same thread.
+    /// Maps to <c>InboundMessage.ConversationId</c> and <c>InboundMessage.ChannelAddress</c>.
+    /// </summary>
+    [JsonPropertyName("conversationId")]
+    public string? ConversationId { get; set; }
+
+    /// <summary>
+    /// Existing session identifier. When set, the gateway resumes the named session
+    /// rather than creating a new one. Maps to <c>InboundMessage.SessionId</c>.
+    /// </summary>
+    [JsonPropertyName("sessionId")]
+    public string? SessionId { get; set; }
+
+    /// <summary>Sender identifier (e.g., user email or system name). Maps to <c>InboundMessage.SenderId</c>.</summary>
+    [JsonPropertyName("senderId")]
+    public string? SenderId { get; set; }
+
+    /// <summary>Message role (e.g., "user"). Informational only; the gateway treats all inbound as user messages.</summary>
+    [JsonPropertyName("role")]
+    public string? Role { get; set; }
+
+    /// <summary>The message text content. Maps to <c>InboundMessage.Content</c>.</summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Reply queue name. When set, outbound replies are sent here instead of the configured
+    /// <see cref="ServiceBusChannelOptions.DefaultReplyQueueName"/>.
+    /// </summary>
+    [JsonPropertyName("replyTo")]
+    public string? ReplyTo { get; set; }
+
+    /// <summary>When the message was created by the sender.</summary>
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset? Timestamp { get; set; }
+
+    /// <summary>
+    /// Caller-supplied key/value metadata forwarded into <c>InboundMessage.Metadata</c>.
+    /// Values are deserialized as <see cref="System.Text.Json.JsonElement"/> by the runtime.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object?>? Metadata { get; set; }
+}
+
+/// <summary>
+/// JSON envelope written to the reply queue by <see cref="ServiceBusChannelAdapter.SendAsync"/>.
+/// </summary>
+public sealed class ServiceBusOutboundEnvelope
+{
+    /// <summary>Gateway-assigned reply message identifier.</summary>
+    [JsonPropertyName("messageId")]
+    public string MessageId { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Correlation identifier copied from the original request, allowing the caller
+    /// to match this reply to its originating request.
+    /// </summary>
+    [JsonPropertyName("correlationId")]
+    public string? CorrelationId { get; set; }
+
+    /// <summary>Agent that produced this reply, when known.</summary>
+    [JsonPropertyName("agentId")]
+    public string? AgentId { get; set; }
+
+    /// <summary>Conversation identifier echoed from the request.</summary>
+    [JsonPropertyName("conversationId")]
+    public string? ConversationId { get; set; }
+
+    /// <summary>Session identifier for the agent session that handled this request.</summary>
+    [JsonPropertyName("sessionId")]
+    public string? SessionId { get; set; }
+
+    /// <summary>Message role; always "assistant" for gateway replies.</summary>
+    [JsonPropertyName("role")]
+    public string Role { get; set; } = "assistant";
+
+    /// <summary>The agent reply text.</summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when the reply was produced.</summary>
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Optional additional metadata attached to the reply.</summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object?>? Metadata { get; set; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusServiceCollectionExtensions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using BotNexus.Gateway.Abstractions.Channels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BotNexus.Extensions.Channels.ServiceBus;
+
+/// <summary>
+/// Dependency-injection extensions for registering the Azure Service Bus channel adapter.
+/// </summary>
+public static class ServiceBusServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Service Bus channel adapter and its options binding.
+    /// </summary>
+    /// <param name="services">Service collection to update.</param>
+    /// <param name="configure">
+    /// Optional inline configuration delegate. Called after any options already bound from
+    /// <c>IConfiguration</c>, so it can override individual properties.
+    /// </param>
+    /// <returns>The same service collection for chaining.</returns>
+    /// <remarks>
+    /// To bind options from <c>IConfiguration</c>, call
+    /// <c>services.Configure&lt;ServiceBusChannelOptions&gt;(config.GetSection("channels:servicebus"))</c>
+    /// before or after this method. For managed-identity authentication, register a custom
+    /// <see cref="IServiceBusAdapterClientFactory"/> as a singleton before calling this method.
+    /// </remarks>
+    public static IServiceCollection AddBotNexusServiceBusChannel(
+        this IServiceCollection services,
+        Action<ServiceBusChannelOptions>? configure = null)
+    {
+        services.AddOptions<ServiceBusChannelOptions>();
+
+        if (configure is not null)
+            services.Configure(configure);
+
+        services.AddSingleton<IChannelAdapter, ServiceBusChannelAdapter>();
+        return services;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/botnexus-extension.json
@@ -1,0 +1,10 @@
+{
+  "id": "botnexus-servicebus",
+  "name": "Azure Service Bus Channel",
+  "description": "Azure Service Bus queue channel adapter — inbound message receive and reply dispatch via Service Bus queues",
+  "version": "1.0.0",
+  "entryAssembly": "BotNexus.Extensions.Channels.ServiceBus.dll",
+  "extensionTypes": [
+    "channel"
+  ]
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.ServiceBus\BotNexus.Extensions.Channels.ServiceBus.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/Fakes/FakeServiceBusAdapterClientFactory.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/Fakes/FakeServiceBusAdapterClientFactory.cs
@@ -1,0 +1,82 @@
+using Azure.Messaging.ServiceBus;
+using BotNexus.Extensions.Channels.ServiceBus;
+
+namespace BotNexus.Extensions.Channels.ServiceBus.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IServiceBusAdapterClientFactory"/> for unit tests.
+/// Returns a <see cref="FakeServiceBusProcessor"/> and <see cref="FakeServiceBusSenderWrapper"/>
+/// instances that record calls without connecting to Azure.
+/// </summary>
+internal sealed class FakeServiceBusAdapterClientFactory : IServiceBusAdapterClientFactory
+{
+    /// <summary>The fake processor returned by <see cref="CreateProcessor"/>.</summary>
+    public FakeServiceBusProcessor Processor { get; } = new();
+
+    /// <summary>Senders created so far, keyed by queue name.</summary>
+    public Dictionary<string, FakeServiceBusSenderWrapper> Senders { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public ServiceBusProcessor CreateProcessor(string queueName, ServiceBusProcessorOptions options)
+        => Processor;
+
+    /// <inheritdoc/>
+    public IServiceBusSenderWrapper CreateSender(string queueName)
+    {
+        var sender = new FakeServiceBusSenderWrapper(queueName);
+        Senders[queueName] = sender;
+        return sender;
+    }
+}
+
+/// <summary>
+/// Fake <see cref="ServiceBusProcessor"/> that records lifecycle calls without
+/// connecting to Azure. Uses the protected parameterless constructor provided by
+/// the Azure SDK for testing purposes.
+/// </summary>
+internal sealed class FakeServiceBusProcessor : ServiceBusProcessor
+{
+    /// <summary>Whether <see cref="StartProcessingAsync"/> was called.</summary>
+    public bool StartCalled { get; private set; }
+
+    /// <summary>Whether <see cref="StopProcessingAsync"/> was called.</summary>
+    public bool StopCalled { get; private set; }
+
+    /// <inheritdoc/>
+    public override Task StartProcessingAsync(CancellationToken cancellationToken = default)
+    {
+        StartCalled = true;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public override Task StopProcessingAsync(CancellationToken cancellationToken = default)
+    {
+        StopCalled = true;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Fake <see cref="IServiceBusSenderWrapper"/> that records sent messages without
+/// connecting to Azure.
+/// </summary>
+internal sealed class FakeServiceBusSenderWrapper(string queueName) : IServiceBusSenderWrapper
+{
+    /// <summary>The queue name this sender targets.</summary>
+    public string QueueName { get; } = queueName;
+
+    /// <summary>All messages sent via <see cref="SendMessageAsync"/>.</summary>
+    public List<ServiceBusMessage> SentMessages { get; } = [];
+
+    /// <inheritdoc/>
+    public Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
+    {
+        SentMessages.Add(message);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/ServiceBusChannelAdapterTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/ServiceBusChannelAdapterTests.cs
@@ -1,0 +1,393 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using BotNexus.Domain.Primitives;
+using BotNexus.Extensions.Channels.ServiceBus.Tests.Fakes;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Extensions.Channels.ServiceBus.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ServiceBusChannelAdapter"/>.
+/// All tests use <see cref="FakeServiceBusAdapterClientFactory"/> to avoid real Azure connections.
+/// </summary>
+public sealed class ServiceBusChannelAdapterTests
+{
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static ServiceBusChannelAdapter CreateAdapter(
+        ServiceBusChannelOptions? options = null,
+        FakeServiceBusAdapterClientFactory? factory = null)
+    {
+        var opts = options ?? new ServiceBusChannelOptions
+        {
+            ConnectionString = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=FAKE=",
+            InboundQueueName = "test-inbound",
+            DefaultReplyQueueName = "test-outbound",
+        };
+
+        return new ServiceBusChannelAdapter(
+            NullLogger<ServiceBusChannelAdapter>.Instance,
+            new OptionsWrapper<ServiceBusChannelOptions>(opts),
+            factory ?? new FakeServiceBusAdapterClientFactory());
+    }
+
+    private static Mock<IChannelDispatcher> StartAdapter(ServiceBusChannelAdapter adapter)
+    {
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        adapter.StartAsync(dispatcher.Object).GetAwaiter().GetResult();
+        return dispatcher;
+    }
+
+    // ── Test 1: Inbound envelope maps all fields correctly ─────────────────────
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_FullEnvelope_DispatchesWithAllFieldsMapped()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        var dispatcher = StartAdapter(adapter);
+
+        var json = JsonSerializer.Serialize(new
+        {
+            messageId = "msg-001",
+            correlationId = "corr-abc",
+            agentId = "coding-agent",
+            conversationId = "conv-xyz",
+            sessionId = "sess-123",
+            senderId = "user@org.com",
+            role = "user",
+            content = "Hello agent",
+            replyTo = "botnexus-outbound",
+            timestamp = "2026-05-13T12:22:56Z",
+        });
+
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        var dispatched = dispatcher.Invocations
+            .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
+            .Select(i => (InboundMessage)i.Arguments[0])
+            .Single();
+
+        dispatched.ChannelType.ShouldBe(ChannelKey.From("servicebus"));
+        dispatched.SenderId.ShouldBe("user@org.com");
+        dispatched.Content.ShouldBe("Hello agent");
+        dispatched.TargetAgentId.ShouldBe("coding-agent");
+        dispatched.SessionId.ShouldBe("sess-123");
+        dispatched.ConversationId.ShouldBe("conv-xyz");
+        dispatched.ChannelAddress.Value.ShouldBe("conv-xyz");
+    }
+
+    // ── Test 2: Missing optional fields handled gracefully ─────────────────────
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_MinimalEnvelope_DispatchesWithFallbacks()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        var dispatcher = StartAdapter(adapter);
+
+        var json = """{ "content": "minimal message", "senderId": "bot@sys.com" }""";
+
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        var dispatched = dispatcher.Invocations
+            .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
+            .Select(i => (InboundMessage)i.Arguments[0])
+            .Single();
+
+        dispatched.Content.ShouldBe("minimal message");
+        dispatched.SenderId.ShouldBe("bot@sys.com");
+        dispatched.TargetAgentId.ShouldBeNull();
+        dispatched.SessionId.ShouldBeNull();
+        dispatched.ConversationId.ShouldBeNull();
+        // ChannelAddress falls back to senderId when conversationId is absent.
+        dispatched.ChannelAddress.Value.ShouldBe("bot@sys.com");
+    }
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_MissingSenderId_UsesUnknownFallback()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        var dispatcher = StartAdapter(adapter);
+
+        var json = """{ "content": "no sender" }""";
+
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        var dispatched = dispatcher.Invocations
+            .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
+            .Select(i => (InboundMessage)i.Arguments[0])
+            .Single();
+
+        dispatched.SenderId.ShouldBe("unknown");
+    }
+
+    // ── Test 3: Allow-list blocks unauthorised senders ─────────────────────────
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_SenderNotInAllowList_DoesNotDispatch()
+    {
+        var options = new ServiceBusChannelOptions
+        {
+            ConnectionString = "Endpoint=sb://fake/;SharedAccessKeyName=x;SharedAccessKey=y=",
+            InboundQueueName = "q",
+            DefaultReplyQueueName = "q-out",
+        };
+        options.AllowedSenderIds.Add("allowed@org.com");
+
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(options, factory);
+        var dispatcher = StartAdapter(adapter);
+
+        var json = """{ "content": "blocked", "senderId": "unknown@evil.com" }""";
+
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        dispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_SenderInAllowList_Dispatches()
+    {
+        var options = new ServiceBusChannelOptions
+        {
+            ConnectionString = "Endpoint=sb://fake/;SharedAccessKeyName=x;SharedAccessKey=y=",
+            InboundQueueName = "q",
+            DefaultReplyQueueName = "q-out",
+        };
+        options.AllowedSenderIds.Add("allowed@org.com");
+
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(options, factory);
+        var dispatcher = StartAdapter(adapter);
+
+        var json = """{ "content": "hello", "senderId": "allowed@org.com" }""";
+
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        dispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Test 4: SendAsync routes to replyTo queue when present ────────────────
+
+    [Fact]
+    public async Task SendAsync_WithReplyToInPendingContext_SendsToReplyToQueue()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        StartAdapter(adapter);
+
+        // Simulate an inbound message that sets up the pending reply context.
+        var json = """{ "content": "hi", "senderId": "u@x.com", "conversationId": "conv-1", "replyTo": "custom-reply-queue", "correlationId": "corr-99" }""";
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        var outbound = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From("conv-1"),
+            Content = "reply text",
+            SessionId = "sess-abc",
+        };
+
+        await adapter.SendAsync(outbound, CancellationToken.None);
+
+        factory.Senders.ShouldContainKey("custom-reply-queue");
+        factory.Senders["custom-reply-queue"].SentMessages.ShouldHaveSingleItem();
+    }
+
+    // ── Test 5: SendAsync falls back to default reply queue ───────────────────
+
+    [Fact]
+    public async Task SendAsync_NoReplyTo_SendsToDefaultReplyQueue()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        StartAdapter(adapter);
+
+        // Inbound with no replyTo → pending context has null ReplyTo.
+        var json = """{ "content": "hi", "senderId": "u@x.com", "conversationId": "conv-2" }""";
+        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+
+        var outbound = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From("conv-2"),
+            Content = "reply",
+        };
+
+        await adapter.SendAsync(outbound, CancellationToken.None);
+
+        factory.Senders.ShouldContainKey("test-outbound");
+        factory.Senders["test-outbound"].SentMessages.ShouldHaveSingleItem();
+    }
+
+    // ── Test 6: Correlation ID preserved in reply ─────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WithCorrelationId_PreservesCorrelationIdInEnvelope()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        StartAdapter(adapter);
+
+        const string correlationId = "corr-preserved-42";
+
+        var inboundJson = $$"""{ "content": "q", "senderId": "s@x.com", "conversationId": "conv-3", "correlationId": "{{correlationId}}" }""";
+        await adapter.HandleMessageBodyAsync(inboundJson, null, CancellationToken.None);
+
+        var outbound = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From("conv-3"),
+            Content = "answer",
+        };
+
+        await adapter.SendAsync(outbound, CancellationToken.None);
+
+        var sent = factory.Senders["test-outbound"].SentMessages.Single();
+        sent.CorrelationId.ShouldBe(correlationId);
+
+        // Also verify the JSON body carries correlationId.
+        var envelope = JsonSerializer.Deserialize<ServiceBusOutboundEnvelope>(
+            sent.Body.ToString(),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        envelope.ShouldNotBeNull();
+        envelope!.CorrelationId.ShouldBe(correlationId);
+    }
+
+    // ── Test 7: Options bind from IOptions ────────────────────────────────────
+
+    [Fact]
+    public void ChannelAdapter_WithConfiguredOptions_ReflectsOptionValues()
+    {
+        var options = new ServiceBusChannelOptions
+        {
+            ConnectionString = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v=",
+            InboundQueueName = "my-inbound",
+            DefaultReplyQueueName = "my-outbound",
+            MaxConcurrentCalls = 4,
+        };
+
+        var adapter = new ServiceBusChannelAdapter(
+            NullLogger<ServiceBusChannelAdapter>.Instance,
+            new OptionsWrapper<ServiceBusChannelOptions>(options),
+            new FakeServiceBusAdapterClientFactory());
+
+        adapter.ChannelType.ShouldBe(ChannelKey.From("servicebus"));
+        adapter.DisplayName.ShouldBe("Azure Service Bus");
+        adapter.SupportsStreaming.ShouldBeFalse();
+    }
+
+    // ── Test 8: Start / stop manages processor lifecycle ─────────────────────
+
+    [Fact]
+    public async Task StartAsync_StartsProcessor_StopAsync_StopsProcessor()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        var dispatcher = new Mock<IChannelDispatcher>();
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        factory.Processor.StartCalled.ShouldBeTrue();
+        adapter.IsRunning.ShouldBeTrue();
+
+        await adapter.StopAsync(CancellationToken.None);
+        factory.Processor.StopCalled.ShouldBeTrue();
+        adapter.IsRunning.ShouldBeFalse();
+    }
+
+    // ── Test 9: Malformed JSON is logged and dropped without throwing ─────────
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_InvalidJson_DropsMessageWithoutException()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        var dispatcher = StartAdapter(adapter);
+
+        // Should not throw; message is silently abandoned (logged at Warning level).
+        await adapter.HandleMessageBodyAsync("not-valid-json}{", null, CancellationToken.None);
+
+        dispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Test: Application properties fall back for missing envelope fields ─────
+
+    [Fact]
+    public async Task HandleMessageBodyAsync_ApplicationPropertiesProvidesFallbacks()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        var dispatcher = StartAdapter(adapter);
+
+        var appProps = new Dictionary<string, object>
+        {
+            ["senderId"] = "fallback@sys.com",
+            ["agentId"] = "fallback-agent",
+            ["conversationId"] = "fallback-conv",
+            ["sessionId"] = "fallback-sess",
+            ["correlationId"] = "fallback-corr",
+            ["replyTo"] = "fallback-queue",
+        };
+
+        // Envelope has only content — everything else from application properties.
+        var json = """{ "content": "from app props" }""";
+
+        await adapter.HandleMessageBodyAsync(json, appProps, CancellationToken.None);
+
+        var dispatched = dispatcher.Invocations
+            .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
+            .Select(i => (InboundMessage)i.Arguments[0])
+            .Single();
+
+        dispatched.SenderId.ShouldBe("fallback@sys.com");
+        dispatched.TargetAgentId.ShouldBe("fallback-agent");
+        dispatched.SessionId.ShouldBe("fallback-sess");
+        dispatched.ConversationId.ShouldBe("fallback-conv");
+    }
+
+    // ── Test: SendAsync uses replyTo from metadata when no pending context ────
+
+    [Fact]
+    public async Task SendAsync_ReplyToInOutboundMetadata_UsedWhenNoPendingContext()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        StartAdapter(adapter);
+
+        // No prior inbound → no pending context; replyTo comes from metadata.
+        var outbound = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From("direct-conv"),
+            Content = "direct reply",
+            Metadata = new Dictionary<string, object?>
+            {
+                [ServiceBusChannelAdapter.MetaReplyTo] = "direct-reply-queue",
+                [ServiceBusChannelAdapter.MetaCorrelationId] = "direct-corr",
+            },
+        };
+
+        await adapter.SendAsync(outbound, CancellationToken.None);
+
+        factory.Senders.ShouldContainKey("direct-reply-queue");
+        var sent = factory.Senders["direct-reply-queue"].SentMessages.Single();
+        sent.CorrelationId.ShouldBe("direct-corr");
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/ServiceBusChannelAdapterTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/ServiceBusChannelAdapterTests.cs
@@ -391,6 +391,69 @@ public sealed class ServiceBusChannelAdapterTests
         sent.CorrelationId.ShouldBe("direct-corr");
     }
 
+    // ── Test: Retry/redelivery of same messageId does not poison FIFO queue ─────
+
+    [Fact]
+    public async Task SendAsync_MessageRedeliveredWithSameMessageId_DoesNotPoisonFifoForNextPendingReply()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        StartAdapter(adapter);
+
+        // 1. First delivery of message A (simulates initial attempt that gets abandoned).
+        const string retryMessageId = "sb-retry-msg-id";
+        const string conversationId = "conv-retry-fifo";
+
+        var jsonA1 = $$"""{ "content": "msg A first delivery", "senderId": "u@x.com", "conversationId": "{{conversationId}}", "replyTo": "reply-queue-A", "correlationId": "corr-A" }""";
+        await adapter.HandleMessageBodyAsync(jsonA1, null, retryMessageId, CancellationToken.None);
+
+        // 2. Service Bus redelivers the same message (identical messageId) after abandonment.
+        var jsonA2 = $$"""{ "content": "msg A retry", "senderId": "u@x.com", "conversationId": "{{conversationId}}", "replyTo": "reply-queue-A", "correlationId": "corr-A" }""";
+        await adapter.HandleMessageBodyAsync(jsonA2, null, retryMessageId, CancellationToken.None);
+
+        // 3. A second, distinct message B arrives for the same conversation.
+        var jsonB = $$"""{ "content": "msg B", "senderId": "u@x.com", "conversationId": "{{conversationId}}", "replyTo": "reply-queue-B", "correlationId": "corr-B" }""";
+        await adapter.HandleMessageBodyAsync(jsonB, null, "sb-distinct-msg-id-B", CancellationToken.None);
+
+        // 4. Reply for A uses FIFO fallback (no MetaRequestKey), mirroring the live gateway path
+        //    where OutboundMessage.Metadata does not carry inbound metadata.
+        //    This dequeues "sb-retry-msg-id" (the only entry), removes context_A, and sends to reply-queue-A.
+        //    Without the fix, the queue would be ["sb-retry-msg-id","sb-retry-msg-id","sb-distinct-msg-id-B"]
+        //    and this step would still succeed — the corruption only manifests in step 5.
+        var outboundA = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From(conversationId),
+            Content = "reply A",
+        };
+        await adapter.SendAsync(outboundA, CancellationToken.None);
+
+        // 5. Reply for B uses FIFO fallback (no MetaRequestKey in metadata).
+        //    With fix: dequeues "sb-distinct-msg-id-B" → routes to reply-queue-B ✓
+        //    Without fix: dequeues stale duplicate "sb-retry-msg-id" → TryRemove fails → null
+        //                 → falls through to default queue "test-outbound" ✗
+        var outboundB = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From(conversationId),
+            Content = "reply B",
+        };
+        await adapter.SendAsync(outboundB, CancellationToken.None);
+
+        // A's reply must have gone to reply-queue-A.
+        factory.Senders.ShouldContainKey("reply-queue-A");
+        factory.Senders["reply-queue-A"].SentMessages.ShouldHaveSingleItem();
+        factory.Senders["reply-queue-A"].SentMessages[0].CorrelationId.ShouldBe("corr-A");
+
+        // B's reply must have gone to reply-queue-B, NOT the default queue.
+        factory.Senders.ShouldContainKey("reply-queue-B");
+        factory.Senders["reply-queue-B"].SentMessages.ShouldHaveSingleItem();
+        factory.Senders["reply-queue-B"].SentMessages[0].CorrelationId.ShouldBe("corr-B");
+
+        // Default queue must NOT have received any message.
+        factory.Senders.ShouldNotContainKey("test-outbound");
+    }
+
     // ── Test: Concurrent inbound messages for same conversation route independently ─
 
     [Fact]

--- a/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/ServiceBusChannelAdapterTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/ServiceBusChannelAdapterTests.cs
@@ -69,7 +69,7 @@ public sealed class ServiceBusChannelAdapterTests
             timestamp = "2026-05-13T12:22:56Z",
         });
 
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         var dispatched = dispatcher.Invocations
             .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
@@ -96,7 +96,7 @@ public sealed class ServiceBusChannelAdapterTests
 
         var json = """{ "content": "minimal message", "senderId": "bot@sys.com" }""";
 
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         var dispatched = dispatcher.Invocations
             .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
@@ -121,7 +121,7 @@ public sealed class ServiceBusChannelAdapterTests
 
         var json = """{ "content": "no sender" }""";
 
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         var dispatched = dispatcher.Invocations
             .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
@@ -150,7 +150,7 @@ public sealed class ServiceBusChannelAdapterTests
 
         var json = """{ "content": "blocked", "senderId": "unknown@evil.com" }""";
 
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         dispatcher.Verify(
             d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()),
@@ -174,7 +174,7 @@ public sealed class ServiceBusChannelAdapterTests
 
         var json = """{ "content": "hello", "senderId": "allowed@org.com" }""";
 
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         dispatcher.Verify(
             d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()),
@@ -192,7 +192,7 @@ public sealed class ServiceBusChannelAdapterTests
 
         // Simulate an inbound message that sets up the pending reply context.
         var json = """{ "content": "hi", "senderId": "u@x.com", "conversationId": "conv-1", "replyTo": "custom-reply-queue", "correlationId": "corr-99" }""";
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         var outbound = new OutboundMessage
         {
@@ -219,7 +219,7 @@ public sealed class ServiceBusChannelAdapterTests
 
         // Inbound with no replyTo → pending context has null ReplyTo.
         var json = """{ "content": "hi", "senderId": "u@x.com", "conversationId": "conv-2" }""";
-        await adapter.HandleMessageBodyAsync(json, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, null, null, CancellationToken.None);
 
         var outbound = new OutboundMessage
         {
@@ -246,7 +246,7 @@ public sealed class ServiceBusChannelAdapterTests
         const string correlationId = "corr-preserved-42";
 
         var inboundJson = $$"""{ "content": "q", "senderId": "s@x.com", "conversationId": "conv-3", "correlationId": "{{correlationId}}" }""";
-        await adapter.HandleMessageBodyAsync(inboundJson, null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(inboundJson, null, null, CancellationToken.None);
 
         var outbound = new OutboundMessage
         {
@@ -320,7 +320,7 @@ public sealed class ServiceBusChannelAdapterTests
         var dispatcher = StartAdapter(adapter);
 
         // Should not throw; message is silently abandoned (logged at Warning level).
-        await adapter.HandleMessageBodyAsync("not-valid-json}{", null, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync("not-valid-json}{", null, null, CancellationToken.None);
 
         dispatcher.Verify(
             d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()),
@@ -349,7 +349,7 @@ public sealed class ServiceBusChannelAdapterTests
         // Envelope has only content — everything else from application properties.
         var json = """{ "content": "from app props" }""";
 
-        await adapter.HandleMessageBodyAsync(json, appProps, CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(json, appProps, null, CancellationToken.None);
 
         var dispatched = dispatcher.Invocations
             .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
@@ -389,5 +389,53 @@ public sealed class ServiceBusChannelAdapterTests
         factory.Senders.ShouldContainKey("direct-reply-queue");
         var sent = factory.Senders["direct-reply-queue"].SentMessages.Single();
         sent.CorrelationId.ShouldBe("direct-corr");
+    }
+
+    // ── Test: Concurrent inbound messages for same conversation route independently ─
+
+    [Fact]
+    public async Task SendAsync_ConcurrentInboundSameConversation_RepliesRouteIndependently()
+    {
+        var factory = new FakeServiceBusAdapterClientFactory();
+        var adapter = CreateAdapter(factory: factory);
+        StartAdapter(adapter);
+
+        // Two inbound messages for the same conversationId but distinct replyTo/correlationId.
+        // This simulates MaxConcurrentCalls > 1 with two messages in-flight simultaneously.
+        var jsonA = """{ "content": "msg A", "senderId": "u@x.com", "conversationId": "conv-concurrent", "replyTo": "reply-queue-A", "correlationId": "corr-A" }""";
+        var jsonB = """{ "content": "msg B", "senderId": "u@x.com", "conversationId": "conv-concurrent", "replyTo": "reply-queue-B", "correlationId": "corr-B" }""";
+
+        await adapter.HandleMessageBodyAsync(jsonA, null, "sb-msg-id-A", CancellationToken.None);
+        await adapter.HandleMessageBodyAsync(jsonB, null, "sb-msg-id-B", CancellationToken.None);
+
+        // Reply for B is sent first (out-of-order) to prove routing is by key, not FIFO.
+        var outboundB = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From("conv-concurrent"),
+            Content = "reply B",
+            Metadata = new Dictionary<string, object?> { [ServiceBusChannelAdapter.MetaRequestKey] = "sb-msg-id-B" },
+        };
+        await adapter.SendAsync(outboundB, CancellationToken.None);
+
+        // Reply for A sent second.
+        var outboundA = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("servicebus"),
+            ChannelAddress = ChannelAddress.From("conv-concurrent"),
+            Content = "reply A",
+            Metadata = new Dictionary<string, object?> { [ServiceBusChannelAdapter.MetaRequestKey] = "sb-msg-id-A" },
+        };
+        await adapter.SendAsync(outboundA, CancellationToken.None);
+
+        // A's reply must land in A's queue with A's correlationId.
+        factory.Senders.ShouldContainKey("reply-queue-A");
+        factory.Senders["reply-queue-A"].SentMessages.ShouldHaveSingleItem();
+        factory.Senders["reply-queue-A"].SentMessages[0].CorrelationId.ShouldBe("corr-A");
+
+        // B's reply must land in B's queue with B's correlationId.
+        factory.Senders.ShouldContainKey("reply-queue-B");
+        factory.Senders["reply-queue-B"].SentMessages.ShouldHaveSingleItem();
+        factory.Senders["reply-queue-B"].SentMessages[0].CorrelationId.ShouldBe("corr-B");
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/xunit.runner.json
+++ b/tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0
+}


### PR DESCRIPTION
## Summary

Adds an **Azure Service Bus queue channel extension** to BotNexus, enabling Teams/proxy and any queue-capable producer/consumer to integrate via generic queue envelopes.

### New envelope schema

The queue envelope carries:
- Agent ID, Conversation ID, Session ID, Sender ID
- Correlation ID, ReplyTo address
- Content (text payload)
- Timestamp
- Metadata dictionary (extensible key-value pairs)

### Core changes

**None.** This is implemented entirely as an extension — no modifications to existing BotNexus core, domain, or gateway code.

### Tests

- New `BotNexus.Extensions.Channels.ServiceBus.Tests` project with **15 tests** covering:
  - Envelope serialization/deserialization
  - Channel send/receive lifecycle
  - Concurrent dispatch (MaxConcurrentCalls > 1) correctness
  - Retry/redelivery duplicate FIFO prevention
- Full solution build and test pass after rebase:
  - `dotnet build BotNexus.slnx --nologo --tl:off` ✅
  - `dotnet test BotNexus.slnx --nologo --tl:off` ✅

### Reviewer-discovered fixes (included)

1. **Per-dispatch pending reply key** — keys pending replies by a per-dispatch request identifier instead of conversation ID, preventing overwrite when `MaxConcurrentCalls > 1` allows concurrent messages on the same conversation.
2. **Duplicate FIFO prevention** — guards against duplicate queue entries when Azure Service Bus retries/redelivers a message (e.g., lock expiry).

### Configuration

Manual setup required:
- Provision Azure Service Bus namespace and queue(s)
- Add `channels:servicebus` section to BotNexus configuration

Closes #211