### PR TITLE
fix(channels): resolve correct adapter for multi-instance same-type channel registrations

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/ChannelBinding.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/ChannelBinding.cs
@@ -13,6 +13,14 @@ public sealed record ChannelBinding
     /// <summary>Gets or sets the channel type for this binding.</summary>
     public ChannelKey ChannelType { get; set; }
 
+    /// <summary>
+    /// Gets or sets the optional adapter instance identifier.
+    /// When multiple adapters of the same <see cref="ChannelType"/> are registered (e.g., two Telegram bots),
+    /// this value selects the correct adapter for outbound delivery via <see cref="IChannelManager.Get(ChannelKey, string?)"/>.
+    /// Null for single-instance channel types.
+    /// </summary>
+    public string? AdapterId { get; set; }
+
     /// <summary>Gets or sets the channel-specific address (e.g. chat id, phone number). Use <see cref="ChannelAddress.Empty"/> for addressless channels.</summary>
     public ChannelAddress ChannelAddress { get; set; } = ChannelAddress.Empty;
 

--- a/src/gateway/BotNexus.Gateway.Channels/ChannelManager.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/ChannelManager.cs
@@ -1,24 +1,41 @@
 using BotNexus.Gateway.Abstractions.Channels;
 using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
-
 namespace BotNexus.Gateway.Channels;
-
 /// <summary>
 /// Read-only registry for registered channel adapters.
 /// </summary>
 public sealed class ChannelManager : IChannelManager
 {
     private readonly List<IChannelAdapter> _adapters = [];
-
     public ChannelManager(IEnumerable<IChannelAdapter> adapters)
     {
         _adapters.AddRange(adapters);
     }
-
     /// <summary>Gets all registered channel adapters.</summary>
     public IReadOnlyList<IChannelAdapter> Adapters => _adapters;
 
     /// <summary>Gets a channel adapter by type, or <c>null</c> if not registered.</summary>
     public IChannelAdapter? Get(ChannelKey channelType)
         => _adapters.Find(a => a.ChannelType.Equals(channelType));
+
+    /// <summary>
+    /// Gets a channel adapter by type and optional adapter ID.
+    /// Falls back to the first adapter of the given type when adapterId is null or not found.
+    /// Returns null when no adapters of that type are registered.
+    /// </summary>
+    public IChannelAdapter? Get(ChannelKey channelType, string? adapterId)
+    {
+        var ofType = _adapters.FindAll(a => a.ChannelType.Equals(channelType));
+        if (ofType.Count == 0)
+            return null;
+
+        if (!string.IsNullOrWhiteSpace(adapterId))
+        {
+            var match = ofType.Find(a => string.Equals(a.AdapterId, adapterId, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+                return match;
+        }
+
+        return ofType[0];
+    }
 }

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelAdapter.cs
@@ -25,6 +25,14 @@ public interface IChannelAdapter
     /// <summary>The channel type identifier (e.g., "telegram", "discord", "tui").</summary>
     ChannelKey ChannelType { get; }
 
+    /// <summary>
+    /// Optional adapter instance identifier used to distinguish multiple adapters of the same
+    /// <see cref="ChannelType"/> (e.g., two Telegram bots). When set, <see cref="IChannelManager"/>
+    /// can select the correct adapter for a given binding.
+    /// Returns <c>null</c> for single-instance channel types.
+    /// </summary>
+    string? AdapterId => null;
+
     /// <summary>Human-readable display name for this channel.</summary>
     string DisplayName { get; }
 
@@ -108,4 +116,3 @@ public interface IStreamEventChannelAdapter
     /// </summary>
     Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default);
 }
-

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelManager.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelManager.cs
@@ -12,4 +12,13 @@ public interface IChannelManager
 
     /// <summary>Gets a channel adapter by type, or <c>null</c> if not registered.</summary>
     IChannelAdapter? Get(ChannelKey channelType);
