### PR TITLE
chore(extensions): add configSchema and enabled to all extension manifests

### DIFF
--- a/src/extensions/BotNexus.Extensions.AudioTranscription/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.AudioTranscription/botnexus-extension.json
@@ -4,5 +4,31 @@
   "description": "Whisper-based audio transcription media handler",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.AudioTranscription.dll",
-  "extensionTypes": ["media-handler"]
+  "extensionTypes": ["media-handler"],
+  "enabled": true,
+  "configSchema": [
+    {
+      "id": "modelPath",
+      "type": "string",
+      "required": true,
+      "sensitive": false,
+      "description": "Path to the Whisper GGML model file."
+    },
+    {
+      "id": "language",
+      "type": "string",
+      "required": false,
+      "default": "en",
+      "sensitive": false,
+      "description": "Language code for transcription (e.g. 'en', 'fr'). Default: 'en'."
+    },
+    {
+      "id": "maxConcurrency",
+      "type": "integer",
+      "required": false,
+      "default": "1",
+      "sensitive": false,
+      "description": "Maximum number of concurrent transcription operations."
+    }
+  ]
 }

--- a/src/extensions/BotNexus.Extensions.Channels.ServiceBus/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.ServiceBus/botnexus-extension.json
@@ -1,10 +1,42 @@
 {
   "id": "botnexus-servicebus",
   "name": "Azure Service Bus Channel",
-  "description": "Azure Service Bus queue channel adapter — inbound message receive and reply dispatch via Service Bus queues",
+  "description": "Azure Service Bus queue channel adapter - inbound message receive and reply dispatch via Service Bus queues",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.Channels.ServiceBus.dll",
-  "extensionTypes": [
-    "channel"
+  "extensionTypes": ["channel"],
+  "enabled": true,
+  "configSchema": [
+    {
+      "id": "connectionString",
+      "type": "string",
+      "required": false,
+      "sensitive": true,
+      "description": "Service Bus connection string from the Azure portal Shared Access Policy. Not required when using managed identity with a custom IServiceBusAdapterClientFactory."
+    },
+    {
+      "id": "inboundQueueName",
+      "type": "string",
+      "required": false,
+      "default": "botnexus-inbound",
+      "sensitive": false,
+      "description": "Name of the Service Bus queue the adapter listens on for inbound messages."
+    },
+    {
+      "id": "defaultReplyQueueName",
+      "type": "string",
+      "required": false,
+      "default": "botnexus-outbound",
+      "sensitive": false,
+      "description": "Default queue for outbound replies when the inbound envelope does not specify a replyTo queue."
+    },
+    {
+      "id": "maxConcurrentCalls",
+      "type": "integer",
+      "required": false,
+      "default": "1",
+      "sensitive": false,
+      "description": "Maximum number of messages processed concurrently by the Service Bus processor."
+    }
   ]
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/botnexus-extension.json
@@ -4,5 +4,7 @@
   "description": "Real-time web communication channel with Blazor WASM client",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.Channels.SignalR.dll",
-  "extensionTypes": ["channel", "endpoint-contributor"]
+  "extensionTypes": ["channel", "endpoint-contributor"],
+  "enabled": true,
+  "configSchema": []
 }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/botnexus-extension.json
@@ -1,10 +1,56 @@
 {
   "id": "botnexus-telegram",
   "name": "Telegram Channel",
-  "description": "Telegram Bot API channel adapter — long polling, DMs and group topics",
+  "description": "Telegram Bot API channel adapter - long polling, DMs and group topics",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.Channels.Telegram.dll",
-  "extensionTypes": [
-    "channel"
+  "extensionTypes": ["channel"],
+  "enabled": true,
+  "configSchema": [
+    {
+      "id": "botToken",
+      "type": "string",
+      "required": true,
+      "sensitive": true,
+      "description": "Telegram Bot API token from @BotFather. Required for all operations."
+    },
+    {
+      "id": "agentId",
+      "type": "string",
+      "required": true,
+      "sensitive": false,
+      "description": "BotNexus agent ID this bot routes messages to."
+    },
+    {
+      "id": "webhookUrl",
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "description": "Webhook URL for webhook mode. When absent, the adapter uses long polling."
+    },
+    {
+      "id": "pollingTimeoutSeconds",
+      "type": "integer",
+      "required": false,
+      "default": "30",
+      "sensitive": false,
+      "description": "Long polling timeout in seconds."
+    },
+    {
+      "id": "streamingBufferMs",
+      "type": "integer",
+      "required": false,
+      "default": "500",
+      "sensitive": false,
+      "description": "Flush interval in milliseconds for buffered streaming deltas."
+    },
+    {
+      "id": "maxMessageLength",
+      "type": "integer",
+      "required": false,
+      "default": "4000",
+      "sensitive": false,
+      "description": "Maximum Telegram message length before payload splitting. Conservative default stays below Telegram's 4096-byte limit."
+    }
   ]
 }

--- a/src/extensions/BotNexus.Extensions.ExecTool/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.ExecTool/botnexus-extension.json
@@ -4,5 +4,7 @@
   "description": "Shell command execution tool for agents",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.ExecTool.dll",
-  "extensionTypes": ["tool"]
+  "extensionTypes": ["tool"],
+  "enabled": true,
+  "configSchema": []
 }

--- a/src/extensions/BotNexus.Extensions.Mcp/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Mcp/botnexus-extension.json
@@ -4,5 +4,7 @@
   "description": "Connects to MCP servers and bridges their tools into agent sessions",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.Mcp.dll",
-  "extensionTypes": ["tool"]
+  "extensionTypes": ["tool"],
+  "enabled": true,
+  "configSchema": []
 }

