### PR TITLE
fix(mobile): notify state after LoadConversationsAsync so conversation dropdown re-renders on agent switch

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileGatewayClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileGatewayClient.cs
@@ -148,6 +148,8 @@ public sealed class MobileGatewayClient : IAsyncDisposable
         {
             await LoadHistoryAsync(baseUrl, _state.ActiveConversationId, ct);
         }
+
+        _state.NotifyChanged();
     }
 
     /// <summary>Load message history for a conversation.</summary>


### PR DESCRIPTION
## Problem

Switching agents in the mobile client populated the agent correctly but the conversation dropdown stayed stale. The REST call to `/api/conversations` was made and returned correct data, but `LoadConversationsAsync` never called `NotifyChanged()` when invoked directly (only `InitializeAsync` called it after the fact on startup).

## Fix

Add `_state.NotifyChanged()` at the end of `LoadConversationsAsync`, after both the conversation list and history loads complete.

## Tested

Browser test — simulated agent switch, confirmed conversation dropdown re-renders with correct conversations for the new agent.