### PR TITLE
fix(portal): exclude sub-agents from top-level agent sidebar dropdown

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -59,14 +59,14 @@
                 @* Scrollable agent/conversation section *@
                 <div class="sidebar-scroll-region">
                 @* Agent dropdown + session list nested under Chat *@
-                @if (Store.Agents.Count > 0)
+                @if (Store.Agents.Values.Any(a => !a.IsReadOnly))
                 {
                     <div class="agent-dropdown-container">
                         <select class="agent-dropdown-select"
                                 value="@Store.ActiveAgentId"
                                 @onchange="OnAgentSelected">
                             <option value="">— select agent —</option>
-                            @foreach (var (agentId, agent) in Store.Agents)
+                            @foreach (var (agentId, agent) in Store.Agents.Where(kv => !kv.Value.IsReadOnly))
                             {
                                 <option value="@agentId">
                                     @FormatAgentName(agent)

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -528,4 +528,41 @@ public sealed class MainLayoutTests : IDisposable
         // Assert: SelectConversationAsync was called for Beta's auto-selected conversation
         _interaction.Received(1).SelectConversationAsync("a-2", "c-2");
     }
+
+    [Fact]
+    public void Sub_agents_in_store_are_not_shown_in_top_level_agent_dropdown()
+    {
+        // A real agent and a sub-agent (IsReadOnly via SessionType=agent-subagent) are both in the store
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.UpsertAgent(new AgentState
+        {
+            AgentId = "sub-xyz",
+            DisplayName = "SubTask",
+            SessionType = "agent-subagent",
+            IsConnected = true
+        });
+
+        var cut = RenderLayout();
+
+        var options = cut.FindAll(".agent-dropdown-select option");
+        Assert.Contains(options, o => o.GetAttribute("value") == "a-1");
+        Assert.DoesNotContain(options, o => o.GetAttribute("value") == "sub-xyz");
+    }
+
+    [Fact]
+    public void Sub_agent_only_store_renders_no_agent_dropdown()
+    {
+        // If the only entries are sub-agents the dropdown should not appear at all
+        _store.UpsertAgent(new AgentState
+        {
+            AgentId = "sub-xyz",
+            DisplayName = "SubTask",
+            SessionType = "agent-subagent",
+            IsConnected = true
+        });
+
+        var cut = RenderLayout();
+
+        Assert.Empty(cut.FindAll(".agent-dropdown-select"));
+    }
 }


### PR DESCRIPTION
Closes #343

## Problem
When `ViewSubAgentAsync` is called, the sub-agent is added to `Store.Agents` (needed for reading its history in `AgentPanel`). Because the sidebar dropdown iterates all `Store.Agents` without filtering, sub-agents appeared as selectable top-level agents alongside real agents.

## Fix
Two one-line changes in `MainLayout.razor`:
1. Guard the dropdown container: `Store.Agents.Values.Any(a => !a.IsReadOnly)` - hides the dropdown entirely if only sub-agents are present.
2. Filter dropdown options: `.Where(kv => !kv.Value.IsReadOnly)` - sub-agents are excluded from the option list.

The existing `IsReadOnly` property on `AgentState` (returns `true` when `SessionType == "agent-subagent"`) is used directly - no new surface area.

## Tests
Two new tests in `MainLayoutTests.cs`:
- `Sub_agents_in_store_are_not_shown_in_top_level_agent_dropdown`
- `Sub_agent_only_store_renders_no_agent_dropdown`

283/283 BlazorClient tests pass. Full suite green.