### PR TITLE
feat(#359): conversation list auto-refresh via SignalR

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
@@ -40,7 +40,8 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnSubAgentKilled += HandleSubAgentKilled;
         _hub.OnSteeringFeedback += HandleSteeringFeedback;
         _hub.OnCanvasUpdated += HandleCanvasUpdated;
-        _hub.OnReconnecting += HandleReconnecting;
+        _hub.OnConversationChanged += HandleConversationChanged;
+                _hub.OnReconnecting += HandleReconnecting;
         _hub.OnReconnected += HandleReconnected;
         _hub.OnDisconnected += HandleDisconnected;
     }
@@ -551,6 +552,21 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
     private void HandleReconnected() => _ = HandleReconnectedAsync();
 
+    public void HandleConversationChanged(ConversationChangedPayload payload)
+    {
+        // Server notified that a conversation was created, updated, or archived.
+        // Re-fetch conversation list for the affected agent so the sidebar stays current.
+        var agentId = payload.AgentId;
+        if (string.IsNullOrWhiteSpace(agentId)) return;
+
+        _ = RefreshConversationsAsync(agentId);
+    }
+
+    // Injected async refresh delegate — wired by AgentInteractionService or PortalLoadService.
+    public Func<string, Task>? ConversationRefreshDelegate { get; set; }
+
+    private Task RefreshConversationsAsync(string agentId)
+        => ConversationRefreshDelegate?.Invoke(agentId) ?? Task.CompletedTask;
     public void Dispose()
     {
         _hub.OnConnected -= HandleConnected;
@@ -568,7 +584,8 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnSubAgentKilled -= HandleSubAgentKilled;
         _hub.OnSteeringFeedback -= HandleSteeringFeedback;
         _hub.OnCanvasUpdated -= HandleCanvasUpdated;
-        _hub.OnReconnecting -= HandleReconnecting;
+        _hub.OnConversationChanged -= HandleConversationChanged;
+                _hub.OnReconnecting -= HandleReconnecting;
         _hub.OnReconnected -= HandleReconnected;
         _hub.OnDisconnected -= HandleDisconnected;
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.SignalR.Client;
+﻿using Microsoft.AspNetCore.SignalR.Client;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
@@ -58,6 +58,9 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     /// <summary>Raised when the current canvas HTML is updated for an agent.</summary>
     public event Action<string, string>? OnCanvasUpdated;
 
+    /// <summary>Raised when a conversation is created, updated, or archived on the server.</summary>
+    public event Action<ConversationChangedPayload>? OnConversationChanged;
+
     /// <summary>Raised when agent configuration changes on the server (add/update/delete).</summary>
     public event Action<AgentsChangedPayload>? OnAgentsChanged;
 
@@ -114,6 +117,7 @@ public sealed class GatewayHubConnection : IAsyncDisposable
         _connection.On<SteeringFeedbackPayload>("SteeringFeedback", p => OnSteeringFeedback?.Invoke(p));
         _connection.On<string, string>("CanvasUpdated", (agentId, html) => OnCanvasUpdated?.Invoke(agentId, html));
         _connection.On<AgentsChangedPayload>("AgentsChanged", p => OnAgentsChanged?.Invoke(p));
+                _connection.On<ConversationChangedPayload>("ConversationChanged", p => OnConversationChanged?.Invoke(p));
 
         _connection.Reconnecting += _ => { OnReconnecting?.Invoke(); return Task.CompletedTask; };
         _connection.Reconnected += _ => { OnReconnected?.Invoke(); return Task.CompletedTask; };

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
@@ -142,6 +142,12 @@ public sealed record SessionHistoryResponse(
 public sealed record AgentsChangedPayload(
     [property: JsonPropertyName("changeType")] string ChangeType,
     [property: JsonPropertyName("agentId")] string? AgentId);
+
+/// <summary>Payload sent via the ConversationChanged client method when a conversation is created, updated, or archived.</summary>
+public sealed record ConversationChangedPayload(
+    [property: JsonPropertyName("changeType")] string ChangeType,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("conversationId")] string ConversationId);
 
 /// <summary>Kind of steering feedback event.</summary>
 public enum SteeringFeedbackKind

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalLoadService.cs
@@ -1,4 +1,4 @@
-namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+﻿namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 /// <summary>
 /// Owns the portal startup sequence: REST first, SignalR second.
@@ -9,6 +9,7 @@ public sealed class PortalLoadService : IPortalLoadService
     private readonly GatewayHubConnection _hub;
     private readonly IClientStateStore _store;
     private readonly IGatewayEventHandler _eventHandler;
+    private readonly IAgentInteractionService? _agentInteraction;
 
     public bool IsReady { get; private set; }
     public bool IsLoading { get; private set; }
@@ -19,12 +20,14 @@ public sealed class PortalLoadService : IPortalLoadService
         IGatewayRestClient restClient,
         GatewayHubConnection hub,
         IClientStateStore store,
-        IGatewayEventHandler eventHandler)
+        IGatewayEventHandler eventHandler,
+        IAgentInteractionService? agentInteraction = null)
     {
         _restClient = restClient;
         _hub = hub;
         _store = store;
         _eventHandler = eventHandler;
+        _agentInteraction = agentInteraction;  // optional — null when not wired (e.g. in tests)
     }
 
     public async Task InitializeAsync(string hubUrl, CancellationToken cancellationToken = default)
