### PR TITLE
feat(extensions): add config schema declaration and enabled flag to extension manifest

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/ExtensionModels.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/ExtensionModels.cs
@@ -1,5 +1,4 @@
 namespace BotNexus.Gateway.Abstractions.Extensions;
-
 /// <summary>
 /// Manifest format stored in botnexus-extension.json.
 /// </summary>
@@ -29,8 +28,37 @@ public sealed record ExtensionManifest
     /// Gets or sets the dependencies.
     /// </summary>
     public IReadOnlyList<string> Dependencies { get; init; } = [];
+    /// <summary>
+    /// Whether this extension is enabled. When false, the extension is discovered but not loaded.
+    /// Defaults to true.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+    /// <summary>
+    /// Configuration field schema declared by this extension.
+    /// Used to validate operator config and apply defaults at startup.
+    /// </summary>
+    public IReadOnlyList<ExtensionConfigFieldSchema> ConfigSchema { get; init; } = [];
 }
-
+/// <summary>
+/// Schema declaration for a single extension configuration field.
+/// Extensions declare these in their botnexus-extension.json manifest so the
+/// gateway can validate operator config and apply defaults at startup.
+/// </summary>
+public sealed record ExtensionConfigFieldSchema
+{
+    /// <summary>Field identifier (key in the extension config object).</summary>
+    public string Id { get; init; } = string.Empty;
+    /// <summary>Expected value type: string, integer, bool, object, array.</summary>
+    public string Type { get; init; } = "string";
+    /// <summary>Default value as a string. Applied when the field is absent and not required.</summary>
+    public string? Default { get; init; }
+    /// <summary>Whether this field must be present in operator config. Missing required fields produce a warning.</summary>
+    public bool Required { get; init; }
+    /// <summary>Whether this field contains a secret/credential (masked in logs and UI).</summary>
+    public bool Sensitive { get; init; }
+    /// <summary>Human-readable description of the field's purpose.</summary>
+    public string? Description { get; init; }
+}
 /// <summary>
 /// Metadata for a discovered extension on disk.
 /// </summary>
@@ -53,7 +81,6 @@ public sealed record ExtensionInfo
     /// </summary>
     public required ExtensionManifest Manifest { get; init; }
 }
-
 /// <summary>
 /// Result of attempting to load an extension.
 /// </summary>
@@ -76,7 +103,6 @@ public sealed record ExtensionLoadResult
     /// </summary>
     public IReadOnlyList<string> RegisteredServices { get; init; } = [];
 }
-
 /// <summary>
 /// Runtime information about an extension that is currently loaded.
 /// </summary>

--- a/src/gateway/BotNexus.Gateway/Extensions/ExtensionConfigValidator.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/ExtensionConfigValidator.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+
+namespace BotNexus.Gateway.Extensions;
+
+/// <summary>
+/// Validates an extension's runtime config against its declared schema.
+/// Produces warnings for missing required fields and applies defaults for optional absent fields.
+/// </summary>
+public sealed class ExtensionConfigValidator
+{
+    /// <summary>
+    /// Validates <paramref name="config"/> against <paramref name="schema"/>.
+    /// </summary>
+    /// <param name="extensionId">Extension ID, used in warning messages.</param>
+    /// <param name="schema">Schema declared in the extension manifest.</param>
+    /// <param name="config">Operator-supplied config element for this extension.</param>
+    public ExtensionConfigValidationResult Validate(
+        string extensionId,
+        IReadOnlyList<ExtensionConfigFieldSchema> schema,
+        JsonElement config)
+    {
+        var warnings = new List<string>();
+        var appliedDefaults = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var field in schema)
+        {
+            var hasValue = config.ValueKind == JsonValueKind.Object
+                && config.TryGetProperty(field.Id, out _);
+
+            if (hasValue)
+                continue;
+
+            if (field.Required)
+            {
+                warnings.Add(
+                    $"Extension '{extensionId}': required config field '{field.Id}' is missing.");
+            }
+            else if (field.Default is not null)
+            {
+                appliedDefaults[field.Id] = field.Default;
+            }
+        }
+
+        return new ExtensionConfigValidationResult(
+            IsValid: warnings.Count == 0,
+            Warnings: warnings,
+            AppliedDefaults: appliedDefaults);
+    }
+}
+
+/// <summary>
+/// Result of validating extension config against its declared schema.
+/// </summary>
+/// <param name="IsValid">True when no required fields are missing.</param>
+/// <param name="Warnings">Human-readable warning messages (one per missing required field).</param>
+/// <param name="AppliedDefaults">Key-value pairs for fields where the schema default was applied.</param>
+public sealed record ExtensionConfigValidationResult(
+    bool IsValid,
+    IReadOnlyList<string> Warnings,
+    IReadOnlyDictionary<string, string> AppliedDefaults);

