### PR TITLE
fix(scripts): restore watchdog recovery flow and script help

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
         text: 'Guides',
         items: [
           { text: 'Audio Recording', link: '/guides/audio-recording' },
+          { text: 'Watchdog Setup', link: '/guides/watchdog-setup' },
         ],
       },
       {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1182,10 +1182,16 @@ botnexus agent list
 
 ### Exit Codes
 
-All commands return:
+Most commands return:
 
 - `0` — Success
 - `1` — Error (check console output for details)
+
+`botnexus update check` uses status-style exit codes for automation:
+
+- `0` — Up to date
+- `1` — Updates available
+- `2` — Check failed (for example, git fetch error)
 
 ---
 

--- a/docs/guides/watchdog-setup.md
+++ b/docs/guides/watchdog-setup.md
@@ -7,7 +7,7 @@ A cross-platform PowerShell script that keeps your BotNexus gateway running, up-
 | Check | Default Interval | Action |
 |---|---|---|
 | **Gateway health** | Every run (1 min) | Restart if `/health` fails; fall back to last-known-good config after N failures |
-| **Git repo updates** | Every 5 minutes | `botnexus update --check` to detect new commits, then `botnexus update` to pull, build, and restart |
+| **Git repo updates** | Every 5 minutes | `botnexus update check` to detect new commits, then `botnexus update` to pull, build, and restart |
 | **CLI tool updates** | Every 60 minutes | `dotnet tool update -g BotNexus.Cli` |
 
 The script itself runs on a short interval (e.g. every minute). Each check type has its own timer so you control how often expensive operations happen independently.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - WebUI Connection: development/webui-connection.md
   - Guides:
       - Audio Recording: guides/audio-recording.md
+      - Watchdog Setup: guides/watchdog-setup.md
   - Features:
       - Sub-Agent Spawning: features/sub-agent-spawning.md
   - Extensions:

--- a/scripts/Install-WatchdogTask.ps1
+++ b/scripts/Install-WatchdogTask.ps1
@@ -9,23 +9,45 @@
     elevated (Administrator) PowerShell prompt.
 
     On Linux/macOS, choose between two scheduling methods via -Method:
-      cron    (default) — adds a crontab entry that runs every minute.
-      systemd           — installs user-level systemd service + timer units
+      cron    (default) - adds a crontab entry that runs every minute.
+      systemd           - installs user-level systemd service and timer units
                           (preferred on systemd-based distros; survives reboots
                           without requiring a cron daemon).
+
+.PARAMETER RepoPath
+    Optional path to the BotNexus git repository passed to botnexus-watchdog.ps1.
+    When omitted, the watchdog script uses its own default path.
+
+.PARAMETER GitCheckIntervalMinutes
+    Interval in minutes between repository update checks performed by the watchdog.
+
+.PARAMETER CliCheckIntervalMinutes
+    Interval in minutes between BotNexus CLI tool update checks performed by the watchdog.
+
+.PARAMETER MaxFailures
+    Consecutive health-check failure threshold before watchdog config fallback is triggered.
+
+.PARAMETER GatewayUrl
+    Gateway base URL used by the watchdog health check.
 
 .PARAMETER Method
     Linux/macOS only. Scheduling back-end: 'cron' (default) or 'systemd'.
     Ignored on Windows.
 
+.PARAMETER Uninstall
+    Removes the previously installed watchdog scheduler integration.
+    - Windows: removes the BotNexusWatchdog scheduled task.
+    - cron: removes the marked crontab entry.
+    - systemd: disables/removes user timer and unit files.
+
 .EXAMPLE
-    # Windows — Scheduled Task
+    # Windows - Scheduled Task
     .\Install-WatchdogTask.ps1
 
-    # Linux — cron (default)
+    # Linux - cron (default)
     ./Install-WatchdogTask.ps1
 
-    # Linux — systemd timer
+    # Linux - systemd timer
     ./Install-WatchdogTask.ps1 -Method systemd
 
     # Custom repo path
@@ -34,6 +56,10 @@
     # Uninstall (removes whichever method was used)
     ./Install-WatchdogTask.ps1 -Uninstall
     ./Install-WatchdogTask.ps1 -Uninstall -Method systemd
+
+.NOTES
+    This script configures scheduling only. Runtime watchdog behavior is implemented in
+    botnexus-watchdog.ps1 and controlled through the forwarded arguments documented above.
 #>
 
 [CmdletBinding()]

--- a/scripts/botnexus-watchdog.ps1
+++ b/scripts/botnexus-watchdog.ps1
@@ -1,4 +1,75 @@
 #!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Performs scheduled BotNexus health checks, update checks, and automated recovery.
+
+.DESCRIPTION
+    Runs a lightweight watchdog loop intended to be triggered by an external scheduler
+    (Task Scheduler, cron, or systemd timer) at a short interval such as every minute.
+
+    On each run, the script:
+    - Checks gateway health via the configured health endpoint.
+    - Tracks consecutive failures and restarts the gateway when health fails.
+    - Restores the last-known-good config after a configurable failure threshold.
+    - Checks for repository updates on a separate interval and runs botnexus update.
+    - Checks for BotNexus CLI tool updates on a separate interval.
+    - Persists state between runs in a JSON state file.
+
+.PARAMETER GatewayUrl
+    Base URL of the BotNexus gateway used for health checks.
+
+.PARAMETER HealthEndpoint
+    Relative endpoint path used for health checks.
+
+.PARAMETER RepoPath
+    Path to the local BotNexus git clone used for repository update checks.
+    Pass an empty string to skip repository checks.
+
+.PARAMETER ConfigDir
+    BotNexus home directory that contains config, logs, state, and backup folders.
+    Defaults to ~/.botnexus when not provided.
+
+.PARAMETER MaxFailures
+    Number of consecutive health-check failures before restoring last-known-good config.
+
+.PARAMETER GitCheckIntervalMinutes
+    Minimum minutes between repository update checks.
+
+.PARAMETER CliCheckIntervalMinutes
+    Minimum minutes between BotNexus CLI tool update checks.
+
+.PARAMETER LogDir
+    Directory where watchdog log files are written.
+    Defaults to <ConfigDir>/logs when not provided.
+
+.PARAMETER StateFile
+    JSON file path used to persist run state between scheduler invocations.
+    Defaults to <ConfigDir>/watchdog-state.json when not provided.
+
+.EXAMPLE
+    ./scripts/botnexus-watchdog.ps1
+
+    Runs watchdog checks with defaults.
+
+.EXAMPLE
+    ./scripts/botnexus-watchdog.ps1 -GitCheckIntervalMinutes 15 -CliCheckIntervalMinutes 120
+
+    Uses less frequent repository and CLI update checks.
+
+.EXAMPLE
+    ./scripts/botnexus-watchdog.ps1 -RepoPath ''
+
+    Runs health monitoring only and skips repository update checks.
+
+.EXAMPLE
+    ./scripts/botnexus-watchdog.ps1 -RepoPath 'D:\botnexus' -ConfigDir 'D:\botnexus-home'
+
+    Uses custom source and home paths.
+
+.NOTES
+    Intended for scheduled execution rather than long-running interactive use.
+    A lock file in the system temp directory prevents overlapping script instances.
+#>
 
 [CmdletBinding()]
 param(

--- a/scripts/botnexus-watchdog.ps1
+++ b/scripts/botnexus-watchdog.ps1
@@ -1,0 +1,333 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [string]$GatewayUrl = 'http://localhost:5005',
+    [string]$HealthEndpoint = '/health',
+    [string]$RepoPath = '',
+    [string]$ConfigDir = '',
+    [ValidateRange(1, 100)]
+    [int]$MaxFailures = 3,
+    [ValidateRange(1, 10080)]
+    [int]$GitCheckIntervalMinutes = 5,
+    [ValidateRange(1, 10080)]
+    [int]$CliCheckIntervalMinutes = 60,
+    [string]$LogDir = '',
+    [string]$StateFile = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $ConfigDir) {
+    $ConfigDir = Join-Path $HOME '.botnexus'
+}
+if (-not $RepoPath) {
+    $RepoPath = Join-Path $HOME 'botnexus'
+}
+if (-not $LogDir) {
+    $LogDir = Join-Path $ConfigDir 'logs'
+}
+if (-not $StateFile) {
+    $StateFile = Join-Path $ConfigDir 'watchdog-state.json'
+}
+
+$backupDir = Join-Path $ConfigDir 'config-backups'
+$currentConfigPath = Join-Path $ConfigDir 'config.json'
+$lastKnownGoodPath = Join-Path $backupDir 'config-last-known-good.json'
+$lockFile = Join-Path ([System.IO.Path]::GetTempPath()) 'botnexus-watchdog.lock'
+
+New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+New-Item -ItemType Directory -Force -Path $backupDir | Out-Null
+
+$logFile = Join-Path $LogDir ("watchdog-{0}.log" -f (Get-Date -Format 'yyyy-MM-dd'))
+
+function Write-Log {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+        [ValidateSet('INF', 'WRN', 'ERR')]
+        [string]$Level = 'INF'
+    )
+
+    $line = '[{0}][{1}] {2}' -f (Get-Date -Format 'yyyyMMdd-HHmmss'), $Level, $Message
+    Add-Content -Path $logFile -Value $line
+    Write-Host $line
+}
+
+function Read-State {
+    if (-not (Test-Path $StateFile)) {
+        return [ordered]@{
+            FailureCount = 0
+            LastGitCheck = $null
+            LastCliCheck = $null
+            LastKnownGoodConfig = $lastKnownGoodPath
+        }
+    }
+
+    try {
+        return Get-Content -Path $StateFile -Raw | ConvertFrom-Json -AsHashtable
+    }
+    catch {
+        Write-Log "State file is invalid JSON. Reinitializing: $StateFile" 'WRN'
+        return [ordered]@{
+            FailureCount = 0
+            LastGitCheck = $null
+            LastCliCheck = $null
+            LastKnownGoodConfig = $lastKnownGoodPath
+        }
+    }
+}
+
+function Write-State {
+    param([hashtable]$State)
+
+    $State.LastKnownGoodConfig = $lastKnownGoodPath
+    $json = $State | ConvertTo-Json -Depth 4
+    Set-Content -Path $StateFile -Value $json -Encoding UTF8
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return ''
+    }
+
+    return (Get-FileHash -Path $Path -Algorithm SHA256).Hash
+}
+
+function Restart-Gateway {
+    Write-Log 'Restarting gateway process...'
+
+    & botnexus gateway stop 2>&1 | ForEach-Object { Write-Log $_ 'INF' }
+    & botnexus gateway start 2>&1 | ForEach-Object { Write-Log $_ 'INF' }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Gateway start failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Save-LastKnownGoodConfig {
+    param([hashtable]$State)
+
+    if (-not (Test-Path $currentConfigPath)) {
+        return
+    }
+
+    $currentHash = Get-Sha256 -Path $currentConfigPath
+    $knownHash = Get-Sha256 -Path $lastKnownGoodPath
+
+    if ($currentHash -and ($currentHash -ne $knownHash)) {
+        Copy-Item -Path $currentConfigPath -Destination $lastKnownGoodPath -Force
+        $State.LastKnownGoodConfig = $lastKnownGoodPath
+        Write-Log 'Current config saved as last-known-good.'
+    }
+}
+
+function Restore-LastKnownGoodConfig {
+    if (-not (Test-Path $lastKnownGoodPath)) {
+        Write-Log 'No last-known-good config found. Skipping fallback restore.' 'WRN'
+        return
+    }
+
+    if (Test-Path $currentConfigPath) {
+        $currentHash = Get-Sha256 -Path $currentConfigPath
+        $knownHash = Get-Sha256 -Path $lastKnownGoodPath
+
+        if ($currentHash -and ($currentHash -ne $knownHash)) {
+            $suspectPath = Join-Path $backupDir ("config-suspect-{0}.json" -f (Get-Date -Format 'yyyyMMdd-HHmmss'))
+            Copy-Item -Path $currentConfigPath -Destination $suspectPath -Force
+            Write-Log "Backed up suspect config to: $suspectPath" 'WRN'
+        }
+    }
+
+    Copy-Item -Path $lastKnownGoodPath -Destination $currentConfigPath -Force
+    Write-Log 'Restored last-known-good config.' 'WRN'
+}
+
+function Test-Health {
+    $uri = "$($GatewayUrl.TrimEnd('/'))/$($HealthEndpoint.TrimStart('/'))"
+    try {
+        $response = Invoke-WebRequest -Uri $uri -Method Get -TimeoutSec 10
+        return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300)
+    }
+    catch {
+        Write-Log "Health check failed: $($_.Exception.Message)" 'WRN'
+        return $false
+    }
+}
+
+function Parse-Time {
+    param([object]$Value)
+
+    if (-not $Value) {
+        return $null
+    }
+
+    try {
+        return [DateTimeOffset]::Parse($Value.ToString())
+    }
+    catch {
+        return $null
+    }
+}
+
+function Is-IntervalDue {
+    param(
+        [object]$LastRun,
+        [int]$Minutes
+    )
+
+    $lastRunTime = Parse-Time -Value $LastRun
+    if (-not $lastRunTime) {
+        return $true
+    }
+
+    return (([DateTimeOffset]::Now - $lastRunTime).TotalMinutes -ge $Minutes)
+}
+
+function Invoke-CliUpdate {
+    Write-Log 'Checking for BotNexus CLI tool updates...'
+    & dotnet tool update -g BotNexus.Cli 2>&1 | ForEach-Object { Write-Log $_ 'INF' }
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log "CLI update check failed with exit code $LASTEXITCODE" 'WRN'
+        return $false
+    }
+
+    Write-Log 'CLI update check completed.'
+    return $true
+}
+
+function Run-GitFallbackCheck {
+    param([string]$Repo)
+
+    if (-not (Test-Path (Join-Path $Repo '.git'))) {
+        Write-Log "Repo path is not a git repository: $Repo" 'WRN'
+        return $false
+    }
+
+    Push-Location $Repo
+    try {
+        & git fetch origin main --quiet
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log 'git fetch failed during fallback check.' 'WRN'
+            return $false
+        }
+
+        $behindCount = (& git rev-list --count HEAD..origin/main).Trim()
+        return [int]$behindCount -gt 0
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Invoke-RepoUpdate {
+    param([string]$Repo)
+
+    if (-not (Test-Path $Repo)) {
+        Write-Log "RepoPath does not exist: $Repo" 'WRN'
+        return $false
+    }
+
+    Write-Log 'Checking repository updates via botnexus update check...'
+    $checkOutput = & botnexus update check --source $Repo 2>&1
+    $checkExit = $LASTEXITCODE
+
+    $checkOutput | ForEach-Object { Write-Log $_ 'INF' }
+
+    if ($checkExit -eq 0) {
+        Write-Log 'Repository is up to date.'
+        return $true
+    }
+
+    if ($checkExit -eq 1) {
+        Write-Log 'Updates available. Running botnexus update...'
+        & botnexus update --source $Repo 2>&1 | ForEach-Object { Write-Log $_ 'INF' }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log "botnexus update failed with exit code $LASTEXITCODE" 'WRN'
+            return $false
+        }
+
+        Write-Log 'Repository update completed successfully.'
+        return $true
+    }
+
+    if ($checkOutput -match 'Unrecognized command|No such command|Was not matched') {
+        Write-Log 'botnexus update check not available; using git fallback check.' 'WRN'
+        if (Run-GitFallbackCheck -Repo $Repo) {
+            Write-Log 'Fallback detected updates. Running botnexus update...'
+            & botnexus update --source $Repo 2>&1 | ForEach-Object { Write-Log $_ 'INF' }
+            if ($LASTEXITCODE -ne 0) {
+                Write-Log "botnexus update failed with exit code $LASTEXITCODE" 'WRN'
+                return $false
+            }
+            Write-Log 'Repository update completed successfully.'
+            return $true
+        }
+
+        Write-Log 'Fallback check found no updates.'
+        return $true
+    }
+
+    Write-Log "update check failed with exit code $checkExit" 'WRN'
+    return $false
+}
+
+if (Test-Path $lockFile) {
+    Write-Log "Another watchdog instance is running. Lock file: $lockFile" 'WRN'
+    exit 0
+}
+
+New-Item -ItemType File -Path $lockFile -Force | Out-Null
+
+try {
+    Write-Log '--- Watchdog check started ---'
+
+    $state = Read-State
+    if (-not $state.ContainsKey('FailureCount')) { $state.FailureCount = 0 }
+    if (-not $state.ContainsKey('LastGitCheck')) { $state.LastGitCheck = $null }
+    if (-not $state.ContainsKey('LastCliCheck')) { $state.LastCliCheck = $null }
+
+    if (Test-Health) {
+        if ($state.FailureCount -ne 0) {
+            Write-Log 'Health restored. Resetting failure count.'
+        }
+
+        $state.FailureCount = 0
+        Save-LastKnownGoodConfig -State $state
+    }
+    else {
+        $state.FailureCount = [int]$state.FailureCount + 1
+        Write-Log "Gateway health check failed ($($state.FailureCount)/$MaxFailures)." 'WRN'
+
+        if ($state.FailureCount -ge $MaxFailures) {
+            Write-Log 'Failure threshold reached. Attempting config fallback and restart.' 'WRN'
+            Restore-LastKnownGoodConfig
+        }
+
+        Restart-Gateway
+    }
+
+    if ($RepoPath -and (Is-IntervalDue -LastRun $state.LastGitCheck -Minutes $GitCheckIntervalMinutes)) {
+        [void](Invoke-RepoUpdate -Repo $RepoPath)
+        $state.LastGitCheck = [DateTimeOffset]::Now.ToString('o')
+    }
+
+    if (Is-IntervalDue -LastRun $state.LastCliCheck -Minutes $CliCheckIntervalMinutes) {
+        [void](Invoke-CliUpdate)
+        $state.LastCliCheck = [DateTimeOffset]::Now.ToString('o')
+    }
+
+    Write-State -State $state
+    Write-Log '--- Watchdog check complete ---'
+}
+catch {
+    Write-Log "Watchdog failed: $($_.Exception.Message)" 'ERR'
+    exit 1
+}
+finally {
+    Remove-Item -Path $lockFile -Force -ErrorAction SilentlyContinue
+}

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -45,7 +45,67 @@ internal class UpdateCommand
             context.ExitCode = await ExecuteAsync(repoRoot, home, port, verbose, context.GetCancellationToken());
         });
 
