### PR TITLE
feat(portal): route canvas to active conversation in portal client

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
@@ -221,6 +221,15 @@ public sealed class ConversationState
     /// <summary>Virtual session kind label (for example, "cron"). Null for normal conversations.</summary>
     public string? VirtualSessionKind { get; set; }
 
+
+    // ── Canvas ──────────────────────────────────────────────────────────────────
+
+    /// <summary>Latest HTML payload published to the Canvas tab for this conversation.</summary>
+    public string? CanvasHtml { get; set; }
+
+    /// <summary>When the latest canvas payload was published to this conversation.</summary>
+    public DateTimeOffset? CanvasUpdatedAt { get; set; }
+
     // ── History flags ────────────────────────────────────────────────────────
 
     /// <summary>Whether the latest page of history has been loaded.</summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
@@ -85,6 +85,13 @@ public interface IGatewayRestClient
         string fileName,
         CancellationToken cancellationToken = default);
 
+    /// <summary>GET /api/agents/{agentId}/conversations/{conversationId}/canvas</summary>
+    /// <returns>The canvas HTML string, or null if none exists.</returns>
+    Task<string?> GetConversationCanvasAsync(
+        string agentId,
+        string conversationId,
+        CancellationToken ct = default);
+
     /// <summary>Current API base URL (set via Configure). Null if not yet configured.</summary>
     string? ApiBaseUrl { get; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -204,6 +204,22 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         _store.SetActiveConversation(agentId, conversationId);
 
+        // Fetch canvas from REST if not already loaded (Phase 3, #413)
+        if (conv is not null && conv.CanvasHtml is null)
+        {
+            try
+            {
+                var canvasHtml = await _restClient.GetConversationCanvasAsync(agentId, conversationId);
+                if (canvasHtml is not null)
+                {
+                    conv.CanvasHtml = canvasHtml;
+                    conv.CanvasUpdatedAt = DateTimeOffset.UtcNow;
+                    _store.NotifyChanged();
+                }
+            }
+            catch { /* canvas fetch is best-effort */ }
+        }
+
         // Load history if not already loaded
         var conv = agent.Conversations.GetValueOrDefault(conversationId);
         if (conv is not null && !conv.HistoryLoaded && !conv.IsLoadingHistory)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -39,7 +39,6 @@ public sealed class AgentInteractionService : IAgentInteractionService
         }
 
         var convIdNow = agent.ActiveConversationId!;
-        var conv = agent.Conversations.GetValueOrDefault(convIdNow);
         if (conv is null) return;
 
         conv.Messages.Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));
@@ -204,6 +203,8 @@ public sealed class AgentInteractionService : IAgentInteractionService
 
         _store.SetActiveConversation(agentId, conversationId);
 
+        var conv = agent.Conversations.GetValueOrDefault(conversationId);
+
         // Fetch canvas from REST if not already loaded (Phase 3, #413)
         if (conv is not null && conv.CanvasHtml is null)
         {
@@ -221,7 +222,6 @@ public sealed class AgentInteractionService : IAgentInteractionService
         }
 
         // Load history if not already loaded
-        var conv = agent.Conversations.GetValueOrDefault(conversationId);
         if (conv is not null && !conv.HistoryLoaded && !conv.IsLoadingHistory)
             await LoadConversationHistoryAsync(agentId, conversationId);
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -39,6 +39,7 @@ public sealed class AgentInteractionService : IAgentInteractionService
         }
 
         var convIdNow = agent.ActiveConversationId!;
+        var conv = _store.GetConversation(convIdNow);
         if (conv is null) return;
 
         conv.Messages.Add(new ChatMessage("User", content, DateTimeOffset.UtcNow));

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -473,8 +473,18 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         if (agent is null)
             return;
 
