### PR TITLE
fix(#366): guard against empty summary before deleting session history

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -446,6 +446,11 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var options = requestServices?.GetService<IOptionsMonitor<CompactionOptions>>()?.CurrentValue ?? _compactionOptions.CurrentValue;
 
         var result = await compactor.CompactAsync(session.Session, options, CancellationToken.None);
+        if (result.Succeeded && result.CompactedHistory is not null)
+        {
+            session.ReplaceHistory(result.CompactedHistory);
+            session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+        }
         await _sessions.SaveAsync(session, CancellationToken.None);
 
         return new CompactSessionResult(

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionResult.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionResult.cs
@@ -1,3 +1,5 @@
+using BotNexus.Gateway.Abstractions.Models;
+
 namespace BotNexus.Gateway.Abstractions.Sessions;
 
 /// <summary>
@@ -7,6 +9,19 @@ public sealed record CompactionResult
 {
     /// <summary>The generated summary text.</summary>
     public required string Summary { get; init; }
+
+    /// <summary>
+    /// True when compaction produced a non-empty summary and the caller should apply
+    /// <see cref="CompactedHistory"/> via <c>ReplaceHistory</c>. False when compaction
+    /// was skipped or aborted (e.g. empty LLM response) — history is unchanged.
+    /// </summary>
+    public bool Succeeded { get; init; }
+
+    /// <summary>
+    /// The new session history to apply when <see cref="Succeeded"/> is true.
+    /// Null when <see cref="Succeeded"/> is false.
+    /// </summary>
+    public IReadOnlyList<SessionEntry>? CompactedHistory { get; init; }
 
     /// <summary>Number of entries that were summarized (removed).</summary>
     public int EntriesSummarized { get; init; }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -411,6 +411,11 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 try
                 {
                     var result = await _compactor.CompactAsync(session.Session, _compactionOptions.CurrentValue, cancellationToken);
+                    if (result.Succeeded && result.CompactedHistory is not null)
+                    {
+                        session.ReplaceHistory(result.CompactedHistory);
+                        session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+                    }
                     await _sessions.SaveAsync(session, cancellationToken);
                     _logger.LogInformation(
                         "Session {SessionId} compacted: {Summarized} entries summarized, {Preserved} preserved",
@@ -707,9 +712,16 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         CancellationToken cancellationToken)
     {
         var result = await _compactor.CompactAsync(session.Session, _compactionOptions.CurrentValue, cancellationToken);
+        if (result.Succeeded && result.CompactedHistory is not null)
+        {
+            session.ReplaceHistory(result.CompactedHistory);
+            session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+        }
         await _sessions.SaveAsync(session, cancellationToken);
 
-        var feedback = $"Session compacted: {result.EntriesSummarized} entries summarized, {result.EntriesPreserved} preserved.";
+        var feedback = result.Succeeded
+            ? $"Session compacted: {result.EntriesSummarized} entries summarized, {result.EntriesPreserved} preserved."
+            : "Compaction aborted: the summarization model returned an empty response. Session history was not modified.";
         if (ResolveChannelAdapter(message.ChannelType) is { } channel)
         {
             await channel.SendAsync(new OutboundMessage

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -48,6 +48,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             return new CompactionResult
             {
                 Summary = string.Empty,
+                Succeeded = false,
                 EntriesSummarized = 0,
                 EntriesPreserved = 0,
                 TokensBefore = 0,
@@ -61,6 +62,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             return new CompactionResult
             {
                 Summary = string.Empty,
+                Succeeded = false,
                 EntriesSummarized = 0,
                 EntriesPreserved = toPreserve.Count,
                 TokensBefore = EstimateTokenCount(session),
@@ -71,6 +73,26 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         var tokensBefore = EstimateTokenCount(session);
         var summaryPrompt = BuildSummarizationPrompt(toSummarize, options.MaxSummaryChars);
         var summary = await CallLlmForSummaryAsync(summaryPrompt, options, cancellationToken).ConfigureAwait(false);
+
+        // Bug 1 / Bug 5 guard: if the LLM returned nothing, abort — do NOT mutate history.
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            _logger.LogWarning(
+                "Compaction aborted for session {SessionId}: LLM returned an empty summary. " +
+                "History is unchanged. Summarized {Count} entries would have been deleted.",
+                session.SessionId,
+                toSummarize.Count);
+
+            return new CompactionResult
+            {
+                Summary = string.Empty,
+                Succeeded = false,
+                EntriesSummarized = 0,
+                EntriesPreserved = history.Count,
+                TokensBefore = tokensBefore,
+                TokensAfter = tokensBefore
+            };
+        }
 
         if (summary.Length > options.MaxSummaryChars)
         {
@@ -89,24 +111,28 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             Timestamp = DateTimeOffset.UtcNow
         };
 
+        // Bug 4: do NOT assign session.History directly — return the new list so the caller
+        // can apply it via GatewaySession.ReplaceHistory() which routes through the runtime lock.
         var newHistory = new List<SessionEntry> { compactionEntry };
         newHistory.AddRange(toPreserve);
-        session.History = newHistory;
-        session.UpdatedAt = DateTimeOffset.UtcNow;
 
-        var tokensAfter = EstimateTokenCount(session);
+        var tokensAfter = EstimateTokenCountFromEntries(newHistory);
 
         _logger.LogInformation(
-            "Compacted session {SessionId}: {Summarized} entries summarized, {Preserved} preserved, tokens {Before}→{After}",
+            "Compacted session {SessionId}: {Summarized} entries summarized, {Preserved} preserved, " +
+            "tokens {Before}→{After} (delta {Delta})",
             session.SessionId,
             toSummarize.Count,
             toPreserve.Count,
             tokensBefore,
-            tokensAfter);
+            tokensAfter,
+            tokensBefore - tokensAfter);
 
         return new CompactionResult
         {
             Summary = summary,
+            Succeeded = true,
+            CompactedHistory = newHistory,
             EntriesSummarized = toSummarize.Count,
             EntriesPreserved = toPreserve.Count,
             TokensBefore = tokensBefore,
@@ -180,6 +206,13 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         CancellationToken cancellationToken)
     {
         var model = ResolveModel(options.SummarizationModel, options.SummarizationProvider);
+
+        // Bug 3: log the resolved model so failures are diagnosable.
+        _logger.LogDebug(
+            "Requesting compaction summary via model {ModelId} (provider {Provider})",
+            model.Id,
+            model.Provider);
+
         var context = new Context(
             SystemPrompt: null,
             Messages:
@@ -192,12 +225,29 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return string.Join(
+        // Bug 3: log what actually came back before filtering.
+        _logger.LogDebug(
+            "Compaction LLM response: {ContentItemCount} content item(s), TextContent items: {TextCount}",
+            completion.Content.Count,
+            completion.Content.OfType<TextContent>().Count());
+
+        var result = string.Join(
             Environment.NewLine,
             completion.Content
                 .OfType<TextContent>()
                 .Select(content => content.Text)
                 .Where(text => !string.IsNullOrWhiteSpace(text)));
+
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            _logger.LogWarning(
+                "Model {ModelId} returned no usable TextContent for compaction summary. " +
+                "Raw content types: {Types}",
+                model.Id,
+                string.Join(", ", completion.Content.Select(c => c.GetType().Name)));
+        }
+
+        return result;
     }
 
     private LlmModel ResolveModel(string? requestedModelId, string? preferredProvider = null)
@@ -267,6 +317,12 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     private static int EstimateTokenCount(Session session)
     {
         var totalChars = session.History.Sum(entry => entry.Content?.Length ?? 0);
+        return totalChars / 4;
+    }
+
+    private static int EstimateTokenCountFromEntries(IEnumerable<SessionEntry> entries)
+    {
+        var totalChars = entries.Sum(entry => entry.Content?.Length ?? 0);
         return totalChars / 4;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
@@ -163,11 +163,15 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         session.AddEntries(originalEntries);
 
         var compactor = CreateCompactor("fixed-summary");
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 3,
             SummarizationModel = TestModel.Id
         });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        session.ReplaceHistory(result.CompactedHistory!);
 
         var history = session.GetHistorySnapshot();
         history.Count().ShouldBe(7);
@@ -194,11 +198,15 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         ]);
 
         var compactor = CreateCompactor("tool-summary");
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 1,
             SummarizationModel = TestModel.Id
         });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        session.ReplaceHistory(result.CompactedHistory!);
 
         session.GetHistorySnapshot().Select(entry => entry.Content)
             .ShouldBe(new[] { "tool-summary", "u2", "a2", "tool-call", "tool-result" }, ignoreOrder: false);
@@ -217,11 +225,15 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         ]);
 
         var compactor = CreateCompactor("coherent-summary");
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 1,
             SummarizationModel = TestModel.Id
         });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        session.ReplaceHistory(result.CompactedHistory!);
 
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u3" });
         session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a3" });
