### PR TITLE
feat(#385): scaffold workspace files for existing agents on startup

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/AgentWorkspaceScaffolder.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentWorkspaceScaffolder.cs
@@ -1,0 +1,43 @@
+using BotNexus.Gateway.Abstractions.Agents;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Configuration;
+
+internal sealed class AgentWorkspaceScaffolder(
+    IAgentRegistry registry,
+    BotNexusHome botNexusHome,
+    ILogger<AgentWorkspaceScaffolder> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var agents = registry.GetAll();
+        var scaffolded = 0;
+
+        foreach (var descriptor in agents)
+        {
+            var agentId = descriptor.AgentId.Value;
+            if (agentId.Contains("--subagent--", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                var agentDir = botNexusHome.GetAgentDirectory(agentId);
+                var workspacePath = System.IO.Path.Combine(agentDir, "workspace");
+                logger.LogDebug("Workspace scaffold verified for agent ''{AgentId}'' at {WorkspacePath}.", agentId, workspacePath);
+                scaffolded++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to scaffold workspace for agent ''{AgentId}''.", agentId);
+            }
+        }
+
+        if (scaffolded > 0)
+            logger.LogInformation("Workspace scaffold check complete: {Count} agent(s) verified.", scaffolded);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/BotNexusHome.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/BotNexusHome.cs
@@ -65,7 +65,7 @@ public sealed class BotNexusHome
             // Fallback to HOME environment variable on Linux/Unix systems
             userProfile = Environment.GetEnvironmentVariable("HOME") ?? string.Empty;
         }
-        
+
         if (string.IsNullOrWhiteSpace(userProfile))
             throw new InvalidOperationException("Unable to determine user home directory. Please set BOTNEXUS_HOME environment variable.");
 
@@ -99,8 +99,50 @@ public sealed class BotNexusHome
     private void ScaffoldAgentWorkspace(string agentDirectory)
     {
         var workspacePath = Path.Combine(agentDirectory, "workspace");
+        EnsureWorkspaceScaffoldFiles(workspacePath);
+        _fileSystem.Directory.CreateDirectory(Path.Combine(agentDirectory, "data", "sessions"));
+    }
+
+    private void MigrateLegacyWorkspace(string agentDirectory)
+    {
+        var workspacePath = Path.Combine(agentDirectory, "workspace");
+        if (_fileSystem.Directory.Exists(workspacePath))
+        {
+            // Workspace subdir already exists — ensure all scaffold files are present (idempotent, never overwrites)
+            EnsureWorkspaceScaffoldFiles(workspacePath);
+            return;
+        }
+
+        var hasLegacyFiles = LegacyWorkspaceFiles
+            .Any(f => _fileSystem.File.Exists(Path.Combine(agentDirectory, f)));
+        if (!hasLegacyFiles)
+        {
+            ScaffoldAgentWorkspace(agentDirectory);
+            return;
+        }
+
         _fileSystem.Directory.CreateDirectory(workspacePath);
         _fileSystem.Directory.CreateDirectory(Path.Combine(agentDirectory, "data", "sessions"));
+        foreach (var file in LegacyWorkspaceFiles)
+        {
+            var src = Path.Combine(agentDirectory, file);
+            var dst = Path.Combine(workspacePath, file);
+            if (_fileSystem.File.Exists(src))
+                _fileSystem.File.Move(src, dst, overwrite: true);
+        }
+
+        // After migration, ensure any newly-required scaffold files are present
+        EnsureWorkspaceScaffoldFiles(workspacePath);
+    }
+
+    /// <summary>
+    /// Ensures all workspace scaffold files exist in the given workspace directory.
+    /// Missing files are created from embedded templates (or written as empty).
+    /// Existing files are never overwritten.
+    /// </summary>
+    internal void EnsureWorkspaceScaffoldFiles(string workspacePath)
+    {
+        _fileSystem.Directory.CreateDirectory(workspacePath);
 
         var assembly = typeof(BotNexusHome).Assembly;
         foreach (var file in WorkspaceScaffoldFiles)
@@ -124,31 +166,6 @@ public sealed class BotNexusHome
             }
 
             _fileSystem.File.WriteAllText(path, string.Empty);
-        }
-    }
-
-    private void MigrateLegacyWorkspace(string agentDirectory)
-    {
-        var workspacePath = Path.Combine(agentDirectory, "workspace");
-        if (_fileSystem.Directory.Exists(workspacePath))
-            return;
-
-        var hasLegacyFiles = LegacyWorkspaceFiles
-            .Any(f => _fileSystem.File.Exists(Path.Combine(agentDirectory, f)));
-        if (!hasLegacyFiles)
-        {
-            ScaffoldAgentWorkspace(agentDirectory);
-            return;
-        }
-
-        _fileSystem.Directory.CreateDirectory(workspacePath);
-        _fileSystem.Directory.CreateDirectory(Path.Combine(agentDirectory, "data", "sessions"));
-        foreach (var file in LegacyWorkspaceFiles)
-        {
-            var src = Path.Combine(agentDirectory, file);
-            var dst = Path.Combine(workspacePath, file);
-            if (_fileSystem.File.Exists(src))
-                _fileSystem.File.Move(src, dst, overwrite: true);
         }
     }
 }

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -205,6 +205,7 @@ public static class GatewayServiceCollectionExtensions
                 return new PlatformConfigAgentWriter(writer, home);
             }));
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentWorkspaceScaffolder>());
         }
 
         return services;
