### PR TITLE
fix(ci): use .NET 10 SDK in publish-cli workflow and add global.json

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -38,9 +38,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          # .NET 10 is not generally available on GitHub-hosted runners.
-          # Use the latest LTS SDK unless you explicitly require .NET 10.
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.204",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Closes #442

## Changes

### `.github/workflows/publish-cli.yml`
- Changed `dotnet-version: '8.0.x'` → `'10.0.x'`
- Removed the stale comment that said `.NET 10 is not generally available on GitHub-hosted runners` (it is now)
- The CLI targets `net10.0`; using 8.x SDK was only working by coincidence (GitHub runners had .NET 10 preview alongside the explicitly installed 8.x)

### `global.json` (new)
- Pins minimum SDK to `10.0.204` with `rollForward: latestMinor`
- Prevents future silently-wrong builds on machines with older SDK installed

## Notes
- This does not change runtime requirements. Users still need .NET 10 runtime to run the CLI tool
- A README doc update noting `.NET 10 SDK required` was listed in the issue — flagging for Jon to add to README separately as a docs-only change