### PR TITLE
fix(conversations): fix conversation switch cross-routing regression (#472)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -326,7 +326,12 @@ public sealed class ClientStateStore : IClientStateStore
         // Immediately bind session to active conversation so TryResolveConversationBySession works
         // without waiting for the async REST refresh. This eliminates the race condition (#314)
         // where MessageStart arrives before RefreshConversationsForAgentAsync completes.
-        if (agent.ActiveConversationId is not null &&
+        // Guard: only stamp if agent.SessionId still points to this session after the assignment
+        // above -- if the user switched conversations between message-send and HandleConnected firing,
+        // agent.SessionId would have been overwritten by a newer session, and we must not cross-stamp
+        // the new active conversation with the old session id (#472).
+        if (agent.SessionId == sessionId &&
+            agent.ActiveConversationId is not null &&
             agent.Conversations.TryGetValue(agent.ActiveConversationId, out var activeConv))
         {
             activeConv.ActiveSessionId = sessionId;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -326,13 +326,13 @@ public sealed class ClientStateStore : IClientStateStore
         // Immediately bind session to active conversation so TryResolveConversationBySession works
         // without waiting for the async REST refresh. This eliminates the race condition (#314)
         // where MessageStart arrives before RefreshConversationsForAgentAsync completes.
-        // Guard: only stamp if agent.SessionId still points to this session after the assignment
-        // above -- if the user switched conversations between message-send and HandleConnected firing,
-        // agent.SessionId would have been overwritten by a newer session, and we must not cross-stamp
-        // the new active conversation with the old session id (#472).
-        if (agent.SessionId == sessionId &&
-            agent.ActiveConversationId is not null &&
-            agent.Conversations.TryGetValue(agent.ActiveConversationId, out var activeConv))
+        // Guard: only stamp if the conversation has no established session yet.
+        // If the active conversation already has an ActiveSessionId, a late RegisterSession call
+        // for a different session must not overwrite it -- doing so routes stream events to the
+        // wrong conversation (#472).
+        if (agent.ActiveConversationId is not null &&
+            agent.Conversations.TryGetValue(agent.ActiveConversationId, out var activeConv) &&
+            activeConv.ActiveSessionId is null)
         {
             activeConv.ActiveSessionId = sessionId;
         }

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -63,36 +63,16 @@ public sealed class DefaultConversationRouter : IConversationRouter
                     reactivated = true;
                 }
 
-                // Bind-on-first-use for explicit conversationId path:
-                // Add a channel address binding if none exists; reactivate a muted binding.
-                // This ensures reconnects without explicit conversationId can find this conversation.
-                var existingBinding = direct.ChannelBindings.FirstOrDefault(b =>
-                    b.ChannelType == channelType && b.ChannelAddress == channelAddress);
-                if (existingBinding is null)
-                {
-                    direct.ChannelBindings.Add(new ChannelBinding
-                    {
-                        ChannelType = channelType,
-                        ChannelAddress = channelAddress,
-                        ThreadId = threadId,
-                        Mode = BindingMode.Interactive
-                    });
-                    reactivated = true;
-                }
-                else if (existingBinding.Mode == BindingMode.Muted)
-                {
-                    existingBinding.Mode = BindingMode.Interactive;
-                    reactivated = true;
-                }
+                // Do NOT bind-on-first-use in the explicit conversationId path.
+                // Bindings represent stable channel identities. Adding a binding here means that
+                // switching to a *different* conversation causes both conversations to share the
+                // same (channelType, channelAddress) binding pair -- the next implicit reconnect
+                // resolves whichever binding sorts first, which is often the wrong one (#472).
+                // If a caller wants a binding, it should be added through ReattachBindingAsync.
+
                 var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
                 var changed = directSessionChanged;
-                if (changed)
-                {
-                    direct.UpdatedAt = DateTimeOffset.UtcNow;
-                    await _conversationStore.SaveAsync(direct, ct);
-                    await NotifyChangedAsync("updated", agentId, direct.ConversationId, ct);
-                }
-                else if (reactivated)
+                if (changed || reactivated)
                 {
                     direct.UpdatedAt = DateTimeOffset.UtcNow;
                     await _conversationStore.SaveAsync(direct, ct);

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -349,9 +349,12 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             }
             session.ChannelType ??= message.ChannelType;
             // Update session ConversationId from dispatch resolution.
-            // Always update (not just when null) so that switching conversations on the same
-            // session correctly routes messages to the new conversation (#314).
-            if (resolution is not null && session.Session.ConversationId != resolution.ConversationId)
+            // Set-once: only stamp when null. Conversation switching is driven by the client
+            // passing explicit conversationId in the message payload (#314). Re-stamping on every
+            // message allows an out-of-order implicit-routing message to overwrite the session's
+            // ConversationId, causing subsequent implicit reconnects to route to the wrong
+            // conversation (#472).
+            if (resolution is not null && session.Session.ConversationId is null)
                 session.Session.ConversationId = resolution.ConversationId;
             session.CallerId ??= message.SenderId;
             session.SessionType = ResolveSessionType(session, message);

--- a/tests/BotNexus.Gateway.Conversation.Tests/ConversationRoutingScenarios.cs
+++ b/tests/BotNexus.Gateway.Conversation.Tests/ConversationRoutingScenarios.cs
@@ -104,15 +104,14 @@ public sealed class ConversationRoutingScenarios
             agentId, SignalR(), ChannelAddress.From("agent1"), null,
             conversationId: secondaryConv.ConversationId.Value);
 
-        // Assert — routes to the correct conversation with NO new binding added
+        // Assert - routes to the correct conversation with NO binding added (#472 regression fix)
         result.Conversation.ConversationId.ShouldBe(secondaryConv.ConversationId,
             "explicit conversationId must route directly to that conversation");
-        // The critical invariant: a channel address binding IS added (for reconnect),
-        // but NOT a ThreadId=conversationId binding (old design causing double fan-out)
-        // (old design added a binding with ThreadId=conversationId, causing double fan-out)
+        // No binding must be added in the explicit path -- adding one causes cross-routing
+        // when the user switches conversations (regression #472).
         var conv = await convStore.GetAsync(secondaryConv.ConversationId);
-        conv!.ChannelBindings.Count.ShouldBe(1,
-            "direct conversationId routing must add exactly one channel-address binding for reconnect, not a ThreadId hack");
+        conv!.ChannelBindings.Count.ShouldBe(0,
+            "explicit conversationId path must not add any channel bindings (#472)");
     }
 
     // ──────────────────────────────────────────────────────────────────────────────

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationSwitchRegressionTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationSwitchRegressionTests.cs
@@ -1,0 +1,67 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Xunit;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Regression tests for #472 -- conversation switch cross-routing bugs in ClientStateStore.
+/// </summary>
+public sealed class ConversationSwitchRegressionTests
+{
+    private static ClientStateStore CreateSeededStore()
+    {
+        var store = new ClientStateStore();
+        store.SeedAgents([new AgentSummary("agent-1", "Agent One")]);
+        store.SeedConversations("agent-1", [CreateConversation("conv-1", "agent-1", "Conv 1")]);
+        store.SetActiveConversation("agent-1", "conv-1");
+        return store;
+    }
+
+    [Fact]
+    public void RegisterSession_DoesNotOverwriteExistingActiveSessionId_WhenSwitchingConversations()
+    {
+        // Regression guard for #472 (ClientStateStore fix).
+        // conv-1 already has an established session. User switches to conv-2 (no session yet).
+        // RegisterSession for sess-2 must stamp conv-2 and leave conv-1 untouched.
+        var store = CreateSeededStore();
+        var agent = store.GetAgent("agent-1")!;
+
+        // Seed both conversations, then restore conv-1's session (SeedConversations resets state)
+        store.SeedConversations("agent-1", [
+            CreateConversation("conv-1", "agent-1", "Conv 1"),
+            CreateConversation("conv-2", "agent-1", "Conv 2")
+        ]);
+        // Set conv-1 to have an existing session (after seed)
+        agent.Conversations["conv-1"].ActiveSessionId = "sess-1";
+        agent.Conversations["conv-2"].ActiveSessionId = null;
+        store.SetActiveConversation("agent-1", "conv-2");
+
+        store.RegisterSession("agent-1", "sess-2");
+
+        Assert.Equal("sess-2", agent.Conversations["conv-2"].ActiveSessionId);
+        // conv-1 must be untouched
+        Assert.Equal("sess-1", agent.Conversations["conv-1"].ActiveSessionId);
+    }
+
+    [Fact]
+    public void RegisterSession_DoesNotStamp_WhenActiveConversationAlreadyHasSession()
+    {
+        // Regression guard for #472.
+        // If the active conversation already has an ActiveSessionId, a late RegisterSession
+        // call with a different session ID must not overwrite it.
+        var store = CreateSeededStore();
+        var agent = store.GetAgent("agent-1")!;
+        agent.Conversations["conv-1"].ActiveSessionId = "sess-existing";
+        store.SetActiveConversation("agent-1", "conv-1");
+
+        store.RegisterSession("agent-1", "sess-late");
+
+        // Must not overwrite
+        Assert.Equal("sess-existing", agent.Conversations["conv-1"].ActiveSessionId);
+    }
+
+    private static ConversationSummaryDto CreateConversation(
+        string conversationId, string agentId, string title) =>
+        new(conversationId, agentId, title, false, "Active", null, 0,
+            DateTimeOffset.UtcNow.AddHours(-1), DateTimeOffset.UtcNow);
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/PortalReconnectTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/PortalReconnectTests.cs
@@ -10,9 +10,9 @@ using Shouldly;
 namespace BotNexus.Gateway.Conversations.Tests.Conversations;
 
 /// <summary>
-/// Tests for SignalR portal reconnect duplicate conversation bug (#441).
-/// When the portal uses an explicit conversationId, the router must bind that
-/// conversation to the (channelType, channelAddress) so reconnects can find it.
+/// Tests for conversation routing with explicit conversationId (#441, #472).
+/// The router must NOT add bindings in the explicit conversationId path (#472 regression fix).
+/// The portal always passes an explicit conversationId, so reconnects always use it too.
 /// </summary>
 public sealed class PortalReconnectTests
 {
@@ -25,11 +25,13 @@ public sealed class PortalReconnectTests
             NullLogger<DefaultConversationRouter>.Instance);
 
     /// <summary>
-    /// First send: conversationId provided, conversation has no binding.
-    /// Router should add a binding so future reconnects can find it.
+    /// Explicit conversationId path must NOT add a binding (#472 regression fix).
+    /// Adding a binding causes the implicit reconnect path to hijack this conversation
+    /// when the user switches to a different conversation.
+    /// The portal always passes conversationId explicitly, so no binding is needed.
     /// </summary>
     [Fact]
-    public async Task ResolveInbound_WithExplicitConversationId_AddsBindingWhenNoneExists()
+    public async Task ResolveInbound_WithExplicitConversationId_DoesNotAddBinding()
     {
         var store = new InMemoryConversationStore();
         var agentId = AgentId.From("nova");
@@ -48,36 +50,31 @@ public sealed class PortalReconnectTests
 
         var router = CreateRouter(store);
 
-        // First send with explicit conversationId, no existing binding
+        // Send with explicit conversationId
         var result = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
 
         result.ShouldNotBeNull();
         result.Conversation.ConversationId.ShouldBe(conv.ConversationId);
 
-        // Binding should now exist on the conversation
+        // Binding must NOT be added (#472 regression guard)
         var updated = await store.GetAsync(conv.ConversationId);
         updated.ShouldNotBeNull();
-        updated!.ChannelBindings.ShouldNotBeEmpty();
-        updated.ChannelBindings.ShouldContain(b =>
-            b.ChannelType == channel &&
-            b.ChannelAddress == address &&
-            b.Mode != BindingMode.Muted,
-            "a binding must be added so reconnects can find this conversation without an explicit conversationId");
+        updated!.ChannelBindings.ShouldBeEmpty(
+            "explicit conversationId path must not add bindings -- would cause cross-routing on conversation switch (#472)");
     }
 
     /// <summary>
-    /// After the binding is created, reconnect without conversationId must find the same conversation.
-    /// This is the core scenario: no duplicate should be created.
+    /// Explicit path must still route correctly even with no binding.
+    /// The portal always passes conversationId, so no binding lookup is needed.
     /// </summary>
     [Fact]
-    public async Task ReconnectWithoutConversationId_FindsExistingConversation_AfterFirstSend()
+    public async Task ResolveInbound_WithExplicitConversationId_RoutesCorrectly_WithoutBinding()
     {
         var store = new InMemoryConversationStore();
         var agentId = AgentId.From("nova");
         var channel = ChannelKey.From("signalr");
         var address = ChannelAddress.From("nova");
 
-        // Pre-create a REST conversation with no bindings
         var conv = new Conversation
         {
             ConversationId = ConversationId.Create(),
@@ -89,15 +86,14 @@ public sealed class PortalReconnectTests
 
         var router = CreateRouter(store);
 
-        // First send: explicit conversationId (adds binding)
-        await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+        // First send with explicit conversationId
+        var result1 = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+        result1.Conversation.ConversationId.ShouldBe(conv.ConversationId);
 
-        // Reconnect: NO conversationId - must find the same conversation
-        var reconnectResult = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: null);
-
-        reconnectResult.ShouldNotBeNull();
-        reconnectResult.Conversation.ConversationId.ShouldBe(conv.ConversationId,
-            "reconnect without conversationId must return the same conversation, not create signalr:nova duplicate");
+        // Second send (reconnect) with same explicit conversationId -- must route to same conversation
+        var result2 = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+        result2.Conversation.ConversationId.ShouldBe(conv.ConversationId,
+            "repeated explicit conversationId must always route to the same conversation");
     }
 
     /// <summary>
@@ -140,10 +136,11 @@ public sealed class PortalReconnectTests
     }
 
     /// <summary>
