### PR TITLE
feat(memory): add pre-compaction memory flush turn

### DIFF
--- a/src/domain/BotNexus.Domain/Primitives/TriggerType.cs
+++ b/src/domain/BotNexus.Domain/Primitives/TriggerType.cs
@@ -15,6 +15,7 @@ public sealed class TriggerType : IEquatable<TriggerType>
     public static readonly TriggerType Cron = Register("cron");
     public static readonly TriggerType Soul = Register("soul");
     public static readonly TriggerType Heartbeat = Register("heartbeat");
+    public static readonly TriggerType Memory = Register("memory");
 
     /// <summary>
     /// Gets the value.

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
@@ -12,7 +12,7 @@ public sealed record CompactionOptions
     public int MaxSummaryChars { get; init; } = 16_000;
 
     /// <summary>
-    /// Token threshold as a fraction of context window (0.0–1.0) at which auto-compaction triggers (default: 0.6).
+    /// Token threshold as a fraction of context window (0.0-1.0) at which auto-compaction triggers (default: 0.6).
     /// </summary>
     public double TokenThresholdRatio { get; init; } = 0.6;
 
@@ -24,4 +24,34 @@ public sealed record CompactionOptions
 
     /// <summary>Provider to use for summarization (e.g., "github-copilot"). If null, auto-detected from registered providers.</summary>
     public string? SummarizationProvider { get; init; }
+
+    /// <summary>Pre-compaction memory flush configuration.</summary>
+    public MemoryFlushOptions MemoryFlush { get; init; } = new();
+}
+
+/// <summary>
+/// Configuration for the pre-compaction memory flush turn.
+/// When enabled, the agent is given a brief turn to write important context to
+/// memory files (e.g. <c>memory/YYYY-MM-DD.md</c>) before the session history
+/// is summarised and truncated.
+/// </summary>
+public sealed record MemoryFlushOptions
+{
+    /// <summary>Whether pre-compaction memory flush is enabled (default: true).</summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// The prompt sent to the agent during the flush turn.
+    /// The agent should use this turn to write important context to memory files.
+    /// </summary>
+    public string PromptText { get; init; } =
+        "Session compaction is about to run. " +
+        "Write any important context, decisions, or open items from this conversation to your daily memory file " +
+        "(memory/YYYY-MM-DD.md) now. Keep it brief and focused on what must survive compaction.";
+
+    /// <summary>Maximum seconds to wait for the flush turn to complete (default: 60).</summary>
+    public int TimeoutSeconds { get; init; } = 60;
+
+    /// <summary>Metadata key used to track the compaction-cycle count at last flush.</summary>
+    public const string MetadataKey = "memoryFlushCompactionCount";
 }

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/IPreCompactionMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/IPreCompactionMemoryFlusher.cs
@@ -1,0 +1,24 @@
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Sessions;
+
+/// <summary>
+/// Pre-compaction memory flush service.
+/// Fires a synthetic memory-trigger agent turn before compaction so the agent
+/// can write important context to disk (e.g. memory/YYYY-MM-DD.md) before the
+/// conversation history is summarised and truncated.
+/// </summary>
+public interface IPreCompactionMemoryFlusher
+{
+    /// <summary>
+    /// Returns true when a memory flush should run before the next compaction cycle.
+    /// </summary>
+    bool ShouldFlush(Session session, CompactionOptions options);
+
+    /// <summary>
+    /// Fires a memory-trigger agent turn and awaits completion (with timeout).
+    /// Non-fatal: exceptions are caught and logged — compaction always proceeds.
+    /// </summary>
+    Task FlushAsync(AgentId agentId, Session session, CompactionOptions options, CancellationToken ct = default);
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -139,6 +139,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<InternalChannelAdapter>();
         services.AddSingleton<IChannelAdapter>(serviceProvider => serviceProvider.GetRequiredService<InternalChannelAdapter>());
         services.AddSingleton<ISessionCompactor, LlmSessionCompactor>();
+        services.AddSingleton<IPreCompactionMemoryFlusher, PreCompactionMemoryFlusher>();
         services.AddSingleton<IMediaPipeline, MediaPipeline>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICommandContributor, BuiltInCommandContributor>());
         services.TryAddSingleton<CommandRegistry>();

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -56,6 +56,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private readonly IConversationRouter? _conversationRouter;
     private readonly SessionLifecycleEvents? _sessionLifecycleEvents;
     private readonly PendingAskUserInterceptor? _pendingAskUserInterceptor;
