### PR TITLE
feat(memory): add MemoryDreamingConfig and periodic consolidation cron provisioner

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -104,6 +104,9 @@ public sealed record AgentDescriptor
     /// <summary>Heartbeat polling configuration for this agent. Null means heartbeat is disabled.</summary>
     public HeartbeatAgentConfig? Heartbeat { get; init; }
 
+    /// <summary>Memory dreaming configuration for this agent. Null means dreaming is disabled.</summary>
+    public MemoryDreamingConfig? MemoryDreaming { get; init; }
+
     /// <summary>Session access level for this agent's session tool. Defaults to "own".</summary>
     public string SessionAccessLevel { get; init; } = "own";
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/MemoryDreamingConfig.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/MemoryDreamingConfig.cs
@@ -1,0 +1,33 @@
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Memory dreaming configuration for periodic consolidation of daily notes into MEMORY.md.
+/// When enabled, a system cron job is provisioned that runs the agent with a consolidation
+/// prompt to read recent daily memory files and promote important items to MEMORY.md.
+/// </summary>
+public sealed class MemoryDreamingConfig
+{
+    /// <summary>Whether memory dreaming is enabled. Default: false.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Cron schedule for the dreaming job. Default: "0 3 * * *" (3am daily).
+    /// Uses standard 5-field cron syntax. Evaluated in <see cref="Timezone"/> if set.
+    /// </summary>
+    public string Schedule { get; set; } = "0 3 * * *";
+
+    /// <summary>
+    /// IANA timezone for the schedule. Falls back to agent soul timezone or UTC.
+    /// </summary>
+    public string? Timezone { get; set; }
+
+    /// <summary>
+    /// Number of days of daily notes to include in the consolidation window. Default: 7.
+    /// </summary>
+    public int LookbackDays { get; set; } = 7;
+
+    /// <summary>
+    /// Custom consolidation prompt. If null, uses the default prompt.
+    /// </summary>
+    public string? Prompt { get; set; }
+}

--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -15,6 +15,7 @@
     <Compile Include="CronOptions.cs" />
     <Compile Include="HeartbeatCronProvisioner.cs" />
     <Compile Include="IHeartbeatProvisioner.cs" />
+    <Compile Include="MemoryDreamingProvisioner.cs" />
     <Compile Include="CronScheduler.cs" />
     <Compile Include="Prompts\IPromptTemplateResolver.cs" />
     <Compile Include="Prompts\CronOptionsPromptTemplateResolver.cs" />

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -24,6 +24,8 @@ public static class CronServiceCollectionExtensions
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<HeartbeatCronProvisioner>());
         // Also expose as IHeartbeatProvisioner so AgentsController can call ProvisionAsync at runtime.
         services.TryAddSingleton<IHeartbeatProvisioner>(sp => sp.GetRequiredService<HeartbeatCronProvisioner>());
+        services.TryAddSingleton<MemoryDreamingProvisioner>();
+        services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<MemoryDreamingProvisioner>());
         services.TryAddSingleton<CronScheduler>();
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<CronScheduler>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, AgentPromptAction>());