+        var checkSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
+        var checkCommand = new Command("check", "Check whether updates are available from origin/main.")
+        {
+            checkSourceOption
+        };
+
+        checkCommand.SetHandler(async context =>
+        {
+            var source = context.ParseResult.GetValueForOption(checkSourceOption);
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var repoRoot = CliPaths.ResolveSource(source);
+            context.ExitCode = await CheckAsync(repoRoot, verbose, context.GetCancellationToken());
+        });
+
+        command.AddCommand(checkCommand);
+
         return command;
+    }
+
+    internal async Task<int> CheckAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
+    {
+        AnsiConsole.MarkupLine("[blue][[update]][/] Checking for updates...");
+
+        var fetchResult = await RunGitFetchAsync(repoRoot, verbose, cancellationToken);
+        if (fetchResult.WasCanceled)
+        {
+            AnsiConsole.MarkupLine("[yellow]⚠[/] Update check cancelled.");
+            return CancelledExitCode;
+        }
+
+        if (fetchResult.ExitCode != 0)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Could not fetch updates from origin/main.");
+            if (!string.IsNullOrWhiteSpace(fetchResult.FailureDetail))
+                AnsiConsole.MarkupLine($"[dim]{Markup.Escape(fetchResult.FailureDetail)}[/]");
+            return 2;
+        }
+
+        var behindResult = await GetBehindCountAsync(repoRoot, cancellationToken);
+        if (behindResult.WasCanceled)
+        {
+            AnsiConsole.MarkupLine("[yellow]⚠[/] Update check cancelled.");
+            return CancelledExitCode;
+        }
+
+        if (behindResult.ExitCode != 0)
+        {
+            AnsiConsole.MarkupLine("[red]✗[/] Could not determine update status.");
+            if (!string.IsNullOrWhiteSpace(behindResult.FailureDetail))
+                AnsiConsole.MarkupLine($"[dim]{Markup.Escape(behindResult.FailureDetail)}[/]");
+            return 2;
+        }
+
+        if (behindResult.BehindCount > 0)
+        {
+            AnsiConsole.MarkupLine($"[yellow]↻[/] Updates available: [bold]{behindResult.BehindCount}[/] commit(s) behind origin/main.");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] Already up to date.");
+        return 0;
     }
 
     internal async Task<int> ExecuteAsync(string repoRoot, string home, int port, bool verbose, CancellationToken cancellationToken)
