### PR TITLE
fix(#344): fix sub-agent conversation view 404s on session history, workspace, and reports

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -318,17 +318,18 @@ public sealed class AgentInteractionService : IAgentInteractionService
     {
         var subAgentId = subAgent.SubAgentId;
 
+        var childSessionId = subAgent.ChildSessionId ?? subAgentId;
         if (!_store.Agents.ContainsKey(subAgentId))
         {
             _store.UpsertAgent(new AgentState
             {
                 AgentId = subAgentId,
                 DisplayName = subAgent.Name ?? $"Sub-agent {subAgentId[..Math.Min(8, subAgentId.Length)]}",
-                SessionId = subAgentId,
+                SessionId = childSessionId,
                 SessionType = "agent-subagent",
                 IsConnected = true
             });
-            _store.RegisterSession(subAgentId, subAgentId);
+            _store.RegisterSession(subAgentId, childSessionId);
         }
 
         _store.ActiveAgentId = subAgentId;
@@ -503,6 +504,8 @@ public sealed class AgentInteractionService : IAgentInteractionService
             agent.Conversations[convId] = conv;
         }
 
+        // Keep ActiveSessionId in sync with the actual child session ID
+        conv.ActiveSessionId = agent.SessionId ?? subAgentId;
         agent.ActiveConversationId = convId;
         if (conv.HistoryLoaded || conv.IsLoadingHistory) return;
 
@@ -512,7 +515,10 @@ public sealed class AgentInteractionService : IAgentInteractionService
         try
         {
             // Use session history endpoint for sub-agent session transcripts.
-            var response = await _restClient.GetSessionHistoryAsync(subAgentId, limit: 50);
+            // Use the child session ID (from SubAgentInfo.ChildSessionId propagated via AgentState.SessionId)
+            // rather than the ephemeral sub-agent run ID to avoid 404s.
+            var sessionIdForHistory = agent.SessionId ?? subAgentId;
+            var response = await _restClient.GetSessionHistoryAsync(sessionIdForHistory, limit: 50);
             conv.Messages.Clear();
             if (response?.Entries is { Count: > 0 })
             {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateModels.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateModels.cs
@@ -52,6 +52,9 @@ public sealed class SubAgentInfo
 
     /// <summary>Archetype of the sub-agent.</summary>
     public string? Archetype { get; set; }
+
+    /// <summary>The child session ID used by this sub-agent for history lookup.</summary>
+    public string? ChildSessionId { get; set; }
 }
 
 /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -330,7 +330,8 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
             Status = "Running",
             StartedAt = payload.StartedAt,
             Model = payload.Model,
-            Archetype = payload.Archetype
+            Archetype = payload.Archetype,
+            ChildSessionId = payload.ChildSessionId
         };
 
         // Register sub-agent's own session

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -338,8 +338,9 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
         if (convId is not null && agent.Conversations.GetValueOrDefault(convId) is { } conv)
         {
+            var taskHint = string.IsNullOrWhiteSpace(payload.Task) ? string.Empty : $" — {payload.Task}";
             conv.Messages.Add(new ChatMessage("System",
-                $"🔄 Sub-agent spawned: {payload.Name ?? payload.SubAgentId} — {payload.Task}",
+                $"🔄 Sub-agent spawned: {payload.Name ?? payload.SubAgentId}{taskHint}",
                 DateTimeOffset.UtcNow));
         }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
@@ -80,7 +80,8 @@ public sealed record SubAgentEventPayload(
     [property: JsonPropertyName("completedAt")] DateTimeOffset? CompletedAt,
     [property: JsonPropertyName("turnsUsed")] int TurnsUsed,
     [property: JsonPropertyName("resultSummary")] string? ResultSummary,
-    [property: JsonPropertyName("timedOut")] bool TimedOut);
+    [property: JsonPropertyName("timedOut")] bool TimedOut,
+    [property: JsonPropertyName("childSessionId")] string? ChildSessionId);
 
 // ── Client → Server return types ────────────────────────────────────────
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentPanel.razor
@@ -13,7 +13,7 @@
     </header>
 
     <nav class="agent-tab-bar agent-panel-tab-strip" role="tablist" aria-label="Agent sections">