-    /// A muted binding should be reactivated (not duplicated) when the conversation is re-used explicitly.
+    /// A muted binding is not reactivated in the explicit path (#472 regression fix).
+    /// Muted binding management belongs in the binding management layer, not the routing layer.
     /// </summary>
     [Fact]
-    public async Task ResolveInbound_WithExplicitConversationId_ReactivatesMutedBinding()
+    public async Task ResolveInbound_WithExplicitConversationId_DoesNotReactivateMutedBinding()
     {
         var store = new InMemoryConversationStore();
         var agentId = AgentId.From("nova");
@@ -167,11 +164,17 @@ public sealed class PortalReconnectTests
 
         var router = CreateRouter(store);
 
-        await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+        var result = await router.ResolveInboundAsync(agentId, channel, address, threadId: null, conversationId: conv.ConversationId.Value);
+
+        result.ShouldNotBeNull();
+        result.Conversation.ConversationId.ShouldBe(conv.ConversationId,
+            "explicit path must still route to the correct conversation even when binding is muted");
 
         var updated = await store.GetAsync(conv.ConversationId);
         updated.ShouldNotBeNull();
-        updated!.ChannelBindings.Count.ShouldBe(1, "muted binding should be reactivated, not duplicated");
-        updated.ChannelBindings[0].Mode.ShouldBe(BindingMode.Interactive, "muted binding must be reactivated to Interactive");
+        updated!.ChannelBindings.Count.ShouldBe(1, "no new binding should be added");
+        // Muted binding stays muted -- reactivation is not the router's job in the explicit path
+        updated.ChannelBindings[0].Mode.ShouldBe(BindingMode.Muted,
+            "muted binding must not be changed in explicit conversationId path");
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
@@ -185,6 +185,110 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
             "after reset, sending to same conversationId should still dispatch with the correct ConversationId");
     }
 