@@ -346,6 +406,136 @@ internal class UpdateCommand
 
     protected virtual Task<GitPullResult> RunGitPullAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
         => RunGitPullCoreAsync(repoRoot, verbose, cancellationToken);
+
+    protected virtual Task<GitCommandResult> RunGitFetchAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
+        => RunGitFetchCoreAsync(repoRoot, verbose, cancellationToken);
+
+    private static async Task<GitCommandResult> RunGitFetchCoreAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
+    {
+        Process? proc = null;
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{repoRoot}\" fetch origin main",
+                UseShellExecute = false,
+                RedirectStandardOutput = !verbose,
+                RedirectStandardError = !verbose,
+                CreateNoWindow = true
+            };
+
+            proc = Process.Start(psi);
+            if (proc is null)
+                return new GitCommandResult(1, "Failed to start git process.", false);
+
+            var stdoutTask = verbose
+                ? Task.FromResult(string.Empty)
+                : proc.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = verbose
+                ? Task.FromResult(string.Empty)
+                : proc.StandardError.ReadToEndAsync(cancellationToken);
+
+            await Task.WhenAll(stdoutTask, stderrTask, proc.WaitForExitAsync(cancellationToken));
+
+            if (proc.ExitCode == 0)
+                return new GitCommandResult(0, null, false);
+
+            var stderr = await stderrTask;
+            var stdout = await stdoutTask;
+            var details = FirstNonEmptyLine(stderr) ?? FirstNonEmptyLine(stdout);
+            return new GitCommandResult(proc.ExitCode, details, false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (proc is { HasExited: false })
+            {
+                try
+                {
+                    proc.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                    // Best-effort kill to avoid orphaned git processes.
+                }
+            }
+
+            return new GitCommandResult(CancelledExitCode, null, true);
+        }
+        catch (Exception ex)
+        {
+            return new GitCommandResult(1, ex.Message, false);
+        }
+        finally
+        {
+            proc?.Dispose();
+        }
+    }
+
+    protected virtual Task<GitBehindResult> GetBehindCountAsync(string repoRoot, CancellationToken cancellationToken)
+        => GetBehindCountCoreAsync(repoRoot, cancellationToken);
+
+    private static async Task<GitBehindResult> GetBehindCountCoreAsync(string repoRoot, CancellationToken cancellationToken)
+    {
+        Process? proc = null;
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{repoRoot}\" rev-list --count HEAD..origin/main",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            proc = Process.Start(psi);
+            if (proc is null)
+                return new GitBehindResult(1, 0, "Failed to start git process.", false);
+
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = proc.StandardError.ReadToEndAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask, proc.WaitForExitAsync(cancellationToken));
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            if (proc.ExitCode != 0)
+            {
+                var details = FirstNonEmptyLine(stderr) ?? FirstNonEmptyLine(stdout);
+                return new GitBehindResult(proc.ExitCode, 0, details, false);
+            }
+
+            if (!int.TryParse(stdout.Trim(), out var count))
+                return new GitBehindResult(1, 0, "Unexpected git output while parsing behind count.", false);
+
+            return new GitBehindResult(0, count, null, false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (proc is { HasExited: false })
+            {
+                try
+                {
+                    proc.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                    // Best-effort kill to avoid orphaned git processes.
+                }
+            }
+
+            return new GitBehindResult(CancelledExitCode, 0, null, true);
+        }
+        catch (Exception ex)
+        {
+            return new GitBehindResult(1, 0, ex.Message, false);
+        }
+        finally
+        {
+            proc?.Dispose();
+        }
+    }
 
     private static async Task<GitPullResult> RunGitPullCoreAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
     {
@@ -659,5 +849,7 @@ internal class UpdateCommand
         }
     }
 
