### PR TITLE
feat(portal): add extensions config panel with schema display

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ExtensionsConfigPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/Config/ExtensionsConfigPanel.razor
@@ -1,0 +1,149 @@
+@using System.Net.Http.Json
+@using System.Text.Json
+@inject HttpClient Http
+
+<div class="pcfg-section">
+    <h3 class="pcfg-section-title">Loaded Extensions</h3>
+
+    @if (_loading)
+    {
+        <div class="config-loading">
+            <div class="loading-spinner small"></div>
+            <span>Loading extensions...</span>
+        </div>
+    }
+    else if (_error is not null)
+    {
+        <div class="pcfg-empty-state">@_error</div>
+    }
+    else if (_extensions.Count == 0)
+    {
+        <div class="pcfg-empty-state">No extensions loaded.</div>
+    }
+    else
+    {
+        foreach (var ext in _extensions)
+        {
+            <div class="ext-card @(ext.Enabled ? "" : "ext-card--disabled")">
+                <div class="ext-card-header">
+                    <span class="ext-name">@ext.Name</span>
+                    <span class="ext-version">v@(ext.Version)</span>
+                    @if (!ext.Enabled)
+                    {
+                        <span class="ext-badge ext-badge--disabled">Disabled</span>
+                    }
+                    else
+                    {
+                        <span class="ext-badge ext-badge--enabled">Loaded</span>
+                    }
+                </div>
+
+                @if (ext.ExtensionTypes.Count > 0)
+                {
+                    <div class="ext-types">
+                        @foreach (var t in ext.ExtensionTypes)
+                        {
+                            <span class="ext-type-chip">@t</span>
+                        }
+                    </div>
+                }
+
+                @if (ext.RegisteredServices.Count > 0)
+                {
+                    <details class="ext-services">
+                        <summary>@ext.RegisteredServices.Count registered service(s)</summary>
+                        <ul>
+                            @foreach (var svc in ext.RegisteredServices)
+                            {
+                                <li>@svc</li>
+                            }
+                        </ul>
+                    </details>
+                }
+
+                @if (ext.ConfigSchema.Count > 0)
+                {
+                    <div class="ext-schema">
+                        <h4>Configuration Schema</h4>
+                        <table class="ext-schema-table">
+                            <thead>
+                                <tr>
+                                    <th>Field</th>
+                                    <th>Type</th>
+                                    <th>Required</th>
+                                    <th>Default</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var field in ext.ConfigSchema)
+                                {
+                                    <tr>
+                                        <td><code>@field.Id</code>@(field.Sensitive ? " 🔒" : "")</td>
+                                        <td>@field.Type</td>
+                                        <td>@(field.Required ? "✓" : "")</td>
+                                        <td>@(field.Default ?? "—")</td>
+                                        <td>@(field.Description ?? "")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        }
+    }
+</div>
+
+@code {
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private bool _loading = true;
+    private string? _error;
+    private List<ExtensionDetailDto> _extensions = [];
+
+    private static readonly JsonSerializerOptions s_jsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadExtensionsAsync();
+    }
+
+    private async Task LoadExtensionsAsync()
+    {
+        _loading = true;
+        _error = null;
+        try
+        {
+            var result = await Http.GetFromJsonAsync<List<ExtensionDetailDto>>("/api/extensions/details", s_jsonOpts);
+            _extensions = result ?? [];
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to load extensions: {ex.Message}";
+            _extensions = [];
+        }
+        _loading = false;
+    }
+
+    private sealed record ExtensionDetailDto(
+        string Id,
+        string Name,
+        string Version,
+        bool Enabled,
+        List<string> ExtensionTypes,
+        List<string> RegisteredServices,
+        List<ExtensionConfigFieldDto> ConfigSchema,
+        string AssemblyFileName);
+
+    private sealed record ExtensionConfigFieldDto(
+        string Id,
+        string Type,
+        string? Default,
+        bool Required,
+        bool Sensitive,
+        string? Description);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -190,6 +190,7 @@
                         <a href="configuration/world"     class="sidebar-subnav-item" @onclick="CloseSidebar">🌍 World Settings</a>
                         <a href="configuration/cron"      class="sidebar-subnav-item" @onclick="CloseSidebar">⏰ Cron</a>
                         <a href="configuration/apikey"    class="sidebar-subnav-item" @onclick="CloseSidebar">🔑 Global API Key</a>
+                        <a href="configuration/extensions" class="sidebar-subnav-item" @onclick="CloseSidebar">🔌 Extensions</a>
                     </div>
                 }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Configuration.razor
@@ -60,6 +60,9 @@
                     case "apikey":
                         <ApiKeyConfigPanel Config="@_config" OnChanged="MarkDirty" />
                         break;
