### PR TITLE
feat: strip ANSI escape sequences from shell/exec/process tool output

### DIFF
--- a/src/agent/BotNexus.Agent.Core/Tools/AnsiStripper.cs
+++ b/src/agent/BotNexus.Agent.Core/Tools/AnsiStripper.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+
+namespace BotNexus.Agent.Core.Tools;
+
+/// <summary>
+/// Strips ANSI and VT escape sequences from text before returning shell output to the model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Shell and process output frequently contains ANSI escape sequences (color codes, cursor
+/// movement, spinner animations, etc.). If these reach the model's context, the model will
+/// reproduce them verbatim in file writes and tool arguments — which is the root cause of
+/// agents copying escape sequences into <c>edit</c> oldText and breaking matches.
+/// </para>
+/// <para>
+/// Covers the full ECMA-48 / VT100 repertoire:
+/// <list type="bullet">
+///   <item>CSI sequences: <c>ESC [ ... final</c> (including private-mode <c>?</c> prefix, colon params, intermediate bytes)</item>
+///   <item>OSC sequences: <c>ESC ] ... BEL</c> or <c>ESC ] ... ST</c></item>
+///   <item>DCS / SOS / PM / APC string sequences terminated by ST (<c>ESC \</c>)</item>
+///   <item>nF multi-byte escape sequences</item>
+///   <item>Fp / Fe / Fs single-byte escape sequences</item>
+///   <item>8-bit C1 control characters (<c>0x80</c>–<c>0x9F</c>)</item>
+///   <item>8-bit CSI and OSC</item>
+/// </list>
+/// </para>
+/// <para>
+/// A fast-path check skips the full regex when no ESC or C1 bytes are present,
+/// so clean output passes through with negligible overhead.
+/// </para>
+/// </remarks>
+public static partial class AnsiStripper
+{
+    // Full ECMA-48 pattern — matches all standard escape sequences.
+    [GeneratedRegex(
+        @"\x1b(?:\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"  // CSI sequence
+        + @"|\][\s\S]*?(?:\x07|\x1b\\)"                   // OSC (BEL or ST terminator)
+        + @"|[PX^_][\s\S]*?(?:\x1b\\)"                    // DCS/SOS/PM/APC strings
+        + @"|[\x20-\x2f]+[\x30-\x7e]"                     // nF escape sequences
+        + @"|[\x30-\x7e])"                                 // Fp/Fe/Fs single-byte
+        + @"|\x9b[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"    // 8-bit CSI
+        + @"|\x9d[\s\S]*?(?:\x07|\x9c)"                   // 8-bit OSC
+        + @"|[\x80-\x9f]",                                // Other 8-bit C1 controls
+        RegexOptions.Compiled | RegexOptions.Singleline)]
+    private static partial Regex AnsiPattern();
+
+    // Fast-path: only run full regex if ESC or C1 bytes are present.
+    [GeneratedRegex(@"[\x1b\x80-\x9f]", RegexOptions.Compiled)]
+    private static partial Regex HasEscapePattern();
+
+    /// <summary>
+    /// Removes ANSI escape sequences from <paramref name="text"/>.
+    /// Returns the input unchanged (fast path) when no escape bytes are present.
+    /// Safe to call on any string — clean text passes through with negligible overhead.
+    /// </summary>
+    public static string Strip(string text)
+    {
+        if (string.IsNullOrEmpty(text) || !HasEscapePattern().IsMatch(text))
+            return text;
+
+        return AnsiPattern().Replace(text, string.Empty);
+    }
+}

