### PR TITLE
feat(agents): add SubAgentRoles for role-based agent_converse grants

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -66,6 +66,12 @@ public sealed record AgentDescriptor
     public IReadOnlyList<string> SubAgentIds { get; init; } = [];
 
     /// <summary>
+    /// Role names this agent can converse with. Any agent whose <c>metadata.role</c> matches
+    /// one of these values is authorized as a sub-agent, in addition to those listed in <see cref="SubAgentIds" />.
+    /// </summary>
+    public IReadOnlyList<string> SubAgentRoles { get; init; } = [];
+
+    /// <summary>
     /// The isolation strategy to use when running this agent.
     /// Defaults to <c>"in-process"</c> if not specified.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -63,8 +63,10 @@ public sealed class AgentExchangeService : IAgentExchangeService
         var hasCrossWorldTarget = CrossWorldAgentReference.TryParse(request.TargetId, out var parsedCrossWorldTarget);
         if (!isLocalTarget && !hasCrossWorldTarget)
             throw new KeyNotFoundException($"Target agent '{request.TargetId}' is not registered.");
+        var targetDescriptor = isLocalTarget ? _registry.Get(request.TargetId) : null;
 
-        if (!initiatorDescriptor.SubAgentIds.Contains(request.TargetId.Value, StringComparer.OrdinalIgnoreCase))
+        if (!initiatorDescriptor.SubAgentIds.Contains(request.TargetId.Value, StringComparer.OrdinalIgnoreCase)
+            && !IsRoleGranted(initiatorDescriptor, targetDescriptor))
             throw new UnauthorizedAccessException(
                 $"Agent '{request.InitiatorId}' is not allowed to converse with '{request.TargetId}'.");
 
@@ -384,5 +386,25 @@ public sealed class AgentExchangeService : IAgentExchangeService
             WorldId = configuredTarget.WorldId,
             AgentId = AgentId.From(configuredTarget.AgentId)
         };
