### PR TITLE
fix(gateway): discard steering when agent is not running instead of falling through

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -378,7 +378,10 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 {
                     if (await HandleSteeringAsync(message, agentId, sessionId, cancellationToken))
                         continue;
-                    // Agent not running — fall through to normal message processing.
+                    // Steering must not fall through to normal message processing.
+                    // Steering is control-plane metadata; discard it rather than converting to a user prompt.
+                    _logger.LogWarning("Steering discarded for session {SessionId} because agent is not running. Control messages must not enter the data plane.", sessionId);
+                    continue;
                 }
                 else if (string.Equals(controlCommand, ControlCompact, StringComparison.OrdinalIgnoreCase))
                 {
@@ -677,7 +680,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         if (handle is null || !handle.IsRunning)
         {
             _logger.LogInformation(
-                "Steering received but agent is not running (instance={HasInstance}, running={IsRunning}). Falling through to normal processing for session {SessionId}",
+                "Steering received but agent is not running (instance={HasInstance}, running={IsRunning}). Steering will be discarded for session {SessionId}.",
                 instance is not null, handle?.IsRunning ?? false, sessionId);
 
             await _activity.PublishAsync(new GatewayActivity

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -559,8 +559,8 @@ public sealed class GatewayHostTests
 
         // Steering was NOT called because agent is not running
         handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        // Instead, message was processed normally via PromptAsync
-        handle.Verify(h => h.PromptAsync(It.Is<AgentUserMessage>(m => m.Content == "nudge"), It.IsAny<CancellationToken>()), Times.Once);
+        // Steering was discarded — PromptAsync should NOT be called
+        handle.Verify(h => h.PromptAsync(It.Is<AgentUserMessage>(m => m.Content == "nudge"), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -522,7 +522,7 @@ public sealed class GatewayHostTests
     }
 
     [Fact]
-    public async Task DispatchAsync_WithSteerControl_WhenAgentNotRunning_FallsThroughToNormalProcessing()
+    public async Task DispatchAsync_WithSteerControl_WhenAgentNotRunning_DoesNotFallThroughToNormalProcessing()
     {
         var router = new Mock<IMessageRouter>();
         router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Closes #192

## Problem

When `HandleSteeringAsync` returns `false` (agent not running), the steering message silently fell through to normal message processing. This converted steering control-plane metadata into a regular user prompt, triggering an assistant response in a potentially wrong or newly-created conversation.

## Fix

Added an explicit `continue` after `HandleSteeringAsync` returns `false`. Steering messages are always discarded (not processed as prompts) when the agent is not running.

Also:
- Updated log message in `HandleSteeringAsync` to reflect discard semantics instead of "falling through"
- Updated the existing regression test `DispatchAsync_WithSteerControl_WhenAgentNotRunning_FallsThroughToNormalProcessing` → renamed and flipped to assert `PromptAsync` is **never** called

## Steering contract

Steering messages are control-plane metadata. They must never:
- Create new conversations
- Appear in session history as normal user messages
- Trigger assistant responses through normal prompt handling

If the target agent is not running, steering is silently discarded (with a warning log) until the agent resumes.