### PR TITLE
fix(portal): refresh workspace and reports panels on agent turn-end

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentPanel.razor
@@ -1,4 +1,4 @@
-@inject IClientStateStore Store
+﻿@inject IClientStateStore Store
 @inject NavigationManager Nav
 @implements IDisposable
 
@@ -40,7 +40,7 @@
         <section id="@GetPanelId(AgentPanelTab.Workspace)"
                  class="agent-tab-pane @(IsActiveTab(AgentPanelTab.Workspace) ? "active" : "")"
                  role="tabpanel">
-            <WorkspacePanel AgentId="@AgentId" />
+            <WorkspacePanel AgentId="@AgentId" Store="Store" />
         </section>
         }
 
@@ -49,7 +49,7 @@
         <section id="@GetPanelId(AgentPanelTab.Reports)"
                  class="agent-tab-pane @(IsActiveTab(AgentPanelTab.Reports) ? "active" : "")"
                  role="tabpanel">
-            <ReportsPanel AgentId="@AgentId" />
+            <ReportsPanel AgentId="@AgentId" Store="Store" />
         </section>
         }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ReportsPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ReportsPanel.razor
@@ -1,4 +1,4 @@
-@inject IGatewayRestClient GatewayRestClient
+﻿@inject IGatewayRestClient GatewayRestClient
 @inject IJSRuntime JS
 @using Microsoft.AspNetCore.Components
 @implements IDisposable
@@ -104,6 +104,13 @@
     private string? _markdownRenderNotice;
     private bool _showMobileViewer;
 
+    // Issue #345: turn-end refresh tracking
+    private bool _wasStreaming;
+
+    /// <summary>Optional state store for turn-end auto-refresh (issue #345).</summary>
+    [Parameter]
+    public IClientStateStore? Store { get; set; }
+
     [Parameter, EditorRequired]
     public string AgentId { get; set; } = default!;
 
