### PR TITLE
[Channels] Enable image send and receive support for all channels (#319)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -27,6 +27,7 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
     public override bool SupportsFollowUp => true;
     public override bool SupportsThinkingDisplay => true;
     public override bool SupportsToolDisplay => true;
+    public override bool SupportsInboundImages => true;
 
     protected override Task OnStartAsync(CancellationToken cancellationToken)
         => Task.CompletedTask;

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
@@ -133,6 +133,31 @@ public sealed class TelegramBotApiClient(
             cancellationToken,
             allowMarkdownFallback: false);
 
+    /// <summary>
+    /// Retrieves file metadata for the given <paramref name="fileId"/> using the Telegram getFile API.
+    /// The returned <see cref="TelegramFile.FilePath"/> can be passed to <see cref="DownloadFileAsync"/>.
+    /// </summary>
+    public Task<TelegramFile> GetFileAsync(string fileId, CancellationToken cancellationToken = default)
+        => PostForResultAsync<TelegramFile>(
+            "getFile",
+            new { file_id = fileId },
+            cancellationToken,
+            allowMarkdownFallback: false);
+
+    /// <summary>
+    /// Downloads a file from the Telegram CDN using the relative path returned by <see cref="GetFileAsync"/>.
+    /// Returns the raw binary content.
+    /// </summary>
+    public async Task<byte[]> DownloadFileAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var url = $"https://api.telegram.org/file/bot{_botToken}/{filePath}";
+        using var response = await _httpClient.GetAsync(url, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"Failed to download Telegram file '{filePath}': {(int)response.StatusCode}");
+
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
+
     private async Task<T> PostForResultAsync<T>(string methodName, object payload, CancellationToken cancellationToken, bool allowMarkdownFallback)
     {
         if (string.IsNullOrWhiteSpace(_botToken))

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -78,6 +78,9 @@ public sealed class TelegramChannelAdapter(
     public override bool SupportsToolDisplay => true;
 
     /// <inheritdoc />
+    public override bool SupportsInboundImages => true;
+
+    /// <inheritdoc />
     protected override async Task OnStartAsync(CancellationToken cancellationToken)
     {
         EnsureBotsInitialized();
@@ -317,10 +320,14 @@ public sealed class TelegramChannelAdapter(
 
     private async Task HandleUpdateAsync(BotRuntime runtime, TelegramUpdate update, CancellationToken cancellationToken)
     {
-        // Only process real user messages \u2014 not channel posts (no authenticated sender)
+        // Only process real user messages — not channel posts (no authenticated sender)
         var message = update.Message
             ?? (runtime.Config.ProcessEditedMessages ? update.EditedMessage : null);
-        if (message?.Chat is null || string.IsNullOrWhiteSpace(message.Text))
+
+        // Accept text messages or photo messages (with optional caption)
+        var hasText = !string.IsNullOrWhiteSpace(message?.Text);
+        var hasPhoto = message?.Photo is { Length: > 0 };
+        if (message?.Chat is null || (!hasText && !hasPhoto))
             return;
 
         var chatId = message.Chat.Id;
@@ -346,12 +353,37 @@ public sealed class TelegramChannelAdapter(
 
         var senderId = message.From.Id.ToString(CultureInfo.InvariantCulture);
 
+        // Build optional image content parts from the attached photo (if any)
+        IReadOnlyList<MessageContentPart>? contentParts = null;
+        if (hasPhoto)
+        {
+            // Telegram provides multiple resolutions; the last element is always the largest.
+            var largestPhoto = message.Photo!.OrderByDescending(p => p.FileSize ?? 0).First();
+            try
+            {
+                var file = await runtime.ApiClient.GetFileAsync(largestPhoto.FileId, cancellationToken);
+                if (!string.IsNullOrWhiteSpace(file.FilePath))
+                {
+                    var imageBytes = await runtime.ApiClient.DownloadFileAsync(file.FilePath, cancellationToken);
+                    contentParts = [new BinaryContentPart { MimeType = "image/jpeg", Data = imageBytes }];
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "bot '{BotName}' failed to download photo for updateId={UpdateId}; proceeding with caption only", runtime.BotName, update.UpdateId);
+            }
+        }
+
+        // Caption is the text for photo messages; Text is the text for regular messages.
+        var textContent = (hasPhoto ? message.Caption : message.Text) ?? string.Empty;
+
         await DispatchInboundAsync(new InboundMessage
         {
             ChannelType = ChannelType,
             SenderId = senderId,
             ChannelAddress = ChannelAddress.From(chatIdText),
-            Content = message.Text,
+            Content = textContent,
+            ContentParts = contentParts,
             TargetAgentId = string.IsNullOrWhiteSpace(runtime.Config.AgentId) ? null : runtime.Config.AgentId,
             ThreadId = message.MessageThreadId.HasValue
                 ? ThreadId.From(message.MessageThreadId.Value.ToString(CultureInfo.InvariantCulture))

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramModels.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramModels.cs
@@ -58,6 +58,20 @@ public sealed record TelegramMessage
 
     [JsonPropertyName("text")]
     public string? Text { get; init; }
+
+    /// <summary>
+    /// Caption accompanying a photo or other media. Up to 1024 characters.
+    /// Null when the message has no caption.
+    /// </summary>
+    [JsonPropertyName("caption")]
+    public string? Caption { get; init; }
+
+    /// <summary>
+    /// Array of photo sizes for a photo message. Telegram provides multiple resolutions;
+    /// the last element is always the largest. Null for non-photo messages.
+    /// </summary>
+    [JsonPropertyName("photo")]
+    public TelegramPhotoSize[]? Photo { get; init; }
 }
 
 public sealed record TelegramChat
@@ -70,4 +84,49 @@ public sealed record TelegramUser
 {
     [JsonPropertyName("id")]
     public long Id { get; init; }
+}
+
+/// <summary>
+/// Represents one resolution variant of a Telegram photo.
+/// Telegram returns an array of these ordered by resolution (last = largest).
+/// </summary>
+public sealed record TelegramPhotoSize
+{
+    [JsonPropertyName("file_id")]
+    public required string FileId { get; init; }
+
+    [JsonPropertyName("file_unique_id")]
+    public required string FileUniqueId { get; init; }
+
+    [JsonPropertyName("width")]
+    public int Width { get; init; }
+
+    [JsonPropertyName("height")]
+    public int Height { get; init; }
+
+    /// <summary>File size in bytes. May be absent for very small photos.</summary>
+    [JsonPropertyName("file_size")]
+    public int? FileSize { get; init; }
+}
+
+/// <summary>
+/// Metadata returned by the Telegram getFile API endpoint.
+/// </summary>
+public sealed record TelegramFile
+{
+    [JsonPropertyName("file_id")]
+    public required string FileId { get; init; }
+
+    [JsonPropertyName("file_unique_id")]
+    public required string FileUniqueId { get; init; }
+
+    /// <summary>
+    /// Relative path used to download the file via
+    /// <c>https://api.telegram.org/file/bot{token}/{FilePath}</c>.
+    /// </summary>
+    [JsonPropertyName("file_path")]
+    public string? FilePath { get; init; }
+
+    [JsonPropertyName("file_size")]
+    public int? FileSize { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Channels/ChannelAdapterBase.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/ChannelAdapterBase.cs
@@ -51,6 +51,9 @@ public abstract class ChannelAdapterBase : IChannelAdapter
     public virtual bool SupportsToolDisplay => false;
 
     /// <inheritdoc />
+    public virtual bool SupportsInboundImages => false;
+
+    /// <inheritdoc />
     public bool IsRunning => _isRunning;
 
     /// <inheritdoc />

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentHandle.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentHandle.cs
@@ -1,6 +1,7 @@
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
+using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
 
 namespace BotNexus.Gateway.Abstractions.Agents;
 
@@ -32,12 +33,21 @@ public interface IAgentHandle : IAsyncDisposable
 
     /// <summary>
     /// Sends a message to the agent and waits for the complete response.
-    /// Use <see cref="StreamAsync"/> for real-time streaming.
+    /// Use <see cref="StreamAsync(string,CancellationToken)"/> for real-time streaming.
     /// </summary>
     /// <param name="message">The user message to send.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The complete agent response.</returns>
     Task<AgentResponse> PromptAsync(string message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a multimodal user message (text + optional images) and waits for the complete response.
+    /// Use the string overload when no images are present.
+    /// </summary>
+    /// <param name="message">The user message, optionally carrying image content parts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The complete agent response.</returns>
+    Task<AgentResponse> PromptAsync(AgentUserMessage message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sends a message to the agent and streams back events in real time.
@@ -47,6 +57,15 @@ public interface IAgentHandle : IAsyncDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async stream of agent events.</returns>
     IAsyncEnumerable<AgentStreamEvent> StreamAsync(string message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a multimodal user message (text + optional images) and streams back events in real time.
+    /// Use the string overload when no images are present.
+    /// </summary>
+    /// <param name="message">The user message, optionally carrying image content parts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async stream of agent events.</returns>
+    IAsyncEnumerable<AgentStreamEvent> StreamAsync(AgentUserMessage message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Aborts the current agent execution, if any.

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelAdapter.cs
@@ -43,6 +43,13 @@ public interface IChannelAdapter
     /// <summary>Whether this channel can render tool call activity output.</summary>
     bool SupportsToolDisplay { get; }
 
+    /// <summary>
+    /// Whether this channel can receive inbound image attachments from users.
+    /// When true, the adapter populates <see cref="BotNexus.Gateway.Abstractions.Models.InboundMessage.ContentParts"/>
+    /// with image binary data for vision-capable models.
+    /// </summary>
+    bool SupportsInboundImages { get; }
+
     /// <summary>Whether the adapter is currently running and accepting messages.</summary>
     bool IsRunning { get; }
 

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading.Channels;
+using BotNexus.Agent.Core.Types;
+using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
 using BotNexus.Gateway.Channels;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -444,8 +446,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     // Capture the resolved source for the lambda closure so the
                     // streaming conversationId includes the ThreadId (fixes #125).
                     var streamingSource = resolvedSource;
+                    var userMessage = BuildUserMessage(message, processedParts ?? originalParts);
                     await StreamingSessionHelper.ProcessAndSaveAsync(
-                        handle.StreamAsync(message.Content, cancellationToken),
+                        handle.StreamAsync(userMessage, cancellationToken),
                         session,
                         _sessions,
                         new StreamingSessionOptions(
@@ -485,7 +488,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 }
                 else
                 {
-                    var response = await handle.PromptAsync(message.Content, cancellationToken);
+                    var userMessage = BuildUserMessage(message, processedParts ?? originalParts);
+                    var response = await handle.PromptAsync(userMessage, cancellationToken);
                     if (IsHeartbeatAck(response.Content))
                     {
                         _logger.LogDebug("Heartbeat ack from agent '{AgentId}' session '{SessionId}'", agentId, sessionId);
@@ -940,6 +944,51 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             channelType,
             string.Join(", ", _channelManager.Adapters.Select(a => a.ChannelType)));
         return null;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="AgentUserMessage"/> from an inbound message, attaching any image
+    /// content parts as <see cref="AgentImageContent"/> so vision-capable models receive them.
+    /// Falls back to a plain text <see cref="AgentUserMessage"/> when no image parts are present.
+    /// </summary>
+    private static AgentUserMessage BuildUserMessage(
+        InboundMessage message,
+        IReadOnlyList<MessageContentPart>? contentParts)
+    {
+        var images = BuildImageContent(contentParts);
+        return images is { Count: > 0 }
+            ? new AgentUserMessage(message.Content, images)
+            : new AgentUserMessage(message.Content);
+    }
+
+    private static IReadOnlyList<AgentImageContent>? BuildImageContent(
+        IReadOnlyList<MessageContentPart>? contentParts)
+    {
+        if (contentParts is null or { Count: 0 })
+            return null;
+
+        List<AgentImageContent>? images = null;
+        foreach (var part in contentParts)
+        {
+            AgentImageContent? imageContent = part switch
+            {
+                // Inline binary — convert to base64 data URI
+                BinaryContentPart bin when bin.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+                    => new AgentImageContent($"data:{bin.MimeType};base64,{Convert.ToBase64String(bin.Data)}"),
+                // External URL reference
+                ReferenceContentPart refPart when refPart.MimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+                    => new AgentImageContent(refPart.Uri),
+                _ => null
+            };
+
+            if (imageContent is not null)
+            {
+                images ??= [];
+                images.Add(imageContent);
+            }
+        }
+
+        return images;
     }
 
     private sealed class SessionQueueState(Channel<QueuedInboundMessage> queue, Task workerTask)

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -633,7 +633,47 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<AgentStreamEvent> StreamAsync(string message, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async Task<AgentResponse> PromptAsync(AgentCoreUserMessage message, CancellationToken cancellationToken = default)
+    {
+        using var activity = AgentDiagnostics.Source.StartActivity("agent.prompt", ActivityKind.Internal);
+        activity?.SetTag("botnexus.agent.id", AgentId);
+        activity?.SetTag("botnexus.session.id", SessionId);
+        activity?.SetTag("botnexus.correlation.id", System.Diagnostics.Activity.Current?.TraceId.ToString());
+        try
+        {
+            var messages = await _agent.PromptAsync(message, cancellationToken);
+            var lastAssistant = messages.OfType<AssistantAgentMessage>().LastOrDefault();
+
+            var response = new AgentResponse
+            {
+                Content = lastAssistant?.Content ?? string.Empty,
+                Usage = lastAssistant?.Usage is { } u ? new AgentResponseUsage(u.InputTokens, u.OutputTokens) : null,
+                ToolCalls = messages.OfType<ToolResultAgentMessage>()
+                    .Select(t => new AgentToolCallInfo(t.ToolCallId, t.ToolName, t.IsError))
+                    .ToList()
+            };
+
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<AgentStreamEvent> StreamAsync(string message, CancellationToken cancellationToken = default)
+        => StreamCoreAsync(ct => _agent.PromptAsync(message, ct), cancellationToken);
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<AgentStreamEvent> StreamAsync(AgentCoreUserMessage message, CancellationToken cancellationToken = default)
+        => StreamCoreAsync(ct => _agent.PromptAsync(message, ct), cancellationToken);
+
+    private async IAsyncEnumerable<AgentStreamEvent> StreamCoreAsync(
+        Func<CancellationToken, Task> runPrompt,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         using var activity = AgentDiagnostics.Source.StartActivity("agent.stream", ActivityKind.Internal);
         activity?.SetTag("botnexus.agent.id", AgentId);
@@ -715,7 +755,7 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
         {
             try
             {
-                await _agent.PromptAsync(message, promptCancellation.Token);
+                await runPrompt(promptCancellation.Token);
             }
             catch (OperationCanceledException) when (promptCancellation.IsCancellationRequested || cancellationToken.IsCancellationRequested)
             {

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -145,6 +146,10 @@ public sealed class GatewayHostBindingRoutingTests
             .Returns(ToAsyncEnumerable([
                 new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hello world" }
             ]));
+        handle.Setup(h => h.StreamAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(ToAsyncEnumerable([
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hello world" }
+            ]));
 
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetOrCreateAsync(
@@ -262,6 +267,8 @@ public sealed class GatewayHostBindingRoutingTests
         handle.SetupGet(h => h.SessionId).Returns(sessionId);
         handle.Setup(h => h.IsRunning).Returns(false);
         handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = content });
+        handle.Setup(h => h.PromptAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentResponse { Content = content });
         return handle;
     }

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway;
 using BotNexus.Gateway.Abstractions.Activity;
@@ -340,6 +341,8 @@ public sealed class MultiChannelFanOutTests
         handle.SetupGet(h => h.SessionId).Returns("dynamic");
         handle.Setup(h => h.IsRunning).Returns(false);
         handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = responseContent });
+        handle.Setup(h => h.PromptAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentResponse { Content = responseContent });
 
         var supervisor = new Mock<IAgentSupervisor>();

--- a/tests/gateway/BotNexus.Gateway.Tests/ChannelCapabilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ChannelCapabilityTests.cs
@@ -67,7 +67,34 @@ public sealed class ChannelCapabilityTests
         adapter.SupportsFollowUp.ShouldBeFalse();
         adapter.SupportsThinkingDisplay.ShouldBeTrue();
         adapter.SupportsToolDisplay.ShouldBeTrue();
+        adapter.SupportsInboundImages.ShouldBeTrue();
         adapter.ShouldBeAssignableTo<IStreamEventChannelAdapter>();
+    }
+
+    [Fact]
+    public void SignalRAdapter_SupportsInboundImages()
+    {
+        var adapter = new SignalRChannelAdapter(
+            NullLogger<SignalRChannelAdapter>.Instance,
+            Mock.Of<IHubContext<GatewayHub, IGatewayHubClient>>());
+
+        adapter.SupportsInboundImages.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TuiAdapter_DoesNotSupportInboundImages()
+    {
+        var adapter = new TuiChannelAdapter(NullLogger<TuiChannelAdapter>.Instance);
+
+        adapter.SupportsInboundImages.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DefaultChannelAdapterBase_DoesNotSupportInboundImages()
+    {
+        IChannelAdapter adapter = new TestChannelAdapter();
+
+        adapter.SupportsInboundImages.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/ChannelManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ChannelManagerTests.cs
@@ -50,6 +50,7 @@ public sealed class ChannelManagerTests
         public bool SupportsFollowUp => false;
         public bool SupportsThinkingDisplay => false;
         public bool SupportsToolDisplay => false;
+        public bool SupportsInboundImages => false;
         public bool IsRunning => true;
 
         public Task StartAsync(IChannelDispatcher dispatcher, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -1077,6 +1077,358 @@ public sealed class TelegramChannelAdapterTests
         dispatched.ShouldBeFalse();
     }
 
+    // ── Photo / Image Message Tests ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Polling_PhotoMessage_DispatchedWithBinaryContentPart()
+    {
+        var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }; // JPEG magic bytes
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var getUpdatesCount = 0;
+
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            // File download is a GET to /file/bot{token}/{filePath}
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri?.AbsolutePath.Contains("/file/bot", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(photoBytes)
+                };
+            }
+
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "getUpdates" when Interlocked.Increment(ref getUpdatesCount) == 1 => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 1,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 100,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Caption = "here is a photo",
+                            Photo =
+                            [
+                                new TelegramPhotoSize { FileId = "small_id", FileUniqueId = "u1", Width = 100, Height = 100, FileSize = 5_000 },
+                                new TelegramPhotoSize { FileId = "large_id", FileUniqueId = "u2", Width = 800, Height = 600, FileSize = 80_000 }
+                            ]
+                        }
+                    }
+                }),
+                "getUpdates" => JsonOk(Array.Empty<TelegramUpdate>()),
+                "getFile" => JsonOk(new TelegramFile { FileId = "large_id", FileUniqueId = "u2", FilePath = "photos/file_1.jpg" }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", PollingTimeoutSeconds = 1 }, handler);
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        msg.Content.ShouldBe("here is a photo");
+        msg.ContentParts.ShouldNotBeNull();
+        msg.ContentParts!.Count.ShouldBe(1);
+        var part = msg.ContentParts[0].ShouldBeOfType<BinaryContentPart>();
+        part.MimeType.ShouldBe("image/jpeg");
+        part.Data.ShouldBe(photoBytes);
+    }
+
+    [Fact]
+    public async Task Polling_PhotoMessage_WithNullCaption_UsesEmptyContent()
+    {
+        var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF };
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var getUpdatesCount = 0;
+
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri?.AbsolutePath.Contains("/file/bot", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(photoBytes) };
+            }
+
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "getUpdates" when Interlocked.Increment(ref getUpdatesCount) == 1 => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 2,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 101,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Caption = null, // no caption
+                            Photo = [new TelegramPhotoSize { FileId = "id1", FileUniqueId = "u1", Width = 400, Height = 300, FileSize = 20_000 }]
+                        }
+                    }
+                }),
+                "getUpdates" => JsonOk(Array.Empty<TelegramUpdate>()),
+                "getFile" => JsonOk(new TelegramFile { FileId = "id1", FileUniqueId = "u1", FilePath = "photos/f.jpg" }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", PollingTimeoutSeconds = 1 }, handler);
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        msg.Content.ShouldBe(string.Empty);
+        msg.ContentParts.ShouldNotBeNull();
+        msg.ContentParts!.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Polling_PhotoMessage_DownloadFails_FallsBackToCaptionOnly()
+    {
+        // When GetFileAsync or DownloadFileAsync throws, the message is still dispatched
+        // using just the caption, with no ContentParts.
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var getUpdatesCount = 0;
+
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "getUpdates" when Interlocked.Increment(ref getUpdatesCount) == 1 => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 3,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 102,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Caption = "image with download error",
+                            Photo = [new TelegramPhotoSize { FileId = "bad_id", FileUniqueId = "u1", Width = 400, Height = 300, FileSize = 20_000 }]
+                        }
+                    }
+                }),
+                "getUpdates" => JsonOk(Array.Empty<TelegramUpdate>()),
+                // getFile returns a server error — simulates network/API failure
+                "getFile" => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent("{\"ok\":false,\"error_code\":500,\"description\":\"server error\"}")
+                },
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", PollingTimeoutSeconds = 1 }, handler);
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        // Adapter must still dispatch; falls back to caption-only (no ContentParts)
+        msg.Content.ShouldBe("image with download error");
+        msg.ContentParts.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Polling_PhotoMessage_SelectsLargestPhotoByFileSize()
+    {
+        // Verifies that among multiple photo sizes, the one with the highest FileSize is chosen.
+        string? usedFileId = null;
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var getUpdatesCount = 0;
+
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri?.AbsolutePath.Contains("/file/bot", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([0xFF]) };
+            }
+
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "getFile")
+            {
+                // Capture which file_id was requested
+                using var doc = JsonDocument.Parse(call.Body);
+                usedFileId = doc.RootElement.TryGetProperty("file_id", out var el) ? el.GetString() : null;
+                return JsonOk(new TelegramFile { FileId = usedFileId!, FileUniqueId = "u", FilePath = "photos/x.jpg" });
+            }
+
+            return call.MethodName switch
+            {
+                "getUpdates" when Interlocked.Increment(ref getUpdatesCount) == 1 => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 4,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 103,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Photo =
+                            [
+                                new TelegramPhotoSize { FileId = "thumb_id", FileUniqueId = "u1", Width = 90,  Height = 90,  FileSize = 3_000 },
+                                new TelegramPhotoSize { FileId = "mid_id",   FileUniqueId = "u2", Width = 320, Height = 240, FileSize = 25_000 },
+                                new TelegramPhotoSize { FileId = "hd_id",    FileUniqueId = "u3", Width = 800, Height = 600, FileSize = 95_000 }
+                            ]
+                        }
+                    }
+                }),
+                "getUpdates" => JsonOk(Array.Empty<TelegramUpdate>()),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", PollingTimeoutSeconds = 1 }, handler);
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        usedFileId.ShouldBe("hd_id");
+    }
+
+    [Fact]
+    public async Task Polling_PhotoMessage_WithNullFileSizeOnAllSizes_StillDispatches()
+    {
+        // TelegramPhotoSize.FileSize can be null; the adapter must not throw.
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var getUpdatesCount = 0;
+
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri?.AbsolutePath.Contains("/file/bot", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([0xFF, 0xD8]) };
+            }
+
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "getUpdates" when Interlocked.Increment(ref getUpdatesCount) == 1 => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 5,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 104,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Photo =
+                            [
+                                // All FileSize = null — order by (null ?? 0) = 0 for all; picks last
+                                new TelegramPhotoSize { FileId = "a", FileUniqueId = "ua", Width = 90,  Height = 90,  FileSize = null },
+                                new TelegramPhotoSize { FileId = "b", FileUniqueId = "ub", Width = 320, Height = 240, FileSize = null }
+                            ]
+                        }
+                    }
+                }),
+                "getUpdates" => JsonOk(Array.Empty<TelegramUpdate>()),
+                "getFile" => JsonOk(new TelegramFile { FileId = "a", FileUniqueId = "ua", FilePath = "photos/null_size.jpg" }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", PollingTimeoutSeconds = 1 }, handler);
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        // Must not throw and should dispatch with at least one ContentPart (or none if download fails)
+        msg.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Polling_PhotoMessage_IsNotFilteredByUnauthorizedUser_WithNoTextGuard()
+    {
+        // Photo messages previously fell through the IsNullOrWhiteSpace(message.Text) guard.
+        // This test confirms they are accepted after the fix when the user is authorized.
+        var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF };
+        var dispatched = new TaskCompletionSource<InboundMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var getUpdatesCount = 0;
+
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri?.AbsolutePath.Contains("/file/bot", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(photoBytes) };
+            }
+
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            return call.MethodName switch
+            {
+                "getUpdates" when Interlocked.Increment(ref getUpdatesCount) == 1 => JsonOk(new[]
+                {
+                    new TelegramUpdate
+                    {
+                        UpdateId = 6,
+                        Message = new TelegramMessage
+                        {
+                            MessageId = 105,
+                            Chat = new TelegramChat { Id = 42 },
+                            From = new TelegramUser { Id = 7 },
+                            Text = null,    // no text
+                            Caption = null, // no caption either — photo only
+                            Photo = [new TelegramPhotoSize { FileId = "p1", FileUniqueId = "u1", Width = 400, Height = 300, FileSize = 12_000 }]
+                        }
+                    }
+                }),
+                "getUpdates" => JsonOk(Array.Empty<TelegramUpdate>()),
+                "getFile" => JsonOk(new TelegramFile { FileId = "p1", FileUniqueId = "u1", FilePath = "photos/photo_only.jpg" }),
+                _ => JsonOk(true)
+            };
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", PollingTimeoutSeconds = 1 }, handler);
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Callback<InboundMessage, CancellationToken>((m, _) => dispatched.TrySetResult(m));
+
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+        var msg = await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await adapter.StopAsync(CancellationToken.None);
+
+        msg.ContentParts.ShouldNotBeNull();
+        msg.ContentParts!.Count.ShouldBe(1);
+        msg.Content.ShouldBe(string.Empty);
+    }
+
     private static TelegramChannelAdapter CreateAdapter(TelegramGatewayOptions options, HttpMessageHandler handler)
     {
         var factory = new StubHttpClientFactory(_ => new HttpClient(handler));

--- a/tests/gateway/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Extensions.Channels.SignalR;
 using BotNexus.Gateway.Abstractions.Activity;
@@ -30,6 +31,8 @@ public sealed class FanOutStaleBindingTests
         h.SetupGet(x => x.SessionId).Returns(sessionId);
         h.Setup(x => x.IsRunning).Returns(false);
         h.Setup(x => x.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = content });
