### PR TITLE
chore(scripts): install npm deps in repo init

### DIFF
--- a/scripts/repo/init.ps1
+++ b/scripts/repo/init.ps1
@@ -1,6 +1,11 @@
 # This script installs all the needed items so agents can 
 # work with the repo.
 
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+
 # Get OS
 $os = $env:OS
 
@@ -22,4 +27,23 @@ if ($os -like "*Linux*") {
     sudo apt update
     sudo apt install -y ripgrep grep
 
+}
+
+# Install local Node.js dependencies (includes VitePress from devDependencies).
+$npmCommand = Get-Command npm -ErrorAction SilentlyContinue
+if (-not $npmCommand) {
+    throw "npm was not found on PATH. Install Node.js and npm, then rerun scripts/repo/init.ps1."
+}
+
+Push-Location $repoRoot
+try {
+    if (Test-Path (Join-Path $repoRoot "package-lock.json")) {
+        npm ci
+    }
+    else {
+        npm install
+    }
+}
+finally {
+    Pop-Location
 }


### PR DESCRIPTION
Adds npm dependency installation to scripts/repo/init.ps1 so local docs tooling (including VitePress) is available after repo initialization.