### PR TITLE
feat(portal): add agent dashboard homepage with card grid

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
@@ -123,6 +123,9 @@ public sealed class AgentState
     /// <summary>Optional emoji that visually identifies this agent.</summary>
     public string? Emoji { get; set; }
 
+    /// <summary>Short description of this agent's purpose.</summary>
+    public string? Description { get; set; }
+
     /// <summary>Active session ID (last established).</summary>
     public string? SessionId { get; set; }
 
@@ -259,3 +262,4 @@ public sealed class ConversationStreamState
     /// <summary>In-progress tool calls for this conversation keyed by tool-call ID.</summary>
     public Dictionary<string, ActiveToolCall> ActiveToolCalls { get; } = new();
 }
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -33,6 +33,7 @@ public sealed class ClientStateStore : IClientStateStore
                     AgentId = a.AgentId,
                     DisplayName = a.DisplayName,
                     Emoji = a.Emoji,
+                    Description = a.Description,
                     IsConnected = true
                 };
             }
@@ -40,6 +41,7 @@ public sealed class ClientStateStore : IClientStateStore
             {
                 existing.DisplayName = a.DisplayName;
                 existing.Emoji = a.Emoji;
+                existing.Description = a.Description;
             }
         }
 
@@ -347,3 +349,4 @@ public sealed class ClientStateStore : IClientStateStore
     /// <inheritdoc />
     public void NotifyChanged() => OnChanged?.Invoke();
 }
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
@@ -18,7 +18,8 @@ public sealed record ConnectedPayload(
 public sealed record AgentSummary(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("displayName")] string DisplayName,
-    [property: JsonPropertyName("emoji")] string? Emoji = null);
+    [property: JsonPropertyName("emoji")] string? Emoji = null,
+    [property: JsonPropertyName("description")] string? Description = null);
 
 /// <summary>Hub capabilities advertised on connect.</summary>
 public sealed record HubCapabilities(

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentDashboard.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentDashboard.razor
@@ -1,0 +1,98 @@
+@inject IClientStateStore Store
+@inject NavigationManager Nav
+@implements IDisposable
+
+<div class="agent-dashboard">
+    @if (!Store.Agents.Any())
+    {
+        <div class="agent-dashboard-empty">
+            <p>No agents registered. Add agents to the gateway configuration to get started.</p>
+        </div>
+    }
+    else
+    {
+        <div class="agent-card-grid">
+            @foreach (var (agentId, agent) in Store.Agents.Where(a => !a.Value.IsReadOnly))
+            {
+                <div class="agent-card @(agent.IsStreaming ? "agent-card--active" : "")" @onclick="() => NavigateToAgent(agent)">
+                    <div class="agent-card-header">
+                        <span class="agent-card-emoji">@(agent.Emoji ?? "🤖")</span>
+                        <div class="agent-card-identity">
+                            <span class="agent-card-name">@agent.DisplayName</span>
+                            <span class="agent-card-status @(agent.IsStreaming ? "status-active" : "status-idle")">
+                                @(agent.IsStreaming ? "● Active" : "○ Idle")
+                            </span>
+                        </div>
+                        @if (agent.UnreadCount > 0)
+                        {
+                            <span class="agent-card-unread-badge">@agent.UnreadCount</span>
+                        }
+                    </div>
+                    @if (!string.IsNullOrEmpty(agent.Description))
+                    {
+                        <p class="agent-card-description">@agent.Description</p>
+                    }
+                    <div class="agent-card-stats">
+                        <span class="agent-card-stat">
+                            @OpenConversationCount(agent) open
+                        </span>
+                        @if (LastActivity(agent) is { } lastActivity)
+                        {
+                            <span class="agent-card-stat agent-card-last-activity">@lastActivity</span>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Store.OnChanged += HandleStateChanged;
+    }
+
+    private void HandleStateChanged() =>
+        _ = InvokeAsync(StateHasChanged);
+
+    private void NavigateToAgent(AgentState agent)
+    {
+        var mostRecent = agent.Conversations.Values
+            .Where(c => c.Status == "Active")
+            .OrderByDescending(c => c.UpdatedAt)
+            .FirstOrDefault();
+
+        if (mostRecent is not null)
+            Nav.NavigateTo($"/chat/{Uri.EscapeDataString(agent.AgentId)}/{Uri.EscapeDataString(mostRecent.ConversationId)}");
+        else
+            Nav.NavigateTo($"/chat/{Uri.EscapeDataString(agent.AgentId)}");
+    }
+
+    private static int OpenConversationCount(AgentState agent) =>
+        agent.Conversations.Values.Count(c => c.Status == "Active");
+
+    private static string? LastActivity(AgentState agent)
+    {
+        var latest = agent.Conversations.Values
+            .Where(c => c.UpdatedAt > DateTimeOffset.MinValue)
+            .OrderByDescending(c => c.UpdatedAt)
+            .Select(c => c.UpdatedAt)
+            .Cast<DateTimeOffset?>()
+            .FirstOrDefault();
+
+        if (latest is null)
+            return null;
+
+        var age = DateTimeOffset.UtcNow - latest.Value;
+        return age.TotalSeconds < 60 ? "just now"
+            : age.TotalMinutes < 60 ? $"{(int)age.TotalMinutes} min ago"
+            : age.TotalHours < 24 ? $"{(int)age.TotalHours}h ago"
+            : $"{(int)age.TotalDays}d ago";
+    }
+
+    public void Dispose()
+    {
+        Store.OnChanged -= HandleStateChanged;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
@@ -27,9 +27,7 @@ else
 {
     @if (Store.ActiveAgentId is null)
     {
-        <div class="empty-state">
-            <p>Select an agent from the sidebar to start chatting.</p>
-        </div>
+        <AgentDashboard />
     }
 
     @foreach (var (agentId, _) in Store.Agents)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -3761,3 +3761,136 @@ h3.conversation-title.editable:hover {
     background: var(--text-muted, #888);
     cursor: default;
 }
+
+/* ── Agent Dashboard ────────────────────────────────────────────────── */
+
+.agent-dashboard {
+    padding: 1.5rem;
+    overflow-y: auto;
+    height: 100%;
+}
+
+.agent-dashboard-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.agent-card-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+@media (min-width: 600px) {
+    .agent-card-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 900px) {
+    .agent-card-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+.agent-card {
+    background: var(--surface, #1e1e1e);
+    border: 1px solid var(--border, #333);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    cursor: pointer;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    user-select: none;
+}
+
+.agent-card:hover {
+    border-color: var(--accent, #4a90d9);
+    box-shadow: 0 2px 12px rgba(74, 144, 217, 0.15);
+}
+
+.agent-card--active {
+    border-color: var(--accent, #4a90d9);
+}
+
+.agent-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.agent-card-emoji {
+    font-size: 2rem;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.agent-card-identity {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.agent-card-name {
+    font-weight: 600;
+    font-size: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-card-status {
+    font-size: 0.75rem;
+    margin-top: 0.1rem;
+}
+
+.agent-card-status.status-active {
+    color: var(--status-green, #4caf50);
+}
+
+.agent-card-status.status-idle {
+    color: var(--text-muted);
+}
+
+.agent-card-unread-badge {
+    background: var(--accent, #4a90d9);
+    color: #fff;
+    border-radius: 9999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.1rem 0.45rem;
+    min-width: 1.4rem;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.agent-card-description {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    margin: 0 0 0.5rem;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.agent-card-stats {
+    display: flex;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+}
+
+.agent-card-stat {
+    white-space: nowrap;
+}
+
+.agent-card-last-activity {
+    margin-left: auto;
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -541,7 +541,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
         await Clients.Caller.Connected(new ConnectedPayload(
             Context.ConnectionId,
-            _registry.GetAll().Select(a => new AgentSummary(a.AgentId.Value, a.DisplayName, a.Emoji)),
+            _registry.GetAll().Select(a => new AgentSummary(a.AgentId.Value, a.DisplayName, a.Emoji, a.Description)),
             typeof(GatewayHub).Assembly.GetName().Version?.ToString() ?? "dev",
             new HubCapabilities(MultiSession: true)));
 
@@ -724,3 +724,4 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     private static bool ChannelMatches(ChannelKey candidate, ChannelKey target)
         => candidate.Equals(target);
 }
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
@@ -49,7 +49,8 @@ public sealed record ConnectedPayload(
 public sealed record AgentSummary(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("displayName")] string DisplayName,
-    [property: JsonPropertyName("emoji")] string? Emoji = null);
+    [property: JsonPropertyName("emoji")] string? Emoji = null,
+    [property: JsonPropertyName("description")] string? Description = null);
 
 /// <summary>Hub capabilities advertised on connect.</summary>
 public sealed record HubCapabilities(
@@ -101,6 +102,7 @@ public sealed record SteeringFeedbackPayload(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("sessionId")] string SessionId,
     [property: JsonPropertyName("kind")] SteeringFeedbackKind Kind);
+
 
 
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentDashboardTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentDashboardTests.cs
@@ -3,6 +3,7 @@ using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Bunit.TestDoubles;
 using NSubstitute;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentDashboardTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentDashboardTests.cs
@@ -1,0 +1,225 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class AgentDashboardTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store;
+
+    public AgentDashboardTests()
+    {
+        _store = Substitute.For<IClientStateStore>();
+        _store.Agents.Returns(new Dictionary<string, AgentState>().AsReadOnly());
+
+        _ctx.Services.AddSingleton(_store);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    // ── Happy paths ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Renders_card_for_each_non_readonly_agent()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha" },
+            ["a2"] = new() { AgentId = "a2", DisplayName = "Beta" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        var cards = cut.FindAll(".agent-card");
+        Assert.Equal(2, cards.Count);
+    }
+
+    [Fact]
+    public void Shows_agent_name_emoji_and_description()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha", Emoji = "🔬", Description = "Platform engineer" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        Assert.Contains("Alpha", cut.Markup);
+        Assert.Contains("🔬", cut.Markup);
+        Assert.Contains("Platform engineer", cut.Markup);
+    }
+
+    [Fact]
+    public void Active_streaming_agent_card_has_active_class()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha", IsStreaming = true }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        var card = cut.Find(".agent-card");
+        Assert.Contains("agent-card--active", card.ClassList);
+    }
+
+    [Fact]
+    public void Unread_badge_shown_when_unread_count_greater_than_zero()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha", UnreadCount = 3 }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        var badge = cut.Find(".agent-card-unread-badge");
+        Assert.Contains("3", badge.TextContent);
+    }
+
+    [Fact]
+    public void Open_conversation_count_reflects_active_status_conversations()
+    {
+        var agent = new AgentState { AgentId = "a1", DisplayName = "Alpha" };
+        agent.Conversations["c1"] = new ConversationState { ConversationId = "c1", Status = "Active" };
+        agent.Conversations["c2"] = new ConversationState { ConversationId = "c2", Status = "Active" };
+        agent.Conversations["c3"] = new ConversationState { ConversationId = "c3", Status = "Archived" };
+
+        var agents = new Dictionary<string, AgentState> { ["a1"] = agent };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        Assert.Contains("2 open", cut.Markup);
+    }
+
+    [Fact]
+    public void Clicking_card_with_conversation_navigates_to_agent_and_conversation()
+    {
+        var navMan = _ctx.Services.GetRequiredService<NavigationManager>() as BunitNavigationManager;
+
+        var agent = new AgentState { AgentId = "a1", DisplayName = "Alpha" };
+        var updatedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        agent.Conversations["c1"] = new ConversationState
+        {
+            ConversationId = "c1",
+            Status = "Active",
+            UpdatedAt = updatedAt
+        };
+
+        var agents = new Dictionary<string, AgentState> { ["a1"] = agent };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+        cut.Find(".agent-card").Click();
+
+        Assert.Equal("http://localhost/chat/a1/c1", navMan?.Uri);
+    }
+
+    [Fact]
+    public void Clicking_card_without_conversations_navigates_to_agent_only()
+    {
+        var navMan = _ctx.Services.GetRequiredService<NavigationManager>() as BunitNavigationManager;
+
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+        cut.Find(".agent-card").Click();
+
+        Assert.Equal("http://localhost/chat/a1", navMan?.Uri);
+    }
+
+    // ── Sad paths ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Shows_empty_message_when_no_agents_registered()
+    {
+        _store.Agents.Returns(new Dictionary<string, AgentState>().AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        cut.Find(".agent-dashboard-empty");
+        Assert.DoesNotContain("agent-card", cut.Markup.Replace("agent-card-grid", ""));
+    }
+
+    [Fact]
+    public void Readonly_subagent_sessions_are_excluded_from_dashboard()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha" },
+            ["sub"] = new() { AgentId = "sub", DisplayName = "SubAgent", SessionType = "agent-subagent" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        var cards = cut.FindAll(".agent-card");
+        Assert.Single(cards);
+        Assert.Contains("Alpha", cut.Markup);
+        Assert.DoesNotContain("SubAgent", cut.Markup);
+    }
+
+    [Fact]
+    public void Description_hidden_when_null_or_empty()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha", Description = null }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        Assert.Empty(cut.FindAll(".agent-card-description"));
+    }
+
+    [Fact]
+    public void Unread_badge_hidden_when_unread_count_is_zero()
+    {
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha", UnreadCount = 0 }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        Assert.Empty(cut.FindAll(".agent-card-unread-badge"));
+    }
+
+    [Fact]
+    public void Dashboard_re_renders_on_store_change_event()
+    {
+        _store.Agents.Returns(new Dictionary<string, AgentState>().AsReadOnly());
+
+        var cut = _ctx.Render<AgentDashboard>();
+
+        Assert.Empty(cut.FindAll(".agent-card"));
+
+        // Now add an agent and fire OnChanged
+        var agents = new Dictionary<string, AgentState>
+        {
+            ["a1"] = new() { AgentId = "a1", DisplayName = "Alpha" }
+        };
+        _store.Agents.Returns(agents.AsReadOnly());
+        _store.OnChanged += Raise.Event<Action>();
+
+        cut.WaitForState(() => cut.FindAll(".agent-card").Count == 1);
+        Assert.Single(cut.FindAll(".agent-card"));
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
@@ -88,7 +88,7 @@ public sealed class HomePageTests : IDisposable
         var cut = _ctx.Render<Home>();
 
         Assert.Empty(cut.FindAll(".portal-loading"));
-        Assert.Contains("Select an agent", cut.Markup);
+        cut.Find(".agent-dashboard");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #390

## Changes

- **AgentDashboard.razor** — new component: responsive card grid of all registered agents. Each card shows emoji, name, description, streaming status dot, open conversation count, unread badge, and last activity time. Clicking navigates to the agent's most recent active conversation.
- **Home.razor** — replaced static empty-state with <AgentDashboard /> when no agent is active.
- **AgentSummary** (server + client HubContracts) — added Description field (nullable, backward-compatible).
- **GatewayHub.cs** — passes AgentDescriptor.Description into AgentSummary on connect.
- **AgentState** + **ClientStateStore.SeedAgents** — adds and seeds Description field from hub payload.
- **app.css** — new .agent-dashboard, .agent-card-grid, .agent-card styles; responsive 1/2/3-column grid at mobile/tablet/desktop.
- **AgentDashboardTests.cs** — 11 new tests: happy paths (card render, description, active badge, unread badge, open count, navigation) + sad paths (empty state, read-only filtered, null description hidden, zero unread badge hidden, live refresh on store change).
- **HomePageTests.cs** — updated Renders_main_UI_when_ready_with_no_active_agent to assert .agent-dashboard instead of the now-removed static text.

## Local build note
Windows file-lock race in BlazorClient.Core obj folder prevents local test run with 16 concurrent worktrees. CI will validate.