### PR TITLE
telegram: switch to MarkdownV2 parse mode for proper markdown rendering

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/Properties/InternalsVisibleTo.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BotNexus.Gateway.Tests")]

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
@@ -7,7 +7,7 @@ namespace BotNexus.Extensions.Channels.Telegram;
 
 /// <summary>
 /// Thin HTTP client for the Telegram Bot API.
-/// One instance per bot token. Uses HTML parse_mode for outbound messages.
+/// One instance per bot token. Uses MarkdownV2 parse_mode for outbound messages.
 /// </summary>
 public sealed class TelegramBotApiClient(
     HttpClient httpClient,
@@ -34,7 +34,7 @@ public sealed class TelegramBotApiClient(
 
     /// <summary>
     /// Sends a text message to a chat, optionally into a forum topic thread.
-    /// HTML parse_mode is used. If Telegram rejects the HTML (400 Bad Request),
+    /// MarkdownV2 parse_mode is used. If Telegram rejects the MarkdownV2 (400 Bad Request),
     /// the message is retried as plain text without any parse_mode.
     /// </summary>
     /// <remarks>
@@ -55,29 +55,29 @@ public sealed class TelegramBotApiClient(
         var isGeneralTopic = messageThreadId is 1;
         var effectiveThreadId = isGeneralTopic ? null : messageThreadId;
 
-        // Try HTML first; fall back to plain text if Telegram rejects it (400).
+        // Try MarkdownV2 first; fall back to plain text if Telegram rejects it (400).
         try
         {
-            var htmlPayload = effectiveThreadId.HasValue
-                ? (object)new { chat_id = chatId, text, parse_mode = "HTML", message_thread_id = effectiveThreadId.Value }
-                : new { chat_id = chatId, text, parse_mode = "HTML" };
+            var markdownPayload = effectiveThreadId.HasValue
+                ? (object)new { chat_id = chatId, text, parse_mode = "MarkdownV2", message_thread_id = effectiveThreadId.Value }
+                : new { chat_id = chatId, text, parse_mode = "MarkdownV2" };
 
-            return await PostForResultAsync<TelegramMessage>("sendMessage", htmlPayload, cancellationToken, allowHtmlFallback: true);
+            return await PostForResultAsync<TelegramMessage>("sendMessage", markdownPayload, cancellationToken, allowMarkdownFallback: true);
         }
-        catch (TelegramHtmlParseException)
+        catch (TelegramMarkdownParseException)
         {
-            // HTML was rejected — retry as plain text
-            _logger.LogWarning("Telegram rejected HTML for sendMessage to chat {ChatId}; retrying as plain text", chatId);
+            // MarkdownV2 was rejected — retry as plain text
+            _logger.LogWarning("Telegram rejected MarkdownV2 for sendMessage to chat {ChatId}; retrying as plain text", chatId);
             var plainPayload = effectiveThreadId.HasValue
                 ? (object)new { chat_id = chatId, text, message_thread_id = effectiveThreadId.Value }
                 : new { chat_id = chatId, text };
 
-            return await PostForResultAsync<TelegramMessage>("sendMessage", plainPayload, cancellationToken, allowHtmlFallback: false);
+            return await PostForResultAsync<TelegramMessage>("sendMessage", plainPayload, cancellationToken, allowMarkdownFallback: false);
         }
     }
 
     /// <summary>
-    /// Edits an existing message's text. Uses HTML parse_mode.
+    /// Edits an existing message's text. Uses MarkdownV2 parse_mode.
     /// </summary>
     public Task<TelegramMessage> EditMessageTextAsync(
         long chatId,
@@ -86,9 +86,9 @@ public sealed class TelegramBotApiClient(
         CancellationToken cancellationToken = default)
         => PostForResultAsync<TelegramMessage>(
             "editMessageText",
-            new { chat_id = chatId, message_id = messageId, text, parse_mode = "HTML" },
+            new { chat_id = chatId, message_id = messageId, text, parse_mode = "MarkdownV2" },
             cancellationToken,
-            allowHtmlFallback: false);
+            allowMarkdownFallback: false);
 
     /// <summary>
     /// Long-polls for new updates from the Telegram Bot API.
@@ -108,7 +108,7 @@ public sealed class TelegramBotApiClient(
                 allowed_updates = AllowedUpdateTypes
             },
             cancellationToken,
-            allowHtmlFallback: false);
+            allowMarkdownFallback: false);
 
         return updates;
     }
@@ -121,7 +121,7 @@ public sealed class TelegramBotApiClient(
             "setWebhook",
             new { url },
             cancellationToken,
-            allowHtmlFallback: false);
+            allowMarkdownFallback: false);
 
     /// <summary>
     /// Removes any previously registered webhook, reverting to long polling mode.
@@ -131,9 +131,9 @@ public sealed class TelegramBotApiClient(
             "deleteWebhook",
             new { drop_pending_updates = false },
             cancellationToken,
-            allowHtmlFallback: false);
+            allowMarkdownFallback: false);
 
