### PR TITLE
fix(mobile): move base href before stylesheets; remove PWA manifest link

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
@@ -2,14 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
+    <base href="/mobile/" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>BotNexus</title>
-    <link rel="manifest" href="manifest.json" />
     <link rel="stylesheet" href="css/mobile.css" />
-    <base href="/mobile/" />
 </head>
 <body>
     <div id="app">


### PR DESCRIPTION
## Problems fixed

**1. CSS MIME type error on devtunnels**
`<base href="/mobile/">` was declared *after* the `<link rel=stylesheet>` tag. Browsers resolve relative URLs in `<link>` tags against the document base as it exists at parse time — if `<base>` hasn't been seen yet, the CSS path resolves to the wrong URL. On devtunnels this caused the CSS request to be intercepted/redirected, returning an empty MIME type.

Fix: move `<base href="/mobile/">` to immediately after `<meta charset>`.

**2. manifest.json CORS error on devtunnels**
The PWA `<link rel=manifest>` triggered a fetch that the devtunnel intercepted and redirected to GitHub OAuth (`global.rel.tunnels.api.visualstudio.com/auth/github`). The redirect had no CORS headers, causing a browser CORS block and console error spam.

Fix: remove the manifest link entirely. The mobile client doesn't need PWA install capabilities to function.