### PR TITLE
[docs] Update documentation for features from 2026-05-16

### DIFF
--- a/docs/user-guide/agents.md
+++ b/docs/user-guide/agents.md
@@ -242,7 +242,7 @@ Available built-in tools:
 - `read_file`, `write_file` — File system operations
 - `web_search`, `web_fetch` — Web access
 - `grep`, `glob` — Code search
-- `bash`, `powershell` — Shell execution
+- `bash`, `powershell` — Shell execution. Output is automatically stripped of ANSI escape sequences before it reaches the model, preventing terminal colour codes from polluting agent context.
 
 See [Extensions Guide](extensions.md) for custom tools and MCP servers.
 


### PR DESCRIPTION
Shell tool output (bash, powershell, exec, process) is automatically stripped of ANSI escape sequences before reaching the model context. Documents this behaviour in the built-in tools list.

Relates to #296