@@ -119,6 +122,14 @@ public sealed class PortalLoadService : IPortalLoadService
                 }
             }
 
+            // Wire conversation-refresh delegate so ConversationChanged SignalR events
+            // trigger a REST re-fetch of the conversation list for the affected agent.
+            if (_eventHandler is GatewayEventHandler concreteHandler)
+            {
+                var agentInteractionRef = _agentInteraction;
+                if (agentInteractionRef is not null)
+                    concreteHandler.ConversationRefreshDelegate = agentId => agentInteractionRef.RefreshConversationsAsync(agentId);
+            }
             await _hub.ConnectAsync(hubUrl);
 
             var subscribeResult = await _hub.SubscribeAllAsync();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using BotNexus.Gateway.Abstractions.Sessions;
 
 namespace BotNexus.Extensions.Channels.SignalR;
@@ -84,6 +84,12 @@ public sealed record SubAgentEventPayload(
 public sealed record AgentsChangedPayload(
     [property: JsonPropertyName("changeType")] string ChangeType,
     [property: JsonPropertyName("agentId")] string? AgentId);
+
+/// <summary>Payload sent via the ConversationChanged client method when a conversation is created, updated, or archived.</summary>
+public sealed record ConversationChangedPayload(
+    [property: JsonPropertyName("changeType")] string ChangeType,
+    [property: JsonPropertyName("agentId")] string AgentId,
+    [property: JsonPropertyName("conversationId")] string ConversationId);
 
 /// <summary>Kind of steering feedback event.</summary>
 public enum SteeringFeedbackKind { Injected, Queued }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
@@ -1,4 +1,4 @@
-using BotNexus.Gateway.Abstractions.Models;
+﻿using BotNexus.Gateway.Abstractions.Models;
 
 namespace BotNexus.Extensions.Channels.SignalR;
 
@@ -22,6 +22,8 @@ public interface IGatewayHubClient
     Task SubAgentFailed(SubAgentEventPayload payload);
     Task SubAgentKilled(SubAgentEventPayload payload);
     Task AgentsChanged(AgentsChangedPayload payload);
+    Task ConversationChanged(ConversationChangedPayload payload);
+
     Task SteeringFeedback(SteeringFeedbackPayload payload);
     Task CanvasUpdated(string agentId, string html);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRConversationChangeNotifier.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRConversationChangeNotifier.cs
@@ -1,0 +1,16 @@
+﻿using BotNexus.Gateway.Abstractions.Conversations;
+using Microsoft.AspNetCore.SignalR;
+
+namespace BotNexus.Extensions.Channels.SignalR;
+
+/// <summary>
+/// Emits conversation lifecycle changes to all connected SignalR clients.
+/// </summary>
+public sealed class SignalRConversationChangeNotifier(IHubContext<GatewayHub, IGatewayHubClient> hubContext) : IConversationChangeNotifier
+{
+    private readonly IHubContext<GatewayHub, IGatewayHubClient> _hubContext = hubContext;
+
+    /// <inheritdoc />
+    public Task NotifyConversationChangedAsync(string changeType, string agentId, string conversationId, CancellationToken cancellationToken = default)
+        => _hubContext.Clients.All.ConversationChanged(new ConversationChangedPayload(changeType, agentId, conversationId));
+}

--- a/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentExchangeResult))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.AgentExchangeTranscriptEntry))]
@@ -52,6 +52,8 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentHandle))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentHandleInspector))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentChangeNotifier))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Conversations.IConversationChangeNotifier))]
+
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentCanvasNotifier))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentRegistry))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Agents.IAgentSupervisor))]

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -1,4 +1,6 @@
-using BotNexus.Domain.Primitives;
+﻿using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -19,16 +21,26 @@ public sealed class ConversationsController : ControllerBase
 {
     private readonly IConversationStore _conversations;
     private readonly ISessionStore _sessions;
+    private readonly IReadOnlyList<IConversationChangeNotifier> _conversationChangeNotifiers;
+    private readonly ILogger<ConversationsController> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConversationsController"/> class.
     /// </summary>
     /// <param name="conversations">The conversation store.</param>
     /// <param name="sessions">The session store (used for history assembly).</param>
-    public ConversationsController(IConversationStore conversations, ISessionStore sessions)
+    /// <param name="conversationChangeNotifiers">Publishes conversation lifecycle notifications to connected channel clients.</param>
+    /// <param name="logger">Logs best-effort transport notification failures.</param>
+    public ConversationsController(
+        IConversationStore conversations,
+        ISessionStore sessions,
+        IEnumerable<IConversationChangeNotifier>? conversationChangeNotifiers = null,
+        ILogger<ConversationsController>? logger = null)
     {
         _conversations = conversations;
         _sessions = sessions;
+        _conversationChangeNotifiers = conversationChangeNotifiers?.ToArray() ?? [];
+        _logger = logger ?? NullLogger<ConversationsController>.Instance;
     }
 
     /// <summary>
@@ -96,6 +108,7 @@ public sealed class ConversationsController : ControllerBase
         };
 
         var created = await _conversations.CreateAsync(conversation, cancellationToken);
