### PR TITLE
feat(#453): add ProviderLoggingHandler DelegatingHandler for provider HTTP tracing

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/Logging/ProviderLoggingHandler.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Logging/ProviderLoggingHandler.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Agent.Providers.Core.Logging;
+
+/// <summary>
+/// <see cref="DelegatingHandler"/> that logs provider HTTP requests and responses at
+/// <see cref="LogLevel.Debug"/> level.
+/// <para>
+/// Auth headers (<c>x-api-key</c>, <c>Authorization</c>) are always redacted to <c>[REDACTED]</c>
+/// before logging, regardless of configuration.
+/// </para>
+/// <para>
+/// For streaming responses the response body is unavailable after headers — only the status code
+/// and elapsed time are logged on the response side. The caller (provider) owns the stream and
+/// must log its own usage data from SSE events.
+/// </para>
+/// </summary>
+public sealed class ProviderLoggingHandler(ILogger<ProviderLoggingHandler> logger) : DelegatingHandler
+{
+    /// <summary>Header names that are always redacted in request logs.</summary>
+    private static readonly HashSet<string> RedactedHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "x-api-key",
+        "Authorization",
+    };
+
+    /// <inheritdoc/>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!logger.IsEnabled(LogLevel.Debug))
+            return await base.SendAsync(request, cancellationToken);
+
+        var requestBody = await ReadRequestBodyAsync(request, cancellationToken);
+        var redactedHeaders = BuildRedactedHeaderString(request.Headers);
+
+        logger.LogDebug(
+            "Provider HTTP request: {Method} {Url} | Headers: {Headers} | Body: {Body}",
+            request.Method,
+            request.RequestUri,
+            redactedHeaders,
+            requestBody);
+
+        var sw = Stopwatch.StartNew();
+        HttpResponseMessage response;
+        try
+        {
+            response = await base.SendAsync(request, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            logger.LogDebug(
+                "Provider HTTP error after {ElapsedMs}ms: {Method} {Url} - {Error}",
+                sw.ElapsedMilliseconds,
+                request.Method,
+                request.RequestUri,
+                ex.Message);
+            throw;
+        }
+
+        sw.Stop();
+
+        // For streaming responses (text/event-stream) we must NOT buffer the body -
+        // the caller reads it as a live stream. Log status + elapsed only.
+        var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
+        if (contentType.Contains("event-stream", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Provider HTTP response: {Method} {Url} | Status: {Status} | Streaming | ElapsedMs: {ElapsedMs}",
+                request.Method,
+                request.RequestUri,
+                (int)response.StatusCode,
+                sw.ElapsedMilliseconds);
+        }
+        else
+        {
+            var responseBody = await ReadResponseBodyAsync(response, cancellationToken);
+            logger.LogDebug(
+                "Provider HTTP response: {Method} {Url} | Status: {Status} | ElapsedMs: {ElapsedMs} | Body: {Body}",
+                request.Method,
+                request.RequestUri,
+                (int)response.StatusCode,
+                sw.ElapsedMilliseconds,
+                responseBody);
+        }
+
+        return response;
+    }
+
+    private static async Task<string> ReadRequestBodyAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (request.Content is null)
+            return string.Empty;
+
+        try
+        {
+            // Buffer the content so the provider can still read it.
+            await request.Content.LoadIntoBufferAsync(cancellationToken);
+            var body = await request.Content.ReadAsStringAsync(cancellationToken);
+            return TruncateIfNeeded(body);
+        }
+        catch
+        {
+            return "<unreadable>";
+        }
+    }
+
+    private static async Task<string> ReadResponseBodyAsync(
+        HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Buffer so the caller can still read.
+            await response.Content.LoadIntoBufferAsync(cancellationToken);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            return TruncateIfNeeded(body);
+        }
+        catch
+        {
+            return "<unreadable>";
+        }
+    }
+
+    private static string BuildRedactedHeaderString(System.Net.Http.Headers.HttpRequestHeaders headers)
+    {
+        var sb = new StringBuilder();
+        foreach (var header in headers)
+        {
+            if (sb.Length > 0) sb.Append(", ");
+            var value = RedactedHeaders.Contains(header.Key)
+                ? "[REDACTED]"
+                : string.Join("; ", header.Value);
+            sb.Append(header.Key).Append('=').Append(value);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Truncates body strings to 4 KB to keep logs manageable.
+    /// Provider request bodies (large context windows) can be very large.
+    /// </summary>
+    private static string TruncateIfNeeded(string body, int maxChars = 4096)
+    {
+        if (body.Length <= maxChars)
+            return body;
+        return string.Concat(body.AsSpan(0, maxChars), $"... [truncated, total {body.Length} chars]");
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Isolation;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Extensions;
+using BotNexus.Agent.Providers.Core.Logging;
 using BotNexus.Agent.Providers.Anthropic;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
@@ -197,9 +198,19 @@ builder.Services.AddSingleton<ApiProviderRegistry>();
 builder.Services.AddSingleton<ModelRegistry>();
 builder.Services.AddSingleton<BuiltInModels>();
 builder.Services.AddHttpClient();
+builder.Services.AddTransient<ProviderLoggingHandler>();
 builder.Services.AddHttpClient("BotNexus", client =>
 {
     client.Timeout = TimeSpan.FromMinutes(10);
+}).AddHttpMessageHandler(sp =>
+{
+    // Conditionally attach the logging handler based on gateway config.
+    // The handler checks IsEnabled(Debug) internally — no log entries emitted when debug is off.
+    var config = sp.GetService<IOptionsMonitor<PlatformConfig>>()?.CurrentValue;
+    if (config?.Gateway?.EnableProviderRequestLogging == true)
+        return sp.GetRequiredService<ProviderLoggingHandler>();
+    // Return a no-op pass-through handler when logging is disabled.
+    return new NoOpDelegatingHandler();
 });
 builder.Services.AddSingleton<HttpClient>(sp =>
 {
@@ -458,3 +469,11 @@ static string? GetGitCommitHash()
 /// Entry point marker for integration testing.
 /// </summary>
 public partial class Program;
+
+/// <summary>No-op delegating handler used when provider HTTP logging is disabled.</summary>
+file sealed class NoOpDelegatingHandler : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+        => base.SendAsync(request, cancellationToken);
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -131,6 +131,13 @@ public sealed class GatewaySettingsConfig
     /// Example: <c>"America/Los_Angeles"</c>.
     /// </summary>
     public string? DefaultTimezone { get; set; }
+
+    /// <summary>
+    /// When true, all provider HTTP requests and responses are logged at Debug level.
+    /// Auth headers are always redacted. Response bodies are not buffered for streaming calls.
+    /// Off by default; enable only for debugging unexpected provider responses.
+    /// </summary>
+    public bool EnableProviderRequestLogging { get; set; } = false;
 }
 
 /// <summary>

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/Logging/ProviderLoggingHandlerTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/Logging/ProviderLoggingHandlerTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Text;
+using BotNexus.Agent.Providers.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BotNexus.Agent.Providers.Core.Tests.Logging;
+
+public class ProviderLoggingHandlerTests
+{
+    // ----- helpers -----
+
+    private static (ProviderLoggingHandler handler, List<(LogLevel level, string msg)> logs) CreateHandler(
+        bool debugEnabled = true, HttpMessageHandler? inner = null)
+    {
+        var captured = new List<(LogLevel level, string msg)>();
+        var loggerMock = new Mock<ILogger<ProviderLoggingHandler>>();
+        loggerMock.Setup(l => l.IsEnabled(It.IsAny<LogLevel>()))
+            .Returns<LogLevel>(l => l == LogLevel.Debug && debugEnabled);
+        loggerMock
+            .Setup(l => l.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback<LogLevel, EventId, object, Exception?, Delegate>((lvl, _, state, _, formatter) =>
+            {
+                captured.Add((lvl, formatter.DynamicInvoke(state, null) as string ?? ""));
+            });
+
+        var handler = new ProviderLoggingHandler(loggerMock.Object)
+        {
+            InnerHandler = inner ?? new OkHandler()
+        };
+        return (handler, captured);
+    }
+
+    private static HttpRequestMessage MakeRequest(string body = "{}", string url = "https://api.anthropic.com/v1/messages")
+        => new(HttpMethod.Post, url)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+
+    // ----- auth header redaction -----
+
+    [Fact]
+    public async Task AuthHeaders_AreAlwaysRedacted_XApiKey()
+    {
+        var (handler, logs) = CreateHandler();
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest();
+        req.Headers.TryAddWithoutValidation("x-api-key", "sk-ant-secret");
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        var requestLog = logs.First(l => l.msg.Contains("request"));
+        Assert.Contains("[REDACTED]", requestLog.msg);
+        Assert.DoesNotContain("sk-ant-secret", requestLog.msg);
+    }
+
+    [Fact]
+    public async Task AuthHeaders_AreAlwaysRedacted_Authorization()
+    {
+        var (handler, logs) = CreateHandler();
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest();
+        req.Headers.TryAddWithoutValidation("Authorization", "Bearer sk-secret-token");
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        var requestLog = logs.First(l => l.msg.Contains("request"));
+        Assert.Contains("[REDACTED]", requestLog.msg);
+        Assert.DoesNotContain("sk-secret-token", requestLog.msg);
+    }
+
+    [Fact]
+    public async Task NonAuthHeaders_AreNotRedacted()
+    {
+        var (handler, logs) = CreateHandler();
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest();
+        req.Headers.TryAddWithoutValidation("anthropic-version", "2023-06-01");
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        var requestLog = logs.First(l => l.msg.Contains("request"));
+        Assert.Contains("2023-06-01", requestLog.msg);
+    }
+
+    // ----- opt-in flag (debug disabled) -----
+
+    [Fact]
+    public async Task WhenDebugDisabled_NoLogsEmitted()
+    {
+        var (handler, logs) = CreateHandler(debugEnabled: false);
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest();
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        Assert.Empty(logs);
+    }
+
+    [Fact]
+    public async Task WhenDebugEnabled_RequestAndResponseLogged()
+    {
+        var (handler, logs) = CreateHandler(debugEnabled: true);
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest();
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        Assert.Contains(logs, l => l.msg.Contains("request"));
+        Assert.Contains(logs, l => l.msg.Contains("response"));
+    }
+
+    // ----- structured fields -----
+
+    [Fact]
+    public async Task RequestLog_ContainsMethodAndUrl()
+    {
+        var (handler, logs) = CreateHandler();
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest(url: "https://api.openai.com/v1/chat/completions");
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        var requestLog = logs.First(l => l.msg.Contains("request"));
+        Assert.Contains("POST", requestLog.msg);
+        Assert.Contains("openai.com", requestLog.msg);
+    }
+
+    [Fact]
+    public async Task ResponseLog_ContainsStatusCode()
+    {
+        var (handler, logs) = CreateHandler(inner: new StatusCodeHandler(HttpStatusCode.OK));
+        var invoker = new HttpMessageInvoker(handler);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        var responseLog = logs.First(l => l.msg.Contains("response"));
+        Assert.Contains("200", responseLog.msg);
+    }
+
+    // ----- streaming path -----
+
+    [Fact]
+    public async Task StreamingResponse_LogsStreamingMarker_NotBody()
+    {
+        var sseBody = "event: message_start\ndata: {}\n\n";
+        var (handler, logs) = CreateHandler(inner: new SseHandler(sseBody));
+        var invoker = new HttpMessageInvoker(handler);
+
+        await invoker.SendAsync(MakeRequest(), CancellationToken.None);
+
+        var responseLog = logs.First(l => l.msg.Contains("response"));
+        Assert.Contains("Streaming", responseLog.msg);
+        // SSE body must NOT be buffered/logged
+        Assert.DoesNotContain("message_start", responseLog.msg);
+    }
+
+    // ----- truncation -----
+
+    [Fact]
+    public async Task LargeBody_IsTruncatedInLog()
+    {
+        var bigBody = new string('x', 10_000);
+        var (handler, logs) = CreateHandler();
+        var invoker = new HttpMessageInvoker(handler);
+        var req = MakeRequest(body: bigBody);
+
+        await invoker.SendAsync(req, CancellationToken.None);
+
+        var requestLog = logs.First(l => l.msg.Contains("request"));
+        Assert.Contains("truncated", requestLog.msg);
+    }
+
+    // ----- inner handler stubs -----
+
+    private sealed class OkHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            });
+    }
+
+    private sealed class StatusCodeHandler(HttpStatusCode code) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(code)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            });
+    }
+
+    private sealed class SseHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "text/event-stream")
+            });
+    }
+}


### PR DESCRIPTION
Closes #453

Adds ProviderLoggingHandler DelegatingHandler for tracing provider HTTP calls.

- Off by default (gateway.enableProviderRequestLogging)
- Auth headers always redacted
- Streaming: logs status+elapsed only, body not buffered
- 9 new tests, 0 failures