+    }
+
+    /// <summary>
+    /// Returns true when the initiator's <c>SubAgentRoles</c> list contains at least one role
+    /// that matches the target's <c>metadata.role</c> value.
+    /// </summary>
+    private static bool IsRoleGranted(AgentDescriptor initiator, AgentDescriptor? target)
+    {
+        if (initiator.SubAgentRoles.Count == 0 || target is null)
+            return false;
+
+        if (!target.Metadata.TryGetValue("role", out var roleRaw) || roleRaw is null)
+            return false;
+
+        var targetRole = roleRaw is System.Text.Json.JsonElement je
+            ? je.GetString()
+            : roleRaw.ToString();
+
+        return !string.IsNullOrWhiteSpace(targetRole)
+            && initiator.SubAgentRoles.Contains(targetRole, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -48,6 +48,7 @@ public static class AgentConfigMerger
             SystemPromptFile = agent.SystemPromptFile,
             SystemPromptFiles = agent.SystemPromptFiles,
             SubAgents = agent.SubAgents,
+            SubAgentRoles = agent.SubAgentRoles,
             IsolationStrategy = agent.IsolationStrategy,
             MaxConcurrentSessions = agent.MaxConcurrentSessions,
             ToolTimeoutSeconds = MergeToolTimeoutSeconds(defaults.ToolTimeoutSeconds, agent.ToolTimeoutSeconds, agentObj),

--- a/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
@@ -153,6 +153,7 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             SystemPromptFile = config.SystemPromptFile,
             ToolIds = config.ToolIds ?? [],
             SubAgentIds = subAgentIds,
+            SubAgentRoles = config.SubAgentRoles ?? [],
             IsolationStrategy = string.IsNullOrWhiteSpace(config.IsolationStrategy) ? "in-process" : config.IsolationStrategy,
             MaxConcurrentSessions = config.MaxConcurrentSessions ?? 0,
             Metadata = ConvertObject(config.Metadata),
@@ -378,6 +379,8 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
         public IReadOnlyList<string>? SubAgents { get; init; }
 
         public IReadOnlyList<string>? SubAgentIds { get; init; }
+
+        public IReadOnlyList<string>? SubAgentRoles { get; init; }
 
         public FileAccessPolicyConfig? FileAccess { get; init; }
     }

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -422,6 +422,8 @@ public sealed class AgentDefinitionConfig
     public int? ToolTimeoutSeconds { get; set; }
     /// <summary>Agent IDs this agent can call as sub-agents.</summary>
     public List<string>? SubAgents { get; set; }
+    /// <summary>Role names this agent can converse with (role-based grants for agent_converse).</summary>
+    public List<string>? SubAgentRoles { get; set; }
     /// <summary>Isolation strategy name (e.g. 'in-process').</summary>
     public string? IsolationStrategy { get; set; }
     /// <summary>Maximum concurrent sessions for this agent.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -95,6 +95,7 @@ public sealed class PlatformConfigAgentSource(
                 ToolIds = effectiveConfig.ToolIds?.ToArray() ?? [],
                 AllowedModelIds = effectiveConfig.AllowedModels?.ToArray() ?? [],
                 SubAgentIds = effectiveConfig.SubAgents?.ToArray() ?? [],
+                SubAgentRoles = effectiveConfig.SubAgentRoles?.ToArray() ?? [],
                 IsolationStrategy = string.IsNullOrWhiteSpace(effectiveConfig.IsolationStrategy)
                     ? "in-process"
                     : effectiveConfig.IsolationStrategy,

--- a/src/gateway/BotNexus.Gateway/Tools/ListAgentsTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ListAgentsTool.cs
@@ -60,6 +60,7 @@ public sealed class ListAgentsTool(
 
         var callerDescriptor = agentRegistry.Get(callerAgentId);
         var subAgentIds = callerDescriptor?.SubAgentIds ?? [];
+        var subAgentRoles = callerDescriptor?.SubAgentRoles ?? [];
 
         var agents = agentRegistry.GetAll()
             .Where(d => MatchesFilter(d, filter))
@@ -70,7 +71,8 @@ public sealed class ListAgentsTool(
                 Description: d.Description,
                 Emoji: d.Emoji,
                 Capabilities: ResolveCapabilities(d),
-                CanConverse: subAgentIds.Contains(d.AgentId.ToString(), StringComparer.OrdinalIgnoreCase)))
+                CanConverse: subAgentIds.Contains(d.AgentId.ToString(), StringComparer.OrdinalIgnoreCase)
+                    || IsRoleGranted(subAgentRoles, d)))
             .OrderBy(e => e.AgentId, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
@@ -115,6 +117,22 @@ public sealed class ListAgentsTool(
                 return [single];
         }
         return [];
+    }
+
+    private static bool IsRoleGranted(IReadOnlyList<string> subAgentRoles, AgentDescriptor target)
+    {
+        if (subAgentRoles.Count == 0)
+            return false;
+
+        if (!target.Metadata.TryGetValue("role", out var roleRaw) || roleRaw is null)
+            return false;
+
+        var targetRole = roleRaw is JsonElement je
+            ? je.GetString()
+            : roleRaw.ToString();
+
+        return !string.IsNullOrWhiteSpace(targetRole)
+            && subAgentRoles.Contains(targetRole, StringComparer.OrdinalIgnoreCase);
     }
 
     private static string? ReadString(IReadOnlyDictionary<string, object?> args, string key)

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -464,7 +464,186 @@ public sealed class AgentExchangeServiceTests
         result.CompletionReason.ShouldBe("objectiveMet");
     }
 