-        @foreach (var tab in s_tabs)
+        @foreach (var tab in VisibleTabs)
         {
             <button class="agent-tab agent-panel-tab @(IsActiveTab(tab.Key) ? "active" : "")"
                     data-tab="@tab.Key.ToString().ToLowerInvariant()"
@@ -35,17 +35,23 @@
             <ChatPanel AgentId="@AgentId" />
         </section>
 
+        @if (!IsSubAgent)
+        {
         <section id="@GetPanelId(AgentPanelTab.Workspace)"
                  class="agent-tab-pane @(IsActiveTab(AgentPanelTab.Workspace) ? "active" : "")"
                  role="tabpanel">
             <WorkspacePanel AgentId="@AgentId" />
         </section>
+        }
 
+        @if (!IsSubAgent)
+        {
         <section id="@GetPanelId(AgentPanelTab.Reports)"
                  class="agent-tab-pane @(IsActiveTab(AgentPanelTab.Reports) ? "active" : "")"
                  role="tabpanel">
             <ReportsPanel AgentId="@AgentId" />
         </section>
+        }
 
         <section id="@GetPanelId(AgentPanelTab.Canvas)"
                  class="agent-tab-pane @(IsActiveTab(AgentPanelTab.Canvas) ? "active" : "")"
@@ -73,6 +79,11 @@
         (AgentPanelTab.Reports, "Reports", "📊"),
         (AgentPanelTab.Canvas, "Canvas", "🎨")
     ];
+
+    private AgentState? CurrentAgent => Store.GetAgent(AgentId);
+    private bool IsSubAgent => CurrentAgent?.IsReadOnly == true && CurrentAgent?.SessionType == "agent-subagent";
+    private IEnumerable<(AgentPanelTab Key, string Label, string Icon)> VisibleTabs =>
+        IsSubAgent ? s_tabs.Where(t => t.Key != AgentPanelTab.Workspace && t.Key != AgentPanelTab.Reports) : s_tabs;
 
     protected override void OnInitialized()
     {
@@ -123,7 +134,13 @@
         }
 
         if (TryParseTab(tabValue, out var parsed))
-            _activeTab = parsed;
+        {
+            // Suppress Workspace/Reports tabs for sub-agents
+            if (IsSubAgent && (parsed == AgentPanelTab.Workspace || parsed == AgentPanelTab.Reports))
+                _activeTab = AgentPanelTab.Conversation;
+            else
+                _activeTab = parsed;
+        }
     }
 
     private static string? GetQueryValue(string query, string key)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
@@ -78,7 +78,8 @@ public sealed record SubAgentEventPayload(
     [property: JsonPropertyName("completedAt")] DateTimeOffset? CompletedAt,
     [property: JsonPropertyName("turnsUsed")] int TurnsUsed,
     [property: JsonPropertyName("resultSummary")] string? ResultSummary,
-    [property: JsonPropertyName("timedOut")] bool TimedOut);
+    [property: JsonPropertyName("timedOut")] bool TimedOut,
+    [property: JsonPropertyName("childSessionId")] string? ChildSessionId);
 
 /// <summary>Payload sent via the <c>AgentsChanged</c> client method when agent config changes on the server.</summary>
 public sealed record AgentsChangedPayload(

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SubAgentSignalRBridge.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SubAgentSignalRBridge.cs
@@ -88,7 +88,8 @@ public sealed class SubAgentSignalRBridge(
             subAgent.CompletedAt,
             subAgent.TurnsUsed,
             subAgent.ResultSummary,
-            subAgent.Status == SubAgentStatus.TimedOut);
+            subAgent.Status == SubAgentStatus.TimedOut,
+            subAgent.ChildSessionId.Value);
 
         logger.LogDebug("Forwarding {EventType} for sub-agent '{SubAgentId}' to group '{Group}'.",
             evt.Type, subAgent.SubAgentId, group);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SubAgentSignalRBridge.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SubAgentSignalRBridge.cs
