### PR TITLE
feat(security): redact secrets at write time and enforce sub-agent spawn policy

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Security;
 
 namespace BotNexus.Gateway.Abstractions.Models;
 
@@ -12,15 +13,17 @@ public sealed class GatewaySession
     private readonly Lock _runtimeLock = new();
     private GatewaySessionRuntime? _runtime;
     private string? _callerId;
+    private readonly ISecretRedactor? _redactor;
 
     public GatewaySession()
-        : this(new Session())
+        : this(new Session(), null)
     {
     }
 
-    public GatewaySession(Session session)
+    public GatewaySession(Session session, ISecretRedactor? redactor = null)
     {
         Session = session ?? throw new ArgumentNullException(nameof(session));
+        _redactor = redactor;
     }
 
     /// <summary>Domain session state for persistence.</summary>
@@ -151,11 +154,11 @@ public sealed class GatewaySession
     /// </summary>
     public SessionReplayBuffer ReplayBuffer => Runtime.ReplayBuffer;
 
-    /// <summary>Thread-safe append to conversation history.</summary>
-    public void AddEntry(SessionEntry entry) => Runtime.AddEntry(entry);
+    /// <summary>Thread-safe append to conversation history. Content is redacted before storage when a redactor is configured.</summary>
+    public void AddEntry(SessionEntry entry) => Runtime.AddEntry(Redact(entry));
 
-    /// <summary>Thread-safe append of multiple entries.</summary>
-    public void AddEntries(IEnumerable<SessionEntry> entries) => Runtime.AddEntries(entries);
+    /// <summary>Thread-safe append of multiple entries. Content is redacted before storage when a redactor is configured.</summary>
+    public void AddEntries(IEnumerable<SessionEntry> entries) => Runtime.AddEntries(entries.Select(Redact));
 
     /// <summary>Replaces the session history with a compacted version.</summary>
     public void ReplaceHistory(IReadOnlyList<SessionEntry> compactedEntries) => Runtime.ReplaceHistory(compactedEntries);
@@ -210,6 +213,21 @@ public sealed class GatewaySession
     /// <param name="session">The session.</param>
     /// <returns>The from session result.</returns>
     public static GatewaySession FromSession(Session session) => new(session);
+
+    // Applies the injected redactor to sensitive fields before the entry is stored.
+    private SessionEntry Redact(SessionEntry entry)
+    {
+        if (_redactor is null)
+            return entry;
+
+        var redactedContent = _redactor.Redact(entry.Content);
+        var redactedArgs = entry.ToolArgs is null ? null : _redactor.Redact(entry.ToolArgs);
+
+        if (ReferenceEquals(redactedContent, entry.Content) && ReferenceEquals(redactedArgs, entry.ToolArgs))
+            return entry;
+
+        return entry with { Content = redactedContent, ToolArgs = redactedArgs };
+    }
 }
 
 /// <summary>

--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
@@ -61,4 +61,17 @@ public sealed record SubAgentSpawnRequest
     /// Gets the behavioral archetype to apply to the sub-agent.
     /// </summary>
     public SubAgentArchetype Archetype { get; init; } = SubAgentArchetype.General;
+
+    /// <summary>
+    /// Gets the spawn depth of this request within the sub-agent tree.
+    /// Zero means the parent is a top-level session; one means the parent is itself a sub-agent.
+    /// Used to enforce <see cref="BotNexus.Gateway.Configuration.SubAgentOptions.MaxDepth"/>.
+    /// </summary>
+    public int SpawnDepth { get; init; }
+
+    /// <summary>
+    /// Gets the union of tool names that the parent agent is denied, inherited from the
+    /// parent's effective deny-list. The spawned sub-agent must not be granted any of these tools.
+    /// </summary>
+    public IReadOnlyList<string>? ParentToolDenyList { get; init; }
 }

--- a/src/domain/BotNexus.Domain/Gateway/Security/ISecretRedactor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Security/ISecretRedactor.cs
@@ -1,0 +1,15 @@
+namespace BotNexus.Gateway.Abstractions.Security;
+
+/// <summary>
+/// Redacts secret-shaped values from text before it is written to the session store.
+/// Applied inline at every transcript append and compaction summary write to prevent
+/// credentials, API keys, and tokens from being persisted unredacted.
+/// </summary>
+public interface ISecretRedactor
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="input"/> with any detected secrets replaced
+    /// by <c>[REDACTED]</c>. Returns the original string unchanged when no secrets are detected.
+    /// </summary>
+    string Redact(string input);
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -7,6 +7,7 @@ using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
 using Microsoft.Extensions.Logging;
 
@@ -38,17 +39,19 @@ public sealed class FileSessionStore : SessionStoreBase
     private readonly SemaphoreSlim _lock = new(1, 1);
     private readonly Dictionary<SessionId, GatewaySession> _cache = [];
     private readonly ILogger<FileSessionStore> _logger;
+    private readonly ISecretRedactor? _redactor;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public FileSessionStore(string storePath, ILogger<FileSessionStore> logger, IFileSystem fileSystem)
+    public FileSessionStore(string storePath, ILogger<FileSessionStore> logger, IFileSystem fileSystem, ISecretRedactor? redactor = null)
     {
         _storePath = storePath;
         _logger = logger;
         _fileSystem = fileSystem;
+        _redactor = redactor;
         _fileSystem.Directory.CreateDirectory(storePath);
     }
 
@@ -89,7 +92,7 @@ public sealed class FileSessionStore : SessionStoreBase
                 return loaded;
             }
 
-            var session = CreateSession(sessionId, agentId, null);
+            var session = CreateSession(sessionId, agentId, null, _redactor);
             _cache[sessionId] = session;
             return session;
         }
@@ -180,18 +183,20 @@ public sealed class FileSessionStore : SessionStoreBase
             cancellationToken).ConfigureAwait(false);
         if (meta is null) return null;
 