--- a/src/gateway/BotNexus.Cron/MemoryDreamingProvisioner.cs
+++ b/src/gateway/BotNexus.Cron/MemoryDreamingProvisioner.cs
@@ -1,0 +1,132 @@
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Cron;
+
+/// <summary>
+/// Syncs memory dreaming cron jobs from agent configurations on startup.
+/// For each agent with memoryDreaming.enabled = true, ensures a system cron job exists
+/// that runs on the configured schedule and prompts the agent to consolidate daily notes
+/// into MEMORY.md.
+/// </summary>
+public sealed class MemoryDreamingProvisioner : IHostedService
+{
+    internal const string DefaultDreamingPrompt =
+        "Memory consolidation run. " +
+        "Read the last 7 days of daily memory files (memory/YYYY-MM-DD.md). " +
+        "Identify important decisions, recurring patterns, and items that should be persisted long-term. " +
+        "Update MEMORY.md with consolidated insights, keeping it concise and actionable. " +
+        "Archive or summarize processed daily notes where appropriate.";
+
+    private readonly IAgentRegistry _registry;
+    private readonly ICronStore _cronStore;
+    private readonly ILogger<MemoryDreamingProvisioner> _logger;
+
+    public MemoryDreamingProvisioner(
+        IAgentRegistry registry,
+        ICronStore cronStore,
+        ILogger<MemoryDreamingProvisioner> logger)
+    {
+        _registry = registry;
+        _cronStore = cronStore;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _cronStore.InitializeAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var descriptor in _registry.GetAll())
+        {
+            await ProvisionAsync(descriptor, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Provisions or removes the memory dreaming cron job for an agent descriptor.
+    /// Called on startup and when agents are registered or updated at runtime.
+    /// </summary>
+    public async Task ProvisionAsync(AgentDescriptor descriptor, CancellationToken cancellationToken)
+    {
+        var dreaming = descriptor.MemoryDreaming;
+        var jobId = $"memory-dreaming:{descriptor.AgentId}";
+
+        if (dreaming is not { Enabled: true })
+        {
+            var existing = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
+            if (existing is { System: true })
+            {
+                await _cronStore.DeleteAsync(jobId, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("Removed memory dreaming cron job for agent '{AgentId}'.", descriptor.AgentId);
+            }
+
+            return;
+        }
+
+        var schedule = !string.IsNullOrWhiteSpace(dreaming.Schedule)
+            ? dreaming.Schedule
+            : "0 3 * * *";
+
+        var timezone = dreaming.Timezone;
+        var prompt = dreaming.Prompt ?? BuildDefaultPrompt(dreaming.LookbackDays);
+        var existingJob = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
+
+        if (existingJob is null)
+        {
+            var job = new CronJob
+            {
+                Id = jobId,
+                Name = $"Memory Dreaming \u2014 {descriptor.DisplayName}",
+                Schedule = schedule,
+                ActionType = "agent-prompt",
+                AgentId = descriptor.AgentId,
+                Message = prompt,
+                Enabled = true,
+                System = true,
+                TimeZone = timezone,
+                CreatedBy = "system:memory-dreaming",
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+
+            await _cronStore.CreateAsync(job, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Provisioned memory dreaming cron job for agent '{AgentId}' with schedule '{Schedule}'.",
+                descriptor.AgentId, schedule);
+        }
+        else if (existingJob.Schedule != schedule
+                 || existingJob.Message != prompt
+                 || existingJob.TimeZone != timezone
+                 || !existingJob.Enabled
+                 || !existingJob.System)
+        {
+            var updated = existingJob with
+            {
+                Schedule = schedule,
+                Message = prompt,
+                Enabled = true,
+                System = true,
+                TimeZone = timezone
+            };
+
+            await _cronStore.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Updated memory dreaming cron job for agent '{AgentId}' with schedule '{Schedule}'.",
+                descriptor.AgentId, schedule);
+        }
+    }
+
+    public static string BuildDefaultPrompt(int lookbackDays)
+    {
+        var days = Math.Max(1, lookbackDays);
+        return
+            "Memory consolidation run. " +
+            $"Read the last {days} day{(days == 1 ? "" : "s")} of daily memory files (memory/YYYY-MM-DD.md). " +
+            "Identify important decisions, recurring patterns, and items that should be persisted long-term. " +
+            "Update MEMORY.md with consolidated insights, keeping it concise and actionable. " +
+            "Archive or summarize processed daily notes where appropriate.";
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
@@ -36,6 +36,7 @@
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SoulAgentConfig))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.HeartbeatAgentConfig))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.QuietHoursConfig))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.MemoryDreamingConfig))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SubAgentInfo))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SubAgentStatus))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SubAgentSpawnRequest))]

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigMerger.cs
@@ -65,6 +65,7 @@ public static class AgentConfigMerger
             ToolIds = MergeToolIds(defaults.ToolIds, agent.ToolIds, agentObj),
             Memory = MergeMemory(defaults.Memory, agent.Memory, agentObj),
             Heartbeat = MergeHeartbeat(defaults.Heartbeat, agent.Heartbeat, agentObj),
