### PR TITLE
fix(cron): use job name as conversation title and pin conversation id after first run

### DIFF
--- a/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
+++ b/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
@@ -53,20 +53,27 @@ public sealed class AgentPromptAction : ICronAction
                     ? "Soul internal trigger is not registered."
                     : "Cron internal trigger is not registered.");
 
+        var triggerRequest = new InternalTriggerRequest
+        {
+            CronJobId = context.Job.Id,
+            JobName = context.Job.Name,
+            ModelOverride = context.Job.Model,
+            ConversationId = context.Job.ConversationId
+        };
         var sessionId = await trigger
             .CreateSessionAsync(
                 AgentId.From(agentId),
                 message,
                 cancellationToken,
-                new InternalTriggerRequest
-                {
-                    CronJobId = context.Job.Id,
-                    ModelOverride = context.Job.Model,
-                    ConversationId = context.Job.ConversationId
-                })
+                triggerRequest)
             .ConfigureAwait(false);
 
         context.RecordSessionId(sessionId);
+
+        // Surface the resolved conversation ID back to the execution context so the
+        // scheduler can persist it to the job record, eliminating the lookup on future runs.
+        if (!string.IsNullOrWhiteSpace(triggerRequest.ResolvedConversationId))
+            context.RecordConversationId(triggerRequest.ResolvedConversationId);
     }
 
     private static bool IsInQuietHours(QuietHoursConfig config, string timezoneId)

--- a/src/gateway/BotNexus.Cron/CronScheduler.cs
+++ b/src/gateway/BotNexus.Cron/CronScheduler.cs
@@ -132,12 +132,26 @@ public sealed class CronScheduler(
             // concurrent changes (schedule updates, NextRunAt corrections, etc.)
             // that occurred while the action was executing.
             var latest = await _cronStore.GetAsync(job.Id, ct).ConfigureAwait(false) ?? job;
+
+            // Persist the resolved conversation ID back to the job record so subsequent
+            // runs skip the conversation lookup and use the fast path directly.
+            var resolvedConversationId = context.ConversationId;
+            var needsConversationPinback = !string.IsNullOrWhiteSpace(resolvedConversationId)
+                && (string.IsNullOrWhiteSpace(latest.ConversationId)
+                    || latest.ConversationId != resolvedConversationId);
+
             await _cronStore.UpdateAsync(latest with
             {
                 LastRunAt = triggeredAt,
                 LastRunStatus = "ok",
-                LastRunError = null
+                LastRunError = null,
+                ConversationId = needsConversationPinback ? resolvedConversationId : latest.ConversationId
             }, ct).ConfigureAwait(false);
+
+            if (needsConversationPinback)
+                _logger.LogInformation(
+                    "Cron job pinned conversation for future runs. JobName: {JobName}, JobId: {JobId}, ConversationId: {ConversationId}",
+                    job.Name, job.Id, resolvedConversationId);
             return run with { Status = "ok", CompletedAt = DateTimeOffset.UtcNow, SessionId = context.SessionId };
         }
         catch (Exception ex) when (!ct.IsCancellationRequested)

--- a/src/gateway/BotNexus.Cron/ICronAction.cs
+++ b/src/gateway/BotNexus.Cron/ICronAction.cs
@@ -15,10 +15,27 @@ public sealed record CronExecutionContext
     public required IServiceProvider Services { get; init; }
     public string? SessionId { get; private set; }
 
