### PR TITLE
fix(cron): cron panel reads from API instead of config file only (#288)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/CronApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/CronApiClient.cs
@@ -1,0 +1,156 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Client for the gateway cron REST API (<c>/api/cron</c>).
+/// Returns the merged view of all jobs — both SQLite-persisted (runtime-created)
+/// and config-file jobs — so the panel is never limited to appsettings.json alone.
+/// </summary>
+public sealed class CronApiClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _http;
+
+    public CronApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    /// <summary>Lists all cron jobs (SQLite + config, system jobs excluded by default).</summary>
+    public async Task<(IReadOnlyList<CronJobDto> Jobs, string? Error)> ListAsync()
+    {
+        try
+        {
+            var result = await _http.GetFromJsonAsync<List<CronJobDto>>("/api/cron", JsonOptions);
+            return (result as IReadOnlyList<CronJobDto> ?? [], null);
+        }
+        catch (Exception ex)
+        {
+            return ([], ex.Message);
+        }
+    }
+
+    /// <summary>Creates a new cron job in the SQLite store.</summary>
+    public async Task<(CronJobDto? Job, string? Error)> CreateAsync(CronJobDto request)
+    {
+        try
+        {
+            var response = await _http.PostAsJsonAsync("/api/cron", request, JsonOptions);
+            if (response.IsSuccessStatusCode)
+            {
+                var dto = await response.Content.ReadFromJsonAsync<CronJobDto>(JsonOptions);
+                return (dto, null);
+            }
+            return (null, await ReadErrorAsync(response));
+        }
+        catch (Exception ex)
+        {
+            return (null, ex.Message);
+        }
+    }
+
+    /// <summary>Updates an existing cron job.</summary>
+    public async Task<(CronJobDto? Job, string? Error)> UpdateAsync(string jobId, CronJobDto request)
+    {
+        try
+        {
+            var response = await _http.PutAsJsonAsync(
+                $"/api/cron/{Uri.EscapeDataString(jobId)}", request, JsonOptions);
+            if (response.IsSuccessStatusCode)
+            {
+                var dto = await response.Content.ReadFromJsonAsync<CronJobDto>(JsonOptions);
+                return (dto, null);
+            }
+            return (null, await ReadErrorAsync(response));
+        }
+        catch (Exception ex)
+        {
+            return (null, ex.Message);
+        }
+    }
+
+    /// <summary>Deletes a cron job by ID.</summary>
+    public async Task<(bool Success, string? Error)> DeleteAsync(string jobId)
+    {
+        try
+        {
+            var response = await _http.DeleteAsync($"/api/cron/{Uri.EscapeDataString(jobId)}");
+            if (response.IsSuccessStatusCode)
+                return (true, null);
+            return (false, await ReadErrorAsync(response));
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
+    /// <summary>Triggers immediate execution of a cron job.</summary>
+    public async Task<(bool Success, string? Error)> RunNowAsync(string jobId)
+    {
+        try
+        {
+            var response = await _http.PostAsync($"/api/cron/{Uri.EscapeDataString(jobId)}/run", null);
+            if (response.IsSuccessStatusCode)
+                return (true, null);
+            return (false, await ReadErrorAsync(response));
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
+    private static async Task<string> ReadErrorAsync(HttpResponseMessage response)
+    {
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                    return errorProp.GetString() ?? body;
+                if (doc.RootElement.TryGetProperty("title", out var titleProp))
+                    return titleProp.GetString() ?? body;
+            }
+            return $"HTTP {(int)response.StatusCode}";
+        }
+        catch
+        {
+            return $"HTTP {(int)response.StatusCode}";
+        }
+    }
+}
+
+/// <summary>Cron job data transfer object — mirrors the gateway's CronJob record.</summary>
+public sealed class CronJobDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Schedule { get; set; } = string.Empty;
+    public string ActionType { get; set; } = "agent-prompt";
+    public string? AgentId { get; set; }
+    public string? Message { get; set; }
+    public string? TemplateName { get; set; }
+    public string? Model { get; set; }
+    public string? WebhookUrl { get; set; }
+    public string? ShellCommand { get; set; }
+    public bool Enabled { get; set; } = true;
+    public bool System { get; set; }
+    public string? TimeZone { get; set; }
+    public string? CreatedBy { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? LastRunAt { get; set; }
+    public DateTimeOffset? NextRunAt { get; set; }
+    public string? LastRunStatus { get; set; }
+    public string? LastRunError { get; set; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/CronConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/CronConfigPanel.razor
@@ -1,33 +1,244 @@
 @using System.Text.Json.Nodes
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
+@inject CronApiClient CronApi
 
 @{ var cron = GetObjectCaseInsensitive(Config, "cron"); }
 
+{{! Global cron settings — these still live in appsettings.json }}
 <BoolField Label="Enabled" Value="@GetBoolCaseInsensitive(cron, "enabled")" ValueChanged="@(v => SetNestedBoolCaseInsensitive("cron", "enabled", v))" />
 <NumberField Label="Tick Interval (seconds)" Value="@GetNullableInt(cron, "tickIntervalSeconds")" ValueChanged="@(v => SetNestedNumCaseInsensitive("cron", "tickIntervalSeconds", v))" />
 
-<DictionarySection Title="Jobs" SectionPath="cron.jobs" Entries="@GetDictCaseInsensitive(cron, "jobs")"
-                   OnAddEntry="@((string key) => AddNestedDictEntryCaseInsensitive("cron", "jobs", key))"
-                   OnDeleteEntry="@((string key) => DeleteNestedDictEntryCaseInsensitive("cron", "jobs", key))">
-    <EntryTemplate Context="entry">
-        <TextField Label="Job Name" Value="@GetStrCaseInsensitive(entry.Value, "name")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "name", v))" />
-        <TextField Label="Schedule (cron)" Value="@GetStrCaseInsensitive(entry.Value, "schedule")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "schedule", v))" />
-        <SelectField Label="Action Type" Value="@GetStrCaseInsensitive(entry.Value, "actionType")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "actionType", v))"
-                     Options="@(new[] { "agent-prompt", "agent-chat", "webhook", "shell" })" />
-        <TextField Label="Agent ID" Value="@GetStrCaseInsensitive(entry.Value, "agentId")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "agentId", v))" />
-        <TextField Label="Target Model" Value="@GetCronModel(entry.Value)" ValueChanged="@(v => SetCronModel(entry.Key, v))" />
-        <TextField Label="Message" Value="@GetStrCaseInsensitive(entry.Value, "message")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "message", v))" />
-        <TextField Label="Webhook URL" Value="@GetStrCaseInsensitive(entry.Value, "webhookUrl")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "webhookUrl", v))" />
-        <TextField Label="Shell Command" Value="@GetStrCaseInsensitive(entry.Value, "shellCommand")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "shellCommand", v))" />
-        <BoolField Label="Enabled" Value="@GetBoolCaseInsensitive(entry.Value, "enabled")" ValueChanged="@(v => SetCronJobBoolCaseInsensitive(entry.Key, "enabled", v))" />
-        <TextField Label="Created By" Value="@GetStrCaseInsensitive(entry.Value, "createdBy")" ValueChanged="@(v => SetCronJobFieldCaseInsensitive(entry.Key, "createdBy", v))" />
-    </EntryTemplate>
-</DictionarySection>
+{{! Jobs — loaded live from GET /api/cron (SQLite + config-file merged view) }}
+<div class="pcfg-dict-section">
+    <div class="pcfg-dict-header">
+        <h4>Jobs</h4>
+        <button class="pcfg-add-btn" @onclick="ShowAddForm" disabled="@_loading">+ Add Job</button>
+    </div>
+
+    @if (_error is not null)
+    {
+        <div class="pcfg-error-banner" role="alert">
+            <span>⚠️ @_error</span>
+            <button class="pcfg-dismiss-btn" @onclick="@(() => _error = null)" aria-label="Dismiss">✕</button>
+        </div>
+    }
+
+    @if (_loading)
+    {
+        <div class="config-loading">
+            <div class="loading-spinner small"></div>
+            <span>Loading jobs…</span>
+        </div>
+    }
+    else
+    {
+        @if (_showForm)
+        {
+            <div class="pcfg-entry pcfg-cron-form">
+                <h4>@(_editingId is not null ? $"Edit: {_form.Name}" : "New Job")</h4>
+
+                <TextField Label="Job ID" Value="@_form.Id" ValueChanged="@(v => _form.Id = v ?? "")"
+                           Placeholder="Leave blank to auto-generate" />
+                <TextField Label="Job Name" Value="@_form.Name" ValueChanged="@(v => _form.Name = v ?? "")" />
+                <TextField Label="Schedule (cron)" Value="@_form.Schedule" ValueChanged="@(v => _form.Schedule = v ?? "")"
+                           Placeholder="e.g. 0 9 * * *" />
+                <SelectField Label="Action Type" Value="@_form.ActionType" ValueChanged="@(v => _form.ActionType = v ?? "agent-prompt")"
+                             Options="@(new[] { "agent-prompt", "webhook", "shell" })" />
+                <TextField Label="Agent ID" Value="@(_form.AgentId ?? "")" ValueChanged="@(v => _form.AgentId = string.IsNullOrEmpty(v) ? null : v)" />
+                <TextField Label="Target Model" Value="@(_form.Model ?? "")" ValueChanged="@(v => _form.Model = string.IsNullOrEmpty(v) ? null : v)" />
+                <TextField Label="Message" Value="@(_form.Message ?? "")" ValueChanged="@(v => _form.Message = string.IsNullOrEmpty(v) ? null : v)" />
+                <TextField Label="Webhook URL" Value="@(_form.WebhookUrl ?? "")" ValueChanged="@(v => _form.WebhookUrl = string.IsNullOrEmpty(v) ? null : v)" />
+                <TextField Label="Shell Command" Value="@(_form.ShellCommand ?? "")" ValueChanged="@(v => _form.ShellCommand = string.IsNullOrEmpty(v) ? null : v)" />
+                <TextField Label="Timezone" Value="@(_form.TimeZone ?? "")" ValueChanged="@(v => _form.TimeZone = string.IsNullOrEmpty(v) ? null : v)"
+                           Placeholder="e.g. America/Los_Angeles (optional)" />
+                <BoolField Label="Enabled" Value="@_form.Enabled" ValueChanged="@(v => _form.Enabled = v)" />
+
+                <div class="pcfg-form-actions">
+                    <button class="toolbar-btn primary" @onclick="SaveForm" disabled="@_saving">
+                        @(_saving ? "Saving…" : (_editingId is not null ? "Update" : "Create"))
+                    </button>
+                    <button class="toolbar-btn" @onclick="CancelForm" disabled="@_saving">Cancel</button>
+                </div>
+            </div>
+        }
+
+        @if (_jobs.Count == 0 && !_showForm)
+        {
+            <div class="text-muted" style="font-size: 0.82rem; padding: 0.25rem 0;">No jobs configured.</div>
+        }
+
+        @foreach (var job in _jobs.Where(j => !j.System))
+        {
+            <div class="pcfg-entry">
+                <div class="pcfg-entry-header">
+                    <span class="pcfg-entry-name">
+                        @job.Name
+                        @if (!job.Enabled)
+                        {
+                            <span class="pcfg-location-badge pcfg-location-badge-unhealthy" title="Disabled">disabled</span>
+                        }
+                        @if (job.LastRunStatus is not null)
+                        {
+                            <span class="pcfg-location-badge pcfg-location-badge-@(job.LastRunStatus == "success" ? "healthy" : "unhealthy")"
+                                  title="Last run: @job.LastRunStatus">@job.LastRunStatus</span>
+                        }
+                    </span>
+                    <span class="pcfg-entry-actions">
+                        <button class="pcfg-entry-action" @onclick="() => RunNow(job.Id)" title="Run now">▶</button>
+                        <button class="pcfg-entry-action" @onclick="() => StartEdit(job)" title="Edit">✏️</button>
+                        <button class="pcfg-entry-delete" @onclick="() => DeleteJob(job.Id)" title="Delete">🗑️</button>
+                    </span>
+                </div>
+                <div class="pcfg-entry-fields">
+                    <div class="pcfg-field"><label>Schedule</label><span class="pcfg-field-value">@job.Schedule</span></div>
+                    <div class="pcfg-field"><label>Action</label><span class="pcfg-field-value">@job.ActionType</span></div>
+                    @if (!string.IsNullOrEmpty(job.AgentId))
+                    {
+                        <div class="pcfg-field"><label>Agent</label><span class="pcfg-field-value">@job.AgentId</span></div>
+                    }
+                    @if (!string.IsNullOrEmpty(job.Message))
+                    {
+                        <div class="pcfg-field"><label>Message</label><span class="pcfg-field-value">@job.Message</span></div>
+                    }
+                    @if (!string.IsNullOrEmpty(job.TimeZone))
+                    {
+                        <div class="pcfg-field"><label>Timezone</label><span class="pcfg-field-value">@job.TimeZone</span></div>
+                    }
+                    @if (job.LastRunAt.HasValue)
+                    {
+                        <div class="pcfg-field"><label>Last Run</label><span class="pcfg-field-value">@job.LastRunAt.Value.ToLocalTime().ToString("g")</span></div>
+                    }
+                    @if (job.NextRunAt.HasValue)
+                    {
+                        <div class="pcfg-field"><label>Next Run</label><span class="pcfg-field-value">@job.NextRunAt.Value.ToLocalTime().ToString("g")</span></div>
+                    }
+                    @if (!string.IsNullOrEmpty(job.LastRunError))
+                    {
+                        <div class="pcfg-field pcfg-field-error"><label>Last Error</label><span class="pcfg-field-value">@job.LastRunError</span></div>
+                    }
+                </div>
+            </div>
+        }
+    }
+</div>
 
 @code {
     [Parameter] public JsonObject? Config { get; set; }
     [Parameter] public EventCallback OnChanged { get; set; }
 
+    private List<CronJobDto> _jobs = [];
+    private bool _loading = true;
+    private bool _saving;
+    private bool _showForm;
+    private string? _editingId;
+    private string? _error;
+    private CronJobDto _form = new();
+
     private void MarkDirty() => OnChanged.InvokeAsync();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadJobs();
+    }
+
+    private async Task LoadJobs()
+    {
+        _loading = true;
+        StateHasChanged();
+        var (jobs, error) = await CronApi.ListAsync();
+        _jobs = jobs.ToList();
+        _error = error;
+        _loading = false;
+        StateHasChanged();
+    }
+
+    private void ShowAddForm()
+    {
+        _editingId = null;
+        _form = new CronJobDto { Enabled = true };
+        _showForm = true;
+    }
+
+    private void StartEdit(CronJobDto job)
+    {
+        _editingId = job.Id;
+        _form = new CronJobDto
+        {
+            Id = job.Id,
+            Name = job.Name,
+            Schedule = job.Schedule,
+            ActionType = job.ActionType,
+            AgentId = job.AgentId,
+            Message = job.Message,
+            Model = job.Model,
+            WebhookUrl = job.WebhookUrl,
+            ShellCommand = job.ShellCommand,
+            TimeZone = job.TimeZone,
+            Enabled = job.Enabled,
+            CreatedBy = job.CreatedBy,
+            CreatedAt = job.CreatedAt,
+        };
+        _showForm = true;
+    }
+
+    private void CancelForm()
+    {
+        _showForm = false;
+        _editingId = null;
+    }
+
+    private async Task SaveForm()
+    {
+        _saving = true;
+        StateHasChanged();
+
+        string? error;
+        if (_editingId is not null)
+        {
+            (_, error) = await CronApi.UpdateAsync(_editingId, _form);
+        }
+        else
+        {
+            (_, error) = await CronApi.CreateAsync(_form);
+        }
+
+        _saving = false;
+
+        if (error is not null)
+        {
+            _error = error;
+            StateHasChanged();
+            return;
+        }
+
+        _showForm = false;
+        _editingId = null;
+        await LoadJobs();
+    }
+
+    private async Task DeleteJob(string jobId)
+    {
+        var (success, error) = await CronApi.DeleteAsync(jobId);
+        if (!success)
+        {
+            _error = error ?? "Failed to delete job.";
+            StateHasChanged();
+            return;
+        }
+        await LoadJobs();
+    }
+
+    private async Task RunNow(string jobId)
+    {
+        var (success, error) = await CronApi.RunNowAsync(jobId);
+        if (!success)
+        {
+            _error = error ?? "Failed to trigger job.";
+            StateHasChanged();
+        }
+    }
+
+    // ── Config-backed helpers (global cron settings only) ───────────────
 
     private static JsonObject? GetObjectCaseInsensitive(JsonObject? parent, string key)
     {
@@ -44,14 +255,6 @@
         return obj.FirstOrDefault(kv => string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase)).Key;
     }
 
-    private static string GetStrCaseInsensitive(JsonObject? obj, string key)
-    {
-        var resolvedKey = ResolveKey(obj, key);
-        var node = resolvedKey is null ? null : obj?[resolvedKey];
-        if (node is JsonValue jv) { var raw = jv.ToString(); return raw == "***" ? "" : raw; }
-        return "";
-    }
-
     private static bool GetBoolCaseInsensitive(JsonObject? obj, string key)
     {
         var resolvedKey = ResolveKey(obj, key);
@@ -63,31 +266,6 @@
     {
         if (obj?[key] is JsonValue jv && jv.TryGetValue<int>(out var i)) return i;
         return null;
-    }
-
-    private static Dictionary<string, JsonObject?> GetDictCaseInsensitive(JsonObject? obj, string key)
-    {
-        var resolvedKey = ResolveKey(obj, key);
-        if (resolvedKey is not null && obj?[resolvedKey] is JsonObject dict) return dict.ToDictionary(kv => kv.Key, kv => kv.Value as JsonObject);
-        return new();
-    }
-
-    private void SetNestedBool(string section, string key, bool value)
-    {
-        EnsureObjectCaseInsensitive(section);
-        var obj = Config![section] as JsonObject;
-        if (obj is null) return;
-        obj[key] = value;
-        MarkDirty();
-    }
-
-    private void SetNestedNum(string section, string key, int? value)
-    {
-        EnsureObjectCaseInsensitive(section);
-        var obj = Config![section] as JsonObject;
-        if (obj is null) return;
-        obj[key] = value.HasValue ? JsonValue.Create(value.Value) : null;
-        MarkDirty();
     }
 
     private void SetNestedBoolCaseInsensitive(string section, string key, bool value)
@@ -112,92 +290,10 @@
         MarkDirty();
     }
 
-    private void SetCronJobFieldCaseInsensitive(string jobKey, string field, string? value)
-    {
-        var cron = GetObjectCaseInsensitive(Config, "cron");
-        var jobs = GetObjectCaseInsensitive(cron, "jobs");
-        var job = jobs?[jobKey] as JsonObject;
-        if (job is null) return;
-        var key = ResolveKey(job, field) ?? field;
-        job[key] = string.IsNullOrEmpty(value) ? null : value;
-        MarkDirty();
-    }
-
-    private void SetCronJobBoolCaseInsensitive(string jobKey, string field, bool value)
-    {
-        var cron = GetObjectCaseInsensitive(Config, "cron");
-        var jobs = GetObjectCaseInsensitive(cron, "jobs");
-        var job = jobs?[jobKey] as JsonObject;
-        if (job is null) return;
-        var key = ResolveKey(job, field) ?? field;
-        job[key] = value;
-        MarkDirty();
-    }
-
-    private void AddNestedDictEntryCaseInsensitive(string section, string dict, string key)
-    {
-        if (Config is null || string.IsNullOrWhiteSpace(key)) return;
-        EnsureObjectCaseInsensitive(section);
-        var sectionKey = ResolveKey(Config, section) ?? section;
-        var parent = Config[sectionKey] as JsonObject;
-        if (parent is null) return;
-        var dictKey = ResolveKey(parent, dict) ?? dict;
-        if (parent[dictKey] is not JsonObject dictObj) { dictObj = new JsonObject(); parent[dictKey] = dictObj; }
-        dictObj[key] = new JsonObject();
-        MarkDirty();
-        StateHasChanged();
-    }
-
-    private void DeleteNestedDictEntryCaseInsensitive(string section, string dict, string key)
-    {
-        var parent = GetObjectCaseInsensitive(Config, section);
-        var dictObj = GetObjectCaseInsensitive(parent, dict);
-        if (dictObj is null) return;
-        dictObj.Remove(key);
-        MarkDirty();
-        StateHasChanged();
-    }
-
     private void EnsureObjectCaseInsensitive(string key)
     {
         if (Config is null) return;
         var resolvedKey = ResolveKey(Config, key) ?? key;
         if (Config[resolvedKey] is not JsonObject) Config[resolvedKey] = new JsonObject();
-    }
-
-    private static string GetCronModel(JsonObject? job)
-    {
-        var model = GetStrCaseInsensitive(job, "model");
-        if (!string.IsNullOrWhiteSpace(model))
-            return model;
-
-        var metadata = ResolveKey(job, "metadata") is { } metadataKey
-            ? job?[metadataKey] as JsonObject
-            : null;
-
-        return GetStrCaseInsensitive(metadata, "model");
-    }
-
-    private void SetCronModel(string jobKey, string? value)
-    {
-        var cron = GetObjectCaseInsensitive(Config, "cron");
-        var jobs = GetObjectCaseInsensitive(cron, "jobs");
-        var job = jobs?[jobKey] as JsonObject;
-        if (job is null) return;
-
-        var modelKey = ResolveKey(job, "model") ?? "model";
-        job[modelKey] = string.IsNullOrWhiteSpace(value) ? null : value;
-
-        if (ResolveKey(job, "metadata") is { } metadataKeyName
-            && job[metadataKeyName] is JsonObject metadata)
-        {
-            if (ResolveKey(metadata, "model") is { } metadataModelKey)
-                metadata.Remove(metadataModelKey);
-
-            if (metadata.Count == 0)
-                job[metadataKeyName] = null;
-        }
-
-        MarkDirty();
     }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -18,5 +18,6 @@ builder.Services.AddScoped<PlatformConfigService>();
 builder.Services.AddScoped<GatewayInfoService>();
 builder.Services.AddScoped<IUpdateStatusService, UpdateStatusService>();
 builder.Services.AddScoped<LocationsApiClient>();
+builder.Services.AddScoped<CronApiClient>();
 
 await builder.Build().RunAsync();

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConfigurationPageTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConfigurationPageTests.cs
@@ -133,6 +133,7 @@ public sealed class ConfigurationPageTests : IDisposable
         };
 
         _ctx.Services.AddSingleton(new PlatformConfigService(httpClient));
+        _ctx.Services.AddSingleton(new CronApiClient(httpClient));
         _ctx.JSInterop.SetupVoid("", _ => true);
     }
 
@@ -158,6 +159,12 @@ public sealed class ConfigurationPageTests : IDisposable
 
             if (path == "/api/config/raw" && request.Method == HttpMethod.Get)
                 return JsonResponse(_raw);
+
+            if (path == "/api/cron" && request.Method == HttpMethod.Get)
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", Encoding.UTF8, "application/json")
+                };
 
             if (path.StartsWith("/api/config/", StringComparison.Ordinal) && request.Method == HttpMethod.Put)
             {

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
@@ -27,6 +27,12 @@ public sealed class ProbeRound3BlazorTests : IDisposable
         _ctx.Services.AddSingleton(_interaction);
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        // CronApiClient needs an HttpClient that returns an empty job list
+        var cronHttp = new HttpClient(new EmptyCronApiHandler())
+        {
+            BaseAddress = new Uri("http://gateway.test")
+        };
+        _ctx.Services.AddSingleton(new CronApiClient(cronHttp));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -200,22 +206,14 @@ public sealed class ProbeRound3BlazorTests : IDisposable
     [Fact]
     public void CronConfigPanel_ReadsMixedCaseConfig_AndShowsAgentPromptOption()
     {
+        // Jobs now come from GET /api/cron (not from the config blob).
+        // The panel still reads cron global settings (enabled) from config.
+        // EmptyCronApiHandler returns [] so we just verify the panel renders without error.
         var config = new JsonObject
         {
             ["Cron"] = new JsonObject
             {
-                ["Enabled"] = true,
-                ["Jobs"] = new JsonObject
-                {
-                    ["daily-summary"] = new JsonObject
-                    {
-                        ["Name"] = "Daily summary",
-                        ["Schedule"] = "0 9 * * *",
-                        ["ActionType"] = "agent-chat",
-                        ["AgentId"] = "assistant",
-                        ["Message"] = "Summarize"
-                    }
-                }
+                ["Enabled"] = true
             }
         };
 
@@ -223,30 +221,23 @@ public sealed class ProbeRound3BlazorTests : IDisposable
             .Add(c => c.Config, config)
             .Add(c => c.OnChanged, Microsoft.AspNetCore.Components.EventCallback.Empty));
 
-        Assert.Contains("Daily summary", cut.Markup);
-        Assert.Contains("agent-prompt", cut.Markup);
+        // Panel should render the global settings area and an empty jobs list
+        cut.Markup.ShouldNotBeNullOrWhiteSpace();
+        Assert.Contains("Enabled", cut.Markup);
+        Assert.Contains("Add Job", cut.Markup);
     }
 
     [Fact]
     public void CronConfigPanel_ModelMetadataField_PreservesMetadataModelValue()
     {
+        // Jobs are now stored via the API (SQLite), not in the config blob.
+        // This test verifies the panel renders without error with a config that
+        // previously had job metadata — the config blob is no longer read for jobs.
         var config = new JsonObject
         {
             ["cron"] = new JsonObject
             {
-                ["jobs"] = new JsonObject
-                {
-                    ["daily-summary"] = new JsonObject
-                    {
-                        ["name"] = "Daily summary",
-                        ["schedule"] = "0 9 * * *",
-                        ["actionType"] = "agent-prompt",
-                        ["metadata"] = new JsonObject
-                        {
-                            ["model"] = "openai/gpt-4.1"
-                        }
-                    }
-                }
+                ["enabled"] = true
             }
         };
 
@@ -255,11 +246,8 @@ public sealed class ProbeRound3BlazorTests : IDisposable
             .Add(c => c.OnChanged, Microsoft.AspNetCore.Components.EventCallback.Empty));
 
         cut.Markup.ShouldNotBeNullOrWhiteSpace();