-    private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target, IReadOnlyList<string> allowedTargets)
+    [Fact]
+    public async Task ConverseAsync_WithSubAgentRole_Succeeds()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("specialist-agent");
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Initiator",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentRoles = ["specialist"]
+        });
+        registry.Setup(r => r.Get(target)).Returns(new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Specialist",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            Metadata = new Dictionary<string, object?> { ["role"] = "specialist" }
+        });
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var sessionStore = new InMemorySessionStore();
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "OBJECTIVE MET" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_WithSubAgentRole_JsonElementRole_Succeeds()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("specialist-agent");
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Initiator",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentRoles = ["specialist"]
+        });
+        // role stored as a JsonElement (as it would be when loaded from JSON config)
+        var meta = new Dictionary<string, object?>
+        {
+            ["role"] = System.Text.Json.JsonDocument.Parse("\"specialist\"").RootElement
+        };
+        registry.Setup(r => r.Get(target)).Returns(new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Specialist",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            Metadata = meta
+        });
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var sessionStore = new InMemorySessionStore();
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "OBJECTIVE MET" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_WithSubAgentRole_NoMatchFails()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("researcher-agent");
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Initiator",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentRoles = ["specialist"]
+        });
+        registry.Setup(r => r.Get(target)).Returns(new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Researcher",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            Metadata = new Dictionary<string, object?> { ["role"] = "researcher" }
+        });
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            Mock.Of<IAgentSupervisor>(),
+            new InMemorySessionStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "hello"
+        });
+
+        await action.ShouldThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ConverseAsync_WithEmptySubAgentRoles_StillChecksIds()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
+        var sessionStore = new InMemorySessionStore();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "OBJECTIVE MET" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+        private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target, IReadOnlyList<string> allowedTargets)
     {
         var registry = new Mock<IAgentRegistry>();
         registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentRolesTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentRolesTests.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Gateway.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Tests for role-based sub-agent grants (SubAgentRoles on AgentDescriptor).
+/// </summary>
+public sealed class SubAgentRolesTests
+{
+    // -------------------------------------------------------------------------
+    // AgentExchangeService — role-based authorization
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ConverseAsync_WithMatchingSubAgentRole_Succeeds()
+    {
+        var initiator = AgentId.From("orchestrator");
+        var target = AgentId.From("researcher");
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Orchestrator",
+            ModelId = "test",
+            ApiProvider = "test",
+            SubAgentIds = [],
+            SubAgentRoles = ["specialist"]
+        });
+        var targetDescriptor = new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Researcher",
+            ModelId = "test",
+            ApiProvider = "test",
+            Metadata = new Dictionary<string, object?> { ["role"] = "specialist" }
+        };
+        registry.Setup(r => r.Get(target)).Returns(targetDescriptor);
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "Done." });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            new InMemorySessionStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_WithNonMatchingSubAgentRole_ThrowsUnauthorized()
+    {
+        var initiator = AgentId.From("orchestrator");
+        var target = AgentId.From("researcher");
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Orchestrator",
+            ModelId = "test",
+            ApiProvider = "test",
+            SubAgentIds = [],
+            SubAgentRoles = ["analyst"] // does not match "specialist"
+        });
+        var targetDescriptor = new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Researcher",
+            ModelId = "test",
+            ApiProvider = "test",
+            Metadata = new Dictionary<string, object?> { ["role"] = "specialist" }
+        };
+        registry.Setup(r => r.Get(target)).Returns(targetDescriptor);
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            Mock.Of<IAgentSupervisor>(),
+            new InMemorySessionStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        await Should.ThrowAsync<UnauthorizedAccessException>(() =>
+            service.ConverseAsync(new AgentExchangeRequest
+            {
+                InitiatorId = initiator,
+                TargetId = target,
+                Message = "Hello",
+                MaxTurns = 1
+            }));
+    }
+
+    [Fact]
+    public async Task ConverseAsync_RoleMatchIsCaseInsensitive()
+    {
+        var initiator = AgentId.From("orchestrator");
+        var target = AgentId.From("researcher");
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Orchestrator",
+            ModelId = "test",
+            ApiProvider = "test",
+            SubAgentIds = [],
+            SubAgentRoles = ["Specialist"] // uppercase
+        });
+        var targetDescriptor = new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Researcher",
+            ModelId = "test",
+            ApiProvider = "test",
+            Metadata = new Dictionary<string, object?> { ["role"] = "specialist" } // lowercase
+        };
+        registry.Setup(r => r.Get(target)).Returns(targetDescriptor);
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "Done." });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            new InMemorySessionStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_TargetWithNoRole_RoleGrantDoesNotApply()
+    {
+        var initiator = AgentId.From("orchestrator");
+        var target = AgentId.From("researcher");
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Orchestrator",
+            ModelId = "test",
+            ApiProvider = "test",
+            SubAgentIds = [],
+            SubAgentRoles = ["specialist"]
+        });
+        var targetDescriptor = new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Researcher",
+            ModelId = "test",
+            ApiProvider = "test"
+            // No metadata.role
+        };
+        registry.Setup(r => r.Get(target)).Returns(targetDescriptor);
+        registry.Setup(r => r.Contains(target)).Returns(true);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            Mock.Of<IAgentSupervisor>(),
+            new InMemorySessionStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        await Should.ThrowAsync<UnauthorizedAccessException>(() =>
+            service.ConverseAsync(new AgentExchangeRequest
+            {
+                InitiatorId = initiator,
+                TargetId = target,
+                Message = "Hello",
+                MaxTurns = 1
+            }));
+    }
+
+    // -------------------------------------------------------------------------
+    // ListAgentsTool — CanConverse reflects role grants
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListAgentsTool_CanConverse_TrueForRoleMatch()
+    {
+        var callerDescriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("caller"),
+            DisplayName = "Caller",
+            ModelId = "test",
+            ApiProvider = "test",
+            SubAgentRoles = ["specialist"]
+        };
+        var specialistAgent = new AgentDescriptor
+        {
+            AgentId = AgentId.From("agent-b"),
+            DisplayName = "Agent B",
+            ModelId = "test",
+            ApiProvider = "test",
+            Metadata = new Dictionary<string, object?> { ["role"] = "specialist" }
+        };
+        var notGranted = new AgentDescriptor
+        {
+            AgentId = AgentId.From("agent-c"),
+            DisplayName = "Agent C",
+            ModelId = "test",
+            ApiProvider = "test"
+        };
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([callerDescriptor, specialistAgent, notGranted]);
+        registry.Setup(r => r.Get(callerDescriptor.AgentId)).Returns(callerDescriptor);
+
+        var tool = new ListAgentsTool(registry.Object, callerDescriptor.AgentId);
+        var result = await tool.ExecuteAsync("tc", new Dictionary<string, object?>());
+
+        var entries = JsonSerializer.Deserialize<JsonElement>(result.Content[0].Value);
+        var bEntry = entries.EnumerateArray().First(e => e.GetProperty("agentId").GetString() == "agent-b");
+        var cEntry = entries.EnumerateArray().First(e => e.GetProperty("agentId").GetString() == "agent-c");
+
+        bEntry.GetProperty("canConverse").GetBoolean().ShouldBeTrue();
+        cEntry.GetProperty("canConverse").GetBoolean().ShouldBeFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // AgentDescriptor — SubAgentRoles default
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AgentDescriptor_SubAgentRoles_DefaultsToEmpty()
+    {
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("test"),
+            DisplayName = "Test",
+            ModelId = "m",
+            ApiProvider = "p"
+        };
+
+        descriptor.SubAgentRoles.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #376

