### PR TITLE
feat(cli): promote --target to global option on root command

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
@@ -9,17 +9,15 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class AgentCommands
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("agent", "Manage configured agents.");
 
         var listCommand = new Command("list", "List configured agents.");
-        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
@@ -30,14 +28,12 @@ internal sealed class AgentCommands
         var modelOption = new Option<string>("--model", () => "gpt-4.1", "Agent model name.");
         var enabledOption = new Option<bool>("--enabled", () => true, "Whether the agent is enabled.");
 
-        var addTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var addCommand = new Command("add", "Add an agent to config.json.")
         {
             idArgument,
             providerOption,
             modelOption,
-            enabledOption,
-            addTargetOption
+            enabledOption
         };
         addCommand.SetHandler(async context =>
         {
@@ -46,37 +42,31 @@ internal sealed class AgentCommands
             var model = context.ParseResult.GetValueForOption(modelOption) ?? "gpt-4.1";
             var enabled = context.ParseResult.GetValueForOption(enabledOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(addTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteAddAsync(id, provider, model, enabled, configPath, verbose, CancellationToken.None);
         });
 
-        var removeTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var removeCommand = new Command("remove", "Remove an agent from config.json.")
         {
-            idArgument,
-            removeTargetOption
+            idArgument
         };
         removeCommand.SetHandler(async context =>
         {
             var id = context.ParseResult.GetValueForArgument(idArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(removeTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteRemoveAsync(id, configPath, verbose, CancellationToken.None);
         });
 
-        var wizardTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        var wizardCommand = new Command("wizard", "Interactively create a new agent using a step-by-step wizard.")
-        {
-            wizardTargetOption
-        };
+        var wizardCommand = new Command("wizard", "Interactively create a new agent using a step-by-step wizard.");
         wizardCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(wizardTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteWizardAsync(configPath, verbose, CancellationToken.None);

--- a/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
@@ -9,41 +9,37 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("config", "Read and update BotNexus configuration.");
 
         var keyArgument = new Argument<string>("key", "Dotted config key path (example: gateway.listenUrl).");
-        var getTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var getCommand = new Command("get", "Get a config value by dotted key.")
         {
-            keyArgument,
-            getTargetOption
+            keyArgument
         };
         getCommand.SetHandler(async context =>
         {
             var key = context.ParseResult.GetValueForArgument(keyArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(getTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteGetAsync(key, configPath, verbose, CancellationToken.None);
         });
 
         var valueArgument = new Argument<string>("value", "Value to set.");
-        var setTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var setCommand = new Command("set", "Set a config value by dotted key.")
         {
             keyArgument,
-            valueArgument,
-            setTargetOption
+            valueArgument
         };
         setCommand.SetHandler(async context =>
         {
             var key = context.ParseResult.GetValueForArgument(keyArgument);
             var value = context.ParseResult.GetValueForArgument(valueArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(setTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteSetAsync(key, value, configPath, verbose, CancellationToken.None);

--- a/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
@@ -8,14 +8,10 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class DoctorCommand
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("doctor", "Run CLI diagnostics.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        var locationsCommand = new Command("locations", "Check location accessibility.")
-        {
-            targetOption
-        };
+        var locationsCommand = new Command("locations", "Check location accessibility.");
         locationsCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);

--- a/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
@@ -17,14 +17,13 @@ internal sealed class GatewayCommand
         _processManager = processManager;
     }
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("gateway", "Manage the BotNexus Gateway lifecycle");
 
         // Common options for start/restart
         var portOption = new Option<int>("--port", () => 5005, "Port to listen on.");
         var sourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         // Start command
         var attachedOption = new Option<bool>("--attached", "Run in foreground instead of detached mode.");
@@ -32,7 +31,6 @@ internal sealed class GatewayCommand
         {
             portOption,
             sourceOption,
-            targetOption,
             attachedOption
         };
         startCommand.SetHandler(async context =>
@@ -48,46 +46,36 @@ internal sealed class GatewayCommand
         });
 
         // Stop command
-        var stopTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
-        var stopCommand = new Command("stop", "Stop the gateway process")
-        {
-            stopTargetOption
-        };
+        var stopCommand = new Command("stop", "Stop the gateway process");
         stopCommand.SetHandler(async context =>
         {
-            var target = context.ParseResult.GetValueForOption(stopTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var home = CliPaths.ResolveTarget(target);
             context.ExitCode = await StopAsync(home, verbose, context.GetCancellationToken());
         });
 
         // Status command
-        var statusTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
-        var statusCommand = new Command("status", "Check gateway process status")
-        {
-            statusTargetOption
-        };
+        var statusCommand = new Command("status", "Check gateway process status");
         statusCommand.SetHandler(async context =>
         {
-            var target = context.ParseResult.GetValueForOption(statusTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var home = CliPaths.ResolveTarget(target);
             context.ExitCode = await StatusAsync(home, verbose, context.GetCancellationToken());
         });
 
         // Restart command
-        var restartTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
         var restartCommand = new Command("restart", "Restart the gateway process")
         {
             portOption,
-            sourceOption,
-            restartTargetOption
+            sourceOption
         };
         restartCommand.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(portOption);
             var source = context.ParseResult.GetValueForOption(sourceOption);
-            var target = context.ParseResult.GetValueForOption(restartTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var repoRoot = CliPaths.ResolveSource(source);
             var home = CliPaths.ResolveTarget(target);

--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -9,14 +9,12 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class InitCommand
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var forceOption = new Option<bool>("--force", "Overwrite existing config.json.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var command = new Command("init", "Initialize ~/.botnexus with a default config and required directories.")
         {
-            forceOption,
-            targetOption
+            forceOption
         };
 
         command.SetHandler(async context =>

--- a/src/gateway/BotNexus.Cli/Commands/LocationsCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/LocationsCommand.cs
@@ -10,17 +10,15 @@ internal sealed class LocationsCommand
     private static readonly string[] ValidTypes = ["filesystem", "api", "mcp-server", "database", "remote-node"];
     private const string RedactedConnectionStringDisplay = "(redacted)";
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("locations", "Manage configured locations.");
 
         var listCommand = new Command("list", "List all registered locations.");
-        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
@@ -39,7 +37,6 @@ internal sealed class LocationsCommand
         var connectionStringOption = new Option<string?>("--connection-string", "Connection string for database locations.");
         var descriptionOption = new Option<string?>("--description", "Location description.");
 
-        var addTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var addCommand = new Command("add", "Add a location to config.json.")
         {
             nameArgument,
@@ -47,8 +44,7 @@ internal sealed class LocationsCommand
             pathOption,
             endpointOption,
             connectionStringOption,
-            descriptionOption,
-            addTargetOption
+            descriptionOption
         };
         addCommand.SetHandler(async context =>
         {
@@ -59,7 +55,7 @@ internal sealed class LocationsCommand
             var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
             var description = context.ParseResult.GetValueForOption(descriptionOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(addTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteAddAsync(name, type, path, endpoint, connectionString, description, configPath, verbose, CancellationToken.None);
@@ -68,14 +64,12 @@ internal sealed class LocationsCommand
         var updatePathOption = new Option<string?>("--path", "Updated path.");
         var updateEndpointOption = new Option<string?>("--endpoint", "Updated endpoint.");
         var updateDescriptionOption = new Option<string?>("--description", "Updated description.");
-        var updateTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var updateCommand = new Command("update", "Update an existing location.")
         {
             nameArgument,
             updatePathOption,
             updateEndpointOption,
-            updateDescriptionOption,
-            updateTargetOption
+            updateDescriptionOption
         };
         updateCommand.SetHandler(async context =>
         {
@@ -84,23 +78,21 @@ internal sealed class LocationsCommand
             var endpoint = context.ParseResult.GetValueForOption(updateEndpointOption);
             var description = context.ParseResult.GetValueForOption(updateDescriptionOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(updateTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteUpdateAsync(name, path, endpoint, description, configPath, verbose, CancellationToken.None);
         });
 
-        var deleteTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var deleteCommand = new Command("delete", "Delete a location from config.json.")
         {
-            nameArgument,
-            deleteTargetOption
+            nameArgument
         };
         deleteCommand.SetHandler(async context =>
         {
             var name = context.ParseResult.GetValueForArgument(nameArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(deleteTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteDeleteAsync(name, configPath, verbose, CancellationToken.None);

--- a/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
@@ -12,17 +12,15 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class MemoryCommands
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("memory", "Memory store operations.");
 
         var agentOption = new Option<string?>("--agent", "Backfill only this agent. If omitted, backfill all agents.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         var backfillCommand = new Command("backfill", "Index conversation turns from existing sessions into memory stores.")
         {
-            agentOption,
-            targetOption
+            agentOption
         };
 
         backfillCommand.SetHandler(async context =>

--- a/src/gateway/BotNexus.Cli/Commands/PromptCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/PromptCommands.cs
@@ -14,11 +14,10 @@ internal sealed class PromptCommands
 {
     private const string PromptSampleResourcePrefix = "PromptSamples/";
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var prompt = new Command("prompt", "Manage prompt templates.");
 
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var configOption = new Option<string?>("--config", () => null, "Explicit config.json path. Overrides --target.");
         var agentOption = new Option<string?>("--agent", () => null, "Agent ID. Defaults to gateway.defaultAgentId.");
         var parameterOption = new Option<string[]>("--param", "Template parameter as key=value. Repeat for multiple values.")
@@ -28,7 +27,6 @@ internal sealed class PromptCommands
 
         var listCommand = new Command("list", "List prompt templates.")
         {
-            targetOption,
             configOption,
             agentOption
         };
@@ -46,7 +44,6 @@ internal sealed class PromptCommands
         var renderCommand = new Command("render", "Render a prompt template.")
         {
             templateArgument,
-            targetOption,
             configOption,
             agentOption,
             parameterOption
@@ -74,7 +71,6 @@ internal sealed class PromptCommands
         var runCommand = new Command("run", "Render and run a prompt template.")
         {
             templateArgument,
-            targetOption,
             configOption,
             agentOption,
             parameterOption,
@@ -106,7 +102,6 @@ internal sealed class PromptCommands
 
         var samplesCommand = new Command("samples", "Initialize sample prompt templates in ~/.botnexus/prompts")
         {
-            targetOption,
             configOption
         };
         samplesCommand.SetHandler(async context =>

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -27,29 +27,25 @@ internal sealed class ProviderCommand
         ["anthropic"] = "apikey"
     };
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("provider", "Configure and authenticate LLM providers.");
 
         var setupCommand = new Command("setup", "Interactively add and authenticate a new provider.");
-        var setupTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        setupCommand.Add(setupTargetOption);
         setupCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(setupTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteSetupAsync(configPath, home, verbose, CancellationToken.None);
         });
 
         var listCommand = new Command("list", "List configured providers.");
-        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
@@ -59,12 +55,10 @@ internal sealed class ProviderCommand
         command.AddCommand(listCommand);
 
         // Default to setup when no subcommand given
-        var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        command.Add(defaultTargetOption);
         command.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(defaultTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteDefaultAsync(configPath, home, verbose, CancellationToken.None);

--- a/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
@@ -15,10 +15,10 @@ internal sealed class ServeCommand
         _gatewayCommand = gatewayCommand;
     }
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         // Gateway lifecycle management
-        var gatewayCommand = _gatewayCommand.Build(verboseOption);
+        var gatewayCommand = _gatewayCommand.Build(verboseOption, targetOption);
 
         var probePortOption = new Option<int>("--port", () => 5050, "Port for the Probe web UI.");
         var probeSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
@@ -43,20 +43,18 @@ internal sealed class ServeCommand
         // serve (default = gateway)
         var servePortOption = new Option<int>("--port", () => 5005, "Port to listen on.");
         var serveSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
-        var serveTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         var command = new Command("serve", "Start a BotNexus service. Defaults to the gateway.")
         {
             servePortOption,
-            serveSourceOption,
-            serveTargetOption
+            serveSourceOption
         };
 
         command.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(servePortOption);
             var source = context.ParseResult.GetValueForOption(serveSourceOption);
-            var target = context.ParseResult.GetValueForOption(serveTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var repoRoot = CliPaths.ResolveSource(source);
             var home = CliPaths.ResolveTarget(target);

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -21,16 +21,14 @@ internal class UpdateCommand
         _processManager = processManager;
     }
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var sourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var portOption = new Option<int>("--port", () => 5005, "Gateway port.");
 
         var command = new Command("update", "Pull latest source, build, and restart the BotNexus gateway.")
         {
             sourceOption,
-            targetOption,
             portOption
         };
 

--- a/src/gateway/BotNexus.Cli/Commands/ValidateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ValidateCommand.cs
@@ -7,16 +7,14 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class ValidateCommand
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var remoteOption = new Option<bool>("--remote", "Validate using the running gateway /api/config/validate endpoint.");
         var gatewayUrlOption = new Option<string?>("--gateway-url", "Gateway base URL override for remote validation.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var command = new Command("validate", "Validate BotNexus platform configuration.")
         {
             remoteOption,
-            gatewayUrlOption,
-            targetOption
+            gatewayUrlOption
         };
 
         command.SetHandler(async context =>

--- a/src/gateway/BotNexus.Cli/Program.cs
+++ b/src/gateway/BotNexus.Cli/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 var verboseOption = new Option<bool>("--verbose", "Show additional command output.");
+var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus or BOTNEXUS_HOME env var.");
 
 using var serviceProvider = new ServiceCollection()
     .AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning))
@@ -32,19 +33,20 @@ using var serviceProvider = new ServiceCollection()
 
 var root = new RootCommand("BotNexus platform CLI");
 root.AddGlobalOption(verboseOption);
-root.AddCommand(serviceProvider.GetRequiredService<ValidateCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<InitCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<AgentCommands>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<MemoryCommands>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<ConfigCommands>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<LocationsCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<DoctorCommand>().Build(verboseOption));
+root.AddGlobalOption(targetOption);
+root.AddCommand(serviceProvider.GetRequiredService<ValidateCommand>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<InitCommand>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<AgentCommands>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<MemoryCommands>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<ConfigCommands>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<LocationsCommand>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<DoctorCommand>().Build(verboseOption, targetOption));
 root.AddCommand(serviceProvider.GetRequiredService<InstallCommand>().Build(verboseOption));
 root.AddCommand(serviceProvider.GetRequiredService<BuildCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<ServeCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<GatewayCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<PromptCommands>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<UpdateCommand>().Build(verboseOption));
-root.AddCommand(serviceProvider.GetRequiredService<ProviderCommand>().Build(verboseOption));
+root.AddCommand(serviceProvider.GetRequiredService<ServeCommand>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<GatewayCommand>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<PromptCommands>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<UpdateCommand>().Build(verboseOption, targetOption));
+root.AddCommand(serviceProvider.GetRequiredService<ProviderCommand>().Build(verboseOption, targetOption));
 root.AddCommand(serviceProvider.GetRequiredService<CronCommands>().Build(verboseOption));
 return await root.InvokeAsync(args);

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -108,7 +108,8 @@ public class UpdateCommandTests
     public void Update_command_is_registered_on_root()
     {
         var verbose = new Option<bool>("--verbose");
-        var command = BuildCommand().Build(verbose);
+        var target = new Option<string?>("--target");
+        var command = BuildCommand().Build(verbose, target);
 
         command.Name.ShouldBe("update");
     }
@@ -117,7 +118,8 @@ public class UpdateCommandTests
     public void Update_command_registers_check_subcommand()
     {
         var verbose = new Option<bool>("--verbose");
-        var command = BuildCommand().Build(verbose);
+        var target = new Option<string?>("--target");
+        var command = BuildCommand().Build(verbose, target);
 
         command.Subcommands.Any(c => c.Name == "check").ShouldBeTrue();
     }
@@ -126,11 +128,13 @@ public class UpdateCommandTests
     public void Update_command_has_expected_options()
     {
         var verbose = new Option<bool>("--verbose");
-        var command = BuildCommand().Build(verbose);
+        var target = new Option<string?>("--target");
+        var command = BuildCommand().Build(verbose, target);
 
         var names = command.Options.Select(o => o.Name).ToList();
         names.ShouldContain("source");
-        names.ShouldContain("target");
+        // --target is now a global option on the root command, not a local command option
+        names.ShouldNotContain("target");
         names.ShouldContain("port");
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Cli/CliTestFixture.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Cli/CliTestFixture.cs
@@ -70,6 +70,52 @@ internal sealed class CliTestFixture : IAsyncDisposable
         return new CliResult(process.ExitCode, await stdoutTask, await stderrTask);
     }
 
+    /// <summary>
+    /// Runs the CLI with <c>BOTNEXUS_HOME</c> cleared so the caller can test the global <c>--target</c> option
+    /// without environment variable interference.
+    /// </summary>
+    public async Task<CliResult> RunCliWithTargetFlagAsync(params string[] args)
+    {
+        // Prepend --target <rootPath> to the args list so the global option is set explicitly.
+        var allArgs = new List<string> { "--target", _rootPath };
+        allArgs.AddRange(args);
+
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        process.StartInfo.ArgumentList.Add(ResolveCliAssemblyPath());
+        foreach (var arg in allArgs)
+            process.StartInfo.ArgumentList.Add(arg);
+
+        // Do NOT set BOTNEXUS_HOME — we want the global --target to be the sole source.
+        process.StartInfo.Environment["BOTNEXUS_HOME"] = string.Empty;
+
+        process.Start();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("CLI command timed out.");
+        }
+
+        return new CliResult(process.ExitCode, await stdoutTask, await stderrTask);
+    }
+
     private static string ResolveCliAssemblyPath()
     {
         var localCopy = Path.Combine(AppContext.BaseDirectory, "BotNexus.Cli.dll");

--- a/tests/gateway/BotNexus.Gateway.Tests/Cli/GlobalTargetOptionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Cli/GlobalTargetOptionTests.cs
@@ -1,0 +1,91 @@
+namespace BotNexus.Gateway.Tests.Cli;
+
+/// <summary>
+/// Tests for the global <c>--target</c> option on the root CLI command.
+/// Verifies that placing <c>--target</c> before any subcommand correctly routes
+/// all commands to the specified BotNexus home directory.
+/// </summary>
+public sealed class GlobalTargetOptionTests
+{
+    [Fact]
+    public async Task GlobalTarget_Validate_RoutesToCorrectHomeDirectory()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync("""
+            {
+              "agents": {
+                "assistant": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1"
+                }
+              }
+            }
+            """);
+
+        // Use --target before the subcommand (global option style)
+        var result = await fixture.RunCliWithTargetFlagAsync("validate");
+
+        result.ExitCode.ShouldBe(0);
+        result.StdOut.ShouldContain("Result: VALID");
+    }
+
+    [Fact]
+    public async Task GlobalTarget_AgentList_RoutesToCorrectHomeDirectory()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync("""
+            {
+              "agents": {
+                "bot-dev": {
+                  "provider": "copilot",
+                  "model": "gpt-4.1",
+                  "enabled": true
+                }
+              }
+            }
+            """);
+
+        var result = await fixture.RunCliWithTargetFlagAsync("agent", "list");
+
+        result.ExitCode.ShouldBe(0);
+        result.StdOut.ShouldContain("bot-dev");
+    }
+
+    [Fact]
+    public async Task GlobalTarget_Init_RoutesToCorrectHomeDirectory()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync();
+
+        var result = await fixture.RunCliWithTargetFlagAsync("init");
+
+        result.ExitCode.ShouldBe(0);
+        File.Exists(fixture.ConfigPath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GlobalTarget_ConfigGet_RoutesToCorrectHomeDirectory()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync("""
+            {
+              "gateway": { "listenUrl": "http://0.0.0.0:9999" },
+              "agents": {}
+            }
+            """);
+
+        var result = await fixture.RunCliWithTargetFlagAsync("config", "get", "gateway.listenUrl");
+
+        result.ExitCode.ShouldBe(0);
+        result.StdOut.ShouldContain("9999");
+    }
+
+    [Fact]
+    public async Task GlobalTarget_AgentAdd_WritesToCorrectHomeDirectory()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync("""{"agents":{}}""");
+
+        var result = await fixture.RunCliWithTargetFlagAsync("agent", "add", "my-agent", "--provider", "copilot", "--model", "gpt-4.1");
+        var config = await fixture.LoadConfigAsync();
+
+        result.ExitCode.ShouldBe(0);
+        config.Agents.ShouldNotBeNull();
+        config.Agents!.ShouldContainKey("my-agent");
+    }
+}


### PR DESCRIPTION
Closes #226

## Changes

Promotes `--target` from per-subcommand option to a global option on the CLI root command.

All command `Build()` methods now accept `Option<string?> targetOption` as a parameter and read
it from ParseResult directly. Removes 22 per-subcommand `--target` declarations.

BOTNEXUS_HOME env var and CliPaths.ResolveTarget() fallback chain unchanged.

Test changes:
- UpdateCommandTests: pass targetOption to Build(), assert --target is NOT in local options
- CliTestFixture: new RunCliWithTargetFlagAsync prepends --target without setting BOTNEXUS_HOME
- 5 new GlobalTargetOptionTests: validate, agent list, init, config get, agent add

Usage:
  botnexus --target ~/.botnexus-dev agent list
  BOTNEXUS_HOME=~/.botnexus-dev botnexus agent list

Note: PR #475 (debug command) has a local --target in DebugCommands.cs that will need updating after merge.