+        h.Setup(x => x.PromptAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentResponse { Content = content });
         return h;
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1140,6 +1140,241 @@ public sealed class GatewayHostTests
         handle.Verify(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task DispatchAsync_WithNonImageBinaryPart_ProducesNoImagesInUserMessage()
+    {
+        // A BinaryContentPart with audio/wav must NOT be converted to an image
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        AgentUserMessage? capturedMessage = null;
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("agent-a");
+        handle.SetupGet(h => h.SessionId).Returns("session-1");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentUserMessage, CancellationToken>((m, _) => capturedMessage = m)
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        var message = CreateMessage("transcribe this", sessionId: "session-1") with
+        {
+            ContentParts = [new BinaryContentPart { MimeType = "audio/wav", Data = [0x52, 0x49, 0x46, 0x46] }]
+        };
+
+        await host.DispatchAsync(message);
+
+        capturedMessage.ShouldNotBeNull();
+        capturedMessage!.Images.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithMixedImageAndNonImageParts_ForwardsOnlyImageParts()
+    {
+        // Only image/* MIME types should be forwarded; non-image parts are silently excluded
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        AgentUserMessage? capturedMessage = null;
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("agent-a");
+        handle.SetupGet(h => h.SessionId).Returns("session-1");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentUserMessage, CancellationToken>((m, _) => capturedMessage = m)
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        var imageData = new byte[] { 0xFF, 0xD8, 0xFF };
+        var message = CreateMessage("analyze this", sessionId: "session-1") with
+        {
+            ContentParts =
+            [
+                new BinaryContentPart { MimeType = "image/png", Data = imageData },
+                new BinaryContentPart { MimeType = "audio/wav", Data = [0x52, 0x49, 0x46, 0x46] },
+                new ReferenceContentPart { MimeType = "application/pdf", Uri = "https://example.com/doc.pdf" }
+            ]
+        };
+
+        await host.DispatchAsync(message);
+
+        capturedMessage.ShouldNotBeNull();
+        capturedMessage!.Images.ShouldNotBeNull();
+        capturedMessage.Images!.Count.ShouldBe(1);
+        capturedMessage.Images[0].Value.ShouldBe($"data:image/png;base64,{Convert.ToBase64String(imageData)}");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithMultipleImageParts_ForwardsAllImages()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        AgentUserMessage? capturedMessage = null;
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("agent-a");
+        handle.SetupGet(h => h.SessionId).Returns("session-1");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentUserMessage, CancellationToken>((m, _) => capturedMessage = m)
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        var jpeg1 = new byte[] { 0xFF, 0xD8, 0xFF };
+        var png1 = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        const string imageUrl = "https://cdn.example.com/img3.webp";
+
+        var message = CreateMessage("compare these", sessionId: "session-1") with
+        {
+            ContentParts =
+            [
+                new BinaryContentPart { MimeType = "image/jpeg", Data = jpeg1 },
+                new BinaryContentPart { MimeType = "image/png", Data = png1 },
+                new ReferenceContentPart { MimeType = "image/webp", Uri = imageUrl }
+            ]
+        };
+
+        await host.DispatchAsync(message);
+
+        capturedMessage.ShouldNotBeNull();
+        capturedMessage!.Images.ShouldNotBeNull();
+        capturedMessage.Images!.Count.ShouldBe(3);
+        capturedMessage.Images[0].Value.ShouldBe($"data:image/jpeg;base64,{Convert.ToBase64String(jpeg1)}");
+        capturedMessage.Images[1].Value.ShouldBe($"data:image/png;base64,{Convert.ToBase64String(png1)}");
+        capturedMessage.Images[2].Value.ShouldBe(imageUrl);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithEmptyContentParts_ProducesNoImages()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        AgentUserMessage? capturedMessage = null;
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("agent-a");
+        handle.SetupGet(h => h.SessionId).Returns("session-1");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentUserMessage, CancellationToken>((m, _) => capturedMessage = m)
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        var message = CreateMessage("plain text", sessionId: "session-1") with
+        {
+            ContentParts = []
+        };
+
+        await host.DispatchAsync(message);
+
+        capturedMessage.ShouldNotBeNull();
+        capturedMessage!.Images.ShouldBeNull();
+    }
+
     private static Mock<IAgentHandle> CreatePromptHandle(string agentId, string sessionId, string content)
     {
         var handle = new Mock<IAgentHandle>();

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1,5 +1,7 @@
 using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
 using ThreadId = BotNexus.Domain.Primitives.ThreadId;
+using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
+using BotNexus.Agent.Core.Types;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
@@ -60,7 +62,7 @@ public sealed class GatewayHostTests
         handle.SetupGet(h => h.AgentId).Returns("agent-a");
         handle.SetupGet(h => h.SessionId).Returns("session-1");
         handle.Setup(h => h.IsRunning).Returns(false);
-        handle.Setup(h => h.StreamAsync("hello", It.IsAny<CancellationToken>()))
+        handle.Setup(h => h.StreamAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
             .Returns(ToAsyncEnumerable(
             [
                 new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hello " },
@@ -142,6 +144,8 @@ public sealed class GatewayHostTests
         handle.Setup(h => h.IsRunning).Returns(false);
         handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string msg, CancellationToken _) => new AgentResponse { Content = $"echo:{msg}" });
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentUserMessage msg, CancellationToken _) => new AgentResponse { Content = $"echo:{msg.Content}" });
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetOrCreateAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
@@ -171,6 +175,8 @@ public sealed class GatewayHostTests
         handle.SetupGet(h => h.SessionId).Returns("session-1");
         handle.Setup(h => h.IsRunning).Returns(false);
         handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetOrCreateAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1"), It.IsAny<CancellationToken>()))
@@ -479,6 +485,8 @@ public sealed class GatewayHostTests
         handle.SetupGet(h => h.IsRunning).Returns(false);
         handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentResponse { Content = "response" });
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "response" });
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetInstance(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1")))
             .Returns(new AgentInstance
@@ -504,7 +512,7 @@ public sealed class GatewayHostTests
         // Steering was NOT called because agent is not running
         handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         // Instead, message was processed normally via PromptAsync
-        handle.Verify(h => h.PromptAsync("nudge", It.IsAny<CancellationToken>()), Times.Once);
+        handle.Verify(h => h.PromptAsync(It.Is<AgentUserMessage>(m => m.Content == "nudge"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -819,6 +827,12 @@ public sealed class GatewayHostTests
                 await Task.Delay(250);
                 return new AgentResponse { Content = "ok" };
             });
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                await Task.Delay(250);
+                return new AgentResponse { Content = "ok" };
+            });
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetOrCreateAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
@@ -868,6 +882,15 @@ public sealed class GatewayHostTests
                 Interlocked.Decrement(ref inFlight);
                 return new AgentResponse { Content = $"echo:{message}" };
             });
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Returns<AgentUserMessage, CancellationToken>(async (message, _) =>
+            {
+                var current = Interlocked.Increment(ref inFlight);
+                Interlocked.Exchange(ref maxInFlight, Math.Max(maxInFlight, current));
+                await Task.Delay(75);
+                Interlocked.Decrement(ref inFlight);
+                return new AgentResponse { Content = $"echo:{message.Content}" };
+            });
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetOrCreateAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(handle.Object);
@@ -888,8 +911,8 @@ public sealed class GatewayHostTests
         await Task.WhenAll(first, second);
 
         maxInFlight.ShouldBe(1);