+
+    /// <summary>
+    /// Gets a channel adapter by type and optional adapter ID.
+    /// When <paramref name="adapterId"/> is provided and a matching adapter is found, that adapter
+    /// is returned. If <paramref name="adapterId"/> is <c>null</c> or no adapter with that ID is
+    /// registered for the type, falls back to the first adapter of the given type.
+    /// Returns <c>null</c> when no adapters of that type are registered at all.
+    /// </summary>
+    IChannelAdapter? Get(ChannelKey channelType, string? adapterId);
 }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -820,7 +820,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
 
         foreach (var binding in outboundBindings)
         {
-            var adapter = ResolveChannelAdapter(binding.ChannelType);
+            var adapter = ResolveChannelAdapter(binding.ChannelType, binding.AdapterId);
             if (adapter is null)
                 continue;
 
@@ -1015,7 +1015,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             {
                 try
                 {
-                    var adapter = ResolveChannelAdapter(binding.ChannelType);
+                    var adapter = ResolveChannelAdapter(binding.ChannelType, binding.AdapterId);
                     if (adapter is null)
                     {
                         _logger.LogWarning(
@@ -1068,14 +1068,15 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         }
     }
 
-    private IChannelAdapter? ResolveChannelAdapter(ChannelKey channelType)
+    private IChannelAdapter? ResolveChannelAdapter(ChannelKey channelType, string? adapterId = null)
     {
-        var adapter = _channelManager.Get(channelType);
+        var adapter = _channelManager.Get(channelType, adapterId);
         if (adapter is not null)
             return adapter;
 
-        _logger.LogWarning("No channel adapter found for type '{ChannelType}'. Available: {Available}",
+        _logger.LogWarning("No channel adapter found for type '{ChannelType}' (adapterId: '{AdapterId}'). Available: {Available}",
             channelType,
+            adapterId ?? "<any>",
             string.Join(", ", _channelManager.Adapters.Select(a => a.ChannelType)));
         return null;
     }
@@ -1138,3 +1139,4 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }
+

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -290,6 +290,8 @@ public sealed class GatewayHostBindingRoutingTests
         manager.SetupGet(m => m.Adapters).Returns(adapter is null ? [] : [adapter]);
         manager.Setup(m => m.Get(It.IsAny<ChannelKey>())).Returns((ChannelKey channelType) =>
             adapter is not null && channelType.Equals(adapter.ChannelType) ? adapter : null);
+        manager.Setup(m => m.Get(It.IsAny<ChannelKey>(), It.IsAny<string?>())).Returns((ChannelKey channelType, string? _) =>
+            adapter is not null && channelType.Equals(adapter.ChannelType) ? adapter : null);
         return manager.Object;
     }
 
@@ -338,4 +340,5 @@ public sealed class GatewayHostBindingRoutingTests
         }
     }
 }
+
 

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -395,6 +395,8 @@ public sealed class MultiChannelFanOutTests
         manager.SetupGet(m => m.Adapters).Returns(adapters);
         manager.Setup(m => m.Get(It.IsAny<ChannelKey>()))
             .Returns((ChannelKey key) => adapters.FirstOrDefault(a => a.ChannelType == key));
+        manager.Setup(m => m.Get(It.IsAny<ChannelKey>(), It.IsAny<string?>()))
+            .Returns((ChannelKey key, string? _) => adapters.FirstOrDefault(a => a.ChannelType == key));
         return manager.Object;
     }
 
@@ -520,4 +522,5 @@ public sealed class MultiChannelFanOutTests
         }
     }
 }
+
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ChannelManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ChannelManagerTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Gateway.Channels;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Domain.Primitives;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -35,16 +36,78 @@ public sealed class ChannelManagerTests
         manager.Adapters.ShouldBeEmpty();
     }
 