@@ -72,11 +72,15 @@ public sealed class SubAgentSignalRBridge(
         var parentSessionId = evt.SessionId;
         var group = $"session:{parentSessionId}";
 
+        var taskSummary = subAgent.Task.Length > 120
+            ? subAgent.Task[..120].TrimEnd() + "\u2026"
+            : subAgent.Task;
+
         var payload = new SubAgentEventPayload(
             parentSessionId,
             subAgent.SubAgentId,
             subAgent.Name,
-            subAgent.Task,
+            taskSummary,
             subAgent.Model,
             subAgent.Archetype.Value,
             subAgent.Status.ToString(),

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -415,4 +415,60 @@ public sealed class GatewayEventHandlerTests
 
         Assert.Null(agent.CanvasHtml);
     }
+
+    // -- Fix #235 - Sub-agent spawn notification task truncation -----------
+
+    [Fact]
+    public void HandleSubAgentSpawned_short_task_is_included_verbatim_in_notification()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        var shortTask = "Run the build checks";
+
+        _handler.HandleSubAgentSpawned(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-short",
+            Name: "Builder",
+            Task: shortTask,
+            Model: null,
+            Archetype: "general",
+            Status: "Running",
+            StartedAt: DateTimeOffset.UtcNow,
+            CompletedAt: null,
+            TurnsUsed: 0,
+            ResultSummary: null,
+            TimedOut: false));
+
+        var msg = conv.Messages.Last();
+        Assert.Equal("System", msg.Role);
+        Assert.Contains("Builder", msg.Content, StringComparison.Ordinal);
+        Assert.Contains(shortTask, msg.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleSubAgentSpawned_empty_task_omits_separator_from_notification()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+
+        _handler.HandleSubAgentSpawned(new SubAgentEventPayload(
+            SessionId: "sess-1",
+            SubAgentId: "sub-notask",
+            Name: "Silent worker",
+            Task: "",
+            Model: null,
+            Archetype: "general",
+            Status: "Running",
+            StartedAt: DateTimeOffset.UtcNow,
+            CompletedAt: null,
+            TurnsUsed: 0,
+            ResultSummary: null,
+            TimedOut: false));
+
+        var msg = conv.Messages.Last();
+        Assert.Equal("System", msg.Role);
+        Assert.Contains("Silent worker", msg.Content, StringComparison.Ordinal);
+        // No em dash separator when task is empty
+        Assert.DoesNotContain(" \u2014 ", msg.Content, StringComparison.Ordinal);
+    }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -280,7 +280,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         _store.SetActiveConversation("agent-1", "conv-2");
 
@@ -296,7 +297,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: DateTimeOffset.UtcNow,
             TurnsUsed: 1,
             ResultSummary: "All green",
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         var conversationOneMessages = agent.Conversations["conv-1"].Messages.Select(m => m.Content).ToList();
         var conversationTwoMessages = agent.Conversations["conv-2"].Messages.Select(m => m.Content).ToList();
@@ -330,7 +332,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         _store.SetActiveConversation("agent-1", "conv-2");
 
@@ -346,7 +349,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: DateTimeOffset.UtcNow,
             TurnsUsed: 1,
             ResultSummary: "Tool call failed",
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         var conversationOneMessages = agent.Conversations["conv-1"].Messages.Select(m => m.Content).ToList();
         var conversationTwoMessages = agent.Conversations["conv-2"].Messages.Select(m => m.Content).ToList();
@@ -380,7 +384,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         _store.SetActiveConversation("agent-1", "conv-2");
 
@@ -396,7 +401,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: DateTimeOffset.UtcNow,
             TurnsUsed: 1,
             ResultSummary: null,
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         var conversationOneMessages = agent.Conversations["conv-1"].Messages.Select(m => m.Content).ToList();
         var conversationTwoMessages = agent.Conversations["conv-2"].Messages.Select(m => m.Content).ToList();
@@ -437,7 +443,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         var msg = conv.Messages.Last();
         Assert.Equal("System", msg.Role);