-        var model = ((config["cron"] as JsonObject)?["jobs"] as JsonObject)?["daily-summary"]?
-            .AsObject()["metadata"]?
-            .AsObject()["model"]?
-            .GetValue<string>();
-        model.ShouldBe("openai/gpt-4.1");
+        // Panel renders — no crash, global settings still editable
+        Assert.Contains("Enabled", cut.Markup);
     }
 
     [Fact]
@@ -535,5 +523,30 @@ public sealed class ProbeRound3BlazorTests : IDisposable
         store.GetAgent("agent-1")!.SubAgents["sub-1"].Status.ShouldBe("Completed");
         agent.Conversations["conv-1"].Messages
             .ShouldContain(m => m.Content.Contains("✅") && m.Content.Contains("Worker"));
+    }
+}
+
+/// <summary>
+/// Returns an empty job list for GET /api/cron so CronConfigPanel tests
+/// don't need a real gateway running.
+/// </summary>
+internal sealed class EmptyCronApiHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+        if (path.StartsWith("/api/cron", StringComparison.OrdinalIgnoreCase) && request.Method == HttpMethod.Get)
+        {
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new System.Net.Http.StringContent(
+                    "[]",
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            };
+            return Task.FromResult(response);
+        }
+        return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
     }
 }


### PR DESCRIPTION
## Problem

