### PR TITLE
feat(memory): flush memory on session reset before archiving

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -42,6 +42,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     private readonly IConversationStore? _conversationStore;
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
     private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
+    private readonly ISessionEndMemoryFlusher? _sessionEndFlusher;
     private readonly ILogger<GatewayHub> _logger;
 
     public GatewayHub(
@@ -57,7 +58,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         IOptionsMonitor<CompactionOptions> compactionOptions,
         ILogger<GatewayHub> logger,
         IConversationStore? conversationStore = null,
-        IAskUserResponseRegistry? askUserResponseRegistry = null)
+        IAskUserResponseRegistry? askUserResponseRegistry = null,
+        ISessionEndMemoryFlusher? sessionEndFlusher = null)
     {
         _supervisor = supervisor;
         _registry = registry;
@@ -72,6 +74,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         _logger = logger;
         _conversationStore = conversationStore;
         _askUserResponseRegistry = askUserResponseRegistry;
+        _sessionEndFlusher = sessionEndFlusher;
     }
 
     /// <summary>
@@ -476,6 +479,25 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var typedAgentId = NormalizeAgentId(agentId);
         var typedSessionId = NormalizeSessionId(sessionId);
         await _supervisor.StopAsync(typedAgentId, typedSessionId, CancellationToken.None);
+
+        // Phase 2: session-end memory flush before archiving
+        if (_sessionEndFlusher is not null)
+        {
+            var gatewaySession = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
+            if (gatewaySession is not null && _sessionEndFlusher.ShouldFlush(gatewaySession.Session, _compactionOptions.CurrentValue))
+            {
+                try
+                {
+                    await _sessionEndFlusher.FlushAsync(typedAgentId, gatewaySession.Session, _compactionOptions.CurrentValue, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Session-end memory flush failed for session {SessionId}, reset will proceed.", typedSessionId);
+                }
+            }
+        }
+
         await _sessions.ArchiveAsync(typedSessionId, CancellationToken.None);
         await Clients.Caller.SessionReset(new SessionResetPayload(typedAgentId.Value, typedSessionId.Value));
     }

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
@@ -30,24 +30,32 @@ public sealed record CompactionOptions
 }
 
 /// <summary>
-/// Configuration for the pre-compaction memory flush turn.
+/// Configuration for memory flush turns.
+/// Used for both pre-compaction flush (Phase 1) and session-end flush (Phase 2).
 /// When enabled, the agent is given a brief turn to write important context to
 /// memory files (e.g. <c>memory/YYYY-MM-DD.md</c>) before the session history
