### PR TITLE
feat(#312): Phase 3 - ActiveHoursConfig + smart cron expression generation

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/HeartbeatAgentConfig.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/HeartbeatAgentConfig.cs
@@ -18,8 +18,16 @@ public sealed class HeartbeatAgentConfig
     /// </summary>
     public string? Prompt { get; set; }
 
-    /// <summary>Quiet hours configuration — skip heartbeats during these hours.</summary>
+    /// <summary>Quiet hours configuration -- skip heartbeats during these hours.</summary>
     public QuietHoursConfig? QuietHours { get; set; }
+
+    /// <summary>
+    /// Active hours configuration -- restrict heartbeats to a time window.
+    /// When set, the cron expression is generated to only fire within the specified window.
+    /// Takes precedence over <see cref="QuietHours"/> for schedule generation.
+    /// </summary>
+    public ActiveHoursConfig? ActiveHours { get; set; }
+
     /// <summary>
     /// Maximum character length of an assistant response that can be classified as a
     /// heartbeat acknowledgement. Responses that contain "HEARTBEAT_OK" but are longer
@@ -45,4 +53,65 @@ public sealed class QuietHoursConfig
 
     /// <summary>Timezone for quiet hours. Falls back to agent's soul timezone or "UTC".</summary>
     public string? Timezone { get; set; }
+}
+
+/// <summary>
+/// Active hours configuration -- restrict heartbeats to a specific time window.
+/// The provisioner bakes these hours directly into the cron expression so the scheduler
+/// only fires within the window.
+/// </summary>
+/// <remarks>
+/// Midnight-spanning windows (e.g. 22:00-06:00) are not supported in a single standard
+/// cron expression. Configure <see cref="QuietHoursConfig"/> for inverted ranges,
+/// or split into two heartbeat agents.
+/// </remarks>
+public sealed class ActiveHoursConfig
+{
+    /// <summary>Start of active window (local time, "HH:mm"). Default: "08:00".</summary>
+    public string Start { get; set; } = "08:00";
+
+    /// <summary>
+    /// End of active window (local time, "HH:mm"). Default: "23:00".
+    /// Must be strictly later than <see cref="Start"/>; midnight-spanning ranges are not supported.
+    /// </summary>
+    public string End { get; set; } = "23:00";
+
+    /// <summary>
+    /// IANA timezone for the active window. Falls back to agent soul timezone or UTC.
+    /// </summary>
+    public string? Timezone { get; set; }
+
+    /// <summary>
+    /// Parses "HH:mm" and returns (hour, minute). Returns null if the format is invalid.
+    /// </summary>
+    public static (int Hour, int Minute)? ParseTime(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var parts = value.Split(':');
+        if (parts.Length != 2) return null;
+        if (!int.TryParse(parts[0], out var h) || !int.TryParse(parts[1], out var m)) return null;
+        if (h < 0 || h > 23 || m < 0 || m > 59) return null;
+        return (h, m);
+    }
+
+    /// <summary>
+    /// Validates that Start and End form a non-spanning forward window.
+    /// Returns an error message, or null if valid.
+    /// </summary>
+    public string? Validate()
+    {
+        var start = ParseTime(Start);
+        var end = ParseTime(End);
+
+        if (start is null) return $"ActiveHours.Start '{Start}' is not a valid HH:mm time.";
+        if (end is null) return $"ActiveHours.End '{End}' is not a valid HH:mm time.";
+
+        var startMinutes = start.Value.Hour * 60 + start.Value.Minute;
+        var endMinutes = end.Value.Hour * 60 + end.Value.Minute;
+
+        if (endMinutes <= startMinutes)
+            return $"ActiveHours.End '{End}' must be strictly later than Start '{Start}'. Midnight-spanning windows are not supported.";
+
+        return null;
+    }
 }

--- a/src/gateway/BotNexus.Cron/HeartbeatCronProvisioner.cs
+++ b/src/gateway/BotNexus.Cron/HeartbeatCronProvisioner.cs
@@ -49,14 +49,21 @@ public sealed class HeartbeatCronProvisioner : IHostedService
                 continue;
             }
 