+    // --- Multi-adapter same type tests (issue #127) ---
+
+    [Fact]
+    public void GetByAdapterId_WithMatchingAdapterId_ReturnsCorrectAdapter()
+    {
+        var adapter1 = new TestChannelAdapter("telegram", adapterId: "bot1");
+        var adapter2 = new TestChannelAdapter("telegram", adapterId: "bot2");
+        var manager = new ChannelManager([adapter1, adapter2]);
+
+        var resolved = manager.Get(ChannelKey.From("telegram"), "bot2");
+
+        resolved.ShouldBeSameAs(adapter2);
+    }
+
+    [Fact]
+    public void GetByAdapterId_WhenAdapterIdNull_FallsBackToFirstOfType()
+    {
+        var adapter1 = new TestChannelAdapter("telegram", adapterId: "bot1");
+        var adapter2 = new TestChannelAdapter("telegram", adapterId: "bot2");
+        var manager = new ChannelManager([adapter1, adapter2]);
+
+        var resolved = manager.Get(ChannelKey.From("telegram"), adapterId: null);
+
+        resolved.ShouldBeSameAs(adapter1);
+    }
+
+    [Fact]
+    public void GetByAdapterId_WhenAdapterIdNotFound_FallsBackToFirstOfType()
+    {
+        var adapter1 = new TestChannelAdapter("telegram", adapterId: "bot1");
+        var adapter2 = new TestChannelAdapter("telegram", adapterId: "bot2");
+        var manager = new ChannelManager([adapter1, adapter2]);
+
+        var resolved = manager.Get(ChannelKey.From("telegram"), adapterId: "bot-unknown");
+
+        resolved.ShouldBeSameAs(adapter1);
+    }
+
+    [Fact]
+    public void GetByAdapterId_WhenNoAdaptersOfType_ReturnsNull()
+    {
+        var adapter1 = new TestChannelAdapter("signalr", adapterId: "hub1");
+        var manager = new ChannelManager([adapter1]);
+
+        var resolved = manager.Get(ChannelKey.From("telegram"), adapterId: "bot1");
+
+        resolved.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetByAdapterId_WithSingleAdapter_NullAdapterId_ReturnsIt()
+    {
+        var adapter = new TestChannelAdapter("telegram");
+        var manager = new ChannelManager([adapter]);
+
+        var resolved = manager.Get(ChannelKey.From("telegram"), adapterId: null);
+
+        resolved.ShouldBeSameAs(adapter);
+    }
+
     private sealed class TestChannelAdapter : IChannelAdapter
     {
-        public TestChannelAdapter(string channelType)
+        public TestChannelAdapter(string channelType, string? adapterId = null)
         {
             ChannelType = ChannelKey.From(channelType);
             DisplayName = channelType;
+            AdapterId = adapterId;
         }
 
         public ChannelKey ChannelType { get; }
         public string DisplayName { get; }
+        public string? AdapterId { get; }
         public bool SupportsStreaming => false;
         public bool SupportsSteering => false;
         public bool SupportsFollowUp => false;

--- a/tests/gateway/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -108,6 +108,8 @@ public sealed class FanOutStaleBindingTests
         channelManager.SetupGet(m => m.Adapters).Returns([primaryAdapter.Object, signalrAdapter.Object]);
         channelManager.Setup(m => m.Get(ChannelKey.From("web"))).Returns(primaryAdapter.Object);
         channelManager.Setup(m => m.Get(ChannelKey.From("signalr"))).Returns(signalrAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("web"), It.IsAny<string?>())).Returns(primaryAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("signalr"), It.IsAny<string?>())).Returns(signalrAdapter.Object);
 
         // Conversation with a stale signalr binding
         var staleBinding = new ChannelBinding
@@ -183,6 +185,8 @@ public sealed class FanOutStaleBindingTests
         channelManager.SetupGet(m => m.Adapters).Returns([primaryAdapter.Object, signalrAdapter.Object]);
         channelManager.Setup(m => m.Get(ChannelKey.From("web"))).Returns(primaryAdapter.Object);
         channelManager.Setup(m => m.Get(ChannelKey.From("signalr"))).Returns(signalrAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("web"), It.IsAny<string?>())).Returns(primaryAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("signalr"), It.IsAny<string?>())).Returns(signalrAdapter.Object);
 
         var conversation = new Conversation
         {
@@ -211,3 +215,5 @@ public sealed class FanOutStaleBindingTests
             "Muted/absent bindings must not receive fan-out");
     }
 }