+        await NotifyConversationChangedBestEffortAsync("created", created.AgentId.Value, created.ConversationId.Value, cancellationToken);
         return CreatedAtAction(nameof(Get), new { conversationId = created.ConversationId.Value }, ToResponse(created));
     }
 
@@ -134,6 +147,7 @@ public sealed class ConversationsController : ControllerBase
             conversation.Purpose = NormalizePurpose(request.Purpose);
         conversation.UpdatedAt = DateTimeOffset.UtcNow;
         await _conversations.SaveAsync(conversation, cancellationToken);
+        await NotifyConversationChangedBestEffortAsync("updated", conversation.AgentId.Value, conversation.ConversationId.Value, cancellationToken);
         return Ok(ToResponse(conversation));
     }
 
@@ -347,9 +361,34 @@ public sealed class ConversationsController : ControllerBase
         await SealConversationSessionsAsync(conversation.ConversationId, cancellationToken);
 
         await _conversations.ArchiveAsync(conversation.ConversationId, cancellationToken);
+        await NotifyConversationChangedBestEffortAsync("archived", conversation.AgentId.Value, conversation.ConversationId.Value, cancellationToken);
         return NoContent();
     }
 
+    // ── Notification helpers ──────────────────────────────────────────────────
+
+    private async Task NotifyConversationChangedBestEffortAsync(string changeType, string agentId, string conversationId, CancellationToken cancellationToken)
+    {
+        if (_conversationChangeNotifiers.Count == 0)
+            return;
+
+        foreach (var notifier in _conversationChangeNotifiers)
+        {
+            try
+            {
+                await notifier.NotifyConversationChangedAsync(changeType, agentId, conversationId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to publish conversation change notification ({ChangeType}) for conversation {ConversationId} via notifier {NotifierType}.",
+                    changeType,
+                    conversationId,
+                    notifier.GetType().FullName);
+            }
+        }
+    }
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static ConversationResponse ToResponse(Conversation c) => new(

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationChangeNotifier.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationChangeNotifier.cs
@@ -1,0 +1,17 @@
+﻿namespace BotNexus.Gateway.Abstractions.Conversations;
+
+/// <summary>
+/// Publishes conversation lifecycle change notifications to external clients.
+/// Implementations bridge gateway-level events to transport-specific channels.
+/// </summary>
+public interface IConversationChangeNotifier
+{
+    /// <summary>
+    /// Notifies channel clients that a conversation has been created, updated, or archived.
+    /// </summary>
+    /// <param name="changeType">Change classification: created, updated, archived.</param>
+    /// <param name="agentId">Agent that owns the conversation.</param>
+    /// <param name="conversationId">Affected conversation identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task NotifyConversationChangedAsync(string changeType, string agentId, string conversationId, CancellationToken cancellationToken = default);
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/AssemblyLoadContextExtensionLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/AssemblyLoadContextExtensionLoader.cs
@@ -1,10 +1,11 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.Loader;
 using System.Text.Json;
 using System.IO.Abstractions;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Extensions;
 using BotNexus.Gateway.Abstractions.Hooks;
@@ -38,6 +39,7 @@ public sealed class AssemblyLoadContextExtensionLoader : IExtensionLoader
         typeof(IAgentRegistry),
         typeof(IAgentSupervisor),
         typeof(IAgentChangeNotifier),
+        typeof(IConversationChangeNotifier),
         typeof(IAgentCanvasNotifier),
         typeof(IAgentCommunicator),
         typeof(IAgentToolContributor),
@@ -397,6 +399,7 @@ public sealed class AssemblyLoadContextExtensionLoader : IExtensionLoader
             if (contract == typeof(IChannelAdapter) || 
                 contract == typeof(IIsolationStrategy) ||
                 contract == typeof(IAgentChangeNotifier) ||
+                contract == typeof(IConversationChangeNotifier) ||
                 contract == typeof(IAgentCanvasNotifier) ||
                 contract == typeof(IAgentToolContributor) ||
                 contract == typeof(IAgentTool) ||


### PR DESCRIPTION
Fixes #359

## Problem
The Portal conversation list sidebar loads once at startup and never refreshes. When a new conversation is created via the REST API the sidebar stays stale until a full page reload.

## Root cause
No SignalR event existed for conversation lifecycle changes. The AgentsChanged event already solved the equivalent problem for agents -- this PR applies the same pattern to conversations.

## Changes

### Server
- HubContracts.cs (SignalR extension): Add ConversationChangedPayload record
- IGatewayHubClient.cs: Add ConversationChanged method
- IConversationChangeNotifier.cs (new): Contract mirroring IAgentChangeNotifier
- SignalRConversationChangeNotifier.cs (new): Broadcasts to all hub clients
- AssemblyLoadContextExtensionLoader.cs: Register IConversationChangeNotifier in plugin DI scan
- TypeForwards.cs: TypeForward for IConversationChangeNotifier
- ConversationsController.cs: Inject notifiers; fire created/updated/archived best-effort on POST/PATCH/DELETE

### Client (BlazorClient.Core)
- HubContracts.cs: Add client-side ConversationChangedPayload
- GatewayHubConnection.cs: OnConversationChanged event + .On wire-up
- GatewayEventHandler.cs: HandleConversationChanged handler
- PortalLoadService.cs: Wire ConversationRefreshDelegate to AgentInteractionService.RefreshConversationsAsync

## Behaviour after this PR
Any client connected to the Gateway hub will receive a ConversationChanged push event whenever a conversation is created, renamed, or archived via the REST API. The Portal sidebar re-fetches that agent conversation list immediately -- no polling, no page reload required.