### PR TITLE
fix(mobile): derive gateway URL from NavigationManager at runtime

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -2,6 +2,7 @@
 @inject MobileState State
 @inject MobileGatewayClient Gateway
 @inject IConfiguration Config
+@inject NavigationManager Nav
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -101,7 +102,12 @@ else
 
         try
         {
-            var gatewayUrl = Config["GatewayUrl"] ?? "http://localhost:5005";
+            // Derive gateway URL from the page origin so the app works over devtunnels,
+            // production hosts, etc. — never hardcode localhost.
+            var origin = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
+            var gatewayUrl = string.IsNullOrEmpty(origin)
+                ? (Config["GatewayUrl"] ?? "http://localhost:5005")
+                : origin;
             await Gateway.InitializeAsync(gatewayUrl);
             _ready = true;
         }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileServiceExtensions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileServiceExtensions.cs
@@ -13,9 +13,9 @@ public static class MobileServiceExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var gatewayUrl = configuration["GatewayUrl"] ?? "http://localhost:5005";
-
-        services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(gatewayUrl) });
+        // Do not set BaseAddress at registration time — the gateway URL is derived
+        // at runtime from NavigationManager so it works across devtunnels and production.
+        services.AddScoped(_ => new HttpClient());
         services.AddScoped<MobileState>();
         services.AddScoped<MobileGatewayClient>();
 


### PR DESCRIPTION
## Problem

The mobile Blazor WASM app showed **"An error has occurred"** when accessed from any non-localhost host (devtunnels, phone, production). The gateway URL was hardcoded to `localhost:5005` via `appsettings.json`, so when the app loaded from `https://p8t-5005.usw3.devtunnels.ms/mobile/` it tried to negotiate SignalR at `http://localhost:5005/hub/gateway` — connection refused, Blazor crashed.

## Fix

Read the gateway URL from `NavigationManager.BaseUri` at runtime instead of config. The app always connects to the same origin it was loaded from.

Also removed the hardcoded `HttpClient.BaseAddress` from the DI registration for the same reason — `MobileGatewayClient` already receives the gateway URL as a parameter.

## Tested

Browser end-to-end on localhost with gateway running:
- App loads, no error banner ✅
- Agents/conversations populate via REST ✅
- SignalR hub connects ✅  
- Message send + response received ✅