-        var session = new GatewaySession
+        var session = new GatewaySession(new Session
         {
             SessionId = sessionId,
             AgentId = meta.AgentId,
             ChannelType = meta.ChannelType,
-            CallerId = meta.CallerId,
             SessionType = meta.SessionType ?? InferSessionType(sessionId, meta.ChannelType),
             Participants = meta.Participants ?? [],
             CreatedAt = meta.CreatedAt,
             UpdatedAt = meta.UpdatedAt,
             Status = meta.Status,
             ExpiresAt = meta.ExpiresAt
+        }, _redactor)
+        {
+            CallerId = meta.CallerId
         };
         session.SetStreamReplayState(meta.NextSequenceId, meta.StreamEvents);
 

--- a/src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
 
 namespace BotNexus.Gateway.Sessions;
@@ -14,6 +15,16 @@ public sealed class InMemorySessionStore : SessionStoreBase
     private static readonly ActivitySource ActivitySource = new("BotNexus.Gateway");
     private readonly Dictionary<SessionId, GatewaySession> _sessions = [];
     private readonly Lock _sync = new();
+    private readonly ISecretRedactor? _redactor;
+
+    /// <summary>Creates an in-memory session store without secret redaction.</summary>
+    public InMemorySessionStore() : this(null) { }
+
+    /// <summary>Creates an in-memory session store that redacts secrets at write time.</summary>
+    public InMemorySessionStore(ISecretRedactor? redactor)
+    {
+        _redactor = redactor;
+    }
 
     /// <inheritdoc />
     public override Task<GatewaySession?> GetAsync(SessionId sessionId, CancellationToken cancellationToken = default)
@@ -34,7 +45,7 @@ public sealed class InMemorySessionStore : SessionStoreBase
             if (_sessions.TryGetValue(sessionId, out var existing))
                 return Task.FromResult(existing);
 
-            var session = CreateSession(sessionId, agentId, null);
+            var session = CreateSession(sessionId, agentId, null, _redactor);
             _sessions[sessionId] = session;
             return Task.FromResult(session);
         }

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -1,5 +1,6 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
 
 namespace BotNexus.Gateway.Sessions;
@@ -71,14 +72,14 @@ public abstract class SessionStoreBase : ISessionStore
         return result.ToList();
     }
 
-    protected static GatewaySession CreateSession(SessionId sessionId, AgentId agentId, ChannelKey? channelType)
-        => new()
+    protected static GatewaySession CreateSession(SessionId sessionId, AgentId agentId, ChannelKey? channelType, ISecretRedactor? redactor = null)
+        => new(new Session
         {
             SessionId = sessionId,
             AgentId = agentId,
             ChannelType = channelType,
             SessionType = InferSessionType(sessionId, channelType)
-        };
+        }, redactor);
 
     protected static SessionType InferSessionType(SessionId sessionId, ChannelKey? channelType)
     {

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -9,6 +9,7 @@ using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
     private readonly IConversationStore? _conversationStore;
     private readonly ILogger<SqliteSessionStore> _logger;
+    private readonly ISecretRedactor? _redactor;
 
     /// <summary>
     /// Initialises a new <see cref="SqliteSessionStore"/>.
@@ -49,14 +51,17 @@ public sealed class SqliteSessionStore : SessionStoreBase
     /// When provided, a startup migration links any orphaned sessions (those with no
     /// <c>conversation_id</c>) to their agent's default conversation.
     /// </param>
+    /// <param name="redactor">When provided, secrets in content are redacted before storage.</param>
     public SqliteSessionStore(
         string connectionString,
         ILogger<SqliteSessionStore> logger,
-        IConversationStore? conversationStore = null)
+        IConversationStore? conversationStore = null,
+        ISecretRedactor? redactor = null)
     {
         _connectionString = connectionString;
         _logger = logger;
         _conversationStore = conversationStore;
+        _redactor = redactor;
     }
 
     /// <inheritdoc />
@@ -104,7 +109,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 return loaded;
             }
 
-            var session = CreateSession(sessionId, agentId, null);
+            var session = CreateSession(sessionId, agentId, null, _redactor);
             _cache[sessionId] = session;
             return session;
         }
