### PR TITLE
feat(conversations): add per-conversation instructions injected into system prompt

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -43,4 +43,7 @@ public sealed record Conversation
 
     /// <summary>Gets or sets the last canvas HTML rendered for this conversation, if any.</summary>
     public string? CanvasHtml { get; set; }
+
+    /// <summary>Gets or sets conversation-scoped instructions injected into the system prompt on session start.</summary>
+    public string? Instructions { get; set; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
@@ -4,12 +4,14 @@ namespace BotNexus.Gateway.Api.Controllers;
 /// <param name="AgentId">The agent that owns the new conversation.</param>
 /// <param name="Title">Optional display title. When omitted, a default title is assigned.</param>
 /// <param name="Purpose">Optional description of the conversation's intended use.</param>
-public sealed record CreateConversationRequest(string AgentId, string? Title, string? Purpose = null);
+/// <param name="Instructions">Optional conversation-scoped instructions injected into the system prompt on session start.</param>
+public sealed record CreateConversationRequest(string AgentId, string? Title, string? Purpose = null, string? Instructions = null);
 
 /// <summary>Request body for patching conversation metadata.</summary>
 /// <param name="Title">Optional replacement display title.</param>
 /// <param name="Purpose">Optional replacement description of the conversation's intended use.</param>
-public sealed record PatchConversationRequest(string? Title = null, string? Purpose = null);
+/// <param name="Instructions">Optional conversation-scoped instructions injected into the system prompt. Pass null to clear.</param>
+public sealed record PatchConversationRequest(string? Title = null, string? Purpose = null, string? Instructions = null);
 
 /// <summary>Request body for adding a channel binding.</summary>
 public sealed record AddBindingRequest(
@@ -26,6 +28,7 @@ public sealed record ConversationResponse(
     string AgentId,
     string Title,
     string? Purpose,
+    string? Instructions,
     bool IsDefault,
     string Status,
     string? ActiveSessionId,

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -107,6 +107,7 @@ public sealed class ConversationsController : ControllerBase
             AgentId = AgentId.From(request.AgentId),
             Title = string.IsNullOrWhiteSpace(request.Title) ? "New conversation" : request.Title,
             Purpose = NormalizePurpose(request.Purpose),
+            Instructions = NormalizeInstructions(request.Instructions),
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
@@ -133,7 +134,7 @@ public sealed class ConversationsController : ControllerBase
         [FromBody] PatchConversationRequest request,
         CancellationToken cancellationToken)
     {
-        if (request.Title is null && request.Purpose is null)
+        if (request.Title is null && request.Purpose is null && request.Instructions is null)
             return BadRequest(new { error = "title or purpose is required." });
 
         if (request.Title is not null && string.IsNullOrWhiteSpace(request.Title))
@@ -150,6 +151,8 @@ public sealed class ConversationsController : ControllerBase
             conversation.Title = request.Title;
         if (request.Purpose is not null)
             conversation.Purpose = NormalizePurpose(request.Purpose);
+        if (request.Instructions is not null)
+            conversation.Instructions = NormalizeInstructions(request.Instructions);
         conversation.UpdatedAt = DateTimeOffset.UtcNow;
         await _conversations.SaveAsync(conversation, cancellationToken);
         await NotifyConversationChangedBestEffortAsync("updated", conversation.AgentId.Value, conversation.ConversationId.Value, cancellationToken);
@@ -402,6 +405,7 @@ public sealed class ConversationsController : ControllerBase
         AgentId: c.AgentId.Value,
         Title: c.Title,
         Purpose: c.Purpose,
+        Instructions: c.Instructions,
         IsDefault: c.IsDefault,
         Status: c.Status.ToString(),
         ActiveSessionId: c.ActiveSessionId?.Value,
@@ -421,6 +425,9 @@ public sealed class ConversationsController : ControllerBase
 
     private static string? NormalizePurpose(string? purpose)
         => string.IsNullOrWhiteSpace(purpose) ? null : purpose.Trim();
+
+    private static string? NormalizeInstructions(string? instructions)
+        => string.IsNullOrWhiteSpace(instructions) ? null : instructions.Trim();
 
     private async Task SealSessionAsync(SessionId sessionId, CancellationToken cancellationToken)
     {

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -274,11 +274,12 @@ public sealed class SqliteConversationStore : IConversationStore
                     c.active_session_id,
                     c.created_at,
                     c.updated_at,
-                    COUNT(b.binding_id)
+                    COUNT(b.binding_id),
+                    c.instructions
                 FROM conversations c
                 LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
                 WHERE c.status = 'Active'
-                GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at
+                GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions
                 ORDER BY c.updated_at DESC
                 """
             : """
@@ -292,11 +293,12 @@ public sealed class SqliteConversationStore : IConversationStore
                     c.active_session_id,
                     c.created_at,
                     c.updated_at,
-                    COUNT(b.binding_id)
+                    COUNT(b.binding_id),
+                    c.instructions
                 FROM conversations c
                 LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
                 WHERE c.agent_id = $agentId AND c.status = 'Active'
-                GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at
+                GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions
                 ORDER BY c.updated_at DESC
                 """;
         if (agentId is not null)
@@ -377,6 +379,7 @@ public sealed class SqliteConversationStore : IConversationStore
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
             await EnsurePurposeColumnAsync(connection, ct).ConfigureAwait(false);
+            await EnsureInstructionsColumnAsync(connection, ct).ConfigureAwait(false);
 
             // One-time migration: archive stale signalr:connection-id conversations created
             // before binding-first routing (#148). Those conversations have a title matching
@@ -432,6 +435,32 @@ public sealed class SqliteConversationStore : IConversationStore
         await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
+    private static async Task EnsureInstructionsColumnAsync(SqliteConnection connection, CancellationToken ct)
+    {
+        await using var tableInfoCommand = connection.CreateCommand();
+        tableInfoCommand.CommandText = "PRAGMA table_info(conversations);";
+
+        var hasColumn = false;
+        await using (var reader = await tableInfoCommand.ExecuteReaderAsync(ct).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                if (string.Equals(reader.GetString(1), "instructions", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasColumn)
+            return;
+
+        await using var alterCommand = connection.CreateCommand();
+        alterCommand.CommandText = "ALTER TABLE conversations ADD COLUMN instructions TEXT;";
+        await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
     private async Task<Conversation?> LoadConversationAsync(ConversationId conversationId, CancellationToken ct)
     {
         await using var connection = CreateConnection();
@@ -443,7 +472,7 @@ public sealed class SqliteConversationStore : IConversationStore
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at
+            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions
             FROM conversations
             WHERE id = $id
             """;
@@ -463,7 +492,8 @@ public sealed class SqliteConversationStore : IConversationStore
             Status = ParseConversationStatus(reader.GetString(5)),
             Metadata = DeserializeMetadata(reader.IsDBNull(7) ? null : reader.GetString(7)),
             CreatedAt = ParseTimestamp(reader.GetString(8)),
-            UpdatedAt = ParseTimestamp(reader.GetString(9))
+            UpdatedAt = ParseTimestamp(reader.GetString(9)),
+            Instructions = reader.IsDBNull(10) ? null : reader.GetString(10)
         };
         if (!reader.IsDBNull(6))
             conversation.ActiveSessionId = SessionId.From(reader.GetString(6));
@@ -514,8 +544,8 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Transaction = transaction;
         conversationCommand.CommandText = upsert
             ? """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions)
                 ON CONFLICT(id) DO UPDATE SET
                     agent_id = excluded.agent_id,
                     title = excluded.title,
@@ -525,11 +555,12 @@ public sealed class SqliteConversationStore : IConversationStore
                     active_session_id = excluded.active_session_id,
                     metadata = excluded.metadata,
                     created_at = excluded.created_at,
-                    updated_at = excluded.updated_at
+                    updated_at = excluded.updated_at,
+                    instructions = excluded.instructions
                 """
             : """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions)
                 """;
         conversationCommand.Parameters.AddWithValue("$id", conversation.ConversationId.Value);
         conversationCommand.Parameters.AddWithValue("$agentId", conversation.AgentId.Value);
@@ -541,6 +572,7 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Parameters.AddWithValue("$metadata", JsonSerializer.Serialize(conversation.Metadata, JsonOptions));
         conversationCommand.Parameters.AddWithValue("$createdAt", conversation.CreatedAt.ToString("O"));
         conversationCommand.Parameters.AddWithValue("$updatedAt", conversation.UpdatedAt.ToString("O"));
+        conversationCommand.Parameters.AddWithValue("$instructions", conversation.Instructions is null ? (object)DBNull.Value : conversation.Instructions);
         await conversationCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         await using var deleteBindingsCommand = connection.CreateCommand();
@@ -611,6 +643,8 @@ public sealed class SqliteConversationStore : IConversationStore
             AgentId = conversation.AgentId,
             Title = conversation.Title,
             Purpose = conversation.Purpose,
+            Instructions = conversation.Instructions,
+            CanvasHtml = conversation.CanvasHtml,
             IsDefault = conversation.IsDefault,
             Status = conversation.Status,
             CreatedAt = conversation.CreatedAt,

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -681,7 +681,6 @@ public sealed class SqliteConversationStore : IConversationStore
             UpdatedAt = conversation.UpdatedAt,
             ActiveSessionId = conversation.ActiveSessionId,
             Metadata = JsonSerializer.Deserialize<Dictionary<string, object?>>(JsonSerializer.Serialize(conversation.Metadata, JsonOptions), JsonOptions) ?? [],
-            CanvasHtml = conversation.CanvasHtml,
             ChannelBindings = conversation.ChannelBindings.Select(binding => new ChannelBinding
             {
                 BindingId = binding.BindingId,

--- a/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
@@ -25,7 +25,7 @@ public sealed record RuntimeInfo
     public IReadOnlyList<string>? Capabilities { get; init; }
 }
 
-public sealed record ConversationContext(string ConversationId, string Title, string? Purpose);
+public sealed record ConversationContext(string ConversationId, string Title, string? Purpose, string? Instructions = null);
 
 public sealed record SystemPromptParams
 {
@@ -128,6 +128,7 @@ public static class SystemPromptBuilder
             .Add(new LambdaPromptSection(110, static context => buildUserIdentitySection(GetGatewayData(context).Parameters.OwnerIdentity, GetGatewayData(context).IsMinimal)))
             .Add(new LambdaPromptSection(120, static context => buildTimeSection(GetGatewayData(context).Parameters.UserTimezone)))
             .Add(new LambdaPromptSection(125, BuildConversationContextSection, HasConversationContext))
+            .Add(new LambdaPromptSection(127, BuildConversationInstructionsSection, HasConversationInstructions))
             .Add(new LambdaPromptSection(130, static _ => ["## Workspace Files (injected)", "These user-editable files are loaded by BotNexus and included below in Project Context.", string.Empty]))
             .Add(new LambdaPromptSection(140, static context => buildReplyTagsSection(GetGatewayData(context).IsMinimal), static _ => IncludeReplyTagsSectionByDefault))
             .Add(new LambdaPromptSection(150, static context => buildMessagingSection(GetGatewayData(context).IsMinimal, GetGatewayData(context).NormalizedTools, GetGatewayData(context).RuntimeChannel, GetGatewayData(context).InlineButtonsEnabled)))
@@ -625,6 +626,25 @@ public static class SystemPromptBuilder
             lines.Add($"- **Purpose**: {conversationContext.Purpose}");
 
         return lines;
+    }
+
+    private static bool HasConversationInstructions(PromptContext context)
+    {
+        var conversationContext = GetGatewayData(context).Parameters.ConversationContext;
+        return conversationContext is not null &&
+               !string.IsNullOrWhiteSpace(conversationContext.Instructions);
+    }
+
+    private static IReadOnlyList<string> BuildConversationInstructionsSection(PromptContext context)
+    {
+        var conversationContext = GetGatewayData(context).Parameters.ConversationContext
+            ?? throw new InvalidOperationException("ConversationContext is required for BuildConversationInstructionsSection.");
+
+        return
+        [
+            "## Conversation Instructions",
+            conversationContext.Instructions!
+        ];
     }
 
     private sealed class LambdaPromptSection(

--- a/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Hooks;
@@ -181,7 +181,7 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
 
         return conversation is null
             ? null
-            : new ConversationContext(conversation.ConversationId.Value, conversation.Title, conversation.Purpose);
+            : new ConversationContext(conversation.ConversationId.Value, conversation.Title, conversation.Purpose, conversation.Instructions);
     }
 
     private static async Task<ContextFile[]> LoadContextFilesAsync(

--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -35,7 +35,7 @@ public sealed class ConversationTool(
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["get", "set_title", "set_purpose", "list", "new"],
+                  "enum": ["get", "set_title", "set_purpose", "set", "list", "new"],
                   "description": "Action to perform."
                 },
                 "conversationId": {
@@ -58,6 +58,10 @@ public sealed class ConversationTool(
                   "type": "string",
                   "description": "Conversation purpose for set_purpose or new."
                 },
+                "instructions": {
+                  "type": ["string", "null"],
+                  "description": "Conversation-scoped instructions injected into the system prompt. Pass null to clear."
+                },
                 "message": {
                   "type": "string",
                   "description": "Optional initial user message to seed the new conversation."
@@ -77,7 +81,8 @@ public sealed class ConversationTool(
             !action.Equals("set_title", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("set_purpose", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("list", StringComparison.OrdinalIgnoreCase) &&
-            !action.Equals("new", StringComparison.OrdinalIgnoreCase))
+            !action.Equals("new", StringComparison.OrdinalIgnoreCase) &&
+            !action.Equals("set", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException($"Unsupported conversation action '{action}'.");
 
         return Task.FromResult(arguments);
@@ -97,6 +102,7 @@ public sealed class ConversationTool(
             "set_purpose" => await SetPurposeAsync(arguments, cancellationToken).ConfigureAwait(false),
             "list" => await ListAsync(arguments, cancellationToken).ConfigureAwait(false),
             "new" => await NewAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "set" => await SetAsync(arguments, cancellationToken).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unsupported conversation action '{action}'.")
         };
     }
@@ -218,6 +224,20 @@ public sealed class ConversationTool(
         return TextResult(JsonSerializer.Serialize(ToToolResponse(created), JsonOptions));
     }
 
+    private async Task<AgentToolResult> SetAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)
+    {
+        var conversation = await ResolveConversationAsync(arguments, ct).ConfigureAwait(false);
+        EnsureCanAccess(conversation.AgentId);
+        var instructions = ReadString(arguments, "instructions");
+        if (arguments.ContainsKey("instructions"))
+        {
+            conversation.Instructions = string.IsNullOrWhiteSpace(instructions) ? null : instructions.Trim();
+            conversation.UpdatedAt = DateTimeOffset.UtcNow;
+        }
+        await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
+        return TextResult("Conversation updated.");
+    }
+
     private async Task<Conversation> ResolveConversationAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)
     {
         ConversationId conversationId;
@@ -262,6 +282,7 @@ public sealed class ConversationTool(
         DisplayName = conversation.Title,
         Title = conversation.Title,
         conversation.Purpose,
+        conversation.Instructions,
         Status = conversation.Status.ToString(),
         conversation.IsDefault,
         ActiveSessionId = conversation.ActiveSessionId?.Value,


### PR DESCRIPTION
Closes #409

## Changes

- `Conversation.Instructions` field added to domain model
- `ConversationContext` record updated with `Instructions` parameter
- `SystemPromptBuilder`: new pipeline section at position 127 (`## Conversation Instructions`) — only injected when non-null/non-whitespace, after conversation context block
- `WorkspaceContextBuilder`: passes `conversation.Instructions` into `ConversationContext`
- `ConversationDtos.cs`: `Instructions` on `CreateConversationRequest`, `PatchConversationRequest`, and `ConversationResponse`
- `ConversationsController`: `Instructions` threaded through create and patch handlers
- `ConversationTool`: new `set` action with `instructions` parameter (supports clear via null/empty)
- `SqliteConversationStore`: `EnsureInstructionsColumnAsync` migration, full SELECT/INSERT/UPDATE coverage
- `FileConversationStore` and `InMemoryConversationStore`: auto-serialized via `Conversation` JSON roundtrip

## Tests

- 73 conversation store tests pass (SQLite and InMemory roundtrip)
- SystemPromptBuilder tests: section present, omitted on null, omitted on whitespace
- ConversationTool tests: set action with instructions
- Full suite: 1565/1565 pass