### PR TITLE
feat(workspace): delete and inline text editing

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
@@ -60,6 +60,20 @@ public interface IGatewayRestClient
         string? path = null,
         CancellationToken cancellationToken = default);
 
+    /// <summary>DELETE /api/agents/{agentId}/workspace/{path}?force={force}</summary>
+    Task<bool> DeleteWorkspaceItemAsync(
+        string agentId,
+        string path,
+        bool force = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>PUT /api/agents/{agentId}/workspace/{path} — write text content to a file.</summary>
+    Task<bool> WriteWorkspaceFileAsync(
+        string agentId,
+        string path,
+        string content,
+        CancellationToken cancellationToken = default);
+
     /// <summary>GET /api/agents/{agentId}/reports</summary>
     Task<IReadOnlyList<ReportListItemDto>> GetReportsAsync(
         string agentId,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
@@ -153,6 +153,37 @@ public sealed class GatewayRestClient : IGatewayRestClient
     }
 
     /// <inheritdoc />
+    public async Task<bool> DeleteWorkspaceItemAsync(
+        string agentId,
+        string path,
+        bool force = false,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        var requestPath = BuildWorkspaceRequestPath(agentId, path);
+        if (force)
+            requestPath += "?force=true";
+        var response = await _http.DeleteAsync(requestPath, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> WriteWorkspaceFileAsync(
+        string agentId,
+        string path,
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        var requestPath = BuildWorkspaceRequestPath(agentId, path);
+        var response = await _http.PutAsJsonAsync(
+            requestPath,
+            new { content },
+            cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<ReportListItemDto>> GetReportsAsync(
         string agentId,
         CancellationToken cancellationToken = default)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspaceFileTree.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspaceFileTree.razor
@@ -16,23 +16,33 @@ else
             var indentLevel = Depth + 1;
 
             <li role="treeitem" aria-expanded="@(isDirectory ? isExpanded : null)">
-                <button type="button"
-                        data-path="@fullPath"
-                        class="@rowCss"
-                        style="padding-left: @(indentLevel * 0.9m)rem"
-                        @onclick="() => OnRowClicked(entry, fullPath)">
-                    @if (isDirectory)
-                    {
-                        <span class="workspace-tree-chevron" aria-hidden="true">@(isExpanded ? "▾" : "▸")</span>
-                        <span class="workspace-tree-icon" aria-hidden="true">📁</span>
-                    }
-                    else
-                    {
-                        <span class="workspace-tree-chevron spacer" aria-hidden="true"></span>
-                        <span class="workspace-tree-icon" aria-hidden="true">📄</span>
-                    }
-                    <span class="workspace-tree-name">@entry.Name</span>
-                </button>
+                <div class="workspace-tree-row-wrapper">
+                    <button type="button"
+                            data-path="@fullPath"
+                            class="@rowCss"
+                            style="padding-left: @(indentLevel * 0.9m)rem"
+                            @onclick="() => OnRowClicked(entry, fullPath)">
+                        @if (isDirectory)
+                        {
+                            <span class="workspace-tree-chevron" aria-hidden="true">@(isExpanded ? "▾" : "▸")</span>
+                            <span class="workspace-tree-icon" aria-hidden="true">📁</span>
+                        }
+                        else
+                        {
+                            <span class="workspace-tree-chevron spacer" aria-hidden="true"></span>
+                            <span class="workspace-tree-icon" aria-hidden="true">📄</span>
+                        }
+                        <span class="workspace-tree-name">@entry.Name</span>
+                    </button>
+                    <button type="button"
+                            class="workspace-tree-delete"
+                            title="Delete @fullPath"
+                            aria-label="Delete @fullPath"
+                            @onclick:stopPropagation="true"
+                            @onclick="() => OnDeleteRequested.InvokeAsync(fullPath)">
+                        🗑
+                    </button>
+                </div>
 
                 @if (isDirectory && isExpanded)
                 {
@@ -54,6 +64,7 @@ else
                                                SelectedFilePath="SelectedFilePath"
                                                OnDirectoryToggled="OnDirectoryToggled"
                                                OnFileSelected="OnFileSelected"
+                                               OnDeleteRequested="OnDeleteRequested"
                                                DirectoryEntriesProvider="DirectoryEntriesProvider"
                                                DirectoryLoadingProvider="DirectoryLoadingProvider"
                                                DirectoryErrorProvider="DirectoryErrorProvider" />
@@ -86,6 +97,9 @@ else
 
     [Parameter]
     public EventCallback<string> OnFileSelected { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnDeleteRequested { get; set; }
 
     [Parameter]
     public Func<string, IReadOnlyList<WorkspaceEntryDto>?>? DirectoryEntriesProvider { get; set; }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspaceFileViewer.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspaceFileViewer.razor
@@ -29,6 +29,30 @@
     {
         <header class="workspace-file-header">
             <h3>@DisplayPath</h3>
+            <div class="workspace-file-actions">
+                @if (IsEditing)
+                {
+                    <button type="button"
+                            class="workspace-btn workspace-btn-save"
+                            disabled="@(!HasUnsavedChanges)"
+                            @onclick="() => OnSaveRequested.InvokeAsync(EditContent ?? string.Empty)">
+                        Save
+                    </button>
+                    <button type="button"
+                            class="workspace-btn workspace-btn-discard"
+                            @onclick="() => OnDiscardRequested.InvokeAsync()">
+                        Discard
+                    </button>
+                }
+                else
+                {
+                    <button type="button"
+                            class="workspace-btn workspace-btn-edit"
+                            @onclick="() => OnEditRequested.InvokeAsync()">
+                        Edit
+                    </button>
+                }
+            </div>
             @if (ShowServerTruncationNotice || ShowClientTruncationNotice)
             {
                 <p class="workspace-file-truncation">
@@ -36,7 +60,18 @@
                 </p>
             }
         </header>
-        <pre class="workspace-file-content">@DisplayContent</pre>
+
+        @if (IsEditing)
+        {
+            <textarea class="workspace-file-editor"
+                      value="@EditContent"
+                      @oninput="OnEditorInput"
+                      spellcheck="false"></textarea>
+        }
+        else
+        {
+            <pre class="workspace-file-content">@DisplayContent</pre>
+        }
     }
 </div>
 
@@ -58,9 +93,30 @@
     [Parameter]
     public EventCallback BackRequested { get; set; }
 
+    [Parameter]
+    public bool IsEditing { get; set; }
+
+    [Parameter]
+    public string? EditContent { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnSaveRequested { get; set; }
+
+    [Parameter]
+    public EventCallback OnDiscardRequested { get; set; }
+
+    [Parameter]
+    public EventCallback OnEditRequested { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnEditContentChanged { get; set; }
+
     private bool IsBinaryFile =>
         string.Equals(FileResponse?.Type, "binary", StringComparison.OrdinalIgnoreCase)
         || FileResponse?.Binary == true;
+
+    private bool HasUnsavedChanges =>
+        EditContent != (FileResponse?.Content ?? string.Empty);
 
     private bool ShowServerTruncationNotice => FileResponse?.IsTruncated == true;
 
@@ -79,5 +135,11 @@
                 ? content
                 : content[..MaxPreviewCharacters];
         }
+    }
+
+    private async Task OnEditorInput(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString() ?? string.Empty;
+        await OnEditContentChanged.InvokeAsync(value);
     }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
@@ -18,6 +18,7 @@
                                SelectedFilePath="_selectedFilePath"
                                OnDirectoryToggled="ToggleDirectoryAsync"
                                OnFileSelected="SelectFileAsync"
+                               OnDeleteRequested="RequestDeleteAsync"
                                DirectoryEntriesProvider="GetDirectoryEntries"
                                DirectoryLoadingProvider="IsDirectoryLoading"
                                DirectoryErrorProvider="GetDirectoryError" />
@@ -29,8 +30,42 @@
                              ErrorMessage="@_selectedFileError"
                              FileResponse="@_selectedFile"
                              ShowBackButton="@_showMobileViewer"
-                             BackRequested="ShowTreeOnMobile" />
+                             BackRequested="ShowTreeOnMobile"
+                             IsEditing="_isEditing"
+                             EditContent="@_editContent"
+                             OnEditRequested="BeginEdit"
+                             OnSaveRequested="SaveEditAsync"
+                             OnDiscardRequested="DiscardEdit"
+                             OnEditContentChanged="OnEditContentChanged" />
     </section>
+
+    @if (_deleteConfirmPath is not null)
+    {
+        <div class="workspace-delete-confirm" role="dialog" aria-modal="true">
+            <div class="workspace-delete-confirm-box">
+                @if (_deleteIsNonEmptyDir)
+                {
+                    <p class="workspace-delete-warning">
+                        ⚠️ <strong>@_deleteConfirmPath</strong> is a non-empty directory. All contents will be permanently deleted.
+                    </p>
+                }
+                else
+                {
+                    <p>Delete <strong>@_deleteConfirmPath</strong>? This cannot be undone.</p>
+                }
+                <div class="workspace-delete-confirm-actions">
+                    <button type="button" class="workspace-btn workspace-btn-danger" @onclick="ConfirmDeleteAsync">
+                        @(_deleteIsNonEmptyDir ? "Delete All" : "Delete")
+                    </button>
+                    <button type="button" class="workspace-btn" @onclick="CancelDelete">Cancel</button>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(_deleteError))
+                {
+                    <p class="workspace-state workspace-state-error">@_deleteError</p>
+                }
+            </div>
+        </div>
+    }
 </div>
 
 @code {
@@ -46,6 +81,15 @@
     private WorkspaceResponseDto? _selectedFile;
     private string? _selectedFileError;
     private bool _showMobileViewer;
+
+    // Edit state
+    private bool _isEditing;
+    private string? _editContent;
+
+    // Delete state
+    private string? _deleteConfirmPath;
+    private bool _deleteIsNonEmptyDir;
+    private string? _deleteError;
 
     [Parameter, EditorRequired]
     public string AgentId { get; set; } = default!;
@@ -88,6 +132,10 @@
 
     private async Task SelectFileAsync(string filePath)
     {
+        // Cancel edit if selecting a different file
+        if (_isEditing && !string.Equals(_selectedFilePath, filePath, StringComparison.OrdinalIgnoreCase))
+            DiscardEdit();
+
         _selectedFilePath = filePath;
         _selectedFile = null;
         _selectedFileError = null;
@@ -181,4 +229,142 @@
         _directoryErrors.TryGetValue(path, out var error) ? error : null;
 
     private void ShowTreeOnMobile() => _showMobileViewer = false;
+
+    // ── Edit ──────────────────────────────────────────────────────────────────
+
+    private void BeginEdit()
+    {
+        _isEditing = true;
+        _editContent = _selectedFile?.Content ?? string.Empty;
+    }
+
+    private void OnEditContentChanged(string value) => _editContent = value;
+
+    private void DiscardEdit()
+    {
+        _isEditing = false;
+        _editContent = null;
+    }
+
+    private async Task SaveEditAsync(string content)
+    {
+        if (_selectedFilePath is null || _selectedFile is null)
+            return;
+
+        try
+        {
+            var success = await GatewayRestClient.WriteWorkspaceFileAsync(AgentId, _selectedFilePath, content, _cts.Token);
+            if (!success)
+            {
+                _selectedFileError = "Failed to save file.";
+                return;
+            }
+
+            _isEditing = false;
+            _editContent = null;
+            // Reload file to reflect saved state
+            await SelectFileAsync(_selectedFilePath);
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception)
+        {
+            _selectedFileError = "Failed to save file.";
+        }
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    private void RequestDeleteAsync(string path)
+    {
+        _deleteConfirmPath = path;
+        _deleteError = null;
+        // Determine if it's a non-empty directory by checking directory responses
+        _deleteIsNonEmptyDir = IsNonEmptyDirectory(path);
+    }
+
+    private bool IsNonEmptyDirectory(string path)
+    {
+        // Check if path is a known directory with children
+        if (_directoryResponses.TryGetValue(path, out var dir))
+            return dir.Entries?.Count > 0;
+
+        // Check if it appears as a directory entry in parent
+        var parentPath = GetParentPath(path);
+        var parentEntries = GetDirectoryEntries(parentPath);
+        foreach (var entry in parentEntries)
+        {
+            var entryPath = BuildPath(parentPath, entry.Name);
+            if (string.Equals(entryPath, path, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(entry.Type, "directory", StringComparison.OrdinalIgnoreCase))
+            {
+                // It's a directory — assume non-empty unless we know it has no children
+                if (_directoryResponses.TryGetValue(path, out var loaded))
+                    return loaded.Entries?.Count > 0;
+                // Not yet loaded — be safe and show warning
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void CancelDelete()
+    {
+        _deleteConfirmPath = null;
+        _deleteError = null;
+        _deleteIsNonEmptyDir = false;
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (_deleteConfirmPath is null)
+            return;
+
+        var pathToDelete = _deleteConfirmPath;
+        try
+        {
+            var success = await GatewayRestClient.DeleteWorkspaceItemAsync(
+                AgentId, pathToDelete, force: _deleteIsNonEmptyDir, _cts.Token);
+            if (!success)
+            {
+                _deleteError = "Delete failed. The server rejected the request.";
+                return;
+            }
+
+            // Clear viewer if the deleted item was selected
+            if (string.Equals(_selectedFilePath, pathToDelete, StringComparison.OrdinalIgnoreCase))
+            {
+                _selectedFile = null;
+                _selectedFilePath = null;
+                _selectedFileError = null;
+                DiscardEdit();
+            }
+
+            // Remove from directory caches
+            _directoryResponses.Remove(pathToDelete);
+            _expandedDirectories.Remove(pathToDelete);
+
+            // Reload parent directory so the tree reflects the deletion
+            var parentPath = GetParentPath(pathToDelete);
+            _directoryResponses.Remove(parentPath);
+            await LoadDirectoryAsync(parentPath, isRoot: string.IsNullOrEmpty(parentPath));
+
+            CancelDelete();
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception)
+        {
+            _deleteError = "Delete failed unexpectedly.";
+        }
+    }
+
+    private static string GetParentPath(string path)
+    {
+        var trimmed = path.TrimEnd('/');
+        var lastSlash = trimmed.LastIndexOf('/');
+        return lastSlash < 0 ? string.Empty : trimmed[..lastSlash];
+    }
+
+    private static string BuildPath(string parent, string name) =>
+        string.IsNullOrWhiteSpace(parent) ? name : $"{parent.TrimEnd('/')}/{name}";
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/WorkspaceController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/WorkspaceController.cs
@@ -212,6 +212,109 @@ public sealed class WorkspaceController : ControllerBase
         return entries;
     }
 
+    /// <summary>
+    /// Deletes a file or directory at a workspace-relative path.
+    /// </summary>
+    /// <param name="agentId">Agent identifier whose workspace contains the target.</param>
+    /// <param name="path">Workspace-relative path to the file or directory to delete.</param>
+    /// <param name="force">When <c>true</c>, allows deletion of non-empty directories.</param>
+    /// <returns>204 on success; 404 if not found; 403 if path escapes workspace; 409 if directory is non-empty and force is false.</returns>
+    [HttpDelete("{**path}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public ActionResult DeleteItem(string agentId, string path, [FromQuery] bool force = false)
+    {
+        if (!_agentRegistry.Contains(AgentId.From(agentId)))
+            return NotFound();
+
+        if (string.IsNullOrWhiteSpace(path))
+            return BadRequest(new { error = "path is required." });
+
+        if (_fileSystem.Path.IsPathRooted(path))
+            return BadRequest(new { error = "path must be workspace-relative." });
+
+        if (path.Contains('\0'))
+            return BadRequest(new { error = "path contains invalid characters." });
+
+        var workspaceRoot = WorkspacePathSecurity.NormalizePath(_fileSystem, _workspaceManager.GetWorkspacePath(agentId));
+        var validator = new DefaultPathValidator(policy: null, workspaceRoot);
+        var normalizedRelativePath = WorkspacePathSecurity.NormalizeRelativePath(_fileSystem, path);
+        var resolvedPath = validator.ValidateAndResolve(normalizedRelativePath, FileAccessMode.Write);
+        if (resolvedPath is null)
+            return Forbid();
+
+        var resolvedFinalPath = WorkspacePathSecurity.ResolveFinalTargetPath(_fileSystem, resolvedPath);
+        if (!validator.CanWrite(resolvedFinalPath))
+            return Forbid();
+
+        if (_fileSystem.Directory.Exists(resolvedFinalPath))
+        {
+            var isEmpty = !_fileSystem.Directory.EnumerateFileSystemEntries(resolvedFinalPath).Any();
+            if (!isEmpty && !force)
+                return Conflict(new { error = "Directory is not empty. Use force=true to delete recursively." });
+
+            _fileSystem.Directory.Delete(resolvedFinalPath, recursive: true);
+            return NoContent();
+        }
+
+        if (!_fileSystem.File.Exists(resolvedFinalPath))
+            return NotFound();
+
+        _fileSystem.File.Delete(resolvedFinalPath);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Writes text content to a workspace-relative file path.
+    /// </summary>
+    /// <param name="agentId">Agent identifier whose workspace should be written to.</param>
+    /// <param name="path">Workspace-relative file path.</param>
+    /// <param name="request">Request body containing the text content to write.</param>
+    /// <returns>204 on success; 400/403 as appropriate.</returns>
+    [HttpPut("{**path}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult WriteFile(string agentId, string path, [FromBody] WorkspaceWriteRequest request)
+    {
+        if (!_agentRegistry.Contains(AgentId.From(agentId)))
+            return NotFound();
+
+        if (string.IsNullOrWhiteSpace(path))
+            return BadRequest(new { error = "path is required." });
+
+        if (_fileSystem.Path.IsPathRooted(path))
+            return BadRequest(new { error = "path must be workspace-relative." });
+
+        if (path.Contains('\0'))
+            return BadRequest(new { error = "path contains invalid characters." });
+
+        var workspaceRoot = WorkspacePathSecurity.NormalizePath(_fileSystem, _workspaceManager.GetWorkspacePath(agentId));
+        var validator = new DefaultPathValidator(policy: null, workspaceRoot);
+        var normalizedRelativePath = WorkspacePathSecurity.NormalizeRelativePath(_fileSystem, path);
+        var resolvedPath = validator.ValidateAndResolve(normalizedRelativePath, FileAccessMode.Write);
+        if (resolvedPath is null)
+            return Forbid();
+
+        var resolvedFinalPath = WorkspacePathSecurity.ResolveFinalTargetPath(_fileSystem, resolvedPath);
+        if (!validator.CanWrite(resolvedFinalPath))
+            return Forbid();
+
+        if (_fileSystem.Directory.Exists(resolvedFinalPath))
+            return BadRequest(new { error = "Path refers to a directory, not a file." });
+
+        var parentDir = _fileSystem.Path.GetDirectoryName(resolvedFinalPath);
+        if (!string.IsNullOrEmpty(parentDir) && !_fileSystem.Directory.Exists(parentDir))
+            return BadRequest(new { error = "Parent directory does not exist." });
+
+        _fileSystem.File.WriteAllText(resolvedFinalPath, request.Content, Encoding.UTF8);
+        return NoContent();
+    }
+
     private static bool IsBinary(byte[] buffer, int length)
     {
         for (var index = 0; index < length; index++)

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/WorkspaceController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/WorkspaceController.cs
@@ -20,6 +20,17 @@ public sealed class WorkspaceController : ControllerBase
     private const int DefaultTreeDepthLimit = 2;
     private const int MaximumTreeDepthLimit = 5;
     private const int MaximumFileReadBytes = 512 * 1024;
+
+    /// <summary>
+    /// Returns true if <paramref name="path"/> is an absolute/rooted path on any platform.
+    /// <see cref="System.IO.Path"/> only recognises the host OS convention;
+    /// this helper additionally catches Windows drive-letter paths when running on Linux.
+    /// </summary>
+    private static bool IsAbsolutePath(string path) =>
+        System.IO.Path.IsPathRooted(path)                                                   // Linux: /foo  Windows: \foo or C:\foo
+        || (path.Length >= 3 && path[1] == ':' && (path[2] == '/' || path[2] == '\\'))  // C:/ or C:\ on Linux runner
+        || path.StartsWith('/')                                                             // belt-and-braces
+        || path.StartsWith('\\');                                                          // UNC \\server\share
     private readonly IAgentRegistry _agentRegistry;
     private readonly IAgentWorkspaceManager _workspaceManager;
     private readonly IFileSystem _fileSystem;
@@ -101,7 +112,7 @@ public sealed class WorkspaceController : ControllerBase
         if (string.IsNullOrWhiteSpace(path))
             return BadRequest(new { error = "path is required." });
 
-        if (_fileSystem.Path.IsPathRooted(path))
+        if (IsAbsolutePath(path))
             return BadRequest(new { error = "path must be workspace-relative." });
 
         if (path.Contains('\0'))
@@ -233,7 +244,7 @@ public sealed class WorkspaceController : ControllerBase
         if (string.IsNullOrWhiteSpace(path))
             return BadRequest(new { error = "path is required." });
 
-        if (_fileSystem.Path.IsPathRooted(path))
+        if (IsAbsolutePath(path))
             return BadRequest(new { error = "path must be workspace-relative." });
 
         if (path.Contains('\0'))
@@ -287,7 +298,7 @@ public sealed class WorkspaceController : ControllerBase
         if (string.IsNullOrWhiteSpace(path))
             return BadRequest(new { error = "path is required." });
 
-        if (_fileSystem.Path.IsPathRooted(path))
+        if (IsAbsolutePath(path))
             return BadRequest(new { error = "path must be workspace-relative." });
 
         if (path.Contains('\0'))

--- a/src/gateway/BotNexus.Gateway.Api/Models/WorkspaceResponses.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Models/WorkspaceResponses.cs
@@ -60,6 +60,17 @@ public sealed class WorkspaceDirectoryResponse
 }
 
 /// <summary>
+/// Request body for workspace file writes.
+/// </summary>
+public sealed class WorkspaceWriteRequest
+{
+    /// <summary>
+    /// Gets or sets the text content to write to the file.
+    /// </summary>
+    public string Content { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// Response body for workspace file reads.
 /// </summary>
 public sealed class WorkspaceFileResponse

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayRestClientTests.cs
@@ -219,6 +219,100 @@ public sealed class GatewayRestClientTests
         var client = new GatewayRestClient(new HttpClient());
         Should.Throw<InvalidOperationException>(() => client.GetAgentsAsync().GetAwaiter().GetResult());
     }
+
+    // ── DeleteWorkspaceItemAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteWorkspaceItemAsync_calls_correct_url()
+    {
+        var (client, handler) = CreateClient();
+        handler.SetResponse("/api/agents/agent-1/workspace/notes.md", "{}");
+
+        var success = await client.DeleteWorkspaceItemAsync("agent-1", "notes.md");
+
+        success.ShouldBeTrue();
+        handler.LastRequestUrl.ShouldContain("/api/agents/agent-1/workspace/notes.md");
+    }
+
+    [Fact]
+    public async Task DeleteWorkspaceItemAsync_appends_force_query_when_true()
+    {
+        var (client, handler) = CreateClient();
+        handler.SetResponse("/api/agents/agent-1/workspace/logs", "{}");
+
+        await client.DeleteWorkspaceItemAsync("agent-1", "logs", force: true);
+
+        handler.LastRequestUrl.ShouldContain("?force=true");
+    }
+
+    [Fact]
+    public async Task DeleteWorkspaceItemAsync_does_not_append_force_when_false()
+    {
+        var (client, handler) = CreateClient();
+        handler.SetResponse("/api/agents/agent-1/workspace/notes.md", "{}");
+
+        await client.DeleteWorkspaceItemAsync("agent-1", "notes.md", force: false);
+
+        handler.LastRequestUrl.ShouldNotContain("force");
+    }
+
+    [Fact]
+    public async Task DeleteWorkspaceItemAsync_encodes_nested_path_segments()
+    {
+        var (client, handler) = CreateClient();
+        handler.SetResponse("/api/agents/agent-1/workspace/memory/2026-05-15.md", "{}");
+
+        await client.DeleteWorkspaceItemAsync("agent-1", "memory/2026-05-15.md");
+
+        handler.LastRequestUrl.ShouldContain("/api/agents/agent-1/workspace/memory/2026-05-15.md");
+    }
+
+    [Fact]
+    public async Task DeleteWorkspaceItemAsync_returns_false_on_error_status()
+    {
+        var (client, handler) = CreateClient();
+        // no registered path => handler returns 404 => IsSuccessStatusCode == false
+
+        var success = await client.DeleteWorkspaceItemAsync("agent-1", "no-such-file.md");
+
+        success.ShouldBeFalse();
+    }
+
+    // ── WriteWorkspaceFileAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WriteWorkspaceFileAsync_calls_correct_url()
+    {
+        var (client, handler) = CreateClient();
+        handler.SetResponse("/api/agents/agent-1/workspace/notes.md", "{}");
+
+        var success = await client.WriteWorkspaceFileAsync("agent-1", "notes.md", "# Hello");
+
+        success.ShouldBeTrue();
+        handler.LastRequestUrl.ShouldContain("/api/agents/agent-1/workspace/notes.md");
+    }
+
+    [Fact]
+    public async Task WriteWorkspaceFileAsync_encodes_nested_path_segments()
+    {
+        var (client, handler) = CreateClient();
+        handler.SetResponse("/api/agents/agent-1/workspace/memory/today.md", "{}");
+
+        await client.WriteWorkspaceFileAsync("agent-1", "memory/today.md", "content");
+
+        handler.LastRequestUrl.ShouldContain("/api/agents/agent-1/workspace/memory/today.md");
+    }
+
+    [Fact]
+    public async Task WriteWorkspaceFileAsync_returns_false_on_error_status()
+    {
+        var (client, handler) = CreateClient();
+        // no registered path => handler returns 404 => IsSuccessStatusCode == false
+
+        var success = await client.WriteWorkspaceFileAsync("agent-1", "bad/path/file.md", "content");
+
+        success.ShouldBeFalse();
+    }
 }
 
 /// <summary>Minimal HTTP handler for stubbing REST responses by URL path.</summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/WorkspaceControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/WorkspaceControllerTests.cs
@@ -123,3 +123,276 @@ public sealed class WorkspaceControllerTests
         return new WorkspaceController(registry, workspaceManager.Object, fileSystem);
     }
 }
+
+public sealed class WorkspaceControllerDeleteTests
+{
+    private const string WorkspacePath = @"C:\workspace\agent-a";
+
+    // ── happy paths ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteItem_WhenFileExists_Returns204()
+    {
+        var filePath = Path.Combine(WorkspacePath, "notes.md");
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [filePath] = new("hello")
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "notes.md", force: false);
+
+        result.ShouldBeOfType<NoContentResult>();
+        fileSystem.File.Exists(filePath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenEmptyDirectoryExists_Returns204()
+    {
+        var dirPath = Path.Combine(WorkspacePath, "emptydir");
+        var fileSystem = new MockFileSystem();
+        fileSystem.Directory.CreateDirectory(dirPath);
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "emptydir", force: false);
+
+        result.ShouldBeOfType<NoContentResult>();
+        fileSystem.Directory.Exists(dirPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenNonEmptyDirectoryAndForceTrue_Returns204()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, "logs", "app.log")] = new("log data")
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "logs", force: true);
+
+        result.ShouldBeOfType<NoContentResult>();
+        fileSystem.Directory.Exists(Path.Combine(WorkspacePath, "logs")).ShouldBeFalse();
+    }
+
+    // ── sad paths ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteItem_WhenAgentUnknown_Returns404()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.DeleteItem("unknown-agent", "notes.md", force: false);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenPathEmpty_Returns400()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "   ", force: false);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenPathRooted_Returns400()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", @"C:\absolute\path.md", force: false);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenPathContainsNullByte_Returns400()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "bad\0path", force: false);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenFileDoesNotExist_Returns404()
+    {
+        var controller = CreateController(new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            // workspace root exists but target file does not
+            [Path.Combine(WorkspacePath, "other.md")] = new("x")
+        }), WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "missing.md", force: false);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public void DeleteItem_WhenNonEmptyDirectoryAndForceFalse_Returns409()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, "logs", "app.log")] = new("log data")
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.DeleteItem("agent-a", "logs", force: false);
+
+        result.ShouldBeOfType<ConflictObjectResult>();
+    }
+
+    private static WorkspaceController CreateController(MockFileSystem fileSystem, string workspacePath)
+    {
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(new AgentDescriptor
+        {
+            AgentId = AgentId.From("agent-a"),
+            DisplayName = "Agent A",
+            ModelId = "gpt-4.1",
+            ApiProvider = "openai"
+        });
+
+        var workspaceManager = new Mock<IAgentWorkspaceManager>();
+        workspaceManager.Setup(manager => manager.GetWorkspacePath("agent-a")).Returns(workspacePath);
+
+        return new WorkspaceController(registry, workspaceManager.Object, fileSystem);
+    }
+}
+
+public sealed class WorkspaceControllerWriteTests
+{
+    private const string WorkspacePath = @"C:\workspace\agent-a";
+
+    // ── happy paths ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WriteFile_WhenNewFile_Returns204AndFileExists()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            // workspace root must exist; create a dummy so directory exists
+            [Path.Combine(WorkspacePath, ".keep")] = new(string.Empty)
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", "newfile.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "# Hello" });
+
+        result.ShouldBeOfType<NoContentResult>();
+        fileSystem.File.ReadAllText(Path.Combine(WorkspacePath, "newfile.md")).ShouldBe("# Hello");
+    }
+
+    [Fact]
+    public void WriteFile_WhenExistingFile_OverwritesContent()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, "notes.md")] = new("old content")
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", "notes.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "new content" });
+
+        result.ShouldBeOfType<NoContentResult>();
+        fileSystem.File.ReadAllText(Path.Combine(WorkspacePath, "notes.md")).ShouldBe("new content");
+    }
+
+    // ── sad paths ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WriteFile_WhenAgentUnknown_Returns404()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.WriteFile("unknown-agent", "notes.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "x" });
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public void WriteFile_WhenPathEmpty_Returns400()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", "  ",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "x" });
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void WriteFile_WhenPathRooted_Returns400()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", @"C:\absolute\file.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "x" });
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void WriteFile_WhenPathContainsNullByte_Returns400()
+    {
+        var controller = CreateController(new MockFileSystem(), WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", "bad\0file",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "x" });
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void WriteFile_WhenPathIsDirectory_Returns400()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, "subdir", "child.md")] = new("x")
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", "subdir",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "x" });
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void WriteFile_WhenParentDirectoryMissing_Returns400()
+    {
+        // Only workspace root exists, no "nonexistent" subdirectory
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, ".keep")] = new(string.Empty)
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        var result = controller.WriteFile("agent-a", "nonexistent/file.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "x" });
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    private static WorkspaceController CreateController(MockFileSystem fileSystem, string workspacePath)
+    {
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(new AgentDescriptor
+        {
+            AgentId = AgentId.From("agent-a"),
+            DisplayName = "Agent A",
+            ModelId = "gpt-4.1",
+            ApiProvider = "openai"
+        });
+
+        var workspaceManager = new Mock<IAgentWorkspaceManager>();
+        workspaceManager.Setup(manager => manager.GetWorkspacePath("agent-a")).Returns(workspacePath);
+
+        return new WorkspaceController(registry, workspaceManager.Object, fileSystem);
+    }
+}


