### PR TITLE
fix(conversation): trigger agent turn when action=new is called with a message

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -16,6 +16,7 @@ using BotNexus.Gateway.Abstractions.Hooks;
 using BotNexus.Gateway.Abstractions.Isolation;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Agents;
@@ -162,13 +163,15 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             var conversationId = await ResolveConversationIdAsync(conversationStore, sessionStore, descriptor.AgentId, context.SessionId, cancellationToken)
                 .ConfigureAwait(false);
             var (conversationAccessLevel, conversationAllowedAgents) = ResolveConversationAccess(descriptor);
+            var conversationDispatcher = _serviceProvider.GetService<IChannelDispatcher>();
             tools.Add(new ConversationTool(
                 conversationStore,
                 descriptor.AgentId,
                 conversationId,
                 conversationAccessLevel,
                 conversationAllowedAgents,
-                sessionStore));
+                sessionStore,
+                conversationDispatcher));
         }
 
         var delayToolOptions = _serviceProvider.GetService<IOptions<DelayToolOptions>>() ?? Options.Create(new DelayToolOptions());

--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -3,6 +3,7 @@ using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -19,7 +20,8 @@ public sealed class ConversationTool(
     ConversationId? currentConversationId = null,
     ConversationAccessLevel accessLevel = ConversationAccessLevel.Own,
     IReadOnlyList<string>? allowedAgents = null,
-    ISessionStore? sessionStore = null) : IAgentTool
+    ISessionStore? sessionStore = null,
+    IChannelDispatcher? channelDispatcher = null) : IAgentTool
 {
     public string Name => "conversation";
     public string Label => "Conversation Context";
@@ -188,6 +190,29 @@ public sealed class ConversationTool(
             created.ActiveSessionId = session.SessionId;
             created.UpdatedAt = DateTimeOffset.UtcNow;
             await conversationStore.SaveAsync(created, ct).ConfigureAwait(false);
+
+            // Trigger agent turn: dispatch a synthetic inbound message so the agent
+            // processes the seeded user message rather than it sitting silently in history.
+            if (channelDispatcher is not null)
+            {
+                await channelDispatcher.DispatchAsync(
+                    new InboundMessage
+                    {
+                        ChannelType = ChannelKey.From("internal"),
+                        SenderId = agentId.Value,
+                        ChannelAddress = ChannelAddress.From(targetAgentId.Value),
+                        Content = message.Trim(),
+                        TargetAgentId = targetAgentId.Value,
+                        SessionId = session.SessionId.Value,
+                        ConversationId = created.ConversationId.Value,
+                        Metadata = new Dictionary<string, object?>
+                        {
+                            ["messageType"] = "message",
+                            ["source"] = "conversation-tool-new"
+                        }
+                    },
+                    ct).ConfigureAwait(false);
+            }
         }
 
         return TextResult(JsonSerializer.Serialize(ToToolResponse(created), JsonOptions));

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
@@ -1,10 +1,12 @@
 using System.Text.Json;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Tools;
+using NSubstitute;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -141,6 +143,95 @@ public sealed class ConversationToolTests
 
         var exception = await act.ShouldThrowAsync<InvalidOperationException>();
         exception.Message.ShouldContain("Session store is required");
+    }
+
+    [Fact]
+    public async Task New_WithMessage_AndDispatcher_DispatchesInboundMessageToTriggerAgentTurn()
+    {
+        // Arrange
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: dispatcher);
+
+        // Act
+        var result = await tool.ExecuteAsync("call-1", Args(
+            "new",
+            agentId: "nova",
+            displayName: "Handoff",
+            message: "Please investigate issue #285"));
+
+        using var document = JsonDocument.Parse(ReadText(result));
+        var conversationId = document.RootElement.GetProperty("conversationId").GetString()!;
+        var activeSessionId = document.RootElement.GetProperty("activeSessionId").GetString()!;
+
+        // Assert: dispatcher was called exactly once with the correct inbound message
+        await dispatcher.Received(1).DispatchAsync(
+            Arg.Is<InboundMessage>(m =>
+                m.TargetAgentId == "nova" &&
+                m.Content == "Please investigate issue #285" &&
+                m.SessionId == activeSessionId &&
+                m.ConversationId == conversationId &&
+                m.ChannelType.Equals(ChannelKey.From("internal"))),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task New_WithMessage_WithoutDispatcher_DoesNotThrowAndStillSeedsHistory()
+    {
+        // Arrange — no dispatcher: existing behaviour is preserved, no agent turn triggered
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: null);
+
+        // Act — must not throw
+        var result = await tool.ExecuteAsync("call-1", Args(
+            "new",
+            agentId: "nova",
+            message: "Seed message without turn trigger"));
+
+        // Assert: conversation and session created, history seeded
+        using var document = JsonDocument.Parse(ReadText(result));
+        var activeSessionId = document.RootElement.GetProperty("activeSessionId").GetString()!;
+        activeSessionId.ShouldNotBeNullOrWhiteSpace();
+
+        var session = await sessionStore.GetAsync(SessionId.From(activeSessionId));
+        session.ShouldNotBeNull();
+        var entry = session.GetHistorySnapshot().ShouldHaveSingleItem();
+        entry.Content.ShouldBe("Seed message without turn trigger");
+    }
+
+    [Fact]
+    public async Task New_WithoutMessage_DoesNotInvokeDispatcher()
+    {
+        // Arrange
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: dispatcher);
+
+        // Act
+        await tool.ExecuteAsync("call-1", Args("new", agentId: "nova", displayName: "Empty conv"));
+
+        // Assert: no dispatch when no message
+        await dispatcher.DidNotReceive().DispatchAsync(
+            Arg.Any<InboundMessage>(),
+            Arg.Any<CancellationToken>());
     }
 
     private static Conversation CreateConversation(string agentId, string title, string? purpose)


### PR DESCRIPTION
Closes #285

## Summary

When `conversation(action='new', message='...')` was called, the initial user message was stored in session history but the agent never produced a response. The message sat silently in the session; no agent turn was triggered.

## Root Cause

`ConversationTool.NewAsync` created the session, added the user message, and saved everything — but never dispatched to the gateway pipeline (`IChannelDispatcher`). Without a dispatch, the session queue never picked up the work.

## Fix

### `ConversationTool`
- Added optional `IChannelDispatcher? channelDispatcher` parameter (backwards-compatible — defaults to null)
- After saving the seeded session, dispatches a synthetic `InboundMessage` with `ChannelType=internal`, `TargetAgentId`, `SessionId`, and `ConversationId` set correctly
- Gateway session queue receives the message and runs the agent turn as normal
- When `channelDispatcher` is null (no DI registration), existing behaviour is preserved: history seeded, no turn triggered — fully backwards-compatible

### `InProcessIsolationStrategy`
- Resolves `IChannelDispatcher` from DI and passes it to `ConversationTool`
- Added `using BotNexus.Gateway.Abstractions.Channels;`

## Tests (TDD — 3 new tests)

- `New_WithMessage_AndDispatcher_DispatchesInboundMessageToTriggerAgentTurn` — happy path: verifies `DispatchAsync` called with correct `TargetAgentId`, `Content`, `SessionId`, `ConversationId`, `ChannelType=internal`
- `New_WithMessage_WithoutDispatcher_DoesNotThrowAndStillSeedsHistory` — sad path / backwards-compat: no dispatcher, no throw, history still seeded
- `New_WithoutMessage_DoesNotInvokeDispatcher` — edge case: no message → dispatcher never called

All 1,524 gateway tests pass. Full suite: 0 failures.