### PR TITLE
fix(portal): defer conversation list refresh while agent is streaming

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -20,6 +20,11 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
     private readonly GatewayHubConnection _hub;
     private readonly HashSet<string> _streamingWhenDisconnected = new();
 
+    // Conversation refreshes that arrive during a streaming turn are deferred
+    // until HandleMessageEnd/HandleError to avoid overwriting ActiveSessionId
+    // mid-turn (breaks stream event routing -- issue #456).
+    private readonly HashSet<string> _pendingConversationRefresh = new();
+
     public GatewayEventHandler(IClientStateStore store, GatewayHubConnection hub)
     {
         _store = store;
@@ -263,6 +268,10 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
         _store.ClearPendingAskUser(convId);
         _store.NotifyChanged();
+
+        // Drain any conversation-list refreshes that were deferred during the stream
+        // (e.g., conversation(action=new) called mid-turn -- issue #456).
+        DrainPendingConversationRefreshes(agentId!);
     }
 
     public void HandleError(AgentStreamEvent evt)
@@ -286,6 +295,10 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         }
 
         _store.NotifyChanged();
+
+        // Drain deferred refreshes on error-exit as well.
+        if (agentId is not null)
+            DrainPendingConversationRefreshes(agentId);
     }
 
     public void HandleUserInputRequired(AgentStreamEvent evt)
@@ -749,6 +762,16 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
         // Fallback: full conversation list refresh (covers create/archive and cases
         // where the conversation is not yet in the local store).
+        // Guard: defer refresh if the agent is mid-stream -- SeedConversations overwrites
+        // ActiveSessionId from server state, which breaks TryResolveConversationBySession
+        // and causes stream events to stop rendering in the portal (issue #456).
+        var streamingAgent = _store.GetAgent(agentId);
+        if (streamingAgent?.IsStreaming == true)
+        {
+            _pendingConversationRefresh.Add(agentId);
+            return;
+        }
+
         _ = RefreshConversationsAsync(agentId);
     }
 
@@ -757,6 +780,14 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
     private Task RefreshConversationsAsync(string agentId)
         => ConversationRefreshDelegate?.Invoke(agentId) ?? Task.CompletedTask;
+
+    private void DrainPendingConversationRefreshes(string agentId)
+    {
+        if (!_pendingConversationRefresh.Remove(agentId))
+            return;
+        _ = RefreshConversationsAsync(agentId);
+    }
+
     public void Dispose()
     {
         _hub.OnConnected -= HandleConnected;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
 
@@ -609,5 +609,60 @@ public sealed class GatewayEventHandlerTests
         Assert.True(found, "session should be directly resolved to conv-2 after RegisterSession");
         Assert.Equal("conv-2", resolvedConvId);
     }
-}
 
+    // -- Fix #456 - Deferred conversation refresh during streaming --------
+
+    [Fact]
+    public void HandleConversationChanged_DefersRefresh_WhenAgentIsStreaming()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.IsStreaming = true;
+
+        var refreshCalled = false;
+        _handler.ConversationRefreshDelegate = _ => { refreshCalled = true; return Task.CompletedTask; };
+
+        // A new conversation arrives that is not in local state (fast path misses)
+        _handler.HandleConversationChanged(new ConversationChangedPayload("create", "agent-1", "new-conv-99"));
+
+        // Must NOT refresh while streaming
+        Assert.False(refreshCalled, "refresh must be deferred during active stream");
+    }
+
+    [Fact]
+    public async Task HandleConversationChanged_DrainsPendingRefresh_AfterMessageEnd()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "hello";
+
+        var refreshCount = 0;
+        _handler.ConversationRefreshDelegate = _ => { refreshCount++; return Task.CompletedTask; };
+
+        // Conversation change arrives mid-stream
+        _handler.HandleConversationChanged(new ConversationChangedPayload("create", "agent-1", "new-conv-99"));
+        Assert.Equal(0, refreshCount); // deferred
+
+        // Stream ends
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        await Task.Delay(20); // allow fire-and-forget refresh to execute
+        Assert.Equal(1, refreshCount); // drained after turn end
+    }
+
+    [Fact]
+    public void HandleConversationChanged_RefreshesImmediately_WhenNotStreaming()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.IsStreaming = false;
+
+        var refreshCalled = false;
+        _handler.ConversationRefreshDelegate = _ => { refreshCalled = true; return Task.CompletedTask; };
+
+        _handler.HandleConversationChanged(new ConversationChangedPayload("create", "agent-1", "new-conv-99"));
+
+        Assert.True(refreshCalled, "refresh must fire immediately when not streaming");
+    }
+
+}


### PR DESCRIPTION
Closes #456

## Problem

When an agent calls `conversation(action=new)` mid-turn, a `ConversationChangedPayload` arrives for a conversation not yet in local state. The fallback `RefreshConversationsAsync` path runs `SeedConversations` synchronously, which overwrites `ActiveSessionId` on existing conversations from a server snapshot that may be slightly stale. Once `TryResolveConversationBySession` breaks, all subsequent stream events (ContentDelta, ToolEnd, MessageEnd) silently fail to route to the originating conversation. The portal goes dark until a page refresh.

## Fix

- Added `_pendingConversationRefresh: HashSet<string>` to `GatewayEventHandler`
- `HandleConversationChanged` fallback path checks `agent.IsStreaming` before firing `RefreshConversationsAsync`; if streaming, queues the agentId instead
- `HandleMessageEnd` and `HandleError` drain the pending set via `DrainPendingConversationRefreshes(agentId!)` after streaming ends
- 3 new unit tests: deferred during stream, drained on MessageEnd, immediate when not streaming