-        handle.Verify(h => h.PromptAsync("one", It.IsAny<CancellationToken>()), Times.Once);
-        handle.Verify(h => h.PromptAsync("two", It.IsAny<CancellationToken>()), Times.Once);
+        handle.Verify(h => h.PromptAsync(It.Is<AgentUserMessage>(m => m.Content == "one"), It.IsAny<CancellationToken>()), Times.Once);
+        handle.Verify(h => h.PromptAsync(It.Is<AgentUserMessage>(m => m.Content == "two"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -964,6 +987,159 @@ public sealed class GatewayHostTests
         supervisor.Verify(s => s.StopAllAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task DispatchAsync_WithBinaryImageContentPart_ForwardsImageToAgent()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        AgentUserMessage? capturedMessage = null;
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("agent-a");
+        handle.SetupGet(h => h.SessionId).Returns("session-1");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentUserMessage, CancellationToken>((m, _) => capturedMessage = m)
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        var imageData = new byte[] { 0xFF, 0xD8, 0xFF }; // minimal JPEG header
+        var message = CreateMessage("look at this", sessionId: "session-1") with
+        {
+            ContentParts = [new BinaryContentPart { MimeType = "image/jpeg", Data = imageData }]
+        };
+
+        await host.DispatchAsync(message);
+
+        capturedMessage.ShouldNotBeNull();
+        capturedMessage!.Images.ShouldNotBeNull();
+        capturedMessage.Images.ShouldHaveSingleItem();
+        capturedMessage.Images![0].Value.ShouldBe($"data:image/jpeg;base64,{Convert.ToBase64String(imageData)}");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithReferenceImageContentPart_ForwardsUrlToAgent()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        AgentUserMessage? capturedMessage = null;
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns("agent-a");
+        handle.SetupGet(h => h.SessionId).Returns("session-1");
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentUserMessage, CancellationToken>((m, _) => capturedMessage = m)
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        const string imageUrl = "https://example.com/photo.jpg";
+        var message = CreateMessage("describe this", sessionId: "session-1") with
+        {
+            ContentParts = [new ReferenceContentPart { MimeType = "image/jpeg", Uri = imageUrl }]
+        };
+
+        await host.DispatchAsync(message);
+
+        capturedMessage.ShouldNotBeNull();
+        capturedMessage!.Images.ShouldNotBeNull();
+        capturedMessage.Images.ShouldHaveSingleItem();
+        capturedMessage.Images![0].Value.ShouldBe(imageUrl);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithNoImageContentParts_UsesStringOverload()
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        var handle = CreatePromptHandle("agent-a", "session-1", "response");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(CreateMessage("plain text", sessionId: "session-1"));
+
+        // GatewayHost always calls the UserMessage overload; string overload is never used directly
+        handle.Verify(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        handle.Verify(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     private static Mock<IAgentHandle> CreatePromptHandle(string agentId, string sessionId, string content)
     {
         var handle = new Mock<IAgentHandle>();
@@ -971,6 +1147,8 @@ public sealed class GatewayHostTests
         handle.SetupGet(h => h.SessionId).Returns(sessionId);
         handle.Setup(h => h.IsRunning).Returns(false);
         handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = content });
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AgentResponse { Content = content });
         return handle;
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/InProcessAgentHandleTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InProcessAgentHandleTests.cs
@@ -61,7 +61,77 @@ public sealed class InProcessAgentHandleTests
             .ShouldContain("hello");
     }
 
-    private static (BotNexus.Agent.Core.Agent Agent, InProcessAgentHandle Handle) CreateHandle()
+    [Fact]
+    public async Task StreamAsync_WithUserMessageContainingImages_PassesImageContentToProvider()
+    {
+        // This is a real end-to-end test: the image travels from UserMessage →
+        // AgentLoopRunner → MessageConverter → provider Context.
+        // We capture the Context passed to the provider and assert it has an ImageContent block.
+        var capturingProvider = new CapturingStreamingTestProvider();
+        var (_, handle) = CreateHandle(capturingProvider);
+
+        var images = new List<AgentImageContent>
+        {
+            new("data:image/jpeg;base64,/9j/4AAQ==")
+        };
+        var userMessage = new BotNexus.Agent.Core.Types.UserMessage("describe this image", images);
+
+        var events = new List<AgentStreamEvent>();
+        await foreach (var evt in handle.StreamAsync(userMessage))
+            events.Add(evt);
+
+        // Verify the provider actually received a call
+        capturingProvider.LastContext.ShouldNotBeNull();
+
+        // Verify the UserMessage was converted to a ProviderUserMessage with ImageContent blocks
+        var providerMessages = capturingProvider.LastContext!.Messages;
+        var userMsg = providerMessages
+            .OfType<BotNexus.Agent.Providers.Core.Models.UserMessage>()
+            .FirstOrDefault();
+
+        userMsg.ShouldNotBeNull();
+        userMsg!.Content.IsText.ShouldBeFalse("image messages use block content, not plain text");
+        userMsg.Content.Blocks.ShouldNotBeNull();
+        userMsg.Content.Blocks!.OfType<ImageContent>().ShouldHaveSingleItem();
+
+        var imageBlock = userMsg.Content.Blocks.OfType<ImageContent>().Single();
+        imageBlock.MimeType.ShouldBe("image/jpeg");
+        imageBlock.Data.ShouldBe("/9j/4AAQ==");
+    }
+
+    [Fact]
+    public async Task PromptAsync_WithUserMessageContainingImages_PassesImageContentToProvider()
+    {
+        // Non-streaming path: PromptAsync(UserMessage) must also forward images to the provider.
+        var capturingProvider = new CapturingStreamingTestProvider();
+        var (_, handle) = CreateHandle(capturingProvider);
+
+        var images = new List<AgentImageContent>
+        {
+            new("https://example.com/diagram.png")
+        };
+        var userMessage = new BotNexus.Agent.Core.Types.UserMessage("explain the diagram", images);
+
+        var response = await handle.PromptAsync(userMessage);
+
+        response.Content.ShouldNotBeEmpty();
+        capturingProvider.LastContext.ShouldNotBeNull();
+
+        var providerMessages = capturingProvider.LastContext!.Messages;
+        var userMsg = providerMessages
+            .OfType<BotNexus.Agent.Providers.Core.Models.UserMessage>()
+            .FirstOrDefault();
+
+        userMsg.ShouldNotBeNull();
+        userMsg!.Content.Blocks.ShouldNotBeNull();
+        var imageBlock = userMsg.Content.Blocks!.OfType<ImageContent>().SingleOrDefault();
+        imageBlock.ShouldNotBeNull();
+        // URL-based image: value is used as data, mimeType defaults to image/png
+        imageBlock!.Data.ShouldBe("https://example.com/diagram.png");
+    }
+
+    private static (BotNexus.Agent.Core.Agent Agent, InProcessAgentHandle Handle) CreateHandle(
+        IApiProvider? provider = null)
     {
         var modelRegistry = new ModelRegistry();
         modelRegistry.Register("test-provider", new LlmModel(
@@ -77,7 +147,7 @@ public sealed class InProcessAgentHandleTests
             MaxTokens: 1024));
 
         var providers = new ApiProviderRegistry();
-        providers.Register(new StreamingTestProvider());
+        providers.Register(provider ?? new StreamingTestProvider());
         var llmClient = new LlmClient(providers, modelRegistry);
         var model = modelRegistry.GetModel("test-provider", "test-model")!;
         var options = new AgentOptions(
@@ -125,6 +195,42 @@ public sealed class InProcessAgentHandleTests
             var withText = partial with { Content = [new TextContent("hello")] };
             stream.Push(new StartEvent(partial));
             stream.Push(new TextDeltaEvent(0, "hello", withText));
+            stream.Push(new DoneEvent(StopReason.Stop, withText));
+            return stream;
+        }
+    }
+
+    /// <summary>
+    /// A test provider that captures the last Context it was called with so tests
+    /// can assert on the actual provider messages (including ImageContent blocks).
+    /// </summary>
+    private sealed class CapturingStreamingTestProvider : IApiProvider
+    {
+        public string Api => "test-api";
+
+        public Context? LastContext { get; private set; }
+
+        public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+            => StreamSimple(model, context, null);
+
+        public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+        {
+            LastContext = context;
+
+            var stream = new LlmStream();
+            var partial = new AssistantMessage(
+                Content: [],
+                Api: model.Api,
+                Provider: model.Provider,
+                ModelId: model.Id,
+                Usage: Usage.Empty(),
+                StopReason: StopReason.Stop,
+                ErrorMessage: null,
+                ResponseId: null,
+                Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            var withText = partial with { Content = [new TextContent("ok")] };
+            stream.Push(new StartEvent(partial));
+            stream.Push(new TextDeltaEvent(0, "ok", withText));
             stream.Push(new DoneEvent(StopReason.Stop, withText));
             return stream;
         }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
@@ -375,6 +375,12 @@ public sealed class CopilotIntegrationTests
             }
         }
 
+        public Task<AgentResponse> PromptAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => PromptAsync(message.Content, cancellationToken);
+
+        public IAsyncEnumerable<AgentStreamEvent> StreamAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => StreamAsync(message.Content, cancellationToken);
+
         public Task AbortAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SteerAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -410,6 +416,7 @@ public sealed class CopilotIntegrationTests
         public bool SupportsFollowUp => false;
         public bool SupportsThinkingDisplay => false;
         public bool SupportsToolDisplay => false;
+        public bool SupportsInboundImages => false;
         public bool IsRunning => true;
 
         public List<OutboundMessage> SentMessages { get; } = [];

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
@@ -449,6 +449,12 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
             IsRunning = false;
         }
 
+        public Task<AgentResponse> PromptAsync(UserMessage message, CancellationToken ct)
+            => PromptAsync(message.Content, ct);
+
+        public IAsyncEnumerable<AgentStreamEvent> StreamAsync(UserMessage message, CancellationToken ct)
+            => StreamAsync(message.Content, ct);
+
         public Task AbortAsync(CancellationToken ct) { IsRunning = false; return Task.CompletedTask; }
         public Task SteerAsync(string message, CancellationToken ct) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken ct) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
@@ -314,6 +314,12 @@ public sealed class Phase5IntegrationTests
             }
         }
 