@@ -207,7 +212,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
         {
             var sessionId = SessionId.From(reader.GetString(0));
             var session = _cache.GetValueOrDefault(sessionId)
-                ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
+                ?? await LoadSessionAsync(connection, sessionId, _redactor, cancellationToken).ConfigureAwait(false);
             if (session is not null)
             {
                 _cache[sessionId] = session;
@@ -424,10 +429,10 @@ public sealed class SqliteSessionStore : SessionStoreBase
     {
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        return await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
+        return await LoadSessionAsync(connection, sessionId, _redactor, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<GatewaySession?> LoadSessionAsync(SqliteConnection connection, SessionId sessionId, CancellationToken cancellationToken)
+    private static async Task<GatewaySession?> LoadSessionAsync(SqliteConnection connection, SessionId sessionId, ISecretRedactor? redactor, CancellationToken cancellationToken)
     {
         await using var sessionCommand = connection.CreateCommand();
         sessionCommand.CommandText = """
@@ -458,20 +463,23 @@ public sealed class SqliteSessionStore : SessionStoreBase
         if (reader.FieldCount > 10 && !reader.IsDBNull(10))
             conversationId = ConversationId.From(reader.GetString(10));
 
-        var session = new GatewaySession
+        var domainSession = new Session
         {
             SessionId = SessionId.From(reader.GetString(0)),
             AgentId = AgentId.From(agentIdValue),
             ChannelType = channelType,
-            CallerId = reader.IsDBNull(3) ? null : reader.GetString(3),
             SessionType = sessionType,
             Participants = participants,
             Status = status,
             CreatedAt = createdAt,
             UpdatedAt = updatedAt,
-            Metadata = metadata
+            Metadata = metadata,
+            ConversationId = conversationId
         };
-        session.Session.ConversationId = conversationId;
+        var session = new GatewaySession(domainSession, redactor)
+        {
+            CallerId = reader.IsDBNull(3) ? null : reader.GetString(3)
+        };
 
         await reader.DisposeAsync().ConfigureAwait(false);
 

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Diagnostics;
+using BotNexus.Gateway.Security;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
     private readonly IAgentWorkspaceManager? _workspaceManager;
     private readonly IOptionsMonitor<GatewayOptions> _options;
     private readonly ILogger<DefaultSubAgentManager> _logger;
+    private readonly DefaultToolPolicyProvider? _policyProvider;
     private readonly ConcurrentDictionary<string, SubAgentInfo> _subAgents = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<SessionId, ConcurrentBag<string>> _parentChildren = [];
     private readonly ConcurrentDictionary<string, AgentId> _parentAgentIds = new(StringComparer.OrdinalIgnoreCase);
@@ -38,7 +40,8 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         IChannelDispatcher dispatcher,
         IOptionsMonitor<GatewayOptions> options,
         ILogger<DefaultSubAgentManager> logger,
-        IAgentWorkspaceManager? workspaceManager = null)
+        IAgentWorkspaceManager? workspaceManager = null,
+        DefaultToolPolicyProvider? policyProvider = null)
     {
         _supervisor = supervisor;
         _registry = registry;
@@ -47,6 +50,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         _workspaceManager = workspaceManager;
         _options = options;
         _logger = logger;
+        _policyProvider = policyProvider;
     }
 
     /// <inheritdoc />
@@ -56,6 +60,31 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
 
         var parentDescriptor = _registry.Get(request.ParentAgentId)
             ?? throw new KeyNotFoundException($"Parent agent '{request.ParentAgentId}' is not registered.");
+
+        // Enforce spawn depth limit
+        var maxDepth = _options.CurrentValue.SubAgents.MaxDepth;
+        if (maxDepth > 0)
+        {
+            var depth = CountSubAgentDepth(request.ParentSessionId);
+            if (depth >= maxDepth)
+                throw new InvalidOperationException(
+                    $"Cannot spawn sub-agent: parent session depth {depth} has reached the maximum depth of {maxDepth}.");
+        }
+
+        // Validate tool grants against parent's deny-list (privilege escalation prevention)
+        if (_policyProvider is not null && request.ToolIds is { Count: > 0 })
+        {
+            var parentDenyList = _policyProvider.GetEffectiveDenyList(request.ParentAgentId.Value);
+            if (parentDenyList.Count > 0)
+            {
+                var denied = request.ToolIds
+                    .Where(t => parentDenyList.Contains(t, StringComparer.OrdinalIgnoreCase))
+                    .ToList();
+                if (denied.Count > 0)
+                    throw new InvalidOperationException(
+                        $"Sub-agent cannot be granted tools denied to the parent: {string.Join(", ", denied)}");
+            }
+        }
 
         var maxConcurrent = _options.CurrentValue.SubAgents.MaxConcurrentPerSession;
         if (maxConcurrent > 0)
@@ -110,6 +139,14 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         _parentAgentIds[subAgentId] = request.ParentAgentId;
         _childAgentIds[subAgentId] = childAgentId;
         _parentChildren.GetOrAdd(request.ParentSessionId, _ => []).Add(subAgentId);
+
+        // Register inherited deny-list so the child agent can't invoke parent-denied tools
+        if (_policyProvider is not null)
+        {
+            var effectiveDenyList = _policyProvider.GetEffectiveDenyList(request.ParentAgentId.Value);
+            if (effectiveDenyList.Count > 0)
+                _policyProvider.SetDynamicDenyList(childAgentId, effectiveDenyList);
+        }
 
         var timeoutSeconds = request.TimeoutSeconds > 0
             ? request.TimeoutSeconds
@@ -452,6 +489,9 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         if (!_childAgentIds.TryRemove(subAgentId, out var childAgentId))
             return;
 
+        // Remove the dynamic deny-list registered for this ephemeral sub-agent
+        _policyProvider?.RemoveDynamicDenyList(childAgentId);
+
         try
         {
             await _supervisor.StopAsync(childAgentId, childSessionId, ct);
@@ -488,5 +528,23 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
                 "Failed cleaning temporary workspace for child agent '{ChildAgentId}'.",
                 childAgentId);
         }
+    }
+
+    /// <summary>
+    /// Counts the sub-agent nesting depth encoded in a session ID.
+    /// A top-level session has depth 0; each <c>::subagent::</c> separator adds one level.
+    /// </summary>
+    private static int CountSubAgentDepth(SessionId sessionId)
+    {
+        const string separator = "::subagent::";
+        var value = sessionId.Value;
+        var depth = 0;
+        var searchFrom = 0;
+        while ((searchFrom = value.IndexOf(separator, searchFrom, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            depth++;
+            searchFrom += separator.Length;
+        }
+        return depth;
     }
 }

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -155,6 +155,7 @@ public static class GatewayServiceCollectionExtensions
         services.TryAddSingleton<DefaultToolPolicyProvider>();
         services.TryAddSingleton<IToolPolicyProvider>(sp => sp.GetRequiredService<DefaultToolPolicyProvider>());
         services.AddSingleton<ToolPolicyHookHandler>();
+        services.TryAddSingleton<ISecretRedactor, SecretRedactor>();
 
         // Built-in isolation strategies
         services.AddSingleton<IIsolationStrategy, InProcessIsolationStrategy>();

--- a/src/gateway/BotNexus.Gateway/Security/DefaultToolPolicyProvider.cs
+++ b/src/gateway/BotNexus.Gateway/Security/DefaultToolPolicyProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Logging;
@@ -31,6 +32,9 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
 
     private readonly ConcurrentDictionary<string, byte> _mcpServerIds = new(StringComparer.OrdinalIgnoreCase);
 
+    // Dynamic deny-lists for ephemeral sub-agents that have no PlatformConfig entry.
+    private readonly ConcurrentDictionary<string, IReadOnlyList<string>> _dynamicDenyLists = new(StringComparer.OrdinalIgnoreCase);
+
     private readonly IOptionsMonitor<PlatformConfig> _config;
     private readonly ILogger<DefaultToolPolicyProvider> _logger;
 
@@ -51,6 +55,45 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
         ArgumentException.ThrowIfNullOrWhiteSpace(serverId);
         _mcpServerIds.TryAdd(serverId, 0);
         _logger.LogDebug("Registered MCP server ID '{ServerId}' for tool policy", serverId);
+    }
+
+    /// <summary>
+    /// Sets the effective deny-list for an ephemeral sub-agent session.
+    /// Called when a sub-agent is spawned to propagate the parent's restrictions.
+    /// </summary>
+    public void SetDynamicDenyList(AgentId agentId, IReadOnlyList<string> denyList)
+    {
+        _dynamicDenyLists[agentId.Value] = denyList;
+        _logger.LogDebug("Set dynamic deny-list ({Count} entries) for sub-agent '{AgentId}'", denyList.Count, agentId);
+        OnDynamicDenyListSet?.Invoke(agentId, denyList);
+    }
+
+    /// <summary>
+    /// Removes the dynamic deny-list for a sub-agent session when it is torn down.
+    /// </summary>
+    public void RemoveDynamicDenyList(AgentId agentId)
+    {
+        if (_dynamicDenyLists.TryRemove(agentId.Value, out _))
+            _logger.LogDebug("Removed dynamic deny-list for sub-agent '{AgentId}'", agentId);
+    }
+
+    /// <summary>
+    /// Test hook: invoked after each successful <see cref="SetDynamicDenyList"/> call.
+    /// Allows tests to verify the child deny-list without requiring a full DI setup.
+    /// </summary>
+    internal Action<AgentId, IReadOnlyList<string>>? OnDynamicDenyListSet { get; set; }
+
+    /// <summary>
+    /// Returns the union of the static config deny-list and any dynamic deny-list for the given agent.
+    /// </summary>
+    public IReadOnlyList<string> GetEffectiveDenyList(string agentId)
+    {
+        var agentPolicy = GetAgentToolPolicy(agentId);
+        var configDenied = agentPolicy?.Denied ?? [];
+        if (!_dynamicDenyLists.TryGetValue(agentId, out var dynamic))
+            return configDenied;
+
+        return configDenied.Union(dynamic, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>
@@ -110,6 +153,7 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
 
     /// <summary>
     /// Checks whether a tool is completely blocked for a specific agent.
+    /// Checks both static config deny-lists and runtime dynamic deny-lists (for sub-agents).
     /// Supports MCP wildcard deny via <c>serverId_*</c> patterns in the denied list.
     /// </summary>
     internal bool IsDenied(string toolName, string? agentId)
@@ -117,12 +161,13 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
         if (agentId is null)
             return false;
 
-        var agentPolicy = GetAgentToolPolicy(agentId);
-        if (agentPolicy?.Denied is null)
-            return false;
+        return IsInDenyList(toolName, GetEffectiveDenyList(agentId));
+    }
 
+    private static bool IsInDenyList(string toolName, IReadOnlyList<string> denied)
+    {
         // Exact match
-        if (agentPolicy.Denied.Contains(toolName, StringComparer.OrdinalIgnoreCase))
+        if (denied.Contains(toolName, StringComparer.OrdinalIgnoreCase))
             return true;
 
         // Wildcard server-level deny: "serverId_*" blocks all tools from that server
@@ -131,7 +176,7 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
         {
             var serverPrefix = toolName[..underscoreIdx];
             var wildcardPattern = $"{serverPrefix}_*";
-            if (agentPolicy.Denied.Contains(wildcardPattern, StringComparer.OrdinalIgnoreCase))
+            if (denied.Contains(wildcardPattern, StringComparer.OrdinalIgnoreCase))
                 return true;
         }
 

--- a/src/gateway/BotNexus.Gateway/Security/SecretRedactor.cs
+++ b/src/gateway/BotNexus.Gateway/Security/SecretRedactor.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+using BotNexus.Gateway.Abstractions.Security;
+
+namespace BotNexus.Gateway.Security;
+
+/// <summary>
+/// Applies compiled regex patterns for common secret formats to redact credentials
+/// from text before it is written to the session store. Each matched value is
+/// replaced with <c>[REDACTED]</c>.
+/// </summary>
+public sealed partial class SecretRedactor : ISecretRedactor
+{
+    // Patterns are applied in order; more-specific patterns appear before generic ones.
+    private static readonly Regex[] Patterns =
+    [
+        // OpenAI project keys (sk-proj-...)
+        OpenAiProjectKeyRegex(),
+
+        // OpenAI legacy keys (sk-...) — must come after project key to avoid partial matches
+        OpenAiLegacyKeyRegex(),
+
+        // Anthropic API keys (sk-ant-...)
+        AnthropicKeyRegex(),
+
+        // GitHub fine-grained personal access token (github_pat_...)
+        GitHubFineGrainedPatRegex(),
+
+        // GitHub classic tokens: ghp_, ghs_, gho_
+        GitHubClassicTokenRegex(),
+
+        // AWS access key IDs (AKIA...)
+        AwsAccessKeyRegex(),
+
+        // Google API keys (AIza...)
+        GoogleApiKeyRegex(),
+
+        // Slack tokens (xox...)
+        SlackTokenRegex(),
+
+        // Stripe live/test secret keys (sk_live_, sk_test_)
+        StripeSecretKeyRegex(),
+
+        // Authorization: Bearer <token> HTTP headers
+        AuthorizationBearerRegex(),
+
+        // Generic api_key / api-key = <value> patterns in text
+        GenericApiKeyRegex(),
+    ];
+
+    /// <inheritdoc />
+    public string Redact(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input;
+
+        var result = input;
+        foreach (var pattern in Patterns)
+            result = pattern.Replace(result, "[REDACTED]");
+
+        return result;
+    }
+
+    // ──────────────────── Compiled regex factories ────────────────────
+
+    [GeneratedRegex(@"sk-proj-[A-Za-z0-9_\-]{40,}", RegexOptions.Compiled)]
+    private static partial Regex OpenAiProjectKeyRegex();
+
+    [GeneratedRegex(@"sk-[A-Za-z0-9]{48,}", RegexOptions.Compiled)]
+    private static partial Regex OpenAiLegacyKeyRegex();
+
+    [GeneratedRegex(@"sk-ant-[A-Za-z0-9_\-]{40,}", RegexOptions.Compiled)]
+    private static partial Regex AnthropicKeyRegex();
+
+    [GeneratedRegex(@"github_pat_[A-Za-z0-9_]{59,}", RegexOptions.Compiled)]
+    private static partial Regex GitHubFineGrainedPatRegex();
+
+    [GeneratedRegex(@"gh[pso]_[A-Za-z0-9]{36}", RegexOptions.Compiled)]
+    private static partial Regex GitHubClassicTokenRegex();
+
+    [GeneratedRegex(@"AKIA[0-9A-Z]{16}", RegexOptions.Compiled)]
+    private static partial Regex AwsAccessKeyRegex();
+
+    [GeneratedRegex(@"AIza[0-9A-Za-z\-_]{35}", RegexOptions.Compiled)]
+    private static partial Regex GoogleApiKeyRegex();
+
+    [GeneratedRegex(@"xox[bprao]-[A-Za-z0-9\-]+", RegexOptions.Compiled)]
+    private static partial Regex SlackTokenRegex();
+
+    [GeneratedRegex(@"sk_(live|test)_[A-Za-z0-9]{20,}", RegexOptions.Compiled)]
+    private static partial Regex StripeSecretKeyRegex();
+
+    // Capture group 1 = prefix up to and including "Bearer "; group 2 = the token itself.
+    // Replace entire match so the header name is preserved: "Authorization: Bearer [REDACTED]"
+    [GeneratedRegex(@"(Authorization:\s*Bearer\s+)[A-Za-z0-9+/=._\-]{20,}", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex AuthorizationBearerRegex();
+
+    // Handles: api_key=VALUE, api-key: VALUE, apiKey=VALUE  (case-insensitive key name)
+    [GeneratedRegex(@"(?i)api[_\-]?key\s*[=:]\s*[A-Za-z0-9+/=._\-]{20,}", RegexOptions.Compiled)]
+    private static partial Regex GenericApiKeyRegex();
+}

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Domain.Primitives;
 using BotNexus.Agent.Providers.Core;
@@ -20,11 +21,13 @@ public sealed class LlmSessionCompactor : ISessionCompactor
 
     private readonly LlmClient _llmClient;
     private readonly ILogger<LlmSessionCompactor> _logger;
+    private readonly ISecretRedactor? _redactor;
 
-    public LlmSessionCompactor(LlmClient llmClient, ILogger<LlmSessionCompactor> logger)
+    public LlmSessionCompactor(LlmClient llmClient, ILogger<LlmSessionCompactor> logger, ISecretRedactor? redactor = null)
     {
         _llmClient = llmClient;
         _logger = logger;
+        _redactor = redactor;
     }
 
     public bool ShouldCompact(Session session, CompactionOptions options)
@@ -73,6 +76,10 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         {
             summary = summary[..options.MaxSummaryChars];
         }
+
+        // Redact any secrets that leaked into the LLM summary before persisting.
+        if (_redactor is not null)
+            summary = _redactor.Redact(summary);
 
         var compactionEntry = new SessionEntry
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnDepthTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnDepthTests.cs
@@ -1,0 +1,143 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Verifies that <see cref="DefaultSubAgentManager"/> enforces the configured maximum
+/// spawn depth, preventing unbounded sub-agent trees.
+/// </summary>
+public sealed class SubAgentSpawnDepthTests
+{
+    [Fact]
+    public async Task SpawnAsync_AtMaxDepth_ThrowsInvalidOperation()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        // MaxDepth = 1 means a sub-agent (depth 1 session) cannot spawn further sub-agents
+        var manager = CreateManager(supervisor.Object, maxDepth: 1);
+
+        // Simulate a request from inside an already-spawned sub-agent session
+        var subAgentParentSessionId = SessionId.ForSubAgent("root-session", "existing-sub");
+        var request = CreateSpawnRequest(parentSessionId: subAgentParentSessionId);
+
+        Func<Task> act = () => manager.SpawnAsync(request);
+
+        (await act.ShouldThrowAsync<InvalidOperationException>())
+            .Message.ShouldContain("depth");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_BelowMaxDepth_Succeeds()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        // MaxDepth = 2 means sub-agents can themselves spawn sub-agents (depth up to 2)
+        var manager = CreateManager(supervisor.Object, maxDepth: 2);
+
+        // A top-level session (depth 0) can spawn sub-agents
+        var topLevelRequest = CreateSpawnRequest(parentSessionId: SessionId.From("root-session"));
+        var result = await manager.SpawnAsync(topLevelRequest);
+
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe(SubAgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_MaxDepthZero_NeverEnforced()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        // MaxDepth = 0 means unlimited
+        var manager = CreateManager(supervisor.Object, maxDepth: 0);
+
+        // Even deeply nested sessions should spawn without error
+        var deepSessionId = SessionId.From("root::subagent::a::subagent::b::subagent::c");
+        var request = CreateSpawnRequest(parentSessionId: deepSessionId);
+
+        var result = await manager.SpawnAsync(request);
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task SpawnAsync_TopLevelSession_MaxDepth1_Succeeds()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        // MaxDepth = 1: top-level sessions (depth 0) CAN spawn sub-agents
+        var manager = CreateManager(supervisor.Object, maxDepth: 1);
+        var request = CreateSpawnRequest(parentSessionId: SessionId.From("root-session"));
+
+        var result = await manager.SpawnAsync(request);
+        result.ShouldNotBeNull();
+    }
+
+    private static DefaultSubAgentManager CreateManager(IAgentSupervisor supervisor, int maxDepth)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry
+            .Setup(r => r.Get(It.IsAny<AgentId>()))
+            .Returns(new AgentDescriptor
+            {
+                AgentId = AgentId.From("parent-agent"),
+                DisplayName = "Parent Agent",
+                ModelId = "gpt-5-mini",
+                ApiProvider = "openai"
+            });
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var options = new TestOptionsMonitor<GatewayOptions>(new GatewayOptions
+        {
+            SubAgents = new SubAgentOptions { MaxDepth = maxDepth }
+        });
+
+        return new DefaultSubAgentManager(
+            supervisor,
+            registry.Object,
+            new Mock<BotNexus.Gateway.Abstractions.Activity.IActivityBroadcaster>().Object,
+            new Mock<BotNexus.Gateway.Abstractions.Channels.IChannelDispatcher>().Object,
+            options,
+            new Mock<Microsoft.Extensions.Logging.ILogger<DefaultSubAgentManager>>().Object);
+    }
+
+    private static SubAgentSpawnRequest CreateSpawnRequest(SessionId? parentSessionId = null)
+        => new()
+        {
+            ParentAgentId = AgentId.From("parent-agent"),
+            ParentSessionId = parentSessionId ?? SessionId.From("root-session"),
+            Task = "Do something",
+            TimeoutSeconds = 600
+        };
+
+    private static Mock<IAgentHandle> CreateHandle()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentId.From("parent-agent"));
+        handle.SetupGet(h => h.SessionId).Returns(SessionId.From("session"));
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+        handle.Setup(h => h.FollowUpAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return handle;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentToolInheritanceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentToolInheritanceTests.cs
@@ -1,0 +1,177 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Security;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Verifies that <see cref="DefaultSubAgentManager"/> enforces tool deny-list inheritance:
+/// sub-agents cannot be granted tools that the parent is denied, and the child's
+/// effective deny-list includes the parent's.
+/// </summary>
+public sealed class SubAgentToolInheritanceTests
+{
+    [Fact]
+    public async Task SpawnAsync_ChildCannotBeGrantedParentDeniedTool()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        var policyProvider = CreatePolicyWithDenied("parent-agent", ["exec", "write"]);
+        var manager = CreateManager(supervisor.Object, policyProvider);
+
+        // The spawn request asks for tools including one the parent is denied
+        var request = CreateSpawnRequest(toolIds: ["read", "exec"]);
+
+        Func<Task> act = () => manager.SpawnAsync(request);
+
+        (await act.ShouldThrowAsync<InvalidOperationException>())
+            .Message.ShouldContain("exec");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_ChildAllowedTools_NotInParentDenyList_Succeeds()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        var policyProvider = CreatePolicyWithDenied("parent-agent", ["exec", "write"]);
+        var manager = CreateManager(supervisor.Object, policyProvider);
+
+        // All requested tools are safe — not in parent deny-list
+        var request = CreateSpawnRequest(toolIds: ["read", "list"]);
+        var result = await manager.SpawnAsync(request);
+
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe(SubAgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_RegistersChildDenyListInPolicyProvider()
+    {
+        AgentId? registeredChildId = null;
+        IReadOnlyList<string>? registeredDenyList = null;
+
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        var policyProvider = CreatePolicyWithDenied("parent-agent", ["exec", "bash"],
+            onSetDynamic: (agentId, denyList) =>
+            {
+                registeredChildId = agentId;
+                registeredDenyList = denyList;
+            });
+
+        var manager = CreateManager(supervisor.Object, policyProvider);
+        var request = CreateSpawnRequest();
+
+        await manager.SpawnAsync(request);
+
+        registeredChildId.ShouldNotBeNull();
+        registeredDenyList.ShouldNotBeNull();
+        registeredDenyList.ShouldContain("exec");
+        registeredDenyList.ShouldContain("bash");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_NoParentDenyList_SpawnsSuccessfully()
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        var policyProvider = CreatePolicyWithDenied("parent-agent", []);
+        var manager = CreateManager(supervisor.Object, policyProvider);
+
+        var request = CreateSpawnRequest(toolIds: ["read", "write"]);
+        var result = await manager.SpawnAsync(request);
+
+        result.ShouldNotBeNull();
+    }
+
+    private static DefaultToolPolicyProvider CreatePolicyWithDenied(
+        string agentId,
+        IReadOnlyList<string> denied,
+        Action<AgentId, IReadOnlyList<string>>? onSetDynamic = null)
+    {
+        var policyConfig = new BotNexus.Gateway.Configuration.PlatformConfig
+        {
+            Agents = new Dictionary<string, BotNexus.Gateway.Configuration.AgentDefinitionConfig>
+            {
+                [agentId] = new() { ToolPolicy = new BotNexus.Gateway.Configuration.ToolPolicyConfig { Denied = [.. denied] } }
+            }
+        };
+        var optionsMonitor = new TestOptionsMonitor<BotNexus.Gateway.Configuration.PlatformConfig>(policyConfig);
+        var provider = new DefaultToolPolicyProvider(optionsMonitor, new Mock<Microsoft.Extensions.Logging.ILogger<DefaultToolPolicyProvider>>().Object);
+
+        if (onSetDynamic is not null)
+            provider.OnDynamicDenyListSet = onSetDynamic;
+
+        return provider;
+    }
+
+    private static DefaultSubAgentManager CreateManager(
+        IAgentSupervisor supervisor,
+        DefaultToolPolicyProvider policyProvider)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry
+            .Setup(r => r.Get(It.IsAny<AgentId>()))
+            .Returns(new AgentDescriptor
+            {
+                AgentId = AgentId.From("parent-agent"),
+                DisplayName = "Parent Agent",
+                ModelId = "gpt-5-mini",
+                ApiProvider = "openai"
+            });
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var options = new TestOptionsMonitor<GatewayOptions>(new GatewayOptions());
+
+        return new DefaultSubAgentManager(
+            supervisor,
+            registry.Object,
+            new Mock<BotNexus.Gateway.Abstractions.Activity.IActivityBroadcaster>().Object,
+            new Mock<BotNexus.Gateway.Abstractions.Channels.IChannelDispatcher>().Object,
+            options,
+            new Mock<Microsoft.Extensions.Logging.ILogger<DefaultSubAgentManager>>().Object,
+            policyProvider: policyProvider);
+    }
+
+    private static SubAgentSpawnRequest CreateSpawnRequest(IReadOnlyList<string>? toolIds = null)
+        => new()
+        {
+            ParentAgentId = AgentId.From("parent-agent"),
+            ParentSessionId = SessionId.From("root-session"),
+            Task = "Do something",
+            TimeoutSeconds = 600,
+            ToolIds = toolIds
+        };
+
+    private static Mock<IAgentHandle> CreateHandle()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentId.From("parent-agent"));
+        handle.SetupGet(h => h.SessionId).Returns(SessionId.From("session"));
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+        handle.Setup(h => h.FollowUpAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return handle;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Security/GatewaySessionRedactionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Security/GatewaySessionRedactionTests.cs
@@ -1,0 +1,98 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Security;
+
+/// <summary>
+/// Verifies that <see cref="GatewaySession"/> applies the injected <see cref="ISecretRedactor"/>
+/// to all content written via <c>AddEntry</c> and <c>AddEntries</c>.
+/// </summary>
+public sealed class GatewaySessionRedactionTests
+{
+    [Fact]
+    public void AddEntry_WithRedactor_RedactsContent()
+    {
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.IsAny<string>())).Returns("[REDACTED]");
+
+        var session = new GatewaySession(new Session(), redactor.Object);
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "my secret" });
+
+        var history = session.GetHistorySnapshot();
+        history.Count.ShouldBe(1);
+        history[0].Content.ShouldBe("[REDACTED]");
+    }
+
+    [Fact]
+    public void AddEntry_WithoutRedactor_ContentUnchanged()
+    {
+        var session = new GatewaySession(new Session());
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "safe text" });
+
+        var history = session.GetHistorySnapshot();
+        history[0].Content.ShouldBe("safe text");
+    }
+
+    [Fact]
+    public void AddEntries_WithRedactor_RedactsAllContent()
+    {
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.IsAny<string>())).Returns("[REDACTED]");
+
+        var session = new GatewaySession(new Session(), redactor.Object);
+        session.AddEntries([
+            new SessionEntry { Role = MessageRole.User, Content = "secret1" },
+            new SessionEntry { Role = MessageRole.Assistant, Content = "secret2" }
+        ]);
+
+        var history = session.GetHistorySnapshot();
+        history.Count.ShouldBe(2);
+        history.ShouldAllBe(e => e.Content == "[REDACTED]");
+    }
+
+    [Fact]
+    public void AddEntry_RedactorCalledOnce_PerEntry()
+    {
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.IsAny<string>())).Returns<string>(s => s);
+
+        var session = new GatewaySession(new Session(), redactor.Object);
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "hello" });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "world" });
+
+        redactor.Verify(r => r.Redact(It.IsAny<string>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void AddEntry_RedactsToolArgs_WhenPresent()
+    {
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.IsAny<string>())).Returns("[REDACTED]");
+
+        var session = new GatewaySession(new Session(), redactor.Object);
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "calling tool",
+            ToolArgs = "{\"api_key\": \"secret-key\"}"
+        });
+
+        var history = session.GetHistorySnapshot();
+        history[0].ToolArgs.ShouldBe("[REDACTED]");
+    }
+
+    [Fact]
+    public void AddEntry_NullContent_HandledGracefully()
+    {
+        // Content is required but we want to ensure no NullReferenceException when
+        // the redactor is wired; an empty string is the safe fallback.
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(string.Empty)).Returns(string.Empty);
+
+        var session = new GatewaySession(new Session(), redactor.Object);
+        var act = () => session.AddEntry(new SessionEntry { Role = MessageRole.System, Content = string.Empty });
+        act.ShouldNotThrow();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Security/SecretRedactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Security/SecretRedactorTests.cs
@@ -1,0 +1,144 @@
+using BotNexus.Gateway.Security;
+
+namespace BotNexus.Gateway.Tests.Security;
+
+/// <summary>
+/// Verifies that <see cref="SecretRedactor"/> replaces common secret-shaped values
+/// with <c>[REDACTED]</c> and leaves safe text untouched.
+/// </summary>
+public sealed class SecretRedactorTests
+{
+    private readonly SecretRedactor _sut = new();
+
+    [Fact]
+    public void Redact_NullOrEmpty_ReturnsInput()
+    {
+        _sut.Redact(string.Empty).ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    [InlineData("sk-abc123XYZdef456UVWghi789JKLmno0123456789PQRSTUVX")]        // 48-char OpenAI legacy key
+    [InlineData("sk-proj-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdefghijklmnopqrstuvwxyz0123456789ABCDE")]
+    public void Redact_OpenAiKey_IsRedacted(string key)
+    {
+        var input = $"Authorization: Bearer {key}";
+        _sut.Redact(input).ShouldNotContain(key);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Theory]
+    [InlineData("sk-ant-api03-AAABBBCCC111222333444555666777888999000aaabbbccc")]
+    [InlineData("sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")]
+    public void Redact_AnthropicKey_IsRedacted(string key)
+    {
+        var input = $"key={key}";
+        _sut.Redact(input).ShouldNotContain(key);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Theory]
+    [InlineData("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")]   // 36 chars after prefix
+    [InlineData("ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")]
+    [InlineData("gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789")]
+    [InlineData("github_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789_ABCDEF123456789012345678")]
+    public void Redact_GitHubToken_IsRedacted(string token)
+    {
+        var input = $"token: {token}";
+        _sut.Redact(input).ShouldNotContain(token);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Theory]
+    [InlineData("AKIAIOSFODNN7EXAMPLE")]     // 20 chars: AKIA + 16 uppercase alphanumeric
+    [InlineData("AKIAJ1234567890ABCDE")]
+    public void Redact_AwsAccessKey_IsRedacted(string key)
+    {
+        var input = $"aws_access_key_id={key}";
+        _sut.Redact(input).ShouldNotContain(key);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Theory]
+    [InlineData("AIzaSyDummyGoogleApiKey1234567890ABCDE")]   // AIza + 35 chars
+    public void Redact_GoogleApiKey_IsRedacted(string key)
+    {
+        var input = $"apiKey: {key}";
+        _sut.Redact(input).ShouldNotContain(key);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Theory]
+    [InlineData("xoxb-TESTONLY-TESTONLY-AbCdEfGhIjKlMnOpQrStUv")]  // Slack bot token (test-only, not a real token)
+    [InlineData("xoxp-TESTONLY-TESTONLY-TESTONLY-abcdef1234567890")]  // Slack user token (test-only, not a real token)
+    public void Redact_SlackToken_IsRedacted(string token)
+    {
+        var input = $"slack_token={token}";
+        _sut.Redact(input).ShouldNotContain(token);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Theory]
+    [InlineData("sk_live_AbCdEfGhIjKlMnOpQrSt")]   // Stripe live secret key
+    [InlineData("sk_test_AbCdEfGhIjKlMnOpQrSt")]   // Stripe test secret key
+    public void Redact_StripeKey_IsRedacted(string key)
+    {
+        var input = $"stripe_key={key}";
+        _sut.Redact(input).ShouldNotContain(key);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_AuthorizationBearerHeader_IsRedacted()
+    {
+        const string token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwR";
+        var input = $"Authorization: Bearer {token}";
+        _sut.Redact(input).ShouldNotContain(token);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_ApiKeyInQueryString_IsRedacted()
+    {
+        const string key = "AbCdEfGhIjKlMnOpQrStUvWxYz12345678901234";
+        var input = $"https://api.example.com/data?api_key={key}";
+        _sut.Redact(input).ShouldNotContain(key);
+        _sut.Redact(input).ShouldContain("[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_NormalText_IsUnchanged()
+    {
+        const string safe = "The quick brown fox jumps over the lazy dog.";
+        _sut.Redact(safe).ShouldBe(safe);
+    }
+
+    [Fact]
+    public void Redact_ShortToken_IsNotRedacted()
+    {
+        // Tokens shorter than the minimum length for each pattern should pass through
+        const string safe = "token=abc123";
+        _sut.Redact(safe).ShouldBe(safe);
+    }
+
+    [Fact]
+    public void Redact_MultipleSecretsInOneLine_AllRedacted()
+    {
+        const string openAiKey = "sk-abc123XYZdef456UVWghi789JKLmno0123456789PQRSTUVX";
+        const string awsKey = "AKIAIOSFODNN7EXAMPLE";
+        var input = $"openai={openAiKey} aws={awsKey}";
+
+        var result = _sut.Redact(input);
+        result.ShouldNotContain(openAiKey);
+        result.ShouldNotContain(awsKey);
+        result.ShouldContain("[REDACTED]");
+    }
+
+    [Fact]
+    public void Redact_IsIdempotent()
+    {
+        const string key = "sk-abc123XYZdef456UVWghi789JKLmno0123456789PQRSTUVX";
+        var firstPass = _sut.Redact(key);
+        var secondPass = _sut.Redact(firstPass);
+        secondPass.ShouldBe(firstPass);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two related security issues around data protection and sub-agent access control.

---

### Issue #261 — Tool results and transcripts redacted at write time

Secret-shaped values in tool outputs and conversation transcripts were persisted unredacted to the session store.

**Changes:**
- `ISecretRedactor` interface in `BotNexus.Gateway.Abstractions.Security`
- `SecretRedactor` implementation with compiled regex patterns for 11 secret formats:
  - OpenAI project keys (`sk-proj-...`) and legacy keys (`sk-...`)
  - Anthropic API keys (`sk-ant-...`)
  - GitHub fine-grained PATs (`github_pat_...`) and classic tokens (`ghp_`, `ghs_`, `gho_`)
  - AWS access key IDs (`AKIA...`)
  - Google API keys (`AIza...`)
  - Slack tokens (`xox[bprao]-...`)
  - Stripe secret keys (`sk_live_...`, `sk_test_...`)
  - `Authorization: Bearer <token>` HTTP headers
  - Generic `api_key`/`api-key` patterns
- `GatewaySession.AddEntry()`/`AddEntries()` now apply redaction to both `Content` and `ToolArgs` via a private `Redact()` helper
- All session stores (`FileSessionStore`, `InMemorySessionStore`, `SqliteSessionStore`) accept an optional `ISecretRedactor` and pass it to session construction
- `LlmSessionCompactor` redacts the LLM-generated summary before creating the compaction entry
- `ISecretRedactor` registered as a singleton in `GatewayServiceCollectionExtensions`

---

### Issue #263 — Sub-agent spawning inherits parent tool restrictions

Spawned sub-agents did not inherit the parent agent's tool deny-list, allowing privilege escalation.

**Changes:**
- `SubAgentSpawnRequest` gains `SpawnDepth` and `ParentToolDenyList` fields
- `DefaultSubAgentManager.SpawnAsync()` now:
  - Enforces `SubAgentOptions.MaxDepth` by counting `::subagent::` segments in the parent session ID (0 = unlimited)
  - Validates `request.ToolIds` against the parent's effective deny-list before spawning; throws if any denied tool is requested
  - Registers the child's inherited deny-list via `DefaultToolPolicyProvider.SetDynamicDenyList()`
- `DefaultSubAgentManager.CleanupChildAgentAsync()` removes the dynamic deny-list when the sub-agent is torn down
- `DefaultToolPolicyProvider` gains:
  - `ConcurrentDictionary`-backed dynamic deny-lists for ephemeral sub-agents with no `PlatformConfig` entry
  - `SetDynamicDenyList(AgentId, ...)` / `RemoveDynamicDenyList(AgentId)` / `GetEffectiveDenyList(string)` public methods
  - Updated `IsDenied()` that checks both static config and dynamic deny-lists
  - `OnDynamicDenyListSet` internal test hook

---

## Tests

All new behaviour is covered by TDD tests (written before implementation):
- `SecretRedactorTests` — 14 pattern tests + idempotency + multi-secret + safe text
- `GatewaySessionRedactionTests` — AddEntry/AddEntries redaction, ToolArgs redaction, no-op without redactor
- `SubAgentSpawnDepthTests` — MaxDepth enforcement (exceeded throws, below succeeds, MaxDepth=0 unlimited)
- `SubAgentToolInheritanceTests` — tool grant validation, deny-list propagation to child agent

Full test suite: 0 failures, 0 warnings.

Closes #261
Closes #263