+                    case "extensions":
+                        <ExtensionsConfigPanel OnChanged="MarkDirty" />
+                        break;
                     default:
                         <GatewayConfigPanel Config="@_config" OnChanged="MarkDirty" />
                         break;

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ExtensionsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ExtensionsController.cs
@@ -8,9 +8,6 @@ namespace BotNexus.Gateway.Api.Controllers;
 /// <summary>
 /// REST API for inspecting loaded runtime extensions.
 /// </summary>
-/// <summary>
-/// Represents extensions controller.
-/// </summary>
 [ApiController]
 [Route("api/[controller]")]
 public sealed class ExtensionsController : ControllerBase
@@ -26,11 +23,6 @@ public sealed class ExtensionsController : ControllerBase
     /// <summary>
     /// Lists loaded extensions and their declared extension types.
     /// </summary>
-    /// <returns>Loaded extension metadata for each extension type.</returns>
-    /// <summary>
-    /// Executes list.
-    /// </summary>
-    /// <returns>The list result.</returns>
     [HttpGet]
     [ProducesResponseType(typeof(IReadOnlyList<ExtensionResponse>), StatusCodes.Status200OK)]
     public ActionResult<IReadOnlyList<ExtensionResponse>> List()
@@ -46,10 +38,32 @@ public sealed class ExtensionsController : ControllerBase
 
         return Ok(responses);
     }
