### PR TITLE
fix(cron): run multiple due jobs concurrently to prevent serial blocking

### DIFF
--- a/src/gateway/BotNexus.Cron/CronScheduler.cs
+++ b/src/gateway/BotNexus.Cron/CronScheduler.cs
@@ -63,6 +63,9 @@ public sealed class CronScheduler(
         var jobs = await _cronStore.ListAsync(ct: ct).ConfigureAwait(false);
         var now = DateTimeOffset.UtcNow;
 
+        // Phase 1 (sequential): resolve NextRunAt for uninitialised or stale jobs.
+        // These are cheap store-only operations with no agent I/O.
+        var dueJobs = new List<(CronJob Job, CronExpression Expression)>();
         foreach (var job in jobs.Where(j => j.Enabled))
         {
             if (!TryGetSchedule(job, out var expression))
@@ -73,10 +76,7 @@ public sealed class CronScheduler(
 
             if (job.NextRunAt is null)
             {
-                var initialized = job with
-                {
-                    NextRunAt = computedNext
-                };
+                var initialized = job with { NextRunAt = computedNext };
                 await _cronStore.UpdateAsync(initialized, ct).ConfigureAwait(false);
                 continue;
             }
@@ -95,15 +95,26 @@ public sealed class CronScheduler(
             if (job.NextRunAt > now)
                 continue;
 
+            dueJobs.Add((job, expression));
+        }
+
+        if (dueJobs.Count == 0)
+            return;
+
+        // Phase 2 (concurrent): execute all due jobs in parallel so a long-running
+        // agent prompt for one job does not delay other due jobs or user-facing sessions.
+        var runTasks = dueJobs.Select(async entry =>
+        {
+            var (job, expression) = entry;
+            var tz = ResolveTimeZone(job);
             await RunActionAsync(job, CronTriggerType.Scheduled, now, ct).ConfigureAwait(false);
 
             var latest = await _cronStore.GetAsync(job.Id, ct).ConfigureAwait(false) ?? job;
-            var updated = latest with
-            {
-                NextRunAt = expression.GetNextOccurrence(now, tz)
-            };
+            var updated = latest with { NextRunAt = expression.GetNextOccurrence(now, tz) };
             await _cronStore.UpdateAsync(updated, ct).ConfigureAwait(false);
-        }
+        });
+
+        await Task.WhenAll(runTasks).ConfigureAwait(false);
     }
 
     private async Task<CronRun> RunActionAsync(CronJob job, CronTriggerType triggerType, DateTimeOffset triggeredAt, CancellationToken ct)

--- a/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
@@ -569,6 +569,100 @@ public sealed class CronSchedulerTests
         action.ExecutionCount.ShouldBe(0);
     }
 