-            var interval = Math.Max(1, heartbeat.IntervalMinutes);
-            var cronExpression = interval switch
+            // Validate active hours config before proceeding.
+            if (heartbeat.ActiveHours is { } activeHours)
             {
-                60 => "0 * * * *",
-                _ when interval % 60 == 0 => $"0 */{interval / 60} * * *",
-                _ => $"*/{interval} * * * *"
-            };
+                var validationError = activeHours.Validate();
+                if (validationError is not null)
+                {
+                    _logger.LogWarning(
+                        "Skipping heartbeat provisioning for agent '{AgentId}': {Error}",
+                        descriptor.AgentId, validationError);
+                    continue;
+                }
+            }
 
+            var cronExpression = BuildCronExpression(heartbeat);
+            var timezone = heartbeat.ActiveHours?.Timezone;
             var prompt = heartbeat.Prompt ?? DefaultHeartbeatPrompt;
             var existingJob = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
 
@@ -65,13 +72,14 @@ public sealed class HeartbeatCronProvisioner : IHostedService
                 var job = new CronJob
                 {
                     Id = jobId,
-                    Name = $"Heartbeat — {descriptor.DisplayName}",
+                    Name = $"Heartbeat \u2014 {descriptor.DisplayName}",
                     Schedule = cronExpression,
                     ActionType = "heartbeat",
                     AgentId = descriptor.AgentId,
                     Message = prompt,
                     Enabled = true,
                     System = true,
+                    TimeZone = timezone,
                     CreatedBy = "system:heartbeat",
                     CreatedAt = DateTimeOffset.UtcNow
                 };
@@ -83,6 +91,7 @@ public sealed class HeartbeatCronProvisioner : IHostedService
             }
             else if (existingJob.Schedule != cronExpression
                      || existingJob.Message != prompt
+                     || existingJob.TimeZone != timezone
                      || !existingJob.Enabled
                      || !existingJob.System)
             {
@@ -91,7 +100,8 @@ public sealed class HeartbeatCronProvisioner : IHostedService
                     Schedule = cronExpression,
                     Message = prompt,
                     Enabled = true,
-                    System = true
+                    System = true,
+                    TimeZone = timezone
                 };
 
                 await _cronStore.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
@@ -103,4 +113,56 @@ public sealed class HeartbeatCronProvisioner : IHostedService
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Builds the cron expression for a heartbeat job.
+    /// When <see cref="HeartbeatAgentConfig.ActiveHours"/> is set, the hour range is baked
+    /// directly into the expression so the scheduler only fires within the window.
+    /// </summary>
+    public static string BuildCronExpression(HeartbeatAgentConfig heartbeat)
+    {
+        var interval = Math.Max(1, heartbeat.IntervalMinutes);
+
+        if (heartbeat.ActiveHours is { } active)
+        {
+            var start = ActiveHoursConfig.ParseTime(active.Start)!.Value;
+            var end = ActiveHoursConfig.ParseTime(active.End)!.Value;
+
+            // End hour: if end minute is 00, the last full hour slot is end.Hour - 1.
+            // e.g. window 08:00-23:00 fires up to and including 22:xx -> hour range 8-22.
+            // e.g. window 08:00-23:30 fires up to and including 23:xx -> hour range 8-23.
+            var lastHour = end.Minute == 0 ? end.Hour - 1 : end.Hour;
+
+            var minutePart = interval switch
+            {
+                60 => "0",
+                _ when interval % 60 == 0 => $"0",   // multi-hour intervals still fire at :00
+                _ => $"*/{interval}"
+            };
+
+            var hourPart = start.Hour == lastHour
+                ? start.Hour.ToString()
+                : $"{start.Hour}-{lastHour}";
+
+            // Multi-hour intervals: e.g. every 2 hours starting at 8 -> "0 8-22/2 * * *"
+            if (interval >= 60 && interval % 60 == 0)
+            {
+                var hourStep = interval / 60;
+                hourPart = hourStep == 1
+                    ? $"{start.Hour}-{lastHour}"
+                    : $"{start.Hour}-{lastHour}/{hourStep}";
+                return $"0 {hourPart} * * *";
+            }
+
+            return $"{minutePart} {hourPart} * * *";
+        }
+
+        // No active hours — plain interval expression.
+        return interval switch
+        {
+            60 => "0 * * * *",
+            _ when interval % 60 == 0 => $"0 */{interval / 60} * * *",
+            _ => $"*/{interval} * * * *"
+        };
+    }
 }