-    protected readonly record struct GitPullResult(int ExitCode, string? FailureDetail, bool WasCanceled);
+    internal readonly record struct GitPullResult(int ExitCode, string? FailureDetail, bool WasCanceled);
+    internal readonly record struct GitCommandResult(int ExitCode, string? FailureDetail, bool WasCanceled);
+    internal readonly record struct GitBehindResult(int ExitCode, int BehindCount, string? FailureDetail, bool WasCanceled);
 }

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -81,6 +81,19 @@ public class UpdateCommandTests
             => RunGitPullStepAsync(repoRoot, verbose, cancellationToken);
     }
 
+    private sealed class ScriptedUpdateCheckCommand(
+        IGatewayProcessManager processManager,
+        UpdateCommand.GitCommandResult fetchResult,
+        UpdateCommand.GitBehindResult behindResult)
+        : UpdateCommand(processManager)
+    {
+        protected override Task<GitCommandResult> RunGitFetchAsync(string repoRoot, bool verbose, CancellationToken cancellationToken)
+            => Task.FromResult(fetchResult);
+
+        protected override Task<GitBehindResult> GetBehindCountAsync(string repoRoot, CancellationToken cancellationToken)
+            => Task.FromResult(behindResult);
+    }
+
     private static UpdateCommand BuildCommand()
     {
         var pm = Substitute.For<IGatewayProcessManager>();
@@ -98,6 +111,15 @@ public class UpdateCommandTests
         var command = BuildCommand().Build(verbose);
 
         command.Name.ShouldBe("update");
+    }
+
+    [Fact]
+    public void Update_command_registers_check_subcommand()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var command = BuildCommand().Build(verbose);
+
+        command.Subcommands.Any(c => c.Name == "check").ShouldBeTrue();
     }
 
     [Fact]
