### PR TITLE
feat(#349): resizable panel splitters for Workspace and Reports tabs

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ReportsPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ReportsPanel.razor
@@ -3,7 +3,7 @@
 @using Microsoft.AspNetCore.Components
 @implements IDisposable
 
-<div class="reports-panel @MobilePaneClass" data-testid="reports-panel">
+<div id="@_containerId" class="reports-panel @MobilePaneClass" data-testid="reports-panel">
     <section class="reports-list-pane">
         @if (_isLoadingReports)
         {
@@ -35,6 +35,8 @@
             </ul>
         }
     </section>
+
+    <div class="panel-splitter" role="separator" aria-orientation="vertical" aria-label="Resize reports panels" title="Drag to resize"></div>
 
     <section class="reports-viewer-pane">
         @if (_showMobileViewer)
@@ -105,6 +107,9 @@
     [Parameter, EditorRequired]
     public string AgentId { get; set; } = default!;
 
+    private string _containerId => $"reports-panel-{AgentId}";
+    private string _storageKey => $"bn-reports-list-width-{AgentId}";
+
     private string MobilePaneClass => _showMobileViewer ? "mobile-viewer" : "mobile-list";
 
     private bool ShowServerTruncationNotice =>
@@ -128,6 +133,14 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadReportsAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("BotNexus.splitter.init", _containerId, _storageKey, 280, 140, 0.65);
+        }
     }
 
     public void Dispose()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
@@ -1,7 +1,8 @@
 @inject IGatewayRestClient GatewayRestClient
+@inject IJSRuntime JS
 @implements IDisposable
 
-<div class="workspace-panel @MobilePaneClass" data-testid="workspace-panel">
+<div id="@_containerId" class="workspace-panel @MobilePaneClass" data-testid="workspace-panel">
     <section class="workspace-tree-pane">
         @if (_isLoadingRoot)
         {
@@ -24,6 +25,8 @@
                                DirectoryErrorProvider="GetDirectoryError" />
         }
     </section>
+
+    <div class="panel-splitter" role="separator" aria-orientation="vertical" aria-label="Resize workspace panels" title="Drag to resize"></div>
 
     <section class="workspace-viewer-pane">
         <WorkspaceFileViewer IsLoading="_isLoadingFile"
@@ -94,11 +97,22 @@
     [Parameter, EditorRequired]
     public string AgentId { get; set; } = default!;
 
+    private string _containerId => $"workspace-panel-{AgentId}";
+    private string _storageKey => $"bn-workspace-tree-width-{AgentId}";
+
     private string MobilePaneClass => _showMobileViewer ? "mobile-viewer" : "mobile-tree";
 
     protected override async Task OnInitializedAsync()
     {
         await LoadRootAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("BotNexus.splitter.init", _containerId, _storageKey, 280, 120, 0.7);
+        }
     }
 
     public void Dispose()

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -934,6 +934,40 @@ html, body, #app {
     border-right: 1px solid var(--border);
     background: var(--bg-secondary);
 }
+/* -- Panel splitter (resizable divider) --------------------------------- */
+.panel-splitter {
+    flex: 0 0 8px;
+    width: 8px;
+    min-width: 8px;
+    cursor: col-resize;
+    background: transparent;
+    position: relative;
+    z-index: 1;
+    transition: background 0.15s;
+    display: none;
+}
+
+.panel-splitter::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 3px;
+    width: 2px;
+    background: var(--border);
+    transition: background 0.15s, width 0.1s, left 0.1s;
+}
+
+.panel-splitter:hover::after,
+.panel-splitter.dragging::after {
+    left: 2px;
+    width: 4px;
+    background: var(--accent);
+}
+
+.panel-splitter.dragging {
+    background: rgba(0, 180, 216, 0.06);
+}
 
 .reports-list {
     list-style: none;
@@ -1868,13 +1902,15 @@ html, body, #app {
         flex-direction: row;
     }
 