-    private async Task<T> PostForResultAsync<T>(string methodName, object payload, CancellationToken cancellationToken, bool allowHtmlFallback)
+    private async Task<T> PostForResultAsync<T>(string methodName, object payload, CancellationToken cancellationToken, bool allowMarkdownFallback)
     {
         if (string.IsNullOrWhiteSpace(_botToken))
             throw new InvalidOperationException("Telegram BotToken is required.");
@@ -160,9 +160,9 @@ public sealed class TelegramBotApiClient(
                 continue;
             }
 
-            // 400 on sendMessage with HTML parse_mode means malformed HTML — signal fallback.
-            if (response.StatusCode == HttpStatusCode.BadRequest && allowHtmlFallback)
-                throw new TelegramHtmlParseException($"Telegram rejected HTML for {methodName}: {body}");
+            // 400 on sendMessage with MarkdownV2 parse_mode means malformed markdown — signal fallback.
+            if (response.StatusCode == HttpStatusCode.BadRequest && allowMarkdownFallback)
+                throw new TelegramMarkdownParseException($"Telegram rejected MarkdownV2 for {methodName}: {body}");
 
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException($"Telegram API call '{methodName}' failed ({(int)response.StatusCode}): {body}");
@@ -208,7 +208,7 @@ public sealed class TelegramBotApiClient(
 }
 
 /// <summary>
-/// Thrown internally when Telegram returns a 400 for an HTML-formatted message,
+/// Thrown internally when Telegram returns a 400 for a MarkdownV2-formatted message,
 /// signalling that <see cref="TelegramBotApiClient"/> should retry as plain text.
 /// </summary>
-internal sealed class TelegramHtmlParseException(string message) : Exception(message);
+internal sealed class TelegramMarkdownParseException(string message) : Exception(message);

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -143,7 +143,7 @@ public sealed class TelegramChannelAdapter(
 
     /// <summary>
     /// Sends a complete outbound message through the Telegram adapter.
-    /// Content is escaped for Telegram HTML parse mode.
+    /// Content is converted from Markdown to Telegram MarkdownV2 format.
     /// </summary>
     public override async Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
     {
@@ -186,7 +186,9 @@ public sealed class TelegramChannelAdapter(
         await state.Lock.WaitAsync(cancellationToken);
         try
         {
-            state.Buffer.Append(EscapeHtml(delta));
+            // Buffer raw delta; MarkdownV2 conversion happens at flush time so formatting
+            // tokens that span multiple deltas (e.g. **bold**) are preserved intact.
+            state.Buffer.Append(delta);
             state.PendingCharacterCount += delta.Length;
             if (ShouldFlush(state, runtime.Config))
                 await FlushStreamingStateAsync(runtime, state, force: false, cancellationToken);
@@ -219,14 +221,15 @@ public sealed class TelegramChannelAdapter(
                     break;
 
                 case AgentStreamEventType.ContentDelta when streamEvent.ContentDelta is not null:
-                    state.Buffer.Append(EscapeHtml(streamEvent.ContentDelta));
+                    // Buffer raw markdown; conversion to MarkdownV2 happens at flush time.
+                    state.Buffer.Append(streamEvent.ContentDelta);
                     state.PendingCharacterCount += streamEvent.ContentDelta.Length;
                     break;
 
                 case AgentStreamEventType.ThinkingDelta when streamEvent.ThinkingContent is not null:
                     AppendLineIfNeeded(state.Buffer);
                     state.Buffer.Append("Thinking: ");
-                    state.Buffer.Append(EscapeHtml(streamEvent.ThinkingContent));
+                    state.Buffer.Append(streamEvent.ThinkingContent);
                     state.PendingCharacterCount += streamEvent.ThinkingContent.Length;
                     break;
 
@@ -235,7 +238,7 @@ public sealed class TelegramChannelAdapter(
                     var toolName = streamEvent.ToolName ?? "tool";
                     AppendLineIfNeeded(state.Buffer);
                     state.Buffer.Append("[");
-                    state.Buffer.Append(EscapeHtml(toolName));
+                    state.Buffer.Append(toolName);
                     state.Buffer.Append("] started");
                     state.PendingCharacterCount += toolName.Length + 10;
                     break;
@@ -247,7 +250,7 @@ public sealed class TelegramChannelAdapter(
                     var toolName = streamEvent.ToolName ?? streamEvent.ToolCallId ?? "tool";
                     AppendLineIfNeeded(state.Buffer);
                     state.Buffer.Append("[");
-                    state.Buffer.Append(EscapeHtml(toolName));
+                    state.Buffer.Append(toolName);
                     state.Buffer.Append("] ");
                     state.Buffer.Append(status);
                     state.PendingCharacterCount += toolName.Length + status.Length + 3;
@@ -260,7 +263,7 @@ public sealed class TelegramChannelAdapter(
 
                     AppendLineIfNeeded(state.Buffer);
                     state.Buffer.Append("⚠️ ");
-                    state.Buffer.Append(EscapeHtml(streamEvent.ErrorMessage));
+                    state.Buffer.Append(streamEvent.ErrorMessage);
                     state.PendingCharacterCount += streamEvent.ErrorMessage.Length + 2;
                     break;
 
@@ -371,8 +374,10 @@ public sealed class TelegramChannelAdapter(
         var maxLength = Math.Max(1, runtime.Config.MaxMessageLength);
         while (state.Buffer.Length > maxLength)
         {
-            var chunk = state.Buffer.ToString(0, maxLength);
-            await SendOrEditStreamingMessageAsync(runtime, state, chunk, cancellationToken);
+            // Convert the raw chunk to MarkdownV2 before sending.
+            var rawChunk = state.Buffer.ToString(0, maxLength);
+            var formattedChunk = TelegramMarkdownFormatter.Convert(rawChunk);
+            await SendOrEditStreamingMessageAsync(runtime, state, formattedChunk, cancellationToken);
             state.MessageId = null;
             state.Buffer.Remove(0, maxLength);
         }
@@ -380,11 +385,15 @@ public sealed class TelegramChannelAdapter(
         if (!force && !ShouldFlush(state, runtime.Config))
             return;
 
-        var text = state.Buffer.ToString();
-        if (string.IsNullOrEmpty(text))
+        var rawText = state.Buffer.ToString();
+        if (string.IsNullOrEmpty(rawText))
             return;
 
-        await SendOrEditStreamingMessageAsync(runtime, state, text, cancellationToken);
+        // Convert accumulated raw markdown to Telegram MarkdownV2 at flush time.
+        // Doing the conversion here (not per-delta) ensures multi-delta formatting tokens
+        // such as **bold** are fully assembled before being transformed.
+        var formattedText = TelegramMarkdownFormatter.Convert(rawText);
+        await SendOrEditStreamingMessageAsync(runtime, state, formattedText, cancellationToken);
         state.LastFlushUtc = DateTimeOffset.UtcNow;
         state.PendingCharacterCount = 0;
     }
@@ -474,26 +483,26 @@ public sealed class TelegramChannelAdapter(
 
         if (!string.IsNullOrWhiteSpace(displayPrefix))
         {
-            builder.Append(EscapeHtml(displayPrefix));
+            builder.Append(TelegramMarkdownFormatter.EscapeMarkdownV2(displayPrefix));
             builder.Append(' ');
         }
 
         if (TryGetMetadataString(metadata, "thinking", out var thinking))
         {
             builder.Append("Thinking: ");
-            builder.Append(EscapeHtml(thinking));
+            builder.Append(TelegramMarkdownFormatter.Convert(thinking));
             builder.AppendLine();
             builder.AppendLine();
         }
 
-        builder.Append(EscapeHtml(content));
+        builder.Append(TelegramMarkdownFormatter.Convert(content));
 
         if (TryGetMetadataString(metadata, "toolCall", out var toolCall))
         {
             builder.AppendLine();
-            builder.Append('[');
-            builder.Append(EscapeHtml(toolCall));
-            builder.Append(']');
+            builder.Append("\\[");
+            builder.Append(TelegramMarkdownFormatter.EscapeMarkdownV2(toolCall));
+            builder.Append("\\]");
         }
 
         return builder.ToString();
@@ -553,17 +562,6 @@ public sealed class TelegramChannelAdapter(
     {
         if (builder.Length > 0)
             builder.AppendLine();
-    }
-
-    private static string EscapeHtml(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-
-        return value
-            .Replace("&", "&amp;", StringComparison.Ordinal)
-            .Replace("<", "&lt;", StringComparison.Ordinal)
-            .Replace(">", "&gt;", StringComparison.Ordinal);
     }
 
     private sealed class BotRuntime(string botName, TelegramBotConfig config, TelegramBotApiClient apiClient)

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramMarkdownFormatter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramMarkdownFormatter.cs
@@ -1,0 +1,410 @@
+using System.Text;
+
+namespace BotNexus.Extensions.Channels.Telegram;
+
+/// <summary>
+/// Converts LLM Markdown output to Telegram MarkdownV2 format so the Telegram client
+/// renders bold, italic, code, links, and headings rather than displaying raw punctuation.
+/// </summary>
+/// <remarks>
+/// Telegram MarkdownV2 reference: https://core.telegram.org/bots/api#markdownv2-style
+///
+/// Conversion rules applied:
+/// - LLM **bold** → Telegram *bold* (single asterisk)
+/// - LLM *italic* → Telegram _italic_ (underscore)
+/// - LLM _italic_ → Telegram _italic_ (unchanged)
+/// - LLM ***bold italic*** → Telegram *_bold italic_*
+/// - LLM ~~strike~~ → Telegram ~strike~ (single tilde)
+/// - LLM `code` → Telegram `code`
+/// - LLM ```lang\n...\n``` → Telegram ```lang\n...\n```
+/// - LLM [text](url) → Telegram [text](url)
+/// - LLM # Heading → Telegram *Heading* (mapped to bold, no native heading support)
+/// - All literal special chars are escaped with a preceding backslash.
+/// </remarks>
+internal static class TelegramMarkdownFormatter
+{
+    // All characters that must be escaped in MarkdownV2 literal text regions.
+    private static readonly HashSet<char> EscapeSet =
+    [
+        '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\'
+    ];
+
+    /// <summary>
+    /// Converts a markdown string (as produced by LLMs) into Telegram MarkdownV2 format.
+    /// Recognized formatting is converted; all other special characters are escaped.
+    /// Returns an empty string for null/empty input.
+    /// </summary>
+    public static string Convert(string? markdown)
+    {
+        if (string.IsNullOrEmpty(markdown)) return string.Empty;
+
+        var sb = new StringBuilder(markdown.Length + markdown.Length / 4);
+        var i = 0;
+
+        while (i < markdown.Length)
+        {
+            var c = markdown[i];
+
+            // Fenced code block: ```[lang]\n...\n```
+            if (c == '`' && Peek(markdown, i + 1) == '`' && Peek(markdown, i + 2) == '`')
+            {
+                i = ProcessCodeBlock(markdown, i, sb);
+                continue;
+            }
+
+            // Inline code: `...`
+            if (c == '`')
+            {
+                i = ProcessInlineCode(markdown, i, sb);
+                continue;
+            }
+
+            // Heading at line start: # text
+            if (c == '#' && (i == 0 || markdown[i - 1] == '\n'))
+            {
+                i = ProcessHeading(markdown, i, sb);
+                continue;
+            }
+
+            // Bold+italic: ***...***
+            if (c == '*' && Peek(markdown, i + 1) == '*' && Peek(markdown, i + 2) == '*')
+            {
+                i = ProcessBoldItalic(markdown, i, sb);
+                continue;
+            }
+
+            // Bold: **...**
+            if (c == '*' && Peek(markdown, i + 1) == '*')
+            {
+                i = ProcessBold(markdown, i, sb);
+                continue;
+            }
+
+            // Strikethrough: ~~...~~
+            if (c == '~' && Peek(markdown, i + 1) == '~')
+            {
+                i = ProcessStrikethrough(markdown, i, sb);
+                continue;
+            }
+
+            // Link: [text](url)
+            if (c == '[')
+            {
+                i = ProcessLink(markdown, i, sb);
+                continue;
+            }
+
+            // Italic with single asterisk: *...*
+            if (c == '*')
+            {
+                i = ProcessItalicStar(markdown, i, sb);
+                continue;
+            }
+
+            // Italic with underscore: _..._
+            if (c == '_')
+            {
+                i = ProcessItalicUnderscore(markdown, i, sb);
+                continue;
+            }
+
+            // Literal character — escape if required by MarkdownV2
+            if (EscapeSet.Contains(c)) sb.Append('\\');
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Escapes all MarkdownV2 special characters in a plain-text string.
+    /// Use this for structural strings (display prefixes, tool names, labels) that
+    /// must appear as literal text with no formatting applied.
+    /// </summary>
+    public static string EscapeMarkdownV2(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+
+        var sb = new StringBuilder(text.Length + text.Length / 4);
+        foreach (var c in text)
+        {
+            if (EscapeSet.Contains(c)) sb.Append('\\');
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    // Processes a fenced code block starting at `start` (the first `).
+    // Emits ```lang\ncontent\n``` with ` and \ escaped inside the block.
+    private static int ProcessCodeBlock(string text, int start, StringBuilder sb)
+    {
+        var openEnd = start + 3; // position after the opening ```
+
+        // Find the newline that terminates the opening fence (and optional lang tag).
+        var newlineIndex = text.IndexOf('\n', openEnd);
+        if (newlineIndex < 0)
+        {
+            // No newline found — treat ``` as escaped literal
+            sb.Append("\\`\\`\\`");
+            return start + 3;
+        }
+
+        var lang = text.Substring(openEnd, newlineIndex - openEnd).Trim();
+        var contentStart = newlineIndex + 1;
+
+        // Find the closing ```, which must appear after a newline.
+        const string ClosePattern = "\n```";
+        var closeIndex = text.IndexOf(ClosePattern, contentStart, StringComparison.Ordinal);
+        if (closeIndex < 0)
+        {
+            // No closing fence — treat opening as escaped literal
+            sb.Append("\\`\\`\\`");
+            return start + 3;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+
+        sb.Append("```");
+        if (!string.IsNullOrEmpty(lang)) sb.Append(lang);
+        sb.Append('\n');
+
+        // Inside pre/code blocks only ` and \ must be escaped.
+        foreach (var c in content)
+        {
+            if (c == '`' || c == '\\') sb.Append('\\');
+            sb.Append(c);
+        }
+
+        sb.Append("\n```");
+
+        // closeIndex points at the \n before ```; skip past \n + ```
+        return closeIndex + ClosePattern.Length;
+    }
+
+    // Processes an inline code span starting at `start` (the opening `).
+    private static int ProcessInlineCode(string text, int start, StringBuilder sb)
+    {
+        var contentStart = start + 1;
+
+        // Locate the closing backtick; do not cross line boundaries.
+        var closeIndex = -1;
+        for (var j = contentStart; j < text.Length; j++)
+        {
+            if (text[j] == '\n') break;
+            if (text[j] == '`') { closeIndex = j; break; }
+        }
+
+        if (closeIndex < 0)
+        {
+            sb.Append("\\`");
+            return start + 1;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+
+        sb.Append('`');
+        foreach (var c in content)
+        {
+            if (c == '`' || c == '\\') sb.Append('\\');
+            sb.Append(c);
+        }
+        sb.Append('`');
+
+        return closeIndex + 1;
+    }
+
+    // Processes a heading line (# / ## / etc.) starting at `start`.
+    // Telegram has no native heading; headings are mapped to bold.
+    private static int ProcessHeading(string text, int start, StringBuilder sb)
+    {
+        var i = start;
+        while (i < text.Length && text[i] == '#') i++;
+
+        // Skip the space between # markers and the heading text.
+        if (i < text.Length && text[i] == ' ') i++;
+
+        var lineEnd = text.IndexOf('\n', i);
+        var headingText = lineEnd >= 0
+            ? text.Substring(i, lineEnd - i)
+            : text.Substring(i);
+
+        sb.Append('*');
+        AppendLiteralEscaped(headingText, sb);
+        sb.Append('*');
+
+        return lineEnd >= 0 ? lineEnd : text.Length;
+    }
+
+    // Processes a bold+italic span ***...*** → Telegram *_..._*
+    private static int ProcessBoldItalic(string text, int start, StringBuilder sb)
+    {
+        var contentStart = start + 3;
+        var closeIndex = text.IndexOf("***", contentStart, StringComparison.Ordinal);
+        if (closeIndex < 0)
+        {
+            sb.Append("\\*\\*\\*");
+            return start + 3;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+        sb.Append("*_");
+        AppendLiteralEscaped(content, sb);
+        sb.Append("_*");
+
+        return closeIndex + 3;
+    }
+
+    // Processes a bold span **...** → Telegram *...*
+    private static int ProcessBold(string text, int start, StringBuilder sb)
+    {
+        var contentStart = start + 2;
+        var closeIndex = text.IndexOf("**", contentStart, StringComparison.Ordinal);
+        if (closeIndex < 0)
+        {
+            sb.Append("\\*\\*");
+            return start + 2;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+        sb.Append('*');
+        AppendLiteralEscaped(content, sb);
+        sb.Append('*');
+
+        return closeIndex + 2;
+    }
+
+    // Processes a strikethrough span ~~...~~ → Telegram ~...~
+    private static int ProcessStrikethrough(string text, int start, StringBuilder sb)
+    {
+        var contentStart = start + 2;
+        var closeIndex = text.IndexOf("~~", contentStart, StringComparison.Ordinal);
+        if (closeIndex < 0)
+        {
+            sb.Append("\\~\\~");
+            return start + 2;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+        sb.Append('~');
+        AppendLiteralEscaped(content, sb);
+        sb.Append('~');
+
+        return closeIndex + 2;
+    }
+
+    // Processes a markdown link [text](url) → Telegram [text](url)
+    private static int ProcessLink(string text, int start, StringBuilder sb)
+    {
+        var closeTextIndex = text.IndexOf(']', start + 1);
+        if (closeTextIndex < 0 || closeTextIndex + 1 >= text.Length || text[closeTextIndex + 1] != '(')
+        {
+            // Not a valid link — escape the [ and move on.
+            sb.Append("\\[");
+            return start + 1;
+        }
+
+        var closeUrlIndex = text.IndexOf(')', closeTextIndex + 2);
+        if (closeUrlIndex < 0)
+        {
+            sb.Append("\\[");
+            return start + 1;
+        }
+
+        var linkText = text.Substring(start + 1, closeTextIndex - start - 1);
+        var url = text.Substring(closeTextIndex + 2, closeUrlIndex - closeTextIndex - 2);
+
+        sb.Append('[');
+        AppendLiteralEscaped(linkText, sb);
+        sb.Append("](");
+
+        // Inside the URL, only ) and \ must be escaped.
+        foreach (var c in url)
+        {
+            if (c == ')' || c == '\\') sb.Append('\\');
+            sb.Append(c);
+        }
+
+        sb.Append(')');
+
+        return closeUrlIndex + 1;
+    }
+
+    // Processes italic *...* → Telegram _..._
+    // Only matches a single * (not **); does not cross line boundaries.
+    private static int ProcessItalicStar(string text, int start, StringBuilder sb)
+    {
+        var contentStart = start + 1;
+
+        var closeIndex = -1;
+        for (var j = contentStart; j < text.Length; j++)
+        {
+            if (text[j] == '\n') break;
+            // Closing * must not be immediately followed by another * (that would be **).
+            if (text[j] == '*' && Peek(text, j + 1) != '*')
+            {
+                closeIndex = j;
+                break;
+            }
+        }
+
+        if (closeIndex < 0)
+        {
+            sb.Append("\\*");
+            return start + 1;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+        sb.Append('_');
+        AppendLiteralEscaped(content, sb);
+        sb.Append('_');
+
+        return closeIndex + 1;
+    }
+
+    // Processes italic _..._ → Telegram _..._
+    // Does not cross line boundaries.
+    private static int ProcessItalicUnderscore(string text, int start, StringBuilder sb)
+    {
+        var contentStart = start + 1;
+
+        var closeIndex = -1;
+        for (var j = contentStart; j < text.Length; j++)
+        {
+            if (text[j] == '\n') break;
+            // Closing _ must not be immediately followed by another _ (that would be __).
+            if (text[j] == '_' && Peek(text, j + 1) != '_')
+            {
+                closeIndex = j;
+                break;
+            }
+        }
+
+        if (closeIndex < 0)
+        {
+            sb.Append("\\_");
+            return start + 1;
+        }
+
+        var content = text.Substring(contentStart, closeIndex - contentStart);
+        sb.Append('_');
+        AppendLiteralEscaped(content, sb);
+        sb.Append('_');
+
+        return closeIndex + 1;
+    }
+
+    // Appends each character of `text` to `sb`, escaping MarkdownV2 special chars.
+    // Used for the content inside formatting spans where no further markdown is parsed.
+    private static void AppendLiteralEscaped(string text, StringBuilder sb)
+    {
+        foreach (var c in text)
+        {
+            if (EscapeSet.Contains(c)) sb.Append('\\');
+            sb.Append(c);
+        }
+    }
+
+    private static char Peek(string text, int index)
+        => index < text.Length ? text[index] : '\0';
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -116,7 +116,7 @@ public sealed class TelegramChannelAdapterTests
     }
 
     [Fact]
-    public async Task SendAsync_EscapesHtml()
+    public async Task SendAsync_EscapesMarkdownV2SpecialChars()
     {
         ApiCall? sendCall = null;
         var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
@@ -141,8 +141,9 @@ public sealed class TelegramChannelAdapterTests
         });
 
         sendCall.ShouldNotBeNull();
-        sendCall!.Text.ShouldBe("a &lt; b &amp;&amp; c &gt; d");
-        sendCall.ParseMode.ShouldBe("HTML");
+        // < and & are not MarkdownV2 special chars; > is and must be escaped.
+        sendCall!.Text.ShouldBe("a < b && c \\> d");
+        sendCall.ParseMode.ShouldBe("MarkdownV2");
     }
 
     [Fact]
@@ -438,7 +439,7 @@ public sealed class TelegramChannelAdapterTests
     }
 
     [Fact]
-    public async Task SendAsync_HtmlParseMode_used()
+    public async Task SendAsync_MarkdownV2ParseMode_used()
     {
         ApiCall? sendCall = null;
         var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
@@ -463,11 +464,11 @@ public sealed class TelegramChannelAdapterTests
         });
 
         sendCall.ShouldNotBeNull();
-        sendCall!.ParseMode.ShouldBe("HTML");
+        sendCall!.ParseMode.ShouldBe("MarkdownV2");
     }
 
     [Fact]
-    public async Task SendAsync_HtmlSendFails_FallsBackToPlainText()
+    public async Task SendAsync_MarkdownV2SendFails_FallsBackToPlainText()
     {
         var sendCalls = new List<ApiCall>();
         var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
@@ -502,7 +503,7 @@ public sealed class TelegramChannelAdapterTests
         });
 
         sendCalls.Count.ShouldBe(2);
-        sendCalls[0].ParseMode.ShouldBe("HTML");
+        sendCalls[0].ParseMode.ShouldBe("MarkdownV2");
         sendCalls[1].ParseMode.ShouldBeNull();
         sendCalls[1].Text.ShouldBe("hello");
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -1086,6 +1086,449 @@ public sealed class TelegramChannelAdapterTests
             factory);
     }
 
+    // ── Core markdown conversion: SendAsync ───────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WithBoldMarkdown_TextArrivesAsBoldMarkdownV2()
+    {
+        // THE CORE FEATURE TEST: verifies that LLM markdown (**bold**) is converted to
+        // Telegram MarkdownV2 (*bold*) before being sent to the API.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "**bold text**"
+        });
+
+        sendCall.ShouldNotBeNull();
+        sendCall!.Text.ShouldBe("*bold text*");
+        sendCall.ParseMode.ShouldBe("MarkdownV2");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithInlineCode_CodeSpanPreserved()
+    {
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "Run `git status` to check."
+        });
+
+        sendCall.ShouldNotBeNull();
+        // The inline code span is preserved; the dot after "check" is escaped.
+        sendCall!.Text.ShouldBe("Run `git status` to check\\.");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFencedCodeBlock_BlockPreservedAndMarkdownInsideNotConverted()
+    {
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "```csharp\nvar x = **1**;\n```"
+        });
+
+        sendCall.ShouldNotBeNull();
+        // ** inside code block must NOT be converted to Telegram bold.
+        sendCall!.Text.ShouldBe("```csharp\nvar x = **1**;\n```");
+    }
+
+    // ── Core markdown conversion: streaming ───────────────────────────────────
+
+    [Fact]
+    public async Task SendStreamEventAsync_ContentDeltaWithMarkdown_FinalTextIsConverted()
+    {
+        // Verifies that markdown in a ContentDelta event is converted to MarkdownV2 at MessageEnd flush.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            StreamingBufferMs = 60_000 // prevent time-based flush during test
+        }, handler);
+
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "**hello**" });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+
+        sendCall.ShouldNotBeNull();
+        // Raw markdown **hello** must be converted to MarkdownV2 *hello* at flush time.
+        sendCall!.Text.ShouldBe("*hello*");
+        sendCall.ParseMode.ShouldBe("MarkdownV2");
+    }
+
+    [Fact]
+    public async Task SendStreamEventAsync_MultiDeltaMarkdownToken_AssembledBeforeConversion()
+    {
+        // CRITICAL: verifies that formatting tokens split across multiple deltas are assembled
+        // BEFORE conversion, not escaped per delta. If escaping happened per delta, **bol would
+        // become \*\*bol and d** would become d\*\*, producing literal asterisks in the output.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            StreamingBufferMs = 60_000 // prevent time-based flush; only flush at MessageEnd
+        }, handler);
+
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        // Simulate streaming where **bold** arrives split across two deltas
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "**bol" });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "d**" });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        // Must be *bold* (bold converted), NOT \*\*bold\*\* (literal asterisks from per-delta escaping).
+        text.ShouldBe("*bold*");
+        text.ShouldNotContain("\\*");
+    }
+
+    [Fact]
+    public async Task SendStreamDeltaAsync_WithMarkdown_ConvertsAtFlush()
+    {
+        // SendStreamDeltaAsync buffers raw content and converts at flush threshold.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        // Send 100 chars of markdown — this hits the StreamingFlushThresholdChars (100) and triggers flush.
+        var boldContent = new string('x', 96);
+        var delta = $"**{boldContent}**"; // 100 chars total: 2 + 96 + 2
+        await adapter.SendStreamDeltaAsync("42", delta);
+
+        sendCall.ShouldNotBeNull();
+        // The raw ** must be converted to * (Telegram bold) at flush time, not escaped as \*.
+        sendCall!.Text.ShouldBe($"*{boldContent}*");
+        sendCall.ParseMode.ShouldBe("MarkdownV2");
+    }
+
+    // ── Streaming: tool and error events ────────────────────────────────────
+
+    [Fact]
+    public async Task SendStreamEventAsync_ToolStartEvent_EscapedInFinalMessage()
+    {
+        // Tool start events add [toolName] started to the raw buffer.
+        // At flush time, Convert() must escape [ and ] as literal chars and escape _ in tool names.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            StreamingBufferMs = 60_000
+        }, handler);
+
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolName = "memory_save" });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        // [memory_save] started → brackets escaped as \[ \], underscore escaped as \_
+        text.ShouldContain("\\[memory\\_save\\] started");
+    }
+
+    [Fact]
+    public async Task SendStreamEventAsync_ToolEndWithError_EscapedInFinalMessage()
+    {
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            StreamingBufferMs = 60_000
+        }, handler);
+
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent
+        {
+            Type = AgentStreamEventType.ToolEnd,
+            ToolName = "read_file",
+            ToolIsError = true
+        });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        text.ShouldContain("\\[read\\_file\\] failed");
+    }
+
+    [Fact]
+    public async Task SendStreamEventAsync_ErrorMessage_SpecialCharsEscaped()
+    {
+        // Error messages containing special chars must be escaped by Convert() at flush time.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            AllowedChatIds = { 42 },
+            StreamingBufferMs = 60_000,
+            ErrorCooldownMs = 0
+        }, handler);
+
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent
+        {
+            Type = AgentStreamEventType.Error,
+            ErrorMessage = "Connection failed. Retry 1/3"
+        });
+        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        // Dot and / must be escaped; ⚠️ emoji is not a MarkdownV2 special char.
+        text.ShouldContain("Connection failed\\. Retry 1/3");
+    }
+
+    // ── BuildOutboundText paths ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_WithDisplayPrefix_PrefixIsEscapedNotConverted()
+    {
+        // displayPrefix goes through EscapeMarkdownV2 (not Convert), so markdown
+        // tokens in the prefix render as literal text, not as formatting.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "response",
+            DisplayPrefix = "_agent_:" // looks like italic markdown in the prefix
+        });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        // EscapeMarkdownV2("_agent_:") must produce \_agent\_: — literal, not italic.
+        text.ShouldStartWith("\\_agent\\_:");
+        // Content is still converted normally.
+        text.ShouldContain("response");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithThinkingMetadata_ThinkingIsConverted()
+    {
+        // The "thinking" metadata value goes through Convert(), not EscapeMarkdownV2.
+        // Markdown formatting in thinking content must render as formatted text.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "answer",
+            Metadata = new Dictionary<string, object?> { ["thinking"] = "**deep thought**" }
+        });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        // thinking goes through Convert() → **deep thought** → *deep thought*
+        text.ShouldContain("Thinking: *deep thought*");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithToolCallMetadata_BracketsAreLiteralAndNameIsEscaped()
+    {
+        // The "toolCall" metadata value must appear with literal [ and ] brackets
+        // and the tool name must have underscores escaped.
+        ApiCall? sendCall = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+                sendCall = call;
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "done",
+            Metadata = new Dictionary<string, object?> { ["toolCall"] = "write_file" }
+        });
+
+        sendCall.ShouldNotBeNull();
+        var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
+        // The hardcoded \[ and \] produce literal brackets; EscapeMarkdownV2(write_file) → write\_file
+        text.ShouldContain("\\[write\\_file\\]");
+    }
+
+    // ── Fallback behavior ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_MarkdownV2RejectedWithMarkdownContent_FallbackSendsAlreadyConvertedText()
+    {
+        // When Telegram rejects MarkdownV2, the plain-text retry sends the already-converted
+        // MarkdownV2 text (e.g., *bold* instead of **bold**). This is expected behavior:
+        // the fallback is readable even if it shows MarkdownV2 syntax as literal characters.
+        var sendCalls = new List<ApiCall>();
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            var call = await ApiCall.FromRequestAsync(request, cancellationToken);
+            if (call.MethodName == "sendMessage")
+            {
+                sendCalls.Add(call);
+                if (sendCalls.Count == 1)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        Content = new StringContent(
+                            "{\"ok\":false,\"description\":\"Bad Request: can't parse entities\"}",
+                            Encoding.UTF8,
+                            "application/json")
+                    };
+                }
+            }
+
+            return JsonOk(new TelegramMessage { MessageId = 1, Chat = new TelegramChat { Id = 42 } });
+        });
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "**bold content**"
+        });
+
+        sendCalls.Count.ShouldBe(2);
+        sendCalls[0].ParseMode.ShouldBe("MarkdownV2");
+        sendCalls[0].Text.ShouldBe("*bold content*"); // already converted
+        sendCalls[1].ParseMode.ShouldBeNull(); // plain text retry — no parse_mode
+        // The fallback sends the converted MarkdownV2 text (not original **bold content**).
+        // This means * renders literally — acceptable degraded fallback.
+        sendCalls[1].Text.ShouldBe("*bold content*");
+    }
+
+    [Fact]
+    public async Task SendAsync_SendThrowsUnexpectedException_PropagatesException()
+    {
+        // Non-400 errors (e.g., network failures) must not be silently swallowed.
+        var handler = new StubHttpMessageHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent(
+                    "{\"ok\":false,\"description\":\"Internal Server Error\"}",
+                    Encoding.UTF8,
+                    "application/json")
+            }));
+
+        var adapter = CreateAdapter(new TelegramGatewayOptions { BotToken = "token", AllowedChatIds = { 42 } }, handler);
+
+        Func<Task> act = () => adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("telegram"),
+            ChannelAddress = ChannelAddress.From("42"),
+            Content = "hello"
+        });
+
+        await act.ShouldThrowAsync<Exception>();
+    }
+
     [Fact]
     public void BindsFromIConfiguration_WhenIOptionsIsEmpty()
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramMarkdownFormatterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramMarkdownFormatterTests.cs
@@ -1,0 +1,220 @@
+using BotNexus.Extensions.Channels.Telegram;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+public sealed class TelegramMarkdownFormatterTests
+{
+    // ─── EscapeMarkdownV2 ────────────────────────────────────────────────────
+
+    [Fact]
+    public void EscapeMarkdownV2_EmptyString_ReturnsEmpty()
+        => TelegramMarkdownFormatter.EscapeMarkdownV2("").ShouldBeEmpty();
+
+    [Fact]
+    public void EscapeMarkdownV2_NullString_ReturnsEmpty()
+        => TelegramMarkdownFormatter.EscapeMarkdownV2(null).ShouldBeEmpty();
+
+    [Fact]
+    public void EscapeMarkdownV2_PlainText_ReturnsUnchanged()
+        => TelegramMarkdownFormatter.EscapeMarkdownV2("hello world").ShouldBe("hello world");
+
+    [Theory]
+    [InlineData("_", "\\_")]
+    [InlineData("*", "\\*")]
+    [InlineData("[", "\\[")]
+    [InlineData("]", "\\]")]
+    [InlineData("(", "\\(")]
+    [InlineData(")", "\\)")]
+    [InlineData("~", "\\~")]
+    [InlineData("`", "\\`")]
+    [InlineData(">", "\\>")]
+    [InlineData("#", "\\#")]
+    [InlineData("+", "\\+")]
+    [InlineData("-", "\\-")]
+    [InlineData("=", "\\=")]
+    [InlineData("|", "\\|")]
+    [InlineData("{", "\\{")]
+    [InlineData("}", "\\}")]
+    [InlineData(".", "\\.")]
+    [InlineData("!", "\\!")]
+    [InlineData("\\", "\\\\")]
+    public void EscapeMarkdownV2_SpecialChar_IsEscaped(string input, string expected)
+        => TelegramMarkdownFormatter.EscapeMarkdownV2(input).ShouldBe(expected);
+
+    [Fact]
+    public void EscapeMarkdownV2_ToolNameWithUnderscore_EscapesUnderscore()
+        => TelegramMarkdownFormatter.EscapeMarkdownV2("memory_save").ShouldBe("memory\\_save");
+
+    // ─── Convert: empty / null ───────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_EmptyString_ReturnsEmpty()
+        => TelegramMarkdownFormatter.Convert("").ShouldBeEmpty();
+
+    [Fact]
+    public void Convert_NullString_ReturnsEmpty()
+        => TelegramMarkdownFormatter.Convert(null).ShouldBeEmpty();
+
+    // ─── Convert: plain text ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_PlainText_EscapesSpecialChars()
+    {
+        var result = TelegramMarkdownFormatter.Convert("Hello world. It costs $1.00!");
+        result.ShouldBe("Hello world\\. It costs $1\\.00\\!");
+    }
+
+    [Fact]
+    public void Convert_PlainTextNoSpecials_ReturnsUnchanged()
+        => TelegramMarkdownFormatter.Convert("hello world").ShouldBe("hello world");
+
+    // ─── Convert: bold ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_Bold_ConvertsTelegramBold()
+        => TelegramMarkdownFormatter.Convert("**bold text**").ShouldBe("*bold text*");
+
+    [Fact]
+    public void Convert_BoldMixedWithPlainText_ConvertsCorrectly()
+        => TelegramMarkdownFormatter.Convert("Hello **world** foo").ShouldBe("Hello *world* foo");
+
+    [Fact]
+    public void Convert_UnclosedBold_EscapesLiteral()
+        => TelegramMarkdownFormatter.Convert("**unclosed").ShouldBe("\\*\\*unclosed");
+
+    // ─── Convert: italic ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_ItalicStar_ConvertsTelegramItalic()
+        => TelegramMarkdownFormatter.Convert("*italic text*").ShouldBe("_italic text_");
+
+    [Fact]
+    public void Convert_ItalicUnderscore_PreservedAsTelegramItalic()
+        => TelegramMarkdownFormatter.Convert("_italic text_").ShouldBe("_italic text_");
+
+    [Fact]
+    public void Convert_UnclosedItalicStar_EscapesLiteral()
+        => TelegramMarkdownFormatter.Convert("*unclosed").ShouldBe("\\*unclosed");
+
+    [Fact]
+    public void Convert_UnclosedItalicUnderscore_EscapesLiteral()
+        => TelegramMarkdownFormatter.Convert("_unclosed").ShouldBe("\\_unclosed");
+
+    // ─── Convert: bold italic ────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_BoldItalic_ConvertsTelegramBoldItalic()
+        => TelegramMarkdownFormatter.Convert("***bold italic***").ShouldBe("*_bold italic_*");
+
+    // ─── Convert: strikethrough ──────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_Strikethrough_ConvertsSingleTilde()
+        => TelegramMarkdownFormatter.Convert("~~struck~~").ShouldBe("~struck~");
+
+    [Fact]
+    public void Convert_UnclosedStrikethrough_EscapesLiteral()
+        => TelegramMarkdownFormatter.Convert("~~unclosed").ShouldBe("\\~\\~unclosed");
+
+    // ─── Convert: inline code ────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_InlineCode_PreservesBackticks()
+        => TelegramMarkdownFormatter.Convert("`some code`").ShouldBe("`some code`");
+
+    [Fact]
+    public void Convert_InlineCode_EscapesBackslashInsideCode()
+        // Inside inline code, only \ and ` need escaping. \ → \\
+        => TelegramMarkdownFormatter.Convert("`code with \\ backslash`").ShouldBe("`code with \\\\ backslash`");
+
+    [Fact]
+    public void Convert_UnclosedInlineCode_EscapesOpeningBacktick()
+        => TelegramMarkdownFormatter.Convert("`unclosed").ShouldBe("\\`unclosed");
+
+    // ─── Convert: code block ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_CodeBlock_PreservesBlock()
+    {
+        var input = "```csharp\nvar x = 1;\n```";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        result.ShouldBe("```csharp\nvar x = 1;\n```");
+    }
+
+    [Fact]
+    public void Convert_CodeBlockNoLang_PreservesBlock()
+    {
+        var input = "```\nhello\n```";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        result.ShouldBe("```\nhello\n```");
+    }
+
+    [Fact]
+    public void Convert_UnclosedCodeBlock_EscapesOpeningFence()
+    {
+        var result = TelegramMarkdownFormatter.Convert("```no closing fence");
+        result.ShouldBe("\\`\\`\\`no closing fence");
+    }
+
+    // ─── Convert: links ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_Link_PreservesLinkFormat()
+        // Per Telegram spec, inside URL only ) and \ need escaping — . is NOT escaped in URLs.
+        => TelegramMarkdownFormatter.Convert("[GitHub](https://github.com)").ShouldBe("[GitHub](https://github.com)");
+
+    [Fact]
+    public void Convert_NotALink_EscapesBracket()
+        => TelegramMarkdownFormatter.Convert("[not a link]").ShouldBe("\\[not a link\\]");
+
+    // ─── Convert: headings ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_H1Heading_ConvertsToBold()
+        => TelegramMarkdownFormatter.Convert("# My Heading").ShouldBe("*My Heading*");
+
+    [Fact]
+    public void Convert_H2Heading_ConvertsToBold()
+        => TelegramMarkdownFormatter.Convert("## Section").ShouldBe("*Section*");
+
+    [Fact]
+    public void Convert_H3Heading_ConvertsToBold()
+        => TelegramMarkdownFormatter.Convert("### Sub").ShouldBe("*Sub*");
+
+    // ─── Convert: tool label lines (structural content) ─────────────────────
+
+    [Fact]
+    public void Convert_ToolLabel_EscapesLiteralBrackets()
+    {
+        // Tool labels like [memory_save] started must render as literal text,
+        // not as links or italic markers.
+        var result = TelegramMarkdownFormatter.Convert("[memory_save] started");
+        result.ShouldBe("\\[memory\\_save\\] started");
+    }
+
+    [Fact]
+    public void Convert_ToolLabel_WithUnderscore_EscapesUnderscore()
+    {
+        var result = TelegramMarkdownFormatter.Convert("[write_file] completed");
+        result.ShouldBe("\\[write\\_file\\] completed");
+    }
+
+    // ─── Convert: mixed content ──────────────────────────────────────────────
+
+    [Fact]
+    public void Convert_MixedContent_RendersCorrectly()
+    {
+        var input = "Here is **bold** and `code` and a [link](https://example.com).";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        // Per Telegram spec, . is not escaped inside link URLs — only ) and \ are.
+        result.ShouldBe("Here is *bold* and `code` and a [link](https://example.com)\\.");
+    }
+
+    [Fact]
+    public void Convert_MultilineContent_ProcessesEachLine()
+    {
+        var input = "# Title\n\nSome **bold** text.\n\n`code here`";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        result.ShouldBe("*Title*\n\nSome *bold* text\\.\n\n`code here`");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramMarkdownFormatterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramMarkdownFormatterTests.cs
@@ -217,4 +217,149 @@ public sealed class TelegramMarkdownFormatterTests
         var result = TelegramMarkdownFormatter.Convert(input);
         result.ShouldBe("*Title*\n\nSome *bold* text\\.\n\n`code here`");
     }
+
+    // ─── Convert: heading placement ──────────────────────────────────────────
+
+    [Fact]
+    public void Convert_HashMidLine_EscapesLiteralHash()
+    {
+        // A # that is not at the start of a line must not be treated as a heading.
+        var result = TelegramMarkdownFormatter.Convert("Not a # heading");
+        result.ShouldBe("Not a \\# heading");
+    }
+
+    [Fact]
+    public void Convert_HeadingOnSecondLine_ConvertsToBold()
+    {
+        // A heading on the second line (preceded by \n) must still be converted.
+        var result = TelegramMarkdownFormatter.Convert("intro\n# Section");
+        result.ShouldBe("intro\n*Section*");
+    }
+
+    // ─── Convert: multiple formatting spans ──────────────────────────────────
+
+    [Fact]
+    public void Convert_MultipleBoldSpans_BothConverted()
+    {
+        // Both bold spans in the same line must be individually converted.
+        var result = TelegramMarkdownFormatter.Convert("**one** and **two**");
+        result.ShouldBe("*one* and *two*");
+    }
+
+    [Fact]
+    public void Convert_AdjacentBoldAndItalic_BothConverted()
+    {
+        // No space between bold and italic tokens — both must still be converted.
+        var result = TelegramMarkdownFormatter.Convert("**bold**_italic_");
+        result.ShouldBe("*bold*_italic_");
+    }
+
+    // ─── Convert: special chars inside formatting spans ──────────────────────
+
+    [Fact]
+    public void Convert_BoldWithDotInContent_DotIsEscaped()
+    {
+        // Special chars inside bold content must be escaped per MarkdownV2 rules.
+        var result = TelegramMarkdownFormatter.Convert("**hello.world**");
+        result.ShouldBe("*hello\\.world*");
+    }
+
+    [Fact]
+    public void Convert_BoldWithUnderscoreInContent_UnderscoreIsEscaped()
+    {
+        // An underscore inside ** bold ** must not trigger italic processing.
+        var result = TelegramMarkdownFormatter.Convert("**hello_world**");
+        result.ShouldBe("*hello\\_world*");
+    }
+
+    [Fact]
+    public void Convert_ItalicWithSpecialCharsInContent_CharsAreEscaped()
+    {
+        var result = TelegramMarkdownFormatter.Convert("_cost: $1.00_");
+        result.ShouldBe("_cost: $1\\.00_");
+    }
+
+    // ─── Convert: code suppresses markdown processing ────────────────────────
+
+    [Fact]
+    public void Convert_FencedCodeBlock_PreservesInternalAsterisks()
+    {
+        // Inside a fenced code block, ** must NOT be converted to Telegram bold.
+        // Only backtick and backslash need escaping inside code blocks.
+        var input = "```\n**not bold**\n```";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        result.ShouldBe("```\n**not bold**\n```");
+    }
+
+    [Fact]
+    public void Convert_FencedCodeBlock_PreservesInternalUnderscores()
+    {
+        // Underscores inside a code block must not trigger italic processing.
+        var input = "```python\nsome_variable = True\n```";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        result.ShouldBe("```python\nsome_variable = True\n```");
+    }
+
+    [Fact]
+    public void Convert_InlineCode_PreservesInternalAsterisks()
+    {
+        // Inside a backtick span, * must NOT be converted.
+        var result = TelegramMarkdownFormatter.Convert("`*not italic*`");
+        result.ShouldBe("`*not italic*`");
+    }
+
+    [Fact]
+    public void Convert_InlineCode_PreservesInternalSpecialChars()
+    {
+        // Most MarkdownV2 special chars are NOT escaped inside inline code.
+        var result = TelegramMarkdownFormatter.Convert("`x.y[0]`");
+        result.ShouldBe("`x.y[0]`");
+    }
+
+    // ─── Convert: empty / degenerate formatting tokens ───────────────────────
+
+    [Fact]
+    public void Convert_EmptyBoldSpan_DoesNotThrow()
+    {
+        // Two consecutive ** pairs with nothing between them must not crash.
+        var act = () => TelegramMarkdownFormatter.Convert("****");
+        act.ShouldNotThrow();
+    }
+
+    [Fact]
+    public void Convert_BoldWithNoClosingOnSameLine_EscapesAsterisks()
+    {
+        // An opening ** followed by content but no closing ** should be treated as
+        // literal characters — not leave dangling MarkdownV2 syntax.
+        var result = TelegramMarkdownFormatter.Convert("** not bold");
+        result.ShouldNotContain("**");
+    }
+
+    // ─── Convert: real LLM output patterns ───────────────────────────────────
+
+    [Fact]
+    public void Convert_NumberedListItem_EscapesDot()
+    {
+        // Numbered list items like "1. Item" — the dot after a digit must be escaped
+        // because "." is a MarkdownV2 special char.
+        var result = TelegramMarkdownFormatter.Convert("1. First item\n2. Second item");
+        result.ShouldBe("1\\. First item\n2\\. Second item");
+    }
+
+    [Fact]
+    public void Convert_BulletListItem_EscapesDash()
+    {
+        // Unordered list items starting with "- " — the dash must be escaped.
+        var result = TelegramMarkdownFormatter.Convert("- item one\n- item two");
+        result.ShouldBe("\\- item one\n\\- item two");
+    }
+
+    [Fact]
+    public void Convert_LlmTypicalOutput_RendersCorrectly()
+    {
+        // Typical LLM output mixing bold headers, inline code, and plain text.
+        var input = "**Summary**\n\nUse `git status` to check changes. Cost: $0.00.";
+        var result = TelegramMarkdownFormatter.Convert(input);
+        result.ShouldBe("*Summary*\n\nUse `git status` to check changes\\. Cost: $0\\.00\\.");
+    }
 }


