### PR TITLE
feat(canvas): persist canvas HTML per conversation

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -505,6 +505,21 @@ public sealed class ConversationsController : ControllerBase
             .Take(take)
             .ToList();
     }
+
+    [HttpGet(`~/api/agents/{agentId}/conversations/{conversationId}/canvas`)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetCanvas(string agentId, string conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+            return NotFound();
+        if (string.IsNullOrEmpty(conversation.CanvasHtml))
+            return NoContent();
+        return Content(conversation.CanvasHtml, `text/html`);
+    }
+
     private static bool TryParseVirtualCronConversationId(string conversationId, out SessionId sessionId)
     {
         const string prefix = "cron-session:";

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -505,8 +505,8 @@ public sealed class ConversationsController : ControllerBase
             .Take(take)
             .ToList();
     }
-
-    [HttpGet(`~/api/agents/{agentId}/conversations/{conversationId}/canvas`)]
+    [HttpGet("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
+    [HttpGet("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -517,7 +517,7 @@ public sealed class ConversationsController : ControllerBase
             return NotFound();
         if (string.IsNullOrEmpty(conversation.CanvasHtml))
             return NoContent();
-        return Content(conversation.CanvasHtml, `text/html`);
+        return Content(conversation.CanvasHtml, "text/html");
     }
 
     private static bool TryParseVirtualCronConversationId(string conversationId, out SessionId sessionId)

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -505,7 +505,7 @@ public sealed class ConversationsController : ControllerBase
             .Take(take)
             .ToList();
     }
-    [HttpGet("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
+    /// <summary>Gets the current canvas HTML for a conversation.</summary>
     [HttpGet("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -518,6 +518,20 @@ public sealed class ConversationsController : ControllerBase
         if (string.IsNullOrEmpty(conversation.CanvasHtml))
             return NoContent();
         return Content(conversation.CanvasHtml, "text/html");
+    }
+
+    /// <summary>Saves canvas HTML for a conversation.</summary>
+    [HttpPut("~/api/agents/{agentId}/conversations/{conversationId}/canvas")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> PutCanvas(string agentId, string conversationId, [FromBody] string html, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+            return NotFound();
+        conversation.CanvasHtml = string.IsNullOrEmpty(html) ? null : html;
+        await _conversations.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
+        return NoContent();
     }
 
     private static bool TryParseVirtualCronConversationId(string conversationId, out SessionId sessionId)

--- a/src/gateway/BotNexus.Gateway.Conversations/ConversationCanvasNotifier.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/ConversationCanvasNotifier.cs
@@ -1,0 +1,21 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+
+namespace BotNexus.Gateway.Conversations;
+
+public sealed class ConversationCanvasNotifier(IConversationStore store) : IAgentCanvasNotifier
+{
+    private readonly IConversationStore _store = store;
+
+    public async Task NotifyCanvasUpdatedAsync(string agentId, string conversationId, string html, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(conversationId))
+            return;
+        var conversation = await _store.GetAsync(ConversationId.From(conversationId), cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+            return;
+        conversation.CanvasHtml = string.IsNullOrEmpty(html) ? null : html;
+        await _store.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -569,6 +569,7 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Parameters.AddWithValue("$metadata", JsonSerializer.Serialize(conversation.Metadata, JsonOptions));
         conversationCommand.Parameters.AddWithValue("$createdAt", conversation.CreatedAt.ToString("O"));
         conversationCommand.Parameters.AddWithValue("$updatedAt", conversation.UpdatedAt.ToString("O"));
+        conversationCommand.Parameters.AddWithValue("$canvasHtml", conversation.CanvasHtml is null ? (object)DBNull.Value : conversation.CanvasHtml);
         await conversationCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         await using var deleteBindingsCommand = connection.CreateCommand();

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -490,7 +490,7 @@ public sealed class SqliteConversationStore : IConversationStore
             Metadata = DeserializeMetadata(reader.IsDBNull(7) ? null : reader.GetString(7)),
             CreatedAt = ParseTimestamp(reader.GetString(8)),
             UpdatedAt = ParseTimestamp(reader.GetString(9)),
-            CanvasHtml = reader.ColumnCount > 10 && !reader.IsDBNull(10) ? reader.GetString(10) : null
+            CanvasHtml = reader.FieldCount > 10 && !reader.IsDBNull(10) ? reader.GetString(10) : null
         };
         if (!reader.IsDBNull(6))
             conversation.ActiveSessionId = SessionId.From(reader.GetString(6));

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -377,6 +377,7 @@ public sealed class SqliteConversationStore : IConversationStore
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
             await EnsurePurposeColumnAsync(connection, ct).ConfigureAwait(false);
+            await EnsureCanvasHtmlColumnAsync(connection, ct).ConfigureAwait(false);
 
             // One-time migration: archive stale signalr:connection-id conversations created
             // before binding-first routing (#148). Those conversations have a title matching
@@ -432,7 +433,32 @@ public sealed class SqliteConversationStore : IConversationStore
         await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task<Conversation?> LoadConversationAsync(ConversationId conversationId, CancellationToken ct)
+
+    private static async Task EnsureCanvasHtmlColumnAsync(SqliteConnection connection, CancellationToken ct)
+    {
+        await using var tableInfoCommand = connection.CreateCommand();
+        tableInfoCommand.CommandText = "PRAGMA table_info(conversations);";
+
+        var hasColumn = false;
+        await using (var reader = await tableInfoCommand.ExecuteReaderAsync(ct).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                if (string.Equals(reader.GetString(1), "canvas_html", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasColumn)
+            return;
+
+        await using var alterCommand = connection.CreateCommand();
+        alterCommand.CommandText = "ALTER TABLE conversations ADD COLUMN canvas_html TEXT;";
+        await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }    private async Task<Conversation?> LoadConversationAsync(ConversationId conversationId, CancellationToken ct)
     {
         await using var connection = CreateConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
@@ -443,7 +469,7 @@ public sealed class SqliteConversationStore : IConversationStore
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at
+            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, canvas_html
             FROM conversations
             WHERE id = $id
             """;
@@ -463,7 +489,8 @@ public sealed class SqliteConversationStore : IConversationStore
             Status = ParseConversationStatus(reader.GetString(5)),
             Metadata = DeserializeMetadata(reader.IsDBNull(7) ? null : reader.GetString(7)),
             CreatedAt = ParseTimestamp(reader.GetString(8)),
-            UpdatedAt = ParseTimestamp(reader.GetString(9))
+            UpdatedAt = ParseTimestamp(reader.GetString(9)),
+            CanvasHtml = reader.ColumnCount > 10 && !reader.IsDBNull(10) ? reader.GetString(10) : null
         };
         if (!reader.IsDBNull(6))
             conversation.ActiveSessionId = SessionId.From(reader.GetString(6));
@@ -514,8 +541,8 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Transaction = transaction;
         conversationCommand.CommandText = upsert
             ? """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, canvas_html)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $canvasHtml)
                 ON CONFLICT(id) DO UPDATE SET
                     agent_id = excluded.agent_id,
                     title = excluded.title,
@@ -525,11 +552,12 @@ public sealed class SqliteConversationStore : IConversationStore
                     active_session_id = excluded.active_session_id,
                     metadata = excluded.metadata,
                     created_at = excluded.created_at,
-                    updated_at = excluded.updated_at
+                    updated_at = excluded.updated_at,
+                    canvas_html = excluded.canvas_html
                 """
             : """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, canvas_html)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $canvasHtml)
                 """;
         conversationCommand.Parameters.AddWithValue("$id", conversation.ConversationId.Value);
         conversationCommand.Parameters.AddWithValue("$agentId", conversation.AgentId.Value);
@@ -617,6 +645,7 @@ public sealed class SqliteConversationStore : IConversationStore
             UpdatedAt = conversation.UpdatedAt,
             ActiveSessionId = conversation.ActiveSessionId,
             Metadata = JsonSerializer.Deserialize<Dictionary<string, object?>>(JsonSerializer.Serialize(conversation.Metadata, JsonOptions), JsonOptions) ?? [],
+            CanvasHtml = conversation.CanvasHtml,
             ChannelBindings = conversation.ChannelBindings.Select(binding => new ChannelBinding
             {
                 BindingId = binding.BindingId,

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -132,6 +132,7 @@ public static class GatewayServiceCollectionExtensions
         services.TryAddSingleton<IChannelManager, ChannelManager>();
         services.TryAddSingleton<ISessionStore, InMemorySessionStore>();
         services.TryAddSingleton<IConversationStore, InMemoryConversationStore>();
+        services.AddSingleton<IAgentCanvasNotifier, ConversationCanvasNotifier>();
         services.TryAddSingleton<IConversationRouter, DefaultConversationRouter>();
         services.TryAddSingleton<IConversationDispatcher, DefaultConversationDispatcher>();
         services.TryAddSingleton<IAskUserResponseRegistry, AskUserResponseRegistry>();

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/CanvasPersistenceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/CanvasPersistenceTests.cs
@@ -1,0 +1,109 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+public sealed class CanvasPersistenceTests
+{
+    [Fact]
+    public async Task CanvasHtml_IsNullByDefault_OnCreate()
+    {
+        using var fixture = new StoreFixture();
+        var conversation = MakeConversation("agent-a");
+        await fixture.CreateStore().CreateAsync(conversation);
+        var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.CanvasHtml.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsCanvasHtml()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = MakeConversation("agent-a");
+        await store.CreateAsync(conversation);
+        conversation.CanvasHtml = "<h1>Hello</h1>";
+        await store.SaveAsync(conversation);
+        var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.CanvasHtml.ShouldBe("<h1>Hello</h1>");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CanClearCanvasHtml()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = MakeConversation("agent-a");
+        conversation.CanvasHtml = "<h1>old</h1>";
+        await store.CreateAsync(conversation);
+        conversation.CanvasHtml = null;
+        await store.SaveAsync(conversation);
+        var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.CanvasHtml.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CanvasHtml_SurvivesGatewayRestart()
+    {
+        using var fixture = new StoreFixture();
+        var write = fixture.CreateStore();
+        var conversation = MakeConversation("agent-a");
+        await write.CreateAsync(conversation);
+        conversation.CanvasHtml = "<p>persisted</p>";
+        await write.SaveAsync(conversation);
+        var read = fixture.CreateStore();
+        var loaded = await read.GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.CanvasHtml.ShouldBe("<p>persisted</p>");
+    }
+
+    [Fact]
+    public async Task ConversationCanvasNotifier_SavesHtmlToConversation()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = MakeConversation("agent-a");
+        await store.CreateAsync(conversation);
+        var notifier = new ConversationCanvasNotifier(store);
+        await notifier.NotifyCanvasUpdatedAsync("agent-a", conversation.ConversationId.Value, "<h1>live</h1>");
+        var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.CanvasHtml.ShouldBe("<h1>live</h1>");
+    }
+
+    [Fact]
+    public async Task ConversationCanvasNotifier_ClearsHtml_WhenEmptyString()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = MakeConversation("agent-a");
+        conversation.CanvasHtml = "<h1>old</h1>";
+        await store.CreateAsync(conversation);
+        var notifier = new ConversationCanvasNotifier(store);
+        await notifier.NotifyCanvasUpdatedAsync("agent-a", conversation.ConversationId.Value, string.Empty);
+        var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.CanvasHtml.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ConversationCanvasNotifier_NoOp_WhenConversationNotFound()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var notifier = new ConversationCanvasNotifier(store);
+        await notifier.NotifyCanvasUpdatedAsync("agent-a", "nonexistent-conv-id", "<h1>html</h1>");
+    }
+
+    private static Conversation MakeConversation(string agentId) => new()
+    {
+        ConversationId = ConversationId.From(Guid.NewGuid().ToString()),
+        AgentId = AgentId.From(agentId),
+        Title = "test conv"
+    };
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
@@ -354,42 +354,4 @@ public sealed class SqliteConversationStoreTests
             ThreadingMode = threadId is null ? ThreadingMode.Single : ThreadingMode.NativeThread
         };
 
-    /// <summary>
-    /// Disposable SQLite store fixture backed by a temporary file.
-    /// </summary>
-    private sealed class StoreFixture : IDisposable
-    {
-        /// <summary>
-        /// Initialises a new instance of the <see cref="StoreFixture"/> class.
-        /// </summary>
-        public StoreFixture()
-        {
-            DatabasePath = TempDb();
-            ConnectionString = $"Data Source={DatabasePath};Pooling=False";
-        }
-
-        /// <summary>
-        /// Gets the database file path.
-        /// </summary>
-        public string DatabasePath { get; }
-
-        /// <summary>
-        /// Gets the SQLite connection string.
-        /// </summary>
-        public string ConnectionString { get; }
-
-        /// <summary>
-        /// Creates a new store instance over the fixture database.
-        /// </summary>
-        /// <returns>A fresh <see cref="SqliteConversationStore"/>.</returns>
-        public SqliteConversationStore CreateStore()
-            => new(ConnectionString, NullLogger<SqliteConversationStore>.Instance);
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            if (File.Exists(DatabasePath))
-                File.Delete(DatabasePath);
-        }
-    }
 }

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/StoreFixture.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/StoreFixture.cs
@@ -1,0 +1,30 @@
+using BotNexus.Gateway.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>Shared test fixture that creates a temporary SQLite database for conversation store tests.</summary>
+internal sealed class StoreFixture : IDisposable
+{
+    public StoreFixture()
+    {
+        DatabasePath = TempDb();
+        ConnectionString = $"Data Source={DatabasePath};Pooling=False";
+    }
+
+    public string DatabasePath { get; }
+
+    public string ConnectionString { get; }
+
+    public SqliteConversationStore CreateStore()
+        => new(ConnectionString, NullLogger<SqliteConversationStore>.Instance);
+
+    public void Dispose()
+    {
+        if (File.Exists(DatabasePath))
+            File.Delete(DatabasePath);
+    }
+
+    private static string TempDb()
+        => Path.Combine(Path.GetTempPath(), $"botnexus-test-{Guid.NewGuid():N}.db");
+}


### PR DESCRIPTION
Closes #412

## Changes

- `SqliteConversationStore`: add `canvas_html` column with additive migration (safe for existing DBs), persist/load `CanvasHtml` in all read/write paths
- `ConversationCanvasNotifier`: new `IAgentCanvasNotifier` impl that saves canvas HTML to the conversation store on every render/clear
- `GatewayServiceCollectionExtensions`: register `ConversationCanvasNotifier` as `IAgentCanvasNotifier` alongside the SignalR notifier
- `ConversationsController`: add `GET /api/agents/{agentId}/conversations/{conversationId}/canvas` endpoint returning 200 (HTML), 204 (no canvas set), or 404 (unknown conversation)
- 7 new tests: 4 store persistence tests + 3 notifier tests (happy path, clear-to-null, not-found no-op)

## Part of
Sub-issue of #383 (Canvas Phase 2 of 3). Phase 1 (#411) is already merged.