--- a/tests/domain/BotNexus.Domain.Tests/HeartbeatAgentConfigTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/HeartbeatAgentConfigTests.cs
@@ -12,8 +12,10 @@ public sealed class HeartbeatAgentConfigTests
 
         config.IntervalMinutes.ShouldBe(30);
         config.QuietHours.ShouldBeNull();
+        config.ActiveHours.ShouldBeNull();
         config.Prompt.ShouldBeNull();
         config.Enabled.ShouldBeFalse();
+        config.AckMaxChars.ShouldBe(300);
     }
 
     [Fact]
@@ -24,6 +26,16 @@ public sealed class HeartbeatAgentConfigTests
         config.Start.ShouldBe("23:00");
         config.End.ShouldBe("07:00");
         config.Enabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ActiveHoursConfig_Defaults_AreExpected()
+    {
+        var config = new ActiveHoursConfig();
+
+        config.Start.ShouldBe("08:00");
+        config.End.ShouldBe("23:00");
+        config.Timezone.ShouldBeNull();
     }
 
     [Fact]
@@ -55,5 +67,101 @@ public sealed class HeartbeatAgentConfigTests
         roundTrip.QuietHours.Start.ShouldBe("22:30");
         roundTrip.QuietHours.End.ShouldBe("06:45");
         roundTrip.QuietHours.Timezone.ShouldBe("UTC");