+        public Task<AgentResponse> PromptAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => PromptAsync(message.Content, cancellationToken);
+
+        public IAsyncEnumerable<AgentStreamEvent> StreamAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => StreamAsync(message.Content, cancellationToken);
+
         public Task AbortAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SteerAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -335,6 +341,7 @@ public sealed class Phase5IntegrationTests
         public bool SupportsFollowUp => false;
         public bool SupportsThinkingDisplay => false;
         public bool SupportsToolDisplay => false;
+        public bool SupportsInboundImages => false;
         public bool IsRunning => true;
         public List<string> StreamDeltas { get; } = [];
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -952,11 +952,17 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         public Task<AgentResponse> PromptAsync(string message, CancellationToken cancellationToken = default)
             => Task.FromResult(new AgentResponse { Content = string.Empty });
 
+        public Task<AgentResponse> PromptAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => PromptAsync(message.Content, cancellationToken);
+
         public async IAsyncEnumerable<AgentStreamEvent> StreamAsync(string message, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await Task.CompletedTask;
             yield break;
         }
+
+        public IAsyncEnumerable<AgentStreamEvent> StreamAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => StreamAsync(message.Content, cancellationToken);
 
         public Task AbortAsync(CancellationToken cancellationToken = default)
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
@@ -324,11 +324,17 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
         public Task<AgentResponse> PromptAsync(string message, CancellationToken cancellationToken = default)
             => Task.FromResult(new AgentResponse { Content = string.Empty });
 