+    /// <summary>
+    /// The conversation ID resolved or created by the trigger for this run.
+    /// Set by the trigger so the scheduler can persist it back to the job record.
+    /// </summary>
+    public string? ConversationId { get; private set; }
+
     public void RecordSessionId(string sessionId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
         SessionId = sessionId;
+    }
+
+    /// <summary>
+    /// Records the conversation ID resolved for this cron run.
+    /// Called by the trigger after conversation creation or lookup so the scheduler
+    /// can persist the value back to the job for fast-path reuse on subsequent runs.
+    /// </summary>
+    public void RecordConversationId(string conversationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ConversationId = conversationId;
     }
 }
 

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -69,12 +69,17 @@ public sealed class CronTrigger(
         if (!string.IsNullOrWhiteSpace(request?.ConversationId))
         {
             conversation = await conversations.GetAsync(ConversationId.From(request.ConversationId), ct).ConfigureAwait(false)
-                ?? await GetOrCreateCronConversationAsync(agentId, request.CronJobId, ct).ConfigureAwait(false);
+                ?? await GetOrCreateCronConversationAsync(agentId, request.CronJobId, request.JobName, ct).ConfigureAwait(false);
         }
         else
         {
-            conversation = await GetOrCreateCronConversationAsync(agentId, request?.CronJobId, ct).ConfigureAwait(false);
+            conversation = await GetOrCreateCronConversationAsync(agentId, request?.CronJobId, request?.JobName, ct).ConfigureAwait(false);
         }
+
+        // Write back the resolved conversation ID so the caller (e.g. scheduler) can persist it to the job
+        // record, enabling subsequent runs to skip the lookup entirely.
+        if (request is not null && string.IsNullOrWhiteSpace(request.ResolvedConversationId))
+            request.ResolvedConversationId = conversation.ConversationId.Value;
 
         if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
             session.Session.ConversationId = conversation.ConversationId;
@@ -111,11 +116,14 @@ public sealed class CronTrigger(
     /// All runs of the same job land in the same conversation.
     /// The conversation is identified by its title "cron:{jobId}" or "cron:unnamed" for jobs without an ID.
     /// </summary>
-    private async Task<Conversation> GetOrCreateCronConversationAsync(AgentId agentId, string? jobId, CancellationToken ct)
+    private async Task<Conversation> GetOrCreateCronConversationAsync(AgentId agentId, string? jobId, string? jobName, CancellationToken ct)
     {
-        var title = string.IsNullOrWhiteSpace(jobId)
-            ? $"cron:{agentId.Value}"
-            : $"cron:{SanitizeSessionIdPart(jobId) ?? agentId.Value}";
+        // Use human-readable job name as title when available; fall back to job-id slug.
+        var title = !string.IsNullOrWhiteSpace(jobName)
+            ? jobName
+            : string.IsNullOrWhiteSpace(jobId)
+                ? $"cron:{agentId.Value}"
+                : $"cron:{SanitizeSessionIdPart(jobId) ?? agentId.Value}";
         var stableConversationId = BuildCronConversationId(agentId, jobId);
 
         // Prefer deterministic lookup by stable conversation id.

--- a/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
@@ -48,4 +48,16 @@ public sealed record InternalTriggerRequest
     /// When null, the trigger determines the conversation (e.g. per-job stable conversation for cron).
     /// </summary>
     public string? ConversationId { get; init; }
+
+    /// <summary>
+    /// Optional human-readable job name used as the conversation title when the trigger creates a new conversation.
+    /// Provided by the caller (e.g. cron scheduler) so the trigger does not need to perform a separate job lookup.
+    /// </summary>
+    public string? JobName { get; init; }
+
+    /// <summary>
+    /// Written back by the trigger after the conversation for this run has been resolved or created.
+    /// Callers can read this value to persist the conversation ID for fast-path reuse on subsequent runs.
+    /// </summary>
+    public string? ResolvedConversationId { get; set; }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -41,11 +41,11 @@ public sealed class CronTriggerTests
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task",
-            request: new InternalTriggerRequest { CronJobId = "job-1", ModelOverride = "openai/gpt-4.1" });
+            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance", ModelOverride = "openai/gpt-4.1" });
 
-        // Assert: conversation created with stable per-job title
+        // Assert: conversation created with human-readable job name as title
         createdConversation.ShouldNotBeNull();
-        createdConversation!.Title.ShouldBe("cron:job-1");
+        createdConversation!.Title.ShouldBe("Scheduled Maintenance");
         createdConversation.AgentId.ShouldBe(AgentId.From("agent-a"));
         createdConversation.IsDefault.ShouldBeFalse();
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -72,7 +72,7 @@ public sealed class CronTriggerTests
         {
             ConversationId = ConversationId.From("conv-job-1"),
             AgentId = AgentId.From("agent-a"),
-            Title = "cron:job-1",
+            Title = "Scheduled Maintenance",
             IsDefault = false,
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
@@ -91,7 +91,7 @@ public sealed class CronTriggerTests
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task run 2",
-            request: new InternalTriggerRequest { CronJobId = "job-1" });
+            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
 
         // Assert: no new conversation created — existing one reused
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -151,7 +151,7 @@ public sealed class CronTriggerTests
         {
             ConversationId = ConversationId.From("conv-job"),
             AgentId = AgentId.From("agent-a"),
-            Title = "cron:job-1",
+            Title = "Scheduled Maintenance",
             IsDefault = false,
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -181,9 +181,9 @@ public sealed class CronTriggerTests
         var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
 
         var first = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 1",
-            request: new InternalTriggerRequest { CronJobId = "job-1" });
+            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
         var second = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 2",
-            request: new InternalTriggerRequest { CronJobId = "job-1" });
+            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
 
         // Different session IDs per run
         first.ShouldNotBe(second);
@@ -201,7 +201,7 @@ public sealed class CronTriggerTests
         {
             ConversationId = ConversationId.From("cronconv:agent-a:job-1"),
             AgentId = AgentId.From("agent-a"),
-            Title = "cron:job-1",
+            Title = "Scheduled Maintenance",
             IsDefault = false,
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -225,7 +225,7 @@ public sealed class CronTriggerTests
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task",
-            request: new InternalTriggerRequest { CronJobId = "job-1" });
+            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
 
         sessionId.Value.ShouldStartWith("cron:job-1:");
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -238,7 +238,7 @@ public sealed class CronTriggerTests
         {
             ConversationId = ConversationId.From("conv-job-1-new"),
             AgentId = AgentId.From("agent-a"),
-            Title = "cron:job-1",
+            Title = "Scheduled Maintenance",
             IsDefault = false,
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
@@ -249,7 +249,7 @@ public sealed class CronTriggerTests
         {
             ConversationId = ConversationId.From("conv-job-1-old"),
             AgentId = AgentId.From("agent-a"),
-            Title = "cron:job-1",
+            Title = "Scheduled Maintenance",
             IsDefault = false,
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
@@ -280,7 +280,7 @@ public sealed class CronTriggerTests
         await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task",
-            request: new InternalTriggerRequest { CronJobId = "job-1" });
+            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
 
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
         conversationStore.Verify(s => s.ArchiveAsync(duplicate.ConversationId, It.IsAny<CancellationToken>()), Times.Once);
@@ -290,6 +290,93 @@ public sealed class CronTriggerTests
             It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
+
+    [Fact]
+    public async Task CreateSessionAsync_WithJobName_UsesJobNameAsConversationTitle()
+    {
+        // Arrange: no existing conversations
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        Conversation? createdConversation = null;
+
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation>());
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Callback<Conversation, CancellationToken>((c, _) => createdConversation = c)
+            .Returns<Conversation, CancellationToken>((c, _) => Task.FromResult(c));
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        // Act
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Run task",
+            request: new InternalTriggerRequest { CronJobId = "job-abc", JobName = "Autonomous Issue and PR Maintenance" });
+
+        // Assert: conversation title is human-readable job name, not the job-id slug
+        createdConversation.ShouldNotBeNull();
+        createdConversation!.Title.ShouldBe("Autonomous Issue and PR Maintenance");
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WithoutJobName_FallsBackToJobIdSlugTitle()
+    {
+        // Arrange: no existing conversations, no job name provided
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        Conversation? createdConversation = null;
+
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation>());
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Callback<Conversation, CancellationToken>((c, _) => createdConversation = c)
+            .Returns<Conversation, CancellationToken>((c, _) => Task.FromResult(c));
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        // Act
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Run task",
+            request: new InternalTriggerRequest { CronJobId = "job-1" });
+
+        // Assert: falls back to slug-based title
+        createdConversation.ShouldNotBeNull();
+        createdConversation!.Title.ShouldBe("cron:job-1");
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_AfterConversationResolved_SetsResolvedConversationIdOnRequest()
+    {
+        // Arrange: no existing conversations
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        Conversation? createdConversation = null;
+
+        conversationStore
+            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Conversation>());
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Callback<Conversation, CancellationToken>((c, _) => createdConversation = c)
+            .Returns<Conversation, CancellationToken>((c, _) => Task.FromResult(c));
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        var request = new InternalTriggerRequest { CronJobId = "job-1", JobName = "My Job" };
+
+        // Act
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Run task",
+            request: request);
+
+        // Assert: ResolvedConversationId is set so the scheduler can pin it back to the job
+        request.ResolvedConversationId.ShouldNotBeNullOrWhiteSpace();
+        createdConversation.ShouldNotBeNull();
+        request.ResolvedConversationId.ShouldBe(createdConversation!.ConversationId.Value);
+    }
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static (Mock<ISessionStore>, Mock<IConversationStore>, Mock<IAgentSupervisor>) BuildStandardMocks()


