### PR TITLE
[Portal] Show conversation name in chat canvas header instead of agent name

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -7,13 +7,12 @@
     <header class="chat-header">
         <div class="chat-header-left">
             <div class="chat-title-stack">
-                <h3>@DisplayName</h3>
-                @if (HasActiveConversation)
-                {
-                    <div class="conversation-title-row">
+                <div class="chat-title-heading-row">
+                    @if (HasActiveConversation)
+                    {
                         @if (_editingTitle)
                         {
-                            <input class="conversation-title-input"
+                            <input class="conversation-title-input conversation-title-h3"
                                    @bind="_titleDraft"
                                    @bind:event="oninput"
                                    @onblur="SaveTitle"
@@ -24,19 +23,23 @@
                         {
                             @if (IsReadOnly)
                             {
-                                <span class="conversation-title">@ActiveConversationTitle</span>
+                                <h3 class="conversation-title">@ActiveConversationTitle</h3>
                             }
                             else
                             {
-                                <span class="conversation-title editable" @onclick="StartEditTitle" title="Click to rename">@ActiveConversationTitle</span>
+                                <h3 class="conversation-title editable" @onclick="StartEditTitle" title="Click to rename">@ActiveConversationTitle</h3>
                             }
                             @if (ActiveConversation?.IsDefault == true)
                             {
                                 <span class="conversation-default-badge">Default</span>
                             }
                         }
-                    </div>
-                }
+                    }
+                    else
+                    {
+                        <h3>@DisplayName</h3>
+                    }
+                </div>
                 <span class="agent-id-label">@AgentId</span>
             </div>
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -1,4 +1,4 @@
-/* ── BotNexus Blazor Client — Dark Theme ─────────────────────────────── */
+﻿/* ── BotNexus Blazor Client — Dark Theme ─────────────────────────────── */
 
 :root {
     --bg-primary: #1a1a2e;
@@ -3385,23 +3385,45 @@ details[open] > .thinking-summary::before {
     white-space: nowrap;
 }
 
-/* ── Chat Header — Conversation Title Row ─────────────────────────────────── */
+/* Chat Header - Conversation Title Heading (was: Conversation Title Row) */
 
-.conversation-title-row {
+.chat-title-heading-row {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: baseline;
     gap: 0.4rem;
-    margin-top: 0.1rem;
 }
 
-.conversation-title {
-    font-size: 0.8rem;
-    font-weight: 400;
-    color: var(--text-secondary);
+h3.conversation-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    cursor: default;
+}
+
+h3.conversation-title.editable {
+    cursor: pointer;
+}
+
+h3.conversation-title.editable:hover {
+    color: var(--accent);
+}
+
+.conversation-title-input {
+    font-size: 1rem;
+    font-weight: 600;
+    background: var(--bg-input, var(--bg-secondary));
+    border: 1px solid var(--border-focus, var(--accent));
+    border-radius: 4px;
+    color: inherit;
+    padding: 0.1rem 0.3rem;
+    margin: 0;
+    outline: none;
+    width: 100%;
+    max-width: 24rem;
 }
 
 /* ── Config Panel Layout ──────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Fixes #279.

The chat canvas header `<h3>` was showing the agent display name, which is redundant -- it already appears in the top-level agent control and above the tabs. This PR promotes the active conversation title to the primary heading.

## Changes

### `ChatPanel.razor`
- Replaced the static `<h3>@DisplayName</h3>` with a conditional:
  - When a conversation is active: renders the conversation title as `<h3 class="conversation-title">` (editable inline via click-to-rename, same as before)
  - When no conversation is active (loading state): falls back to `<h3>@DisplayName</h3>`
- Replaced `.conversation-title-row` wrapper div with `.chat-title-heading-row`

### `app.css`
- Replaced `.conversation-title-row` block with `.chat-title-heading-row` (flex row, baseline-aligned)
- Scoped `.conversation-title` styles to `h3.conversation-title` (1rem, weight 600 -- same as the old agent-name heading)
- Added hover colour for `h3.conversation-title.editable`
- Added `.conversation-title-input` rule for the inline-edit input (matches heading size/weight)

## Behaviour unchanged
- Click-to-rename still works
- Default badge still renders when `IsDefault == true`
- Agent ID label still visible below the heading
- All action buttons unchanged
- Read-only mode shows non-clickable title
- Streaming badge unchanged

## Tests
Pre-commit ran the full test suite: **0 failures**.