### PR TITLE
fix(mobile): async OnAgentChanged — reload conversations and clear state on agent switch

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -94,6 +94,7 @@ else
     private bool _isSending;
     private bool _menuOpen;
     private bool _ready;
+    private string _gatewayUrl = "";
     private ElementReference _messageStreamRef;
 
     protected override async Task OnInitializedAsync()
@@ -105,10 +106,10 @@ else
             // Derive gateway URL from the page origin so the app works over devtunnels,
             // production hosts, etc. — never hardcode localhost.
             var origin = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
-            var gatewayUrl = string.IsNullOrEmpty(origin)
+            _gatewayUrl = string.IsNullOrEmpty(origin)
                 ? (Config["GatewayUrl"] ?? "http://localhost:5005")
                 : origin;
-            await Gateway.InitializeAsync(gatewayUrl);
+            await Gateway.InitializeAsync(_gatewayUrl);
             _ready = true;
         }
         catch (Exception ex)
@@ -139,11 +140,24 @@ else
         catch (ObjectDisposedException) { /* component disposed, ignore */ }
     }
 
-    private void OnAgentChanged(ChangeEventArgs e)
+    private async Task OnAgentChanged(ChangeEventArgs e)
     {
-        State.ActiveAgentId = e.Value?.ToString();
+        var agentId = e.Value?.ToString();
+        if (string.IsNullOrEmpty(agentId) || agentId == State.ActiveAgentId) return;
+        State.ActiveAgentId = agentId;
+        State.ActiveConversationId = null;
+        State.Conversations.Clear();
+        State.Messages.Clear();
+        State.NotifyChanged();
         _menuOpen = false;
-        // Could reload conversations here if needed
+        try
+        {
+            await Gateway.LoadConversationsAsync(_gatewayUrl, agentId, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] LoadConversations failed after agent switch: {ex.Message}");
+        }
     }
 
     private void OnConvChanged(ChangeEventArgs e)


### PR DESCRIPTION
## Problem

`OnAgentChanged` was a sync stub (comment: *'Could reload conversations here if needed'*). It set `ActiveAgentId` but never cleared the previous agent's `ActiveConversationId`. So when the user switched from Larry → Nova and sent a message, it was sent with Larry's old `conversationId` — routed into the wrong conversation on the gateway side.

## Fix

- Make `OnAgentChanged` async  
- Immediately clear `ActiveConversationId`, `Conversations`, and `Messages` + notify so the UI empties  
- Await `LoadConversationsAsync` which fetches the new agent's conversations, sets `ActiveConversationId` to the first one, and loads its history  
- Cache `_gatewayUrl` in a field (set during `OnInitializedAsync`) so it's available at the time of the agent switch

## Tested

Browser end-to-end: switched to Nova, conversation dropdown populated with Nova's conversations, correct history loaded, message routing confirmed against Nova's Default conversation.