@@ -392,6 +414,48 @@ public class UpdateCommandTests
 
         exitCode.ShouldBe(0);
         cmd.CliUpdateWarningPrinted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenRepositoryIsUpToDate_ReturnsZero()
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        var cmd = new ScriptedUpdateCheckCommand(
+            pm,
+            new UpdateCommand.GitCommandResult(0, null, false),
+            new UpdateCommand.GitBehindResult(0, 0, null, false));
+
+        var exitCode = await cmd.CheckAsync("unused", verbose: false, CancellationToken.None);
+
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenRepositoryIsBehind_ReturnsOne()
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        var cmd = new ScriptedUpdateCheckCommand(
+            pm,
+            new UpdateCommand.GitCommandResult(0, null, false),
+            new UpdateCommand.GitBehindResult(0, 3, null, false));
+
+        var exitCode = await cmd.CheckAsync("unused", verbose: false, CancellationToken.None);
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenFetchFails_ReturnsErrorCodeTwo()
+    {
+        var pm = Substitute.For<IGatewayProcessManager>();
+        var cmd = new ScriptedUpdateCheckCommand(
+            pm,
+            new UpdateCommand.GitCommandResult(128, "fatal: not a git repository", false),
+            new UpdateCommand.GitBehindResult(0, 0, null, false));
+
+        var exitCode = await cmd.CheckAsync("unused", verbose: false, CancellationToken.None);
+
+        exitCode.ShouldBe(2);
     }
 
     private static async Task<string> CaptureAnsiConsoleOutputAsync(Func<Task> action)


### PR DESCRIPTION
## Summary
- restore watchdog update detection by reintroducing `botnexus update check` semantics in the CLI
- add/extend PowerShell comment-based help for watchdog scripts using standard conventions
- align CLI reference exit-code docs with `update check` status codes used by automation

## Validation
- `dotnet build BotNexus.slnx --nologo --tl:off`
- `dotnet test BotNexus.slnx --nologo --tl:off`
- targeted `BotNexus.Cli.Tests` and `UpdateCommandTests` execution