## Problem

`agent_converse` requires per-agent `subAgentIds` in config — no way to grant access to whole classes of agents without listing each one.

## Solution (Option B from spec)

Add `subAgentRoles` config field: any agent whose `metadata.role` matches a value in the caller's `subAgentRoles` list is automatically authorized.

## Changes

- `AgentDescriptor`: new `SubAgentRoles` property (default `[]`)
- `AgentConfigurationFile` + `PlatformConfig.AgentDefinitionConfig`: new `subAgentRoles` JSON field
- `AgentConfigMerger`: passes through `SubAgentRoles` (identity field, not inherited)
- `FileAgentConfigurationSource` + `PlatformConfigAgentSource`: wire `SubAgentRoles`
- `AgentExchangeService.ConverseAsync`: checks `SubAgentRoles` against target `metadata.role` when `SubAgentIds` check fails
- `ListAgentsTool`: `CanConverse=true` when target's role matches caller's `SubAgentRoles`
- 10 new tests (role match, case-insensitive, role mismatch, no-role, JsonElement role field, ListAgentsTool)

## Backward Compatibility

Existing `subAgentIds` behavior unchanged. `subAgentRoles` is additive — either grant mechanism is sufficient.

## Example Config

```json
{
  "agentId": "nova",
  "subAgentIds": ["farnsworth"],
  "subAgentRoles": ["specialist", "researcher"]
}
```

Any agent with `metadata.role: specialist` or `metadata.role: researcher` is automatically reachable from `nova`.

## Test Results
- 1622 gateway tests passed, 0 failed