### PR TITLE
feat(gateway): add server default timezone for get_datetime tool fallback

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -124,6 +124,13 @@ public sealed class GatewaySettingsConfig
 
     /// <summary>Auto-update settings for self-updating the gateway via the BotNexus CLI.</summary>
     public AutoUpdateConfig? AutoUpdate { get; set; }
+
+    /// <summary>
+    /// Server-wide default IANA timezone ID used when an agent has no Soul timezone configured.
+    /// Falls back to UTC when null or invalid.
+    /// Example: <c>"America/Los_Angeles"</c>.
+    /// </summary>
+    public string? DefaultTimezone { get; set; }
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -191,7 +191,9 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         }
         var delayToolOptions = _serviceProvider.GetService<IOptions<DelayToolOptions>>() ?? Options.Create(new DelayToolOptions());
         tools.Add(new DelayTool(delayToolOptions));
-        tools.Add(new DateTimeTool(descriptor.Soul?.Timezone));
+        var platformConfig = _serviceProvider.GetService<IOptions<PlatformConfig>>();
+        var serverTimezone = platformConfig?.Value.Gateway?.DefaultTimezone;
+        tools.Add(new DateTimeTool(descriptor.Soul?.Timezone ?? serverTimezone));
 
         var fileWatcherToolOptions = _serviceProvider.GetService<IOptions<FileWatcherToolOptions>>() ?? Options.Create(new FileWatcherToolOptions());
         tools.Add(new FileWatcherTool(fileWatcherToolOptions, pathValidator));

--- a/src/gateway/BotNexus.Gateway/Tools/DateTimeTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/DateTimeTool.cs
@@ -46,7 +46,7 @@ public sealed class DateTimeTool : IAgentTool
               "properties": {
                 "timezone": {
                   "type": "string",
-                  "description": "Optional IANA timezone ID (for example, 'America/Los_Angeles'). Defaults to the agent timezone, or UTC when no agent timezone is configured."
+                  "description": "Optional IANA timezone ID (for example, 'America/Los_Angeles'). Defaults to the agent timezone, or the server default timezone, or UTC when neither is configured."
                 }
               }
             }

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/DateTimeToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/DateTimeToolTests.cs
@@ -56,8 +56,46 @@ public sealed class DateTimeToolTests
         json.GetProperty("offset").GetString().ShouldBe("00:00:00");
     }
 
-    private static DateTimeTool CreateTool(string? defaultTimezone = null)
-        => new(defaultTimezone, () => FixedUtcNow);
+
+    [Fact]
+    public async Task ExecuteAsync_WithServerTimezone_FallsBackToServerDefault_WhenNoAgentTimezone()
+    {
+        // Simulates: server has DefaultTimezone configured, agent has no Soul.Timezone
+        var tool = CreateTool(serverTimezone: "Europe/London");
+
+        var json = await ExecuteJsonAsync(tool, new Dictionary<string, object?>());
+
+        json.GetProperty("timezone").GetString().ShouldBe("Europe/London");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AgentTimezoneOverridesServerDefault()
+    {
+        // Agent Soul.Timezone takes precedence over server DefaultTimezone
+        var tool = CreateTool(agentTimezone: "America/New_York", serverTimezone: "Europe/London");
+
+        var json = await ExecuteJsonAsync(tool, new Dictionary<string, object?>());
+
+        json.GetProperty("timezone").GetString().ShouldBe("America/New_York");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoAgentOrServerTimezone_FallsBackToUtc()
+    {
+        var tool = CreateTool();
+
+        var json = await ExecuteJsonAsync(tool, new Dictionary<string, object?>());
+
+        json.GetProperty("timezone").GetString().ShouldBe("UTC");
+    }
+
+    private static DateTimeTool CreateTool(string? agentTimezone = null, string? serverTimezone = null)
+    {
+        var effectiveTimezone = agentTimezone ?? serverTimezone;
+        return new(effectiveTimezone, () => FixedUtcNow);
+    }
+
+
 
     private static async Task<JsonElement> ExecuteJsonAsync(
         IAgentTool tool,


### PR DESCRIPTION
Closes #286

## Changes

- Added `DefaultTimezone` to `GatewaySettingsConfig` in `PlatformConfig.cs`
- `InProcessIsolationStrategy` now reads `Gateway.DefaultTimezone` from `IOptions<PlatformConfig>` and passes it as the fallback timezone to `DateTimeTool`
- `DateTimeTool` tool description updated to mention the server timezone in the fallback chain

## Fallback resolution order

1. Explicit `timezone` argument passed to the tool
2. Agent Soul timezone (`descriptor.Soul?.Timezone`)
3. Server default timezone (`gateway.defaultTimezone` in config)
4. UTC

## Tests

3 new tests in `DateTimeToolTests.cs`:
- `ExecuteAsync_WithServerTimezone_FallsBackToServerDefault_WhenNoAgentTimezone`
- `ExecuteAsync_AgentTimezoneOverridesServerDefault`
- `ExecuteAsync_NoAgentOrServerTimezone_FallsBackToUtc`

## Notes

Portal settings UI for `DefaultTimezone` is tracked as a follow-up in #286 (Settings UI section). The config field is immediately usable via `config.json` / `botnexus config set gateway.defaultTimezone`.