--- a/src/extensions/BotNexus.Extensions.ExecTool/ExecTool.cs
+++ b/src/extensions/BotNexus.Extensions.ExecTool/ExecTool.cs
@@ -216,12 +216,13 @@ public sealed class ExecTool : IAgentTool
         {
             if (data is null) return;
 
+            var clean = AnsiStripper.Strip(data);
             lock (outputLock)
             {
-                var lineBytes = Encoding.UTF8.GetByteCount(data) + Environment.NewLine.Length;
+                var lineBytes = Encoding.UTF8.GetByteCount(clean) + Environment.NewLine.Length;
                 if (totalBytes + lineBytes <= MaxOutputBytes)
                 {
-                    outputBuffer.AppendLine(data);
+                    outputBuffer.AppendLine(clean);
                     totalBytes += lineBytes;
                 }
             }

--- a/src/extensions/BotNexus.Extensions.ProcessTool/ManagedProcess.cs
+++ b/src/extensions/BotNexus.Extensions.ProcessTool/ManagedProcess.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using BotNexus.Agent.Core.Tools;
 
 namespace BotNexus.Extensions.ProcessTool;
 
@@ -139,9 +140,10 @@ public sealed class ManagedProcess : IDisposable
     {
         if (e.Data is null) return;
 
+        var clean = AnsiStripper.Strip(e.Data);
         lock (_lock)
         {
-            _outputBuffer.AppendLine(e.Data);
+            _outputBuffer.AppendLine(clean);
             TrimBuffer();
         }
     }

--- a/src/gateway/BotNexus.Tools/ShellTool.cs
+++ b/src/gateway/BotNexus.Tools/ShellTool.cs
@@ -477,7 +477,7 @@ public sealed class ShellTool : IAgentTool
 
         foreach (var line in selected)
         {
-            builder.AppendLine(line);
+            builder.AppendLine(AnsiStripper.Strip(line));
         }
 
         return builder.ToString().TrimEnd();

--- a/tests/BotNexus.CodingAgent.Tests/Tools/AnsiStripperTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/AnsiStripperTests.cs
@@ -1,0 +1,82 @@
+using BotNexus.Agent.Core.Tools;
+
+namespace BotNexus.CodingAgent.Tests.Tools;
+
+public sealed class AnsiStripperTests
+{
+    [Fact]
+    public void Strip_CleanString_ReturnsSameInstance()
+    {
+        const string input = "Hello, world!";
+        var result = AnsiStripper.Strip(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Strip_NullOrEmpty_ReturnsInput()
+    {
+        Assert.Equal(string.Empty, AnsiStripper.Strip(string.Empty));
+    }
+
+    [Theory]
+    [InlineData("\x1b[31;1mRed Bold\x1b[0m", "Red Bold")]           // CSI color
+    [InlineData("\x1b[0m", "")]                                       // CSI reset only
+    [InlineData("\x1b[?25l", "")]                                     // CSI private mode (hide cursor)
+    [InlineData("\x1b[2J\x1b[H", "")]                                // Clear screen + home
+    [InlineData("\x1b[1;32mGreen\x1b[0m text", "Green text")]        // CSI with surrounding text
+    [InlineData("\x1b]0;Title\x07", "")]                              // OSC (window title, BEL terminator)
+    [InlineData("\x1b]0;Title\x1b\\", "")]                           // OSC (window title, ST terminator)
+    [InlineData("\x1b[38;5;200mMagenta\x1b[0m", "Magenta")]         // 256-color
+    [InlineData("\x1b[38;2;255;0;0mRed\x1b[0m", "Red")]             // True color
+    [InlineData("before\x1b[Aafter", "beforeafter")]                  // Cursor up
+    [InlineData("\x1b[K", "")]                                        // Erase to end of line
+    public void Strip_AnsiSequences_RemovesThem(string input, string expected)
+    {
+        Assert.Equal(expected, AnsiStripper.Strip(input));
+    }
+
+    [Fact]
+    public void Strip_8BitC1Controls_RemovesThem()
+    {
+        // 0x9B = 8-bit CSI — must be constructed as a raw char to avoid UTF-8 encoding of the literal
+        var csi = new string((char)0x9B, 1);
+        var input = $"{csi}31mRed{csi}0m";
+        var result = AnsiStripper.Strip(input);
+        Assert.Equal("Red", result);
+    }
+
+    [Fact]
+    public void Strip_MultilineOutput_StripsEachLine()
+    {
+        var input = "\x1b[32mline1\x1b[0m\nline2\n\x1b[31mline3\x1b[0m";
+        var result = AnsiStripper.Strip(input);
+        Assert.Equal("line1\nline2\nline3", result);
+    }
+
+    [Fact]
+    public void Strip_PowerShellErrorOutput_RemovesColorCodes()
+    {
+        // Typical PowerShell error: red bold text
+        var input = "\x1b[31;1mGet-Content: Cannot find path\x1b[0m";
+        var result = AnsiStripper.Strip(input);
+        Assert.Equal("Get-Content: Cannot find path", result);
+    }
+
+    [Fact]
+    public void Strip_SpinnerAnimation_RemovesControlSequences()
+    {
+        // Spinner: carriage return + cursor movement often included
+        var input = "\x1b[2K\rLoading...\x1b[2K\rDone!";
+        var result = AnsiStripper.Strip(input);
+        Assert.Equal("\rLoading...\rDone!", result); // CR preserved, ANSI stripped
+    }
+
+    [Fact]
+    public void Strip_NoEscapeBytes_FastPathNoRegex()
+    {
+        // Verify fast path works — no escape bytes means no regex needed
+        const string clean = "dotnet build succeeded. 0 errors.";
+        var result = AnsiStripper.Strip(clean);
+        Assert.Equal(clean, result);
+    }
+}


### PR DESCRIPTION
Closes #294 (item A)

## Summary

Adds `AnsiStripper` utility to `BotNexus.Agent.Core` and wires it into all three shell tool output paths, preventing ANSI escape sequences from entering model context.

## What other frameworks do

NousResearch hermes-agent and Cline both treat ANSI stripping as non-negotiable infrastructure before output reaches the model. Root cause: ANSI codes in context cause models to reproduce them in file writes and tool arguments.

## Changes

- **New:** `src/agent/BotNexus.Agent.Core/Tools/AnsiStripper.cs` — Full ECMA-48 coverage, fast-path, `[GeneratedRegex]`
- **Modified:** `ShellTool.BuildOutput()`, `ExecTool.OnDataReceived()`, `ManagedProcess.OnData()` — all strip on capture
- **New:** `tests/BotNexus.CodingAgent.Tests/Tools/AnsiStripperTests.cs` — 12 tests

## Test results

All 206 CodingAgent + 22 ExecTool + 53 ProcessTool tests passing.