+    private readonly IPreCompactionMemoryFlusher? _memoryFlusher;
     private readonly ConcurrentDictionary<string, SessionQueueState> _sessionQueues = new(StringComparer.OrdinalIgnoreCase);
 
     public GatewayHost(
@@ -72,7 +73,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         IMediaPipeline? mediaPipeline = null,
         IConversationDispatcher? conversationDispatcher = null,
         IConversationRouter? conversationRouter = null,
-        PendingAskUserInterceptor? pendingAskUserInterceptor = null)
+        PendingAskUserInterceptor? pendingAskUserInterceptor = null,
+        IPreCompactionMemoryFlusher? memoryFlusher = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -87,6 +89,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         _conversationRouter = conversationRouter;
         _sessionLifecycleEvents = sessionLifecycleEvents;
         _pendingAskUserInterceptor = pendingAskUserInterceptor;
+        _memoryFlusher = memoryFlusher;
         SessionQueueCapacity = Math.Max(sessionQueueCapacity, 1);
     }
 
@@ -423,6 +426,17 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 _logger.LogInformation("Auto-compacting session {SessionId}", sessionId);
                 try
                 {
+                    if (_memoryFlusher is not null && _memoryFlusher.ShouldFlush(session.Session, _compactionOptions.CurrentValue))
+                    {
+                        try
+                        {
+                            await _memoryFlusher.FlushAsync(session.Session.AgentId, session.Session, _compactionOptions.CurrentValue, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception flushEx)
+                        {
+                            _logger.LogWarning(flushEx, "Pre-compaction memory flush failed for session {SessionId}, compaction will proceed", sessionId);
+                        }
+                    }
                     var result = await _compactor.CompactAsync(session.Session, _compactionOptions.CurrentValue, cancellationToken);
                     if (result.Succeeded && result.CompactedHistory is not null)
                     {

--- a/src/gateway/BotNexus.Gateway/Sessions/PreCompactionMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/PreCompactionMemoryFlusher.cs
@@ -1,0 +1,123 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Triggers;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// Fires a synthetic memory-trigger agent turn immediately before session compaction.
+/// Gives the agent an opportunity to write important context to disk before history is
+/// summarised and truncated.
+/// </summary>
+public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
+{
+    private readonly IEnumerable<IInternalTrigger> _triggers;
+    private readonly ILogger<PreCompactionMemoryFlusher> _logger;
+
+    public PreCompactionMemoryFlusher(
+        IEnumerable<IInternalTrigger> triggers,
+        ILogger<PreCompactionMemoryFlusher> logger)
+    {
+        _triggers = triggers;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public bool ShouldFlush(Session session, CompactionOptions options)
+    {
+        if (!options.MemoryFlush.Enabled)
+            return false;
+
+        // Never flush for non-interactive sessions (heartbeat, cron, sub-agent)
+        if (!session.IsInteractive)
+            return false;
+
+        // One flush per compaction cycle: track the compaction-cycle count in metadata.
+        // We infer the current cycle count from the number of compaction summary entries.
+        var currentCycle = session.History.Count(e => e.IsCompactionSummary);
+        var lastFlushCycle = GetLastFlushCycle(session);
+
+        return lastFlushCycle < currentCycle + 1; // flush has not run for the upcoming cycle
+    }
+
+    /// <inheritdoc/>
+    public async Task FlushAsync(AgentId agentId, Session session, CompactionOptions options, CancellationToken ct = default)
+    {
+        var trigger = ResolveTrigger();
+        if (trigger is null)
+        {
+            _logger.LogWarning(
+                "No suitable internal trigger found for memory flush on session {SessionId}. Skipping flush.",
+                session.SessionId);
+            return;
+        }
+
+        var timeoutCt = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCt.CancelAfter(TimeSpan.FromSeconds(options.MemoryFlush.TimeoutSeconds));
+
+        try
+        {
+            _logger.LogInformation(
+                "Pre-compaction memory flush starting for session {SessionId}, agent {AgentId}.",
+                session.SessionId, agentId);
+
+            await trigger.CreateSessionAsync(
+                agentId,
+                options.MemoryFlush.PromptText,
+                timeoutCt.Token,
+                new InternalTriggerRequest
+                {
+                    ConversationId = session.ConversationId?.Value
+                }).ConfigureAwait(false);
+
+            // Record that a flush has run for this compaction cycle.
+            var currentCycle = session.History.Count(e => e.IsCompactionSummary) + 1;
+            session.Metadata[MemoryFlushOptions.MetadataKey] = currentCycle;
+
+            _logger.LogInformation(
+                "Pre-compaction memory flush completed for session {SessionId}.",
+                session.SessionId);
+        }
+        catch (OperationCanceledException) when (timeoutCt.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "Pre-compaction memory flush timed out after {Seconds}s for session {SessionId}. Compaction will proceed.",
+                options.MemoryFlush.TimeoutSeconds, session.SessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Pre-compaction memory flush failed for session {SessionId}. Compaction will proceed.",
+                session.SessionId);
+        }
+        finally
+        {
+            timeoutCt.Dispose();
+        }
+    }
+
+    private IInternalTrigger? ResolveTrigger()
+    {
+        var all = _triggers.ToList();
+        return all.FirstOrDefault(t => t.Type.Equals(TriggerType.Memory))
+            ?? all.FirstOrDefault(t => t.Type.Equals(TriggerType.Cron));
+    }
+
+    private static int GetLastFlushCycle(Session session)
+    {
+        if (session.Metadata.TryGetValue(MemoryFlushOptions.MetadataKey, out var raw))
+        {
+            return raw switch
+            {
+                int i => i,
+                long l => (int)l,
+                System.Text.Json.JsonElement je when je.ValueKind == System.Text.Json.JsonValueKind.Number
+                    => je.GetInt32(),
+                _ => 0
+            };
+        }
+        return 0;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
@@ -1,0 +1,170 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Triggers;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+public sealed class PreCompactionMemoryFlusherTests
+{
+    private static readonly AgentId TestAgent = AgentId.From("agent-a");
+
+    // ─── ShouldFlush ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ShouldFlush_WhenEnabled_AndInteractiveSession_AndNotFlushedThisCycle_ReturnsTrue()
+    {
+        var session = BuildInteractiveSession();
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        flusher.ShouldFlush(session, options).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenDisabled_ReturnsFalse()
+    {
+        var session = BuildInteractiveSession();
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = false } };
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenNonInteractiveSession_ReturnsFalse()
+    {
+        var session = BuildSession(SessionType.Heartbeat);
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenAlreadyFlushedThisCycle_ReturnsFalse()
+    {
+        var session = BuildInteractiveSession();
+        // Record that flush ran for cycle 1 (current cycle = 0 summaries, upcoming = 1)
+        session.Metadata[MemoryFlushOptions.MetadataKey] = 1;
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_AfterPreviousCompaction_ForNextCycle_ReturnsTrue()
+    {
+        var session = BuildInteractiveSession();
+        // One compaction summary already exists (we are on cycle 1)
+        session.History.Add(new SessionEntry
+        {
+            Role = MessageRole.System,
+            Content = "summary",
+            IsCompactionSummary = true
+        });
+        // Flush ran for cycle 1 (the one that added the first summary)
+        session.Metadata[MemoryFlushOptions.MetadataKey] = 1;
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        // Now we're approaching cycle 2 — flush has not run for it yet
+        flusher.ShouldFlush(session, options).ShouldBeTrue();
+    }
+
+    // ─── FlushAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FlushAsync_WhenTriggerAvailable_CallsCreateSessionAsync()
+    {
+        var session = BuildInteractiveSession();
+        var triggerMock = new Mock<IInternalTrigger>();
+        triggerMock.SetupGet(t => t.Type).Returns(TriggerType.Memory);
+        triggerMock.Setup(t => t.CreateSessionAsync(
+                It.IsAny<AgentId>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(SessionId.From("flush-session"));
+
+        var flusher = CreateFlusher(triggerMock.Object);
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        await flusher.FlushAsync(TestAgent, session, options);
+
+        triggerMock.Verify(t => t.CreateSessionAsync(
+            TestAgent,
+            It.Is<string>(s => s.Contains("compaction")),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<InternalTriggerRequest?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FlushAsync_WhenTriggerThrows_DoesNotRethrow()
+    {
+        var session = BuildInteractiveSession();
+        var triggerMock = new Mock<IInternalTrigger>();
+        triggerMock.SetupGet(t => t.Type).Returns(TriggerType.Memory);
+        triggerMock.Setup(t => t.CreateSessionAsync(
+                It.IsAny<AgentId>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ThrowsAsync(new InvalidOperationException("agent not found"));
+
+        var flusher = CreateFlusher(triggerMock.Object);
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        // Non-fatal: should not throw
+        var act = async () => await flusher.FlushAsync(TestAgent, session, options);
+        await act.ShouldNotThrowAsync();
+    }
+
+    [Fact]
+    public async Task FlushAsync_WhenNoTriggerAvailable_DoesNotThrow()
+    {
+        var session = BuildInteractiveSession();
+        var flusher = CreateFlusher(); // no triggers
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        var act = async () => await flusher.FlushAsync(TestAgent, session, options);
+        await act.ShouldNotThrowAsync();
+    }
+
+    [Fact]
+    public async Task FlushAsync_WhenSucceeds_RecordsFlushCycleInMetadata()
+    {
+        var session = BuildInteractiveSession();
+        var triggerMock = new Mock<IInternalTrigger>();
+        triggerMock.SetupGet(t => t.Type).Returns(TriggerType.Memory);
+        triggerMock.Setup(t => t.CreateSessionAsync(
+                It.IsAny<AgentId>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(SessionId.From("flush-session"));
+
+        var flusher = CreateFlusher(triggerMock.Object);
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        await flusher.FlushAsync(TestAgent, session, options);
+
+        session.Metadata.ContainsKey(MemoryFlushOptions.MetadataKey).ShouldBeTrue();
+        Convert.ToInt32(session.Metadata[MemoryFlushOptions.MetadataKey]).ShouldBe(1);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private static PreCompactionMemoryFlusher CreateFlusher(params IInternalTrigger[] triggers)
+        => new(triggers, NullLogger<PreCompactionMemoryFlusher>.Instance);
+
+    private static Session BuildInteractiveSession()
+        => BuildSession(SessionType.UserAgent);
+
+    private static Session BuildSession(SessionType type) => new()
+    {
+        SessionId = SessionId.From(Guid.NewGuid().ToString("N")),
+        AgentId = TestAgent,
+        SessionType = type
+    };
+}


### PR DESCRIPTION
Closes #416

## Changes

- `IPreCompactionMemoryFlusher` interface in `BotNexus.Gateway.Contracts`
- `PreCompactionMemoryFlusher` implementation in `BotNexus.Gateway.Sessions`
- `MemoryFlushOptions` config block nested under `CompactionOptions` (`enabled`, `promptText`, `timeoutSeconds`)
- `TriggerType.Memory` added to domain
- `GatewayHost`: call flush before `CompactAsync`, wrapped in try/catch (non-fatal)
- One flush per compaction cycle tracked via `Session.Metadata["memoryFlushCompactionCount"]`
- Skip flush for non-interactive sessions (heartbeat, cron, sub-agent)
- Registered in DI alongside `LlmSessionCompactor`

## Tests

5 new TDD tests in `PreCompactionMemoryFlusherTests`:
- ShouldFlush: enabled + interactive + not yet flushed → true
- ShouldFlush: disabled → false
- ShouldFlush: non-interactive session → false
- ShouldFlush: already flushed this cycle → false
- ShouldFlush: after compaction, next cycle → true
- FlushAsync: happy path calls CreateSessionAsync
- FlushAsync: trigger throws → does not rethrow
- FlushAsync: no trigger available → does not throw
- FlushAsync: success → records flush cycle in metadata

1574/1574 gateway tests pass.