### PR TITLE
fix(#384): re-provision heartbeat cron job when agent registered/updated at runtime

### DIFF
--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -14,6 +14,7 @@
     <Compile Include="SqliteCronStore.cs" />
     <Compile Include="CronOptions.cs" />
     <Compile Include="HeartbeatCronProvisioner.cs" />
+    <Compile Include="IHeartbeatProvisioner.cs" />
     <Compile Include="CronScheduler.cs" />
     <Compile Include="Prompts\IPromptTemplateResolver.cs" />
     <Compile Include="Prompts\CronOptionsPromptTemplateResolver.cs" />

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -22,6 +22,8 @@ public static class CronServiceCollectionExtensions
         });
         services.TryAddSingleton<HeartbeatCronProvisioner>();
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<HeartbeatCronProvisioner>());
+        // Also expose as IHeartbeatProvisioner so AgentsController can call ProvisionAsync at runtime.
+        services.TryAddSingleton<IHeartbeatProvisioner>(sp => sp.GetRequiredService<HeartbeatCronProvisioner>());
         services.TryAddSingleton<CronScheduler>();
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<CronScheduler>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, AgentPromptAction>());

--- a/src/gateway/BotNexus.Cron/HeartbeatCronProvisioner.cs
+++ b/src/gateway/BotNexus.Cron/HeartbeatCronProvisioner.cs
@@ -8,8 +8,10 @@ namespace BotNexus.Cron;
 /// <summary>
 /// Syncs heartbeat cron jobs from agent configurations on startup.
 /// For each agent with heartbeat.enabled = true, ensures a system cron job exists.
+/// Also implements <see cref="IHeartbeatProvisioner"/> for runtime re-provisioning
+/// when agents are registered or updated via the API.
 /// </summary>