+    // ── Regression #472: switching conversations does not cross-route messages ──
+
+    [Fact]
+    public async Task Hub_SwitchConversation_DoesNotCrossRouteMessages()
+    {
+        // Regression guard for #472:
+        // Sending to conv-A then conv-B must not stamp the session with conv-B's ID,
+        // which would cause subsequent implicit-route messages to land in conv-B.
+        var dispatcher = new RecordingDispatcher();
+        await using var factory = CreateTestFactory(services =>
+        {
+            services.RemoveAll<IChannelDispatcher>();
+            services.AddSingleton<IChannelDispatcher>(dispatcher);
+        });
+        using var cts = CreateTimeout();
+        await RegisterAgentAsync(factory, cts.Token);
+
+        using var client = factory.CreateClient();
+
+        // Create two conversations
+        var convAResp = await client.PostAsJsonAsync("/api/conversations",
+            new { agentId = TestAgentId, title = "Conversation A" }, cts.Token);
+        convAResp.EnsureSuccessStatusCode();
+        var convAId = JsonDocument.Parse(await convAResp.Content.ReadAsStringAsync(cts.Token))
+            .RootElement.GetProperty("conversationId").GetString()!;
+
+        var convBResp = await client.PostAsJsonAsync("/api/conversations",
+            new { agentId = TestAgentId, title = "Conversation B" }, cts.Token);
+        convBResp.EnsureSuccessStatusCode();
+        var convBId = JsonDocument.Parse(await convBResp.Content.ReadAsStringAsync(cts.Token))
+            .RootElement.GetProperty("conversationId").GetString()!;
+
+        await using var connection = await CreateStartedConnection(factory, cts.Token);
+
+        // Send to conv-A first
+        await connection.InvokeAsync<JsonElement>(
+            "SendMessage", TestAgentId, "signalr", "message to A", convAId, cts.Token);
+
+        // Switch: send to conv-B
+        await connection.InvokeAsync<JsonElement>(
+            "SendMessage", TestAgentId, "signalr", "message to B", convBId, cts.Token);
+
+        // Both messages must carry their respective conversationIds
+        dispatcher.Messages.Count.ShouldBe(2);
+        dispatcher.Messages[0].ConversationId.ShouldBe(convAId,
+            "first message should be routed to conv-A");
+        dispatcher.Messages[1].ConversationId.ShouldBe(convBId,
+            "second message should be routed to conv-B, not conv-A");
+
+        // Conv-A bindings must not have been polluted with conv-B's channel address
+        var convStore = factory.Services.GetRequiredService<IConversationStore>();
+        var convA = await convStore.GetAsync(ConversationId.From(convAId), cts.Token);
+        convA.ShouldNotBeNull();
+        var convB = await convStore.GetAsync(ConversationId.From(convBId), cts.Token);
+        convB.ShouldNotBeNull();
+
+        // Both conversations should have at most one binding each (not cross-contaminated)
+        convA!.ChannelBindings.Count.ShouldBeLessThanOrEqualTo(1,
+            "conv-A must not accumulate bindings from other conversations");
+        convB!.ChannelBindings.Count.ShouldBeLessThanOrEqualTo(1,
+            "conv-B must not accumulate bindings from other conversations");
+    }
+
+    [Fact]
+    public async Task Hub_ImplicitRouting_AfterSwitch_DoesNotRouteToOldConversation()
+    {
+        // Regression guard for #472:
+        // A REST-created conversation opened via explicit conversationId must NOT
+        // accumulate a channel binding. Without the fix, bind-on-first-use would add
+        // a signalr binding to conv-B, which would then intercept subsequent implicit
+        // reconnects that should route to the default conversation.
+        var dispatcher = new RecordingDispatcher();
+        await using var factory = CreateTestFactory(services =>
+        {
+            services.RemoveAll<IChannelDispatcher>();
+            services.AddSingleton<IChannelDispatcher>(dispatcher);
+        });
+        using var cts = CreateTimeout();
+        await RegisterAgentAsync(factory, cts.Token);
+
+        using var client = factory.CreateClient();
+
+        // Create conv-B via REST (no channel binding)
+        var convBResp = await client.PostAsJsonAsync("/api/conversations",
+            new { agentId = TestAgentId, title = "Explicit Conv B" }, cts.Token);
+        convBResp.EnsureSuccessStatusCode();
+        var convBId = JsonDocument.Parse(await convBResp.Content.ReadAsStringAsync(cts.Token))
+            .RootElement.GetProperty("conversationId").GetString()!;
+
+        await using var connection = await CreateStartedConnection(factory, cts.Token);
+
+        // Send to conv-B via explicit conversationId
+        await connection.InvokeAsync<JsonElement>(
+            "SendMessage", TestAgentId, "signalr", "explicit to B", convBId, cts.Token);
+
+        // conv-B must NOT have acquired a channel binding from the explicit path
+        var convStore = factory.Services.GetRequiredService<IConversationStore>();
+        var convB = await convStore.GetAsync(ConversationId.From(convBId), cts.Token);
+        convB.ShouldNotBeNull(
+            "conv-B must exist in the store after being opened via explicit conversationId");
+        convB!.ChannelBindings.ShouldBeEmpty(
+            "explicit conversationId path must not add bindings -- would intercept future implicit reconnects");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static WebApplicationFactory<Program> CreateTestFactory(Action<IServiceCollection>? configureServices = null)


### PR DESCRIPTION
## Summary

Fixes three interacting regressions introduced by #422 and #443 that caused messages to route to the wrong conversation and named conversations to be silently lost when switching.

## Root Causes

**Bug 1 — GatewayHost.cs:** Session ConversationId guard changed from `is null` to `!= resolution`, causing re-stamping on every message. Any message sent to a different conversation would overwrite the session's ConversationId, causing subsequent implicit-route messages to land in the wrong conversation.

**Bug 2 — DefaultConversationRouter.cs:** Bind-on-first-use in the explicit conversationId path added a `signalr:{address}` binding to every conversation opened by ID. When the user switched conversations, the old conversation still had a binding, and implicit reconnects hijacked it.

**Bug 3 — ClientStateStore.cs:** `RegisterSession` blindly stamped `ActiveSessionId` on whatever `ActiveConversationId` was at call time, overwriting existing sessions and causing stream events to fan-out to the wrong conversation.

## Changes

- `GatewayHost.cs` — Reverted ConversationId guard to set-once (`is null`)
- `DefaultConversationRouter.cs` — Removed bind-on-first-use from explicit conversationId path
- `ClientStateStore.cs` — Added `ActiveSessionId is null` guard before stamping

## Tests

- Updated `PortalReconnectTests` and `ConversationRoutingScenarios` to reflect new contract
- Added `ConversationSwitchRegressionTests` (2 client-side regression guards)
- Added `Hub_SwitchConversation_DoesNotCrossRouteMessages` (server integration test)
- Added `Hub_ImplicitRouting_AfterSwitch_DoesNotRouteToOldConversation`

## Related

- Closes #472
- Filed #473 for missing conversation-switch round-trip test coverage
