### PR TITLE
docs: fix stale memory/daily/ path in getting-started-release

### DIFF
--- a/docs/getting-started-release.md
+++ b/docs/getting-started-release.md
@@ -242,7 +242,8 @@ The configuration is loaded automatically. BotNexus creates a workspace director
 ├── MEMORY.md         # Long-term distilled knowledge
 ├── HEARTBEAT.md      # Periodic task instructions
 └── memory/
-    └── daily/        # Daily memory logs (YYYY-MM-DD.md)
+    ├── 2026-04-01.md    # Daily memory notes (YYYY-MM-DD.md)
+    └── ...            (one per day)
 ```
 
 ### Customize your agent


### PR DESCRIPTION
## Summary

Fixes a stale workspace tree diagram in `docs/getting-started-release.md` that incorrectly showed a `daily/` subdirectory under `memory/`.

### Actual layout
```text
~/.botnexus/agents/assistant/
└── memory/
    ├── 2026-04-01.md    # Daily memory notes (YYYY-MM-DD.md)
    └── ...              (one per day)
```

Daily notes are stored **directly** in `memory/` as `YYYY-MM-DD.md` files. There is no `daily/` subfolder.

## Audit

Full repo scan performed before this fix:

| File | Status |
|------|--------|
| `docs/getting-started-release.md` | ❌ **Fixed** — showed `daily/` subfolder |
| `docs/development/workspace-and-memory.md` | ✅ Already correct (flat layout) |
| C# source (`*.cs`) | ✅ Zero references to a `daily/` path |
| `AGENTS.md` (repo root) | ✅ Already correct (`memory/YYYY-MM-DD.md`) |
| `docs/cron-and-scheduling.md` | ✅ Uses "daily" as adjective only (not a path) |
| `docs/configuration.md` | ✅ Uses "daily" as adjective only |
| `docs/observability.md` | ✅ Uses "daily" as adjective only (rolling log files) |

No code changes required.