@@ -132,7 +139,32 @@
 
     protected override async Task OnInitializedAsync()
     {
+        if (Store is not null)
+        {
+            _wasStreaming = Store.GetAgent(AgentId)?.IsStreaming == true;
+            Store.OnChanged += HandleStateChanged;
+        }
         await LoadReportsAsync();
+    }
+
+    private void HandleStateChanged()
+    {
+        var agent = Store?.GetAgent(AgentId);
+        if (agent is null) return;
+
+        var isStreaming = agent.IsStreaming;
+        if (_wasStreaming && !isStreaming)
+        {
+            _wasStreaming = false;
+            _ = InvokeAsync(async () =>
+            {
+                await LoadReportsAsync();
+                StateHasChanged();
+            });
+            return;
+        }
+
+        _wasStreaming = isStreaming;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -145,6 +177,8 @@
 
     public void Dispose()
     {
+        if (Store is not null)
+            Store.OnChanged -= HandleStateChanged;
         _cts.Cancel();
         _cts.Dispose();
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/WorkspacePanel.razor
@@ -1,4 +1,4 @@
-@inject IGatewayRestClient GatewayRestClient
+﻿@inject IGatewayRestClient GatewayRestClient
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -94,6 +94,13 @@
     private bool _deleteIsNonEmptyDir;
     private string? _deleteError;
 
+    // Issue #345: turn-end refresh tracking
+    private bool _wasStreaming;
+
+    /// <summary>Optional state store for turn-end auto-refresh (issue #345).</summary>
+    [Parameter]
+    public IClientStateStore? Store { get; set; }
+
     [Parameter, EditorRequired]
     public string AgentId { get; set; } = default!;
 
@@ -104,7 +111,35 @@
 
     protected override async Task OnInitializedAsync()
     {
+        if (Store is not null)
+        {
+            _wasStreaming = Store.GetAgent(AgentId)?.IsStreaming == true;
+            Store.OnChanged += HandleStateChanged;
+        }
         await LoadRootAsync();
+    }
+
+    private void HandleStateChanged()
+    {
+        var agent = Store?.GetAgent(AgentId);
+        if (agent is null) return;
+
+        var isStreaming = agent.IsStreaming;
+        if (_wasStreaming && !isStreaming)
+        {
+            // Turn just ended for our agent -- clear cached directories and reload
+            _wasStreaming = false;
+            _directoryResponses.Clear();
+            _expandedDirectories.Clear();
+            _ = InvokeAsync(async () =>
+            {
+                await LoadRootAsync();
+                StateHasChanged();
+            });
+            return;
+        }
+
+        _wasStreaming = isStreaming;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -117,6 +152,8 @@
 
     public void Dispose()
     {
+        if (Store is not null)
+            Store.OnChanged -= HandleStateChanged;
         _cts.Cancel();
         _cts.Dispose();
     }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ReportsPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ReportsPanelTests.cs
@@ -1,9 +1,10 @@
-using Bunit;
+﻿using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System.Globalization;
+using Shouldly;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -203,6 +204,69 @@ public sealed class ReportsPanelTests : IDisposable
         css.ShouldContain(".reports-panel.mobile-list .reports-viewer-pane");
         css.ShouldContain(".reports-panel.mobile-viewer .reports-list-pane");
         css.ShouldContain(".reports-list-row");
+    }
+
+    // ── Issue #345: auto-refresh on turn-end ───────────────────────────────────
+
+    [Fact]
+    public void Refreshes_reports_when_active_agent_turn_ends()
+    {
+        // Arrange: store with active streaming agent
+        var store = new ClientStateStore();
+        store.UpsertAgent(new AgentState { AgentId = "agent-1", IsStreaming = true });
+        store.ActiveAgentId = "agent-1";
+
+        var callCount = 0;
+        _restClient.GetReportsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult<IReadOnlyList<ReportListItemDto>>([]);
+            });
+
+        var cut = _ctx.Render<ReportsPanel>(parameters => parameters
+            .Add(x => x.AgentId, "agent-1")
+            .Add(x => x.Store, store));
+        cut.WaitForAssertion(() => callCount.ShouldBeGreaterThan(0));
+        var loadCountAfterMount = callCount;
+
+        // Act: turn ends
+        store.GetAgent("agent-1")!.IsStreaming = false;
+        store.NotifyChanged();
+
+        // Assert: reports were reloaded
+        cut.WaitForAssertion(() => callCount.ShouldBeGreaterThan(loadCountAfterMount));
+    }
+
+    [Fact]
+    public void Does_not_refresh_reports_when_background_agent_turn_ends()
+    {
+        // Arrange: agent-1 is active (not streaming), agent-2 is background
+        var store = new ClientStateStore();
+        store.UpsertAgent(new AgentState { AgentId = "agent-1", IsStreaming = false });
+        store.UpsertAgent(new AgentState { AgentId = "agent-2", IsStreaming = true });
+        store.ActiveAgentId = "agent-1";
+
+        var callCount = 0;
+        _restClient.GetReportsAsync("agent-1", Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult<IReadOnlyList<ReportListItemDto>>([]);
+            });
+
+        var cut = _ctx.Render<ReportsPanel>(parameters => parameters
+            .Add(x => x.AgentId, "agent-1")
+            .Add(x => x.Store, store));
+        cut.WaitForAssertion(() => callCount.ShouldBeGreaterThan(0));
+        var loadCountAfterMount = callCount;
+
+        // Act: background agent turn ends
+        store.GetAgent("agent-2")!.IsStreaming = false;
+        store.NotifyChanged();
+
+        // Confirm no reload fired for the active panel
+        cut.WaitForAssertion(() => callCount.ShouldBe(loadCountAfterMount));
     }
 
     private static string FindRepositoryRoot()

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/WorkspacePanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/WorkspacePanelTests.cs
@@ -1,9 +1,10 @@
-using Bunit;
+﻿using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System.Globalization;
+using Shouldly;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -239,6 +240,71 @@ public sealed class WorkspacePanelTests : IDisposable
         css.ShouldContain(".workspace-mobile-back");
         css.ShouldContain(".workspace-tree-row-wrapper");
         css.ShouldContain(".workspace-tree-delete");
