### PR TITLE
fix(conversations): add bind-on-first-use to prevent duplicate portal conversations on reconnect

### DIFF
--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -63,7 +63,40 @@ public sealed class DefaultConversationRouter : IConversationRouter
                     reactivated = true;
                 }
 
-                var (directSessionId, directIsNew, changed) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
+                // Bind-on-first-use: if the conversation has no active binding for (channelType, channelAddress),
+                // add one so future reconnects can find it without an explicit conversationId (#441).
+                var bindingChanged = false;
+                var existingBinding = direct.ChannelBindings.FirstOrDefault(b =>
+                    b.ChannelType.Equals(channelType) &&
+                    b.ChannelAddress == channelAddress &&
+                    (threadId is null ? b.ThreadId is null : b.ThreadId == threadId));
+
+                if (existingBinding is null)
+                {
+                    direct.ChannelBindings.Add(new ChannelBinding
+                    {
+                        ChannelType = channelType,
+                        ChannelAddress = channelAddress,
+                        ThreadId = threadId,
+                        Mode = BindingMode.Interactive
+                    });
+                    bindingChanged = true;
+                    _logger.LogDebug(
+                        "ResolveInbound: added binding ({ChannelType}:{ChannelAddress}) to conversation {ConversationId} on first use",
+                        channelType, channelAddress, direct.ConversationId);
+                }
+                else if (existingBinding.Mode == BindingMode.Muted)
+                {
+                    // Reactivate a previously-muted binding when the conversation is explicitly re-used.
+                    existingBinding.Mode = BindingMode.Interactive;
+                    bindingChanged = true;
+                    _logger.LogDebug(
+                        "ResolveInbound: reactivated muted binding ({ChannelType}:{ChannelAddress}) in conversation {ConversationId}",
+                        channelType, channelAddress, direct.ConversationId);
+                }
+
+                var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
+                var changed = bindingChanged || directSessionChanged;
                 if (changed)
                 {
                     direct.UpdatedAt = DateTimeOffset.UtcNow;

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -64,7 +64,8 @@ public sealed class DefaultConversationRouter : IConversationRouter
                 }
 
                 // Bind-on-first-use for explicit conversationId path:
-                // Add a binding if none exists; reactivate a muted binding.
+                // Add a channel address binding if none exists; reactivate a muted binding.
+                // This ensures reconnects without explicit conversationId can find this conversation.
                 var existingBinding = direct.ChannelBindings.FirstOrDefault(b =>
                     b.ChannelType == channelType && b.ChannelAddress == channelAddress);
                 if (existingBinding is null)
@@ -83,7 +84,6 @@ public sealed class DefaultConversationRouter : IConversationRouter
                     existingBinding.Mode = BindingMode.Interactive;
                     reactivated = true;
                 }
-
                 var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
                 var changed = directSessionChanged;
                 if (changed)

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -63,9 +63,26 @@ public sealed class DefaultConversationRouter : IConversationRouter
                     reactivated = true;
                 }
 
-                // Explicit conversationId path: do NOT add bindings here.
-                // The portal always sends the known conversationId, so no binding is needed.
-                // Bind-on-first-use lives in the implicit path (below) for channel reconnects (#441).
+                // Bind-on-first-use for explicit conversationId path:
+                // Add a binding if none exists; reactivate a muted binding.
+                var existingBinding = direct.ChannelBindings.FirstOrDefault(b =>
+                    b.ChannelType == channelType && b.ChannelAddress == channelAddress);
+                if (existingBinding is null)
+                {
+                    direct.ChannelBindings.Add(new ChannelBinding
+                    {
+                        ChannelType = channelType,
+                        ChannelAddress = channelAddress,
+                        ThreadId = threadId,
+                        Mode = BindingMode.Interactive
+                    });
+                    reactivated = true;
+                }
+                else if (existingBinding.Mode == BindingMode.Muted)
+                {
+                    existingBinding.Mode = BindingMode.Interactive;
+                    reactivated = true;
+                }
 
                 var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
                 var changed = directSessionChanged;

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -63,40 +63,12 @@ public sealed class DefaultConversationRouter : IConversationRouter
                     reactivated = true;
                 }
 
-                // Bind-on-first-use: if the conversation has no active binding for (channelType, channelAddress),
-                // add one so future reconnects can find it without an explicit conversationId (#441).
-                var bindingChanged = false;
-                var existingBinding = direct.ChannelBindings.FirstOrDefault(b =>
-                    b.ChannelType.Equals(channelType) &&
-                    b.ChannelAddress == channelAddress &&
-                    (threadId is null ? b.ThreadId is null : b.ThreadId == threadId));
-
-                if (existingBinding is null)
-                {
-                    direct.ChannelBindings.Add(new ChannelBinding
-                    {
-                        ChannelType = channelType,
-                        ChannelAddress = channelAddress,
-                        ThreadId = threadId,
-                        Mode = BindingMode.Interactive
-                    });
-                    bindingChanged = true;
-                    _logger.LogDebug(
-                        "ResolveInbound: added binding ({ChannelType}:{ChannelAddress}) to conversation {ConversationId} on first use",
-                        channelType, channelAddress, direct.ConversationId);
-                }
-                else if (existingBinding.Mode == BindingMode.Muted)
-                {
-                    // Reactivate a previously-muted binding when the conversation is explicitly re-used.
-                    existingBinding.Mode = BindingMode.Interactive;
-                    bindingChanged = true;
-                    _logger.LogDebug(
-                        "ResolveInbound: reactivated muted binding ({ChannelType}:{ChannelAddress}) in conversation {ConversationId}",
-                        channelType, channelAddress, direct.ConversationId);
-                }
+                // Explicit conversationId path: do NOT add bindings here.
+                // The portal always sends the known conversationId, so no binding is needed.
+                // Bind-on-first-use lives in the implicit path (below) for channel reconnects (#441).
 
                 var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
