### PR TITLE
feat(mobile): initial mobile Blazor WASM client

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/extensions/BotNexus.Extensions.ExecTool/BotNexus.Extensions.ExecTool.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/BotNexus.Extensions.Channels.SignalR.BlazorClient.csproj" />
+    <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Tui/BotNexus.Extensions.Channels.Tui.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.ServiceBus/BotNexus.Extensions.Channels.ServiceBus.csproj" />

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/App.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/App.razor
@@ -1,0 +1,11 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MobileLayout)" />
+    </Found>
+    <NotFound>
+        <PageTitle>Not found</PageTitle>
+        <LayoutView Layout="@typeof(Layout.MobileLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+    <StaticWebAssetBasePath>/mobile</StaticWebAssetBasePath>
+  </PropertyGroup>
+
+  <!-- Same NuGet packages as the desktop client. Services are duplicated in this project
+       because a WASM project cannot reference another WASM project without asset conflicts.
+       Future: extract shared services to a BotNexus.Extensions.Channels.SignalR.BlazorClient.Core
+       class library that both desktop and mobile reference. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ServiceWorker Include="wwwroot\service-worker.js" ProfileName="release" />
+  </ItemGroup>
+</Project>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Layout/MobileLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Layout/MobileLayout.razor
@@ -1,0 +1,3 @@
+@inherits LayoutComponentBase
+
+@Body

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -1,0 +1,189 @@
+@page "/"
+@inject MobileState State
+@inject MobileGatewayClient Gateway
+@inject IConfiguration Config
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>BotNexus</PageTitle>
+
+@if (!_ready)
+{
+    <div class="portal-loading">
+        <div class="portal-load-spinner">Connecting…</div>
+    </div>
+}
+else
+{
+    <div class="mobile-app">
+
+        <!-- TOP BAR -->
+        <div class="top-bar">
+            <select class="agent-select" value="@State.ActiveAgentId" @onchange="OnAgentChanged">
+                @foreach (var agent in State.Agents)
+                {
+                    <option value="@agent.AgentId">@(agent.Emoji is not null ? agent.Emoji + " " : "")@agent.DisplayName</option>
+                }
+            </select>
+
+            <select class="conv-select" value="@State.ActiveConversationId" @onchange="OnConvChanged">
+                @foreach (var conv in State.Conversations)
+                {
+                    <option value="@conv.ConversationId">@conv.Title</option>
+                }
+            </select>
+
+            <div class="overflow-menu-wrapper">
+                <button class="overflow-btn" @onclick="ToggleMenu" aria-label="Menu">⋮</button>
+                @if (_menuOpen)
+                {
+                    <div class="overflow-dropdown">
+                        <div class="menu-session-id" title="Session ID">
+                            <span>Session: </span><span class="session-id-text">@(State.ActiveSessionId ?? "—")</span>
+                        </div>
+                        <button class="menu-action" @onclick="NewSession">New session</button>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- MESSAGE STREAM -->
+        <div class="message-stream" @ref="_messageStreamRef">
+            @foreach (var msg in State.Messages)
+            {
+                <div class="message @GetMessageClass(msg)">
+                    @if (msg.IsToolCall)
+                    {
+                        <div class="tool-call-label">🔧 @msg.ToolName</div>
+                    }
+                    <div class="message-content">@msg.Content</div>
+                    <div class="message-time">@msg.Timestamp.ToLocalTime().ToString("HH:mm")</div>
+                </div>
+            }
+
+            @if (State.IsStreaming && !string.IsNullOrEmpty(State.StreamBuffer))
+            {
+                <div class="message assistant streaming">
+                    <div class="message-content">@State.StreamBuffer<span class="stream-cursor">▌</span></div>
+                </div>
+            }
+        </div>
+
+        <!-- BOTTOM BAR -->
+        <div class="bottom-bar">
+            <textarea
+                class="input-textarea"
+                placeholder="Message…"
+                rows="1"
+                @bind="_inputText"
+                @bind:event="oninput"
+                @onkeydown="OnKeyDown"
+                disabled="@_isSending">
+            </textarea>
+            <button class="send-btn" @onclick="SendMessage" disabled="@(_isSending || string.IsNullOrWhiteSpace(_inputText))">
+                →
+            </button>
+        </div>
+
+    </div>
+}
+
+@code {
+    private string _inputText = "";
+    private bool _isSending;
+    private bool _menuOpen;
+    private bool _ready;
+    private ElementReference _messageStreamRef;
+
+    protected override async Task OnInitializedAsync()
+    {
+        State.OnChanged += HandleStateChanged;
+
+        try
+        {
+            var gatewayUrl = Config["GatewayUrl"] ?? "http://localhost:5005";
+            await Gateway.InitializeAsync(gatewayUrl);
+            _ready = true;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] Init failed: {ex.Message}");
+            _ready = true; // show UI anyway
+        }
+    }
+
+    private void HandleStateChanged() =>
+        _ = InvokeAsync(async () =>
+        {
+            StateHasChanged();
+            await ScrollToBottomAsync();
+        });
+
+    private void OnAgentChanged(ChangeEventArgs e)
+    {
+        State.ActiveAgentId = e.Value?.ToString();
+        _menuOpen = false;
+        // Could reload conversations here if needed
+    }
+
+    private void OnConvChanged(ChangeEventArgs e)
+    {
+        State.ActiveConversationId = e.Value?.ToString();
+    }
+
+    private async Task SendMessage()
+    {
+        if (string.IsNullOrWhiteSpace(_inputText)) return;
+        var content = _inputText.Trim();
+        _inputText = "";
+        _isSending = true;
+        try
+        {
+            await Gateway.SendMessageAsync(content);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] Send failed: {ex.Message}");
+        }
+        finally
+        {
+            _isSending = false;
+        }
+    }
+
+    private async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !e.ShiftKey)
+            await SendMessage();
+    }
+
+    private void ToggleMenu() => _menuOpen = !_menuOpen;
+
+    private async Task NewSession()
+    {
+        _menuOpen = false;
+        await Gateway.ResetSessionAsync();
+    }
+
+    private static string GetMessageClass(ChatMessage msg)
+    {
+        if (msg.IsToolCall) return "tool";
+        if (msg.Role == "thinking") return "thinking";
+        return msg.Role == "user" ? "user" : "assistant";
+    }
+
+    private async Task ScrollToBottomAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("eval",
+                "document.querySelector('.message-stream')?.scrollTo({top:1e9,behavior:'smooth'})");
+        }
+        catch { /* ignore JS interop errors */ }
+    }
+
+    public void Dispose()
+    {
+        State.OnChanged -= HandleStateChanged;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Program.cs
@@ -1,0 +1,12 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+// Reuse service registrations from desktop client
+builder.Services.AddBotNexusMobileServices(builder.Configuration);
+
+await builder.Build().RunAsync();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileGatewayClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileGatewayClient.cs
@@ -1,0 +1,307 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services;
+
+// ── Minimal wire DTOs ──────────────────────────────────────────────────────────
+
+file sealed record AgentSummaryDto(
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("displayName")] string DisplayName,
+    [property: JsonPropertyName("emoji")] string? Emoji = null);
+
+file sealed record ConversationSummaryDto(
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("title")] string Title);
+
+file sealed record HistoryMessage(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("sessionId")] string SessionId,
+    [property: JsonPropertyName("role")] string Role,
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("timestamp")] DateTimeOffset Timestamp,
+    [property: JsonPropertyName("toolName")] string? ToolName = null,
+    [property: JsonPropertyName("toolCallId")] string? ToolCallId = null);
+
+file sealed record ConversationHistoryResponseDto(
+    [property: JsonPropertyName("messages")] IReadOnlyList<HistoryMessage>? Messages,
+    [property: JsonPropertyName("nextCursor")] string? NextCursor,
+    [property: JsonPropertyName("hasMore")] bool HasMore);
+
+file sealed record SendMessageResult(
+    [property: JsonPropertyName("sessionId")] string SessionId,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("channelType")] string? ChannelType);
+
+file sealed record AgentStreamEvent
+{
+    [JsonPropertyName("type")] public string? Type { get; init; }
+    [JsonPropertyName("sessionId")] public string? SessionId { get; init; }
+    [JsonPropertyName("contentDelta")] public string? ContentDelta { get; init; }
+    [JsonPropertyName("thinkingContent")] public string? ThinkingContent { get; init; }
+    [JsonPropertyName("toolName")] public string? ToolName { get; init; }
+    [JsonPropertyName("toolCallId")] public string? ToolCallId { get; init; }
+    [JsonPropertyName("toolResult")] public string? ToolResult { get; init; }
+    [JsonPropertyName("errorMessage")] public string? ErrorMessage { get; init; }
+}
+
+// ── Main client ────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Handles REST data loading and SignalR streaming for the mobile Blazor WASM client.
+/// Self-contained — no dependency on the desktop BlazorClient assembly.
+/// </summary>
+public sealed class MobileGatewayClient : IAsyncDisposable
+{
+    private readonly HttpClient _http;
+    private readonly MobileState _state;
+    private HubConnection? _hub;
+
+    public MobileGatewayClient(HttpClient http, MobileState state)
+    {
+        _http = http;
+        _state = state;
+    }
+
+    /// <summary>
+    /// Loads agents + conversations via REST and connects the SignalR hub.
+    /// Safe to call multiple times — subsequent calls are no-ops if already connected.
+    /// </summary>
+    public async Task InitializeAsync(string gatewayUrl, CancellationToken ct = default)
+    {
+        if (_hub?.State == HubConnectionState.Connected)
+            return;
+
+        var baseUrl = gatewayUrl.TrimEnd('/') + "/";
+
+        // ── REST: agents ──────────────────────────────────────────────────────
+        try
+        {
+            var agents = await _http.GetFromJsonAsync<List<AgentSummaryDto>>($"{baseUrl}api/agents", ct);
+            _state.Agents.Clear();
+            if (agents is not null)
+            {
+                foreach (var a in agents)
+                    _state.Agents.Add(new AgentOption { AgentId = a.AgentId, DisplayName = a.DisplayName, Emoji = a.Emoji });
+            }
+
+            if (_state.ActiveAgentId is null && _state.Agents.Count > 0)
+                _state.ActiveAgentId = _state.Agents[0].AgentId;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] Failed to load agents: {ex.Message}");
+        }
+
+        // ── REST: conversations for active agent ──────────────────────────────
+        if (_state.ActiveAgentId is not null)
+        {
+            await LoadConversationsAsync(baseUrl, _state.ActiveAgentId, ct);
+        }
+
+        // ── SignalR ───────────────────────────────────────────────────────────
+        _hub = new HubConnectionBuilder()
+            .WithUrl($"{gatewayUrl.TrimEnd('/')}/hub/gateway")
+            .WithAutomaticReconnect()
+            .Build();
+
+        RegisterHubHandlers();
+
+        try
+        {
+            await _hub.StartAsync(ct);
+            await _hub.InvokeAsync<object>("SubscribeAll", ct);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] Hub connection failed: {ex.Message}");
+        }
+
+        _state.NotifyChanged();
+    }
+
+    /// <summary>Load conversations for an agent and optionally select the first one.</summary>
+    public async Task LoadConversationsAsync(string baseUrl, string agentId, CancellationToken ct = default)
+    {
+        try
+        {
+            var convs = await _http.GetFromJsonAsync<List<ConversationSummaryDto>>(
+                $"{baseUrl}api/conversations?agentId={Uri.EscapeDataString(agentId)}", ct);
+            _state.Conversations.Clear();
+            if (convs is not null)
+            {
+                foreach (var c in convs)
+                    _state.Conversations.Add(new ConversationOption { ConversationId = c.ConversationId, Title = c.Title });
+            }
+
+            if (_state.ActiveConversationId is null && _state.Conversations.Count > 0)
+                _state.ActiveConversationId = _state.Conversations[0].ConversationId;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] Failed to load conversations: {ex.Message}");
+        }
+
+        // ── REST: history for active conversation ─────────────────────────────
+        if (_state.ActiveConversationId is not null)
+        {
+            await LoadHistoryAsync(baseUrl, _state.ActiveConversationId, ct);
+        }
+    }
+
+    /// <summary>Load message history for a conversation.</summary>
+    public async Task LoadHistoryAsync(string baseUrl, string conversationId, CancellationToken ct = default)
+    {
+        try
+        {
+            var history = await _http.GetFromJsonAsync<ConversationHistoryResponseDto>(
+                $"{baseUrl}api/conversations/{Uri.EscapeDataString(conversationId)}/history", ct);
+            _state.Messages.Clear();
+            if (history?.Messages is not null)
+            {
+                foreach (var m in history.Messages)
+                {
+                    _state.Messages.Add(new ChatMessage
+                    {
+                        Role = m.Role,
+                        Content = m.Content,
+                        ToolName = m.ToolName,
+                        IsToolCall = m.ToolName is not null,
+                        Timestamp = m.Timestamp
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] Failed to load history: {ex.Message}");
+        }
+    }
+
+    /// <summary>Send a user message via SignalR.</summary>
+    public async Task SendMessageAsync(string content)
+    {
+        if (_hub?.State != HubConnectionState.Connected || _state.ActiveAgentId is null)
+            return;
+
+        // Optimistic: add user message immediately
+        _state.Messages.Add(new ChatMessage { Role = "user", Content = content });
+        _state.NotifyChanged();
+
+        try
+        {
+            var result = await _hub.InvokeAsync<SendMessageResult>(
+                "SendMessage",
+                _state.ActiveAgentId,
+                "signalr",
+                content,
+                _state.ActiveConversationId);
+
+            _state.ActiveSessionId = result.SessionId;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] SendMessage failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>Reset the current session.</summary>
+    public async Task ResetSessionAsync()
+    {
+        if (_hub?.State != HubConnectionState.Connected || _state.ActiveAgentId is null)
+            return;
+
+        try
+        {
+            await _hub.InvokeAsync("ResetSession", _state.ActiveAgentId);
+            _state.Messages.Clear();
+            _state.ActiveSessionId = null;
+            _state.StreamBuffer = string.Empty;
+            _state.IsStreaming = false;
+            _state.NotifyChanged();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] ResetSession failed: {ex.Message}");
+        }
+    }
+
+    private void RegisterHubHandlers()
+    {
+        if (_hub is null) return;
+
+        _hub.On<AgentStreamEvent>("MessageStart", e =>
+        {
+            _state.IsStreaming = true;
+            _state.StreamBuffer = string.Empty;
+            _state.NotifyChanged();
+        });
+
+        _hub.On<AgentStreamEvent>("ContentDelta", e =>
+        {
+            _state.StreamBuffer += e.ContentDelta ?? string.Empty;
+            _state.NotifyChanged();
+        });
+
+        _hub.On<AgentStreamEvent>("ThinkingDelta", e =>
+        {
+            // Ignore thinking deltas in mobile for now
+        });
+
+        _hub.On<AgentStreamEvent>("ToolStart", e =>
+        {
+            // Could add tool call indicator
+        });
+
+        _hub.On<AgentStreamEvent>("ToolEnd", e =>
+        {
+            if (e.ToolName is not null)
+            {
+                _state.Messages.Add(new ChatMessage
+                {
+                    Role = "tool",
+                    Content = e.ToolResult ?? string.Empty,
+                    ToolName = e.ToolName,
+                    IsToolCall = true
+                });
+            }
+        });
+
+        _hub.On<AgentStreamEvent>("MessageEnd", e =>
+        {
+            if (!string.IsNullOrEmpty(_state.StreamBuffer))
+            {
+                _state.Messages.Add(new ChatMessage
+                {
+                    Role = "assistant",
+                    Content = _state.StreamBuffer
+                });
+            }
+            _state.IsStreaming = false;
+            _state.StreamBuffer = string.Empty;
+            _state.NotifyChanged();
+        });
+
+        _hub.On<AgentStreamEvent>("Error", e =>
+        {
+            _state.IsStreaming = false;
+            _state.StreamBuffer = string.Empty;
+            if (e.ErrorMessage is not null)
+            {
+                _state.Messages.Add(new ChatMessage
+                {
+                    Role = "system",
+                    Content = $"⚠ {e.ErrorMessage}"
+                });
+            }
+            _state.NotifyChanged();
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_hub is not null)
+            await _hub.DisposeAsync();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileServiceExtensions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileServiceExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services;
+
+/// <summary>
+/// Registers the self-contained mobile service layer.
+/// No dependency on the desktop BlazorClient assembly.
+/// </summary>
+public static class MobileServiceExtensions
+{
+    public static IServiceCollection AddBotNexusMobileServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var gatewayUrl = configuration["GatewayUrl"] ?? "http://localhost:5005";
+
+        services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(gatewayUrl) });
+        services.AddScoped<MobileState>();
+        services.AddScoped<MobileGatewayClient>();
+
+        return services;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileState.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileState.cs
@@ -1,0 +1,45 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services;
+
+/// <summary>Represents a selectable agent.</summary>
+public sealed class AgentOption
+{
+    public required string AgentId { get; init; }
+    public required string DisplayName { get; init; }
+    public string? Emoji { get; init; }
+}
+
+/// <summary>Represents a selectable conversation.</summary>
+public sealed class ConversationOption
+{
+    public required string ConversationId { get; init; }
+    public required string Title { get; init; }
+}
+
+/// <summary>A single message in the chat history.</summary>
+public sealed class ChatMessage
+{
+    /// <summary>Role: "user", "assistant", "system", "tool", "thinking"</summary>
+    public required string Role { get; init; }
+    public required string Content { get; init; }
+    public string? ToolName { get; init; }
+    public bool IsToolCall { get; init; }
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>Lightweight observable state container for the mobile chat UI.</summary>
+public sealed class MobileState
+{
+    public List<AgentOption> Agents { get; } = [];
+    public List<ConversationOption> Conversations { get; } = [];
+    public List<ChatMessage> Messages { get; } = [];
+
+    public string? ActiveAgentId { get; set; }
+    public string? ActiveConversationId { get; set; }
+    public string? ActiveSessionId { get; set; }
+
+    public bool IsStreaming { get; set; }
+    public string StreamBuffer { get; set; } = string.Empty;
+
+    public event Action? OnChanged;
+    public void NotifyChanged() => OnChanged?.Invoke();
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/_Imports.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/_Imports.razor
@@ -1,0 +1,13 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Layout
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Pages
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Services
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/appsettings.json
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "GatewayUrl": "http://localhost:5005"
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
@@ -1,0 +1,297 @@
+/* ── Reset & base ─────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: #0a1628;
+    color: #d0dff0;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 15px;
+    -webkit-text-size-adjust: 100%;
+}
+
+/* ── App shell ────────────────────────────────────────────────────────────── */
+.mobile-app {
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+/* ── Loading / error states ───────────────────────────────────────────────── */
+.portal-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100dvh;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.portal-load-spinner { color: #64a0dc; }
+.portal-load-error   { color: #f87171; padding: 16px; text-align: center; }
+
+/* ── Top bar ──────────────────────────────────────────────────────────────── */
+.top-bar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: #111d2e;
+    border-bottom: 1px solid rgba(100, 160, 220, 0.15);
+    padding: 8px 12px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-height: 56px;
+}
+
+.agent-select,
+.conv-select {
+    flex: 1;
+    background: #0d1926;
+    color: #d0dff0;
+    border: 1px solid rgba(100, 160, 220, 0.2);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 14px;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%2364a0dc'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    padding-right: 24px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ── Overflow (⋮) menu ───────────────────────────────────────────────────── */
+.overflow-menu-wrapper {
+    position: relative;
+}
+
+.overflow-btn {
+    background: transparent;
+    border: 1px solid rgba(100, 160, 220, 0.2);
+    border-radius: 6px;
+    color: #d0dff0;
+    font-size: 20px;
+    line-height: 1;
+    padding: 4px 10px;
+    cursor: pointer;
+    min-width: 36px;
+}
+
+.overflow-dropdown {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 6px);
+    background: #111d2e;
+    border: 1px solid rgba(100, 160, 220, 0.2);
+    border-radius: 8px;
+    padding: 8px 0;
+    min-width: 210px;
+    z-index: 100;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.overflow-dropdown hr {
+    border: none;
+    border-top: 1px solid rgba(100, 160, 220, 0.1);
+    margin: 6px 0;
+}
+
+.menu-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    cursor: pointer;
+    font-size: 14px;
+    color: #d0dff0;
+    user-select: none;
+}
+
+.menu-toggle:hover { background: rgba(100, 160, 220, 0.08); }
+
+.menu-toggle input[type="checkbox"] {
+    accent-color: #64a0dc;
+    width: 16px;
+    height: 16px;
+}
+
+.menu-session-id {
+    padding: 8px 16px;
+    font-size: 12px;
+    color: #7a9cbf;
+    cursor: pointer;
+    overflow: hidden;
+}
+
+.session-id-text {
+    font-family: monospace;
+    word-break: break-all;
+}
+
+.menu-action {
+    display: block;
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: #d0dff0;
+    font-size: 14px;
+    padding: 9px 16px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.menu-action:hover { background: rgba(100, 160, 220, 0.08); }
+
+/* ── Message stream ───────────────────────────────────────────────────────── */
+.message-stream {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overscroll-behavior: contain;
+}
+
+/* ── Message bubbles ─────────────────────────────────────────────────────── */
+.message {
+    max-width: 82%;
+    border-radius: 12px;
+    padding: 8px 12px;
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+.message.user {
+    align-self: flex-end;
+    background: #1a3a5c;
+    border-bottom-right-radius: 3px;
+}
+
+.message.assistant {
+    align-self: flex-start;
+    background: #162030;
+    border-bottom-left-radius: 3px;
+}
+
+.message.tool {
+    align-self: flex-start;
+    background: #0f1a25;
+    border: 1px solid rgba(100, 160, 220, 0.15);
+    font-size: 13px;
+    opacity: 0.85;
+}
+
+.message.thinking {
+    align-self: flex-start;
+    background: #0d1826;
+    border: 1px dashed rgba(100, 160, 220, 0.2);
+    font-size: 13px;
+    color: #7a9cbf;
+    font-style: italic;
+}
+
+.message.streaming { opacity: 0.9; }
+
+.tool-call-label {
+    font-size: 11px;
+    color: #64a0dc;
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+
+.message-content { line-height: 1.5; }
+
+.message-time {
+    font-size: 10px;
+    color: rgba(208, 223, 240, 0.4);
+    margin-top: 4px;
+    text-align: right;
+}
+
+.stream-cursor {
+    display: inline-block;
+    animation: blink 0.8s step-end infinite;
+    color: #64a0dc;
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0; }
+}
+
+/* ── Bottom bar ───────────────────────────────────────────────────────────── */
+.bottom-bar {
+    position: sticky;
+    bottom: 0;
+    background: #111d2e;
+    border-top: 1px solid rgba(100, 160, 220, 0.15);
+    padding: 8px 12px;
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+    min-height: 60px;
+}
+
+.input-textarea {
+    flex: 1;
+    background: #0d1926;
+    color: #d0dff0;
+    border: 1px solid rgba(100, 160, 220, 0.2);
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 15px;
+    font-family: inherit;
+    resize: none;
+    line-height: 1.4;
+    max-height: 120px;
+    overflow-y: auto;
+    field-sizing: content; /* auto-expand where supported */
+}
+
+.input-textarea:focus {
+    outline: none;
+    border-color: rgba(100, 160, 220, 0.5);
+}
+
+.input-textarea:disabled { opacity: 0.5; }
+
+.send-btn {
+    background: #1a4a80;
+    color: #d0dff0;
+    border: none;
+    border-radius: 8px;
+    width: 44px;
+    height: 44px;
+    font-size: 18px;
+    cursor: pointer;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s;
+}
+
+.send-btn:hover:not(:disabled) { background: #235a99; }
+.send-btn:disabled { opacity: 0.4; cursor: default; }
+
+/* ── Blazor error UI ─────────────────────────────────────────────────────── */
+#blazor-error-ui {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #7b2121;
+    color: #fff;
+    padding: 10px 16px;
+    z-index: 1000;
+    font-size: 14px;
+}
+
+#blazor-error-ui .reload { color: #ffcc88; margin-left: 8px; }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <title>BotNexus</title>
+    <link rel="manifest" href="manifest.json" />
+    <link rel="stylesheet" href="css/mobile.css" />
+    <base href="/mobile/" />
+</head>
+<body>
+    <div id="app">
+        <div style="display:flex;align-items:center;justify-content:center;height:100dvh;background:#0a1628;color:#d0dff0;">
+            Loading…
+        </div>
+    </div>
+    <div id="blazor-error-ui">An error has occurred. <a href="" class="reload">Reload</a></div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/manifest.json
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "BotNexus",
+  "short_name": "BotNexus",
+  "start_url": "/mobile/",
+  "display": "standalone",
+  "background_color": "#0a1628",
+  "theme_color": "#111d2e",
+  "icons": [{ "src": "icon-192.png", "sizes": "192x192", "type": "image/png" }]
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/service-worker.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/service-worker.js
@@ -1,0 +1,40 @@
+// Minimal service worker for offline capability.
+// Caches app shell assets on install and serves from cache when offline.
+
+const CACHE_NAME = 'botnexus-mobile-v1';
+
+const APP_SHELL = [
+    './',
+    './index.html',
+    './css/mobile.css',
+    './manifest.json',
+];
+
+self.addEventListener('install', event => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then(cache => cache.addAll(APP_SHELL))
+    );
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+    event.waitUntil(
+        caches.keys().then(keys =>
+            Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+        )
+    );
+    self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+    // Only handle GET requests
+    if (event.request.method !== 'GET') return;
+
+    // Pass through SignalR/API requests
+    const url = new URL(event.request.url);
+    if (url.pathname.startsWith('/hub/') || url.pathname.startsWith('/api/')) return;
+
+    event.respondWith(
+        caches.match(event.request).then(cached => cached ?? fetch(event.request))
+    );
+});

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj
@@ -36,4 +36,16 @@
     <Copy SourceFiles="@(BlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
 
+  <!-- Publish the mobile Blazor WASM client and bundle at blazor-mobile/ -->
+  <Target Name="PublishMobileBlazorClient" AfterTargets="Build">
+    <Exec Command="dotnet publish &quot;$(MSBuildProjectDirectory)\..\BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile\BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj&quot; -c $(Configuration) -o &quot;$(IntermediateOutputPath)blazor-mobile-publish&quot; --nologo -v:q" />
+  </Target>
+
+  <Target Name="CopyMobileBlazorClient" AfterTargets="PublishMobileBlazorClient">
+    <ItemGroup>
+      <MobileBlazorPublishFiles Include="$(IntermediateOutputPath)blazor-mobile-publish\wwwroot\**" />
+    </ItemGroup>
+    <Copy SourceFiles="@(MobileBlazorPublishFiles)" DestinationFolder="$(OutputPath)blazor-mobile\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
+
   </Project>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalREndpointContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalREndpointContributor.cs
@@ -18,32 +18,53 @@ public class SignalREndpointContributor : IEndpointContributor
 
         var extensionDir = Path.GetDirectoryName(typeof(SignalREndpointContributor).Assembly.Location)!;
         var blazorPath = Path.Combine(extensionDir, "blazor");
+        var mobilePath = Path.Combine(extensionDir, "blazor-mobile");
 
-        if (!Directory.Exists(blazorPath))
-            return;
+        if (Directory.Exists(blazorPath))
+            MapBlazorApp(app, blazorPath, pathPrefix: null);
 
-        var blazorFileProvider = new PhysicalFileProvider(blazorPath);
+        if (Directory.Exists(mobilePath))
+            MapBlazorApp(app, mobilePath, pathPrefix: "/mobile");
+    }
+
+    private static void MapBlazorApp(WebApplication app, string blazorPath, string? pathPrefix)
+    {
+        var fileProvider = new PhysicalFileProvider(blazorPath);
         var indexBytes = File.ReadAllBytes(Path.Combine(blazorPath, "index.html"));
+        var prefix = pathPrefix ?? string.Empty;
 
-        // Serve Blazor WASM client at the root URL.
-        // API, hub, health, and swagger paths are excluded so they reach their own handlers.
         app.Use(async (context, next) =>
         {
             var path = context.Request.Path.Value ?? "";
 
-            // Let API, hub, health, and swagger requests pass through
-            if (path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) ||
-                path.StartsWith("/hub/", StringComparison.OrdinalIgnoreCase) ||
-                path.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase) ||
-                path.Equals("/health", StringComparison.OrdinalIgnoreCase))
+            // Only handle requests under this prefix
+            if (!string.IsNullOrEmpty(prefix))
             {
-                await next();
-                return;
+                if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    await next();
+                    return;
+                }
+                // Strip prefix for file lookup
+                path = path[prefix.Length..];
+                if (string.IsNullOrEmpty(path)) path = "/";
+            }
+            else
+            {
+                // Desktop: let API/hub/health/swagger pass through
+                if (path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) ||
+                    path.StartsWith("/hub/", StringComparison.OrdinalIgnoreCase) ||
+                    path.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase) ||
+                    path.Equals("/health", StringComparison.OrdinalIgnoreCase) ||
+                    path.StartsWith("/mobile", StringComparison.OrdinalIgnoreCase))
+                {
+                    await next();
+                    return;
+                }
             }
 
-            // Try to serve a static file from the Blazor output
             var subPath = path == "/" ? "/index.html" : path;
-            var fileInfo = blazorFileProvider.GetFileInfo(subPath);
+            var fileInfo = fileProvider.GetFileInfo(subPath);
 
             if (fileInfo.Exists && !fileInfo.IsDirectory)
             {
@@ -55,7 +76,7 @@ public class SignalREndpointContributor : IEndpointContributor
                 return;
             }
 
-            // SPA fallback for client-side routes (paths without file extensions)
+            // SPA fallback for client-side routes
             if (!subPath.Contains('.'))
             {
                 context.Response.ContentType = "text/html";
@@ -63,7 +84,6 @@ public class SignalREndpointContributor : IEndpointContributor
                 return;
             }
 
-            // Fall through for non-Blazor requests or missing files
             await next();
         });
     }


### PR DESCRIPTION
Closes #303

Adds `BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile` — a mobile-first Blazor WASM client served at `/mobile`.

## Architecture

Separate project that references the desktop client for its service layer (`IClientStateStore`, `GatewayHubConnection`, `GatewayRestClient`, `IAgentInteractionService`, `GatewayEventHandler` etc.). Owns its own pages, layout, and CSS — no shared Razor components with the desktop.

## UI

Single `Chat.razor` page with three sticky zones:

```
┌─────────────────────────────────────┐
│ [Agent ▼]  [Conversation ▼]    [⋮] │  sticky top bar
├─────────────────────────────────────┤
│  Message stream (scrollable)        │  flex: 1
│  • User messages right-aligned      │
│  • Assistant messages left-aligned  │
│  • Thinking hidden by default       │
│  • Tool calls hidden by default     │
├─────────────────────────────────────┤
│ [textarea auto-expand]      [Send→] │  sticky bottom bar
└─────────────────────────────────────┘
```

## ⋮ menu

- Show thinking (off by default, localStorage persisted)
- Show tool calls (off by default, localStorage persisted)
- Session ID (tap to copy)
- New session
- Archive conversation

## PWA

manifest.json + service worker — installable to homescreen on iOS/Android.

## Notes

Static asset conflict resolved: when a Blazor WASM project references another WASM project both emit `_framework/` assets. Custom MSBuild target strips the desktop project's framework assets so only the mobile project's copies (under `/mobile/_framework/`) are served.