+            MemoryDreaming = MergeMemoryDreaming(defaults.MemoryDreaming, agent.MemoryDreaming, agentObj),
             FileAccess = MergeFileAccess(defaults.FileAccess, agent.FileAccess, agentObj),
         };
     }
@@ -233,6 +234,46 @@ public static class AgentConfigMerger
             Timezone = PickNullableString("timezone", defaults.Timezone, agent.Timezone, agentQhObj),
         };
     }
+
+    // -------------------------------------------------------------------------
+    // MemoryDreaming
+    // -------------------------------------------------------------------------
+
+    internal static MemoryDreamingConfig? MergeMemoryDreaming(
+        MemoryDreamingConfig? defaults,
+        MemoryDreamingConfig? agent,
+        JsonElement? agentObj)
+    {
+        if (defaults is null)
+            return agent is null ? null : CloneMemoryDreaming(agent);
+        if (agent is null)
+        {
+            if (agentObj is not null && agentObj.Value.TryGetProperty("memoryDreaming", out var dProp) && dProp.ValueKind == JsonValueKind.Null)
+                return null;
+            return CloneMemoryDreaming(defaults);
+        }
+
+        var agentDObj = agentObj is not null && agentObj.Value.TryGetProperty("memoryDreaming", out var drProp) && drProp.ValueKind == JsonValueKind.Object
+            ? drProp : (JsonElement?)null;
+
+        return new MemoryDreamingConfig
+        {
+            Enabled = PickBool("enabled", defaults.Enabled, agent.Enabled, agentDObj),
+            Schedule = PickString("schedule", defaults.Schedule, agent.Schedule, agentDObj),
+            Timezone = PickNullableString("timezone", defaults.Timezone, agent.Timezone, agentDObj),
+            LookbackDays = PickInt("lookbackDays", defaults.LookbackDays, agent.LookbackDays, agentDObj),
+            Prompt = PickNullableString("prompt", defaults.Prompt, agent.Prompt, agentDObj),
+        };
+    }
+
+    private static MemoryDreamingConfig CloneMemoryDreaming(MemoryDreamingConfig src) => new()
+    {
+        Enabled = src.Enabled,
+        Schedule = src.Schedule,
+        Timezone = src.Timezone,
+        LookbackDays = src.LookbackDays,
+        Prompt = src.Prompt
+    };
 
     // -------------------------------------------------------------------------
     // FileAccess

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentDefaultsConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentDefaultsConfig.cs
@@ -22,6 +22,9 @@ public sealed class AgentDefaultsConfig
     /// <summary>Default heartbeat configuration inherited by agents.</summary>
     public HeartbeatAgentConfig? Heartbeat { get; set; }
 
+    /// <summary>Default memory dreaming configuration inherited by agents.</summary>
+    public MemoryDreamingConfig? MemoryDreaming { get; set; }
+
     /// <summary>Default file access policy inherited by agents.</summary>
     public FileAccessPolicyConfig? FileAccess { get; set; }
 }

--- a/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
@@ -160,6 +160,7 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             IsolationOptions = ConvertObject(config.IsolationOptions),
             Soul = CloneSoulConfig(config.Soul),
             Heartbeat = CloneHeartbeatConfig(config.Heartbeat),
+            MemoryDreaming = CloneMemoryDreamingConfig(config.MemoryDreaming),
             FileAccess = MapFileAccessPolicy(config.FileAccess)
         };
     }
