### PR TITLE
feat(agents): add SessionType.MultiAgent and invite_agent tool for multi-agent collab

### DIFF
--- a/src/domain/BotNexus.Domain/Primitives/SessionType.cs
+++ b/src/domain/BotNexus.Domain/Primitives/SessionType.cs
@@ -19,6 +19,7 @@ public sealed class SessionType : IEquatable<SessionType>
     public static readonly SessionType Soul = Register("soul");
     public static readonly SessionType Cron = Register("cron");
     public static readonly SessionType Heartbeat = Register("heartbeat");
+    public static readonly SessionType MultiAgent = Register("multi-agent");
 
     /// <summary>
     /// Gets the value.

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Linq;
 using System.Text.Json;
@@ -238,6 +238,14 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 || effectiveToolIds.Contains("list_agents", StringComparer.OrdinalIgnoreCase);
             if (includeListAgents)
                 tools.Add(new ListAgentsTool(agentRegistry, descriptor.AgentId));
+
+            if (conversationService is not null && sessionStore is not null)
+            {
+                var includeInvite = effectiveToolIds.Count == 0
+                    || effectiveToolIds.Contains("invite_agent", StringComparer.OrdinalIgnoreCase);
+                if (includeInvite)
+                    tools.Add(new InviteAgentTool(agentRegistry, conversationService, sessionStore, descriptor.AgentId, context.SessionId));
+            }
         }
 
         var includeCanvas = effectiveToolIds.Count == 0

