### PR TITLE
fix(agents): inherit parent conversation id in sub-agent sessions (#468)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
@@ -80,4 +80,11 @@ public sealed record SubAgentSpawnRequest
     /// parent's effective deny-list. The spawned sub-agent must not be granted any of these tools.
     /// </summary>
     public IReadOnlyList<string>? ParentToolDenyList { get; init; }
+
+    /// <summary>
+    /// Gets the optional conversation ID inherited from the parent session.
+    /// When set, the sub-agent will route its task into this existing conversation
+    /// instead of creating a new one — keeping all output visible in the same portal thread.
+    /// </summary>
+    public string? InheritedConversationId { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -1,3 +1,4 @@
+﻿using BotNexus.Gateway.Abstractions.Sessions;
 using System.Collections.Concurrent;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Activity;
@@ -26,6 +27,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
     private readonly IOptionsMonitor<GatewayOptions> _options;
     private readonly ILogger<DefaultSubAgentManager> _logger;
     private readonly DefaultToolPolicyProvider? _policyProvider;
+    private readonly ISessionStore? _sessionStore;
     private readonly ConcurrentDictionary<string, SubAgentInfo> _subAgents = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<SessionId, ConcurrentBag<string>> _parentChildren = [];
     private readonly ConcurrentDictionary<string, AgentId> _parentAgentIds = new(StringComparer.OrdinalIgnoreCase);
@@ -41,7 +43,8 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         IOptionsMonitor<GatewayOptions> options,
         ILogger<DefaultSubAgentManager> logger,
         IAgentWorkspaceManager? workspaceManager = null,
-        DefaultToolPolicyProvider? policyProvider = null)
+        DefaultToolPolicyProvider? policyProvider = null,
+        ISessionStore? sessionStore = null)
     {
         _supervisor = supervisor;
         _registry = registry;
@@ -51,6 +54,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         _options = options;
         _logger = logger;
         _policyProvider = policyProvider;
+        _sessionStore = sessionStore;
     }
 
     /// <inheritdoc />
@@ -170,7 +174,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
         _timeouts[subAgentId] = timeoutCts;
 
-        _ = Task.Run(() => RunSubAgentAsync(subAgentId, handle, request.Task, timeoutSeconds), CancellationToken.None);
+        _ = Task.Run(() => RunSubAgentAsync(subAgentId, handle, request.Task, timeoutSeconds, request.InheritedConversationId), CancellationToken.None);
 
         _logger.LogInformation(
             "Spawned sub-agent '{SubAgentId}' for parent session '{ParentSessionId}' in child session '{ChildSessionId}'.",
@@ -382,14 +386,24 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             await CleanupChildAgentAsync(subAgentId, updated.ChildSessionId, CancellationToken.None);
         }
     }