+        public Task<AgentResponse> PromptAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => PromptAsync(message.Content, cancellationToken);
+
         public async IAsyncEnumerable<AgentStreamEvent> StreamAsync(string message, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await Task.CompletedTask;
             yield break;
         }
+
+        public IAsyncEnumerable<AgentStreamEvent> StreamAsync(UserMessage message, CancellationToken cancellationToken = default)
+            => StreamAsync(message.Content, cancellationToken);
 
         public Task AbortAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SteerAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
@@ -158,7 +158,7 @@ public sealed class StreamingPipelineTests
         handle.SetupGet(h => h.AgentId).Returns("agent-a");
         handle.SetupGet(h => h.SessionId).Returns("session-1");
         handle.Setup(h => h.IsRunning).Returns(false);
-        handle.Setup(h => h.StreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        handle.Setup(h => h.StreamAsync(It.IsAny<BotNexus.Agent.Core.Types.UserMessage>(), It.IsAny<CancellationToken>()))
             .Returns(streamEvents);
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.GetOrCreateAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1"), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Closes #319

## Summary

Wires the existing multimodal infrastructure (`MessageContentPart`, `AgentImageContent`, `UserMessage`) into the full pipeline from channel adapters → GatewayHost → IAgentHandle → Agent → LLM.

Previously, `GatewayHost` silently discarded any images in `InboundMessage.ContentParts` by calling the string-only `handle.StreamAsync(message.Content)`. This PR closes that gap end-to-end.

## Changes

### Contract layer
- **`IAgentHandle`** — adds `PromptAsync(UserMessage, CT)` and `StreamAsync(UserMessage, CT)` overloads for the multimodal path
- **`IChannelAdapter`** — adds `bool SupportsInboundImages { get; }` capability flag
- **`ChannelAdapterBase`** — default `SupportsInboundImages = false` (adapters opt in)

### Gateway pipeline
- **`GatewayHost`** — `BuildUserMessage()` converts `InboundMessage.ContentParts` → `UserMessage` with `AgentImageContent`; binary parts become `data:mime;base64,...` URIs, reference parts pass their URL. Both streaming and non-streaming paths use the new overloads.
- **`InProcessIsolationStrategy`** — implements the two new `IAgentHandle` overloads; refactored `StreamAsync` to use a shared `StreamCoreAsync` helper

### Telegram channel
- `SupportsInboundImages = true`
- `HandleUpdateAsync` accepts photo messages, downloads the highest-resolution photo, and attaches a `BinaryContentPart(image/jpeg)` to the `InboundMessage`; `Caption` is used as the text field
- `TelegramBotApiClient` gains `GetFileAsync` / `DownloadFileAsync`
- `TelegramModels` gains `TelegramPhotoSize`, `TelegramFile`, `Caption` and `Photo` on `TelegramMessage`

### SignalR channel
- `SupportsInboundImages = true` — was already wired via `GatewayHub.SendMessageWithMedia`

## Tests
- 3 new `GatewayHostTests`: binary image forwarding, URL reference forwarding, plain-text path (no images)
- `ChannelCapabilityTests` extended with `SupportsInboundImages` assertions for all adapters
- All test fakes updated for the new interface members
- All 1,546 unit tests pass ✅, 0 compiler warnings

## Out of scope
- Outbound image rendering (agents return text today)
- ServiceBus / TUI image support