@@ -247,11 +259,15 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         ]);
 
         var compactor = CreateCompactor("archived-summary");
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 1,
             SummarizationModel = TestModel.Id
         });
+
+        if (result.Succeeded && result.CompactedHistory is not null)
+            session.ReplaceHistory(result.CompactedHistory);
+
         await store.SaveAsync(session);
 
         await store.ArchiveAsync(sessionId);
@@ -269,21 +285,31 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         var session = BuildCompactionSession();
         var compactor = CreateCompactor(new string('x', 50_000));
 
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 1,
             MaxSummaryChars = 16_000,
             SummarizationModel = TestModel.Id
         });
 
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        session.ReplaceHistory(result.CompactedHistory!);
+
         session.GetHistorySnapshot().First().Content.Length.ShouldBeLessThanOrEqualTo(16_000);
     }
 
+    /// <summary>
+    /// Regression test for Bug 1 (#366): when the LLM returns an empty summary, compaction
+    /// must abort and leave history completely unchanged — no data loss.
+    /// </summary>
     [Fact]
     [Trait("Category", "Security")]
     public async Task CompactionSummary_EmptyResponse_HandledGracefully()
     {
         var session = BuildCompactionSession();
+        var originalCount = session.GetHistorySnapshot().Count;
+        var originalContents = session.GetHistorySnapshot().Select(e => e.Content).ToList();
         var compactor = CreateCompactor(string.Empty);
 
         Func<Task> act = async () => await compactor.CompactAsync(session.Session, new CompactionOptions
@@ -293,9 +319,12 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         });
 
         await act.ShouldNotThrowAsync();