-        agent.CanvasHtml = string.IsNullOrWhiteSpace(html) ? null : html;
-        agent.CanvasUpdatedAt = DateTimeOffset.UtcNow;
+        // Route canvas to conversation (Phase 3, #413)
+        var conv = string.IsNullOrWhiteSpace(conversationId)
+            ? null
+            : agent.Conversations.GetValueOrDefault(conversationId);
+        if (conv is null)
+        {
+            // Fallback: unknown conversation — nothing to update
+            _store.NotifyChanged();
+            return;
+        }
+        conv.CanvasHtml = string.IsNullOrWhiteSpace(html) ? null : html;
+        conv.CanvasUpdatedAt = DateTimeOffset.UtcNow;
         _store.NotifyChanged();
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
@@ -20,6 +20,25 @@ public sealed class GatewayRestClient : IGatewayRestClient
     public string? ApiBaseUrl => _apiBaseUrl;
 
     /// <inheritdoc />
+    public async Task<string?> GetConversationCanvasAsync(
+        string agentId,
+        string conversationId,
+        CancellationToken ct = default)
+    {
+        var url = $"{_apiBase}/api/agents/{Uri.EscapeDataString(agentId)}/conversations/{Uri.EscapeDataString(conversationId)}/canvas";
+        try
+        {
+            var response = await _http.GetAsync(url, ct);
+            if (response.StatusCode == System.Net.HttpStatusCode.NoContent) return null;
+            if (!response.IsSuccessStatusCode) return null;
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public void Configure(string apiBaseUrl)
     {
         _apiBaseUrl = apiBaseUrl.TrimEnd('/') + "/";

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
@@ -25,7 +25,7 @@ public sealed class GatewayRestClient : IGatewayRestClient
         string conversationId,
         CancellationToken ct = default)
     {
-        var url = $"{_apiBase}/api/agents/{Uri.EscapeDataString(agentId)}/conversations/{Uri.EscapeDataString(conversationId)}/canvas";
+        var url = $"{_apiBaseUrl}/api/agents/{Uri.EscapeDataString(agentId)}/conversations/{Uri.EscapeDataString(conversationId)}/canvas";
         try
         {
             var response = await _http.GetAsync(url, ct);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/CanvasPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/CanvasPanel.razor
@@ -22,7 +22,27 @@
     [Parameter, EditorRequired]
     public string AgentId { get; set; } = default!;
 
-    private string? CanvasHtml => Store.GetAgent(AgentId)?.CanvasHtml;
+    /// <summary>
+    /// Optional conversation ID. When set, canvas is read from the conversation state.
+    /// Falls back to agent-level canvas when null (legacy support).
+    /// </summary>
+    [Parameter]
+    public string? ConversationId { get; set; }
+
+    private string? CanvasHtml
+    {
+        get
+        {
+            if (ConversationId is not null)
+            {
+                var conv = Store.GetConversation(ConversationId);
+                if (conv is not null)
+                    return conv.CanvasHtml;
+            }
+            // Legacy fallback: agent-level canvas
+            return Store.GetAgent(AgentId)?.CanvasHtml;
+        }
+    }
 
     protected override void OnInitialized()
     {

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPerConversationTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPerConversationTests.cs
@@ -1,5 +1,5 @@
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
-using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;
+
 using NSubstitute;
 using Xunit;
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPerConversationTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPerConversationTests.cs
@@ -1,0 +1,130 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for canvas-per-conversation routing (#413 Phase 3).
+/// </summary>
+public sealed class CanvasPerConversationTests
+{
+    private readonly ClientStateStore _store = new();
+    private readonly IGatewayRestClient _restClient = Substitute.For<IGatewayRestClient>();
+    private readonly GatewayHubConnection _hub = new();
+    private readonly GatewayEventHandler _handler;
+    private readonly AgentInteractionService _interaction;
+
+    public CanvasPerConversationTests()
+    {
+        _handler = new GatewayEventHandler(_store, _hub);
+        _interaction = new AgentInteractionService(_store, _hub, _restClient);
+    }
+
+    private AgentState SeedAgent(string agentId)
+    {
+        _store.SeedAgents([new AgentSummary(agentId, "Test Agent")]);
+        return _store.GetAgent(agentId)!;
+    }
+
+    private ConversationState SeedConversation(AgentState agent, string convId)
+    {
+        _store.SeedConversations(agent.AgentId, [
+            new ConversationSummaryDto(convId, agent.AgentId, "Test", false, "Active", null, 0,
+                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        return agent.Conversations[convId];
+    }
+
+    // ── HandleCanvasUpdated routes to conversation ────────────────────────
+
+    [Fact]
+    public void HandleCanvasUpdated_RoutesToConversation_NotAgent()
+    {
+        var agent = SeedAgent("agent-1");
+        var conv = SeedConversation(agent, "conv-1");
+
+        _handler.HandleCanvasUpdated("agent-1", "conv-1", "<h1>Hello</h1>");
+
+        Assert.Equal("<h1>Hello</h1>", conv.CanvasHtml);
+        Assert.NotNull(conv.CanvasUpdatedAt);
+        // Agent-level canvas should NOT be set
+        Assert.Null(agent.CanvasHtml);
+    }
+
+    [Fact]
+    public void HandleCanvasUpdated_EmptyHtml_ClearsConversationCanvas()
+    {
+        var agent = SeedAgent("agent-2");
+        var conv = SeedConversation(agent, "conv-2");
+        conv.CanvasHtml = "<p>Old</p>";
+
+        _handler.HandleCanvasUpdated("agent-2", "conv-2", "");
+
+        Assert.Null(conv.CanvasHtml);
+    }
+
+    [Fact]
+    public void HandleCanvasUpdated_UnknownConversation_DoesNotThrow()
+    {
+        var agent = SeedAgent("agent-3");
+
+        // Should not throw even when conversationId doesn't exist in the store
+        _handler.HandleCanvasUpdated("agent-3", "unknown-conv", "<p>test</p>");
+
+        Assert.Null(agent.CanvasHtml);
+    }
+
+    [Fact]
+    public void HandleCanvasUpdated_UnknownAgent_DoesNotThrow()
+    {
+        // Should not throw when agent doesn't exist
+        _handler.HandleCanvasUpdated("unknown-agent", "conv-1", "<p>test</p>");
+    }
+
+    [Fact]
+    public void HandleCanvasUpdated_SwitchConversations_EachHasOwnCanvas()
+    {
+        var agent = SeedAgent("agent-4");
+        var convA = SeedConversation(agent, "conv-a");
+        var convB = SeedConversation(agent, "conv-b");
+
+        _handler.HandleCanvasUpdated("agent-4", "conv-a", "<h1>Conv A</h1>");
+        _handler.HandleCanvasUpdated("agent-4", "conv-b", "<h2>Conv B</h2>");
+
+        Assert.Equal("<h1>Conv A</h1>", convA.CanvasHtml);
+        Assert.Equal("<h2>Conv B</h2>", convB.CanvasHtml);
+    }
+
+    // ── SelectConversation fetches canvas from REST ───────────────────────
+
+    [Fact]
+    public async Task SelectConversationAsync_FetchesCanvasFromRest_WhenCanvasIsNull()
+    {
+        var agent = SeedAgent("agent-5");
+        var conv = SeedConversation(agent, "conv-5");
+
+        _restClient.GetConversationCanvasAsync("agent-5", "conv-5", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>("<p>Persisted</p>"));
+
+        await _interaction.SelectConversationAsync("agent-5", "conv-5");
+
+        Assert.Equal("<p>Persisted</p>", conv.CanvasHtml);
+    }
+
+    [Fact]
+    public async Task SelectConversationAsync_DoesNotOverwriteExistingCanvas()
+    {
+        var agent = SeedAgent("agent-6");
+        var conv = SeedConversation(agent, "conv-6");
+        conv.CanvasHtml = "<p>Already Live</p>";
+
+        await _interaction.SelectConversationAsync("agent-6", "conv-6");
+
+        // REST should not be called when canvas is already populated
+        await _restClient.DidNotReceive().GetConversationCanvasAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        Assert.Equal("<p>Already Live</p>", conv.CanvasHtml);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPerConversationTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPerConversationTests.cs
@@ -28,13 +28,18 @@ public sealed class CanvasPerConversationTests
         return _store.GetAgent(agentId)!;
     }
 
-    private ConversationState SeedConversation(AgentState agent, string convId)
+    private static ConversationState SeedConversation(AgentState agent, string convId)
     {
-        _store.SeedConversations(agent.AgentId, [
-            new ConversationSummaryDto(convId, agent.AgentId, "Test", false, "Active", null, 0,
-                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
-        ]);
-        return agent.Conversations[convId];
+        // Add directly to avoid SeedConversations removing previously added conversations
+        var conv = new ConversationState
+        {
+            ConversationId = convId,
+            Title = "Test",
+            IsDefault = false,
+            Status = "Active"
+        };
+        agent.Conversations[convId] = conv;
+        return conv;
     }
 
     // ── HandleCanvasUpdated routes to conversation ────────────────────────

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -313,26 +313,28 @@ public sealed class GatewayEventHandlerTests
     }
 
     [Fact]
-    public void HandleCanvasUpdated_updates_canvas_for_matching_agent()
+    public void HandleCanvasUpdated_updates_canvas_for_matching_conversation()
     {
         var agent = _store.GetAgent("agent-1")!;
-        agent.CanvasHtml = null;
+        var conv = agent.Conversations["conv-1"];
+        conv.CanvasHtml = null;
 
         _handler.HandleCanvasUpdated("agent-1", "conv-1", "<div>Canvas</div>");
 
-        Assert.Equal("<div>Canvas</div>", agent.CanvasHtml);
-        Assert.NotNull(agent.CanvasUpdatedAt);
+        Assert.Equal("<div>Canvas</div>", conv.CanvasHtml);
+        Assert.NotNull(conv.CanvasUpdatedAt);
     }
 
     [Fact]
     public void HandleCanvasUpdated_ignores_unknown_agent()
     {
         var agent = _store.GetAgent("agent-1")!;
-        agent.CanvasHtml = "<p>existing</p>";
+        var conv = agent.Conversations["conv-1"];
+        conv.CanvasHtml = "<p>existing</p>";
 
         _handler.HandleCanvasUpdated("missing-agent", "conv-1", "<div>new</div>");
 
-        Assert.Equal("<p>existing</p>", agent.CanvasHtml);
+        Assert.Equal("<p>existing</p>", conv.CanvasHtml);
     }
 
     [Fact]
@@ -495,11 +497,12 @@ public sealed class GatewayEventHandlerTests
     public void HandleCanvasUpdated_empty_html_clears_canvas_state()
     {
         var agent = _store.GetAgent("agent-1")!;
-        agent.CanvasHtml = "<html><body>existing</body></html>";
+        var conv = agent.Conversations["conv-1"];
+        conv.CanvasHtml = "<html><body>existing</body></html>";
 
         _handler.HandleCanvasUpdated("agent-1", "conv-1", " ");
 
-        Assert.Null(agent.CanvasHtml);
+        Assert.Null(conv.CanvasHtml);
     }
 
     // -- Fix #235 - Sub-agent spawn notification task truncation -----------


### PR DESCRIPTION
Closes #413

## Changes

- Add `CanvasHtml` + `CanvasUpdatedAt` to `ConversationState`
- `GatewayEventHandler.HandleCanvasUpdated` now writes to conversation (not agent)
- `CanvasPanel.razor` accepts optional `ConversationId` param, reads from conversation with fallback to agent-level for backward compat
- `IGatewayRestClient.GetConversationCanvasAsync` added; fetched on `SelectConversationAsync` when canvas is not yet loaded
- `AgentInteractionService.SelectConversationAsync` fetches canvas from REST (best-effort) when conversation canvas is null
- 7 new tests: canvas routing, empty clear, unknown agent/conv, per-conversation isolation, REST fetch on select, no-overwrite guard

## Notes
- Depends on #412 (PR #427) for REST persistence. Canvas REST fetch is best-effort (catch-all) and will no-op until #427 merges.
- Blazor Client.Core obj directory race on Windows (15+ worktrees) blocked local test run; CI validates.

Sub-issue of #383.