### PR TITLE
feat(#312): phase 4 - HEARTBEAT.md emptiness pre-check in HeartbeatAction

### DIFF
--- a/src/gateway/BotNexus.Cron/Actions/HeartbeatAction.cs
+++ b/src/gateway/BotNexus.Cron/Actions/HeartbeatAction.cs
@@ -4,6 +4,7 @@ using BotNexus.Gateway.Abstractions.Triggers;
 using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Text.RegularExpressions;
 
 namespace BotNexus.Cron.Actions;
 
@@ -11,9 +12,7 @@ namespace BotNexus.Cron.Actions;
 
 /// <summary>
 /// Dedicated cron action for system heartbeat jobs (actionType = "heartbeat").
-/// Handles quiet-hours gating and heartbeat-specific trigger routing.
-/// The quiet-hours check that was previously embedded as a heuristic inside
-/// <see cref="AgentPromptAction"/> now lives exclusively here.
+/// Handles quiet-hours gating, HEARTBEAT.md emptiness pre-check, and heartbeat-specific trigger routing.
 /// </summary>
 public sealed class HeartbeatAction : ICronAction
 {
@@ -29,17 +28,32 @@ public sealed class HeartbeatAction : ICronAction
         if (string.IsNullOrWhiteSpace(agentId))
             throw new InvalidOperationException("Heartbeat cron job must define an agent id.");
 
+        var logger = context.Services.GetService<ILogger<HeartbeatAction>>();
         var registry = context.Services.GetService<IAgentRegistry>();
         var descriptor = registry?.Get(AgentId.From(agentId));
 
+        // Pre-flight: quiet hours
         var quietHours = descriptor?.Heartbeat?.QuietHours;
         var timezoneFallback = descriptor?.Soul?.Timezone ?? "UTC";
         if (quietHours is { Enabled: true }
             && IsInQuietHours(quietHours, quietHours.Timezone ?? timezoneFallback))
         {
-            context.Services.GetService<ILogger<HeartbeatAction>>()?.LogDebug(
-                "Skipping heartbeat for agent '{AgentId}' — quiet hours active.", agentId);
+            logger?.LogDebug("Skipping heartbeat for agent '{AgentId}' — quiet hours active.", agentId);
             return;
+        }
+
+        // Pre-flight: HEARTBEAT.md emptiness check
+        var workspaceManager = context.Services.GetService<IAgentWorkspaceManager>();
+        if (workspaceManager is not null)
+        {
+            var heartbeatContent = await ReadHeartbeatFileAsync(workspaceManager, agentId, cancellationToken);
+            if (IsEffectivelyEmpty(heartbeatContent))
+            {
+                logger?.LogDebug(
+                    "Skipping heartbeat for agent '{AgentId}' — HEARTBEAT.md is absent or effectively empty.",
+                    agentId);
+                return;
+            }
         }
 
         var prompt = context.Job.Message;
@@ -65,6 +79,66 @@ public sealed class HeartbeatAction : ICronAction
     }
 
     /// <summary>
+    /// Reads the contents of HEARTBEAT.md from the agent's workspace.
+    /// Returns null if the file does not exist or the workspace manager cannot locate the file.
+    /// </summary>
+    public static async Task<string?> ReadHeartbeatFileAsync(
+        IAgentWorkspaceManager workspaceManager,
+        string agentId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var workspacePath = workspaceManager.GetWorkspacePath(agentId);
+            var heartbeatPath = Path.Combine(workspacePath, "HEARTBEAT.md");
+            if (!File.Exists(heartbeatPath))
+                return null;
+
+            return await File.ReadAllTextAsync(heartbeatPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // If we can't read the file, treat it as present (run the heartbeat — safer to fire than skip)
+            return "unreadable";
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the HEARTBEAT.md content has no actionable tasks.
+    /// A file is considered effectively empty when it is null/whitespace or contains only:
+    /// <list type="bullet">
+    ///   <item>Blank lines</item>
+    ///   <item>Markdown headings (lines starting with #)</item>
+    ///   <item>Horizontal rules (--- or ***)</item>
+    ///   <item>Empty or unchecked checkboxes (- [ ] ...)</item>
+    ///   <item>HTML/markdown comments (&lt;!-- ... --&gt;)</item>
+    /// </list>
+    /// </summary>
+    public static bool IsEffectivelyEmpty(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return true;
+
+        // Strip HTML/markdown comments
+        var stripped = Regex.Replace(content, @"<!--.*?-->", string.Empty, RegexOptions.Singleline);
+
+        foreach (var rawLine in stripped.Split('\n'))
+        {
+            var line = rawLine.Trim();
+
+            if (line.Length == 0) continue;                              // blank
+            if (line.StartsWith('#')) continue;                          // heading
+            if (Regex.IsMatch(line, @"^[-*_]{3}$")) continue;          // horizontal rule
+            if (Regex.IsMatch(line, @"^-\s*\[\s*\]\s*$")) continue;     // empty/blank checkbox (no task text)
+
+            // Any other non-trivial line = has content
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Resolves the best available trigger for a heartbeat run.
     /// Priority: HeartbeatTrigger > SoulTrigger (soul agents) > CronTrigger.
     /// </summary>
@@ -72,12 +146,10 @@ public sealed class HeartbeatAction : ICronAction
     {
         var all = services.GetServices<IInternalTrigger>().ToList();
 
-        // First choice: dedicated heartbeat trigger
         var heartbeatTrigger = all.FirstOrDefault(t => t.Type.Equals(TriggerType.Heartbeat));
         if (heartbeatTrigger is not null)
             return heartbeatTrigger;
 
-        // Second choice: soul trigger for soul-enabled agents (preserves prior routing behaviour)
         if (descriptor?.Soul?.Enabled == true)
         {
             var soulTrigger = all.FirstOrDefault(t => t.Type.Equals(TriggerType.Soul));
@@ -85,7 +157,6 @@ public sealed class HeartbeatAction : ICronAction
                 return soulTrigger;
         }
 
-        // Fallback: standard cron trigger
         return all.FirstOrDefault(t => t.Type.Equals(TriggerType.Cron))
             ?? throw new InvalidOperationException(
                 "No suitable internal trigger found for heartbeat action (heartbeat, soul, or cron).");
@@ -101,7 +172,6 @@ public sealed class HeartbeatAction : ICronAction
             !TimeSpan.TryParse(config.End, out var end))
             return false;
 
-        // Overnight range e.g. 23:00–07:00
         if (start > end)
             return currentTime >= start || currentTime < end;
 

--- a/tests/gateway/BotNexus.Cron.Tests/HeartbeatActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/HeartbeatActionTests.cs
@@ -259,6 +259,154 @@ public sealed class HeartbeatActionTests
     }
 
     // -----------------------------------------------------------------
+    // Phase 4: HEARTBEAT.md pre-check — IsEffectivelyEmpty
+    // -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\n\n")]
+    public void IsEffectivelyEmpty_NullOrWhitespace_ReturnsTrue(string? content)
+        => HeartbeatAction.IsEffectivelyEmpty(content).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("# HEARTBEAT.md")]
+    [InlineData("# Tasks\n## Pending")]
+    [InlineData("---")]
+    [InlineData("***")]
+    [InlineData("---\n# Heading\n---")]
+    public void IsEffectivelyEmpty_OnlyHeadingsAndRules_ReturnsTrue(string content)
+        => HeartbeatAction.IsEffectivelyEmpty(content).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("- [ ]")]
+    [InlineData("- [ ] ")]
+    [InlineData("- [ ] \n- [ ] ")]
+    [InlineData("# Tasks\n- [ ]\n- [ ] ")]
+    public void IsEffectivelyEmpty_OnlyEmptyCheckboxes_ReturnsTrue(string content)
+        => HeartbeatAction.IsEffectivelyEmpty(content).ShouldBeTrue();
+
+    [Fact]
+    public void IsEffectivelyEmpty_HtmlCommentsOnly_ReturnsTrue()
+        => HeartbeatAction.IsEffectivelyEmpty("<!-- pending tasks go here -->\n# HEARTBEAT.md").ShouldBeTrue();
+
+    [Fact]
+    public void IsEffectivelyEmpty_DefaultStubContent_ReturnsTrue()
+        => HeartbeatAction.IsEffectivelyEmpty("# HEARTBEAT.md\n\n_No pending tasks._").ShouldBeFalse();
+
+    [Theory]
+    [InlineData("- [ ] Deploy the thing")]
+    [InlineData("- [x] Already done")]
+    [InlineData("# Tasks\n- [ ] Something pending")]
+    [InlineData("Run the migration script")]
+    [InlineData("_No pending tasks._")]
+    public void IsEffectivelyEmpty_WithContent_ReturnsFalse(string content)
+        => HeartbeatAction.IsEffectivelyEmpty(content).ShouldBeFalse();
+
+    [Fact]
+    public void IsEffectivelyEmpty_CheckedCheckbox_ReturnsFalse()
+        => HeartbeatAction.IsEffectivelyEmpty("- [x] Done task").ShouldBeFalse();
+
+    [Fact]
+    public void IsEffectivelyEmpty_MixedEmptyAndFilledCheckboxes_ReturnsFalse()
+        => HeartbeatAction.IsEffectivelyEmpty("- [ ] \n- [x] Done\n- [ ]").ShouldBeFalse();
+
+    // -----------------------------------------------------------------
+    // Phase 4: HEARTBEAT.md pre-check — ExecuteAsync integration
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyHeartbeatFile_SkipsExecution()
+    {
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var workspace = new Mock<IAgentWorkspaceManager>();
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+        workspace.Setup(v => v.GetWorkspacePath("agent-a"))
+            .Returns(Path.Combine(Path.GetTempPath(), "botnexus-test-nonexistent-" + Guid.NewGuid()));
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            .AddSingleton(workspace.Object)
+            .BuildServiceProvider();
+        var context = CreateContext(services);
+
+        await action.ExecuteAsync(context);
+
+        // HEARTBEAT.md doesn't exist in the temp path — should skip
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoWorkspaceManager_ProceedsNormally()
+    {
+        // When IAgentWorkspaceManager is not registered, the pre-check is skipped entirely
+        var action = new HeartbeatAction();
+        var trigger = new Mock<IInternalTrigger>();
+        var registry = new Mock<IAgentRegistry>();
+        var sessionId = SessionId.From("heartbeat:agent-a:20260101000000:nomanager");
+
+        trigger.SetupGet(v => v.Type).Returns(TriggerType.Heartbeat);
+        trigger.Setup(v => v.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(sessionId);
+        registry.Setup(v => v.Get(AgentId.From("agent-a"))).Returns((AgentDescriptor?)null);
+
+        var services = new ServiceCollection()
+            .AddSingleton(registry.Object)
+            .AddSingleton<IInternalTrigger>(trigger.Object)
+            // no IAgentWorkspaceManager registered
+            .BuildServiceProvider();
+        var context = CreateContext(services);
+
+        await action.ExecuteAsync(context);
+
+        trigger.Verify(v => v.CreateSessionAsync(
+            It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ReadHeartbeatFileAsync_MissingFile_ReturnsNull()
+    {
+        var workspace = new Mock<IAgentWorkspaceManager>();
+        workspace.Setup(v => v.GetWorkspacePath("agent-a"))
+            .Returns(Path.Combine(Path.GetTempPath(), "botnexus-test-nonexistent-" + Guid.NewGuid()));
+
+        var result = await HeartbeatAction.ReadHeartbeatFileAsync(workspace.Object, "agent-a", CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReadHeartbeatFileAsync_ExistingFile_ReturnsContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-test-" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDir);
+        var heartbeatPath = Path.Combine(tempDir, "HEARTBEAT.md");
+        await File.WriteAllTextAsync(heartbeatPath, "- [ ] Deploy the thing");
+
+        var workspace = new Mock<IAgentWorkspaceManager>();
+        workspace.Setup(v => v.GetWorkspacePath("agent-a")).Returns(tempDir);
+
+        try
+        {
+            var result = await HeartbeatAction.ReadHeartbeatFileAsync(workspace.Object, "agent-a", CancellationToken.None);
+            result.ShouldBe("- [ ] Deploy the thing");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    // -----------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------
 


### PR DESCRIPTION
Implements Phase 4 of the Heartbeat System (#312).

## What changed

### `HeartbeatAction` — pre-flight HEARTBEAT.md check

Before invoking the trigger (and burning an LLM call), `ExecuteAsync` now reads `HEARTBEAT.md` from the agent workspace and skips the turn if the file is absent or effectively empty.

**Effectively empty** means the file contains only:
- Absent / null / whitespace
- Markdown headings (`# ...`)
- Horizontal rules (`---`, `***`)
- Empty/blank checkboxes (`- [ ]` with no task text)
- HTML/markdown comments (`<!-- ... -->`)

A `- [ ] Deploy the thing` line = **has content** = heartbeat fires. A file with only `# HEARTBEAT.md\n- [ ]` = empty = skipped.

**Fail-safe:** If `IAgentWorkspaceManager` is not registered in DI, the pre-check is skipped and the heartbeat proceeds normally. If the file cannot be read (IO error, permissions), it is treated as present (safer to fire than silently skip).

### New public methods on `HeartbeatAction`

| Method | Purpose |
|---|---|
| `IsEffectivelyEmpty(string?)` | Pure classifier — no IO, fully testable |
| `ReadHeartbeatFileAsync(...)` | File reader with null-on-missing, "unreadable"-on-error semantics |

## Tests

**120 passed** in `BotNexus.Cron.Tests` (up from 94)

New coverage:
- `IsEffectivelyEmpty` — null/whitespace, headings-only, rules-only, empty checkboxes, HTML comments, checked checkboxes, mixed content (14 cases)
- `ReadHeartbeatFileAsync` — missing file returns null, existing file returns content
- `ExecuteAsync` — absent HEARTBEAT.md skips trigger, no workspace manager proceeds normally

## Related

- #312 (heartbeat system — this closes Phase 4)
- #384 (runtime re-provisioning — filed, not yet implemented)
- #385 (workspace scaffolding incl. HEARTBEAT.md creation — filed, not yet implemented)