### PR TITLE
fix(portal): eliminate steering toggle flicker between tool calls

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
@@ -1,4 +1,4 @@
-namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+﻿namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 /// <summary>
 /// Single in-memory source of truth for all portal state.
@@ -244,6 +244,7 @@ public sealed class ConversationState
     public ConversationStreamState StreamState { get; } = new();
 }
 
+
 /// <summary>Stream-buffer state for an active or recently active conversation.</summary>
 public sealed class ConversationStreamState
 {
@@ -258,4 +259,10 @@ public sealed class ConversationStreamState
 
     /// <summary>In-progress tool calls for this conversation keyed by tool-call ID.</summary>
     public Dictionary<string, ActiveToolCall> ActiveToolCalls { get; } = new();
+
+    /// <summary>Whether the agent turn is still active -- either streaming or awaiting tool results.
+    /// Use this instead of IsStreaming to keep Steer/Abort controls visible
+    /// between the end of an LLM generation and the start of the next one while tools run.</summary>
+    public bool IsTurnActive => IsStreaming || ActiveToolCalls.Count > 0;
 }
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -1,4 +1,4 @@
-@inject IJSRuntime JS
+﻿@inject IJSRuntime JS
 @inject IClientStateStore Store
 @inject IAgentInteractionService Interaction
 @implements IDisposable
@@ -396,8 +396,8 @@
     private string? ActiveConversationTitle => ActiveConversation?.Title;
 private bool IsStreaming =>
         Agent?.ActiveConversationId is string activeConvId
-            ? Store.GetStreamState(activeConvId).IsStreaming
-            : false; // no active conversation = not streaming
+            ? Store.GetStreamState(activeConvId).IsTurnActive
+            : false; // no active conversation = not in turn
     private bool IsReadOnly => (Agent?.IsReadOnly ?? false) || (ActiveConversation?.IsVirtualSession ?? false);
     private bool IsConnected => Agent?.IsConnected ?? false;
     private bool ShowThinking => Agent?.ShowThinking ?? true;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -1,4 +1,4 @@
-using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+﻿using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -105,6 +105,86 @@ public sealed class GatewayEventHandlerTests
         Assert.Equal("Assistant", conv.Messages[0].Role);
         Assert.Equal("done", conv.Messages[0].Content);
         Assert.Equal("thinking", conv.Messages[0].ThinkingContent);
+    }
+
+    // ---- IsTurnActive tests (issue #253 steering flicker fix) ----
+
+    [Fact]
+    public void IsTurnActive_is_true_when_streaming()
+    {
+        var conv = _store.GetAgent("agent-1")!.Conversations["conv-1"];
+        conv.StreamState.IsStreaming = true;
+
+        Assert.True(conv.StreamState.IsTurnActive);
+    }
+
+    [Fact]
+    public void IsTurnActive_is_false_when_not_streaming_and_no_tool_calls()
+    {
+        var conv = _store.GetAgent("agent-1")!.Conversations["conv-1"];
+        conv.StreamState.IsStreaming = false;
+        conv.StreamState.ActiveToolCalls.Clear();
+
+        Assert.False(conv.StreamState.IsTurnActive);
+    }
+
+    [Fact]
+    public void IsTurnActive_is_true_after_message_end_when_tool_calls_still_pending()
+    {
+        // Arrange: simulate the flicker window -- MessageEnd fired but ToolEnd has not yet
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "I will search for that.";
+
+        // ToolStart fired during stream -- tool is tracked
+        _handler.HandleToolStart(new AgentStreamEvent
+        {
+            SessionId = "sess-1",
+            ToolCallId = "tool-abc",
+            ToolName = "web_search"
+        });
+
+        // MessageEnd fires -- LLM generation done, but tool is still in flight
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        // IsStreaming is now false on the stream state
+        Assert.False(conv.StreamState.IsStreaming);
+        // But the tool call is still registered
+        Assert.True(conv.StreamState.ActiveToolCalls.ContainsKey("tool-abc"));
+        // IsTurnActive must be true so portal keeps Steer/Abort visible
+        Assert.True(conv.StreamState.IsTurnActive);
+    }
+
+    [Fact]
+    public void IsTurnActive_is_false_after_tool_end_and_message_end_both_complete()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "done";
+
+        _handler.HandleToolStart(new AgentStreamEvent
+        {
+            SessionId = "sess-1",
+            ToolCallId = "tool-xyz",
+            ToolName = "read"
+        });
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+        _handler.HandleToolEnd(new AgentStreamEvent
+        {
+            SessionId = "sess-1",
+            ToolCallId = "tool-xyz",
+            ToolName = "read",
+            ToolResult = "file contents"
+        });
+
+        // After both MessageEnd and ToolEnd: turn is fully complete
+        Assert.False(conv.StreamState.IsStreaming);
+        Assert.False(conv.StreamState.ActiveToolCalls.ContainsKey("tool-xyz"));
+        Assert.False(conv.StreamState.IsTurnActive);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #253 — steering/direct-message toggle flickered between tool calls.

## Root Cause

Between `MessageEnd` and the next `MessageStart`, `conv.StreamState.IsStreaming` is `false` even though the agent turn is still active (tools are executing). `ChatPanel.IsStreaming` was bound directly to `IsStreaming`, so the portal briefly showed the Send button instead of Steer/Abort during that gap.

## Fix

Added `ConversationStreamState.IsTurnActive` computed property:

```csharp
public bool IsTurnActive => IsStreaming || ActiveToolCalls.Count > 0;
```

Updated `ChatPanel.IsStreaming` to use `IsTurnActive` so Steer/Abort controls remain visible for the full duration of a multi-tool turn — not just during LLM streaming.

## Tests

4 new tests in `GatewayEventHandlerTests`:
- `IsTurnActive_is_true_when_streaming`
- `IsTurnActive_is_false_when_not_streaming_and_no_tool_calls`
- `IsTurnActive_is_true_after_message_end_when_tool_calls_still_pending` — the key regression test
- `IsTurnActive_is_false_after_tool_end_and_message_end_both_complete`

All 1579 tests pass.

Closes #253