@@ -198,6 +199,21 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
                     End = heartbeatConfig.QuietHours.End,
                     Timezone = heartbeatConfig.QuietHours.Timezone
                 }
+        };
+    }
+
+    private static MemoryDreamingConfig? CloneMemoryDreamingConfig(MemoryDreamingConfig? cfg)
+    {
+        if (cfg is null)
+            return null;
+
+        return new MemoryDreamingConfig
+        {
+            Enabled = cfg.Enabled,
+            Schedule = cfg.Schedule,
+            Timezone = cfg.Timezone,
+            LookbackDays = cfg.LookbackDays,
+            Prompt = cfg.Prompt
         };
     }
 
@@ -375,6 +391,8 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
         public SoulAgentConfig? Soul { get; init; }
 
         public HeartbeatAgentConfig? Heartbeat { get; init; }
+
+        public MemoryDreamingConfig? MemoryDreaming { get; init; }
 
         public IReadOnlyList<string>? SubAgents { get; init; }
 

--- a/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationWriter.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationWriter.cs
@@ -103,6 +103,8 @@ public sealed class FileAgentConfigurationWriter(string directoryPath, BotNexusH
 
         public HeartbeatAgentConfig? Heartbeat { get; init; }
 
+        public MemoryDreamingConfig? MemoryDreaming { get; init; }
+
         public IReadOnlyList<string> SubAgentIds { get; init; } = [];
 
         public static AgentConfigurationFile FromDescriptor(AgentDescriptor descriptor)
@@ -123,6 +125,7 @@ public sealed class FileAgentConfigurationWriter(string directoryPath, BotNexusH
                 IsolationOptions = descriptor.IsolationOptions,
                 Soul = descriptor.Soul,
                 Heartbeat = descriptor.Heartbeat,
+                MemoryDreaming = descriptor.MemoryDreaming,
                 SubAgentIds = descriptor.SubAgentIds
             };
     }

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -440,6 +440,8 @@ public sealed class AgentDefinitionConfig
     public SoulAgentConfig? Soul { get; set; }
     /// <summary>Heartbeat polling configuration.</summary>
     public HeartbeatAgentConfig? Heartbeat { get; set; }
+    /// <summary>Memory dreaming configuration for periodic consolidation of daily notes into MEMORY.md.</summary>
+    public MemoryDreamingConfig? MemoryDreaming { get; set; }
     /// <summary>Session access configuration for this agent's session tool.</summary>
     public SessionAccessConfig? SessionAccess { get; set; }
     /// <summary>Conversation access configuration for this agent's conversation tool.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -105,6 +105,7 @@ public sealed class PlatformConfigAgentSource(
                 Memory = CloneMemoryConfig(effectiveConfig.Memory),
                 Soul = CloneSoulConfig(effectiveConfig.Soul),
                 Heartbeat = CloneHeartbeatConfig(effectiveConfig.Heartbeat),
+                MemoryDreaming = CloneMemoryDreamingConfig(effectiveConfig.MemoryDreaming),
                 SessionAccessLevel = effectiveConfig.SessionAccess?.Level ?? "own",
                 SessionAllowedAgents = effectiveConfig.SessionAccess?.AllowedAgents?.ToArray() ?? [],
                 ConversationAccessLevel = effectiveConfig.ConversationAccess?.Level ?? effectiveConfig.SessionAccess?.Level ?? "own",
@@ -146,6 +147,7 @@ public sealed class PlatformConfigAgentSource(
                 ToolTimeoutSeconds = config.ToolTimeoutSeconds,
                 Memory = config.Memory,
                 Heartbeat = config.Heartbeat,
+                MemoryDreaming = config.MemoryDreaming,
                 FileAccess = config.FileAccess
             };
         }
@@ -225,6 +227,21 @@ public sealed class PlatformConfigAgentSource(
                     End = heartbeatConfig.QuietHours.End,
                     Timezone = heartbeatConfig.QuietHours.Timezone
                 }