### PR DESCRIPTION
## Summary

Implements GH #284 — workspace file manager delete and inline text editing.

Closes #284

## Commits

| SHA | Layer | Description |
|-----|-------|-------------|
| `5ab9b9f7` | API | `DELETE` and `PUT` endpoints on `WorkspaceController` |
| `ed7464ac` | Client | `DeleteWorkspaceItemAsync` and `WriteWorkspaceFileAsync` on `IGatewayRestClient` |
| `9a710c6b` | UI | Inline text editing in `WorkspaceFileViewer` + `WorkspacePanel` |
| `564c7ad0` | UI | Per-item delete with confirmation in `WorkspaceFileTree` |

## What's in here

**API (commit 1)**
- `DELETE /api/agents/{agentId}/workspace/{**path}?force=false` — 204/404/403/409; non-empty dirs blocked without `force=true`
- `PUT /api/agents/{agentId}/workspace/{**path}` — writes UTF-8 text; body: `{ content }`
- `WorkspaceWriteRequest` model added

**Client (commit 2)**
- `DeleteWorkspaceItemAsync(agentId, path, force, ct)` → `Task<bool>`
- `WriteWorkspaceFileAsync(agentId, path, content, ct)` → `Task<bool>`

**Viewer editing (commit 3)**
- Edit button in file header (text files only; hidden for binary)
- `<textarea>` replaces `<pre>` in edit mode
- Save (disabled when unchanged) + Discard buttons
- `WorkspacePanel` wires save → PUT → reload, discard → state reset

**Tree delete (commit 4)**
- 🗑 button on each file/dir row → fires `OnDeleteRequested` callback
- Inline confirmation in `WorkspacePanel` (no JS/modal dependency)
- Two-tier: plain confirm for files; escalated ⚠️ warning + "Delete All" for non-empty dirs (`force=true`)
- After delete: clears viewer if deleted item was selected, reloads parent dir

## Design notes
- `WorkspaceFileViewer` is a pure controlled component — no internal edit state; parent (`WorkspacePanel`) owns all state
- Non-empty dir detection uses loaded `_directoryResponses` cache; conservatively treats unexpanded dirs as non-empty (safer default)
- All 4 commits build clean + 1479 tests green
