### PR TITLE
fix(conversations): update update date and notify clients on message activity

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
@@ -250,6 +250,9 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         conv.StreamState.IsStreaming = false;
         agent.IsStreaming = false;
         agent.ProcessingStage = null;
+
+        // Update timestamp client-side so sort order reflects recent activity (issue #382).
+        conv.UpdatedAt = DateTimeOffset.UtcNow;
 
         if (agent.AgentId != _store.ActiveAgentId)
             agent.UnreadCount++;
@@ -556,10 +559,25 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
     public void HandleConversationChanged(ConversationChangedPayload payload)
     {
         // Server notified that a conversation was created, updated, or archived.
-        // Re-fetch conversation list for the affected agent so the sidebar stays current.
         var agentId = payload.AgentId;
         if (string.IsNullOrWhiteSpace(agentId)) return;
 
+        // Fast path: if the payload carries the new UpdatedAt, apply it directly
+        // to the client state without a REST round-trip (issue #382).
+        if (payload.UpdatedAt.HasValue && _store.GetAgent(agentId) is { } agent)
+        {
+            var convId = payload.ConversationId;
+            if (!string.IsNullOrWhiteSpace(convId) &&
+                agent.Conversations.TryGetValue(convId, out var conv))
+            {
+                conv.UpdatedAt = payload.UpdatedAt.Value;
+                _store.NotifyChanged();
+                return;
+            }
+        }
+
+        // Fallback: full conversation list refresh (covers create/archive and cases
+        // where the conversation is not yet in the local store).
         _ = RefreshConversationsAsync(agentId);
     }
 
@@ -591,3 +609,4 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnDisconnected -= HandleDisconnected;
     }
 }
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
@@ -148,7 +148,8 @@ public sealed record AgentsChangedPayload(
 public sealed record ConversationChangedPayload(
     [property: JsonPropertyName("changeType")] string ChangeType,
     [property: JsonPropertyName("agentId")] string AgentId,
-    [property: JsonPropertyName("conversationId")] string ConversationId);
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset? UpdatedAt = null);
 
 /// <summary>Kind of steering feedback event.</summary>
 public enum SteeringFeedbackKind
@@ -164,3 +165,5 @@ public sealed record SteeringFeedbackPayload(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("sessionId")] string SessionId,
     [property: JsonPropertyName("kind")] SteeringFeedbackKind Kind);
+
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using BotNexus.Gateway.Abstractions.Sessions;
 
 namespace BotNexus.Extensions.Channels.SignalR;
@@ -90,7 +90,8 @@ public sealed record AgentsChangedPayload(
 public sealed record ConversationChangedPayload(
     [property: JsonPropertyName("changeType")] string ChangeType,
     [property: JsonPropertyName("agentId")] string AgentId,
-    [property: JsonPropertyName("conversationId")] string ConversationId);
+    [property: JsonPropertyName("conversationId")] string ConversationId,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset? UpdatedAt = null);
 
 /// <summary>Kind of steering feedback event.</summary>
 public enum SteeringFeedbackKind { Injected, Queued }
@@ -100,4 +101,6 @@ public sealed record SteeringFeedbackPayload(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("sessionId")] string SessionId,
     [property: JsonPropertyName("kind")] SteeringFeedbackKind Kind);
+
+
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRConversationChangeNotifier.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRConversationChangeNotifier.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Conversations;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BotNexus.Extensions.Channels.SignalR;
@@ -12,5 +12,5 @@ public sealed class SignalRConversationChangeNotifier(IHubContext<GatewayHub, IG
 
     /// <inheritdoc />
     public Task NotifyConversationChangedAsync(string changeType, string agentId, string conversationId, CancellationToken cancellationToken = default)
-        => _hubContext.Clients.All.ConversationChanged(new ConversationChangedPayload(changeType, agentId, conversationId));
+        => _hubContext.Clients.All.ConversationChanged(new ConversationChangedPayload(changeType, agentId, conversationId, DateTimeOffset.UtcNow));
 }

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -16,16 +16,19 @@ public sealed class DefaultConversationRouter : IConversationRouter
 {
     private readonly IConversationStore _conversationStore;
     private readonly ISessionStore _sessionStore;
+    private readonly IConversationChangeNotifier? _changeNotifier;
     private readonly ILogger<DefaultConversationRouter> _logger;
 
     public DefaultConversationRouter(
         IConversationStore conversationStore,
         ISessionStore sessionStore,
-        ILogger<DefaultConversationRouter> logger)
+        ILogger<DefaultConversationRouter> logger,
+        IConversationChangeNotifier? changeNotifier = null)
     {
         _conversationStore = conversationStore;
         _sessionStore = sessionStore;
         _logger = logger;
+        _changeNotifier = changeNotifier;
     }
 
     /// <inheritdoc />