--- a/src/gateway/BotNexus.Gateway/Extensions/ExtensionConfigValidator.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/ExtensionConfigValidator.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Extensions;
 
 namespace BotNexus.Gateway.Extensions;
 

--- a/src/gateway/BotNexus.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -77,16 +77,30 @@ public static class ServiceCollectionExtensions
             }
         }
 
+        // Filter out extensions disabled via manifest Enabled = false
+        var enabledExtensions = discovered
+            .Where(ext => ext.Manifest.Enabled)
+            .ToList();
+        if (enabledExtensions.Count < discovered.Count)
+        {
+            foreach (var disabled in discovered.Where(ext => !ext.Manifest.Enabled))
+            {
+                deduplicationLogger?.LogInformation(
+                    "Skipping extension '{ExtensionId}' because its manifest has Enabled = false.",
+                    disabled.Manifest.Id);
+            }
+        }
+
         IReadOnlyList<ExtensionInfo> ordered;
         try
         {
-            ordered = TopologicallySort(discovered);
+            ordered = TopologicallySort(enabledExtensions);
         }
         catch (Exception ex)
         {
             loggerFactory?.CreateLogger("BotNexus.Gateway.Extensions")
                 .LogWarning(ex, "Extension dependency graph could not be fully ordered. Falling back to discovery order.");
-            ordered = discovered;
+            ordered = enabledExtensions;
         }
 
         List<ExtensionLoadResult> results = [];