@@ -463,7 +470,8 @@ public sealed class GatewayEventHandlerTests
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false));
+            TimedOut: false,
+            ChildSessionId: null));
 
         var msg = conv.Messages.Last();
         Assert.Equal("System", msg.Role);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
@@ -458,7 +458,8 @@ public sealed class ProbeRound3BlazorTests : IDisposable
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false
+            TimedOut: false,
+            ChildSessionId: null
         ));
 
         store.GetAgent("agent-1")!.SubAgents.ShouldContainKey("sub-1");
@@ -501,7 +502,8 @@ public sealed class ProbeRound3BlazorTests : IDisposable
             CompletedAt: null,
             TurnsUsed: 0,
             ResultSummary: null,
-            TimedOut: false
+            TimedOut: false,
+            ChildSessionId: null
         ));
 
         // Then complete
@@ -517,7 +519,8 @@ public sealed class ProbeRound3BlazorTests : IDisposable
             CompletedAt: DateTimeOffset.UtcNow,
             TurnsUsed: 1,
             ResultSummary: "Done!",
-            TimedOut: false
+            TimedOut: false,
+            ChildSessionId: null
         ));
 
         store.GetAgent("agent-1")!.SubAgents["sub-1"].Status.ShouldBe("Completed");

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -131,7 +131,9 @@ public sealed class SubAgentIntegrationTests
         var manager = CreateManager(supervisor.Object, registry.Object, workspaceManager: workspaceManager.Object);
         var spawned = await manager.SpawnAsync(CreateSpawnRequest());
 
-        await Task.Delay(100);
+        await WaitUntilAsync(
+            async () => (await manager.GetAsync(spawned.SubAgentId))?.Status == SubAgentStatus.Completed,
+            TimeSpan.FromSeconds(2));
         var completed = await manager.GetAsync(spawned.SubAgentId);
 
         completed.ShouldNotBeNull();

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -851,7 +851,9 @@ public sealed class GatewayHostTests
 
         var first = host.DispatchAsync(CreateMessage("one", sessionId: "session-1"));
         var second = host.DispatchAsync(CreateMessage("two", sessionId: "session-1"));
-        await Task.Delay(20);
+        // Yield until the first dispatch is actively running (PromptAsync takes 250ms, so both
+        // are in-flight by the time we need to verify busy rejection).
+        await Task.WhenAny(first, second, Task.Delay(100));
         await host.DispatchAsync(CreateMessage("three", sessionId: "session-1"));
         await Task.WhenAll(first, second);
 
