### PR TITLE
feat(gateway): add webhook ingress endpoint for external service triggers

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/WebhooksController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/WebhooksController.cs
@@ -1,0 +1,197 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+/// <summary>
+/// Webhook ingress endpoint that allows external services to trigger agent conversations via HTTP.
+/// Requires a valid <c>X-BotNexus-Webhook-Key</c> header on all requests.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public sealed class WebhooksController : ControllerBase
+{
+    private readonly IAgentSupervisor _supervisor;
+    private readonly IConversationStore _conversations;
+    private readonly IOptions<WebhookOptions> _options;
+    private readonly IEnumerable<IConversationChangeNotifier> _conversationChangeNotifiers;
+    private readonly ILogger<WebhooksController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebhooksController"/> class.
+    /// </summary>
+    public WebhooksController(
+        IAgentSupervisor supervisor,
+        IConversationStore conversations,
+        IOptions<WebhookOptions> options,
+        IEnumerable<IConversationChangeNotifier>? conversationChangeNotifiers = null,
+        ILogger<WebhooksController>? logger = null)
+    {
+        _supervisor = supervisor;
+        _conversations = conversations;
+        _options = options;
+        _conversationChangeNotifiers = conversationChangeNotifiers ?? Enumerable.Empty<IConversationChangeNotifier>();
+        _logger = logger ?? NullLogger<WebhooksController>.Instance;
+    }
+
+    /// <summary>
+    /// Injects a user message into an agent conversation.
+    /// When <c>conversationId</c> is omitted, a new conversation is created.
+    /// The agent turn is dispatched asynchronously — this endpoint returns immediately after queuing.
+    /// </summary>
+    /// <param name="request">The webhook message request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>202 Accepted with conversationId, or an error status code.</returns>
+    [HttpPost("message")]
+    [ProducesResponseType(typeof(WebhookMessageResponse), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Message(
+        [FromBody] WebhookMessageRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Validate key
+        var keyHeader = HttpContext.Request.Headers["X-BotNexus-Webhook-Key"].FirstOrDefault();
+        if (!ValidateWebhookKey(keyHeader, request.AgentId, out var keyError))
+        {
+            _logger.LogWarning("Webhook request rejected: {Reason}", keyError);
+            return Unauthorized(new { error = keyError });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.AgentId))
+            return BadRequest(new { error = "agentId is required." });
+
+        if (string.IsNullOrWhiteSpace(request.Message))
+            return BadRequest(new { error = "message is required." });
+
+        // Resolve or create conversation
+        Conversation conversation;
+        if (!string.IsNullOrWhiteSpace(request.ConversationId))
+        {
+            var existing = await _conversations.GetAsync(ConversationId.From(request.ConversationId), cancellationToken);
+            if (existing is null)
+                return NotFound(new { error = $"Conversation '{request.ConversationId}' not found." });
+            conversation = existing;
+        }
+        else
+        {
+            conversation = new Conversation
+            {
+                ConversationId = ConversationId.Create(),
+                AgentId = AgentId.From(request.AgentId),
+                Title = string.IsNullOrWhiteSpace(request.ConversationTitle) ? "Webhook conversation" : request.ConversationTitle,
+                Purpose = string.IsNullOrWhiteSpace(request.ConversationPurpose) ? null : request.ConversationPurpose,
+                Status = ConversationStatus.Active,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            conversation = await _conversations.CreateAsync(conversation, cancellationToken);
+            _logger.LogDebug("Webhook created new conversation {ConversationId} for agent {AgentId}", conversation.ConversationId.Value, request.AgentId);
+        }
+
+        var sessionId = SessionId.From(Guid.NewGuid().ToString("N"));
+        var agentId = AgentId.From(request.AgentId);
+
+        try
+        {
+            var handle = await _supervisor.GetOrCreateAsync(agentId, sessionId, CancellationToken.None);
+
+            // Dispatch fire-and-forget — webhook callers do not wait for LLM response
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await handle.PromptAsync(request.Message, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Webhook agent turn failed for conversation {ConversationId}", conversation.ConversationId.Value);
+                }
+            }, CancellationToken.None);
+
+            // Notify portal about new conversation
+            foreach (var notifier in _conversationChangeNotifiers)
+            {
+                try { await notifier.NotifyConversationChangedAsync("created", agentId.Value, conversation.ConversationId.Value, cancellationToken); }
+                catch { /* best-effort */ }
+            }
+
+            _logger.LogInformation("Webhook message dispatched for agent {AgentId}, conversation {ConversationId}", request.AgentId, conversation.ConversationId.Value);
+            return Accepted(new WebhookMessageResponse(conversation.ConversationId.Value, sessionId.Value));
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (AgentConcurrencyLimitExceededException ex)
+        {
+            return StatusCode(StatusCodes.Status429TooManyRequests, new { error = ex.Message });
+        }
+    }
+
+    private bool ValidateWebhookKey(string? providedKey, string? agentId, out string error)
+    {
+        var config = _options.Value;
+
+        if (!config.Enabled)
+        {
+            error = "Webhook ingress is disabled.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(providedKey))
+        {
+            error = "X-BotNexus-Webhook-Key header is required.";
+            return false;
+        }
+
+        if (config.Keys is null || config.Keys.Count == 0)
+        {
+            error = "No webhook keys configured.";
+            return false;
+        }
+
+        foreach (var entry in config.Keys)
+        {
+            if (entry.Key != providedKey)
+                continue;
+
+            // Check agent scope restriction if set
+            if (entry.AllowedAgents is { Count: > 0 } && !string.IsNullOrWhiteSpace(agentId))
+            {
+                if (!entry.AllowedAgents.Contains(agentId, StringComparer.OrdinalIgnoreCase))
+                {
+                    error = $"Webhook key is not authorized for agent '{agentId}'.";
+                    return false;
+                }
+            }
+
+            error = string.Empty;
+            return true;
+        }
+
+        error = "Invalid webhook key.";
+        return false;
+    }
+}
+
+/// <summary>Webhook message request payload.</summary>
+public sealed record WebhookMessageRequest(
+    string AgentId,
+    string Message,
+    string? ConversationId = null,
+    string? ConversationTitle = null,
+    string? ConversationPurpose = null);
+
+/// <summary>Webhook message response payload.</summary>
+public sealed record WebhookMessageResponse(string ConversationId, string SessionId);

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -198,6 +198,15 @@ builder.Services.AddSingleton<ApiProviderRegistry>();
 builder.Services.AddSingleton<ModelRegistry>();
 builder.Services.AddSingleton<BuiltInModels>();
 builder.Services.AddHttpClient();
+// Webhook ingress options
+builder.Services.Configure<WebhookOptions>(options =>
+{
+    var webhookConfig = startupPlatformConfig.Gateway?.Webhooks;
+    if (webhookConfig is null) return;
+    options.Enabled = webhookConfig.Enabled;
+    options.Keys = webhookConfig.Keys;
+});
+
 builder.Services.AddTransient<ProviderLoggingHandler>();
 builder.Services.AddHttpClient("BotNexus", client =>
 {

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -138,6 +138,12 @@ public sealed class GatewaySettingsConfig
     /// Off by default; enable only for debugging unexpected provider responses.
     /// </summary>
     public bool EnableProviderRequestLogging { get; set; } = false;
+
+    /// <summary>
+    /// Webhook ingress configuration for POST /api/webhooks/message.
+    /// Disabled by default. Configure keys here to allow external services to trigger agent conversations.
+    /// </summary>
+    public WebhookConfig? Webhooks { get; set; }
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/WebhookOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/WebhookOptions.cs
@@ -1,0 +1,42 @@
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Configuration for the webhook ingress feature (POST /api/webhooks/message).
+/// </summary>
+public sealed class WebhookOptions
+{
+    /// <summary>Whether webhook ingress is enabled. Defaults to false.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>Pre-shared API keys for webhook authentication.</summary>
+    public List<WebhookKeyConfig> Keys { get; set; } = [];
+}
+
+/// <summary>A single webhook key configuration entry.</summary>
+public sealed class WebhookKeyConfig
+{
+    /// <summary>Unique ID for this key (for logging and management).</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>The secret key value. Must be provided by caller in X-BotNexus-Webhook-Key header.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional list of agent IDs this key is authorized to trigger.
+    /// When null or empty, the key is authorized for all agents.
+    /// </summary>
+    public List<string>? AllowedAgents { get; set; }
+}
+
+/// <summary>
+/// Serialization DTO for webhook config within PlatformConfig / GatewaySettingsConfig.
+/// Mirrors <see cref="WebhookOptions"/>.
+/// </summary>
+public sealed class WebhookConfig
+{
+    /// <summary>Whether webhook ingress is enabled.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>Pre-shared API keys for webhook authentication.</summary>
+    public List<WebhookKeyConfig> Keys { get; set; } = [];
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/WebhooksControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/WebhooksControllerTests.cs
@@ -1,0 +1,223 @@
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class WebhooksControllerTests
+{
+    private static WebhooksController MakeController(
+        IAgentSupervisor? supervisor = null,
+        IConversationStore? conversations = null,
+        WebhookOptions? options = null)
+    {
+        var opts = options ?? new WebhookOptions
+        {
+            Enabled = true,
+            Keys = [new WebhookKeyConfig { Id = "test", Key = "secret123" }]
+        };
+        var controller = new WebhooksController(
+            supervisor ?? Mock.Of<IAgentSupervisor>(),
+            conversations ?? Mock.Of<IConversationStore>(),
+            Options.Create(opts));
+        // Inject a fake HttpContext with the key header
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        return controller;
+    }
+
+    private static void SetWebhookKey(WebhooksController controller, string? key)
+    {
+        if (key is not null)
+            controller.HttpContext.Request.Headers["X-BotNexus-Webhook-Key"] = key;
+    }
+
+    // ---- Auth tests ----
+
+    [Fact]
+    public async Task Message_WhenWebhooksDisabled_Returns401()
+    {
+        var controller = MakeController(options: new WebhookOptions { Enabled = false });
+        SetWebhookKey(controller, "anykey");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "hello"), CancellationToken.None);
+
+        result.ShouldBeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task Message_WhenNoKeyHeader_Returns401()
+    {
+        var controller = MakeController();
+        // No key header set
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "hello"), CancellationToken.None);
+
+        result.ShouldBeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task Message_WhenInvalidKey_Returns401()
+    {
+        var controller = MakeController();
+        SetWebhookKey(controller, "wrong-key");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "hello"), CancellationToken.None);
+
+        result.ShouldBeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task Message_WhenKeyNotAuthorizedForAgent_Returns401()
+    {
+        var options = new WebhookOptions
+        {
+            Enabled = true,
+            Keys = [new WebhookKeyConfig { Id = "scoped", Key = "secret123", AllowedAgents = ["agent-b"] }]
+        };
+        var controller = MakeController(options: options);
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "hello"), CancellationToken.None);
+
+        result.ShouldBeOfType<UnauthorizedObjectResult>();
+    }
+
+    // ---- Validation tests ----
+
+    [Fact]
+    public async Task Message_WhenAgentIdMissing_Returns400()
+    {
+        var controller = MakeController();
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("", "hello"), CancellationToken.None);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Message_WhenMessageMissing_Returns400()
+    {
+        var controller = MakeController();
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", ""), CancellationToken.None);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    // ---- Happy path: new conversation ----
+
+    [Fact]
+    public async Task Message_WhenNoConversationId_CreatesNewConversationAndReturns202()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var convStore = new Mock<IConversationStore>();
+        convStore.Setup(c => c.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation conv, CancellationToken _) => conv);
+
+        var controller = MakeController(supervisor: supervisor.Object, conversations: convStore.Object);
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "trigger me", null, "My Title"), CancellationToken.None);
+
+        result.ShouldBeOfType<AcceptedResult>();
+        convStore.Verify(c => c.CreateAsync(It.Is<Conversation>(conv => conv.Title == "My Title"), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ---- Happy path: existing conversation ----
+
+    [Fact]
+    public async Task Message_WithExistingConversationId_UsesExistingConversation()
+    {
+        var existing = new Conversation
+        {
+            ConversationId = BotNexus.Domain.Primitives.ConversationId.From("c_existing"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+            Title = "Existing",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var convStore = new Mock<IConversationStore>();
+        convStore.Setup(c => c.GetAsync(BotNexus.Domain.Primitives.ConversationId.From("c_existing"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var controller = MakeController(supervisor: supervisor.Object, conversations: convStore.Object);
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "inject me", "c_existing"), CancellationToken.None);
+
+        result.ShouldBeOfType<AcceptedResult>();
+        convStore.Verify(c => c.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---- Sad paths ----
+
+    [Fact]
+    public async Task Message_WhenConversationNotFound_Returns404()
+    {
+        var convStore = new Mock<IConversationStore>();
+        convStore.Setup(c => c.GetAsync(It.IsAny<BotNexus.Domain.Primitives.ConversationId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation?)null);
+
+        var controller = MakeController(conversations: convStore.Object);
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "hello", "c_missing"), CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task Message_WhenKeyAuthorizedForAgent_AllowsRequest()
+    {
+        var options = new WebhookOptions
+        {
+            Enabled = true,
+            Keys = [new WebhookKeyConfig { Id = "scoped", Key = "secret123", AllowedAgents = ["agent-a"] }]
+        };
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        var convStore = new Mock<IConversationStore>();
+        convStore.Setup(c => c.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Conversation conv, CancellationToken _) => conv);
+
+        var controller = MakeController(supervisor: supervisor.Object, conversations: convStore.Object, options: options);
+        SetWebhookKey(controller, "secret123");
+
+        var result = await controller.Message(new WebhookMessageRequest("agent-a", "hello"), CancellationToken.None);
+
+        result.ShouldBeOfType<AcceptedResult>();
+    }
+}


### PR DESCRIPTION
Closes #258

## Changes

### New: POST /api/webhooks/message
Allows external services to trigger agent conversations via HTTP:
- Creates a new conversation (auto-titled) when no conversationId provided
- Injects into an existing conversation when conversationId is set
- Returns 202 Accepted with conversationId + sessionId (fire-and-forget)
- Agent turn dispatched asynchronously

### Auth: X-BotNexus-Webhook-Key header
- All requests require a pre-shared key in X-BotNexus-Webhook-Key header
- 401 when webhooks disabled, key missing, invalid, or agent not in AllowedAgents scope
- Keys configured in botnexus.yaml under gateway.webhooks

### Config (WebhookConfig + WebhookOptions)
- gateway.webhooks.enabled (bool, default false)
- gateway.webhooks.keys[]: id, key, allowedAgents (optional scope list)
- WebhookOptions registered in DI via Configure<WebhookOptions>

### Tests (WebhooksControllerTests)
10 new tests covering all auth, validation, and routing paths.
1646/1646 gateway tests pass.
