### PR TITLE
feat(scripts): cross-platform watchdog installer with cron and systemd support

### DIFF
--- a/docs/guides/watchdog-setup.md
+++ b/docs/guides/watchdog-setup.md
@@ -1,0 +1,311 @@
+# BotNexus Watchdog — Automated Health, Updates & Recovery
+
+A cross-platform PowerShell script that keeps your BotNexus gateway running, up-to-date, and self-healing on Windows and Linux.
+
+## What It Does
+
+| Check | Default Interval | Action |
+|---|---|---|
+| **Gateway health** | Every run (1 min) | Restart if `/health` fails; fall back to last-known-good config after N failures |
+| **Git repo updates** | Every 5 minutes | `botnexus update --check` to detect new commits, then `botnexus update` to pull, build, and restart |
+| **CLI tool updates** | Every 60 minutes | `dotnet tool update -g BotNexus.Cli` |
+
+The script itself runs on a short interval (e.g. every minute). Each check type has its own timer so you control how often expensive operations happen independently.
+
+## Prerequisites
+
+- **Windows** 10/11 or Windows Server 2016+, **or Linux** (any distro with pwsh support)
+- [PowerShell 7+](https://github.com/PowerShell/PowerShell/releases) (`pwsh`)
+- [.NET SDK](https://dotnet.microsoft.com/download) installed
+- BotNexus CLI installed (`dotnet tool install -g BotNexus.Cli`)
+- Git installed and on PATH (only if using repo sync)
+- A running BotNexus gateway (`botnexus gateway start`)
+
+## Quick Start
+
+=== "Windows"
+
+    ```powershell
+    # 1. Test the script manually first
+    .\scripts\botnexus-watchdog.ps1
+
+    # 2. Register a Windows Scheduled Task (runs every 1 minute)
+    .\scripts\Install-WatchdogTask.ps1
+
+    # 3. Check the logs
+    Get-Content "$HOME\.botnexus\logs\watchdog-*.log" -Tail 50
+    ```
+
+=== "Linux"
+
+    ```bash
+    # 1. Test the script manually first
+    pwsh ./scripts/botnexus-watchdog.ps1
+
+    # 2a. Install using cron (default)
+    pwsh ./scripts/Install-WatchdogTask.ps1
+
+    # 2b. Or install using a systemd timer (preferred on systemd-based distros)
+    pwsh ./scripts/Install-WatchdogTask.ps1 -Method systemd
+
+    # 3. Check the logs
+    tail -50 ~/.botnexus/logs/watchdog-*.log
+    ```
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-GatewayUrl` | `http://localhost:5005` | Gateway base URL |
+| `-HealthEndpoint` | `/health` | Health check path |
+| `-RepoPath` | `~/botnexus` | Path to local BotNexus git clone (empty string to skip) |
+| `-ConfigDir` | `~/.botnexus` | BotNexus user data directory |
+| `-MaxFailures` | `3` | Consecutive health failures before config fallback |
+| `-GitCheckIntervalMinutes` | `5` | Minutes between git fetch checks |
+| `-CliCheckIntervalMinutes` | `60` | Minutes between CLI update checks |
+| `-LogDir` | `~/.botnexus/logs` | Log file directory |
+| `-StateFile` | `~/.botnexus/watchdog-state.json` | Persists timers and failure counts between runs |
+
+## How the Health Recovery Works
+
+```
+Health check fails
+       │
+       ▼
+  Failure count < MaxFailures?
+       │              │
+      YES             NO
+       │              │
+       ▼              ▼
+  Stop + Restart    Back up current config as "suspect"
+       │            Restore last-known-good config
+       │            Stop + Restart
+       │              │
+       ▼              ▼
+  Success? ────► Reset failure count to 0
+                 Save current config as new "last-known-good"
+```
+
+**Last-known-good config** is automatically saved when a health check passes and the config file has changed (compared by SHA256 hash). Config backups are stored in `~/.botnexus/config-backups/`:
+
+- `config-last-known-good.json` — most recent working config (only updated when the config changes)
+- `config-suspect-20260517-143022.json` — timestamped backup of the config that was replaced (skipped if identical to last-known-good)
+
+## Scheduling the Watchdog
+
+### Windows
+
+#### Option A: Use the installer script
+
+```powershell
+.\scripts\Install-WatchdogTask.ps1
+```
+
+This creates a task named `BotNexusWatchdog` that runs every minute. Pass parameters to customise:
+
+```powershell
+.\scripts\Install-WatchdogTask.ps1 -RepoPath "D:\botnexus" -GitCheckIntervalMinutes 15 -CliCheckIntervalMinutes 120
+```
+
+To remove:
+
+```powershell
+.\scripts\Install-WatchdogTask.ps1 -Uninstall
+```
+
+#### Option B: Manual Task Scheduler setup
+
+1. Open **Task Scheduler** (`taskschd.msc`)
+2. Click **Create Task**
+3. **General** tab:
+   - Name: `BotNexusWatchdog`
+   - Check: *Run whether user is logged on or not*
+   - Check: *Run with highest privileges*
+4. **Triggers** tab → New:
+   - Begin the task: On a schedule
+   - Repeat every: **1 minute** for a duration of **Indefinitely**
+   - Check: *Enabled*
+5. **Actions** tab → New:
+   - Program: `pwsh` (or full path to `pwsh.exe`)
+   - Arguments:
+     ```
+     -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "C:\src\botnexus\scripts\botnexus-watchdog.ps1" -GitCheckIntervalMinutes 5 -CliCheckIntervalMinutes 60
+     ```
+6. **Settings** tab:
+   - Check: *Do not start a new instance if already running*
+   - Uncheck: *Stop the task if it runs longer than*
+
+#### Option C: Using `schtasks` from the command line
+
+```powershell
+$pwsh    = (Get-Command pwsh).Source
+$script  = "C:\src\botnexus\scripts\botnexus-watchdog.ps1"
+$taskArgs = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$script`""
+
+schtasks /Create /TN "BotNexusWatchdog" /TR "`"$pwsh`" $taskArgs" /SC MINUTE /MO 1 /RL HIGHEST /F
+```
+
+To remove:
+
+```powershell
+schtasks /Delete /TN "BotNexusWatchdog" /F
+```
+
+### Linux
+
+#### Option A: Use the installer script (cron)
+
+```bash
+# Install with defaults (cron, every 1 minute)
+pwsh ./scripts/Install-WatchdogTask.ps1
+
+# Customise parameters
+pwsh ./scripts/Install-WatchdogTask.ps1 -GitCheckIntervalMinutes 15 -CliCheckIntervalMinutes 120
+
+# Remove
+pwsh ./scripts/Install-WatchdogTask.ps1 -Uninstall
+```
+
+#### Option B: Use the installer script (systemd timer)
+
+Preferred on systemd-based distros. Installs user-level units — no root required.
+
+```bash
+# Install
+pwsh ./scripts/Install-WatchdogTask.ps1 -Method systemd
+
+# Customise parameters
+pwsh ./scripts/Install-WatchdogTask.ps1 -Method systemd -GitCheckIntervalMinutes 15
+
+# Remove
+pwsh ./scripts/Install-WatchdogTask.ps1 -Uninstall -Method systemd
+```
+
+#### Option C: Manual cron setup
+
+```bash
+# Add the cron entry
+(crontab -l 2>/dev/null; echo '* * * * * /usr/bin/pwsh -NoProfile -NonInteractive -File ~/botnexus/scripts/botnexus-watchdog.ps1') | crontab -
+
+# Verify
+crontab -l
+```
+
+To customise parameters:
+
+```bash
+(crontab -l 2>/dev/null; echo '* * * * * /usr/bin/pwsh -NoProfile -NonInteractive -File ~/botnexus/scripts/botnexus-watchdog.ps1 -GitCheckIntervalMinutes 15 -CliCheckIntervalMinutes 120') | crontab -
+```
+
+To remove:
+
+```bash
+crontab -l | grep -v botnexus-watchdog | crontab -
+```
+
+#### Option D: Manual systemd timer setup
+
+Create two unit files:
+
+`~/.config/systemd/user/botnexus-watchdog.service`:
+
+```ini
+[Unit]
+Description=BotNexus Watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/pwsh -NoProfile -NonInteractive -File %h/botnexus/scripts/botnexus-watchdog.ps1
+```
+
+`~/.config/systemd/user/botnexus-watchdog.timer`:
+
+```ini
+[Unit]
+Description=Run BotNexus Watchdog every minute
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=5
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and start:
+
+```bash
+mkdir -p ~/.config/systemd/user
+# (create the two files above)
+systemctl --user daemon-reload
+systemctl --user enable --now botnexus-watchdog.timer
+
+# Check status
+systemctl --user status botnexus-watchdog.timer
+journalctl --user -u botnexus-watchdog.service -f
+```
+
+To disable:
+
+```bash
+systemctl --user disable --now botnexus-watchdog.timer
+```
+
+## Customising Check Intervals
+
+The script runs every time the scheduler fires (e.g. every minute), but each check tracks its own timer in `watchdog-state.json`. Examples:
+
+```powershell
+# Health every 1 min, git every 2 min, CLI every 30 min
+./botnexus-watchdog.ps1 -GitCheckIntervalMinutes 2 -CliCheckIntervalMinutes 30
+
+# Health-only — no git or CLI updates (pass empty RepoPath)
+./botnexus-watchdog.ps1 -RepoPath ''
+
+# Aggressive polling (useful during active development)
+./botnexus-watchdog.ps1 -GitCheckIntervalMinutes 1 -CliCheckIntervalMinutes 5
+
+# Conservative (production — check git every 15 min, CLI daily)
+./botnexus-watchdog.ps1 -GitCheckIntervalMinutes 15 -CliCheckIntervalMinutes 1440
+
+# Custom repo location
+./botnexus-watchdog.ps1 -RepoPath "/opt/botnexus"    # Linux
+./botnexus-watchdog.ps1 -RepoPath "D:\botnexus"      # Windows
+```
+
+## Logs & State
+
+**Log files** are written daily to `~/.botnexus/logs/watchdog-YYYY-MM-DD.log`:
+
+```
+[2026-05-17 14:30:01] [INFO] --- Watchdog check started ---
+[2026-05-17 14:30:01] [INFO] Git repo is up to date.
+[2026-05-17 14:30:01] [INFO] CLI tool is already at the latest version.
+[2026-05-17 14:30:02] [INFO] Current config saved as last-known-good.
+[2026-05-17 14:30:02] [INFO] --- Watchdog check complete ---
+```
+
+**State file** (`~/.botnexus/watchdog-state.json`) persists between runs:
+
+```json
+{
+  "FailureCount": 0,
+  "LastGitCheck": "2026-05-17T14:30:01.1234567+00:00",
+  "LastCliCheck": "2026-05-17T14:00:01.1234567+00:00",
+  "LastKnownGoodConfig": "/home/you/.botnexus/config-backups/config-last-known-good.json"
+}
+```
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| Script never runs | Verify `pwsh` is on PATH: `Get-Command pwsh` |
+| "Another instance running" | Delete the lock file if a previous run crashed — `%TEMP%\botnexus-watchdog.lock` (Windows) or `/tmp/botnexus-watchdog.lock` (Linux) |
+| Gateway keeps failing | Check `~/.botnexus/logs/` for gateway errors; verify config with `botnexus validate` |
+| Git check not triggering | Ensure `-RepoPath` points to a valid git repo with an `origin` remote |
+| CLI update fails | Run `dotnet tool update -g BotNexus.Cli` manually to see errors |
+| Config fallback loop | Inspect `config-backups/` — the "last-known-good" may also be broken; restore manually |

--- a/scripts/Install-WatchdogTask.ps1
+++ b/scripts/Install-WatchdogTask.ps1
@@ -1,0 +1,157 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Registers the BotNexus Watchdog as a recurring background task.
+
+.DESCRIPTION
+    On Windows, creates a Scheduled Task named "BotNexusWatchdog" that runs
+    botnexus-watchdog.ps1 every minute using Task Scheduler. Run once from an
+    elevated (Administrator) PowerShell prompt.
+
+    On Linux/macOS, installs a crontab entry that runs botnexus-watchdog.ps1
+    every minute via pwsh. No elevation required.
+
+.EXAMPLE
+    # Install with defaults
+    .\Install-WatchdogTask.ps1
+
+    # Install with a custom repo path
+    .\Install-WatchdogTask.ps1 -RepoPath "~/projects/botnexus"
+
+    # Uninstall
+    .\Install-WatchdogTask.ps1 -Uninstall
+#>
+
+[CmdletBinding()]
+param(
+    [string]$RepoPath              = '',
+    [int]   $GitCheckIntervalMinutes  = 5,
+    [int]   $CliCheckIntervalMinutes  = 60,
+    [int]   $MaxFailures              = 3,
+    [string]$GatewayUrl               = 'http://localhost:5005',
+    [switch]$Uninstall
+)
+
+$TaskName    = 'BotNexusWatchdog'
+$CronMarker  = '# BotNexusWatchdog'
+$IsWindows   = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+
+# ── Locate dependencies ─────────────────────────────────────────────────────
+
+$pwshPath = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+if (-not $pwshPath) {
+    Write-Error "pwsh not found on PATH. Install PowerShell 7+: https://github.com/PowerShell/PowerShell/releases"
+    exit 1
+}
+
+$scriptDir      = $PSScriptRoot
+$watchdogScript = Join-Path $scriptDir 'botnexus-watchdog.ps1'
+if (-not (Test-Path $watchdogScript)) {
+    Write-Error "Watchdog script not found at: $watchdogScript"
+    exit 1
+}
+
+# ── Uninstall ────────────────────────────────────────────────────────────────
+
+if ($Uninstall) {
+    if ($IsWindows) {
+        Write-Host "Removing scheduled task '$TaskName'..."
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+    } else {
+        Write-Host "Removing crontab entry for '$TaskName'..."
+        $existing = & crontab -l 2>/dev/null
+        $filtered = $existing | Where-Object { $_ -notmatch [regex]::Escape($CronMarker) }
+        $filtered | & crontab -
+    }
+    Write-Host 'Done.'
+    exit 0
+}
+
+# ── Build argument string ───────────────────────────────────────────────────
+
+$argParts = @(
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-File', "`"$watchdogScript`""
+)
+
+if ($RepoPath) {
+    $argParts += '-RepoPath', "`"$RepoPath`""
+}
+$argParts += '-GitCheckIntervalMinutes', $GitCheckIntervalMinutes
+$argParts += '-CliCheckIntervalMinutes', $CliCheckIntervalMinutes
+$argParts += '-MaxFailures', $MaxFailures
+$argParts += '-GatewayUrl', "`"$GatewayUrl`""
+
+$arguments = $argParts -join ' '
+
+# ── Install ──────────────────────────────────────────────────────────────────
+
+if ($IsWindows) {
+    # Windows: Task Scheduler
+    Write-Host "Creating scheduled task '$TaskName'..."
+    Write-Host "  pwsh:      $pwshPath"
+    Write-Host "  script:    $watchdogScript"
+    Write-Host "  arguments: $arguments"
+    Write-Host ''
+
+    $action  = New-ScheduledTaskAction -Execute $pwshPath -Argument $arguments
+    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration ([TimeSpan]::MaxValue)
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+        -MultipleInstances IgnoreNew
+
+    $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType S4U -RunLevel Highest
+
+    # Remove existing task if present before re-creating
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Action $action `
+        -Trigger $trigger `
+        -Settings $settings `
+        -Principal $principal `
+        -Description 'BotNexus Watchdog — gateway health, git sync, and CLI auto-update'
+
+    Write-Host ''
+    Write-Host "Scheduled task '$TaskName' created successfully." -ForegroundColor Green
+    Write-Host ''
+    Write-Host 'To verify:  Get-ScheduledTask -TaskName BotNexusWatchdog'
+    Write-Host 'To run now: Start-ScheduledTask -TaskName BotNexusWatchdog'
+    Write-Host "To remove:  ./Install-WatchdogTask.ps1 -Uninstall"
+    Write-Host "Logs:       $env:USERPROFILE\.botnexus\logs\watchdog-*.log"
+
+} else {
+    # Linux/macOS: crontab
+    Write-Host "Installing crontab entry for '$TaskName'..."
+    Write-Host "  pwsh:      $pwshPath"
+    Write-Host "  script:    $watchdogScript"
+    Write-Host "  arguments: $arguments"
+    Write-Host ''
+
+    $cronLine = "* * * * * $pwshPath $arguments $CronMarker"
+
+    # Fetch existing crontab, strip any prior BotNexus entry, append new line
+    $existing = & crontab -l 2>/dev/null
+    $filtered = @($existing | Where-Object { $_ -notmatch [regex]::Escape($CronMarker) })
+    $filtered += $cronLine
+    $filtered | & crontab -
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "crontab install failed."
+        exit 1
+    }
+
+    Write-Host ''
+    Write-Host "Crontab entry installed successfully." -ForegroundColor Green
+    Write-Host ''
+    Write-Host 'To verify:  crontab -l'
+    Write-Host "To remove:  ./Install-WatchdogTask.ps1 -Uninstall"
+    Write-Host "Logs:       ~/.botnexus/logs/watchdog-*.log"
+}

--- a/scripts/Install-WatchdogTask.ps1
+++ b/scripts/Install-WatchdogTask.ps1
@@ -8,33 +8,52 @@
     botnexus-watchdog.ps1 every minute using Task Scheduler. Run once from an
     elevated (Administrator) PowerShell prompt.
 
-    On Linux/macOS, installs a crontab entry that runs botnexus-watchdog.ps1
-    every minute via pwsh. No elevation required.
+    On Linux/macOS, choose between two scheduling methods via -Method:
+      cron    (default) — adds a crontab entry that runs every minute.
+      systemd           — installs user-level systemd service + timer units
+                          (preferred on systemd-based distros; survives reboots
+                          without requiring a cron daemon).
+
+.PARAMETER Method
+    Linux/macOS only. Scheduling back-end: 'cron' (default) or 'systemd'.
+    Ignored on Windows.
 
 .EXAMPLE
-    # Install with defaults
+    # Windows — Scheduled Task
     .\Install-WatchdogTask.ps1
 
-    # Install with a custom repo path
-    .\Install-WatchdogTask.ps1 -RepoPath "~/projects/botnexus"
+    # Linux — cron (default)
+    ./Install-WatchdogTask.ps1
 
-    # Uninstall
-    .\Install-WatchdogTask.ps1 -Uninstall
+    # Linux — systemd timer
+    ./Install-WatchdogTask.ps1 -Method systemd
+
+    # Custom repo path
+    ./Install-WatchdogTask.ps1 -RepoPath "~/projects/botnexus" -Method systemd
+
+    # Uninstall (removes whichever method was used)
+    ./Install-WatchdogTask.ps1 -Uninstall
+    ./Install-WatchdogTask.ps1 -Uninstall -Method systemd
 #>
 
 [CmdletBinding()]
 param(
-    [string]$RepoPath              = '',
+    [string]$RepoPath                 = '',
     [int]   $GitCheckIntervalMinutes  = 5,
     [int]   $CliCheckIntervalMinutes  = 60,
     [int]   $MaxFailures              = 3,
     [string]$GatewayUrl               = 'http://localhost:5005',
+    [ValidateSet('cron', 'systemd')]
+    [string]$Method                   = 'cron',
     [switch]$Uninstall
 )
 
-$TaskName    = 'BotNexusWatchdog'
-$CronMarker  = '# BotNexusWatchdog'
-$IsWindows   = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+$TaskName       = 'BotNexusWatchdog'
+$CronMarker     = '# BotNexusWatchdog'
+$SystemdService = 'botnexus-watchdog.service'
+$SystemdTimer   = 'botnexus-watchdog.timer'
+$SystemdDir     = Join-Path $HOME '.config' 'systemd' 'user'
+$IsWindows      = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
 
 # ── Locate dependencies ─────────────────────────────────────────────────────
 
@@ -57,6 +76,13 @@ if ($Uninstall) {
     if ($IsWindows) {
         Write-Host "Removing scheduled task '$TaskName'..."
         Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+    } elseif ($Method -eq 'systemd') {
+        Write-Host "Disabling systemd timer '$SystemdTimer'..."
+        & systemctl --user disable --now $SystemdTimer 2>&1 | ForEach-Object { Write-Host "  $_" }
+        Remove-Item (Join-Path $SystemdDir $SystemdService) -Force -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $SystemdDir $SystemdTimer)   -Force -ErrorAction SilentlyContinue
+        & systemctl --user daemon-reload
+        Write-Host "Unit files removed and daemon reloaded."
     } else {
         Write-Host "Removing crontab entry for '$TaskName'..."
         $existing = & crontab -l 2>/dev/null
@@ -86,29 +112,25 @@ $argParts += '-GatewayUrl', "`"$GatewayUrl`""
 
 $arguments = $argParts -join ' '
 
-# ── Install ──────────────────────────────────────────────────────────────────
+# ── Install: Windows ─────────────────────────────────────────────────────────
 
 if ($IsWindows) {
-    # Windows: Task Scheduler
     Write-Host "Creating scheduled task '$TaskName'..."
     Write-Host "  pwsh:      $pwshPath"
     Write-Host "  script:    $watchdogScript"
     Write-Host "  arguments: $arguments"
     Write-Host ''
 
-    $action  = New-ScheduledTaskAction -Execute $pwshPath -Argument $arguments
-    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration ([TimeSpan]::MaxValue)
-
+    $action   = New-ScheduledTaskAction -Execute $pwshPath -Argument $arguments
+    $trigger  = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration ([TimeSpan]::MaxValue)
     $settings = New-ScheduledTaskSettingsSet `
         -AllowStartIfOnBatteries `
         -DontStopIfGoingOnBatteries `
         -StartWhenAvailable `
         -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
         -MultipleInstances IgnoreNew
-
     $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType S4U -RunLevel Highest
 
-    # Remove existing task if present before re-creating
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
 
     Register-ScheduledTask `
@@ -127,8 +149,64 @@ if ($IsWindows) {
     Write-Host "To remove:  ./Install-WatchdogTask.ps1 -Uninstall"
     Write-Host "Logs:       $env:USERPROFILE\.botnexus\logs\watchdog-*.log"
 
+# ── Install: Linux/macOS — systemd ───────────────────────────────────────────
+
+} elseif ($Method -eq 'systemd') {
+    Write-Host "Installing systemd user units for '$TaskName'..."
+    Write-Host "  pwsh:      $pwshPath"
+    Write-Host "  script:    $watchdogScript"
+    Write-Host "  unit dir:  $SystemdDir"
+    Write-Host ''
+
+    New-Item -ItemType Directory -Force -Path $SystemdDir | Out-Null
+
+    $serviceContent = @"
+[Unit]
+Description=BotNexus Watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$pwshPath $arguments
+"@
+
+    $timerContent = @"
+[Unit]
+Description=Run BotNexus Watchdog every minute
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=5
+
+[Install]
+WantedBy=timers.target
+"@
+
+    Set-Content -Path (Join-Path $SystemdDir $SystemdService) -Value $serviceContent -Encoding UTF8
+    Set-Content -Path (Join-Path $SystemdDir $SystemdTimer)   -Value $timerContent   -Encoding UTF8
+
+    Write-Host "Reloading systemd and enabling timer..."
+    & systemctl --user daemon-reload
+    & systemctl --user enable --now $SystemdTimer
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "systemctl enable failed. Ensure systemd --user is available on this system."
+        exit 1
+    }
+
+    Write-Host ''
+    Write-Host "systemd timer '$SystemdTimer' installed and started." -ForegroundColor Green
+    Write-Host ''
+    Write-Host "To verify:      systemctl --user status $SystemdTimer"
+    Write-Host "To view logs:   journalctl --user -u botnexus-watchdog.service -f"
+    Write-Host "To remove:      ./Install-WatchdogTask.ps1 -Uninstall -Method systemd"
+    Write-Host "Log files:      ~/.botnexus/logs/watchdog-*.log"
+
+# ── Install: Linux/macOS — cron ──────────────────────────────────────────────
+
 } else {
-    # Linux/macOS: crontab
     Write-Host "Installing crontab entry for '$TaskName'..."
     Write-Host "  pwsh:      $pwshPath"
     Write-Host "  script:    $watchdogScript"
@@ -137,7 +215,6 @@ if ($IsWindows) {
 
     $cronLine = "* * * * * $pwshPath $arguments $CronMarker"
 
-    # Fetch existing crontab, strip any prior BotNexus entry, append new line
     $existing = & crontab -l 2>/dev/null
     $filtered = @($existing | Where-Object { $_ -notmatch [regex]::Escape($CronMarker) })
     $filtered += $cronLine


### PR DESCRIPTION
## Summary

Updates `Install-WatchdogTask.ps1` to work on Windows, Linux, and macOS, and adds a choice between `cron` and `systemd` on Linux.

## Changes

### `scripts/Install-WatchdogTask.ps1`

- **Windows**: behaviour unchanged — registers a Scheduled Task via `Register-ScheduledTask`
- **Linux/macOS (cron)**: default; adds a tagged crontab entry (`* * * * *`) using `crontab`
- **Linux/macOS (systemd)**: new `-Method systemd` option — writes user-level `.service` + `.timer` unit files to `~/.config/systemd/user/`, reloads the daemon, and enables the timer via `systemctl --user`
- **Uninstall** handles all three paths correctly (`-Uninstall [-Method systemd]`)

### `docs/guides/watchdog-setup.md`

Linux "Scheduling the Watchdog" section reorganised:

| Option | Method |
|---|---|
| A | Installer — cron (default) |
| B | Installer — systemd timer *(new, preferred on systemd distros)* |
| C | Manual cron |
| D | Manual systemd |

## Usage

```powershell
# Windows
.\scripts\Install-WatchdogTask.ps1

# Linux — cron (default)
./scripts/Install-WatchdogTask.ps1

# Linux — systemd timer
./scripts/Install-WatchdogTask.ps1 -Method systemd

# Uninstall
./scripts/Install-WatchdogTask.ps1 -Uninstall
./scripts/Install-WatchdogTask.ps1 -Uninstall -Method systemd
```