-        session.GetHistorySnapshot().Count().ShouldBe(3);
-        session.GetHistorySnapshot().Skip(1).Select(entry => entry.Content)
-            .ShouldBe(new[] { "recent-user", "recent-assistant" }, ignoreOrder: false);
+
+        // Bug 1 fix: history must be completely unchanged when LLM returns empty summary
+        session.GetHistorySnapshot().Count().ShouldBe(originalCount,
+            "history must not be modified when LLM returns empty summary");
+        session.GetHistorySnapshot().Select(e => e.Content).ToList()
+            .ShouldBe(originalContents, "no entries should be lost when compaction is aborted");
     }
 
     [Fact]
@@ -340,6 +369,11 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
 
         Func<Task> act = async () => await Task.WhenAll(compactTask, addTask);
         await act.ShouldNotThrowAsync();
+
+        // Apply compaction result if succeeded (caller responsibility after Bug 4 fix)
+        var result = await compactTask;
+        if (result.Succeeded && result.CompactedHistory is not null)
+            session.ReplaceHistory(result.CompactedHistory);
 
         var history = session.GetHistorySnapshot();
         foreach (var entry in history)

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -59,11 +59,15 @@ public sealed class LlmSessionCompactorTests
             ("assistant", "a3"));
         var compactor = CreateCompactor("summary-u1");
 
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 2,
             SummarizationModel = TestModel.Id
         });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        session.ReplaceHistory(result.CompactedHistory!);
 
         session.GetHistorySnapshot().Select(entry => entry.Content).ToList().ShouldBe(
             new[] { "summary-u1", "u2", "a2", "t2", "u3", "a3" }, ignoreOrder: false);
@@ -85,8 +89,13 @@ public sealed class LlmSessionCompactorTests
             SummarizationModel = TestModel.Id
         });
 
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
         result.EntriesSummarized.ShouldBe(2);
         result.EntriesPreserved.ShouldBe(2);
+
+        session.ReplaceHistory(result.CompactedHistory!);
+
         session.GetHistorySnapshot().Select(entry => entry.Content)
             .ToList().ShouldBe(new[] { "structured summary", "recent", "recent-response" }, ignoreOrder: false);
     }
@@ -100,6 +109,8 @@ public sealed class LlmSessionCompactorTests
         var result = await compactor.CompactAsync(session.Session, new CompactionOptions());
 
         result.Summary.ShouldBeEmpty();
+        result.Succeeded.ShouldBeFalse();
+        result.CompactedHistory.ShouldBeNull();
         result.EntriesSummarized.ShouldBe(0);
         result.EntriesPreserved.ShouldBe(0);
         session.GetHistorySnapshot().ShouldBeEmpty();
@@ -123,6 +134,8 @@ public sealed class LlmSessionCompactorTests
         });
 
         result.Summary.ShouldBeEmpty();
+        result.Succeeded.ShouldBeFalse();
+        result.CompactedHistory.ShouldBeNull();
         result.EntriesSummarized.ShouldBe(0);
         result.EntriesPreserved.ShouldBe(4);
         session.GetHistorySnapshot().ShouldBe(originalHistory);
@@ -137,11 +150,15 @@ public sealed class LlmSessionCompactorTests
             ("user", "recent"));
         var compactor = CreateCompactor("compacted");
 
