### PR TITLE
[Portal] Remove redundant agent ID from chat canvas header (#292)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -40,7 +40,6 @@
                         <h3>@DisplayName</h3>
                     }
                 </div>
-                <span class="agent-id-label">@AgentId</span>
             </div>
 
             @if (IsStreaming)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -1,4 +1,4 @@
-﻿/* ── BotNexus Blazor Client — Dark Theme ─────────────────────────────── */
+/* ── BotNexus Blazor Client — Dark Theme ─────────────────────────────── */
 
 :root {
     --bg-primary: #1a1a2e;
@@ -1038,11 +1038,6 @@ html, body, #app {
     margin: 0;
 }
 
-.agent-id-label {
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-}
 
 .streaming-badge {
     font-size: 0.7rem;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -64,13 +64,15 @@ public sealed class ChatPanelTests : IDisposable
     }
 
     [Fact]
-    public void Renders_agent_id_label_in_header()
+    public void Agent_id_label_is_not_rendered_in_header()
     {
+        // The agent ID label was removed from the chat canvas header (#292)
+        // as it is redundant with the top-level agent control.
         CreateAndSeedAgent("agent-xyz");
 
         var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-xyz"));
 
-        Assert.Contains("agent-xyz", cut.Markup);
+        Assert.DoesNotContain("agent-id-label", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Removes the `agent-id-label` span from the chat canvas header. The agent ID is already shown in the top-level agent control and the tabs area, so this is redundant. Removes one line of markup and its CSS rule, making the header narrower.

Follows on from #287 which removed the agent display name from the same header.

## Changes

- `ChatPanel.razor` — removed `<span class=\"agent-id-label\">@AgentId</span>` (1 line)
- `app.css` — removed `.agent-id-label` rule (5 lines)
- `ChatPanelTests.cs` — updated test: was asserting the label renders, now asserts it does NOT render

Closes #292