### PR TITLE
fix(mobile): guard HandleStateChanged against ObjectDisposedException crash

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -118,12 +118,26 @@ else
         }
     }
 
-    private void HandleStateChanged() =>
-        _ = InvokeAsync(async () =>
+    private void HandleStateChanged()
+    {
+        try
         {
-            StateHasChanged();
-            await ScrollToBottomAsync();
-        });
+            _ = InvokeAsync(async () =>
+            {
+                try
+                {
+                    StateHasChanged();
+                    await ScrollToBottomAsync();
+                }
+                catch (ObjectDisposedException) { /* component disposed, ignore */ }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[Mobile] Render error: {ex.Message}");
+                }
+            });
+        }
+        catch (ObjectDisposedException) { /* component disposed, ignore */ }
+    }
 
     private void OnAgentChanged(ChangeEventArgs e)
     {


### PR DESCRIPTION
## Problem

After a successful message exchange the mobile client showed **'An error has occurred'**. The message and response were correct but the UI crashed post-render.

Root cause: hub event handlers (`NotifyChanged`) fire from thread pool threads. If a hub event arrives after the Blazor component begins disposal (page reload, navigation away), `HandleStateChanged` calls `InvokeAsync` on a disposed renderer → `ObjectDisposedException` → Blazor error UI.

## Fix

Catch `ObjectDisposedException` in both the outer `InvokeAsync` call and the inner async body. Log other unexpected exceptions to console instead of letting them surface as the full-page error UI.