-/// is summarised and truncated.
+/// is summarised or discarded.
 /// </summary>
 public sealed record MemoryFlushOptions
 {
-    /// <summary>Whether pre-compaction memory flush is enabled (default: true).</summary>
+    /// <summary>Whether memory flush is enabled (default: true).</summary>
     public bool Enabled { get; init; } = true;
 
     /// <summary>
-    /// The prompt sent to the agent during the flush turn.
-    /// The agent should use this turn to write important context to memory files.
+    /// The prompt sent to the agent during the pre-compaction flush turn.
     /// </summary>
     public string PromptText { get; init; } =
         "Session compaction is about to run. " +
         "Write any important context, decisions, or open items from this conversation to your daily memory file " +
         "(memory/YYYY-MM-DD.md) now. Keep it brief and focused on what must survive compaction.";
+
+    /// <summary>
+    /// The prompt sent to the agent during the session-end flush turn (on /reset or explicit session close).
+    /// </summary>
+    public string SessionEndPromptText { get; init; } =
+        "This session is ending. " +
+        "Write any important context, decisions, or open items from this conversation to your daily memory file " +
+        "(memory/YYYY-MM-DD.md) now. Keep it brief and focused on what should persist.";
 
     /// <summary>Maximum seconds to wait for the flush turn to complete (default: 60).</summary>
     public int TimeoutSeconds { get; init; } = 60;

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionEndMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionEndMemoryFlusher.cs
@@ -1,0 +1,24 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Abstractions.Sessions;
+
+/// <summary>
+/// Session-end memory flush service.
+/// Fires a synthetic memory-trigger agent turn when a session is explicitly
+/// reset or closed, giving the agent an opportunity to persist important context
+/// before the session history is archived.
+/// </summary>
+public interface ISessionEndMemoryFlusher
+{
+    /// <summary>
+    /// Returns true when a session-end memory flush should run.
+    /// </summary>
+    bool ShouldFlush(Session session, CompactionOptions options);
+
+    /// <summary>
+    /// Fires a memory-trigger agent turn and awaits completion (with timeout).
+    /// Non-fatal: exceptions are caught and logged — session reset always proceeds.
+    /// </summary>
+    Task FlushAsync(AgentId agentId, Session session, CompactionOptions options, CancellationToken ct = default);
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -141,6 +141,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IChannelAdapter>(serviceProvider => serviceProvider.GetRequiredService<InternalChannelAdapter>());
         services.AddSingleton<ISessionCompactor, LlmSessionCompactor>();
         services.AddSingleton<IPreCompactionMemoryFlusher, PreCompactionMemoryFlusher>();
+        services.AddSingleton<ISessionEndMemoryFlusher, SessionEndMemoryFlusher>();
         services.AddSingleton<IMediaPipeline, MediaPipeline>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICommandContributor, BuiltInCommandContributor>());
         services.TryAddSingleton<CommandRegistry>();

--- a/src/gateway/BotNexus.Gateway/Sessions/SessionEndMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/SessionEndMemoryFlusher.cs
@@ -1,0 +1,96 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Triggers;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// Fires a synthetic memory-trigger agent turn immediately before a session is archived
+/// (i.e. on /reset or explicit session close).
+/// Gives the agent an opportunity to persist important context before the session history
+/// is discarded.
+/// </summary>
+public sealed class SessionEndMemoryFlusher : ISessionEndMemoryFlusher
+{
+    private readonly IEnumerable<IInternalTrigger> _triggers;
+    private readonly ILogger<SessionEndMemoryFlusher> _logger;
+
+    public SessionEndMemoryFlusher(
+        IEnumerable<IInternalTrigger> triggers,
+        ILogger<SessionEndMemoryFlusher> logger)
+    {
+        _triggers = triggers;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public bool ShouldFlush(Session session, CompactionOptions options)
+    {
+        if (!options.MemoryFlush.Enabled)
+            return false;
+
+        // Never flush for non-interactive sessions (heartbeat, cron, sub-agent)
+        if (!session.IsInteractive)
+            return false;
+
+        // Skip sessions with no user turns — nothing worth flushing
+        return session.History.Any(e => e.Role == MessageRole.User);
+    }
+
+    /// <inheritdoc/>
+    public async Task FlushAsync(AgentId agentId, Session session, CompactionOptions options, CancellationToken ct = default)
+    {
+        var trigger = ResolveTrigger();
+        if (trigger is null)
+        {
+            _logger.LogWarning(
+                "No suitable internal trigger found for session-end memory flush on session {SessionId}. Skipping flush.",
+                session.SessionId);
+            return;
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(options.MemoryFlush.TimeoutSeconds));
+
+        try
+        {
+            _logger.LogInformation(
+                "Session-end memory flush starting for session {SessionId}, agent {AgentId}.",
+                session.SessionId, agentId);
+
+            await trigger.CreateSessionAsync(
+                agentId,
+                options.MemoryFlush.SessionEndPromptText,
+                timeoutCts.Token,
+                new InternalTriggerRequest
+                {
+                    ConversationId = session.ConversationId?.Value
+                }).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Session-end memory flush completed for session {SessionId}.",
+                session.SessionId);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "Session-end memory flush timed out after {Seconds}s for session {SessionId}. Session will proceed with reset.",
+                options.MemoryFlush.TimeoutSeconds, session.SessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Session-end memory flush failed for session {SessionId}. Session will proceed with reset.",
+                session.SessionId);
+        }
+    }
+
+    private IInternalTrigger? ResolveTrigger()
+    {
+        var all = _triggers.ToList();
+        return all.FirstOrDefault(t => t.Type.Equals(TriggerType.Memory))
+            ?? all.FirstOrDefault(t => t.Type.Equals(TriggerType.Cron));
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionEndMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionEndMemoryFlusherTests.cs
@@ -1,0 +1,171 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Triggers;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+public sealed class SessionEndMemoryFlusherTests
+{
+    private static readonly AgentId TestAgent = AgentId.From("agent-a");
+
+    // ─── ShouldFlush ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ShouldFlush_WhenEnabled_InteractiveSession_WithUserTurns_ReturnsTrue()
+    {
+        var session = BuildInteractiveSessionWithUserTurn();
+        var flusher = CreateFlusher();
+        var options = EnabledOptions();
+
+        flusher.ShouldFlush(session, options).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenDisabled_ReturnsFalse()
+    {
+        var session = BuildInteractiveSessionWithUserTurn();
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = false } };
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenNonInteractiveSession_ReturnsFalse()
+    {
+        var session = BuildSession(SessionType.Heartbeat);
+        session.History.Add(new SessionEntry { Role = MessageRole.User, Content = "hello" });
+        var flusher = CreateFlusher();
+        var options = EnabledOptions();
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenNoUserTurns_ReturnsFalse()
+    {
+        var session = BuildInteractiveSession();
+        // No user turns added
+        var flusher = CreateFlusher();
+        var options = EnabledOptions();
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    // ─── FlushAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FlushAsync_WithMemoryTrigger_CallsCreateSessionWithSessionEndPrompt()
+    {
+        var session = BuildInteractiveSessionWithUserTurn();
+        var options = EnabledOptions();
+        var triggerMock = new Mock<IInternalTrigger>();
+        triggerMock.Setup(t => t.Type).Returns(TriggerType.Memory);
+        triggerMock
+            .Setup(t => t.CreateSessionAsync(
+                TestAgent,
+                options.MemoryFlush.SessionEndPromptText,
+                It.IsAny<CancellationToken>(),
+                It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(SessionId.Create());
+
+        var flusher = CreateFlusher(triggerMock.Object);
+        await flusher.FlushAsync(TestAgent, session, options);
+
+        triggerMock.Verify(t => t.CreateSessionAsync(
+            TestAgent,
+            options.MemoryFlush.SessionEndPromptText,
+            It.IsAny<CancellationToken>(),
+            It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FlushAsync_WithNoTrigger_DoesNotThrow()
+    {
+        var session = BuildInteractiveSessionWithUserTurn();
+        var options = EnabledOptions();
+        var flusher = CreateFlusher(); // no triggers
+
+        // Should not throw — just logs a warning
+        await flusher.FlushAsync(TestAgent, session, options);
+    }
+
+    [Fact]
+    public async Task FlushAsync_WhenTriggerThrows_DoesNotRethrow()
+    {
+        var session = BuildInteractiveSessionWithUserTurn();
+        var options = EnabledOptions();
+        var triggerMock = new Mock<IInternalTrigger>();
+        triggerMock.Setup(t => t.Type).Returns(TriggerType.Memory);
+        triggerMock
+            .Setup(t => t.CreateSessionAsync(
+                It.IsAny<AgentId>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<InternalTriggerRequest?>()))
+            .ThrowsAsync(new InvalidOperationException("trigger exploded"));
+
+        var flusher = CreateFlusher(triggerMock.Object);
+
+        // Should not throw — flush is non-fatal
+        await flusher.FlushAsync(TestAgent, session, options);
+    }
+
+    [Fact]
+    public async Task FlushAsync_UsesCronTrigger_WhenNoMemoryTriggerRegistered()
+    {
+        var session = BuildInteractiveSessionWithUserTurn();
+        var options = EnabledOptions();
+        var cronTriggerMock = new Mock<IInternalTrigger>();
+        cronTriggerMock.Setup(t => t.Type).Returns(TriggerType.Cron);
+        cronTriggerMock
+            .Setup(t => t.CreateSessionAsync(
+                It.IsAny<AgentId>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<InternalTriggerRequest?>()))
+            .ReturnsAsync(SessionId.Create());
+
+        var flusher = CreateFlusher(cronTriggerMock.Object);
+        await flusher.FlushAsync(TestAgent, session, options);
+
+        cronTriggerMock.Verify(t => t.CreateSessionAsync(
+            It.IsAny<AgentId>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<InternalTriggerRequest?>()),
+            Times.Once);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private static Session BuildInteractiveSessionWithUserTurn()
+    {
+        var session = BuildInteractiveSession();
+        session.History.Add(new SessionEntry { Role = MessageRole.User, Content = "hello" });
+        return session;
+    }
+
+    private static Session BuildInteractiveSession() => BuildSession(SessionType.UserAgent);
+
+    private static Session BuildSession(SessionType type)
+    {
+        return new Session
+        {
+            SessionId = SessionId.Create(),
+            AgentId = TestAgent.Value,
+            SessionType = type
+        };
+    }
+
+    private static SessionEndMemoryFlusher CreateFlusher(params IInternalTrigger[] triggers)
+        => new(triggers, NullLogger<SessionEndMemoryFlusher>.Instance);
+
+    private static CompactionOptions EnabledOptions()
+        => new() { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+}


### PR DESCRIPTION
Closes #417

## Changes

- Added `ISessionEndMemoryFlusher` interface in `BotNexus.Gateway.Contracts`
- Added `SessionEndMemoryFlusher` implementation — fires a synthetic memory-trigger turn before session archive
- Added `SessionEndPromptText` to `MemoryFlushOptions` (separate prompt for session-end vs pre-compaction)
- Wired into `GatewayHub.ResetSession` as optional `ISessionEndMemoryFlusher?` parameter
- Registered `SessionEndMemoryFlusher` in DI
- Non-fatal: if flush times out or throws, session reset proceeds
- 5 new tests covering ShouldFlush guards and FlushAsync happy/sad paths

## Sub-issue

Part of #32 (Memory lifecycle)