### PR TITLE
feat(agents): add additionalReadPaths and additionalWritePaths to spawn_subagent

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Security;
 
 namespace BotNexus.Gateway.Abstractions.Models;
 
@@ -87,4 +88,18 @@ public sealed record SubAgentSpawnRequest
     /// instead of creating a new one — keeping all output visible in the same portal thread.
     /// </summary>
     public string? InheritedConversationId { get; init; }
+
+    /// <summary>
+    /// Gets additional file paths the sub-agent is allowed to read.
+    /// These are merged with the parent's <see cref="FileAccessPolicy.AllowedReadPaths" /> at spawn time.
+    /// Only paths the parent itself can read are accepted; others are silently filtered.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalReadPaths { get; init; } = [];
+
+    /// <summary>
+    /// Gets additional file paths the sub-agent is allowed to write.
+    /// These are merged with the parent's <see cref="FileAccessPolicy.AllowedWritePaths" /> at spawn time.
+    /// Only paths the parent itself can write are accepted; others are silently filtered.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalWritePaths { get; init; } = [];
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -4,6 +4,7 @@ using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Diagnostics;
 using BotNexus.Gateway.Security;
@@ -122,10 +123,17 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
 
         if (!_registry.Contains(childAgentId))
         {
+            var childFileAccess = MergeFileAccess(
+                parentDescriptor.FileAccess,
+                baseDescriptor.FileAccess,
+                request.AdditionalReadPaths,
+                request.AdditionalWritePaths);
+
             _registry.Register(baseDescriptor with
             {
                 AgentId = childAgentId,
-                DisplayName = $"{baseDescriptor.DisplayName} ({archetype.Value})"
+                DisplayName = $"{baseDescriptor.DisplayName} ({archetype.Value})",
+                FileAccess = childFileAccess
             });
         }
 
@@ -572,5 +580,53 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             searchFrom += separator.Length;
         }
         return depth;