-                var changed = bindingChanged || directSessionChanged;
+                var changed = directSessionChanged;
                 if (changed)
                 {
                     direct.UpdatedAt = DateTimeOffset.UtcNow;

--- a/tests/BotNexus.Gateway.Conversation.Tests/ConversationRoutingScenarios.cs
+++ b/tests/BotNexus.Gateway.Conversation.Tests/ConversationRoutingScenarios.cs
@@ -107,12 +107,12 @@ public sealed class ConversationRoutingScenarios
         // Assert — routes to the correct conversation with NO new binding added
         result.Conversation.ConversationId.ShouldBe(secondaryConv.ConversationId,
             "explicit conversationId must route directly to that conversation");
-
-        // The critical invariant: no duplicate thread binding was added
+        // The critical invariant: a channel address binding IS added (for reconnect),
+        // but NOT a ThreadId=conversationId binding (old design causing double fan-out)
         // (old design added a binding with ThreadId=conversationId, causing double fan-out)
         var conv = await convStore.GetAsync(secondaryConv.ConversationId);
-        conv.ShouldNotBeNull();
-        conv!.ChannelBindings.Count.ShouldBe(0,
+        conv!.ChannelBindings.Count.ShouldBe(1,
+            "direct conversationId routing must add exactly one channel-address binding for reconnect, not a ThreadId hack");
             "direct conversationId routing must NOT add a binding — no binding hack");
     }
 

--- a/tests/BotNexus.Gateway.Conversation.Tests/ConversationRoutingScenarios.cs
+++ b/tests/BotNexus.Gateway.Conversation.Tests/ConversationRoutingScenarios.cs
@@ -113,7 +113,6 @@ public sealed class ConversationRoutingScenarios
         var conv = await convStore.GetAsync(secondaryConv.ConversationId);
         conv!.ChannelBindings.Count.ShouldBe(1,
             "direct conversationId routing must add exactly one channel-address binding for reconnect, not a ThreadId hack");