--- a/src/gateway/BotNexus.Gateway/Tools/InviteAgentTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/InviteAgentTool.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+
+namespace BotNexus.Gateway.Tools;
+
+/// <summary>
+/// Invites another registered agent into the current session as a participant.
+/// Upgrades the session type to MultiAgent, adds the target agent to the participants list,
+/// and sends a briefing message to orient the invited agent.
+/// </summary>
+public sealed class InviteAgentTool(
+    IAgentRegistry agentRegistry,
+    IAgentExchangeService exchangeService,
+    ISessionStore sessionStore,
+    AgentId initiatorAgentId,
+    SessionId sessionId) : IAgentTool
+{
+    private const int MaxMultiAgentDepth = 5;
+
+    public string Name => "invite_agent";
+    public string Label => "Invite Agent";
+
+    public Tool Definition => new(
+        Name,
+        "Invite another registered agent into the current session as a participant. The invited agent receives a briefing context and can then converse in the shared session.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "agentId": { "type": "string", "description": "ID of the agent to invite." },
+                "role": { "type": "string", "description": "Role the agent will play in the session (e.g., 'reviewer', 'specialist', 'assistant')." },
+                "context": { "type": "string", "description": "Briefing context to send to the invited agent." }
+              },
+              "required": ["agentId", "context"]
+            }
+            """).RootElement.Clone());
+
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(ReadString(arguments, "agentId")))
+            throw new ArgumentException("Missing required argument: agentId.");
+        if (string.IsNullOrWhiteSpace(ReadString(arguments, "context")))
+            throw new ArgumentException("Missing required argument: context.");
+        return Task.FromResult(arguments);
+    }
+
+    public async Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        var targetAgentIdStr = ReadString(arguments, "agentId")
+            ?? throw new ArgumentException("Missing required argument: agentId.");
+        var context = ReadString(arguments, "context")
+            ?? throw new ArgumentException("Missing required argument: context.");
+        var role = ReadString(arguments, "role");
+
+        var targetAgentId = AgentId.From(targetAgentIdStr);
+
+        // Verify target agent exists
+        var targetDescriptor = agentRegistry.Get(targetAgentId);
+        if (targetDescriptor is null)
+        {
+            return ErrorResult($"Agent '{targetAgentIdStr}' not found in registry.");
+        }
+
+        // Load current session for cycle detection and participant count
+        var currentSession = await sessionStore.GetAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (currentSession is null)
+        {
+            return ErrorResult("Current session not found.");
+        }
+
+        // Cycle detection: prevent an agent from inviting itself or re-inviting already present agents
+        if (targetAgentId.Equals(initiatorAgentId))
+        {
+            return ErrorResult("An agent cannot invite itself.");
+        }
+
+        var existingParticipant = currentSession.Participants
+            .FirstOrDefault(p => p.Type == ParticipantType.Agent
+                && string.Equals(p.Id, targetAgentIdStr, StringComparison.OrdinalIgnoreCase));
+        if (existingParticipant is not null)
+        {
+            return ErrorResult($"Agent '{targetAgentIdStr}' is already a participant in this session.");
+        }
+
+        // Depth limit: prevent runaway invitation chains
+        var agentParticipantCount = currentSession.Participants.Count(p => p.Type == ParticipantType.Agent);
+        if (agentParticipantCount >= MaxMultiAgentDepth)
+        {
+            return ErrorResult($"Maximum multi-agent depth ({MaxMultiAgentDepth}) reached for this session.");
+        }
+
+        // Add target agent as participant
+        var participant = new SessionParticipant
+        {
+            Type = ParticipantType.Agent,
+            Id = targetAgentIdStr,
+            Role = role
+        };
+        currentSession.Participants.Add(participant);
+
+        // Upgrade session type to MultiAgent
+        currentSession.SessionType = SessionType.MultiAgent;
+
+        // Persist the updated session
+        await sessionStore.SaveAsync(currentSession, cancellationToken).ConfigureAwait(false);
+
+        // Send briefing message to the invited agent via agent exchange
+        var briefing = $"You have been invited to join a collaborative session by agent '{initiatorAgentId.Value}'." +
+                       (role is not null ? $" Your role: {role}." : string.Empty) +
+                       $"\n\nContext:\n{context}";
+
+        var exchangeResult = await exchangeService.ConverseAsync(
+            new AgentExchangeRequest
+            {
+                InitiatorId = initiatorAgentId,
+                TargetId = targetAgentId,
+                Message = briefing,
+                Objective = $"Join collaborative session as {role ?? "participant"} and acknowledge readiness.",
+                MaxTurns = 1,
+                CallChain = [initiatorAgentId]
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        var result = new
+        {
+            agentId = targetAgentIdStr,
+            role,
+            status = "invited",
+            sessionType = SessionType.MultiAgent.Value,
+            participantCount = currentSession.Participants.Count(p => p.Type == ParticipantType.Agent),
+            briefingResponse = exchangeResult.FinalResponse
+        };
+
+        return new AgentToolResult(
+            [new AgentToolContent(AgentToolContentType.Text, JsonSerializer.Serialize(result, JsonOptions))]);
+    }
+
+    private static AgentToolResult ErrorResult(string message) =>
+        new([new AgentToolContent(AgentToolContentType.Text,
+            JsonSerializer.Serialize(new { error = message }, JsonOptions))]);
+
+    private static string? ReadString(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value) || value is null)
+            return null;
+        return value switch
+        {
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            JsonElement element => element.ToString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/InviteAgentToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/InviteAgentToolTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Gateway.Tools;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Tools;
+
+public sealed class InviteAgentToolTests
+{
+    private static AgentDescriptor MakeDescriptor(string id) => new()
+    {
+        AgentId = AgentId.From(id),
+        DisplayName = id,
+        ModelId = "test-model",
+        ApiProvider = "test-provider"
+    };
+
+    private static AgentExchangeResult MakeResult(string response = "Acknowledged") => new()
+    {
+        SessionId = "target::agent-agent::initiator::abc123",
+        Status = "sealed",
+        Turns = 1,
+        FinalResponse = response,
+        Transcript = []
+    };
+
+    private static IReadOnlyDictionary<string, object?> Args(string agentId, string context, string? role = null)
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["agentId"] = agentId,
+            ["context"] = context
+        };
+        if (role is not null)
+            dict["role"] = role;
+        return dict;
+    }
+
+    [Fact]
+    public void Tool_HasExpectedNameAndLabel()
+    {
+        var tool = new InviteAgentTool(
+            Mock.Of<IAgentRegistry>(),
+            Mock.Of<IAgentExchangeService>(),
+            new InMemorySessionStore(),
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        tool.Name.ShouldBe("invite_agent");
+        tool.Label.ShouldBe("Invite Agent");
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenAgentIdMissing_Throws()
+    {
+        var tool = new InviteAgentTool(
+            Mock.Of<IAgentRegistry>(),
+            Mock.Of<IAgentExchangeService>(),
+            new InMemorySessionStore(),
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        Func<Task> action = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["context"] = "hello" });
+        await action.ShouldThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenContextMissing_Throws()
+    {
+        var tool = new InviteAgentTool(
+            Mock.Of<IAgentRegistry>(),
+            Mock.Of<IAgentExchangeService>(),
+            new InMemorySessionStore(),
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        Func<Task> action = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["agentId"] = "agent-b" });
+        await action.ShouldThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTargetAgentNotFound_ReturnsError()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var store = new InMemorySessionStore();
+        await store.GetOrCreateAsync("session-1", "host-agent");
+
+        var tool = new InviteAgentTool(
+            registry.Object,
+            Mock.Of<IAgentExchangeService>(),
+            store,
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("unknown-agent", "help me"));
+
+        var json = JsonDocument.Parse(result.Content[0].Value);
+        json.RootElement.GetProperty("error").GetString()!.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInvitingSelf_ReturnsError()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>()))
+            .Returns(MakeDescriptor("host-agent"));
+
+        var store = new InMemorySessionStore();
+        await store.GetOrCreateAsync("session-1", "host-agent");
+
+        var tool = new InviteAgentTool(
+            registry.Object,
+            Mock.Of<IAgentExchangeService>(),
+            store,
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("host-agent", "briefing"));
+        var json = JsonDocument.Parse(result.Content[0].Value);
+        json.RootElement.GetProperty("error").GetString()!.ShouldContain("cannot invite itself");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAgentAlreadyParticipant_ReturnsError()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("agent-b")))
+            .Returns(MakeDescriptor("agent-b"));
+
+        var store = new InMemorySessionStore();
+        var session = await store.GetOrCreateAsync("session-1", "host-agent");
+        session.Participants.Add(new SessionParticipant
+        {
+            Type = ParticipantType.Agent,
+            Id = "agent-b"
+        });
+        await store.SaveAsync(session);
+
+        var tool = new InviteAgentTool(
+            registry.Object,
+            Mock.Of<IAgentExchangeService>(),
+            store,
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("agent-b", "briefing"));
+        var json = JsonDocument.Parse(result.Content[0].Value);
+        json.RootElement.GetProperty("error").GetString()!.ShouldContain("already a participant");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAtMaxDepth_ReturnsError()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("agent-new")))
+            .Returns(MakeDescriptor("agent-new"));
+
+        var store = new InMemorySessionStore();
+        var session = await store.GetOrCreateAsync("session-1", "host-agent");
+        for (var i = 0; i < 5; i++)
+        {
+            session.Participants.Add(new SessionParticipant
+            {
+                Type = ParticipantType.Agent,
+                Id = $"agent-{i}"
+            });
+        }
+        await store.SaveAsync(session);
+
+        var tool = new InviteAgentTool(
+            registry.Object,
+            Mock.Of<IAgentExchangeService>(),
+            store,
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("agent-new", "briefing"));
+        var json = JsonDocument.Parse(result.Content[0].Value);
+        json.RootElement.GetProperty("error").GetString()!.ShouldContain("Maximum multi-agent depth");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_AddsParticipantAndUpgradesSessionType()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("agent-b")))
+            .Returns(MakeDescriptor("agent-b"));
+
+        var exchange = new Mock<IAgentExchangeService>();
+        exchange.Setup(e => e.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeResult("Ready to collaborate."));
+
+        var store = new InMemorySessionStore();
+        await store.GetOrCreateAsync("session-1", "host-agent");
+
+        var tool = new InviteAgentTool(
+            registry.Object,
+            exchange.Object,
+            store,
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("agent-b", "Please review the plan.", "reviewer"));
+
+        var json = JsonDocument.Parse(result.Content[0].Value);
+        json.RootElement.GetProperty("status").GetString().ShouldBe("invited");
+        json.RootElement.GetProperty("agentId").GetString().ShouldBe("agent-b");
+        json.RootElement.GetProperty("role").GetString().ShouldBe("reviewer");
+        json.RootElement.GetProperty("sessionType").GetString().ShouldBe("multi-agent");
+        json.RootElement.GetProperty("participantCount").GetInt32().ShouldBe(1);
+
+        // Verify session was persisted with MultiAgent type and participant added
+        var updatedSession = await store.GetAsync("session-1");
+        updatedSession.ShouldNotBeNull();
+        updatedSession!.SessionType.ShouldBe(SessionType.MultiAgent);
+        updatedSession.Participants.ShouldContain(p => p.Id == "agent-b" && p.Role == "reviewer");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_SendsBriefingWithRoleInContext()
+    {
+        AgentExchangeRequest? capturedRequest = null;
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("agent-b")))
+            .Returns(MakeDescriptor("agent-b"));
+
+        var exchange = new Mock<IAgentExchangeService>();
+        exchange.Setup(e => e.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentExchangeRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(MakeResult());
+
+        var store = new InMemorySessionStore();
+        await store.GetOrCreateAsync("session-1", "host-agent");
+
+        var tool = new InviteAgentTool(
+            registry.Object,
+            exchange.Object,
+            store,
+            AgentId.From("host-agent"),
+            SessionId.From("session-1"));
+
+        await tool.ExecuteAsync("call-1", Args("agent-b", "This is the briefing context.", "specialist"));
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest!.TargetId.Value.ShouldBe("agent-b");
+        capturedRequest.Message.ShouldContain("host-agent");
+        capturedRequest.Message.ShouldContain("specialist");
+        capturedRequest.Message.ShouldContain("This is the briefing context.");
+    }
+}


### PR DESCRIPTION
Closes #414

## Changes

### `SessionType.MultiAgent`
- Registered `'multi-agent'` as a new session type alongside existing types

### `InviteAgentTool` — new `invite_agent` tool
- Accepts `agentId` (required), `context` (required), `role` (optional)
- Verifies target agent exists in registry
- Cycle detection: self-invite guard, duplicate-participant guard, max depth (5)
- Adds target as `SessionParticipant(Type=Agent, Id, Role)` to current session
- Upgrades session type to `MultiAgent`
- Persists session
- Sends briefing to invited agent via `IAgentExchangeService`
- Returns JSON with `agentId`, `role`, `status`, `sessionType`, `participantCount`, `briefingResponse`

### `InProcessIsolationStrategy`
- `invite_agent` wired in alongside `list_agents` (both require `IAgentRegistry`)

## Tests
- 9 new tests: tool name/label, missing args, agent not found, self-invite, already-participant, max depth, happy path + session persistence, briefing message content
- 1645/1645 gateway tests pass

## Sub-issue
Part of #378 (multi-agent collab)