### PR DESCRIPTION
## What

Enables proper Telegram markdown rendering by switching from `parse_mode=HTML` (which was never actually converting markdown) to `parse_mode=MarkdownV2` with a proper LLM-markdown→MarkdownV2 converter.

## Root cause

The adapter was sending raw LLM output with `parse_mode=HTML` but only calling `EscapeHtml()` — never actually converting `**bold**` to `<b>bold</b>`. So users saw literal asterisks.

## Solution

- **`TelegramMarkdownFormatter`** — new converter that translates LLM markdown to Telegram MarkdownV2: `**bold**` → `*bold*`, `*italic*` → `_italic_`, `` `code` `` preserved, fenced code blocks preserved, `# Headings` → `*bold*`, links preserved, all other special chars escaped per MarkdownV2 rules
- **`TelegramBotApiClient`** — switched to `parse_mode=MarkdownV2`; retains plain-text fallback when Telegram rejects the parse (400 → retry without parse_mode)  
- **`TelegramChannelAdapter`** — streaming path now **buffers raw content** and converts at flush time, so formatting tokens split across multiple LLM deltas (e.g. `**bol` + `d**`) are assembled before conversion

## Key design choices

- **Buffer-then-convert** for streaming: per-delta escaping would corrupt multi-delta tokens like `**bold**` → `\*\*bol` + `d\*\*`
- **Separate escape paths**: structural text (displayPrefix, toolCall brackets) uses `EscapeMarkdownV2()`; LLM content uses `Convert()` so markdown renders
- **Fallback retained**: if MarkdownV2 is rejected by Telegram, the already-converted text is resent without parse_mode

## Test coverage

- 30 formatter unit tests (edge cases: headings, bold/italic, code blocks, links, mixed content, tool labels)
- 18 adapter integration tests including:
  - **Core feature**: `SendAsync **bold** → *bold*` in API call
  - **Critical multi-delta test**: `**bol` + `d**` assembled before conversion → `*bold*` (not `\*\*bold\*\*`)
  - Streaming path converts at flush time
  - `SendStreamDeltaAsync` converts at threshold flush
  - Tool/error events properly escaped
  - displayPrefix is escaped (not converted)
  - thinking/toolCall metadata paths
  - MarkdownV2 rejection fallback behaviour
  - 500 errors propagate as exceptions

Closes #322