-
-    private async Task RunSubAgentAsync(string subAgentId, IAgentHandle handle, string task, int timeoutSeconds)
+    private async Task RunSubAgentAsync(string subAgentId, IAgentHandle handle, string task, int timeoutSeconds, string? inheritedConversationId = null)
     {
         if (!_timeouts.TryGetValue(subAgentId, out var timeoutCts))
             return;
 
         try
         {
+            // Pin the sub-agent session to the parent conversation before running (#468).
+            if (!string.IsNullOrWhiteSpace(inheritedConversationId) && _sessionStore is not null)
+            {
+                var session = await _sessionStore.GetAsync(handle.SessionId, timeoutCts.Token).ConfigureAwait(false);
+                if (session is not null)
+                {
+                    session.Session.ConversationId = new BotNexus.Domain.Primitives.ConversationId(inheritedConversationId);
+                    await _sessionStore.SaveAsync(session, timeoutCts.Token).ConfigureAwait(false);
+                }
+            }
+
             var response = await handle.PromptAsync(task, timeoutCts.Token);
             await OnCompletedAsync(subAgentId, response.Content);
         }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -211,9 +211,11 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 || effectiveToolIds.Contains("list_subagents", StringComparer.OrdinalIgnoreCase);
             var includeManage = effectiveToolIds.Count == 0
                 || effectiveToolIds.Contains("manage_subagent", StringComparer.OrdinalIgnoreCase);
-
             if (includeSpawn)
-                tools.Add(new SubAgentSpawnTool(subAgentManager, descriptor.AgentId, context.SessionId));
+            {
+                ConversationId? spawnConversationId = conversationStore is not null ? await ResolveConversationIdAsync(conversationStore, sessionStore, descriptor.AgentId, context.SessionId, cancellationToken).ConfigureAwait(false) : null;
+                tools.Add(new SubAgentSpawnTool(subAgentManager, descriptor.AgentId, context.SessionId, spawnConversationId));
+            }
             if (includeList)
                 tools.Add(new SubAgentListTool(subAgentManager, context.SessionId));
             if (includeManage)

--- a/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
@@ -11,7 +11,8 @@ namespace BotNexus.Gateway.Tools;
 public sealed class SubAgentSpawnTool(
     ISubAgentManager subAgentManager,
     AgentId agentId,
-    SessionId sessionId) : IAgentTool
+    SessionId sessionId,
+    ConversationId? conversationId = null) : IAgentTool
 {
     public string Name => "spawn_subagent";
     public string Label => "Spawn Sub-Agent";
@@ -81,7 +82,8 @@ public sealed class SubAgentSpawnTool(
             MaxTurns = ReadInt(arguments, "maxTurns", 30),
             TimeoutSeconds = ReadInt(arguments, "timeoutSeconds", 600),
             Archetype = ReadArchetype(arguments),
-            TargetAgentId = ReadString(arguments, "targetAgentId")
+            TargetAgentId = ReadString(arguments, "targetAgentId"),
+            InheritedConversationId = conversationId?.Value
         };
 
         var spawned = await subAgentManager.SpawnAsync(request, cancellationToken).ConfigureAwait(false);

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentConversationInheritanceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentConversationInheritanceTests.cs
@@ -1,0 +1,134 @@
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class SubAgentConversationInheritanceTests
+{
+    [Fact]
+    public async Task SpawnAsync_WithInheritedConversationId_PinsSessionConversationBeforePrompt()
+    {
+        // Arrange
+        const string inheritedConversationId = "conv-parent-123";
+        var capturedConversationId = (string?)null;
+
+        var gatewaySession = new GatewaySession();
+
+        var sessionStore = new Mock<ISessionStore>();
+        sessionStore
+            .Setup(s => s.GetAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gatewaySession);
+        sessionStore
+            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Callback<GatewaySession, CancellationToken>((sess, _) =>
+                capturedConversationId = sess.Session.ConversationId?.Value)
+            .Returns(Task.CompletedTask);
+
+        var handle = BuildHandle();
+        var manager = BuildManager(handle, sessionStore: sessionStore.Object);
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("parent-agent"),
+            ParentSessionId = SessionId.From("parent-session"),
+            Task = "do something",
+            InheritedConversationId = inheritedConversationId
+        };
+
+        // Act
+        await manager.SpawnAsync(request);
+        await Task.Delay(600); // allow background Task to complete
+
+        // Assert
+        capturedConversationId.ShouldBe(inheritedConversationId);
+        handle.Verify(h => h.PromptAsync("do something", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_WithoutInheritedConversationId_DoesNotPinConversation()
+    {
+        // Arrange
+        var sessionStore = new Mock<ISessionStore>();
+
+        var handle = BuildHandle();
+        var manager = BuildManager(handle, sessionStore: sessionStore.Object);
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("parent-agent"),
+            ParentSessionId = SessionId.From("parent-session"),
+            Task = "do something"
+            // No InheritedConversationId
+        };
+
+        // Act
+        await manager.SpawnAsync(request);
+        await Task.Delay(600);
+
+        // Assert — session store NOT touched for conversation pinning
+        sessionStore.Verify(s => s.GetAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        sessionStore.Verify(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()), Times.Never);
+        handle.Verify(h => h.PromptAsync("do something", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Mock<IAgentHandle> BuildHandle()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.AgentId).Returns(AgentId.From("child-agent"));
+        handle.Setup(h => h.SessionId).Returns(SessionId.From("child-session"));
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+        return handle;
+    }
+
+    private static DefaultSubAgentManager BuildManager(
+        Mock<IAgentHandle> handle,
+        ISessionStore? sessionStore = null)
+    {
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns(CreateDescriptor());
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var activity = new Mock<IActivityBroadcaster>();
+        activity.Setup(a => a.PublishAsync(It.IsAny<GatewayActivity>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+
+        var options = new Mock<IOptionsMonitor<GatewayOptions>>();
+        options.Setup(o => o.CurrentValue).Returns(new GatewayOptions());
+
+        return new DefaultSubAgentManager(
+            supervisor.Object,
+            registry.Object,
+            activity.Object,
+            dispatcher.Object,
+            options.Object,
+            NullLogger<DefaultSubAgentManager>.Instance,
+            sessionStore: sessionStore);
+    }
+
+    private static AgentDescriptor CreateDescriptor() => new()
+    {
+        AgentId = AgentId.From("parent-agent"),
+        DisplayName = "Parent",
+        ModelId = "test-model",
+        ApiProvider = "test-provider",
+        SystemPrompt = "You are a test agent."
+    };
+}


### PR DESCRIPTION
Fixes #468

## Problem
Sub-agents spawned within a cron turn (or any agent turn) create their own conversations in the portal instead of routing into the parent's conversation. This results in multiple conversations appearing for what should be a single execution thread.

## Root Cause
`DefaultSubAgentManager.RunSubAgentAsync` called `handle.PromptAsync` directly without setting the session's `ConversationId`. The sub-agent session had no conversation pinned, so `GatewayHost` routed it through normal conversation resolution — which created a new conversation.

## Fix
1. **`SubAgentSpawnRequest`** — added `InheritedConversationId` property
2. **`SubAgentSpawnTool`** — accepts `ConversationId?` at construction; passes it as `InheritedConversationId` on the request
3. **`InProcessIsolationStrategy`** — resolves `ConversationId` from the active session when wiring `SubAgentSpawnTool`
4. **`DefaultSubAgentManager`** — accepts `ISessionStore?` (optional, backward-compatible); `RunSubAgentAsync` pins `session.Session.ConversationId` to `InheritedConversationId` before calling `PromptAsync`, so `GatewayHost` routes the sub-agent's output into the existing conversation

## Tests
- 2 new TDD tests: `SpawnAsync_WithInheritedConversationId_PinsSessionConversationBeforePrompt` and `SpawnAsync_WithoutInheritedConversationId_DoesNotPinConversation`
- 1636/1636 gateway tests pass
