### PR TITLE
fix(mobile): reload history on conversation switch; filter hub events by session

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -163,9 +163,22 @@ else
         }
     }
 
-    private void OnConvChanged(ChangeEventArgs e)
+    private async Task OnConvChanged(ChangeEventArgs e)
     {
-        State.ActiveConversationId = e.Value?.ToString();
+        var convId = e.Value?.ToString();
+        if (string.IsNullOrEmpty(convId) || convId == State.ActiveConversationId) return;
+        State.ActiveConversationId = convId;
+        State.Messages.Clear();
+        State.ActiveSessionId = null;
+        State.NotifyChanged();
+        try
+        {
+            await Gateway.LoadHistoryAsync(convId, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Mobile] LoadHistory failed after conv switch: {ex.Message}");
+        }
     }
 
     private async Task SendMessage()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileGatewayClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Services/MobileGatewayClient.cs
@@ -187,8 +187,14 @@ public sealed class MobileGatewayClient : IAsyncDisposable
     {
         if (_hub is null) return;
 
+        // Only process events for the active session — ignore events from other
+        // agents/conversations that arrive while the user has switched away.
+        bool IsActiveSession(AgentStreamEvent e) =>
+            e.SessionId is null || _state.ActiveSessionId is null || e.SessionId == _state.ActiveSessionId;
+
         _hub.On<AgentStreamEvent>("MessageStart", e =>
         {
+            if (!IsActiveSession(e)) return;
             _state.IsStreaming = true;
             _state.StreamBuffer = string.Empty;
             _state.NotifyChanged();
@@ -196,6 +202,7 @@ public sealed class MobileGatewayClient : IAsyncDisposable
 
         _hub.On<AgentStreamEvent>("ContentDelta", e =>
         {
+            if (!IsActiveSession(e)) return;
             _state.StreamBuffer += e.ContentDelta ?? string.Empty;
             _state.NotifyChanged();
         });
@@ -212,6 +219,7 @@ public sealed class MobileGatewayClient : IAsyncDisposable
 
         _hub.On<AgentStreamEvent>("ToolEnd", e =>
         {
+            if (!IsActiveSession(e)) return;
             if (e.ToolName is not null)
             {
                 _state.Messages.Add(new ChatMessage("tool", e.ToolResult ?? string.Empty, DateTimeOffset.UtcNow)
@@ -224,6 +232,7 @@ public sealed class MobileGatewayClient : IAsyncDisposable
 
         _hub.On<AgentStreamEvent>("MessageEnd", e =>
         {
+            if (!IsActiveSession(e)) return;
             if (!string.IsNullOrEmpty(_state.StreamBuffer))
             {
                 _state.Messages.Add(new ChatMessage("assistant", _state.StreamBuffer, DateTimeOffset.UtcNow));
@@ -235,6 +244,7 @@ public sealed class MobileGatewayClient : IAsyncDisposable
 
         _hub.On<AgentStreamEvent>("Error", e =>
         {
+            if (!IsActiveSession(e)) return;
             _state.IsStreaming = false;
             _state.StreamBuffer = string.Empty;
             if (e.ErrorMessage is not null)


### PR DESCRIPTION
## Problems fixed

**1. Conversation switch does not reload history**
`OnConvChanged` set `ActiveConversationId` but never fetched history. Switching conversations left the chat area empty or stale.

Fix: make `OnConvChanged` async, clear messages, reset `ActiveSessionId`, await `LoadHistoryAsync`.

**2. Hub events bleed across conversations/agents**
Streaming events for a different session (slow response, background tool call) were appended to whatever view was active.

Fix: `IsActiveSession(e)` guard in all hub handlers — skip events where `e.SessionId != State.ActiveSessionId`. Null on either side = pass-through (safe before first send).