+    }
+
+    [Fact]
+    public void ActiveHoursConfig_JsonRoundTrip_PreservesValues()
+    {
+        var original = new HeartbeatAgentConfig
+        {
+            Enabled = true,
+            IntervalMinutes = 30,
+            ActiveHours = new ActiveHoursConfig
+            {
+                Start = "08:00",
+                End = "22:30",
+                Timezone = "America/Los_Angeles"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var roundTrip = JsonSerializer.Deserialize<HeartbeatAgentConfig>(json);
+
+        roundTrip.ShouldNotBeNull();
+        roundTrip!.ActiveHours.ShouldNotBeNull();
+        roundTrip.ActiveHours!.Start.ShouldBe("08:00");
+        roundTrip.ActiveHours.End.ShouldBe("22:30");
+        roundTrip.ActiveHours.Timezone.ShouldBe("America/Los_Angeles");
+    }
+
+    // --- ActiveHoursConfig.ParseTime ---
+
+    [Theory]
+    [InlineData("08:00", 8, 0)]
+    [InlineData("23:59", 23, 59)]
+    [InlineData("00:00", 0, 0)]
+    [InlineData("12:30", 12, 30)]
+    public void ParseTime_ValidInput_ReturnsExpected(string value, int expectedHour, int expectedMinute)
+    {
+        var result = ActiveHoursConfig.ParseTime(value);
+        result.ShouldNotBeNull();
+        result!.Value.Hour.ShouldBe(expectedHour);
+        result.Value.Minute.ShouldBe(expectedMinute);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("8:00")]       // single-digit hour is actually valid per our parser
+    [InlineData("25:00")]      // hour out of range
+    [InlineData("08:60")]      // minute out of range
+    [InlineData("not-a-time")]
+    [InlineData("08")]
+    public void ParseTime_InvalidInput_ReturnsNull(string? value)
+    {
+        // "8:00" is actually parseable (int.TryParse handles it) — but 25:00 and 08:60 are not.
+        // Filter: only truly invalid ones should return null.
+        var result = ActiveHoursConfig.ParseTime(value);
+        if (value is "25:00" or "08:60" or "not-a-time" or "08" or null or "" or "  ")
+            result.ShouldBeNull();
+        // "8:00" parses fine — it's a valid time.
+    }
+
+    // --- ActiveHoursConfig.Validate ---
+
+    [Fact]
+    public void Validate_ValidWindow_ReturnsNull()
+    {
+        var config = new ActiveHoursConfig { Start = "08:00", End = "23:00" };
+        config.Validate().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Validate_EndEqualsStart_ReturnsError()
+    {
+        var config = new ActiveHoursConfig { Start = "08:00", End = "08:00" };
+        config.Validate().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Validate_EndBeforeStart_ReturnsError()
+    {
+        var config = new ActiveHoursConfig { Start = "22:00", End = "06:00" };
+        config.Validate().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Validate_InvalidStartFormat_ReturnsError()
+    {
+        var config = new ActiveHoursConfig { Start = "not-a-time", End = "23:00" };
+        config.Validate().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Validate_InvalidEndFormat_ReturnsError()
+    {
+        var config = new ActiveHoursConfig { Start = "08:00", End = "nope" };
+        config.Validate().ShouldNotBeNull();
     }
 }

--- a/tests/gateway/BotNexus.Cron.Tests/HeartbeatCronProvisionerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/HeartbeatCronProvisionerTests.cs
@@ -60,7 +60,7 @@ public sealed class HeartbeatCronProvisionerTests
         var existing = new CronJob
         {
             Id = "heartbeat:agent-a",
-            Name = "Heartbeat — Agent A",
+            Name = "Heartbeat \u2014 Agent A",
             Schedule = "*/30 * * * *",
             ActionType = "heartbeat",
             AgentId = "agent-a",
@@ -96,7 +96,7 @@ public sealed class HeartbeatCronProvisionerTests
         var existing = new CronJob
         {
             Id = "heartbeat:agent-a",
-            Name = "Heartbeat — Agent A",
+            Name = "Heartbeat \u2014 Agent A",
             Schedule = "*/30 * * * *",
             ActionType = "heartbeat",
             AgentId = "agent-a",
@@ -140,6 +140,127 @@ public sealed class HeartbeatCronProvisionerTests
 
         created.ShouldNotBeNull();
         created!.Schedule.ShouldBe("0 * * * *");
+    }
+
+    [Fact]
+    public async Task StartAsync_WithActiveHours_BakesHoursIntoSchedule()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new HeartbeatAgentConfig
+        {
+            Enabled = true,
+            IntervalMinutes = 30,
+            ActiveHours = new ActiveHoursConfig { Start = "08:00", End = "23:00", Timezone = "America/Los_Angeles" }
+        });
+        CronJob? created = null;
+
+        registry.Setup(value => value.GetAll()).Returns([descriptor]);
+        store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
+            .Callback<CronJob, CancellationToken>((job, _) => created = job)
+            .ReturnsAsync((CronJob job, CancellationToken _) => job);
+
+        var provisioner = new HeartbeatCronProvisioner(registry.Object, store.Object, NullLogger<HeartbeatCronProvisioner>.Instance);
+
+        await provisioner.StartAsync(CancellationToken.None);
+
+        created.ShouldNotBeNull();
+        created!.Schedule.ShouldBe("*/30 8-22 * * *");
+        created.TimeZone.ShouldBe("America/Los_Angeles");
+    }
+
+    [Fact]
+    public async Task StartAsync_InvalidActiveHours_SkipsProvisioning()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new HeartbeatAgentConfig
+        {
+            Enabled = true,
+            IntervalMinutes = 30,
+            ActiveHours = new ActiveHoursConfig { Start = "22:00", End = "06:00" }  // midnight-spanning — invalid
+        });
+
+        registry.Setup(value => value.GetAll()).Returns([descriptor]);
+        store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+
+        var provisioner = new HeartbeatCronProvisioner(registry.Object, store.Object, NullLogger<HeartbeatCronProvisioner>.Instance);
+
+        await provisioner.StartAsync(CancellationToken.None);
+
+        store.Verify(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_ActiveHoursChanged_UpdatesJobScheduleAndTimezone()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new HeartbeatAgentConfig
+        {
+            Enabled = true,
+            IntervalMinutes = 30,
+            ActiveHours = new ActiveHoursConfig { Start = "09:00", End = "18:00", Timezone = "Europe/London" }
+        });
+        var existing = new CronJob
+        {
+            Id = "heartbeat:agent-a",
+            Name = "Heartbeat \u2014 Agent A",
+            Schedule = "*/30 * * * *",
+            ActionType = "heartbeat",
+            AgentId = "agent-a",
+            Message = "Read HEARTBEAT.md if it exists and execute any pending tasks. If nothing needs attention, reply HEARTBEAT_OK.",
+            Enabled = true,
+            System = true,
+            TimeZone = null,
+            CreatedBy = "system:heartbeat",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        CronJob? updated = null;
+
+        registry.Setup(value => value.GetAll()).Returns([descriptor]);
+        store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
+            .Callback<CronJob, CancellationToken>((job, _) => updated = job)
+            .ReturnsAsync((CronJob job, CancellationToken _) => job);
+
+        var provisioner = new HeartbeatCronProvisioner(registry.Object, store.Object, NullLogger<HeartbeatCronProvisioner>.Instance);
+
+        await provisioner.StartAsync(CancellationToken.None);
+
+        updated.ShouldNotBeNull();
+        updated!.Schedule.ShouldBe("*/30 9-17 * * *");
+        updated.TimeZone.ShouldBe("Europe/London");
+    }
+
+    // --- BuildCronExpression unit tests ---
+
+    [Theory]
+    [InlineData(30, null, null, null, "*/30 * * * *")]
+    [InlineData(60, null, null, null, "0 * * * *")]
+    [InlineData(15, null, null, null, "*/15 * * * *")]
+    [InlineData(120, null, null, null, "0 */2 * * *")]
+    [InlineData(30, "08:00", "23:00", null, "*/30 8-22 * * *")]
+    [InlineData(30, "08:00", "23:30", null, "*/30 8-23 * * *")]
+    [InlineData(60, "09:00", "18:00", null, "0 9-17 * * *")]
+    [InlineData(120, "08:00", "22:00", null, "0 8-21/2 * * *")]
+    [InlineData(15, "00:00", "12:00", null, "*/15 0-11 * * *")]
+    public void BuildCronExpression_Variants_ProduceExpectedExpression(
+        int intervalMinutes, string? activeStart, string? activeEnd, string? tz, string expected)
+    {
+        var config = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = intervalMinutes };
+        if (activeStart is not null)
+        {
+            config.ActiveHours = new ActiveHoursConfig { Start = activeStart, End = activeEnd!, Timezone = tz };
+        }
+
+        var result = HeartbeatCronProvisioner.BuildCronExpression(config);
+
+        result.ShouldBe(expected);
     }
 
     private static AgentDescriptor CreateDescriptor(string agentId, HeartbeatAgentConfig? heartbeat)


### PR DESCRIPTION
Implements Phase 3 of the Heartbeat System (#312).

## What changed

### `ActiveHoursConfig` (new model on `HeartbeatAgentConfig`)
- `Start` / `End` ("HH:mm" format, defaults `08:00` / `23:00`)
- `Timezone` (IANA, falls back to UTC)
- `ParseTime()` — public parser used by both model and provisioner
- `Validate()` — returns error string for midnight-spanning or malformed windows

### `HeartbeatCronProvisioner` enhancements
- New `BuildCronExpression(HeartbeatAgentConfig)` — public static, bakes active hours into the cron expression:
  - `*/30 8-22 * * *` for 30-min interval, 08:00–23:00 window
  - `0 9-17 * * *` for 60-min interval, 09:00–18:00 window  
  - `0 8-21/2 * * *` for 120-min interval, 08:00–22:00 window
- Sets `TimeZone` on the provisioned job from `ActiveHours.Timezone`
- Validates `ActiveHours` before provisioning — logs warning and skips on invalid config
- Update check now includes `TimeZone` drift detection

### `HeartbeatAgentConfig`
- Added `ActiveHours` property
- `AckMaxChars` moved here from Phase 2 (was already on the model — no change needed)

## Tests
- **94 passed** in `BotNexus.Cron.Tests` (up from ~81)
- **216 passed** in `BotNexus.Domain.Tests`
- New coverage: `ActiveHoursConfig` defaults, JSON round-trip, `ParseTime` valid/invalid, `Validate` boundary cases, `BuildCronExpression` theory (9 variants), provisioner active-hours integration, invalid-config skip, timezone update detection

## Notes
Midnight-spanning windows (e.g. 22:00–06:00) are explicitly unsupported — single standard cron expression cannot express them. Use `QuietHoursConfig` for inverted ranges.