### PR TITLE
feat(portal): add client-side preferences system with auto-expanding chat input

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IPortalPreferencesService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IPortalPreferencesService.cs
@@ -1,0 +1,22 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;
+
+/// <summary>
+/// Manages browser-local portal preferences backed by localStorage.
+/// </summary>
+public interface IPortalPreferencesService
+{
+    /// <summary>Current preferences snapshot.</summary>
+    PortalPreferences Current { get; }
+
+    /// <summary>Raised when any preference changes.</summary>
+    event Action OnChanged;
+
+    /// <summary>Load preferences from localStorage. Falls back to defaults on missing or invalid data.</summary>
+    Task LoadAsync();
+
+    /// <summary>Persist current preferences to localStorage.</summary>
+    Task SaveAsync();
+
+    /// <summary>Update the expanding-input preference and persist.</summary>
+    Task SetExpandingInputAsync(bool enabled);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalPreferences.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalPreferences.cs
@@ -1,0 +1,13 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Browser-local portal preferences. Stored in localStorage. Not synced to server.
+/// </summary>
+public sealed class PortalPreferences
+{
+    /// <summary>Auto-expand the chat textarea as the user types.</summary>
+    public bool ExpandingInput { get; set; } = true;
+
+    /// <summary>Maximum visible rows before the textarea scrolls internally.</summary>
+    public int ExpandingInputMaxLines { get; set; } = 8;
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalPreferencesService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalPreferencesService.cs
@@ -1,0 +1,58 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;
+using Microsoft.JSInterop;
+using System.Text.Json;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// localStorage-backed portal preferences service.
+/// </summary>
+public sealed class PortalPreferencesService : IPortalPreferencesService
+{
+    private const string StorageKey = "botnexus.portal.prefs";
+    private readonly IJSRuntime _js;
+    private PortalPreferences _current = new();
+
+    public PortalPreferencesService(IJSRuntime js) => _js = js;
+
+    /// <inheritdoc/>
+    public PortalPreferences Current => _current;
+
+    /// <inheritdoc/>
+    public event Action OnChanged = delegate { };
+
+    /// <inheritdoc/>
+    public async Task LoadAsync()
+    {
+        try
+        {
+            var json = await _js.InvokeAsync<string>("portalPrefs.load", StorageKey);
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                var loaded = JsonSerializer.Deserialize<PortalPreferences>(json);
+                if (loaded is not null)
+                    _current = loaded;
+            }
+        }
+        catch
+        {
+            // Malformed JSON or JS interop failure — silently fall back to defaults
+            _current = new PortalPreferences();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync()
+    {
+        var json = JsonSerializer.Serialize(_current);
+        await _js.InvokeAsync<object>("portalPrefs.save", StorageKey, json);
+    }
+
+    /// <inheritdoc/>
+    public async Task SetExpandingInputAsync(bool enabled)
+    {
+        _current.ExpandingInput = enabled;
+        await SaveAsync();
+        OnChanged.Invoke();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -320,7 +320,7 @@
                           @ref="_inputElement"
                           @bind="_inputText"
                           @bind:event="oninput"
-                          @oninput="HandleInputChanged"
+                          @bind:after="HandleInputChanged"
                           @onkeydown="HandleKeyDown"
                           placeholder="@InputPlaceholder"
                           disabled="@(!IsConnected)" />

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -412,7 +412,7 @@ private bool IsStreaming =>
         ActiveConversationId is not null ? Store.GetPendingAskUser(ActiveConversationId) : null;
     private string ThinkingBuffer => ActiveConversation?.StreamState.ThinkingBuffer ?? string.Empty;
     private string CurrentStreamBuffer => ActiveConversation?.StreamState.Buffer ?? string.Empty;
-    private string ExpandingInputClass => Prefs.Current.ExpandingInput ? "expanding" : string.Empty;
+    private string ExpandingInputClass => Prefs?.Current?.ExpandingInput == true ? "expanding" : string.Empty;
 
     private string _inputText = "";
     private ElementReference _messagesContainer;
@@ -420,7 +420,7 @@ private bool IsStreaming =>
 
     private async Task HandleInputChanged()
     {
-        if (Prefs.Current.ExpandingInput)
+        if (Prefs?.Current?.ExpandingInput == true)
             await JS.InvokeVoidAsync("chatScroll.autoResizeTextarea", _inputElement, Prefs.Current.ExpandingInputMaxLines);
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -316,7 +316,7 @@
         <div class="chat-input-area">
             @if (!IsReadOnly)
             {
-                <textarea class="chat-input @(Prefs.Current.ExpandingInput ? ""expanding"" : """")"
+                <textarea class="chat-input @ExpandingInputClass"
                           @ref="_inputElement"
                           @bind="_inputText"
                           @bind:event="oninput"
@@ -412,6 +412,7 @@ private bool IsStreaming =>
         ActiveConversationId is not null ? Store.GetPendingAskUser(ActiveConversationId) : null;
     private string ThinkingBuffer => ActiveConversation?.StreamState.ThinkingBuffer ?? string.Empty;
     private string CurrentStreamBuffer => ActiveConversation?.StreamState.Buffer ?? string.Empty;
+    private string ExpandingInputClass => Prefs.Current.ExpandingInput ? "expanding" : string.Empty;
 
     private string _inputText = "";
     private ElementReference _messagesContainer;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -1,6 +1,7 @@
 @inject IJSRuntime JS
 @inject IClientStateStore Store
 @inject IAgentInteractionService Interaction
+@inject IPortalPreferencesService Prefs
 @implements IDisposable
 
 <div class="chat-panel">
@@ -315,10 +316,11 @@
         <div class="chat-input-area">
             @if (!IsReadOnly)
             {
-                <textarea class="chat-input"
+                <textarea class="chat-input @(Prefs.Current.ExpandingInput ? ""expanding"" : """")"
                           @ref="_inputElement"
                           @bind="_inputText"
                           @bind:event="oninput"
+                          @oninput="HandleInputChanged"
                           @onkeydown="HandleKeyDown"
                           placeholder="@InputPlaceholder"
                           disabled="@(!IsConnected)" />
@@ -413,7 +415,16 @@ private bool IsStreaming =>
 
     private string _inputText = "";
     private ElementReference _messagesContainer;
-    private ElementReference _inputElement;
+        private ElementReference _inputElement;
+
+    private async Task HandleInputChanged()
+    {
+        if (Prefs.Current.ExpandingInput)
+            await JS.InvokeVoidAsync("chatScroll.autoResizeTextarea", _inputElement, Prefs.Current.ExpandingInputMaxLines);
+    }
+
+    private async Task ToggleExpandingInput()
+        => await Prefs.SetExpandingInputAsync(!Prefs.Current.ExpandingInput);
     private bool _enterPreventionBound;
     private bool _wasReadOnly;
     private bool _hadAskUserPrompt;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/PortalSettingsPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/PortalSettingsPanel.razor
@@ -1,0 +1,60 @@
+@inject IPortalPreferencesService Prefs
+@inject IJSRuntime JS
+@implements IDisposable
+
+@if (_show)
+{
+    <div class="portal-settings-overlay" @onclick="Close">
+        <div class="portal-settings-panel" @onclick:stopPropagation="true">
+            <div class="portal-settings-header">
+                <h3>Portal Settings</h3>
+                <button class="portal-settings-close" @onclick="Close" title="Close">x</button>
+            </div>
+            <div class="portal-settings-body">
+                <div class="portal-settings-row">
+                    <label class="portal-settings-label">Auto-expand chat input</label>
+                    <input type="checkbox"
+                           checked="@Prefs.Current.ExpandingInput"
+                           @onchange="ToggleExpandingInput" />
+                </div>
+                <div class="portal-settings-hint">
+                    Textarea grows as you type, up to @Prefs.Current.ExpandingInputMaxLines rows.
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private bool _show;
+
+    protected override void OnInitialized()
+    {
+        Prefs.OnChanged += HandleChanged;
+    }
+
+    public void Open()
+    {
+        _show = true;
+        StateHasChanged();
+    }
+
+    private void Close()
+    {
+        _show = false;
+        StateHasChanged();
+    }
+
+    private async Task ToggleExpandingInput(ChangeEventArgs e)
+    {
+        var enabled = e.Value is bool b ? b : bool.Parse(e.Value?.ToString() ?? "false");
+        await Prefs.SetExpandingInputAsync(enabled);
+    }
+
+    private void HandleChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        Prefs.OnChanged -= HandleChanged;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -11,6 +11,7 @@
 @implements IAsyncDisposable
 
 <div class="app-shell">
+<PortalSettingsPanel @ref="_settingsPanel" />
     @* Top bar with burger + logo *@
     <header class="app-banner">
         <div class="banner-header">
@@ -21,6 +22,7 @@
             </button>
             <span class="banner-logo">🤖</span>
             <span class="banner-title">BotNexus</span>
+            <button class="banner-settings-btn" @onclick="OpenSettings" title="Portal settings">x</button>
         </div>
     </header>
 
@@ -260,7 +262,8 @@
 @code {
     private record Announcement(string Id, string Text, string Type = "info");
     private List<Announcement> _announcements = [];
-    private bool _restarting;
+        private bool _restarting;
+    private PortalSettingsPanel? _settingsPanel;
     private bool _sidebarOpen = false;
     private bool _isMobile = false;
     private const string SidebarKey = "botnexus-sidebar-open";
@@ -531,6 +534,8 @@
             return $"yesterday {local:HH:mm}";
         return local.ToString("MMM d HH:mm");
     }
+
+    private void OpenSettings() => _settingsPanel?.Open();
 
     private void ShowUpdateConfirm() => _showUpdateConfirm = true;
     private void CancelUpdate() => _showUpdateConfirm = false;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -19,5 +19,6 @@ builder.Services.AddScoped<GatewayInfoService>();
 builder.Services.AddScoped<IUpdateStatusService, UpdateStatusService>();
 builder.Services.AddScoped<LocationsApiClient>();
 builder.Services.AddScoped<CronApiClient>();
+builder.Services.AddScoped<IPortalPreferencesService, PortalPreferencesService>();
 
 await builder.Build().RunAsync();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/_Imports.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/_Imports.razor
@@ -11,3 +11,5 @@
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components.Config
+
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -3761,3 +3761,65 @@ h3.conversation-title.editable:hover {
     background: var(--text-muted, #888);
     cursor: default;
 }
+
+/* ---- Auto-expanding textarea ---- */
+.chat-input.expanding {
+    resize: none;
+    overflow-y: hidden;
+    transition: height 0.1s ease;
+}
+
+/* ---- Portal settings ---- */
+.banner-settings-btn {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: var(--text-muted, #999);
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+}
+.banner-settings-btn:hover { background: var(--hover-bg, rgba(255,255,255,0.08)); }
+
+.portal-settings-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 2000;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+}
+.portal-settings-panel {
+    background: var(--panel-bg, #1e1e2e);
+    border-left: 1px solid var(--border, #333);
+    width: 320px;
+    height: 100%;
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+.portal-settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+.portal-settings-close {
+    background: none;
+    border: none;
+    color: var(--text-muted, #999);
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+.portal-settings-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+}
+.portal-settings-hint {
+    font-size: 0.8rem;
+    color: var(--text-muted, #999);
+    padding-bottom: 0.5rem;
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/chat.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/js/chat.js
@@ -47,6 +47,21 @@ window.chatScroll = {
         return window.innerWidth <= 768;
     },
 
+        /** Auto-resizes a textarea to fit its content, capped at maxRows rows. */
+    autoResizeTextarea: function (element, maxRows) {
+        if (!element) return;
+        element.style.height = 'auto';
+        var lineHeight = parseInt(getComputedStyle(element).lineHeight) || 20;
+        var maxHeight = lineHeight * maxRows;
+        element.style.height = Math.min(element.scrollHeight, maxHeight) + 'px';
+        element.style.overflowY = element.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    },
+
+    /** Resets a textarea height to its natural (CSS) default. */
+    resetTextareaHeight: function (element) {
+        if (element) { element.style.height = ''; element.style.overflowY = ''; }
+    }
+
     preventEnterSubmit: function (element) {
         if (!element || typeof element.addEventListener !== 'function' || element._preventEnterBound) return;
         element.addEventListener('keydown', function (e) {
@@ -56,4 +71,9 @@ window.chatScroll = {
         });
         element._preventEnterBound = true;
     }
+};
+
+window.portalPrefs = {
+    load: function (key) { return localStorage.getItem(key); },
+    save: function (key, value) { localStorage.setItem(key, value); }
 };

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentPanelVerticalSliceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentPanelVerticalSliceTests.cs
@@ -38,6 +38,7 @@ public sealed class AgentPanelVerticalSliceTests : IDisposable
         _ctx.Services.AddSingleton<IClientStateStore>(_store);
         _ctx.Services.AddSingleton(_portalLoad);
         _ctx.Services.AddSingleton(Substitute.For<IAgentInteractionService>());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient { BaseAddress = new Uri("http://localhost/") });
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -22,6 +22,7 @@ public sealed class ChatPanelTests : IDisposable
         _ctx.Services.AddSingleton(_interaction);
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GlobalUsings.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/HomePageTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Pages;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -119,6 +119,7 @@ public sealed class HomePageTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IAgentInteractionService>());
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         var cut = _ctx.Render<Home>();
 
@@ -141,6 +142,7 @@ public sealed class HomePageTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IAgentInteractionService>());
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         var cut = _ctx.Render<Home>();
 
@@ -164,6 +166,7 @@ public sealed class HomePageTests : IDisposable
 
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         _ctx.Render<Home>(p => p.Add(c => c.AgentId, "agent-2"));
 
@@ -196,6 +199,7 @@ public sealed class HomePageTests : IDisposable
 
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         _ctx.Render<Home>(p => p
             .Add(c => c.AgentId, "agent-2")
@@ -223,6 +227,7 @@ public sealed class HomePageTests : IDisposable
 
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         _ctx.Render<Home>(p => p.Add(c => c.AgentId, "agent-2"));
 
@@ -259,6 +264,7 @@ public sealed class HomePageTests : IDisposable
 
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         _ctx.Render<Home>(p => p
             .Add(c => c.AgentId, encodedAgentId)
@@ -297,6 +303,7 @@ public sealed class HomePageTests : IDisposable
 
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         _ctx.Render<Home>(p => p
             .Add(c => c.AgentId, "missing-agent")
@@ -335,6 +342,7 @@ public sealed class HomePageTests : IDisposable
 
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
 
         _ctx.Render<Home>(p => p
             .Add(c => c.AgentId, "missing-agent")
@@ -345,3 +353,4 @@ public sealed class HomePageTests : IDisposable
         _interaction.DidNotReceive().SelectConversationAsync(Arg.Any<string>(), Arg.Any<string>());
     }
 }
+

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -36,6 +36,7 @@ public sealed class MainLayoutTests : IDisposable
         _ctx.Services.AddSingleton(hub);
         _ctx.Services.AddSingleton(gatewayInfo);
         _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(http);
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/PortalPreferencesServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/PortalPreferencesServiceTests.cs
@@ -1,0 +1,90 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;
+using Microsoft.JSInterop;
+using NSubstitute;
+using System.Text.Json;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public class PortalPreferencesServiceTests
+{
+    private readonly IJSRuntime _js;
+    private readonly PortalPreferencesService _sut;
+
+    public PortalPreferencesServiceTests()
+    {
+        _js = Substitute.For<IJSRuntime>();
+        _sut = new PortalPreferencesService(_js);
+    }
+
+    [Fact]
+    public void Current_BeforeLoad_ReturnsDefaults()
+    {
+        var prefs = _sut.Current;
+        Assert.True(prefs.ExpandingInput);
+        Assert.Equal(8, prefs.ExpandingInputMaxLines);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenNoStoredData_UsesDefaults()
+    {
+        _js.InvokeAsync<string>("portalPrefs.load", Arg.Any<object[]>())
+           .Returns(new ValueTask<string>((string?)null!));
+
+        await _sut.LoadAsync();
+
+        Assert.True(_sut.Current.ExpandingInput);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithStoredData_RestoresPreferences()
+    {
+        var stored = JsonSerializer.Serialize(new PortalPreferences { ExpandingInput = false, ExpandingInputMaxLines = 4 });
+        _js.InvokeAsync<string>("portalPrefs.load", Arg.Any<object[]>())
+           .Returns(new ValueTask<string>(stored));
+
+        await _sut.LoadAsync();
+
+        Assert.False(_sut.Current.ExpandingInput);
+        Assert.Equal(4, _sut.Current.ExpandingInputMaxLines);
+    }
+
+    [Fact]
+    public async Task SetExpandingInputAsync_UpdatesPreferenceAndSaves()
+    {
+        await _sut.SetExpandingInputAsync(false);
+
+        Assert.False(_sut.Current.ExpandingInput);
+        await _js.Received(1).InvokeAsync<object>("portalPrefs.save", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public async Task SetExpandingInputAsync_RaisesOnChanged()
+    {
+        var raised = false;
+        _sut.OnChanged += () => raised = true;
+
+        await _sut.SetExpandingInputAsync(false);
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesToLocalStorage()
+    {
+        await _sut.SaveAsync();
+
+        await _js.Received(1).InvokeAsync<object>("portalPrefs.save", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithInvalidJson_UsesDefaults()
+    {
+        _js.InvokeAsync<string>("portalPrefs.load", Arg.Any<object[]>())
+           .Returns(new ValueTask<string>("not-valid-json"));
+
+        await _sut.LoadAsync(); // should not throw
+
+        Assert.True(_sut.Current.ExpandingInput);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
@@ -29,6 +29,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
         _ctx.Services.AddSingleton(new HttpClient());
         _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -178,6 +179,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         ctx.Services.AddSingleton(restClient);
         ctx.Services.AddSingleton(http);
         ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
+        ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
         store.SeedAgents([new AgentSummary("a-1", "Agent One")]);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound3BlazorTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Text.Json.Nodes;
 using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
@@ -33,6 +33,7 @@ public sealed class ProbeRound3BlazorTests : IDisposable
             BaseAddress = new Uri("http://gateway.test")
         };
         _ctx.Services.AddSingleton(new CronApiClient(cronHttp));
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +42,7 @@ public sealed class UpdateBadgeTests : IDisposable
         _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(_updateSvc);
+        _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 


### PR DESCRIPTION
Closes #251

## Changes

### New: `IPortalPreferencesService` + `PortalPreferencesService`
- `PortalPreferences` record: `ExpandingInput` (default `true`), `ExpandingInputMaxLines` (default `8`)
- `PortalPreferencesService`: localStorage-backed, `LoadAsync` / `SaveAsync` / `SetExpandingInputAsync`
- Graceful fallback to defaults on missing or malformed JSON

### New: `PortalSettingsPanel.razor`
- Slide-in overlay panel (⚙ button in banner)
- Expanding-input toggle checkbox

### Modified: `ChatPanel.razor`
- Injects `IPortalPreferencesService`
- `HandleInputChanged`: calls `chatScroll.autoResizeTextarea` when expanding mode active
- Quick toggle button in header toolbar

### Modified: `MainLayout.razor`
- ⚙ settings button in banner header opens `PortalSettingsPanel`

### JS (`chat.js`)
- `chatScroll.autoResizeTextarea(element, maxRows)`: auto-resize on input
- `chatScroll.resetTextareaHeight(element)`: reset after send
- `window.portalPrefs.load/save`: localStorage wrappers

### CSS (`app.css`)
- `.chat-input.expanding` — expanding textarea styles
- `.portal-settings-*` — settings panel overlay styles

### DI
- `IPortalPreferencesService` registered as scoped in `Program.cs`

## Tests
7 new tests in `PortalPreferencesServiceTests` covering defaults, load/restore, save, OnChanged, and invalid JSON fallback.