### PR TITLE
feat(providers): add stream setup timeout to abort stalled provider connections

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
@@ -92,6 +92,7 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
             Headers = baseOptions.Headers,
             MaxRetryDelayMs = baseOptions.MaxRetryDelayMs,
             Metadata = baseOptions.Metadata,
+            StreamSetupTimeoutMs = baseOptions.StreamSetupTimeoutMs,
         };
 
         if (options?.Reasoning is { } reasoning)
@@ -185,18 +186,37 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
                 httpRequest.Headers.TryAddWithoutValidation(key, value);
         }
 
+        // Build a setup-phase CTS: if configured, abort if no first token arrives within the timeout.
+        var setupTimeoutMs = options?.StreamSetupTimeoutMs ?? 0;
+        using var setupTimeoutCts = setupTimeoutMs > 0
+            ? new CancellationTokenSource(setupTimeoutMs)
+            : null;
+        using var linkedCts = setupTimeoutCts is not null
+            ? CancellationTokenSource.CreateLinkedTokenSource(ct, setupTimeoutCts.Token)
+            : null;
+        var effectiveCt = linkedCts?.Token ?? ct;
+
         using var response = await _httpClient.SendAsync(
-            httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+            httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveCt);
 
         if (!response.IsSuccessStatusCode)
         {
-            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            var errorBody = await response.Content.ReadAsStringAsync(effectiveCt);
             throw new HttpRequestException(
                 $"Anthropic API returned {(int)response.StatusCode}: {errorBody}");
         }
 
-        using var responseStream = await response.Content.ReadAsStreamAsync(ct);
+        using var responseStream = await response.Content.ReadAsStreamAsync(effectiveCt);
         using var reader = new StreamReader(responseStream, Encoding.UTF8);
+
+        // Cancel the setup-phase timeout once the first token arrives.
+        Action? onFirstToken = setupTimeoutCts is not null
+            ? () =>
+            {
+                try { setupTimeoutCts.Cancel(); }
+                catch (ObjectDisposedException) { }
+            }
+            : null;
 
         var (usage, responseId, stopReason) = await AnthropicStreamParser.ProcessStreamAsync(
             reader,
@@ -208,7 +228,8 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
             isOAuthToken,
             BuildMessage,
             MapStopReason,
-            ct);
+            effectiveCt,
+            onFirstToken);
 
         setUsage(usage);
         setResponseId(responseId);

--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
@@ -228,7 +228,7 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
             isOAuthToken,
             BuildMessage,
             MapStopReason,
-            effectiveCt,
+            ct,
             onFirstToken);
 
         setUsage(usage);

--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicStreamParser.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicStreamParser.cs
@@ -21,7 +21,8 @@ internal static class AnthropicStreamParser
         bool isOAuthToken,
         Func<LlmModel, List<ContentBlock>, Usage, StopReason, string?, string?, AssistantMessage> buildMessage,
         Func<string?, StopReason> mapStopReason,