+    [Fact]
+    public async Task Scheduler_MultipleDueJobs_RunConcurrently_NotSerially()
+    {
+        // Two jobs each take ~150ms. Serial execution would take >=300ms.
+        // Concurrent execution should finish in <250ms.
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var action = new DelayedAction("slow-action", TimeSpan.FromMilliseconds(150));
+
+        for (var i = 1; i <= 2; i++)
+        {
+            var job = CronStoreTestContext.CreateJob($"job-{i}", actionType: "slow-action") with
+            {
+                NextRunAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+            };
+            await context.Store.CreateAsync(job);
+        }
+
+        var scheduler = CreateScheduler(context.Store, [action]);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await InvokeProcessTickAsync(scheduler);
+        sw.Stop();
+
+        action.ExecutionCount.ShouldBe(2, "both jobs must run");
+        sw.ElapsedMilliseconds.ShouldBeLessThan(280,
+            "concurrent execution of two 150ms jobs should complete well under 300ms");
+    }
+
+    [Fact]
+    public async Task Scheduler_MultipleDueJobs_PartialFailure_AllRunAndFailuresRecorded()
+    {
+        // Three jobs: first fails, second and third succeed.
+        // With concurrent execution, all three must run (not abort on first failure).
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var failAction = new ThrowingAction("fail-action", "kaboom");
+        var okAction = new RecordingAction("ok-action");
+
+        var jobs = new[]
+        {
+            ("job-fail", "fail-action"),
+            ("job-ok-1", "ok-action"),
+            ("job-ok-2", "ok-action")
+        };
+        foreach (var (id, type) in jobs)
+        {
+            var job = CronStoreTestContext.CreateJob(id, actionType: type) with
+            {
+                NextRunAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+            };
+            await context.Store.CreateAsync(job);
+        }
+
+        var scheduler = CreateScheduler(context.Store, [failAction, okAction]);
+        await InvokeProcessTickAsync(scheduler);
+
+        okAction.ExecutionCount.ShouldBe(2, "both ok jobs should run despite the first job failing");
+        var failHistory = await context.Store.GetRunHistoryAsync("job-fail");
+        failHistory.ShouldHaveSingleItem().Status.ShouldBe("error");
+        var ok1History = await context.Store.GetRunHistoryAsync("job-ok-1");
+        ok1History.ShouldHaveSingleItem().Status.ShouldBe("ok");
+        var ok2History = await context.Store.GetRunHistoryAsync("job-ok-2");
+        ok2History.ShouldHaveSingleItem().Status.ShouldBe("ok");
+    }
+
+    [Fact]
+    public async Task Scheduler_MultipleDueJobs_NextRunAt_UpdatedIndependently()
+    {
+        // Verify that concurrent runs each update their own NextRunAt independently.
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var action = new RecordingAction("test-action");
+
+        for (var i = 1; i <= 3; i++)
+        {
+            var job = CronStoreTestContext.CreateJob($"job-{i}", actionType: "test-action") with
+            {
+                NextRunAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+            };
+            await context.Store.CreateAsync(job);
+        }
+
+        var scheduler = CreateScheduler(context.Store, [action]);
+        await InvokeProcessTickAsync(scheduler);
+
+        action.ExecutionCount.ShouldBe(3);
+        for (var i = 1; i <= 3; i++)
+        {
+            var updated = await context.Store.GetAsync($"job-{i}");
+            updated.ShouldNotBeNull();
+            updated!.NextRunAt.ShouldNotBeNull(
+                $"job-{i} NextRunAt should be updated after concurrent run");
+            updated.NextRunAt!.Value.ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddSeconds(-5),
+                $"job-{i} NextRunAt should be a future time");
+        }
+    }
+
     private static CronScheduler CreateScheduler(
         ICronStore store,
         IEnumerable<ICronAction> actions,
@@ -601,6 +695,19 @@ public sealed class CronSchedulerTests
         var task = method!.Invoke(scheduler, [options, CancellationToken.None]) as Task;
         Assert.NotNull(task);
         await task!;
+    }
+
+    private sealed class DelayedAction(string actionType, TimeSpan delay) : ICronAction
+    {
+        private int _executionCount;
+        public int ExecutionCount => _executionCount;
+        public string ActionType => actionType;
+
+        public async Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(delay, cancellationToken);
+            Interlocked.Increment(ref _executionCount);
+        }
     }
 
     private sealed class RecordingAction(string actionType) : ICronAction


### PR DESCRIPTION
Closes #401

## Changes

### Root cause
`CronScheduler.ProcessTickAsync` iterated due jobs in a sequential `foreach` loop using `await`, so each job's `RunActionAsync` had to complete before the next job started. A long-running `agent-prompt` job (which calls `PromptAsync` to the LLM) would delay every other job due on the same tick.

### Fix
`ProcessTickAsync` is refactored into two phases:
1. **Phase 1 (sequential):** Resolve `NextRunAt` for uninitialised or stale jobs — cheap store operations, no ordering concern.
2. **Phase 2 (concurrent):** Collect all due jobs and dispatch them with `Task.WhenAll`, so long-running agent prompts for one job cannot block other jobs or delay user-facing sessions.

### Files changed
- `src/gateway/BotNexus.Cron/CronScheduler.cs` — refactored `ProcessTickAsync` into two-phase concurrent dispatch
- `tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs` — 3 new tests

## Tests
- `Scheduler_MultipleDueJobs_RunConcurrently_NotSerially` — two 150ms jobs must complete in under 280ms (proves parallel, not serial)
- `Scheduler_MultipleDueJobs_PartialFailure_AllRunAndFailuresRecorded` — three jobs (one failing), all three must run and histories recorded correctly
- `Scheduler_MultipleDueJobs_NextRunAt_UpdatedIndependently` — concurrent runs each update their own NextRunAt without clobbering

All 129/129 cron tests pass.