@@ -46,7 +49,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
             if (direct is null)
             {
                 _logger.LogWarning(
-                    "ResolveInbound: explicit conversationId {ConversationId} not found — falling back to binding lookup",
+                    "ResolveInbound: explicit conversationId {ConversationId} not found -- falling back to binding lookup",
                     conversationId);
                 // Fall through to binding lookup below
             }
@@ -65,11 +68,13 @@ public sealed class DefaultConversationRouter : IConversationRouter
                 {
                     direct.UpdatedAt = DateTimeOffset.UtcNow;
                     await _conversationStore.SaveAsync(direct, ct);
+                    await NotifyChangedAsync("updated", agentId, direct.ConversationId, ct);
                 }
                 else if (reactivated)
                 {
                     direct.UpdatedAt = DateTimeOffset.UtcNow;
                     await _conversationStore.SaveAsync(direct, ct);
+                    await NotifyChangedAsync("updated", agentId, direct.ConversationId, ct);
                 }
 
                 return new ConversationRoutingResult(direct, directSessionId, directIsNew);
@@ -88,7 +93,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
         if (conversation is null)
         {
             // Every unique (channelType, channelAddress, threadId) gets its own conversation.
-            // There is no special "default" conversation for addressless channels — an empty
+            // There is no special "default" conversation for addressless channels -- an empty
             // address is a valid stable identity (e.g. a future channel with no external ID).
             var title = threadId is not null
                 ? $"{channelType}:{channelAddress}/{threadId}"
@@ -123,6 +128,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
         {
             conversation.UpdatedAt = DateTimeOffset.UtcNow;
             await _conversationStore.SaveAsync(conversation, ct);
+            await NotifyChangedAsync("updated", agentId, conversation.ConversationId, ct);
         }
 
         // Resolve the originating binding so callers don't need a second lookup into the binding list.
@@ -145,21 +151,21 @@ public sealed class DefaultConversationRouter : IConversationRouter
         var session = await _sessionStore.GetAsync(sessionId, ct);
         if (session is null)
         {
-            _logger.LogDebug("GetOutboundBindings: session {SessionId} not found — returning empty", sessionId);
+            _logger.LogDebug("GetOutboundBindings: session {SessionId} not found -- returning empty", sessionId);
             return [];
         }
 
         var conversationId = session.Session.ConversationId;
         if (conversationId is null)
         {
-            _logger.LogDebug("GetOutboundBindings: session {SessionId} has no ConversationId — returning empty", sessionId);
+            _logger.LogDebug("GetOutboundBindings: session {SessionId} has no ConversationId -- returning empty", sessionId);
             return [];
         }
 
         var conversation = await _conversationStore.GetAsync(conversationId.Value, ct);
         if (conversation is null)
         {
-            _logger.LogDebug("GetOutboundBindings: conversation {ConversationId} not found — returning empty", conversationId);
+            _logger.LogDebug("GetOutboundBindings: conversation {ConversationId} not found -- returning empty", conversationId);
             return [];
         }
 
@@ -277,7 +283,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
             var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
             if (existingSession is { Status: not SessionStatus.Sealed })
             {
-                // Reuse Active AND Expired sessions — GatewayHost reactivates Expired sessions.
+                // Reuse Active AND Expired sessions -- GatewayHost reactivates Expired sessions.
                 // Only Sealed sessions (explicit reset/archive) should trigger a new session.
                 sessionId = conversation.ActiveSessionId.Value;
                 _logger.LogDebug("Reusing {Status} session {SessionId} for conversation {ConversationId}",
@@ -354,5 +360,17 @@ public sealed class DefaultConversationRouter : IConversationRouter
             archived.ConversationId, agentId, channelType, channelAddress, threadId);
 
         return archived;
+    }
+
+    private Task NotifyChangedAsync(string changeType, AgentId agentId, ConversationId conversationId, CancellationToken ct)
+    {
+        if (_changeNotifier is null)
+            return Task.CompletedTask;
+
+        return _changeNotifier.NotifyConversationChangedAsync(
+            changeType,
+            agentId.Value,
+            conversationId.Value,
+            ct);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/BotNexus.Gateway.Conversations.Tests.csproj
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/BotNexus.Gateway.Conversations.Tests.csproj
@@ -40,3 +40,6 @@
     <Compile Include="..\BotNexus.Gateway.Tests\TestOptionsMonitor.cs" Link="TestOptionsMonitor.cs" />
   </ItemGroup>
 </Project>
+
+
+

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -5,6 +5,8 @@ using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
 
 namespace BotNexus.Gateway.Conversations.Tests.Conversations;
 
@@ -381,6 +383,79 @@ public sealed class DefaultConversationRouterTests
         var bindings = await router.GetOutboundBindingsAsync(sessionId, BindingId.From("src"));
 
         bindings.ShouldContain(b => b.ChannelAddress == ChannelAddress.From("notify-only-chan") && b.Mode == BindingMode.NotifyOnly);
+    }
+
+    // ── Issue #382: IConversationChangeNotifier is called when conversation changes ──
+
+    [Fact]
+    public async Task ResolveInbound_NewConversation_CallsNotifierWithUpdated()
+    {
+        var notifier = new Mock<IConversationChangeNotifier>();
+        notifier
+            .Setup(n => n.NotifyConversationChangedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var router = new DefaultConversationRouter(
+            new InMemoryConversationStore(),
+            new InMemorySessionStore(),
+            NullLogger<DefaultConversationRouter>.Instance,
+            notifier.Object);
+
+        await router.ResolveInboundAsync(Agent(), Channel(), ChannelAddress.From("chat-notify-new"), null);
+
+        notifier.Verify(
+            n => n.NotifyConversationChangedAsync(
+                "updated",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ResolveInbound_ExistingConversationSameSession_DoesNotCallNotifier()
+    {
+        // A second resolve on an already-active conversation with no changes
+        // should not fire the notifier.
+        var notifier = new Mock<IConversationChangeNotifier>();
+        notifier
+            .Setup(n => n.NotifyConversationChangedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = new DefaultConversationRouter(
+            conversationStore,
+            sessionStore,
+            NullLogger<DefaultConversationRouter>.Instance,
+            notifier.Object);
+
+        var agentId = Agent("agent-stable");
+        // First call creates and saves -- fires notifier.
+        await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-stable-382"), null);
+        notifier.Invocations.Clear();
+
+        // Second call -- same conversation, same session, nothing changed.
+        await router.ResolveInboundAsync(agentId, Channel(), ChannelAddress.From("chat-stable-382"), null);
+
+        notifier.Verify(
+            n => n.NotifyConversationChangedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveInbound_WithoutNotifier_DoesNotThrow()
+    {
+        // Notifier is optional -- null is fine for backwards compatibility.
+        var router = CreateRouter();
+
+        var ex = await Record.ExceptionAsync(() =>
+            router.ResolveInboundAsync(Agent(), Channel(), ChannelAddress.From("chat-no-notifier-382"), null));
+
+        ex.ShouldBeNull();
     }
 }
 


### PR DESCRIPTION
Closes #382

## Summary

Fixes the frozen conversation timestamp and broken sort order in the portal sidebar. Three coordinated fixes:

### Fix 1 — Server: `DefaultConversationRouter` calls `IConversationChangeNotifier`

`DefaultConversationRouter` now accepts an optional `IConversationChangeNotifier` (injected automatically via DI). After any `SaveAsync` that sets `UpdatedAt` (new conversation, session change, reopen/reactivate), it calls `NotifyConversationChangedAsync` so clients receive a `ConversationChanged` SignalR push.

### Fix 2 — Client: `HandleMessageEnd` updates `conv.UpdatedAt`

As a defensive client-side fix, `GatewayEventHandler.HandleMessageEnd` now sets `conv.UpdatedAt = DateTimeOffset.UtcNow` immediately on streaming completion. This keeps the sort order current even before the server push arrives.

### Fix 3 — `ConversationChangedPayload` carries `UpdatedAt`

`ConversationChangedPayload` in both server (`BotNexus.Extensions.Channels.SignalR`) and client (`BlazorClient.Core`) HubContracts now includes `DateTimeOffset? UpdatedAt`. `SignalRConversationChangeNotifier` passes `DateTimeOffset.UtcNow`. `HandleConversationChanged` fast-paths when `UpdatedAt` is present — applies it directly to the local conversation state without a REST round-trip; falls back to full refresh for create/archive events.

## Tests

3 new unit tests in `DefaultConversationRouterTests`:
- `ResolveInbound_NewConversation_CallsNotifierWithUpdated` — notifier fires on new conversation
- `ResolveInbound_ExistingConversationSameSession_DoesNotCallNotifier` — no spurious fires when nothing changed
- `ResolveInbound_WithoutNotifier_DoesNotThrow` — backwards-compatible null notifier