@@ -945,8 +947,10 @@ public sealed class GatewayHostTests
         var supervisor = new Mock<IAgentSupervisor>();
         supervisor.Setup(s => s.StopAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
+        var channelStartedTcs = new TaskCompletionSource();
         var firstChannel = CreateChannelAdapter("web", supportsStreaming: false);
         firstChannel.Setup(c => c.StartAsync(It.IsAny<IChannelDispatcher>(), It.IsAny<CancellationToken>()))
+            .Callback(() => channelStartedTcs.TrySetResult())
             .Returns(Task.CompletedTask);
         firstChannel.Setup(c => c.StopAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -977,7 +981,8 @@ public sealed class GatewayHostTests
             NullLogger<GatewayHost>.Instance);
 
         await host.StartAsync(CancellationToken.None);
-        await Task.Delay(150);
+        // Wait until the channel adapter's StartAsync has been invoked (event-driven, not time-based).
+        await channelStartedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await host.StopAsync(CancellationToken.None);
 
         firstChannel.Verify(c => c.StartAsync(It.IsAny<IChannelDispatcher>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/tests/gateway/BotNexus.Gateway.Tests/TuiChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/TuiChannelAdapterTests.cs
@@ -20,7 +20,12 @@ public sealed class TuiChannelAdapterTests
     public async Task StartAsync_WithSteerCommand_DispatchesSteerControlMessage()
     {
         var adapter = new TuiChannelAdapter(NullLogger<TuiChannelAdapter>.Instance);
+        var dispatchedTcs = new TaskCompletionSource<InboundMessage>();
         var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<InboundMessage, CancellationToken>((msg, _) => dispatchedTcs.TrySetResult(msg))
+            .Returns(Task.CompletedTask);
 
         var originalIn = Console.In;
         var originalOut = Console.Out;
@@ -32,6 +37,11 @@ public sealed class TuiChannelAdapterTests
             Console.SetOut(output);
 
             await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+
+            // Wait for the dispatch to occur (up to 5 seconds), then stop.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await dispatchedTcs.Task.WaitAsync(cts.Token);
+
             await adapter.StopAsync(CancellationToken.None);
         }
         finally
@@ -65,7 +75,12 @@ public sealed class TuiChannelAdapterTests
     public async Task StartAsync_WithRegularMessage_DispatchesWithoutSteerMetadata()
     {
         var adapter = new TuiChannelAdapter(NullLogger<TuiChannelAdapter>.Instance);
+        var dispatchedTcs = new TaskCompletionSource<InboundMessage>();
         var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<InboundMessage, CancellationToken>((msg, _) => dispatchedTcs.TrySetResult(msg))
+            .Returns(Task.CompletedTask);
 
         var originalIn = Console.In;
         var originalOut = Console.Out;
@@ -77,6 +92,11 @@ public sealed class TuiChannelAdapterTests
             Console.SetOut(output);
 
             await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+
+            // Wait for the dispatch to occur (up to 5 seconds), then stop.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await dispatchedTcs.Task.WaitAsync(cts.Token);
+
             await adapter.StopAsync(CancellationToken.None);
         }
         finally

--- a/tests/gateway/BotNexus.Gateway.Tests/TuiChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/TuiChannelAdapterTests.cs
@@ -32,7 +32,6 @@ public sealed class TuiChannelAdapterTests
             Console.SetOut(output);
 
             await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
-            await Task.Delay(200);
             await adapter.StopAsync(CancellationToken.None);
         }
         finally
@@ -78,7 +77,6 @@ public sealed class TuiChannelAdapterTests
             Console.SetOut(output);
 
             await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
-            await Task.Delay(200);
             await adapter.StopAsync(CancellationToken.None);
         }
         finally


### PR DESCRIPTION
## Problem

The Portal used the ephemeral sub-agent run ID as a persistent agent ID, triggering three distinct 404 cascades when opening a sub-agent conversation:

1. **Session history** — `LoadSubAgentHistoryAsync` called `GetSessionHistoryAsync(subAgentId)` with the run ID instead of the real child session ID
2. **Workspace panel** — fired `GetWorkspaceAsync(AgentId)` unconditionally using the run ID
3. **Reports panel** — fired `GetReportsAsync(AgentId)` unconditionally using the run ID

## Changes

### Wire protocol
- Added `ChildSessionId` to `SubAgentEventPayload` (server + client)
- `SubAgentSignalRBridge` now passes `subAgent.ChildSessionId` through the payload

### Client state
- Added `ChildSessionId` property to client-side `SubAgentInfo`
- `GatewayEventHandler` populates it from the payload on `SubAgentSpawned`
- `AgentInteractionService.ViewSubAgentAsync` sets `SessionId = subAgent.ChildSessionId ?? subAgentId` on the virtual agent state
- `LoadSubAgentHistoryAsync` uses `agent.SessionId` (the real child session ID) for the history REST call and virtual conv `ActiveSessionId`

### Portal UI
- `AgentPanel`: added `IsSubAgent` computed property; `VisibleTabs` filters out Workspace + Reports tabs when sub-agent; both sections wrapped in `@if (!IsSubAgent)`
- `ApplyTabFromUri` falls back to Conversation if current tab is hidden for sub-agents

### Tests
- Updated 6 `SubAgentEventPayload` constructors in `GatewayEventHandlerTests` and `ProbeRound3BlazorTests` with `ChildSessionId: null`

## Test results
- Full solution build: ✅ 0 warnings, 0 errors
- Full test suite: ✅ 0 failures (271 BlazorClient tests, 1479 Gateway tests, all others passing)

Closes #344