-public sealed class HeartbeatCronProvisioner : IHostedService
+public sealed class HeartbeatCronProvisioner : IHostedService, IHeartbeatProvisioner
 {
     private const string DefaultHeartbeatPrompt =
         "Read HEARTBEAT.md if it exists and execute any pending tasks. If nothing needs attention, reply HEARTBEAT_OK.";
@@ -34,85 +36,91 @@ public sealed class HeartbeatCronProvisioner : IHostedService
 
         foreach (var descriptor in _registry.GetAll())
         {
-            var heartbeat = descriptor.Heartbeat;
-            var jobId = $"heartbeat:{descriptor.AgentId}";
-
-            if (heartbeat is not { Enabled: true })
-            {
-                var existing = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-                if (existing is { System: true })
-                {
-                    await _cronStore.DeleteAsync(jobId, cancellationToken).ConfigureAwait(false);
-                    _logger.LogInformation("Removed heartbeat cron job for agent '{AgentId}'.", descriptor.AgentId);
-                }
-
-                continue;
-            }
-
-            // Validate active hours config before proceeding.
-            if (heartbeat.ActiveHours is { } activeHours)
-            {
-                var validationError = activeHours.Validate();
-                if (validationError is not null)
-                {
-                    _logger.LogWarning(
-                        "Skipping heartbeat provisioning for agent '{AgentId}': {Error}",
-                        descriptor.AgentId, validationError);
-                    continue;
-                }
-            }
-
-            var cronExpression = BuildCronExpression(heartbeat);
-            var timezone = heartbeat.ActiveHours?.Timezone;
-            var prompt = heartbeat.Prompt ?? DefaultHeartbeatPrompt;
-            var existingJob = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-
-            if (existingJob is null)
-            {
-                var job = new CronJob
-                {
-                    Id = jobId,
-                    Name = $"Heartbeat \u2014 {descriptor.DisplayName}",
-                    Schedule = cronExpression,
-                    ActionType = "heartbeat",
-                    AgentId = descriptor.AgentId,
-                    Message = prompt,
-                    Enabled = true,
-                    System = true,
-                    TimeZone = timezone,
-                    CreatedBy = "system:heartbeat",
-                    CreatedAt = DateTimeOffset.UtcNow
-                };
-
-                await _cronStore.CreateAsync(job, cancellationToken).ConfigureAwait(false);
-                _logger.LogInformation(
-                    "Provisioned heartbeat cron job for agent '{AgentId}' with schedule '{Schedule}'.",
-                    descriptor.AgentId, cronExpression);
-            }
-            else if (existingJob.Schedule != cronExpression
-                     || existingJob.Message != prompt
-                     || existingJob.TimeZone != timezone
-                     || !existingJob.Enabled
-                     || !existingJob.System)
-            {
-                var updated = existingJob with
-                {
-                    Schedule = cronExpression,
-                    Message = prompt,
-                    Enabled = true,
-                    System = true,
-                    TimeZone = timezone
-                };
-
-                await _cronStore.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
-                _logger.LogInformation(
-                    "Updated heartbeat cron job for agent '{AgentId}' with schedule '{Schedule}'.",
-                    descriptor.AgentId, cronExpression);
-            }
+            await ProvisionAsync(descriptor, cancellationToken).ConfigureAwait(false);
         }
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async Task ProvisionAsync(AgentDescriptor descriptor, CancellationToken cancellationToken)
+    {
+        var heartbeat = descriptor.Heartbeat;
+        var jobId = $"heartbeat:{descriptor.AgentId}";
+
+        if (heartbeat is not { Enabled: true })
+        {
+            var existing = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
+            if (existing is { System: true })
+            {
+                await _cronStore.DeleteAsync(jobId, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("Removed heartbeat cron job for agent '{AgentId}'.", descriptor.AgentId);
+            }
+
+            return;
+        }
+
+        // Validate active hours config before proceeding.
+        if (heartbeat.ActiveHours is { } activeHours)
+        {
+            var validationError = activeHours.Validate();
+            if (validationError is not null)
+            {
+                _logger.LogWarning(
+                    "Skipping heartbeat provisioning for agent '{AgentId}': {Error}",
+                    descriptor.AgentId, validationError);
+                return;
+            }
+        }
+
+        var cronExpression = BuildCronExpression(heartbeat);
+        var timezone = heartbeat.ActiveHours?.Timezone;
+        var prompt = heartbeat.Prompt ?? DefaultHeartbeatPrompt;
+        var existingJob = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
+
+        if (existingJob is null)
+        {
+            var job = new CronJob
+            {
+                Id = jobId,
+                Name = $"Heartbeat \u2014 {descriptor.DisplayName}",
+                Schedule = cronExpression,
+                ActionType = "heartbeat",
+                AgentId = descriptor.AgentId,
+                Message = prompt,
+                Enabled = true,
+                System = true,
+                TimeZone = timezone,
+                CreatedBy = "system:heartbeat",
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+
+            await _cronStore.CreateAsync(job, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Provisioned heartbeat cron job for agent '{AgentId}' with schedule '{Schedule}'.",
+                descriptor.AgentId, cronExpression);
+        }
+        else if (existingJob.Schedule != cronExpression
+                 || existingJob.Message != prompt
+                 || existingJob.TimeZone != timezone
+                 || !existingJob.Enabled
+                 || !existingJob.System)
+        {
+            var updated = existingJob with
+            {
+                Schedule = cronExpression,
+                Message = prompt,
+                Enabled = true,
+                System = true,
+                TimeZone = timezone
+            };
+
+            await _cronStore.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Updated heartbeat cron job for agent '{AgentId}' with schedule '{Schedule}'.",
+                descriptor.AgentId, cronExpression);
+        }
+    }
 
     /// <summary>
     /// Builds the cron expression for a heartbeat job.
@@ -157,7 +165,7 @@ public sealed class HeartbeatCronProvisioner : IHostedService
             return $"{minutePart} {hourPart} * * *";
         }
 
-        // No active hours — plain interval expression.
+        // No active hours - plain interval expression.
         return interval switch
         {
             60 => "0 * * * *",

--- a/src/gateway/BotNexus.Cron/IHeartbeatProvisioner.cs
+++ b/src/gateway/BotNexus.Cron/IHeartbeatProvisioner.cs
@@ -1,0 +1,17 @@
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Cron;
+
+/// <summary>
+/// Provisions or removes the heartbeat cron job for a single agent.
+/// Called at startup (via <see cref="HeartbeatCronProvisioner"/>) and at runtime
+/// when an agent is registered or updated via the API.
+/// </summary>
+public interface IHeartbeatProvisioner
+{
+    /// <summary>
+    /// Ensures the heartbeat cron job for <paramref name="descriptor"/> is in sync
+    /// with its current configuration. Creates, updates, or removes the job as needed.
+    /// </summary>
+    Task ProvisionAsync(AgentDescriptor descriptor, CancellationToken cancellationToken);
+}

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs
@@ -1,3 +1,4 @@
+using BotNexus.Cron;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
@@ -12,9 +13,6 @@ namespace BotNexus.Gateway.Api.Controllers;
 /// <summary>
 /// REST API for agent registration and lifecycle management.
 /// </summary>
-/// <summary>
-/// Represents agents controller.
-/// </summary>
 [ApiController]
 [Route("api/[controller]")]
 public sealed class AgentsController : ControllerBase
@@ -23,44 +21,33 @@ public sealed class AgentsController : ControllerBase
     private readonly IAgentSupervisor _supervisor;
     private readonly IAgentConfigurationWriter _configurationWriter;
     private readonly IReadOnlyList<IAgentChangeNotifier> _agentChangeNotifiers;
+    private readonly IHeartbeatProvisioner? _heartbeatProvisioner;
     private readonly ILogger<AgentsController> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentsController"/> class.
     /// </summary>
-    /// <param name="registry">The agent registry for accessing registered agents.</param>
-    /// <param name="supervisor">The agent supervisor for managing agent instances and their lifecycle.</param>
-    /// <param name="configurationWriter">Persists mutable agent configuration changes.</param>
-    /// <param name="agentChangeNotifiers">Publishes agent lifecycle notifications to connected channel clients.</param>
-    /// <param name="logger">Logs best-effort transport notification failures.</param>
     public AgentsController(
         IAgentRegistry registry,
         IAgentSupervisor supervisor,
         IAgentConfigurationWriter configurationWriter,
         IEnumerable<IAgentChangeNotifier>? agentChangeNotifiers = null,
+        IHeartbeatProvisioner? heartbeatProvisioner = null,
         ILogger<AgentsController>? logger = null)
     {
         _registry = registry;
         _supervisor = supervisor;
         _configurationWriter = configurationWriter;
         _agentChangeNotifiers = agentChangeNotifiers?.ToArray() ?? [];
+        _heartbeatProvisioner = heartbeatProvisioner;
         _logger = logger ?? NullLogger<AgentsController>.Instance;
     }
 
     /// <summary>Lists all registered agents.</summary>
-    /// <summary>
-    /// Executes list.
-    /// </summary>
-    /// <returns>The list result.</returns>
     [HttpGet]
     public ActionResult<IReadOnlyList<AgentDescriptor>> List() => Ok(_registry.GetAll());
 
     /// <summary>Gets a specific agent by ID.</summary>
-    /// <summary>
-    /// Executes get.
-    /// </summary>
-    /// <param name="agentId">The agent id.</param>
-    /// <returns>The get result.</returns>
     [HttpGet("{agentId}")]
     public ActionResult<AgentDescriptor> Get(string agentId)
     {
@@ -69,12 +56,6 @@ public sealed class AgentsController : ControllerBase
     }
 
     /// <summary>Registers a new agent.</summary>
-    /// <summary>
-    /// Executes register.
-    /// </summary>
-    /// <param name="descriptor">The descriptor.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The register result.</returns>
     [HttpPost]
     public async Task<ActionResult> Register([FromBody] AgentDescriptor descriptor, CancellationToken cancellationToken)
     {
@@ -82,6 +63,10 @@ public sealed class AgentsController : ControllerBase
         {
             _registry.Register(descriptor);
             await _configurationWriter.SaveAsync(descriptor, cancellationToken);
+
+            if (_heartbeatProvisioner is not null)
+                await _heartbeatProvisioner.ProvisionAsync(descriptor, cancellationToken);
+
             await NotifyAgentsChangedBestEffortAsync("added", descriptor.AgentId.Value, cancellationToken);
             return CreatedAtAction(nameof(Get), new { agentId = descriptor.AgentId }, descriptor);
         }
@@ -94,14 +79,6 @@ public sealed class AgentsController : ControllerBase
     /// <summary>
     /// Updates an existing agent descriptor.
     /// </summary>
-    /// <param name="agentId">The route agent identifier.</param>
-    /// <param name="descriptor">The descriptor payload to persist.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The updated descriptor when found; otherwise 404.</returns>
-    /// <remarks>
-    /// If <paramref name="descriptor" /> omits <see cref="AgentDescriptor.AgentId" />, the route value is used.
-    /// If both are provided, they must match.
-    /// </remarks>
     [HttpPut("{agentId}")]
     [ProducesResponseType(typeof(AgentDescriptor), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -126,17 +103,15 @@ public sealed class AgentsController : ControllerBase
             return NotFound();
 
         await _configurationWriter.SaveAsync(updatedDescriptor, cancellationToken);
+
+        if (_heartbeatProvisioner is not null)
+            await _heartbeatProvisioner.ProvisionAsync(updatedDescriptor, cancellationToken);
+
         await NotifyAgentsChangedBestEffortAsync("updated", updatedDescriptor.AgentId.Value, cancellationToken);
         return Ok(updatedDescriptor);
     }
 
     /// <summary>Unregisters an agent.</summary>
-    /// <summary>
-    /// Executes unregister.
-    /// </summary>
-    /// <param name="agentId">The agent id.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The unregister result.</returns>
     [HttpDelete("{agentId}")]
     public async Task<ActionResult> Unregister(string agentId, CancellationToken cancellationToken)
     {
@@ -153,12 +128,6 @@ public sealed class AgentsController : ControllerBase
     }
 
     /// <summary>Gets the status of a running agent instance.</summary>
-    /// <summary>
-    /// Executes get instance status.
-    /// </summary>
-    /// <param name="agentId">The agent id.</param>
-    /// <param name="sessionId">The session id.</param>
-    /// <returns>The get instance status result.</returns>
     [HttpGet("{agentId}/sessions/{sessionId}/status")]
     public ActionResult<AgentInstance> GetInstanceStatus(string agentId, string sessionId)
     {
@@ -167,20 +136,10 @@ public sealed class AgentsController : ControllerBase
     }
 
     /// <summary>Lists all active agent instances.</summary>
-    /// <summary>
-    /// Executes list instances.
-    /// </summary>
-    /// <returns>The list instances result.</returns>
     [HttpGet("instances")]
     public ActionResult<IReadOnlyList<AgentInstance>> ListInstances() => Ok(_supervisor.GetAllInstances());
 
     /// <summary>Gets runtime health for active instances of an agent.</summary>
-    /// <summary>
-    /// Executes get health.
-    /// </summary>
-    /// <param name="agentId">The agent id.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The get health result.</returns>
     [HttpGet("{agentId}/health")]
     public async Task<ActionResult<AgentHealthResponse>> GetHealth(string agentId, CancellationToken cancellationToken)
     {
@@ -214,13 +173,6 @@ public sealed class AgentsController : ControllerBase
     }
 
     /// <summary>Stops a specific agent instance.</summary>
-    /// <summary>
-    /// Executes stop instance.
-    /// </summary>
-    /// <param name="agentId">The agent id.</param>
-    /// <param name="sessionId">The session id.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The stop instance result.</returns>
     [HttpPost("{agentId}/sessions/{sessionId}/stop")]
     public async Task<ActionResult> StopInstance(string agentId, string sessionId, CancellationToken cancellationToken)
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs
@@ -1,3 +1,4 @@
+using BotNexus.Cron;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Agents;
@@ -493,4 +494,91 @@ public sealed class AgentsControllerTests
             new NoOpAgentConfigurationWriter(),
             [notifier.Object]);
     }
+
+    // ── Heartbeat re-provisioning tests (issue #384) ──────────────────────────
+
+    [Fact]
+    public async Task Register_WithHeartbeatProvisioner_CallsProvisionAsync()
+    {
+        var provisioner = new Mock<IHeartbeatProvisioner>();
+        provisioner
+            .Setup(p => p.ProvisionAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var descriptor = CreateDescriptorWithHeartbeat("agent-hb");
+        var notifier = CreateNotifier();
+        var controller = new AgentsController(
+            new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance),
+            Mock.Of<IAgentSupervisor>(),
+            new NoOpAgentConfigurationWriter(),
+            [notifier.Object],
+            provisioner.Object);
+
+        _ = await controller.Register(descriptor, CancellationToken.None);
+
+        provisioner.Verify(
+            p => p.ProvisionAsync(
+                It.Is<AgentDescriptor>(d => d.AgentId == "agent-hb"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Update_WithHeartbeatProvisioner_CallsProvisionAsync()
+    {
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptorWithHeartbeat("agent-hb"));
+
+        var provisioner = new Mock<IHeartbeatProvisioner>();
+        provisioner
+            .Setup(p => p.ProvisionAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var notifier = CreateNotifier();
+        var controller = new AgentsController(
+            registry,
+            Mock.Of<IAgentSupervisor>(),
+            new NoOpAgentConfigurationWriter(),
+            [notifier.Object],
+            provisioner.Object);
+
+        var updatedDescriptor = CreateDescriptorWithHeartbeat("agent-hb") with
+        {
+            Heartbeat = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 60 }
+        };
+        _ = await controller.Update("agent-hb", updatedDescriptor, CancellationToken.None);
+
+        provisioner.Verify(
+            p => p.ProvisionAsync(
+                It.Is<AgentDescriptor>(d => d.AgentId == "agent-hb"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Register_WithoutHeartbeatProvisioner_SucceedsWithoutError()
+    {
+        var descriptor = CreateDescriptorWithHeartbeat("agent-hb");
+        var notifier = CreateNotifier();
+        // No IHeartbeatProvisioner injected — backwards-compatible default.
+        var controller = new AgentsController(
+            new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance),
+            Mock.Of<IAgentSupervisor>(),
+            new NoOpAgentConfigurationWriter(),
+            [notifier.Object]);
+
+        var result = await controller.Register(descriptor, CancellationToken.None);
+
+        result.ShouldBeOfType<CreatedAtActionResult>();
+    }
+
+    private static AgentDescriptor CreateDescriptorWithHeartbeat(string agentId)
+        => new()
+        {
+            AgentId = agentId,
+            DisplayName = $"{agentId}-display",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            Heartbeat = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 30 }
+        };
 }


### PR DESCRIPTION
Closes #384

## Summary

Fixes the gap where newly registered agents never got their heartbeat cron job created until the next gateway restart.

## Changes

### `IHeartbeatProvisioner` (new interface)
Extracts `ProvisionAsync(AgentDescriptor, CancellationToken)` from `HeartbeatCronProvisioner` into an interface, enabling injection into `AgentsController` without a circular dependency.

### `HeartbeatCronProvisioner`
- Implements `IHeartbeatProvisioner` in addition to `IHostedService`
- `StartAsync` loop refactored to call `ProvisionAsync` per-agent (DRY, no logic duplication)
- Behaviour at startup is identical to before

### `CronServiceCollectionExtensions`
- Registers `IHeartbeatProvisioner` pointing to the same `HeartbeatCronProvisioner` singleton

### `AgentsController`
- Optional `IHeartbeatProvisioner?` constructor parameter (backwards compatible — defaults to null)
- `Register` calls `ProvisionAsync` after successful save
- `Update` calls `ProvisionAsync` after successful save (handles enable/disable/interval changes)

### `BotNexus.Cron.csproj`
- Added `IHeartbeatProvisioner.cs` to explicit `<Compile>` list (project has `EnableDefaultCompileItems=false`)

## Tests
3 new tests in `AgentsControllerTests`:
- `Register_WithHeartbeatProvisioner_CallsProvisionAsync`
- `Update_WithHeartbeatProvisioner_CallsProvisionAsync`
- `Register_WithoutHeartbeatProvisioner_SucceedsWithoutError` (backwards compat)

All 1,524 tests pass.