+    }
+
+    /// <summary>
+    /// Merges parent and base descriptor file access policies with the additional paths requested
+    /// by the spawn request. The result is constrained to what the parent agent is allowed:
+    /// sub-agents cannot exceed their parent's permissions (privilege escalation prevention).
+    /// </summary>
+    private static FileAccessPolicy? MergeFileAccess(
+        FileAccessPolicy? parentAccess,
+        FileAccessPolicy? baseAccess,
+        IReadOnlyList<string> additionalReadPaths,
+        IReadOnlyList<string> additionalWritePaths)
+    {
+        // Start with the base descriptor's access (parent clone or target agent)
+        var baseRead = baseAccess?.AllowedReadPaths ?? [];
+        var baseWrite = baseAccess?.AllowedWritePaths ?? [];
+        var denied = baseAccess?.DeniedPaths ?? [];
+
+        if (additionalReadPaths.Count == 0 && additionalWritePaths.Count == 0)
+        {
+            // No additions requested -- return base access as-is
+            return baseAccess;
+        }
+
+        // Filter additional paths to only those the parent can access (privilege confinement).
+        // If parentAccess is null, the parent has no restrictions -- allow any path.
+        var parentAllowedRead = parentAccess?.AllowedReadPaths;
+        var parentAllowedWrite = parentAccess?.AllowedWritePaths;
+
+        var grantedRead = additionalReadPaths
+            .Where(p => parentAllowedRead is null || parentAllowedRead.Any(allowed =>
+                p.StartsWith(allowed, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        var grantedWrite = additionalWritePaths
+            .Where(p => parentAllowedWrite is null || parentAllowedWrite.Any(allowed =>
+                p.StartsWith(allowed, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        var mergedRead = baseRead.Concat(grantedRead).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var mergedWrite = baseWrite.Concat(grantedWrite).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        return new FileAccessPolicy
+        {
+            AllowedReadPaths = mergedRead,
+            AllowedWritePaths = mergedWrite,
+            DeniedPaths = denied
+        };
     }
 }

--- a/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
@@ -42,7 +42,17 @@ public sealed class SubAgentSpawnTool(
                   "enum": ["researcher", "coder", "planner", "reviewer", "writer", "general"],
                   "description": "Optional behavioral archetype for the sub-agent."
                 },
-                "targetAgentId": { "type": "string", "description": "Optional registered agent ID to use as the sub-agent identity. When set, the sub-agent runs as this agent's descriptor instead of cloning the parent." }
+                "targetAgentId": { "type": "string", "description": "Optional registered agent ID to use as the sub-agent identity. When set, the sub-agent runs as this agent's descriptor instead of cloning the parent." },
+                "additionalReadPaths": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Additional absolute paths the sub-agent may read. Merged with parent workspace access. Only paths the parent can read are accepted."
+                },
+                "additionalWritePaths": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Additional absolute paths the sub-agent may write. Merged with parent workspace access. Only paths the parent can write are accepted."
+                }
               },
               "required": ["task"]
             }
@@ -83,7 +93,9 @@ public sealed class SubAgentSpawnTool(
             TimeoutSeconds = ReadInt(arguments, "timeoutSeconds", 600),
             Archetype = ReadArchetype(arguments),
             TargetAgentId = ReadString(arguments, "targetAgentId"),
-            InheritedConversationId = conversationId?.Value
+            InheritedConversationId = conversationId?.Value,
+            AdditionalReadPaths = ReadStringArray(arguments, "additionalReadPaths") ?? [],
+            AdditionalWritePaths = ReadStringArray(arguments, "additionalWritePaths") ?? []
         };
 
         var spawned = await subAgentManager.SpawnAsync(request, cancellationToken).ConfigureAwait(false);

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentFileAccessTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentFileAccessTests.cs
@@ -1,0 +1,201 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using Moq;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Tests for <see cref="DefaultSubAgentManager"/> file access path merging (#236).
+/// </summary>
+public sealed class SubAgentFileAccessTests
+{
+    // ── MergeFileAccess: no additional paths ──────────────────────────────────
+
+    [Fact]
+    public async Task SpawnAsync_WithNoAdditionalPaths_InheritsBaseDescriptorFileAccess()
+    {
+        var parentFileAccess = new FileAccessPolicy
+        {
+            AllowedReadPaths = ["/parent/workspace"],
+            AllowedWritePaths = ["/parent/workspace"]
+        };
+
+        AgentDescriptor? registered = null;
+        var (manager, _) = CreateManagerWithCapture(
+            parentAccess: parentFileAccess,
+            onRegister: d => registered = d);
+
+        await manager.SpawnAsync(CreateSpawnRequest());
+
+        registered.ShouldNotBeNull();
+        registered!.FileAccess.ShouldNotBeNull();
+        registered.FileAccess!.AllowedReadPaths.ShouldBe(["/parent/workspace"]);
+        registered.FileAccess.AllowedWritePaths.ShouldBe(["/parent/workspace"]);
+    }
+
+    // ── MergeFileAccess: additional read paths within parent's grant ─────────
+
+    [Fact]
+    public async Task SpawnAsync_WithAdditionalReadPaths_MergesGrantedPaths()
+    {
+        var parentFileAccess = new FileAccessPolicy
+        {
+            AllowedReadPaths = ["/repos/project", "/parent/workspace"],
+            AllowedWritePaths = ["/parent/workspace"]
+        };
+
+        AgentDescriptor? registered = null;
+        var (manager, _) = CreateManagerWithCapture(
+            parentAccess: parentFileAccess,
+            onRegister: d => registered = d);
+
+        await manager.SpawnAsync(CreateSpawnRequest(
+            additionalReadPaths: ["/repos/project/src"]));
+
+        registered.ShouldNotBeNull();
+        registered!.FileAccess.ShouldNotBeNull();
+        registered.FileAccess!.AllowedReadPaths.ShouldContain("/repos/project/src");
+        registered.FileAccess.AllowedReadPaths.ShouldContain("/parent/workspace"); // base preserved
+    }
+
+    // ── MergeFileAccess: privilege confinement ────────────────────────────────
+
+    [Fact]
+    public async Task SpawnAsync_WithPathsOutsideParentGrant_FiltersThemOut()
+    {
+        // Parent can only read /parent/workspace. Sub-agent requests /etc/secrets -- must be filtered.
+        var parentFileAccess = new FileAccessPolicy
+        {
+            AllowedReadPaths = ["/parent/workspace"],
+            AllowedWritePaths = ["/parent/workspace"]
+        };
+
+        AgentDescriptor? registered = null;
+        var (manager, _) = CreateManagerWithCapture(
+            parentAccess: parentFileAccess,
+            onRegister: d => registered = d);
+
+        await manager.SpawnAsync(CreateSpawnRequest(
+            additionalReadPaths: ["/etc/secrets", "/parent/workspace/sub"]));
+
+        registered.ShouldNotBeNull();
+        registered!.FileAccess.ShouldNotBeNull();
+        // /etc/secrets must NOT appear -- outside parent grant
+        registered.FileAccess!.AllowedReadPaths.ShouldNotContain("/etc/secrets");
+        // /parent/workspace/sub IS within parent grant
+        registered.FileAccess.AllowedReadPaths.ShouldContain("/parent/workspace/sub");
+    }
+
+    // ── MergeFileAccess: parent with no restrictions allows any path ──────────
+
+    [Fact]
+    public async Task SpawnAsync_WithNullParentFileAccess_AllowsAnyAdditionalPath()
+    {
+        // Parent descriptor has no FileAccess policy (no restrictions). All paths should be granted.
+        AgentDescriptor? registered = null;
+        var (manager, _) = CreateManagerWithCapture(
+            parentAccess: null,
+            onRegister: d => registered = d);
+
+        await manager.SpawnAsync(CreateSpawnRequest(
+            additionalReadPaths: ["/any/path"],
+            additionalWritePaths: ["/another/path"]));
+
+        registered.ShouldNotBeNull();
+        registered!.FileAccess.ShouldNotBeNull();
+        registered.FileAccess!.AllowedReadPaths.ShouldContain("/any/path");
+        registered.FileAccess.AllowedWritePaths.ShouldContain("/another/path");
+    }
+
+    // ── MergeFileAccess: write paths ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SpawnAsync_WithAdditionalWritePaths_MergesIntoWriteGrant()
+    {
+        var parentFileAccess = new FileAccessPolicy
+        {
+            AllowedReadPaths = ["/parent/workspace"],
+            AllowedWritePaths = ["/parent/workspace", "/shared/output"]
+        };
+
+        AgentDescriptor? registered = null;
+        var (manager, _) = CreateManagerWithCapture(
+            parentAccess: parentFileAccess,
+            onRegister: d => registered = d);
+
+        await manager.SpawnAsync(CreateSpawnRequest(
+            additionalWritePaths: ["/shared/output/report.txt"]));
+
+        registered.ShouldNotBeNull();
+        registered!.FileAccess.ShouldNotBeNull();
+        registered.FileAccess!.AllowedWritePaths.ShouldContain("/shared/output/report.txt");
+        registered.FileAccess.AllowedWritePaths.ShouldContain("/parent/workspace"); // base preserved
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static SubAgentSpawnRequest CreateSpawnRequest(
+        IReadOnlyList<string>? additionalReadPaths = null,
+        IReadOnlyList<string>? additionalWritePaths = null) => new()
+    {
+        ParentAgentId = AgentId.From("parent-agent"),
+        ParentSessionId = SessionId.From("parent-session"),
+        Task = "File access test task",
+        AdditionalReadPaths = additionalReadPaths ?? [],
+        AdditionalWritePaths = additionalWritePaths ?? []
+    };
+
+    private static (DefaultSubAgentManager manager, Mock<IAgentRegistry> registry) CreateManagerWithCapture(
+        FileAccessPolicy? parentAccess,
+        Action<AgentDescriptor> onRegister)
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentId.From("parent-agent"));
+        handle.SetupGet(h => h.SessionId).Returns(SessionId.From("session"));
+        handle.SetupGet(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+        handle.Setup(h => h.FollowUpAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var registry = new Mock<IAgentRegistry>();
+        registry
+            .Setup(r => r.Get(AgentId.From("parent-agent")))
+            .Returns(new AgentDescriptor
+            {
+                AgentId = AgentId.From("parent-agent"),
+                DisplayName = "Parent",
+                ModelId = "gpt-4o",
+                ApiProvider = "openai",
+                FileAccess = parentAccess
+            });
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        registry
+            .Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback<AgentDescriptor>(onRegister);
+
+        var options = new TestOptionsMonitor<GatewayOptions>(new GatewayOptions());
+
+        var manager = new DefaultSubAgentManager(
+            supervisor.Object,
+            registry.Object,
+            new Mock<IActivityBroadcaster>().Object,
+            new Mock<IChannelDispatcher>().Object,
+            options,
+            new Mock<Microsoft.Extensions.Logging.ILogger<DefaultSubAgentManager>>().Object);
+
+        return (manager, registry);
+    }
+}


### PR DESCRIPTION
Closes #236

## Changes

### `SubAgentSpawnRequest.cs`
- Added `AdditionalReadPaths` and `AdditionalWritePaths` properties (default empty)

### `DefaultSubAgentManager.cs`
- New `MergeFileAccess` static method merges base descriptor FileAccess with requested additional paths
- Privilege confinement: paths outside the parent agent own allowed set are silently filtered -- sub-agents cannot exceed parent permissions
- When parent `FileAccess` is null (no restrictions), all requested additional paths are granted
- Called at spawn time before registering child descriptor

### `SubAgentSpawnTool.cs`
- Added `additionalReadPaths` and `additionalWritePaths` to JSON schema
- Wired in `ExecuteAsync` via existing `ReadStringArray` helper

## Tests
- 5 new tests in `SubAgentFileAccessTests.cs`:
  - No additional paths: inherits base access unchanged
  - Read paths within parent grant: merged correctly
  - Paths outside parent grant: filtered (privilege confinement)
  - Null parent access (no restrictions): all paths granted
  - Write paths: merged into write grant
- 1641/1641 tests pass