--- a/src/extensions/BotNexus.Extensions.McpInvoke/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.McpInvoke/botnexus-extension.json
@@ -4,5 +4,7 @@
   "description": "On-demand MCP server invocation tool for agents",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.McpInvoke.dll",
-  "extensionTypes": ["tool"]
+  "extensionTypes": ["tool"],
+  "enabled": true,
+  "configSchema": []
 }

--- a/src/extensions/BotNexus.Extensions.ProcessTool/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.ProcessTool/botnexus-extension.json
@@ -4,5 +4,7 @@
   "description": "Long-running process management tool for agents",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.ProcessTool.dll",
-  "extensionTypes": ["tool"]
+  "extensionTypes": ["tool"],
+  "enabled": true,
+  "configSchema": []
 }

--- a/src/extensions/BotNexus.Extensions.Skills/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Skills/botnexus-extension.json
@@ -4,5 +4,53 @@
   "description": "Dynamic skill loading and command contributions for agents",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.Skills.dll",
-  "extensionTypes": ["tool", "command"]
+  "extensionTypes": ["tool", "command"],
+  "enabled": true,
+  "configSchema": [
+    {
+      "id": "enabled",
+      "type": "bool",
+      "required": false,
+      "default": "true",
+      "sensitive": false,
+      "description": "Whether the skills system is enabled for this agent."
+    },
+    {
+      "id": "autoLoad",
+      "type": "array",
+      "required": false,
+      "sensitive": false,
+      "description": "Skill names to always load automatically for this agent."
+    },
+    {
+      "id": "disabled",
+      "type": "array",
+      "required": false,
+      "sensitive": false,
+      "description": "Skill names that are explicitly denied and never loaded."
+    },
+    {
+      "id": "allowed",
+      "type": "array",
+      "required": false,
+      "sensitive": false,
+      "description": "Skill names explicitly allowed. When null, all skills are allowed."
+    },
+    {
+      "id": "maxLoadedSkills",
+      "type": "integer",
+      "required": false,
+      "default": "20",
+      "sensitive": false,
+      "description": "Maximum number of skills that can be loaded simultaneously."
+    },
+    {
+      "id": "maxSkillContentChars",
+      "type": "integer",
+      "required": false,
+      "default": "100000",
+      "sensitive": false,
+      "description": "Maximum total characters of skill content included in the prompt."
+    }
+  ]
 }

--- a/src/extensions/BotNexus.Extensions.WebTools/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.WebTools/botnexus-extension.json
@@ -4,5 +4,47 @@
   "description": "Web search and fetch tools for agents",
   "version": "1.0.0",
   "entryAssembly": "BotNexus.Extensions.WebTools.dll",
-  "extensionTypes": ["tool"]
+  "extensionTypes": ["tool"],
+  "enabled": true,
+  "configSchema": [
+    {
+      "id": "search.provider",
+      "type": "string",
+      "required": false,
+      "default": "brave",
+      "sensitive": false,
+      "description": "Search provider to use: 'brave', 'tavily', 'bing', or 'copilot'."
+    },
+    {
+      "id": "search.apiKey",
+      "type": "string",
+      "required": false,
+      "sensitive": true,
+      "description": "API key for the configured search provider. Supports ${env:VAR} syntax."
+    },
+    {
+      "id": "search.maxResults",
+      "type": "integer",
+      "required": false,
+      "default": "5",
+      "sensitive": false,
+      "description": "Maximum number of search results to return."
+    },
+    {
+      "id": "fetch.maxLengthChars",
+      "type": "integer",
+      "required": false,
+      "default": "20000",
+      "sensitive": false,
+      "description": "Maximum content length in characters returned by the web fetch tool."
+    },
+    {
+      "id": "fetch.timeoutSeconds",
+      "type": "integer",
+      "required": false,
+      "default": "30",
+      "sensitive": false,
+      "description": "HTTP timeout in seconds for web fetch requests."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #437 — adds `configSchema` and `enabled` fields to all 10 existing extension manifests.

## Changes

All `botnexus-extension.json` manifests under `src/extensions/` updated with:
- `"enabled": true` — explicit opt-in flag (default was already true)
- `"configSchema": [...]` — field declarations derived from each extension's Options/Config class

### Schema coverage per extension

| Extension | Schema fields |
|---|---|
| AudioTranscription | `modelPath` (required), `language`, `maxConcurrency` |
| ServiceBus | `connectionString` (sensitive), `inboundQueueName`, `defaultReplyQueueName`, `maxConcurrentCalls` |
| SignalR | none (no operator config) |
| Telegram | `botToken` (required, sensitive), `agentId` (required), `webhookUrl`, `pollingTimeoutSeconds`, `streamingBufferMs`, `maxMessageLength` |
| ExecTool | none (no operator config) |
| Mcp | none (server config is per-agent) |
| McpInvoke | none (server config is per-agent) |
| ProcessTool | none (no operator config) |
| Skills | `enabled`, `autoLoad`, `disabled`, `allowed`, `maxLoadedSkills`, `maxSkillContentChars` |
| WebTools | `search.provider`, `search.apiKey` (sensitive), `search.maxResults`, `fetch.maxLengthChars`, `fetch.timeoutSeconds` |

## Testing

Build: ✅ clean  
Extension tests: ✅ all pass  
Pre-existing Gateway test failures (ConfigPathResolver, FanOut) are unrelated to this change and also fail on main.
