### PR TITLE
feat(conversation): add message action to dispatch to existing conversations

### DIFF
--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -35,7 +35,7 @@ public sealed class ConversationTool(
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["get", "set_title", "set_purpose", "list", "new"],
+                  "enum": ["get", "set_title", "set_purpose", "list", "new", "message"],
                   "description": "Action to perform."
                 },
                 "conversationId": {
@@ -77,7 +77,8 @@ public sealed class ConversationTool(
             !action.Equals("set_title", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("set_purpose", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("list", StringComparison.OrdinalIgnoreCase) &&
-            !action.Equals("new", StringComparison.OrdinalIgnoreCase))
+            !action.Equals("new", StringComparison.OrdinalIgnoreCase) &&
+            !action.Equals("message", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException($"Unsupported conversation action '{action}'.");
 
         return Task.FromResult(arguments);
@@ -97,8 +98,78 @@ public sealed class ConversationTool(
             "set_purpose" => await SetPurposeAsync(arguments, cancellationToken).ConfigureAwait(false),
             "list" => await ListAsync(arguments, cancellationToken).ConfigureAwait(false),
             "new" => await NewAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "message" => await SendMessageAsync(arguments, cancellationToken).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unsupported conversation action '{action}'.")
         };
+    }
+
+
+    private async Task<AgentToolResult> SendMessageAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)
+    {
+        var message = ReadString(arguments, "message")
+            ?? throw new ArgumentException("Missing required argument: message.");
+        if (string.IsNullOrWhiteSpace(message))
+            throw new ArgumentException("message must not be empty.");
+
+        if (channelDispatcher is null)
+            throw new InvalidOperationException("Channel dispatcher is required to send a message to a conversation.");
+
+        if (sessionStore is null)
+            throw new InvalidOperationException("Session store is required to send a message to a conversation.");
+
+        var conversation = await ResolveConversationAsync(arguments, ct).ConfigureAwait(false);
+        EnsureCanAccess(conversation.AgentId);
+
+        // Reuse active session if present, otherwise create a fresh one.
+        GatewaySession session;
+        if (conversation.ActiveSessionId is { } existingSessionId)
+        {
+            var existing = await sessionStore.GetAsync(existingSessionId, ct).ConfigureAwait(false);
+            if (existing is not null)
+            {
+                session = existing;
+            }
+            else
+            {
+                session = await sessionStore.GetOrCreateAsync(SessionId.Create(), conversation.AgentId, ct).ConfigureAwait(false);
+                session.Session.ConversationId = conversation.ConversationId;
+                conversation.ActiveSessionId = session.SessionId;
+                conversation.UpdatedAt = DateTimeOffset.UtcNow;
+                await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            session = await sessionStore.GetOrCreateAsync(SessionId.Create(), conversation.AgentId, ct).ConfigureAwait(false);
+            session.Session.ConversationId = conversation.ConversationId;
+            conversation.ActiveSessionId = session.SessionId;
+            conversation.UpdatedAt = DateTimeOffset.UtcNow;
+            await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
+        }
+
+        await channelDispatcher.DispatchAsync(
+            new InboundMessage
+            {
+                ChannelType = ChannelKey.From("internal"),
+                SenderId = agentId.Value,
+                ChannelAddress = ChannelAddress.From(conversation.AgentId.Value),
+                Content = message.Trim(),
+                TargetAgentId = conversation.AgentId.Value,
+                SessionId = session.SessionId.Value,
+                ConversationId = conversation.ConversationId.Value,
+                Metadata = new Dictionary<string, object?>
+                {
+                    ["messageType"] = "message",
+                    ["source"] = "conversation-tool-message"
+                }
+            },
+            ct).ConfigureAwait(false);
+
+        return TextResult(JsonSerializer.Serialize(new
+        {
+            conversationId = conversation.ConversationId.Value,
+            sessionId = session.SessionId.Value
+        }, JsonOptions));
     }
 
     private async Task<AgentToolResult> GetAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
@@ -234,6 +234,141 @@ public sealed class ConversationToolTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task SendMessage_DispatchesInboundMessageToTargetConversation()
+    {
+        // Arrange
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var conversation = await conversationStore.CreateAsync(CreateConversation("nova", "Planning", null));
+
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: dispatcher);
+
+        // Act
+        var result = await tool.ExecuteAsync("call-1", Args(
+            "message",
+            conversationId: conversation.ConversationId.Value,
+            message: "Hello Nova!"));
+
+        // Assert: dispatcher called with the user message
+        await dispatcher.Received(1).DispatchAsync(
+            Arg.Is<InboundMessage>(m =>
+                m.Content == "Hello Nova!" &&
+                m.TargetAgentId == "nova" &&
+                m.ChannelType == ChannelKey.From("internal")),
+            Arg.Any<CancellationToken>());
+
+        // Result includes conversation and session IDs
+        using var document = JsonDocument.Parse(ReadText(result));
+        document.RootElement.GetProperty("conversationId").GetString().ShouldBe(conversation.ConversationId.Value);
+        document.RootElement.GetProperty("sessionId").GetString().ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task SendMessage_WithoutMessage_Throws()
+    {
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var conversation = await conversationStore.CreateAsync(CreateConversation("nova", "Planning", null));
+
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: null);
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args(
+            "message",
+            conversationId: conversation.ConversationId.Value));
+
+        await act.ShouldThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task SendMessage_WithoutDispatcher_Throws()
+    {
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var conversation = await conversationStore.CreateAsync(CreateConversation("nova", "Planning", null));
+
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: null);
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args(
+            "message",
+            conversationId: conversation.ConversationId.Value,
+            message: "Hi!"));
+
+        await act.ShouldThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task SendMessage_DeniedByAccessLevel_Throws()
+    {
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var conversation = await conversationStore.CreateAsync(CreateConversation("nova", "Planning", null));
+
+        // agent-a with Own access cannot message nova's conversation
+        var tool = new ConversationTool(
+            conversationStore,
+            "agent-a",
+            accessLevel: ConversationAccessLevel.Own,
+            sessionStore: sessionStore,
+            channelDispatcher: dispatcher);
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args(
+            "message",
+            conversationId: conversation.ConversationId.Value,
+            message: "Sneak message"));
+
+        await act.ShouldThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task SendMessage_ReusesExistingActiveSession_WhenPresent()
+    {
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var dispatcher = Substitute.For<IChannelDispatcher>();
+
+        var session = await sessionStore.GetOrCreateAsync(SessionId.Create(), AgentId.From("nova"), default);
+        var conversation = await conversationStore.CreateAsync(
+            CreateConversation("nova", "Planning", null) with
+            {
+                ActiveSessionId = session.SessionId
+            });
+        session.Session.ConversationId = conversation.ConversationId;
+        await sessionStore.SaveAsync(session, default);
+
+        var tool = new ConversationTool(
+            conversationStore,
+            "orchestrator",
+            accessLevel: ConversationAccessLevel.All,
+            sessionStore: sessionStore,
+            channelDispatcher: dispatcher);
+
+        var result = await tool.ExecuteAsync("call-1", Args(
+            "message",
+            conversationId: conversation.ConversationId.Value,
+            message: "Use existing session"));
+
+        using var document = JsonDocument.Parse(ReadText(result));
+        document.RootElement.GetProperty("sessionId").GetString().ShouldBe(session.SessionId.Value);
+    }
+
     private static Conversation CreateConversation(string agentId, string title, string? purpose)
         => new()
         {


### PR DESCRIPTION
Closes #354

## Changes

- Added `message` action to `ConversationTool` — dispatches an `InboundMessage` to an existing conversation via `IChannelDispatcher`
- Resolves or creates an active session for the target conversation
- Reuses existing `ActiveSessionId` session when present; creates fresh session otherwise
- Returns `{ conversationId, sessionId }` to the caller
- Access control: honours existing `ConversationAccessLevel` — `Own`, `Allowlist`, `All`

## Tests (5 new)

- `SendMessage_DispatchesInboundMessageToTargetConversation` — happy path, dispatcher called, result contains IDs
- `SendMessage_WithoutMessage_Throws` — missing message argument
- `SendMessage_WithoutDispatcher_Throws` — null dispatcher guard
- `SendMessage_DeniedByAccessLevel_Throws` — Own access cannot send to other agent's conversation
- `SendMessage_ReusesExistingActiveSession_WhenPresent` — session reuse when ActiveSessionId set

## Fixes latent bug from issue body

Also addressed in PR #399 (`action=new` with `message` now dispatches). This PR adds `action=message` for sending to **existing** conversations.