### PR TITLE
feat(agents): add list_agents tool for agent discovery

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Linq;
 using System.Text.Json;
@@ -225,6 +225,15 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 || effectiveToolIds.Contains("agent_converse", StringComparer.OrdinalIgnoreCase);
             if (includeConverse)
                 tools.Add(new AgentConverseTool(conversationService, sessionStore, descriptor.AgentId, context.SessionId));
+        }
+
+        var agentRegistry = _serviceProvider.GetService<IAgentRegistry>();
+        if (agentRegistry is not null)
+        {
+            var includeListAgents = effectiveToolIds.Count == 0
+                || effectiveToolIds.Contains("list_agents", StringComparer.OrdinalIgnoreCase);
+            if (includeListAgents)
+                tools.Add(new ListAgentsTool(agentRegistry, descriptor.AgentId));
         }
 
         var includeCanvas = effectiveToolIds.Count == 0
@@ -915,4 +924,5 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
         }
     }
 }
+
 

--- a/src/gateway/BotNexus.Gateway/Tools/ListAgentsTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ListAgentsTool.cs
@@ -1,0 +1,145 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Gateway.Tools;
+
+/// <summary>
+/// Tool that lets agents discover other registered agents and their capabilities.
+/// </summary>
+public sealed class ListAgentsTool(
+    IAgentRegistry agentRegistry,
+    AgentId callerAgentId) : IAgentTool
+{
+    public string Name => "list_agents";
+    public string Label => "List Agents";
+
+    public Tool Definition => new(
+        Name,
+        "List registered agents and their capabilities. Use to discover available specialists before calling agent_converse or spawn_subagent.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "filter": {
+                  "type": "string",
+                  "description": "Optional free-text filter applied to agent ID, display name, or description (case-insensitive)."
+                },
+                "capability": {
+                  "type": "string",
+                  "description": "Optional capability or archetype hint (e.g. research, code, planning)."
+                }
+              },
+              "required": []
+            }
+            """).RootElement.Clone());
+
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(arguments);
+    }
+
+    public Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var filter = ReadString(arguments, "filter");
+        var capability = ReadString(arguments, "capability");
+
+        var callerDescriptor = agentRegistry.Get(callerAgentId);
+        var subAgentIds = callerDescriptor?.SubAgentIds ?? [];
+
+        var agents = agentRegistry.GetAll()
+            .Where(d => MatchesFilter(d, filter))
+            .Where(d => MatchesCapability(d, capability))
+            .Select(d => new AgentEntry(
+                AgentId: d.AgentId.ToString(),
+                DisplayName: d.DisplayName,
+                Description: d.Description,
+                Emoji: d.Emoji,
+                Capabilities: ResolveCapabilities(d),
+                CanConverse: subAgentIds.Contains(d.AgentId.ToString(), StringComparer.OrdinalIgnoreCase)))
+            .OrderBy(e => e.AgentId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var json = JsonSerializer.Serialize(agents, JsonOptions);
+        return Task.FromResult(new AgentToolResult(
+            [new AgentToolContent(AgentToolContentType.Text, json)]));
+    }
+
+    private static bool MatchesFilter(AgentDescriptor d, string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+            return true;
+        return d.AgentId.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || d.DisplayName.Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || (d.Description?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private static bool MatchesCapability(AgentDescriptor d, string? capability)
+    {
+        if (string.IsNullOrWhiteSpace(capability))
+            return true;
+        var caps = ResolveCapabilities(d);
+        return caps.Any(c => c.Contains(capability, StringComparison.OrdinalIgnoreCase))
+            || (d.Description?.Contains(capability, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private static IReadOnlyList<string> ResolveCapabilities(AgentDescriptor d)
+    {
+        if (d.Metadata.TryGetValue("capabilities", out var raw) && raw is not null)
+        {
+            if (raw is JsonElement { ValueKind: JsonValueKind.Array } element)
+            {
+                return element.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString()!)
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToList();
+            }
+            if (raw is IEnumerable<string> strings)
+                return strings.ToList();
+            if (raw is string single)
+                return [single];
+        }
+        return [];
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value) || value is null)
+            return null;
+        return value switch
+        {
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            JsonElement element => element.ToString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private sealed record AgentEntry(
+        string AgentId,
+        string DisplayName,
+        string? Description,
+        string? Emoji,
+        IReadOnlyList<string> Capabilities,
+        bool CanConverse);
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/ListAgentsToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/ListAgentsToolTests.cs
@@ -1,0 +1,197 @@
+﻿using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Tools;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Tools;
+
+public sealed class ListAgentsToolTests
+{
+    private static AgentDescriptor MakeAgent(string id, string? description = null, string? emoji = null, IReadOnlyList<string>? capabilities = null)
+    {
+        var meta = new Dictionary<string, object?>();
+        if (capabilities is not null)
+            meta["capabilities"] = JsonDocument.Parse(
+                JsonSerializer.Serialize(capabilities)).RootElement;
+        return new AgentDescriptor
+        {
+            AgentId = AgentId.From(id),
+            DisplayName = id.ToUpperInvariant(),
+            Description = description,
+            Emoji = emoji,
+            ModelId = "test-model",
+            ApiProvider = "test",
+            Metadata = meta
+        };
+    }
+
+    private static Mock<IAgentRegistry> MakeRegistry(params AgentDescriptor[] agents)
+    {
+        var mock = new Mock<IAgentRegistry>();
+        mock.Setup(r => r.GetAll()).Returns(agents.ToList());
+        foreach (var a in agents)
+            mock.Setup(r => r.Get(a.AgentId)).Returns(a);
+        return mock;
+    }
+
+    [Fact]
+    public void Tool_HasExpectedNameAndLabel()
+    {
+        var tool = new ListAgentsTool(Mock.Of<IAgentRegistry>(), AgentId.From("caller"));
+        tool.Name.ShouldBe("list_agents");
+        tool.Label.ShouldBe("List Agents");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoFilter_ReturnsAllAgentsOrdered()
+    {
+        var registry = MakeRegistry(
+            MakeAgent("zebra"),
+            MakeAgent("alpha"),
+            MakeAgent("mango"));
+        registry.Setup(r => r.Get(AgentId.From("caller"))).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var json = result.Content[0].Value;
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(json)!;
+        list.Count.ShouldBe(3);
+        list[0].GetProperty("agentId").GetString().ShouldBe("alpha");
+        list[1].GetProperty("agentId").GetString().ShouldBe("mango");
+        list[2].GetProperty("agentId").GetString().ShouldBe("zebra");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFilter_ReturnsMatchingAgents()
+    {
+        var registry = MakeRegistry(
+            MakeAgent("coder", "Expert at coding tasks"),
+            MakeAgent("planner", "Project planning specialist"));
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var args = new Dictionary<string, object?> { ["filter"] = "coder" };
+        var result = await tool.ExecuteAsync("t1", args);
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.Count.ShouldBe(1);
+        list[0].GetProperty("agentId").GetString().ShouldBe("coder");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterMatchesDescription_ReturnsAgent()
+    {
+        var registry = MakeRegistry(
+            MakeAgent("nova", "Handles documentation and writing"),
+            MakeAgent("codey", "Writes and reviews code"));
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var args = new Dictionary<string, object?> { ["filter"] = "documentation" };
+        var result = await tool.ExecuteAsync("t1", args);
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.Count.ShouldBe(1);
+        list[0].GetProperty("agentId").GetString().ShouldBe("nova");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCapabilityFilter_ReturnsMatchingAgents()
+    {
+        var registry = MakeRegistry(
+            MakeAgent("researcher", capabilities: ["research", "web-search"]),
+            MakeAgent("coder", capabilities: ["code", "review"]));
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var args = new Dictionary<string, object?> { ["capability"] = "research" };
+        var result = await tool.ExecuteAsync("t1", args);
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.Count.ShouldBe(1);
+        list[0].GetProperty("agentId").GetString().ShouldBe("researcher");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallerHasSubAgentId_CanConverseIsTrue()
+    {
+        var callerDescriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("caller"),
+            DisplayName = "Caller",
+            ModelId = "m",
+            ApiProvider = "p",
+            SubAgentIds = ["specialist"]
+        };
+        var specialist = MakeAgent("specialist");
+        var other = MakeAgent("other");
+
+        var registry = MakeRegistry(specialist, other);
+        registry.Setup(r => r.Get(AgentId.From("caller"))).Returns(callerDescriptor);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        var specialistEntry = list.First(e => e.GetProperty("agentId").GetString() == "specialist");
+        var otherEntry = list.First(e => e.GetProperty("agentId").GetString() == "other");
+
+        specialistEntry.GetProperty("canConverse").GetBoolean().ShouldBeTrue();
+        otherEntry.GetProperty("canConverse").GetBoolean().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyRegistry_ReturnsEmptyList()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([]);
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterMatchesNone_ReturnsEmptyList()
+    {
+        var registry = MakeRegistry(MakeAgent("coder"), MakeAgent("planner"));
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var args = new Dictionary<string, object?> { ["filter"] = "zzz-no-match" };
+        var result = await tool.ExecuteAsync("t1", args);
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AgentWithEmojiAndDescription_IncludedInOutput()
+    {
+        var registry = MakeRegistry(MakeAgent("farnsworth", "Platform engineer", "🔬"));
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var json = result.Content[0].Value;
+        json.ShouldContain("farnsworth");
+        json.ShouldContain("Platform engineer");
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_ReturnsArgumentsUnchanged()
+    {
+        var tool = new ListAgentsTool(Mock.Of<IAgentRegistry>(), AgentId.From("caller"));
+        var args = new Dictionary<string, object?> { ["filter"] = "test" };
+        var result = await tool.PrepareArgumentsAsync(args);
+        result.ShouldBe(args);
+    }
+}


### PR DESCRIPTION
Closes #375

## Changes

New `list_agents` tool for runtime agent discovery.

- `ListAgentsTool`: filter by agent ID/name/description, capability matching via metadata or description keywords, `canConverse` flag from caller's subAgentIds, alphabetical order
- `InProcessIsolationStrategy`: wires `list_agents` alongside `agent_converse`
- 10 new tests (happy + sad paths)

## Test results
1540 passed, 35 failed (pre-existing CLI env failures, unrelated)