`CronConfigPanel` read jobs directly from the `appsettings.json` config blob passed down through `Configuration.razor`. Any job created at runtime via the `cron` tool was stored in SQLite and completely invisible in the UI.

## Solution

Split the panel into two layers:

**Config-file backed (unchanged):** `Enabled` and `TickIntervalSeconds` global settings still read/write `appsettings.json` via the existing `Config`/`OnChanged` props.

**API-backed (new):** The jobs section now self-loads from `GET /api/cron`, which returns the merged view of all jobs — SQLite-persisted runtime jobs **and** config-file jobs. Create/update/delete all call the REST API directly. Run-now button added per job.

## Changes

| File | Change |
|---|---|
| `BlazorClient.Core/Services/CronApiClient.cs` | New typed client for `/api/cron` (List, Create, Update, Delete, RunNow) |
| `BlazorClient/Program.cs` | `AddScoped<CronApiClient>()` |
| `BlazorClient/Components/Config/CronConfigPanel.razor` | Rewritten — jobs section is now self-loading from API; global settings remain config-backed |
| `BlazorClient.Tests/ProbeRound3BlazorTests.cs` | Register `CronApiClient` stub; update two tests that previously asserted config-blob job content |
| `BlazorClient.Tests/ConfigurationPageTests.cs` | Register `CronApiClient` + `FakeConfigApiHandler` handles `GET /api/cron → []` |

Closes #288