--- a/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionConfigSchemaTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionConfigSchemaTests.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Extensions;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Extensions;
+
+public sealed class ExtensionConfigSchemaTests : IDisposable
+{
+    private readonly string _rootPath;
+
+    public ExtensionConfigSchemaTests()
+    {
+        _rootPath = Path.Combine(Path.GetTempPath(), "botnexus-config-schema-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_rootPath);
+    }
+
+    public void Dispose() => Directory.Delete(_rootPath, recursive: true);
+
+    // ExtensionManifest.Enabled
+
+    [Fact]
+    public async Task LoadConfiguredExtensionsAsync_SkipsExtension_WhenManifestEnabledIsFalse()
+    {
+        var dir = CreateExtensionDir("disabled-ext", enabled: false);
+        var platformConfig = BuildPlatformConfig(dir);
+
+        var services = new ServiceCollection().AddLogging();
+        var results = await services.LoadConfiguredExtensionsAsync(
+            platformConfig, NullLoggerFactory.Instance);
+
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadConfiguredExtensionsAsync_LoadsExtension_WhenManifestEnabledIsTrue()
+    {
+        var dir = CreateExtensionDir("enabled-ext", enabled: true);
+        var platformConfig = BuildPlatformConfig(dir);
+
+        var services = new ServiceCollection().AddLogging();
+        var results = await services.LoadConfiguredExtensionsAsync(
+            platformConfig, NullLoggerFactory.Instance);
+
+        results.Count.ShouldBe(1);
+        results[0].ExtensionId.ShouldBe("enabled-ext");
+    }
+
+    // ExtensionConfigFieldSchema deserialization
+
+    [Fact]
+    public void ExtensionManifest_Deserializes_ConfigSchema()
+    {
+        var json = """
+            {
+              "id": "my-ext",
+              "name": "My Ext",
+              "version": "1.0.0",
+              "entryAssembly": "my.dll",
+              "extensionTypes": ["tool"],
+              "configSchema": [
+                { "id": "apiKey", "type": "string", "required": true, "sensitive": true, "description": "API key" },
+                { "id": "timeout", "type": "integer", "default": "30", "required": false, "description": "Timeout seconds" }
+              ]
+            }
+            """;
+
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var manifest = JsonSerializer.Deserialize<ExtensionManifest>(json, opts)!;
+
+        manifest.ConfigSchema.Count.ShouldBe(2);
+        manifest.ConfigSchema[0].Id.ShouldBe("apiKey");
+        manifest.ConfigSchema[0].Type.ShouldBe("string");
+        manifest.ConfigSchema[0].Required.ShouldBeTrue();
+        manifest.ConfigSchema[0].Sensitive.ShouldBeTrue();
+        manifest.ConfigSchema[0].Default.ShouldBeNull();
+        manifest.ConfigSchema[1].Id.ShouldBe("timeout");
+        manifest.ConfigSchema[1].Default.ShouldBe("30");
+        manifest.ConfigSchema[1].Required.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ExtensionManifest_ConfigSchema_DefaultsToEmpty_WhenNotDeclared()
+    {
+        var json = """
+            {
+              "id": "minimal",
+              "name": "Minimal",
+              "version": "1.0.0",
+              "entryAssembly": "m.dll",
+              "extensionTypes": ["tool"]
+            }
+            """;
+
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var manifest = JsonSerializer.Deserialize<ExtensionManifest>(json, opts)!;
+
+        manifest.ConfigSchema.ShouldBeEmpty();
+    }
+
+    // ExtensionConfigValidator
+
+    [Fact]
+    public void ExtensionConfigValidator_ReturnsValid_WhenAllRequiredFieldsPresent()
+    {
+        var schema = new[]
+        {
+            new ExtensionConfigFieldSchema { Id = "apiKey", Type = "string", Required = true }
+        };
+        var config = JsonDocument.Parse("""{"apiKey":"abc123"}""").RootElement;
+
+        var validator = new ExtensionConfigValidator();
+        var result = validator.Validate("my-ext", schema, config);
+
+        result.IsValid.ShouldBeTrue();
+        result.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ExtensionConfigValidator_ReturnsInvalid_WhenRequiredFieldMissing()
+    {
+        var schema = new[]
+        {
+            new ExtensionConfigFieldSchema { Id = "apiKey", Type = "string", Required = true }
+        };
+        var config = JsonDocument.Parse("{}").RootElement;
+
+        var validator = new ExtensionConfigValidator();
+        var result = validator.Validate("my-ext", schema, config);
+
+        result.IsValid.ShouldBeFalse();
+        result.Warnings.ShouldHaveSingleItem();
+        result.Warnings[0].ShouldContain("apiKey");
+    }
+
+    [Fact]
+    public void ExtensionConfigValidator_AppliesDefault_WhenOptionalFieldMissingAndDefaultDeclared()
+    {
+        var schema = new[]
+        {
+            new ExtensionConfigFieldSchema { Id = "timeout", Type = "integer", Required = false, Default = "30" }
+        };
+        var config = JsonDocument.Parse("{}").RootElement;
+
+        var validator = new ExtensionConfigValidator();
+        var result = validator.Validate("my-ext", schema, config);
+
+        result.IsValid.ShouldBeTrue();
+        result.AppliedDefaults.ShouldContainKey("timeout");
+        result.AppliedDefaults["timeout"].ShouldBe("30");
+    }
+
+    [Fact]
+    public void ExtensionConfigValidator_NoWarning_WhenOptionalFieldMissingAndNoDefault()
+    {
+        var schema = new[]
+        {
+            new ExtensionConfigFieldSchema { Id = "optionalFlag", Type = "bool", Required = false }
+        };
+        var config = JsonDocument.Parse("{}").RootElement;
+
+        var validator = new ExtensionConfigValidator();
+        var result = validator.Validate("my-ext", schema, config);
+
+        result.IsValid.ShouldBeTrue();
+        result.Warnings.ShouldBeEmpty();
+        result.AppliedDefaults.ShouldBeEmpty();
+    }
+
+    // Helpers
+
+    private string CreateExtensionDir(string id, bool enabled)
+    {
+        var dir = Path.Combine(_rootPath, id);
+        Directory.CreateDirectory(dir);
+        var manifest = new ExtensionManifest
+        {
+            Id = id,
+            Name = id,
+            Version = "1.0.0",
+            EntryAssembly = "entry.dll",
+            ExtensionTypes = ["tool"],
+            Enabled = enabled
+        };
+        File.WriteAllText(
+            Path.Combine(dir, "botnexus-extension.json"),
+            JsonSerializer.Serialize(manifest));
+        File.WriteAllText(Path.Combine(dir, "entry.dll"), "placeholder");
+        return dir;
+    }
+
+    private PlatformConfig BuildPlatformConfig(string extensionsDir) => new()
+    {
+        Gateway = new()
+        {
+            Extensions = new ExtensionsConfig
+            {
+                Enabled = true,
+                Path = Path.GetDirectoryName(extensionsDir)
+            }
+        }
+    };
+}


### PR DESCRIPTION
Closes #419

## Changes

### `ExtensionManifest` (ExtensionModels.cs)
- Added `Enabled` property (default `true`). Extensions with `"enabled": false` in their manifest are discovered but skipped at load time.
- Added `ConfigSchema` property (`IReadOnlyList<ExtensionConfigFieldSchema>`). Extensions declare their configuration fields in the manifest for gateway validation.

### New: `ExtensionConfigFieldSchema` (ExtensionModels.cs)
Fields: `Id`, `Type` (string/integer/bool/object/array), `Default` (string), `Required` (bool), `Sensitive` (bool), `Description` (string).

### New: `ExtensionConfigValidator` (Gateway/Extensions/)
- `Validate(extensionId, schema, config)` — checks all required fields are present, collects warnings for missing required fields, records applied defaults for optional absent fields with a declared default.
- Returns `ExtensionConfigValidationResult { IsValid, Warnings, AppliedDefaults }`.

### `ServiceCollectionExtensions.LoadConfiguredExtensionsAsync`
- After dedup, filters out extensions where `manifest.Enabled == false`, logs info for each skipped extension.
- `TopologicallySort` and the load loop now operate on the filtered (enabled-only) list.

## Tests
6 new tests in `ExtensionConfigSchemaTests`:
- `LoadConfiguredExtensionsAsync_SkipsExtension_WhenManifestEnabledIsFalse`
- `LoadConfiguredExtensionsAsync_LoadsExtension_WhenManifestEnabledIsTrue`
- `ExtensionManifest_Deserializes_ConfigSchema`
- `ExtensionManifest_ConfigSchema_DefaultsToEmpty_WhenNotDeclared`
- `ExtensionConfigValidator_ReturnsValid_WhenAllRequiredFieldsPresent`
- `ExtensionConfigValidator_ReturnsInvalid_WhenRequiredFieldMissing`
- `ExtensionConfigValidator_AppliesDefault_WhenOptionalFieldMissingAndDefaultDeclared`
- `ExtensionConfigValidator_NoWarning_WhenOptionalFieldMissingAndNoDefault`

## Notes
- Config storage (`extensions.<id>`) already exists via `ExtensionsConfig.Defaults` and `AgentDefinitionConfig.Extensions`. This PR adds the schema contract extensions use to describe their expected fields.
- Validation is exposed as a utility class; call sites (startup logging) are the next phase (#420 UI).
- Local build blocked by Windows worktree file-lock race (15+ active worktrees sharing obj directories) — CI validates on fresh checkout.