-            "direct conversationId routing must NOT add a binding — no binding hack");
     }
 
     // ──────────────────────────────────────────────────────────────────────────────

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/PortalReconnectTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/PortalReconnectTests.cs
@@ -1,0 +1,177 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace BotNexus.Gateway.Conversations.Tests.Conversations;
+
+/// <summary>
+/// Tests for SignalR portal reconnect duplicate conversation bug (#441).
+/// When the portal uses an explicit conversationId, the router must bind that
+/// conversation to the (channelType, channelAddress) so reconnects can find it.
+/// </summary>
+public sealed class PortalReconnectTests
+{
+    private static DefaultConversationRouter CreateRouter(
+        IConversationStore? conversationStore = null,
+        ISessionStore? sessionStore = null)
+        => new(
+            conversationStore ?? new InMemoryConversationStore(),
+            sessionStore ?? new InMemorySessionStore(),
+            NullLogger<DefaultConversationRouter>.Instance);
+
+    /// <summary>
+    /// First send: conversationId provided, conversation has no binding.
+    /// Router should add a binding so future reconnects can find it.
+    /// </summary>
+    [Fact]
+    public async Task ResolveInbound_WithExplicitConversationId_AddsBindingWhenNoneExists()
+    {
+        var store = new InMemoryConversationStore();
+        var agentId = AgentId.From("nova");
+        var channel = ChannelKey.From("signalr");
+        var address = ChannelAddress.From("nova");
+
+        // Pre-create a conversation with NO bindings (REST-created conversation)
+        var conv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "My Conversation",
+            IsDefault = false
+        };
+        await store.SaveAsync(conv);
+
+        var router = CreateRouter(store);
+
+        // First send with explicit conversationId, no existing binding
+        var result = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+
+        result.ShouldNotBeNull();
+        result.Conversation.ConversationId.ShouldBe(conv.ConversationId);
+
+        // Binding should now exist on the conversation
+        var updated = await store.GetAsync(conv.ConversationId);
+        updated.ShouldNotBeNull();
+        updated!.ChannelBindings.ShouldNotBeEmpty();
+        updated.ChannelBindings.ShouldContain(b =>
+            b.ChannelType == channel &&
+            b.ChannelAddress == address &&
+            b.Mode != BindingMode.Muted,
+            "a binding must be added so reconnects can find this conversation without an explicit conversationId");
+    }
+
+    /// <summary>
+    /// After the binding is created, reconnect without conversationId must find the same conversation.
+    /// This is the core scenario: no duplicate should be created.
+    /// </summary>
+    [Fact]
+    public async Task ReconnectWithoutConversationId_FindsExistingConversation_AfterFirstSend()
+    {
+        var store = new InMemoryConversationStore();
+        var agentId = AgentId.From("nova");
+        var channel = ChannelKey.From("signalr");
+        var address = ChannelAddress.From("nova");
+
+        // Pre-create a REST conversation with no bindings
+        var conv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "My Conversation",
+            IsDefault = false
+        };
+        await store.SaveAsync(conv);
+
+        var router = CreateRouter(store);
+
+        // First send: explicit conversationId (adds binding)
+        await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+
+        // Reconnect: NO conversationId - must find the same conversation
+        var reconnectResult = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: null);
+
+        reconnectResult.ShouldNotBeNull();
+        reconnectResult.Conversation.ConversationId.ShouldBe(conv.ConversationId,
+            "reconnect without conversationId must return the same conversation, not create signalr:nova duplicate");
+    }
+
+    /// <summary>
+    /// If the conversation already has a binding for (channelType, channelAddress), do not add a duplicate.
+    /// </summary>
+    [Fact]
+    public async Task ResolveInbound_WithExplicitConversationId_DoesNotDuplicateExistingBinding()
+    {
+        var store = new InMemoryConversationStore();
+        var agentId = AgentId.From("nova");
+        var channel = ChannelKey.From("signalr");
+        var address = ChannelAddress.From("nova");
+
+        // Pre-create a conversation that ALREADY has the binding
+        var bindingId = BindingId.Create();
+        var conv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "signalr:nova",
+            IsDefault = false
+        };
+        conv.ChannelBindings.Add(new ChannelBinding
+        {
+            BindingId = bindingId,
+            ChannelType = channel,
+            ChannelAddress = address,
+            Mode = BindingMode.Interactive
+        });
+        await store.SaveAsync(conv);
+
+        var router = CreateRouter(store);
+
+        await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+
+        var updated = await store.GetAsync(conv.ConversationId);
+        updated.ShouldNotBeNull();
+        updated!.ChannelBindings.Count.ShouldBe(1, "no duplicate binding should be added when one already exists");
+        updated.ChannelBindings[0].BindingId.ShouldBe(bindingId, "original binding must not be replaced");
+    }
+
+    /// <summary>
+    /// A muted binding should be reactivated (not duplicated) when the conversation is re-used explicitly.
+    /// </summary>
+    [Fact]
+    public async Task ResolveInbound_WithExplicitConversationId_ReactivatesMutedBinding()
+    {
+        var store = new InMemoryConversationStore();
+        var agentId = AgentId.From("nova");
+        var channel = ChannelKey.From("signalr");
+        var address = ChannelAddress.From("nova");
+
+        var conv = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "signalr:nova",
+            IsDefault = false
+        };
+        conv.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = channel,
+            ChannelAddress = address,
+            Mode = BindingMode.Muted
+        });
+        await store.SaveAsync(conv);
+
+        var router = CreateRouter(store);
+
+        await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+
+        var updated = await store.GetAsync(conv.ConversationId);
+        updated.ShouldNotBeNull();
+        updated!.ChannelBindings.Count.ShouldBe(1, "muted binding should be reactivated, not duplicated");
+        updated.ChannelBindings[0].Mode.ShouldBe(BindingMode.Interactive, "muted binding must be reactivated to Interactive");
+    }
+}


### PR DESCRIPTION
Closes #441

## Problem

Every portal reconnect (hard refresh or new browser session) created a new \signalr:{agentId}\ conversation. When the portal sent a message with an explicit \conversationId\ (e.g. a REST-created conversation with no channel binding), the router stored the conversation but did not add a binding for \(signalr, agentId)\. On subsequent reconnects without a \conversationId\, \ResolveByBindingAsync\ returned null and a new duplicate conversation was created.

## Fix

Added **bind-on-first-use** to \DefaultConversationRouter.ResolveInboundAsync\ fast path:

- When a conversation is found via explicit \conversationId\ but has **no active binding** for \(channelType, channelAddress)\, one is added automatically.
- If the binding exists but is **muted** (e.g. stale disconnect mute), it is reactivated to \Interactive\.
- If an active binding already exists, no change is made (idempotent).

This ensures future reconnects without a \conversationId\ can find the conversation via binding lookup, eliminating duplicates.

## Tests

4 new tests in \PortalReconnectTests.cs\:
- \ResolveInbound_WithExplicitConversationId_AddsBindingWhenNoneExists\
- \ReconnectWithoutConversationId_FindsExistingConversation_AfterFirstSend\
- \ResolveInbound_WithExplicitConversationId_DoesNotDuplicateExistingBinding\
- \ResolveInbound_WithExplicitConversationId_ReactivatesMutedBinding\

84/84 conversation tests pass.