### PR TITLE
fix(portal): restore sidebar default width and delete icon alignment

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ReportsPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ReportsPanel.razor
@@ -139,7 +139,7 @@
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("BotNexus.splitter.init", _containerId, _storageKey, 280, 140, 0.65);
+            await JS.InvokeVoidAsync("BotNexus.splitter.init", _containerId, _storageKey, 384, 140, 0.65, 0.33);
         }
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
@@ -111,7 +111,7 @@
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("BotNexus.splitter.init", _containerId, _storageKey, 280, 120, 0.7);
+            await JS.InvokeVoidAsync("BotNexus.splitter.init", _containerId, _storageKey, 384, 120, 0.7, 0.33);
         }
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -803,8 +803,17 @@ html, body, #app {
     min-height: 0;
 }
 
+.workspace-tree-row-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
 .workspace-tree-row {
     width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
     display: flex;
     align-items: center;
     gap: 0.35rem;
@@ -854,6 +863,29 @@ html, body, #app {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.workspace-tree-delete {
+    flex: 0 0 auto;
+    width: 1.6rem;
+    height: 1.6rem;
+    margin-right: 0.45rem;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1;
+}
+
+.workspace-tree-delete:hover {
+    background: rgba(255, 90, 90, 0.12);
+    color: #ff8e8e;
+}
+
+.workspace-tree-delete:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
 }
 
 .workspace-viewer {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/splitter.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/splitter.js
@@ -1,13 +1,13 @@
 // BotNexus Blazor Client — Resizable panel splitter
 // Supports any two-pane flex layout.
-// Usage: BotNexus.splitter.init(containerId, storageKey, defaultPx, minPx, maxFraction)
+// Usage: BotNexus.splitter.init(containerId, storageKey, defaultPx, minPx, maxFraction, defaultFraction)
 window.BotNexus = window.BotNexus || {};
 window.BotNexus.splitter = (function () {
     'use strict';
 
     var _instances = {};
 
-    function init(containerId, storageKey, defaultPx, minPx, maxFraction) {
+    function init(containerId, storageKey, defaultPx, minPx, maxFraction, defaultFraction) {
         var container = document.getElementById(containerId);
         if (!container) return;
 
@@ -17,9 +17,18 @@ window.BotNexus.splitter = (function () {
         var leftPane = splitter.previousElementSibling;
         if (!leftPane) return;
 
-        // Restore persisted width, else use default
+        var containerWidth = container.getBoundingClientRect().width;
+
+        // Restore persisted width, else use default.
+        // defaultFraction allows preserving legacy proportional defaults
+        // (for example 33% capped by a px value) on first load.
+        var defaultFromFraction = defaultPx;
+        if (typeof defaultFraction === 'number' && defaultFraction > 0 && defaultFraction <= 1) {
+            defaultFromFraction = Math.min(defaultPx, Math.floor(containerWidth * defaultFraction));
+        }
+
         var savedPx = parseInt(localStorage.getItem(storageKey), 10);
-        var initialPx = (!isNaN(savedPx) && savedPx > 0) ? savedPx : defaultPx;
+        var initialPx = (!isNaN(savedPx) && savedPx > 0) ? savedPx : defaultFromFraction;
         applyWidth(container, leftPane, initialPx, minPx, maxFraction);
 
         var dragging = false;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ReportsPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ReportsPanelTests.cs
@@ -3,6 +3,7 @@ using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using System.Globalization;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -42,6 +43,23 @@ public sealed class ReportsPanelTests : IDisposable
         var cut = _ctx.Render<ReportsPanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
 
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("No reports found in this workspace yet."));
+    }
+
+    [Fact]
+    public void First_render_initializes_splitter_with_legacy_default_width_baseline()
+    {
+        _restClient.GetReportsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ReportListItemDto>>([]));
+
+        _ctx.Render<ReportsPanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
+
+        var invocation = Assert.Single(_ctx.JSInterop.Invocations, i => i.Identifier == "BotNexus.splitter.init");
+        Assert.Equal("reports-panel-agent-1", Assert.IsType<string>(invocation.Arguments[0]));
+        Assert.Equal("bn-reports-list-width-agent-1", Assert.IsType<string>(invocation.Arguments[1]));
+        Assert.Equal(384, Convert.ToInt32(invocation.Arguments[2], CultureInfo.InvariantCulture));
+        Assert.Equal(140, Convert.ToInt32(invocation.Arguments[3], CultureInfo.InvariantCulture));
+        Assert.Equal(0.65d, Convert.ToDouble(invocation.Arguments[4], CultureInfo.InvariantCulture), 3);
+        Assert.Equal(0.33d, Convert.ToDouble(invocation.Arguments[5], CultureInfo.InvariantCulture), 3);
     }
 
     [Fact]

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/WorkspacePanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/WorkspacePanelTests.cs
@@ -3,6 +3,7 @@ using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using System.Globalization;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -41,6 +42,23 @@ public sealed class WorkspacePanelTests : IDisposable
         var cut = _ctx.Render<WorkspacePanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
 
         cut.WaitForAssertion(() => cut.Markup.ShouldContain("Workspace is empty."));
+    }
+
+    [Fact]
+    public void First_render_initializes_splitter_with_legacy_default_width_baseline()
+    {
+        _restClient.GetWorkspaceAsync("agent-1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<WorkspaceResponseDto?>(new WorkspaceResponseDto("directory", "", [], null, null, null, null, null)));
+
+        _ctx.Render<WorkspacePanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
+
+        var invocation = Assert.Single(_ctx.JSInterop.Invocations, i => i.Identifier == "BotNexus.splitter.init");
+        Assert.Equal("workspace-panel-agent-1", Assert.IsType<string>(invocation.Arguments[0]));
+        Assert.Equal("bn-workspace-tree-width-agent-1", Assert.IsType<string>(invocation.Arguments[1]));
+        Assert.Equal(384, Convert.ToInt32(invocation.Arguments[2], CultureInfo.InvariantCulture));
+        Assert.Equal(120, Convert.ToInt32(invocation.Arguments[3], CultureInfo.InvariantCulture));
+        Assert.Equal(0.7d, Convert.ToDouble(invocation.Arguments[4], CultureInfo.InvariantCulture), 3);
+        Assert.Equal(0.33d, Convert.ToDouble(invocation.Arguments[5], CultureInfo.InvariantCulture), 3);
     }
 
     [Fact]
@@ -219,6 +237,8 @@ public sealed class WorkspacePanelTests : IDisposable
         css.ShouldContain(".workspace-panel.mobile-tree .workspace-viewer-pane");
         css.ShouldContain(".workspace-panel.mobile-viewer .workspace-tree-pane");
         css.ShouldContain(".workspace-mobile-back");
+        css.ShouldContain(".workspace-tree-row-wrapper");
+        css.ShouldContain(".workspace-tree-delete");
     }
 
     private static string FindRepositoryRoot()


### PR DESCRIPTION
## Summary
- restore initial workspace/reports list pane sizing to the legacy baseline behavior (`min(33%, 24rem)`) while keeping adjustable splitter behavior and persisted widths
- fix workspace tree delete button row layout so delete controls are consistently aligned with file/folder rows
- add regression coverage for splitter init arguments and workspace tree CSS selectors

## Validation
- `dotnet build BotNexus.slnx --nologo --tl:off`
- `dotnet test BotNexus.slnx --nologo --tl:off`

## Notes
- branch: `dev/github/fix-sidebar-default-width`
- commit: `89f40d8a`