### PR TITLE
feat(canvas): scope canvas to conversation via ConversationId parameter

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -40,4 +40,7 @@ public sealed record Conversation
 
     /// <summary>Gets or sets arbitrary extension metadata for this conversation.</summary>
     public Dictionary<string, object?> Metadata { get; set; } = [];
+
+    /// <summary>Gets or sets the last canvas HTML rendered for this conversation, if any.</summary>
+    public string? CanvasHtml { get; set; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -445,7 +445,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _store.NotifyChanged();
     }
 
-    public void HandleCanvasUpdated(string agentId, string html)
+    public void HandleCanvasUpdated(string agentId, string conversationId, string html)
     {
         var agent = string.IsNullOrWhiteSpace(agentId) ? null : _store.GetAgent(agentId);
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.SignalR.Client;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
@@ -56,7 +56,7 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     public event Action<SteeringFeedbackPayload>? OnSteeringFeedback;
 
     /// <summary>Raised when the current canvas HTML is updated for an agent.</summary>
-    public event Action<string, string>? OnCanvasUpdated;
+    public event Action<string, string, string>? OnCanvasUpdated;
 
     /// <summary>Raised when a conversation is created, updated, or archived on the server.</summary>
     public event Action<ConversationChangedPayload>? OnConversationChanged;
@@ -115,7 +115,7 @@ public sealed class GatewayHubConnection : IAsyncDisposable
         _connection.On<SubAgentEventPayload>("SubAgentFailed", p => OnSubAgentFailed?.Invoke(p));
         _connection.On<SubAgentEventPayload>("SubAgentKilled", p => OnSubAgentKilled?.Invoke(p));
         _connection.On<SteeringFeedbackPayload>("SteeringFeedback", p => OnSteeringFeedback?.Invoke(p));
-        _connection.On<string, string>("CanvasUpdated", (agentId, html) => OnCanvasUpdated?.Invoke(agentId, html));
+        _connection.On<string, string, string>("CanvasUpdated", (agentId, conversationId, html) => OnCanvasUpdated?.Invoke(agentId, conversationId, html));
         _connection.On<AgentsChangedPayload>("AgentsChanged", p => OnAgentsChanged?.Invoke(p));
                 _connection.On<ConversationChangedPayload>("ConversationChanged", p => OnConversationChanged?.Invoke(p));
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Models;
 
 namespace BotNexus.Extensions.Channels.SignalR;
 
@@ -25,5 +25,5 @@ public interface IGatewayHubClient
     Task ConversationChanged(ConversationChangedPayload payload);
 
     Task SteeringFeedback(SteeringFeedbackPayload payload);
-    Task CanvasUpdated(string agentId, string html);
+    Task CanvasUpdated(string agentId, string conversationId, string html);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRCanvasNotifier.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRCanvasNotifier.cs
@@ -1,12 +1,9 @@
 using BotNexus.Gateway.Abstractions.Agents;
 using Microsoft.AspNetCore.SignalR;
-
 namespace BotNexus.Extensions.Channels.SignalR;
-
 public sealed class SignalRCanvasNotifier(IHubContext<GatewayHub, IGatewayHubClient> hubContext) : IAgentCanvasNotifier
 {
     private readonly IHubContext<GatewayHub, IGatewayHubClient> _hubContext = hubContext;
-
-    public Task NotifyCanvasUpdatedAsync(string agentId, string html, CancellationToken cancellationToken = default)
-        => _hubContext.Clients.All.CanvasUpdated(agentId, html);
+    public Task NotifyCanvasUpdatedAsync(string agentId, string conversationId, string html, CancellationToken cancellationToken = default)
+        => _hubContext.Clients.All.CanvasUpdated(agentId, conversationId, html);
 }

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentCanvasNotifier.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentCanvasNotifier.cs
@@ -1,12 +1,11 @@
 namespace BotNexus.Gateway.Abstractions.Agents;
-
 /// <summary>
-/// Broadcasts agent-scoped canvas HTML updates to interested transports.
+/// Broadcasts canvas HTML updates to interested transports, scoped to agent and conversation.
 /// </summary>
 public interface IAgentCanvasNotifier
 {
     /// <summary>
-    /// Publishes the latest canvas HTML for a specific agent.
+    /// Publishes the latest canvas HTML for a specific agent and conversation.
     /// </summary>
-    Task NotifyCanvasUpdatedAsync(string agentId, string html, CancellationToken cancellationToken = default);
+    Task NotifyCanvasUpdatedAsync(string agentId, string conversationId, string html, CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -217,7 +217,14 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         if (includeCanvas)
         {
             var canvasNotifiers = _serviceProvider.GetServices<IAgentCanvasNotifier>().ToArray();
-            tools.Add(new CanvasTool(descriptor.AgentId, canvasNotifiers));
+            ConversationId? canvasConversationId = null;
+            var canvasConvStore = _serviceProvider.GetService<IConversationStore>();
+            if (canvasConvStore is not null)
+            {
+                canvasConversationId = await ResolveConversationIdAsync(canvasConvStore, sessionStore, descriptor.AgentId, context.SessionId, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            tools.Add(new CanvasTool(descriptor.AgentId, canvasConversationId, canvasNotifiers));
         }
 
         List<object> extensionResourcesToDispose = [];

--- a/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
@@ -4,19 +4,17 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
-
 namespace BotNexus.Gateway.Tools;
-
 public sealed class CanvasTool(
     AgentId agentId,
+    ConversationId? conversationId,
     IReadOnlyList<IAgentCanvasNotifier>? canvasNotifiers = null) : IAgentTool
 {
     private readonly AgentId _agentId = agentId;
+    private readonly string _conversationId = conversationId?.Value ?? string.Empty;
     private readonly IReadOnlyList<IAgentCanvasNotifier> _canvasNotifiers = canvasNotifiers ?? [];
-
     public string Name => "canvas";
     public string Label => "Canvas";
-
     public Tool Definition => new(
         Name,
         "Publish Canvas tab HTML for the current agent scope. Use action='render' with html content to replace output, or action='clear' to clear output.",
@@ -37,23 +35,18 @@ public sealed class CanvasTool(
               "required": ["action"]
             }
             """).RootElement.Clone());
-
     public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
         IReadOnlyDictionary<string, object?> arguments,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-
         var action = ReadRequiredString(arguments, "action").Trim().ToLowerInvariant();
         if (action is not ("render" or "clear"))
             throw new ArgumentException("Argument 'action' must be either 'render' or 'clear'.");
-
         if (action == "render" && string.IsNullOrWhiteSpace(ReadString(arguments, "html")))
             throw new ArgumentException("Argument 'html' is required when action is 'render'.");
-
         return Task.FromResult(arguments);
     }
-
     public async Task<AgentToolResult> ExecuteAsync(
         string toolCallId,
         IReadOnlyDictionary<string, object?> arguments,
@@ -62,30 +55,24 @@ public sealed class CanvasTool(
     {
         var action = ReadRequiredString(arguments, "action").Trim().ToLowerInvariant();
         var html = action == "clear" ? string.Empty : ReadString(arguments, "html") ?? string.Empty;
-
         foreach (var notifier in _canvasNotifiers)
-            await notifier.NotifyCanvasUpdatedAsync(_agentId.Value, html, cancellationToken).ConfigureAwait(false);
-
+            await notifier.NotifyCanvasUpdatedAsync(_agentId.Value, _conversationId, html, cancellationToken).ConfigureAwait(false);
         var message = action == "clear"
             ? "Canvas cleared for current agent."
             : "Canvas rendered for current agent.";
         return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, message)]);
     }
-
     private static string ReadRequiredString(IReadOnlyDictionary<string, object?> arguments, string key)
     {
         var value = ReadString(arguments, key);
         if (string.IsNullOrWhiteSpace(value))
             throw new ArgumentException($"Missing required argument: {key}.");
-
         return value;
     }
-
     private static string? ReadString(IReadOnlyDictionary<string, object?> arguments, string key)
     {
         if (!arguments.TryGetValue(key, out var value) || value is null)
             return null;
-
         return value switch
         {
             JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -238,7 +238,7 @@ public sealed class GatewayEventHandlerTests
         var agent = _store.GetAgent("agent-1")!;
         agent.CanvasHtml = null;
 
-        _handler.HandleCanvasUpdated("agent-1", "<div>Canvas</div>");
+        _handler.HandleCanvasUpdated("agent-1", "conv-1", "<div>Canvas</div>");
 
         Assert.Equal("<div>Canvas</div>", agent.CanvasHtml);
         Assert.NotNull(agent.CanvasUpdatedAt);
@@ -250,7 +250,7 @@ public sealed class GatewayEventHandlerTests
         var agent = _store.GetAgent("agent-1")!;
         agent.CanvasHtml = "<p>existing</p>";
 
-        _handler.HandleCanvasUpdated("missing-agent", "<div>new</div>");
+        _handler.HandleCanvasUpdated("missing-agent", "conv-1", "<div>new</div>");
 
         Assert.Equal("<p>existing</p>", agent.CanvasHtml);
     }
@@ -417,7 +417,7 @@ public sealed class GatewayEventHandlerTests
         var agent = _store.GetAgent("agent-1")!;
         agent.CanvasHtml = "<html><body>existing</body></html>";
 
-        _handler.HandleCanvasUpdated("agent-1", " ");
+        _handler.HandleCanvasUpdated("agent-1", "conv-1", " ");
 
         Assert.Null(agent.CanvasHtml);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRCanvasNotifierTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRCanvasNotifierTests.cs
@@ -1,31 +1,40 @@
 using BotNexus.Extensions.Channels.SignalR;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
-
 namespace BotNexus.Gateway.Tests;
-
 public sealed class SignalRCanvasNotifierTests
 {
     [Fact]
-    public async Task NotifyCanvasUpdatedAsync_BroadcastsCanvasUpdatedArguments()
+    public async Task NotifyCanvasUpdatedAsync_BroadcastsCanvasUpdatedWithConversationId()
     {
         var clientProxy = new Mock<IGatewayHubClient>();
-        clientProxy.Setup(proxy => proxy.CanvasUpdated(It.IsAny<string>(), It.IsAny<string>()))
+        clientProxy.Setup(proxy => proxy.CanvasUpdated(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns(Task.CompletedTask);
-
         var clients = new Mock<IHubClients<IGatewayHubClient>>();
         clients.Setup(value => value.All).Returns(clientProxy.Object);
-
         var hubContext = new Mock<IHubContext<GatewayHub, IGatewayHubClient>>();
         hubContext.SetupGet(value => value.Clients).Returns(clients.Object);
-
         var notifier = new SignalRCanvasNotifier(hubContext.Object);
-
-        await notifier.NotifyCanvasUpdatedAsync("agent-a", "<p>hello</p>");
-
+        await notifier.NotifyCanvasUpdatedAsync("agent-a", "conv-1", "<p>hello</p>");
         clientProxy.Verify(proxy => proxy.CanvasUpdated(
                 "agent-a",
+                "conv-1",
                 "<p>hello</p>"),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyCanvasUpdatedAsync_EmptyConversationId_StillBroadcasts()
+    {
+        var clientProxy = new Mock<IGatewayHubClient>();
+        clientProxy.Setup(proxy => proxy.CanvasUpdated(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients<IGatewayHubClient>>();
+        clients.Setup(value => value.All).Returns(clientProxy.Object);
+        var hubContext = new Mock<IHubContext<GatewayHub, IGatewayHubClient>>();
+        hubContext.SetupGet(value => value.Clients).Returns(clients.Object);
+        var notifier = new SignalRCanvasNotifier(hubContext.Object);
+        await notifier.NotifyCanvasUpdatedAsync("agent-a", "", "<p>hello</p>");
+        clientProxy.Verify(proxy => proxy.CanvasUpdated("agent-a", "", "<p>hello</p>"), Times.Once);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolTests.cs
@@ -1,38 +1,34 @@
+// Updated CanvasToolTests.cs - tests with conversationId
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Tools;
 using Moq;
-
 namespace BotNexus.Gateway.Tests.Tools;
-
 public sealed class CanvasToolTests
 {
     [Fact]
     public void Tool_HasExpectedNameAndLabel()
     {
-        var tool = new CanvasTool(AgentId.From("agent-a"));
-
+        var tool = new CanvasTool(AgentId.From("agent-a"), null, null);
         tool.Name.ShouldBe("canvas");
         tool.Label.ShouldBe("Canvas");
     }
 
     [Fact]
-    public async Task ExecuteAsync_Render_PublishesHtmlForCurrentAgent()
+    public async Task ExecuteAsync_Render_PublishesHtmlWithConversationId()
     {
         var notifier = new Mock<IAgentCanvasNotifier>();
-        var tool = new CanvasTool(AgentId.From("agent-a"), [notifier.Object]);
-
+        var tool = new CanvasTool(AgentId.From("agent-a"), ConversationId.From("conv-1"), [notifier.Object]);
         var result = await ExecuteAsync(tool, new Dictionary<string, object?>
         {
             ["action"] = "render",
             ["html"] = "<h1>Hello</h1>",
-            ["agentId"] = "agent-b"
         });
-
         notifier.Verify(value => value.NotifyCanvasUpdatedAsync(
                 "agent-a",
+                "conv-1",
                 "<h1>Hello</h1>",
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -40,18 +36,35 @@ public sealed class CanvasToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_Clear_PublishesEmptyHtmlForCurrentAgent()
+    public async Task ExecuteAsync_Render_NullConversationId_PassesEmptyString()
     {
         var notifier = new Mock<IAgentCanvasNotifier>();
-        var tool = new CanvasTool(AgentId.From("agent-a"), [notifier.Object]);
+        var tool = new CanvasTool(AgentId.From("agent-a"), null, [notifier.Object]);
+        await ExecuteAsync(tool, new Dictionary<string, object?>
+        {
+            ["action"] = "render",
+            ["html"] = "<h1>Hello</h1>",
+        });
+        notifier.Verify(value => value.NotifyCanvasUpdatedAsync(
+                "agent-a",
+                "",
+                "<h1>Hello</h1>",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 
+    [Fact]
+    public async Task ExecuteAsync_Clear_PublishesEmptyHtmlWithConversationId()
+    {
+        var notifier = new Mock<IAgentCanvasNotifier>();
+        var tool = new CanvasTool(AgentId.From("agent-a"), ConversationId.From("conv-1"), [notifier.Object]);
         var result = await ExecuteAsync(tool, new Dictionary<string, object?>
         {
             ["action"] = "clear"
         });
-
         notifier.Verify(value => value.NotifyCanvasUpdatedAsync(
                 "agent-a",
+                "conv-1",
                 string.Empty,
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -61,26 +74,22 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task PrepareArgumentsAsync_RenderRequiresHtml()
     {
-        var tool = new CanvasTool(AgentId.From("agent-a"));
-
+        var tool = new CanvasTool(AgentId.From("agent-a"), null, null);
         Func<Task> action = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?>
         {
             ["action"] = "render"
         });
-
         await action.ShouldThrowAsync<ArgumentException>();
     }
 
     [Fact]
     public async Task PrepareArgumentsAsync_RejectsInvalidAction()
     {
-        var tool = new CanvasTool(AgentId.From("agent-a"));
-
+        var tool = new CanvasTool(AgentId.From("agent-a"), null, null);
         Func<Task> action = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?>
         {
             ["action"] = "paint"
         });
-
         await action.ShouldThrowAsync<ArgumentException>();
     }
 


### PR DESCRIPTION
Closes #411

## Changes

**Sub-issue of #383**

### Phase 1: Per-conversation canvas scoping in domain model and CanvasTool

- IAgentCanvasNotifier.NotifyCanvasUpdatedAsync — added conversationId parameter
- CanvasTool — added ConversationId? constructor parameter; passes it through to notifier
- SignalRCanvasNotifier — forwards conversationId in CanvasUpdated hub event
- IGatewayHubClient.CanvasUpdated — added conversationId parameter
- GatewayHubConnection.OnCanvasUpdated — updated to Action<string, string, string> (agentId, conversationId, html)
- GatewayEventHandler.HandleCanvasUpdated — updated signature to include conversationId
- InProcessIsolationStrategy — resolves ConversationId when building CanvasTool
- Conversation domain model — added CanvasHtml field

### Tests
- CanvasToolTests — updated to pass ConversationId and assert it's forwarded
- SignalRCanvasNotifierTests — updated to assert conversationId in CanvasUpdated call
- GatewayEventHandlerTests — updated 3 canvas tests to pass conversationId

### Notes
- Agent-level CanvasHtml retained for backwards compatibility; conversation-level CanvasHtml is additive
- Phase 2 (persist + REST endpoint) and Phase 3 (portal multi-browser routing) are follow-up issues #412 and #413