+
+

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1017,6 +1017,12 @@ public sealed class GatewayHostTests
                 : channelType.Equals(ChannelKey.From("telegram"))
                     ? secondChannel.Object
                     : null);
+        manager.Setup(m => m.Get(It.IsAny<ChannelKey>(), It.IsAny<string?>())).Returns((ChannelKey channelType, string? _) =>
+            channelType.Equals(ChannelKey.From("web"))
+                ? firstChannel.Object
+                : channelType.Equals(ChannelKey.From("telegram"))
+                    ? secondChannel.Object
+                    : null);
 
         await using var host = new GatewayHost(
             supervisor.Object,
@@ -1460,6 +1466,10 @@ public sealed class GatewayHostTests
             adapter is not null && channelType.Equals(adapter.ChannelType)
                 ? adapter
                 : null);
+        manager.Setup(m => m.Get(It.IsAny<ChannelKey>(), It.IsAny<string?>())).Returns((ChannelKey channelType, string? _) =>
+            adapter is not null && channelType.Equals(adapter.ChannelType)
+                ? adapter
+                : null);
         return manager.Object;
     }
 
@@ -1590,3 +1600,4 @@ public sealed class GatewayHostTests
         savedSession.Session.ConversationId!.Value.Value.ShouldBe("c_stamptest1");
     }
 }
+

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
@@ -166,6 +166,7 @@ public sealed class StreamingPipelineTests
         var channelManager = new Mock<IChannelManager>();
         channelManager.SetupGet(c => c.Adapters).Returns(streamingChannel is null ? [] : [streamingChannel]);
         channelManager.Setup(c => c.Get("web")).Returns(streamingChannel);
+        channelManager.Setup(c => c.Get(It.IsAny<ChannelKey>(), It.IsAny<string?>())).Returns((ChannelKey _, string? __) => streamingChannel);
         return new GatewayHost(
             supervisor.Object,
             router.Object,
@@ -233,5 +234,6 @@ public sealed class StreamingPipelineTests
         }
     }
 }
+
 
 


### PR DESCRIPTION
Closes #127

## Problem

`ChannelManager.Get(ChannelKey)` always returns the **first** adapter of the given type. When multiple adapters of the same type are registered (e.g., two Telegram bots), fan-out in `GatewayHost` always delivers via the wrong adapter for secondary bindings.

## Changes

### `IChannelAdapter` — new optional `AdapterId` property
Default interface member (`string? AdapterId => null`) — no breaking change to existing adapters.

### `IChannelManager` — new `Get(ChannelKey, string?)` overload
- Resolves by `(channelType, adapterId)` when `adapterId` is provided and a matching adapter is found
- Falls back to first-of-type when `adapterId` is null or no matching adapter is registered
- Returns null when no adapters of that type are registered at all

### `ChannelManager` — implements the new overload

### `ChannelBinding` — new `AdapterId` property (nullable, default null)
Additive, backward-compatible. Allows bindings to record which adapter instance they belong to.

### `GatewayHost.ResolveChannelAdapter` — passes `binding.AdapterId`
Both call sites (direct send and fan-out loop) now forward the binding's `AdapterId` to the new overload.

## Tests

- 5 new `ChannelManagerTests` covering: exact match, null-adapterId fallback, unknown-adapterId fallback, no-adapters-of-type returns null, single-adapter null-adapterId
- All mock `IChannelManager.Get(ChannelKey, string?)` overloads added in: `GatewayHostTests`, `FanOutStaleBindingTests`, `StreamingPipelineTests`, `MultiChannelFanOutTests`, `GatewayHostBindingRoutingTests`
- Full suite: 1570 Gateway + 73 Conversations = 1643 pass, 0 fail