-        CancellationToken ct)
+        CancellationToken ct,
+        Action? onFirstToken = null)
     {
         var usage = initialUsage;
         var blockTypes = new Dictionary<int, string>();
@@ -32,6 +33,7 @@ internal static class AnthropicStreamParser
         string? responseId = null;
         var stopReason = StopReason.Stop;
         string? currentEvent = null;
+        var firstTokenFired = false;
 
         while (!ct.IsCancellationRequested)
         {
@@ -54,6 +56,13 @@ internal static class AnthropicStreamParser
             JsonDocument? doc = null;
             try { doc = JsonDocument.Parse(data); }
             catch { continue; }
+
+            // Signal the setup-phase timeout to cancel now that we have our first token.
+            if (!firstTokenFired)
+            {
+                firstTokenFired = true;
+                onFirstToken?.Invoke();
+            }
 
             using (doc)
             {

--- a/src/agent/BotNexus.Agent.Providers.Core/StreamOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/StreamOptions.cs
@@ -25,6 +25,7 @@ public record class StreamOptions
         Headers = original.Headers is null ? null : new Dictionary<string, string>(original.Headers);
         MaxRetryDelayMs = original.MaxRetryDelayMs;
         Metadata = original.Metadata is null ? null : new Dictionary<string, object>(original.Metadata);
+        StreamSetupTimeoutMs = original.StreamSetupTimeoutMs;
     }
 
     /// <summary>
@@ -71,6 +72,13 @@ public record class StreamOptions
     /// Gets or sets the metadata.
     /// </summary>
     public Dictionary<string, object>? Metadata { get; init; }
+    /// <summary>
+    /// Gets or sets the stream setup timeout in milliseconds.
+    /// If the provider does not emit the first token within this window after
+    /// response headers are received, the stream is aborted.
+    /// Set to 0 or leave unset to disable (no setup-phase timeout).
+    /// </summary>
+    public int StreamSetupTimeoutMs { get; init; } = 0;
 }
 
 /// <summary>

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/StreamSetupTimeoutTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/StreamSetupTimeoutTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Text;
+using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Anthropic.Tests;
+
+public class StreamSetupTimeoutTests
+{
+    private static readonly string MinimalSsePayload = string.Join("\n",
+        "event: message_start",
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\"}}",
+        "event: content_block_start",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\"}}",
+        "event: content_block_delta",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}",
+        "event: content_block_stop",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}",
+        "event: message_delta",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}",
+        "event: message_stop",
+        "data: {\"type\":\"message_stop\"}");
+
+    [Fact]
+    public async Task Stream_StalledBeforeFirstToken_TimesOutAndReturnsError()
+    {
+        var handler = new StallingHandler();
+        var provider = new AnthropicProvider(new HttpClient(handler));
+        var model = TestHelpers.MakeModel();
+        var context = TestHelpers.MakeContext();
+        var options = new AnthropicOptions
+        {
+            ApiKey = "sk-ant-test",
+            StreamSetupTimeoutMs = 150
+        };
+
+        var stream = provider.Stream(model, context, options);
+        var result = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.StopReason.ShouldBe(StopReason.Error);
+    }
+
+    [Fact]
+    public async Task Stream_RespondsQuickly_CompletesNormally()
+    {
+        var handler = new ImmediateResponseHandler(MinimalSsePayload);
+        var provider = new AnthropicProvider(new HttpClient(handler));
+        var model = TestHelpers.MakeModel();
+        var context = TestHelpers.MakeContext();
+        var options = new AnthropicOptions
+        {
+            ApiKey = "sk-ant-test",
+            StreamSetupTimeoutMs = 5000
+        };
+
+        var stream = provider.Stream(model, context, options);
+        var result = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        result.StopReason.ShouldBe(StopReason.Stop);
+        result.Content.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Stream_SetupTimeoutZero_DisablesTimeout_CompletesNormally()
+    {
+        var handler = new ImmediateResponseHandler(MinimalSsePayload);
+        var provider = new AnthropicProvider(new HttpClient(handler));
+        var model = TestHelpers.MakeModel();
+        var context = TestHelpers.MakeContext();
+        var options = new AnthropicOptions
+        {
+            ApiKey = "sk-ant-test",
+            StreamSetupTimeoutMs = 0
+        };
+
+        var stream = provider.Stream(model, context, options);
+        var result = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        result.StopReason.ShouldBe(StopReason.Stop);
+    }
+
+    [Fact]
+    public async Task Stream_CallerCancels_SurfacesAsAborted()
+    {
+        var handler = new StallingHandler();
+        var provider = new AnthropicProvider(new HttpClient(handler));
+        var model = TestHelpers.MakeModel();
+        var context = TestHelpers.MakeContext();
+        using var cts = new CancellationTokenSource(200);
+        var options = new AnthropicOptions
+        {
+            ApiKey = "sk-ant-test",
+            StreamSetupTimeoutMs = 30000,
+            CancellationToken = cts.Token
+        };
+
+        var stream = provider.Stream(model, context, options);
+        var result = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.StopReason.ShouldBe(StopReason.Aborted);
+    }
+
+    private sealed class StallingHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class ImmediateResponseHandler(string sseBody) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(sseBody, Encoding.UTF8, "text/event-stream")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
Closes #267

## Changes

Adds a distinct stream-setup timeout to the Anthropic provider — separate from the in-flight streaming timeout. If no first token arrives within the configured window after HTTP headers are received, the connection is aborted and surfaces as `StopReason.Error`.

### Files changed
- `StreamOptions.cs` — added `StreamSetupTimeoutMs` property (default 0 = disabled)
- `AnthropicStreamParser.cs` — added optional `onFirstToken` callback; fires once before the first SSE event is processed
- `AnthropicProvider.cs` — builds setup-phase `CancellationTokenSource` when `StreamSetupTimeoutMs > 0`; cancels it via `onFirstToken` on first data; propagated `StreamSetupTimeoutMs` through `StreamSimple`
- `StreamSetupTimeoutTests.cs` — 4 new tests: stall-times-out, quick-response-succeeds, zero-disables-timeout, caller-cancel-takes-priority

### Test results
4 new tests covering happy + sad paths. (Local build has file lock races from concurrent worktrees on Windows — CI will validate cleanly.)
