### PR TITLE
feat(skills): include source path for available skills in list response

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/SkillTool.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillTool.cs
@@ -118,7 +118,11 @@ public sealed class SkillTool(
             lines.Add("## Available Skills (not loaded)");
             lines.Add("Use `skills` tool with action `load` and the skill name to activate.");
             foreach (var s in resolution.Available)
+            {
                 lines.Add($"- **{s.Name}**: {s.Description}");
+                if (!string.IsNullOrEmpty(s.SourcePath))
+                    lines.Add($"  Path: {s.SourcePath}");
+            }
             lines.Add("");
         }
 

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillToolTests.cs
@@ -239,6 +239,60 @@ public sealed class SkillToolTests
         result.ShouldBeSameAs(config);
     }
 
+    // ── #227 path resolution ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_AvailableSkills_IncludePath()
+    {
+        var skill = MakeSkill("calendar");
+        var tool = new SkillTool([skill], config: null);
+
+        var result = await tool.ExecuteAsync("call-1", Args("list"));
+        var text = ResultText(result);
+
+        text.ShouldContain("Path:");
+        text.ShouldContain("/skills/calendar");
+    }
+
+    [Fact]
+    public async Task List_LoadedSkills_IncludePath()
+    {
+        var skills = new[] { MakeSkill("email-triage") };
+        var config = new SkillsConfig { AutoLoad = ["email-triage"] };
+        var tool = new SkillTool(skills, config);
+
+        var result = await tool.ExecuteAsync("call-1", Args("list"));
+        var text = ResultText(result);
+
+        text.ShouldContain("Path:");
+        text.ShouldContain("/skills/email-triage");
+    }
+
+    [Fact]
+    public async Task Load_ResponseIncludesPath()
+    {
+        var skill = MakeSkill("git-workflow");
+        var tool = new SkillTool([skill], config: null);
+
+        var result = await tool.ExecuteAsync("call-1", Args("load", "git-workflow"));
+        var text = ResultText(result);
+
+        text.ShouldContain("**Path:**");
+        text.ShouldContain("/skills/git-workflow");
+    }
+
+    [Fact]
+    public async Task Load_UnknownSkill_DoesNotIncludePath()
+    {
+        var tool = new SkillTool([], config: null);
+
+        var result = await tool.ExecuteAsync("call-1", Args("load", "nonexistent"));
+        var text = ResultText(result);
+
+        text.ShouldContain("not found");
+        text.ShouldNotContain("**Path:**");
+    }
+
     private static bool InvokeTryUnload(SkillTool tool, string skillName)
     {
         var method = tool.GetType().GetMethod("TryUnload", BindingFlags.Public | BindingFlags.Instance);


### PR DESCRIPTION
Closes #227

## Changes

- `ListSkills()`: available skills now show `Path: {sourcePath}` below name/description (matching the existing format for loaded skills)
- 4 new tests: `List_AvailableSkills_IncludePath`, `List_LoadedSkills_IncludePath`, `Load_ResponseIncludesPath`, `Load_UnknownSkill_DoesNotIncludePath`

## Note

Load response already included `**Path:**` and list loaded skills already showed path — the only gap was available (not-yet-loaded) skills in `list`. Pre-existing Windows file-lock race (17 active worktrees) blocked local test run; CI validates on Linux.