### PR TITLE
feat(agents): provision temp workspace and support shareWorkspace/grantedPaths on spawn_subagent

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
@@ -87,4 +87,18 @@ public sealed record SubAgentSpawnRequest
     /// instead of creating a new one — keeping all output visible in the same portal thread.
     /// </summary>
     public string? InheritedConversationId { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, grants the sub-agent read and write access to the parent agent's
+    /// workspace directory in addition to its own temp workspace.
+    /// Defaults to <c>false</c> (isolated by default).
+    /// </summary>
+    public bool ShareParentWorkspace { get; init; }
+
+    /// <summary>
+    /// Additional absolute paths the sub-agent may read and write beyond its temp workspace.
+    /// Paths that are not within the parent's own <see cref="BotNexus.Gateway.Abstractions.Security.FileAccessPolicy"/>
+    /// are silently filtered to prevent privilege escalation.
+    /// </summary>
+    public IReadOnlyList<string> GrantedPaths { get; init; } = [];
 }

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentWorkspaceManager.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentWorkspaceManager.cs
@@ -61,4 +61,17 @@ public interface IAgentWorkspaceManager
     /// <param name="agentName">The agent identifier.</param>
     /// <returns><c>true</c> when the workspace was removed or did not exist; otherwise <c>false</c>.</returns>
     bool TryCleanupWorkspace(string agentName) => false;
+
+    /// <summary>
+    /// Provisions (creates) the workspace directory for an agent if it does not already exist.
+    /// </summary>
+    /// <param name="agentName">The agent identifier.</param>
+    /// <returns>The absolute workspace path.</returns>
+    string ProvisionWorkspace(string agentName)
+    {
+        var path = GetWorkspacePath(agentName);
+        if (!Directory.Exists(path))
+            Directory.CreateDirectory(path);
+        return path;
+    }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -9,6 +9,7 @@ using BotNexus.Gateway.Diagnostics;
 using BotNexus.Gateway.Security;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -120,12 +121,30 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             baseDescriptor = parentDescriptor;
         }
 
+        // Provision temporary workspace directory for the sub-agent.
+        // Sub-agents identify as "--subagent--" names, which GetWorkspacePath routes
+        // to a temp directory under the platform temp root.
+        string? childWorkspacePath = null;
+        if (_workspaceManager is not null)
+        {
+            childWorkspacePath = _workspaceManager.ProvisionWorkspace(childAgentId.Value);
+        }
+
+        // Build FileAccess for the child: always includes its own temp workspace.
+        // Optionally includes parent workspace (shareWorkspace) and caller-granted paths.
+        var childFileAccess = BuildChildFileAccess(
+            request,
+            childWorkspacePath,
+            baseDescriptor,
+            parentDescriptor);
+
         if (!_registry.Contains(childAgentId))
         {
             _registry.Register(baseDescriptor with
             {
                 AgentId = childAgentId,
-                DisplayName = $"{baseDescriptor.DisplayName} ({archetype.Value})"
+                DisplayName = $"{baseDescriptor.DisplayName} ({archetype.Value})",
+                FileAccess = childFileAccess
             });
         }
 
@@ -572,5 +591,103 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             searchFrom += separator.Length;
         }
         return depth;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="FileAccessPolicy"/> for a newly-spawned sub-agent.