+
+    /// <summary>
+    /// Lists loaded extensions with full manifest details including config schema.
+    /// </summary>
+    [HttpGet("details")]
+    [ProducesResponseType(typeof(IReadOnlyList<ExtensionDetailResponse>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<ExtensionDetailResponse>> Details()
+    {
+        var responses = _extensionLoader.GetLoaded()
+            .Select(ext => new ExtensionDetailResponse(
+                ext.ExtensionId,
+                ext.Name,
+                ext.Version,
+                ext.Enabled,
+                ext.ExtensionTypes,
+                ext.RegisteredServices,
+                ext.ConfigSchema,
+                Path.GetFileName(ext.EntryAssemblyPath)))
+            .ToArray();
+
+        return Ok(responses);
+    }
 }
 
 /// <summary>
-/// Loaded extension response payload.
+/// Loaded extension response payload (legacy flat format).
 /// </summary>
 /// <param name="Name">The extension display name.</param>
 /// <param name="Version">The extension version.</param>
@@ -60,3 +74,24 @@ public sealed record ExtensionResponse(
     string Version,
     string Type,
     string AssemblyPath);
+
+/// <summary>
+/// Loaded extension detail response payload — includes config schema and enabled status.
+/// </summary>
+/// <param name="Id">The extension ID.</param>
+/// <param name="Name">The extension display name.</param>
+/// <param name="Version">The extension version.</param>
+/// <param name="Enabled">Whether the extension is enabled per its manifest.</param>
+/// <param name="ExtensionTypes">Extension type identifiers declared in the manifest.</param>
+/// <param name="RegisteredServices">Service contract names registered by this extension.</param>
+/// <param name="ConfigSchema">Configuration field schema declared by this extension.</param>
+/// <param name="AssemblyFileName">The entry assembly filename.</param>
+public sealed record ExtensionDetailResponse(
+    string Id,
+    string Name,
+    string Version,
+    bool Enabled,
+    IReadOnlyList<string> ExtensionTypes,
+    IReadOnlyList<string> RegisteredServices,
+    IReadOnlyList<ExtensionConfigFieldSchema> ConfigSchema,
+    string AssemblyFileName);

--- a/src/gateway/BotNexus.Gateway.Contracts/ExtensionModels.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/ExtensionModels.cs
@@ -140,4 +140,12 @@ public sealed record LoadedExtension
     /// Gets or sets the registered services.
     /// </summary>
     public IReadOnlyList<string> RegisteredServices { get; init; } = [];
+    /// <summary>
+    /// Whether this extension is enabled. Sourced from the manifest.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+    /// <summary>
+    /// Configuration field schema declared by this extension in the manifest.
+    /// </summary>
+    public IReadOnlyList<ExtensionConfigFieldSchema> ConfigSchema { get; init; } = [];
 }

--- a/src/gateway/BotNexus.Gateway/Extensions/AssemblyLoadContextExtensionLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/AssemblyLoadContextExtensionLoader.cs
@@ -169,7 +169,9 @@ public sealed class AssemblyLoadContextExtensionLoader : IExtensionLoader
                 EntryAssemblyPath = extension.EntryAssemblyPath,
                 ExtensionTypes = extension.Manifest.ExtensionTypes,
                 LoadedAtUtc = DateTimeOffset.UtcNow,
-                RegisteredServices = registeredServiceNames
+                RegisteredServices = registeredServiceNames,
+                Enabled = extension.Manifest.Enabled,
+                ConfigSchema = extension.Manifest.ConfigSchema
             };
 
             lock (_sync)

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Components/Config/ExtensionsConfigPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/Components/Config/ExtensionsConfigPanelTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components.Config;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.Components.Config;
+
+public sealed class ExtensionsConfigPanelTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void ShowsLoadedExtensions_WithNameAndVersion()
+    {
+        RegisterFakeExtensionsApi(new[]
+        {
+            BuildExtension("ext-a", "Test Extension", "1.0.0", enabled: true, types: ["channel"]),
+        });
+
+        var cut = _ctx.Render<ExtensionsConfigPanel>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".ext-name").TextContent.ShouldBe("Test Extension");
+            cut.Find(".ext-version").TextContent.ShouldContain("1.0.0");
+        });
+    }
+
+    [Fact]
+    public void ShowsDisabledBadge_WhenExtensionIsDisabled()
+    {
+        RegisterFakeExtensionsApi(new[]
+        {
+            BuildExtension("ext-b", "Disabled Ext", "2.0.0", enabled: false, types: []),
+        });
+
+        var cut = _ctx.Render<ExtensionsConfigPanel>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".ext-badge--disabled").ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ShowsEmptyState_WhenNoExtensionsLoaded()
+    {
+        RegisterFakeExtensionsApi([]);
+
+        var cut = _ctx.Render<ExtensionsConfigPanel>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.ShouldContain("No extensions loaded");
+        });
+    }
+
+    [Fact]
+    public void ShowsConfigSchema_WhenExtensionHasFields()
+    {
+        RegisterFakeExtensionsApi(new[]
+        {
+            BuildExtensionWithSchema("ext-c", "Schema Ext", "3.0.0", new[]
+            {
+                new { Id = "apiKey", Type = "string", Required = true, Sensitive = true, Default = (string?)null, Description = "API key" }
+            })
+        });
+
+        var cut = _ctx.Render<ExtensionsConfigPanel>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.ShouldContain("apiKey");
+            cut.Markup.ShouldContain("🔒"); // sensitive indicator
+            cut.Markup.ShouldContain("API key");
+        });
+    }
+
+    [Fact]
+    public void ShowsErrorMessage_WhenApiCallFails()
+    {
+        RegisterFailingExtensionsApi();
+
+        var cut = _ctx.Render<ExtensionsConfigPanel>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.ShouldContain("Failed to load extensions");
+        });
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private void RegisterFakeExtensionsApi(object[] extensions)
+    {
+        var json = JsonSerializer.Serialize(extensions);
+        var handler = new FakeHttpHandler(json, HttpStatusCode.OK);
+        _ctx.Services.AddSingleton<HttpClient>(_ => new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost/")
+        });
+    }
+
+    private void RegisterFailingExtensionsApi()
+    {
+        var handler = new FakeHttpHandler("{}", HttpStatusCode.InternalServerError);
+        _ctx.Services.AddSingleton<HttpClient>(_ => new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost/")
+        });
+    }
+
+    private static object BuildExtension(string id, string name, string version, bool enabled, string[] types)
+        => new
+        {
+            id,
+            name,
+            version,
+            enabled,
+            extensionTypes = types,
+            registeredServices = Array.Empty<string>(),
+            configSchema = Array.Empty<object>(),
+            assemblyFileName = $"{id}.dll"
+        };
+
+    private static object BuildExtensionWithSchema(string id, string name, string version, dynamic[] schema)
+        => new
+        {
+            id,
+            name,
+            version,
+            enabled = true,
+            extensionTypes = new[] { "tool" },
+            registeredServices = Array.Empty<string>(),
+            configSchema = schema,
+            assemblyFileName = $"{id}.dll"
+        };
+
+    private sealed class FakeHttpHandler(string responseJson, HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+            });
+    }
+}


### PR DESCRIPTION
Closes #420

## Changes

### API
- Added `ConfigSchema` and `Enabled` fields to `LoadedExtension` model (populated from manifest at load time)
- Added `GET /api/extensions/details` endpoint returning full extension details including config schema
- `ExtensionDetailResponse` record includes: Id, Name, Version, Enabled, ExtensionTypes, RegisteredServices, ConfigSchema, AssemblyFileName

### Portal UI
- New `ExtensionsConfigPanel.razor` under `Components/Config/`
- Lists all loaded extensions with name, version, enabled/disabled badge, extension types, registered services (expandable), and config schema table
- Config schema table shows: field ID, type, required, default, description; sensitive fields marked with lock icon
- Added `/configuration/extensions` route to `Configuration.razor` switch
- Added Extensions nav link in `MainLayout.razor` sidebar sub-nav

### Tests
- 5 new bunit tests: loaded extensions list, disabled badge, empty state, schema display, error state

## Sub-issue

Part of #406 (Extension configuration schema and UI)