+    }
+
+    // ── Issue #345: auto-refresh on turn-end ───────────────────────────────────
+
+    [Fact]
+    public void Refreshes_workspace_when_active_agent_turn_ends()
+    {
+        // Arrange: set up store with active agent that starts streaming
+        var store = new ClientStateStore();
+        store.UpsertAgent(new AgentState { AgentId = "agent-1", IsStreaming = true });
+        store.ActiveAgentId = "agent-1";
+
+        var callCount = 0;
+        _restClient.GetWorkspaceAsync("agent-1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult<WorkspaceResponseDto?>(new WorkspaceResponseDto(
+                    "directory", "", [], null, null, null, null, null));
+            });
+
+        var cut = _ctx.Render<WorkspacePanel>(parameters => parameters
+            .Add(x => x.AgentId, "agent-1")
+            .Add(x => x.Store, store));
+        cut.WaitForAssertion(() => callCount.ShouldBeGreaterThan(0));
+        var loadCountAfterMount = callCount;
+
+        // Act: agent turn ends (IsStreaming transitions false)
+        store.GetAgent("agent-1")!.IsStreaming = false;
+        store.NotifyChanged();
+
+        // Assert: workspace was reloaded
+        cut.WaitForAssertion(() => callCount.ShouldBeGreaterThan(loadCountAfterMount));
+    }
+
+    [Fact]
+    public void Does_not_refresh_workspace_when_background_agent_turn_ends()
+    {
+        // Arrange: store has agent-1 as active, agent-2 is background
+        var store = new ClientStateStore();
+        store.UpsertAgent(new AgentState { AgentId = "agent-1", IsStreaming = false });
+        store.UpsertAgent(new AgentState { AgentId = "agent-2", IsStreaming = true });
+        store.ActiveAgentId = "agent-1";
+
+        var callCount = 0;
+        _restClient.GetWorkspaceAsync("agent-1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult<WorkspaceResponseDto?>(new WorkspaceResponseDto(
+                    "directory", "", [], null, null, null, null, null));
+            });
+
+        var cut = _ctx.Render<WorkspacePanel>(parameters => parameters
+            .Add(x => x.AgentId, "agent-1")
+            .Add(x => x.Store, store));
+        cut.WaitForAssertion(() => callCount.ShouldBeGreaterThan(0));
+        var loadCountAfterMount = callCount;
+
+        // Act: background agent-2 turn ends
+        store.GetAgent("agent-2")!.IsStreaming = false;
+        store.NotifyChanged();
+
+        // Small delay to confirm no reload fired
+        cut.WaitForAssertion(() => callCount.ShouldBe(loadCountAfterMount));
     }
 
     private static string FindRepositoryRoot()


### PR DESCRIPTION
Closes #345

## Problem

`WorkspacePanel` and `ReportsPanel` both loaded their data exactly once at `OnInitializedAsync` mount time. If an agent wrote new files to the workspace or reports directory during a session, they were invisible until the user navigated away and back.

## Root Cause

Neither panel subscribed to any events or implemented any refresh mechanism. Both called their API exactly once at mount.

## Fix (Option 2 from issue — reload on turn-end event)

### `WorkspacePanel.razor`
- Added optional `Store` `[Parameter]` (`IClientStateStore?`)
- Subscribe to `Store.OnChanged` in `OnInitializedAsync`; unsubscribe in `Dispose`
- Track `_wasStreaming` for the panel's `AgentId`
- When streaming transitions `true → false` for this agent: clear all cached directory responses and reload the root
- Background agent state changes (different agent) do not trigger a reload

### `ReportsPanel.razor`
- Same pattern: optional `Store` `[Parameter]`, subscribe/unsubscribe, `_wasStreaming` guard, reload `LoadReportsAsync()` on turn-end

### `AgentPanel.razor`
- Passes its existing `Store` to both child panels

## Tests (4 new, TDD)

- `WorkspacePanelTests.Refreshes_workspace_when_active_agent_turn_ends`
- `WorkspacePanelTests.Does_not_refresh_workspace_when_background_agent_turn_ends`
- `ReportsPanelTests.Refreshes_reports_when_active_agent_turn_ends`
- `ReportsPanelTests.Does_not_refresh_reports_when_background_agent_turn_ends`

All 285 BlazorClient tests pass. Full suite: 0 failures.

## Design Notes

- `Store` is a `[Parameter]` (not `@inject`) so existing tests that don't provide a store continue to work without modification — fully backwards compatible
- The directory cache is cleared on reload so expanded/cached entries reflect the new filesystem state
- `InvokeAsync` is used for thread-safe Blazor component updates from the event callback