@@ -299,6 +300,7 @@ public static class GatewayServiceCollectionExtensions
             return new PlatformConfigAgentWriter(writer, home);
         }));
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentWorkspaceScaffolder>());
 
         return services;
     }
@@ -504,6 +506,7 @@ public static class GatewayServiceCollectionExtensions
     {
         services.AddSingleton<IAgentConfigurationSource, T>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentWorkspaceScaffolder>());
         return services;
     }
 
@@ -538,6 +541,7 @@ public static class GatewayServiceCollectionExtensions
                 serviceProvider.GetRequiredService<IFileSystem>())));
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentWorkspaceScaffolder>());
         return services;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentWorkspaceScaffolderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentWorkspaceScaffolderTests.cs
@@ -1,0 +1,78 @@
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class AgentWorkspaceScaffolderTests
+{
+    private static readonly string HomePath = Path.Combine(Path.GetTempPath(), "botnexus-scaffold-tests");
+
+    [Fact]
+    public async Task StartAsync_EnsuresScaffoldForAllRegisteredAgents()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath);
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor("nova"));
+        registry.Register(CreateDescriptor("farnsworth"));
+        var scaffolder = new AgentWorkspaceScaffolder(registry, home, NullLogger<AgentWorkspaceScaffolder>.Instance);
+
+        await scaffolder.StartAsync(CancellationToken.None);
+
+        foreach (var agentId in new[] { "nova", "farnsworth" })
+        {
+            var workspacePath = Path.Combine(HomePath, "agents", agentId, "workspace");
+            fs.Directory.Exists(workspacePath).ShouldBeTrue($"{agentId} workspace should exist");
+            fs.File.Exists(Path.Combine(workspacePath, "SOUL.md")).ShouldBeTrue($"{agentId} SOUL.md should be scaffolded");
+            fs.File.Exists(Path.Combine(workspacePath, "BOOTSTRAP.md")).ShouldBeTrue($"{agentId} BOOTSTRAP.md should be scaffolded");
+            fs.File.Exists(Path.Combine(workspacePath, "IDENTITY.md")).ShouldBeTrue($"{agentId} IDENTITY.md should be scaffolded");
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenWorkspaceAlreadyExists_EnsuresMissingFilesWithoutOverwriting()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath);
+        // Pre-create workspace with only SOUL.md - simulates existing agent missing BOOTSTRAP.md
+        var workspacePath = Path.Combine(HomePath, "agents", "nova", "workspace");
+        fs.Directory.CreateDirectory(workspacePath);
+        fs.File.WriteAllText(Path.Combine(workspacePath, "SOUL.md"), "custom soul content");
+
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor("nova"));
+        var scaffolder = new AgentWorkspaceScaffolder(registry, home, NullLogger<AgentWorkspaceScaffolder>.Instance);
+
+        await scaffolder.StartAsync(CancellationToken.None);
+
+        // Existing file must not be overwritten
+        fs.File.ReadAllText(Path.Combine(workspacePath, "SOUL.md")).ShouldBe("custom soul content");
+        // Missing files must be created
+        fs.File.Exists(Path.Combine(workspacePath, "BOOTSTRAP.md")).ShouldBeTrue();
+        fs.File.Exists(Path.Combine(workspacePath, "IDENTITY.md")).ShouldBeTrue();
+        fs.File.Exists(Path.Combine(workspacePath, "USER.md")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StartAsync_SkipsSubAgentWorkspaces()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath);
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor("nova--subagent--general--abc123"));
+        var scaffolder = new AgentWorkspaceScaffolder(registry, home, NullLogger<AgentWorkspaceScaffolder>.Instance);
+
+        await scaffolder.StartAsync(CancellationToken.None);
+
+        // Sub-agent should not be scaffolded in the persistent agents directory
+        fs.Directory.Exists(Path.Combine(HomePath, "agents", "nova--subagent--general--abc123")).ShouldBeFalse();
+    }
+
+    private static AgentDescriptor CreateDescriptor(string agentId) =>
+        new() { AgentId = AgentId.From(agentId), DisplayName = agentId, ModelId = "model", ApiProvider = "provider" };
+}


### PR DESCRIPTION
## Summary

Fixes the gap identified in #385: existing agents with a `workspace/` directory but missing scaffold files were never re-scaffolded.

## Changes

### `BotNexusHome.cs`
- Extracted `EnsureWorkspaceScaffoldFiles(workspacePath)` — idempotent scaffold pass (never overwrites existing files)
- `MigrateLegacyWorkspace` now calls `EnsureWorkspaceScaffoldFiles` when `workspace/` already exists, instead of returning early
- `ScaffoldAgentWorkspace` simplified to delegate to `EnsureWorkspaceScaffoldFiles`

### `AgentWorkspaceScaffolder.cs` (new)
- `IHostedService` that runs on startup, iterates all registered agents, and calls `GetAgentDirectory` to trigger the scaffold check
- Skips sub-agents (temp workspaces)
- Logs at `Debug` per agent and `Information` for the summary

### `GatewayServiceCollectionExtensions.cs`
- Registers `AgentWorkspaceScaffolder` alongside `AgentConfigurationHostedService` at all 4 registration sites (runs after agents are loaded)

### `AgentWorkspaceScaffolderTests.cs` (new, 3 tests)
- Scaffolds all registered agents on startup
- Does not overwrite existing files on existing workspaces
- Skips sub-agent workspaces

## Test results
15/15 targeted tests pass (BotNexusHome + FileAgentWorkspaceManager + AgentWorkspaceScaffolder)

Closes #385
Related: #331, #384