### PR TITLE
fix(#362): flush session entries to store on TurnEnd (Option B)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentExecution.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentExecution.cs
@@ -123,5 +123,7 @@ public enum AgentStreamEventType
     MessageEnd,
 
     /// <summary>An error occurred during processing.</summary>
-    Error
+    Error,
+    /// <summary>A turn (LLM call + tool cycle) has completed. Used for mid-run persistence checkpoints.</summary>
+    TurnEnd
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -724,6 +724,8 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
                     },
                     MessageEndEvent end when end.Message is AssistantAgentMessage
                         => new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd, MessageId = messageId },
+                    TurnEndEvent
+                        => new AgentStreamEvent { Type = AgentStreamEventType.TurnEnd, MessageId = messageId },
                     _ => null
                 };
 

--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -69,6 +69,31 @@ public static class StreamingSessionHelper
                         Content = $"Agent stream error: {evt.ErrorMessage}"
                     });
                     break;
+                case AgentStreamEventType.TurnEnd when streamedHistory.Count > 0 || streamedContent.Length > 0:
+                    // Flush accumulated entries at each turn boundary so a second client
+                    // opening the session mid-run sees partial progress rather than nothing.
+                    // The final SaveAsync below remains the authoritative write for the
+                    // completed assistant message; this flush persists tool calls eagerly.
+                    // Fixes #362.
+                    var turnSnapshot = streamedHistory.ToList();
+                    streamedHistory.Clear();
+                    if (streamedContent.Length > 0)
+                    {
+                        turnSnapshot.Add(new SessionEntry { Role = MessageRole.Assistant, Content = streamedContent.ToString() });
+                        streamedContent.Clear();
+                    }
+                    session.AddEntries(turnSnapshot);
+                    try
+                    {
+                        await sessionStore.SaveAsync(session, cancellationToken);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        // Best-effort mid-run flush — log but don't abort the stream.
+                        // The final SaveAsync at AgentEnd is still authoritative.
+                        _ = ex; // Suppress unused-variable warning; caller's logger not available here.
+                    }
+                    break;
             }
 
             if (options.OnEventAsync is not null)
@@ -77,6 +102,8 @@ public static class StreamingSessionHelper
             }
         }
 
+        // Final write: append any remaining content not yet flushed by a TurnEnd
+        // (single-turn runs, or the last partial turn before AgentEnd).
         session.AddEntries(streamedHistory);
         if (streamedContent.Length > 0)
             session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = streamedContent.ToString() });

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -781,9 +781,11 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
                 AgentStreamEventType.ToolEnd => "ToolEnd",
                 AgentStreamEventType.MessageEnd => "MessageEnd",
                 AgentStreamEventType.Error => "Error",
+                AgentStreamEventType.TurnEnd => null, // internal persistence signal -- not forwarded to Hub clients
                 _ => throw new ArgumentOutOfRangeException()
             };
 
+            if (method is null) continue; // TurnEnd is internal-only, not forwarded to Hub clients
             var payload = await handlers[method].Task.WaitAsync(cts.Token);
             payload.Type.ShouldBe(expected);
         }


### PR DESCRIPTION
Fixes #362

## What

Adds mid-run session persistence by flushing accumulated entries to the store at each `TurnEnd` boundary (after each LLM call + tool cycle completes), rather than only at the end of the full agent run.

## Why

A second client opening a session mid-run (e.g. mobile view while desktop has a long multi-tool run in flight) saw empty or stale history because `StreamingSessionHelper` batched all writes until `AgentEnd`.

## How

**3 production files changed, 1 test file updated:**

| File | Change |
|------|--------|
| `AgentExecution.cs` | Added `TurnEnd` to `AgentStreamEventType` enum — internal persistence signal only |
| `InProcessIsolationStrategy.cs` | Emits `AgentStreamEvent { Type = TurnEnd }` when `TurnEndEvent` fires in the agent loop |
| `StreamingSessionHelper.cs` | On `TurnEnd`: drains `streamedHistory` + `streamedContent` into the session and calls `SaveAsync` immediately. Best-effort (store errors swallowed to avoid aborting the stream). Final `SaveAsync` at `AgentEnd` remains authoritative. |
| `SignalRIntegrationTests.cs` | Updated `Hub_ChannelAdapter_AllEventTypes` to skip `TurnEnd` (internal-only, not forwarded to Hub clients via `_ => Task.CompletedTask` in `SignalRChannelAdapter`) |

## Not changed

- `TurnEnd` is **not** forwarded to SignalR Hub clients — `SignalRChannelAdapter.SendStreamEventAsync` already has `_ => Task.CompletedTask` as the default case
- Single-turn runs and the final partial turn are still covered by the end-of-run `SaveAsync`
- Non-streaming (`PromptAsync`) path is unchanged — tracked separately in #363 (write-ahead + crash sentinel)

## Related

- Companion issue: #363 — gateway restart during run causes silent data loss (write-ahead + crash sentinel, separate PR)