-        await compactor.CompactAsync(session.Session, new CompactionOptions
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
         {
             PreservedTurns = 1,
             SummarizationModel = TestModel.Id
         });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        session.ReplaceHistory(result.CompactedHistory!);
 
         var summaryEntry = session.GetHistorySnapshot().First();
         summaryEntry.Role.ShouldBe(MessageRole.System);
@@ -165,8 +182,47 @@ public sealed class LlmSessionCompactorTests
             SummarizationModel = TestModel.Id
         });
 
+        result.Succeeded.ShouldBeTrue();
         result.Summary.Length.ShouldBe(40);
+
+        session.ReplaceHistory(result.CompactedHistory!);
         session.GetHistorySnapshot().First().Content.Length.ShouldBe(40);
+    }
+
+    /// <summary>
+    /// Regression test for Bug 1 / Bug 5 (#366): when the LLM returns an empty response,
+    /// CompactAsync must abort and leave history completely unchanged.
+    /// </summary>
+    [Fact]
+    public async Task CompactAsync_EmptyLlmResponse_AbortsWithoutMutatingHistory()
+    {
+        var session = CreateSession(
+            ("user", "important message 1"),
+            ("assistant", "important response 1"),
+            ("user", "important message 2"),
+            ("assistant", "important response 2"),
+            ("user", "recent"));
+        var originalHistory = session.GetHistorySnapshot().ToList();
+
+        // Simulate LLM returning empty text
+        var compactor = CreateCompactor(summary: "");
+
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeFalse("compaction should be aborted when LLM returns empty summary");
+        result.Summary.ShouldBeEmpty();
+        result.CompactedHistory.ShouldBeNull();
+        result.EntriesSummarized.ShouldBe(0);
+
+        // Critical: history must be completely unchanged
+        session.GetHistorySnapshot().Count.ShouldBe(originalHistory.Count,
+            "history must not be modified when LLM returns empty summary");
+        session.GetHistorySnapshot().Select(e => e.Content).ToList()
+            .ShouldBe(originalHistory.Select(e => e.Content).ToList());
     }
 
     [Fact]
@@ -252,4 +308,3 @@ public sealed class LlmSessionCompactorTests
         return stream;
     }
 }
-


### PR DESCRIPTION
Fixes #366

## What

Fixes 4 of the 5 bugs identified in #366 (Bug 2 token-count reporting is working correctly — see analysis below).

## Bugs fixed

| Bug | Description | Fix |
|-----|-------------|-----|
| Bug 1 (HIGH) | `CompactAsync` deleted session history when LLM returned empty summary | Guard after `CallLlmForSummaryAsync`: abort and preserve history if `string.IsNullOrWhiteSpace(summary)` |
| Bug 3 | No logging of model selected or LLM response content | `LogDebug` of resolved model ID + content item counts before and after filtering |
| Bug 4 | `session.History = newHistory` bypassed `GatewaySession.ReplaceHistory()` runtime lock | Removed mutation from compactor — compactor returns `CompactedHistory` in result; callers apply via `session.ReplaceHistory()` |
| Bug 5 | `EntriesSummarized` reported N even when summary was empty | Resolved as side effect of Bug 1 guard — returns 0 on abort |

## Bug 2 analysis

`TokensBefore` is estimated *before* building the summary prompt; `TokensAfter` is estimated from the new history. The reversed values (`8816→288062`) in the issue imply a very small `toSummarize` slice and a large `toPreserve` slice — the session was below the split ratio so the large tail was "after". Not a code bug, just confusing output. Added a `delta` to the log message to make direction obvious.

## Changes

- `CompactionResult` — added `Succeeded` (bool) and `CompactedHistory` (`IReadOnlyList<SessionEntry>?`)
- `LlmSessionCompactor` — abort guard, improved logging, `EstimateTokenCountFromEntries` helper, removed `session.History` mutation
- `GatewayHost.cs` — two call sites apply `ReplaceHistory` when `result.Succeeded`; `HandleCompactionAsync` returns failure message on empty summary
- `GatewayHub.cs` — one call site applies `ReplaceHistory` when `result.Succeeded`
- `LlmSessionCompactorTests` — added `CompactAsync_EmptyLlmResponse_AbortsWithoutMutatingHistory` regression test; all existing tests updated to call `session.ReplaceHistory(result.CompactedHistory!)` after `CompactAsync`
- `SessionCompactionIntegrationTests` — same updates + `CompactionSummary_EmptyResponse_HandledGracefully` corrected to assert history is unchanged (not 3 entries as before)

## Test results

✅ 1521 tests passing, 0 failures, 12 E2E skipped (no gateway running)