### PR DESCRIPTION
Closes #403

## Changes

### Root causes addressed
1. **Duplicate/ugly conversation titles** — `GetOrCreateCronConversationAsync` now accepts `jobName` and uses it as the conversation title instead of the `cron:{jobId}` slug. Falls back to slug if no name is provided (backward-compatible).
2. **Repeated conversation lookup on every run** — `InternalTriggerRequest` gains a `ResolvedConversationId` write-back field. After the trigger resolves/creates the conversation, it sets this field. `AgentPromptAction` surfaces it via `context.RecordConversationId()`. `CronScheduler.RunActionAsync` reads `context.ConversationId` and persists it back to the `CronJob.ConversationId` field, so subsequent runs take the fast path (no lookup).

### Files changed
- `BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs` — add `JobName` and `ResolvedConversationId` to `InternalTriggerRequest`
- `BotNexus.Cron/ICronAction.cs` — add `RecordConversationId()` to `CronExecutionContext`
- `BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs` — pass `JobName`, use local `triggerRequest` variable, call `context.RecordConversationId()`
- `BotNexus.Cron/CronScheduler.cs` — pin `context.ConversationId` back to `CronJob.ConversationId` after successful run
- `BotNexus.Gateway.Api/Triggers/CronTrigger.cs` — use `jobName` param for title, write `request.ResolvedConversationId`
- `BotNexus.Gateway.Tests/Api/CronTriggerTests.cs` — update existing tests + 3 new tests covering job name as title, slug fallback, and `ResolvedConversationId` set

## Test results
- 10/10 `CronTriggerTests` pass
- 1530/1530 `BotNexus.Gateway.Tests` pass
- All other test suites: zero failures