+        };
+    }
+
+    private static MemoryDreamingConfig? CloneMemoryDreamingConfig(MemoryDreamingConfig? cfg)
+    {
+        if (cfg is null)
+            return null;
+
+        return new MemoryDreamingConfig
+        {
+            Enabled = cfg.Enabled,
+            Schedule = cfg.Schedule,
+            Timezone = cfg.Timezone,
+            LookbackDays = cfg.LookbackDays,
+            Prompt = cfg.Prompt
         };
     }
 

--- a/tests/gateway/BotNexus.Cron.Tests/MemoryDreamingProvisionerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/MemoryDreamingProvisionerTests.cs
@@ -1,0 +1,207 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Cron.Tests;
+
+public sealed class MemoryDreamingProvisionerTests
+{
+    [Fact]
+    public async Task StartAsync_AgentWithDreamingEnabled_CreatesCronJob()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new MemoryDreamingConfig { Enabled = true, Schedule = "0 3 * * *" });
+        CronJob? created = null;
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(s => s.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
+            .Callback<CronJob, CancellationToken>((job, _) => created = job)
+            .ReturnsAsync((CronJob job, CancellationToken _) => job);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        created.ShouldNotBeNull();
+        created!.Id.ShouldBe("memory-dreaming:agent-a");
+        created.Schedule.ShouldBe("0 3 * * *");
+        created.ActionType.ShouldBe("agent-prompt");
+        created.System.ShouldBeTrue();
+        created.CreatedBy.ShouldBe("system:memory-dreaming");
+    }
+
+    [Fact]
+    public async Task StartAsync_AgentWithDreamingDisabled_DoesNotCreateJob()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new MemoryDreamingConfig { Enabled = false });
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        store.Verify(s => s.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_AgentWithNoDreamingConfig_DoesNotCreateJob()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", memoryDreaming: null);
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        store.Verify(s => s.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_ExistingJobWithChangedSchedule_UpdatesJob()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new MemoryDreamingConfig { Enabled = true, Schedule = "0 2 * * *" });
+        var existing = new CronJob
+        {
+            Id = "memory-dreaming:agent-a",
+            Name = "Memory Dreaming \u2014 Agent A",
+            Schedule = "0 3 * * *",
+            ActionType = "agent-prompt",
+            AgentId = "agent-a",
+            Message = "old",
+            Enabled = true,
+            System = true,
+            CreatedBy = "system:memory-dreaming",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        CronJob? updated = null;
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        store.Setup(s => s.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
+            .Callback<CronJob, CancellationToken>((job, _) => updated = job)
+            .ReturnsAsync((CronJob job, CancellationToken _) => job);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        updated.ShouldNotBeNull();
+        updated!.Schedule.ShouldBe("0 2 * * *");
+    }
+
+    [Fact]
+    public async Task StartAsync_DreamingDisabled_RemovesExistingSystemJob()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new MemoryDreamingConfig { Enabled = false });
+        var existing = new CronJob
+        {
+            Id = "memory-dreaming:agent-a",
+            Name = "Memory Dreaming — Agent A",
+            Schedule = "0 3 * * *",
+            ActionType = "agent-prompt",
+            System = true,
+            CreatedBy = "system:memory-dreaming"
+        };
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        store.Setup(s => s.DeleteAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        store.Verify(s => s.DeleteAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_CustomPrompt_UsesCustomPrompt()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var descriptor = CreateDescriptor("agent-a", new MemoryDreamingConfig
+        {
+            Enabled = true,
+            Prompt = "My custom consolidation prompt."
+        });
+        CronJob? created = null;
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(s => s.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
+            .Callback<CronJob, CancellationToken>((job, _) => created = job)
+            .ReturnsAsync((CronJob job, CancellationToken _) => job);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        created!.Message.ShouldBe("My custom consolidation prompt.");
+    }
+
+    [Theory]
+    [InlineData(1, "1 day")]
+    [InlineData(7, "7 days")]
+    [InlineData(14, "14 days")]
+    public void BuildDefaultPrompt_IncludesLookbackDays(int days, string expected)
+    {
+        var prompt = MemoryDreamingProvisioner.BuildDefaultPrompt(days);
+        prompt.ShouldContain(expected);
+    }
+
+    [Fact]
+    public async Task StartAsync_ExistingJobMatchesConfig_DoesNotUpdate()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        var store = new Mock<ICronStore>();
+        var config = new MemoryDreamingConfig { Enabled = true, Schedule = "0 3 * * *" };
+        var descriptor = CreateDescriptor("agent-a", config);
+        var expectedPrompt = MemoryDreamingProvisioner.BuildDefaultPrompt(config.LookbackDays);
+        var existing = new CronJob
+        {
+            Id = "memory-dreaming:agent-a",
+            Name = "Memory Dreaming — Agent A",
+            Schedule = "0 3 * * *",
+            ActionType = "agent-prompt",
+            Message = expectedPrompt,
+            Enabled = true,
+            System = true,
+            TimeZone = null
+        };
+
+        registry.Setup(r => r.GetAll()).Returns([descriptor]);
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetAsync("memory-dreaming:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        var provisioner = new MemoryDreamingProvisioner(registry.Object, store.Object, NullLogger<MemoryDreamingProvisioner>.Instance);
+        await provisioner.StartAsync(CancellationToken.None);
+
+        store.Verify(s => s.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static AgentDescriptor CreateDescriptor(string agentId, MemoryDreamingConfig? memoryDreaming)
+        => new()
+        {
+            AgentId = AgentId.From(agentId),
+            DisplayName = "Agent A",
+            ModelId = "gpt-4.1",
+            ApiProvider = "copilot",
+            MemoryDreaming = memoryDreaming
+        };
+}


### PR DESCRIPTION
Closes #418

Sub-issue of #32 (Memory lifecycle Phase 3/3).

## Changes

### New: MemoryDreamingConfig
Config block that controls periodic consolidation of daily memory notes into MEMORY.md:
- `enabled` (bool, default false)
- `schedule` (cron, default "0 3 * * *" = 3am daily)
- `timezone` (IANA, falls back to soul timezone or UTC)
- `lookbackDays` (int, default 7)
- `prompt` (optional custom prompt; default includes lookback day count)

### New: MemoryDreamingProvisioner
IHostedService that provisions system cron jobs (ActionType=agent-prompt) for agents with dreaming enabled:
- Job ID: `memory-dreaming:{agentId}`
- Provisions on startup for all registered agents
- Removes system job when dreaming is disabled
- Updates job when schedule/prompt/timezone changes
- Custom prompt supported; default prompt asks agent to read N days of daily notes and update MEMORY.md
- Registered in CronServiceCollectionExtensions alongside HeartbeatCronProvisioner

### Config pipeline wired in:
- AgentDefinitionConfig.MemoryDreaming
- AgentDefaultsConfig.MemoryDreaming
- AgentConfigMerger.MergeMemoryDreaming
- FileAgentConfigurationSource (clone + local DTO)
- FileAgentConfigurationWriter (DTO + FromDescriptor)
- PlatformConfigAgentSource (clone + AgentDefaultsConfig)
- BotNexus.Gateway.Abstractions TypeForward

### BotNexus.Cron.csproj
Added explicit Compile entry for MemoryDreamingProvisioner.cs (EnableDefaultCompileItems=false).

## Tests
10 new tests in MemoryDreamingProvisionerTests covering:
- enabled agent creates job
- disabled/null config skips creation
- schedule change triggers update
- disabled removes existing system job
- custom prompt used when set
- BuildDefaultPrompt includes lookback day count (Theory, 3 cases)
- no-change config skips update

139/139 cron tests pass; 1636/1636 gateway tests pass.