+    /// Always grants the sub-agent its own temp workspace (read + write).
+    /// Optionally shares the parent workspace when <see cref="SubAgentSpawnRequest.ShareParentWorkspace"/> is true.
+    /// Additional <see cref="SubAgentSpawnRequest.GrantedPaths"/> are filtered against the parent's allowed set
+    /// to prevent privilege escalation.
+    /// </summary>
+    private FileAccessPolicy? BuildChildFileAccess(
+        SubAgentSpawnRequest request,
+        string? childWorkspacePath,
+        AgentDescriptor baseDescriptor,
+        AgentDescriptor parentDescriptor)
+    {
+        var readPaths = new List<string>();
+        var writePaths = new List<string>();
+
+        // Always include child's own temp workspace.
+        if (!string.IsNullOrWhiteSpace(childWorkspacePath))
+        {
+            readPaths.Add(childWorkspacePath);
+            writePaths.Add(childWorkspacePath);
+        }
+
+        // Optionally share parent workspace.
+        if (request.ShareParentWorkspace && _workspaceManager is not null)
+        {
+            var parentWorkspace = _workspaceManager.GetWorkspacePath(parentDescriptor.AgentId.Value);
+            if (!string.IsNullOrWhiteSpace(parentWorkspace))
+            {
+                readPaths.Add(parentWorkspace);
+                writePaths.Add(parentWorkspace);
+            }
+        }
+
+        // Merge caller-granted paths, filtered against parent's allowed set (privilege confinement).
+        if (request.GrantedPaths.Count > 0)
+        {
+            var parentPolicy = parentDescriptor.FileAccess;
+            foreach (var path in request.GrantedPaths)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                // If parent has no FileAccess restriction, all paths are permitted.
+                // If parent has a policy, the path must be within parent's allowed set.
+                if (parentPolicy is null || IsWithinParentGrant(path, parentPolicy))
+                {
+                    if (!readPaths.Contains(path, StringComparer.OrdinalIgnoreCase))
+                        readPaths.Add(path);
+                    if (!writePaths.Contains(path, StringComparer.OrdinalIgnoreCase))
+                        writePaths.Add(path);
+                }
+                else
+                {
+                    _logger.LogDebug(
+                        "GrantedPath '{Path}' is outside parent's FileAccess grant and was filtered for sub-agent.",
+                        path);
+                }
+            }
+        }
+
+        // If no workspace or paths were resolved, return null (workspace-only default).
+        if (readPaths.Count == 0 && writePaths.Count == 0)
+            return null;
+
+        // Carry through any denied paths from the base descriptor.
+        return new FileAccessPolicy
+        {
+            AllowedReadPaths = readPaths,
+            AllowedWritePaths = writePaths,
+            DeniedPaths = baseDescriptor.FileAccess?.DeniedPaths ?? []
+        };
+    }
+
+    private static bool IsWithinParentGrant(string path, FileAccessPolicy parentPolicy)
+    {
+        var fullPath = Path.GetFullPath(path);
+        foreach (var allowed in parentPolicy.AllowedReadPaths)
+        {
+            var allowedFull = Path.GetFullPath(allowed);
+            var prefix = allowedFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            if (fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                fullPath.Equals(allowedFull, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        foreach (var allowed in parentPolicy.AllowedWritePaths)
+        {
+            var allowedFull = Path.GetFullPath(allowed);
+            var prefix = allowedFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            if (fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                fullPath.Equals(allowedFull, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/FileAgentWorkspaceManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/FileAgentWorkspaceManager.cs
@@ -71,6 +71,15 @@ public sealed class FileAgentWorkspaceManager : IAgentWorkspaceManager
         return Path.Combine(_botNexusHome.GetAgentDirectory(normalizedAgentName), "workspace");
     }
 
+    string IAgentWorkspaceManager.ProvisionWorkspace(string agentName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
+        var path = GetWorkspacePath(agentName);
+        if (!_fileSystem.Directory.Exists(path))
+            _fileSystem.Directory.CreateDirectory(path);
+        return path;
+    }
+
     public bool TryCleanupWorkspace(string agentName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentName);

--- a/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
@@ -42,7 +42,13 @@ public sealed class SubAgentSpawnTool(
                   "enum": ["researcher", "coder", "planner", "reviewer", "writer", "general"],
                   "description": "Optional behavioral archetype for the sub-agent."
                 },
-                "targetAgentId": { "type": "string", "description": "Optional registered agent ID to use as the sub-agent identity. When set, the sub-agent runs as this agent's descriptor instead of cloning the parent." }
+                "targetAgentId": { "type": "string", "description": "Optional registered agent ID to use as the sub-agent identity. When set, the sub-agent runs as this agent's descriptor instead of cloning the parent." },
+                "shareWorkspace": { "type": "boolean", "description": "When true, grants the sub-agent read and write access to the parent's workspace. Default: false." },
+                "grantedPaths": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Optional list of absolute paths the sub-agent may read and write. Paths outside the parent's allowed set are silently filtered."
+                }
               },
               "required": ["task"]
             }
@@ -83,7 +89,9 @@ public sealed class SubAgentSpawnTool(
             TimeoutSeconds = ReadInt(arguments, "timeoutSeconds", 600),
             Archetype = ReadArchetype(arguments),
             TargetAgentId = ReadString(arguments, "targetAgentId"),
-            InheritedConversationId = conversationId?.Value
+            InheritedConversationId = conversationId?.Value,
+            ShareParentWorkspace = ReadBool(arguments, "shareWorkspace"),
+            GrantedPaths = ReadStringArray(arguments, "grantedPaths") ?? []
         };
 
         var spawned = await subAgentManager.SpawnAsync(request, cancellationToken).ConfigureAwait(false);
@@ -153,6 +161,20 @@ public sealed class SubAgentSpawnTool(
         }
 
         return null;
+    }
+
+    private static bool ReadBool(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value) || value is null)
+            return false;
+
+        return value switch
+        {
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            bool b => b,
+            _ => false
+        };
     }
 
     private static SubAgentArchetype ReadArchetype(IReadOnlyDictionary<string, object?> args)

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentWorkspaceIsolationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentWorkspaceIsolationTests.cs
@@ -1,0 +1,255 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Tests for sub-agent workspace isolation: temp workspace provisioning,
+/// shareWorkspace, and grantedPaths privilege confinement (issue #466).
+/// </summary>
+public sealed class SubAgentWorkspaceIsolationTests
+{
+    private static readonly AgentId ParentAgentId = AgentId.From("parent-agent");
+    private static readonly SessionId ParentSessionId = SessionId.From("parent-session");
+
+    [Fact]
+    public async Task SpawnAsync_ProvisionsTempWorkspace_WhenWorkspaceManagerPresent()
+    {
+        // Verify that SpawnAsync calls ProvisionWorkspace on the workspace manager for the child agent.
+        var workspaceManagerMock = new Mock<IAgentWorkspaceManager>();
+        workspaceManagerMock
+            .Setup(wm => wm.ProvisionWorkspace(It.IsAny<string>()))
+            .Returns((string agentName) => Path.Combine(Path.GetTempPath(), "botnexus-subagent-workspaces", agentName, "workspace"));
+        workspaceManagerMock
+            .Setup(wm => wm.GetWorkspacePath(It.IsAny<string>()))
+            .Returns((string agentName) => Path.Combine(Path.GetTempPath(), "botnexus-subagent-workspaces", agentName, "workspace"));
+
+        var (manager, _) = CreateManager(workspaceManager: workspaceManagerMock.Object);
+
+        await manager.SpawnAsync(CreateSpawnRequest());
+
+        workspaceManagerMock.Verify(
+            wm => wm.ProvisionWorkspace(It.Is<string>(s => s.Contains("--subagent--", StringComparison.Ordinal))),
+            Times.Once,
+            "ProvisionWorkspace should be called exactly once for the child agent");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_NoWorkspaceManager_DoesNotThrow()
+    {
+        // No IAgentWorkspaceManager registered — should still spawn successfully.
+        var (manager, _) = CreateManager(workspaceManager: null);
+
+        var info = await manager.SpawnAsync(CreateSpawnRequest());
+
+        info.ShouldNotBeNull();
+        info.Status.ShouldBe(SubAgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_ShareParentWorkspace_True_IncludesParentWorkspaceInFileAccess()
+    {
+        var fileSystem = new MockFileSystem();
+        var homePath = "/botnexus-home";
+        var workspaceManager = new FileAgentWorkspaceManager(
+            new BotNexus.Gateway.Configuration.BotNexusHome(fileSystem, homePath),
+            fileSystem);
+
+        AgentDescriptor? capturedDescriptor = null;
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(ParentAgentId)).Returns(MakeParentDescriptor());
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback<AgentDescriptor>(d => capturedDescriptor = d);
+
+        var (manager, _) = CreateManager(
+            workspaceManager: workspaceManager,
+            registry: registry);
+
+        await manager.SpawnAsync(CreateSpawnRequest(shareParentWorkspace: true));
+
+        capturedDescriptor.ShouldNotBeNull();
+        var parentWorkspacePath = workspaceManager.GetWorkspacePath(ParentAgentId.Value);
+        capturedDescriptor!.FileAccess.ShouldNotBeNull();
+        capturedDescriptor.FileAccess!.AllowedReadPaths
+            .ShouldContain(p => p.Equals(parentWorkspacePath, StringComparison.OrdinalIgnoreCase),
+                "parent workspace path should be in child read grants");
+        capturedDescriptor.FileAccess.AllowedWritePaths
+            .ShouldContain(p => p.Equals(parentWorkspacePath, StringComparison.OrdinalIgnoreCase),
+                "parent workspace path should be in child write grants");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_GrantedPaths_WithinParentGrant_AreIncluded()
+    {
+        // Parent has unrestricted access (FileAccess == null) — all granted paths should pass through.
+        var fileSystem = new MockFileSystem();
+        var homePath = "/botnexus-home";
+        var workspaceManager = new FileAgentWorkspaceManager(
+            new BotNexus.Gateway.Configuration.BotNexusHome(fileSystem, homePath),
+            fileSystem);
+        var grantedPath = Path.GetFullPath("/shared/repo");
+
+        AgentDescriptor? capturedDescriptor = null;
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(ParentAgentId)).Returns(MakeParentDescriptor(fileAccess: null));
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback<AgentDescriptor>(d => capturedDescriptor = d);
+
+        var (manager, _) = CreateManager(workspaceManager: workspaceManager, registry: registry);
+
+        await manager.SpawnAsync(CreateSpawnRequest(grantedPaths: [grantedPath]));
+
+        capturedDescriptor.ShouldNotBeNull();
+        capturedDescriptor!.FileAccess!.AllowedReadPaths
+            .ShouldContain(p => p.Equals(grantedPath, StringComparison.OrdinalIgnoreCase));
+        capturedDescriptor.FileAccess.AllowedWritePaths
+            .ShouldContain(p => p.Equals(grantedPath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SpawnAsync_GrantedPaths_OutsideParentGrant_AreFiltered()
+    {
+        // Parent has a restricted FileAccess — paths outside parent's grant must be filtered.
+        var fileSystem = new MockFileSystem();
+        var homePath = "/botnexus-home";
+        var workspaceManager = new FileAgentWorkspaceManager(
+            new BotNexus.Gateway.Configuration.BotNexusHome(fileSystem, homePath),
+            fileSystem);
+        var allowedPath = Path.GetFullPath("/allowed/zone");
+        var forbiddenPath = Path.GetFullPath("/secret/configs");
+
+        var parentPolicy = new FileAccessPolicy
+        {
+            AllowedReadPaths = [allowedPath],
+            AllowedWritePaths = [allowedPath]
+        };
+
+        AgentDescriptor? capturedDescriptor = null;
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(ParentAgentId)).Returns(MakeParentDescriptor(fileAccess: parentPolicy));
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback<AgentDescriptor>(d => capturedDescriptor = d);
+
+        var (manager, _) = CreateManager(workspaceManager: workspaceManager, registry: registry);
+
+        await manager.SpawnAsync(CreateSpawnRequest(
+            grantedPaths: [allowedPath, forbiddenPath]));
+
+        capturedDescriptor.ShouldNotBeNull();
+        var readPaths = capturedDescriptor!.FileAccess!.AllowedReadPaths;
+        readPaths.ShouldContain(p => p.Equals(allowedPath, StringComparison.OrdinalIgnoreCase),
+            "path within parent grant should be included");
+        readPaths.ShouldNotContain(p => p.Equals(forbiddenPath, StringComparison.OrdinalIgnoreCase),
+            "path outside parent grant must be filtered");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_DefaultIsolation_DoesNotIncludeParentWorkspace()
+    {
+        // Default spawn (no shareWorkspace, no grantedPaths) — parent workspace should NOT appear.
+        var fileSystem = new MockFileSystem();
+        var homePath = "/botnexus-home";
+        var workspaceManager = new FileAgentWorkspaceManager(
+            new BotNexus.Gateway.Configuration.BotNexusHome(fileSystem, homePath),
+            fileSystem);
+
+        AgentDescriptor? capturedDescriptor = null;
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(ParentAgentId)).Returns(MakeParentDescriptor());
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback<AgentDescriptor>(d => capturedDescriptor = d);
+
+        var (manager, _) = CreateManager(workspaceManager: workspaceManager, registry: registry);
+
+        await manager.SpawnAsync(CreateSpawnRequest());
+
+        capturedDescriptor.ShouldNotBeNull();
+        var parentWorkspacePath = workspaceManager.GetWorkspacePath(ParentAgentId.Value);
+        // FileAccess may be null (no policy) or may only include child temp workspace.
+        if (capturedDescriptor!.FileAccess is not null)
+        {
+            capturedDescriptor.FileAccess.AllowedReadPaths
+                .ShouldNotContain(p => p.Equals(parentWorkspacePath, StringComparison.OrdinalIgnoreCase),
+                    "parent workspace must NOT appear in child grants by default");
+        }
+    }
+
+    // ---- Helpers ----------------------------------------------------------------
+
+    private static SubAgentSpawnRequest CreateSpawnRequest(
+        bool shareParentWorkspace = false,
+        IReadOnlyList<string>? grantedPaths = null)
+        => new()
+        {
+            ParentAgentId = ParentAgentId,
+            ParentSessionId = ParentSessionId,
+            Task = "Do isolated work",
+            ShareParentWorkspace = shareParentWorkspace,
+            GrantedPaths = grantedPaths ?? []
+        };
+
+    private static AgentDescriptor MakeParentDescriptor(FileAccessPolicy? fileAccess = null)
+        => new()
+        {
+            AgentId = ParentAgentId,
+            DisplayName = "Parent Agent",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            FileAccess = fileAccess
+        };
+
+    private static (DefaultSubAgentManager Manager, Mock<IAgentRegistry> Registry) CreateManager(
+        IAgentWorkspaceManager? workspaceManager = null,
+        Mock<IAgentRegistry>? registry = null,
+        Action<AgentId>? onChildAgentId = null)
+    {
+        var isCallerRegistry = registry is not null;
+        registry ??= new Mock<IAgentRegistry>();
+
+        if (!isCallerRegistry)
+        {
+            registry.Setup(r => r.Get(ParentAgentId)).Returns(MakeParentDescriptor());
+            registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        }
+
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(ParentAgentId);
+        handle.SetupGet(h => h.SessionId).Returns(ParentSessionId);
+        handle.SetupGet(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentId, SessionId, CancellationToken>((agentId, _, _) => onChildAgentId?.Invoke(agentId))
+            .ReturnsAsync(handle.Object);
+        supervisor
+            .Setup(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var manager = new DefaultSubAgentManager(
+            supervisor.Object,
+            registry.Object,
+            Mock.Of<IActivityBroadcaster>(),
+            Mock.Of<IChannelDispatcher>(),
+            new TestOptionsMonitor<GatewayOptions>(new GatewayOptions()),
+            NullLogger<DefaultSubAgentManager>.Instance,
+            workspaceManager: workspaceManager);
+
+        return (manager, registry);
+    }
+}


### PR DESCRIPTION
Closes #466

## Changes

### `SubAgentSpawnRequest.cs`
- Added `ShareParentWorkspace` (bool, default false) and `GrantedPaths` (string[], default [])

### `IAgentWorkspaceManager.cs`
- Added `ProvisionWorkspace(agentName)` default interface method — creates the workspace directory and returns path

### `FileAgentWorkspaceManager.cs`
- Explicit interface implementation of `ProvisionWorkspace` using injected `IFileSystem` for testability

### `DefaultSubAgentManager.cs`
- `SpawnAsync` calls `_workspaceManager.ProvisionWorkspace(childAgentId.Value)` to create temp workspace before registering the child descriptor
- New `BuildChildFileAccess` method constructs a `FileAccessPolicy` that always includes the child's temp workspace, optionally the parent workspace (`ShareParentWorkspace`), and caller-granted paths filtered against parent's allowed set (privilege confinement)
- New `IsWithinParentGrant` helper for path confinement checks

### `SubAgentSpawnTool.cs`
- Added `shareWorkspace` and `grantedPaths` to JSON schema
- Wired in `ExecuteAsync` via new `ReadBool` helper

## Tests
- 6 new tests in `SubAgentWorkspaceIsolationTests.cs`:
  - `SpawnAsync_ProvisionsTempWorkspace_WhenWorkspaceManagerPresent` — ProvisionWorkspace called for child agent
  - `SpawnAsync_NoWorkspaceManager_DoesNotThrow` — graceful when no workspace manager registered
  - `SpawnAsync_ShareParentWorkspace_True_IncludesParentWorkspaceInFileAccess` — parent workspace in read+write grants
  - `SpawnAsync_GrantedPaths_WithinParentGrant_AreIncluded` — unrestricted parent allows all granted paths
  - `SpawnAsync_GrantedPaths_OutsideParentGrant_AreFiltered` — paths outside parent policy are filtered
  - `SpawnAsync_DefaultIsolation_DoesNotIncludeParentWorkspace` — parent workspace absent by default
- 1642/1642 tests pass