+    .panel-splitter {
+        display: flex;
+    }
+
     .workspace-tree-pane {
-        flex: 0 0 min(33%, 24rem);
         border-right: 1px solid var(--border);
     }
 
     .reports-list-pane {
-        flex: 0 0 min(33%, 24rem);
         border-right: 1px solid var(--border);
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/index.html
@@ -30,6 +30,7 @@
     <script src="js/markdown.js"></script>
     <script src="js/chat.js"></script>
     <script src="js/audio.js"></script>
+    <script src="js/splitter.js"></script>
     <script>
         // Clipboard helper for copy-to-clipboard via JS interop
         window.BotNexus = window.BotNexus || {};

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/splitter.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/splitter.js
@@ -1,0 +1,117 @@
+// BotNexus Blazor Client — Resizable panel splitter
+// Supports any two-pane flex layout.
+// Usage: BotNexus.splitter.init(containerId, storageKey, defaultPx, minPx, maxFraction)
+window.BotNexus = window.BotNexus || {};
+window.BotNexus.splitter = (function () {
+    'use strict';
+
+    var _instances = {};
+
+    function init(containerId, storageKey, defaultPx, minPx, maxFraction) {
+        var container = document.getElementById(containerId);
+        if (!container) return;
+
+        var splitter = container.querySelector('.panel-splitter');
+        if (!splitter) return;
+
+        var leftPane = splitter.previousElementSibling;
+        if (!leftPane) return;
+
+        // Restore persisted width, else use default
+        var savedPx = parseInt(localStorage.getItem(storageKey), 10);
+        var initialPx = (!isNaN(savedPx) && savedPx > 0) ? savedPx : defaultPx;
+        applyWidth(container, leftPane, initialPx, minPx, maxFraction);
+
+        var dragging = false;
+        var startX = 0;
+        var startWidth = 0;
+
+        function onMouseDown(e) {
+            if (e.button !== 0) return;
+            dragging = true;
+            startX = e.clientX;
+            startWidth = leftPane.getBoundingClientRect().width;
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+            splitter.classList.add('dragging');
+            e.preventDefault();
+        }
+
+        function onMouseMove(e) {
+            if (!dragging) return;
+            var delta = e.clientX - startX;
+            var newPx = Math.round(startWidth + delta);
+            newPx = applyWidth(container, leftPane, newPx, minPx, maxFraction);
+            localStorage.setItem(storageKey, String(newPx));
+        }
+
+        function onMouseUp() {
+            if (!dragging) return;
+            dragging = false;
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+            splitter.classList.remove('dragging');
+        }
+
+        // Touch support
+        function onTouchStart(e) {
+            if (e.touches.length !== 1) return;
+            dragging = true;
+            startX = e.touches[0].clientX;
+            startWidth = leftPane.getBoundingClientRect().width;
+            splitter.classList.add('dragging');
+        }
+
+        function onTouchMove(e) {
+            if (!dragging || e.touches.length !== 1) return;
+            var delta = e.touches[0].clientX - startX;
+            var newPx = Math.round(startWidth + delta);
+            newPx = applyWidth(container, leftPane, newPx, minPx, maxFraction);
+            localStorage.setItem(storageKey, String(newPx));
+            e.preventDefault();
+        }
+
+        function onTouchEnd() {
+            dragging = false;
+            splitter.classList.remove('dragging');
+        }
+
+        splitter.addEventListener('mousedown', onMouseDown);
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+        splitter.addEventListener('touchstart', onTouchStart, { passive: true });
+        document.addEventListener('touchmove', onTouchMove, { passive: false });
+        document.addEventListener('touchend', onTouchEnd);
+
+        // Clean up on re-init for the same container
+        if (_instances[containerId]) {
+            _instances[containerId]();
+        }
+        _instances[containerId] = function () {
+            splitter.removeEventListener('mousedown', onMouseDown);
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+            splitter.removeEventListener('touchstart', onTouchStart);
+            document.removeEventListener('touchmove', onTouchMove);
+            document.removeEventListener('touchend', onTouchEnd);
+        };
+    }
+
+    function applyWidth(container, leftPane, desiredPx, minPx, maxFraction) {
+        var containerWidth = container.getBoundingClientRect().width;
+        var maxPx = Math.floor(containerWidth * maxFraction);
+        var clamped = Math.max(minPx, Math.min(desiredPx, maxPx));
+        leftPane.style.flex = '0 0 ' + clamped + 'px';
+        leftPane.style.width = clamped + 'px';
+        return clamped;
+    }
+
+    function destroy(containerId) {
+        if (_instances[containerId]) {
+            _instances[containerId]();
+            delete _instances[containerId];
+        }
+    }
+
+    return { init: init, destroy: destroy };
+}());

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/WorkspacePanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/WorkspacePanelTests.cs
@@ -14,6 +14,7 @@ public sealed class WorkspacePanelTests : IDisposable
     public WorkspacePanelTests()
     {
         _ctx.Services.AddSingleton(_restClient);
+        _ctx.JSInterop.SetupVoid("BotNexus.splitter.init", _ => true);
     }
 
     public void Dispose() => _ctx.Dispose();


### PR DESCRIPTION
Implements draggable resize handles between the left (tree/list) and right (content) panes in both the Workspace and Reports tabs, with localStorage persistence per-agent.

Changes:
- splitter.js: New vanilla drag handler with localStorage persistence, touch support, cleanup on re-init
- WorkspacePanel.razor: Add panel-splitter div, id on container, OnAfterRenderAsync init (280px default, 120px min, 70% max)
- ReportsPanel.razor: Same treatment (280px default, 140px min, 65% max)  
- index.html: Load splitter.js
- app.css: Add .panel-splitter styles (hidden on mobile, display:flex on desktop); remove old hard-coded flex: 0 0 min(33%, 24rem) left-pane rules
- WorkspacePanelTests.cs: Stub BotNexus.splitter.init in bUnit JSInterop fixture

Behaviour:
- Desktop: 8px hit-target splitter with 2px visual line; accents on hover/drag
- Drag persists to localStorage keys bn-workspace-tree-width-{agentId} and bn-reports-list-width-{agentId}
- Mobile: splitter hidden, mobile pane-switching unchanged
- Touch events supported

Closes #349