### PR TITLE
fix(portal): hide desktop agent dropdown on mobile and route to /mobile/ path

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -498,7 +498,7 @@
         // The desktop and mobile portals are separate apps served at "/" and "/mobile/".
         var target = _isMobile ? "/mobile/" + relPath : relPath;
 
-        var current = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd("/");
+        var current = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
         if (!string.Equals(current, relPath, StringComparison.OrdinalIgnoreCase))
             Nav.NavigateTo(target, forceLoad: _isMobile);
     }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -61,7 +61,7 @@
                 @* Scrollable agent/conversation section *@
                 <div class="sidebar-scroll-region">
                 @* Agent dropdown + session list nested under Chat *@
-                @if (Store.Agents.Values.Any(a => !a.IsReadOnly))
+                @if (!_isMobile && Store.Agents.Values.Any(a => !a.IsReadOnly))
                 {
                     <div class="agent-dropdown-container">
                         <select class="agent-dropdown-select"
@@ -490,13 +490,17 @@
     private void NavigateToChat(string agentId, string? conversationId = null)
     {
         var encodedAgentId = Uri.EscapeDataString(agentId);
-        var target = string.IsNullOrWhiteSpace(conversationId)
+        var relPath = string.IsNullOrWhiteSpace(conversationId)
             ? $"chat/{encodedAgentId}"
             : $"chat/{encodedAgentId}/{Uri.EscapeDataString(conversationId)}";
 
-        var current = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
-        if (!string.Equals(current, target, StringComparison.OrdinalIgnoreCase))
-            Nav.NavigateTo(target);
+        // On mobile, navigate to the mobile app path (/mobile/chat/...).
+        // The desktop and mobile portals are separate apps served at "/" and "/mobile/".
+        var target = _isMobile ? "/mobile/" + relPath : relPath;
+
+        var current = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd("/");
+        if (!string.Equals(current, relPath, StringComparison.OrdinalIgnoreCase))
+            Nav.NavigateTo(target, forceLoad: _isMobile);
     }
 
     private async Task ArchiveConversationAsync(string agentId, string conversationId, string title, bool isVirtualSession)

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -566,4 +566,37 @@ public sealed class MainLayoutTests : IDisposable
 
         Assert.Empty(cut.FindAll(".agent-dropdown-select"));
     }
+
+    [Fact]
+    public void AgentDropdown_NotRendered_WhenIsMobileIsTrue()
+    {
+        // Arrange: seed an agent so the dropdown would normally appear
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.NotifyChanged();
+
+        // Simulate JS isMobileView returning true (fires in OnAfterRenderAsync)
+        _ctx.JSInterop.Setup<bool>("chatScroll.isMobileView").SetResult(true);
+
+        // Act
+        var cut = RenderLayout();
+        // Wait for after-render to fire (_isMobile to be set)
+        cut.WaitForAssertion(() =>
+            Assert.Empty(cut.FindAll(".agent-dropdown-select")),
+            TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void AgentDropdown_Rendered_WhenIsMobileIsFalse()
+    {
+        // Desktop default: isMobileView returns false (default Loose mock behavior)
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.NotifyChanged();
+
+        _ctx.JSInterop.Setup<bool>("chatScroll.isMobileView").SetResult(false);
+
+        var cut = RenderLayout();
+
+        // Dropdown should be visible on desktop
+        cut.Find(".agent-dropdown-select");
+    }
 }


### PR DESCRIPTION
Closes #444

## Changes

### `MainLayout.razor`
1. **Agent dropdown hidden on mobile**: Wrapped the `@if (Store.Agents.Values.Any(a => !a.IsReadOnly))` block with `@if (!_isMobile && ...)`. After JS detection fires and sets `_isMobile=true`, the dropdown no longer renders, preventing mobile users from accidentally triggering desktop navigation.
2. **`NavigateToChat` routes to `/mobile/` on mobile**: When `_isMobile` is true, navigation prepends `/mobile/` to navigate to the mobile app path (e.g. `/mobile/chat/{agentId}/{convId}`) with `forceLoad: true`. This keeps mobile users in the mobile shell.

## Tests Added
- `AgentDropdown_NotRendered_WhenIsMobileIsTrue` — asserts dropdown is absent after JS returns `isMobileView=true`
- `AgentDropdown_Rendered_WhenIsMobileIsFalse` — regression: dropdown is present on desktop