### PR TITLE
feat(agents): add built-in platform agents for common roles

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/BuiltInAgentConfigurationSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/BuiltInAgentConfigurationSource.cs
@@ -1,0 +1,185 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Provides the six built-in platform agents (researcher, coder, planner, reviewer, writer, analyst).
+/// These agents are always available on every BotNexus instance and cannot be overridden by config.
+/// </summary>
+/// <remarks>
+/// Built-in agents are registered before file/platform config sources so that
+/// <see cref="AgentConfigurationHostedService"/> will skip any config-file agent with the same ID
+/// (the code-based guard fires first).
+/// Their <c>metadata.role</c> value matches the agent ID, making them discoverable via
+/// <see cref="AgentDescriptor.SubAgentRoles"/> role-based grants.
+/// </remarks>
+public sealed class BuiltInAgentConfigurationSource : IAgentConfigurationSource
+{
+    /// <summary>
+    /// Built-in agent IDs — a caller may check these to avoid accidentally shadowing them.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AgentIds =
+    [
+        "researcher",
+        "coder",
+        "planner",
+        "reviewer",
+        "writer",
+        "analyst"
+    ];
+
+    private static readonly IReadOnlyList<AgentDescriptor> _agents = BuildAgents();
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<AgentDescriptor>> LoadAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_agents);
+
+    /// <inheritdoc/>
+    public IDisposable? Watch(Action<IReadOnlyList<AgentDescriptor>> onChanged) => null;
+
+    private static IReadOnlyList<AgentDescriptor> BuildAgents()
+    {
+        return
+        [
+            new AgentDescriptor
+            {
+                AgentId = AgentId.From("researcher"),
+                DisplayName = "Researcher",
+                Emoji = "🔍",
+                Description = "Web research, URL fetch, and summarization. Read-only — no code execution or file writes.",
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot",
+                IsolationStrategy = "in-process",
+                SystemPrompt = "You are Researcher 🔍, a focused information-gathering agent. Your job is to find, fetch, and summarize information from the web and memory. You do not write or execute code. Return your findings clearly and concisely.",
+                ToolIds =
+                [
+                    "web_search",
+                    "web_fetch",
+                    "memory_search",
+                    "memory_get",
+                    "read",
+                    "glob",
+                    "grep"
+                ],
+                Metadata = new Dictionary<string, object?> { ["role"] = "researcher" }
+            },
+
+            new AgentDescriptor
+            {
+                AgentId = AgentId.From("coder"),
+                DisplayName = "Coder",
+                Emoji = "💻",
+                Description = "Code writing, editing, building, and testing. Full file and shell access.",
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot",
+                IsolationStrategy = "in-process",
+                SystemPrompt = "You are Coder 💻, a focused software-engineering agent. Your job is to write, edit, build, and test code. Work precisely and methodically. Always verify your changes compile and tests pass before finishing.",
+                ToolIds =
+                [
+                    "read",
+                    "write",
+                    "edit",
+                    "glob",
+                    "grep",
+                    "shell",
+                    "exec",
+                    "process",
+                    "watch_file"
+                ],
+                Metadata = new Dictionary<string, object?> { ["role"] = "coder" }
+            },
+
+            new AgentDescriptor
+            {
+                AgentId = AgentId.From("planner"),
+                DisplayName = "Planner",
+                Emoji = "📋",
+                Description = "Issue decomposition, spec writing, and task breakdown. Memory and GitHub access.",
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot",
+                IsolationStrategy = "in-process",
+                SystemPrompt = "You are Planner 📋, a focused planning and decomposition agent. Your job is to break down complex problems into clear, actionable sub-tasks, write specs, and track progress. Be thorough and precise.",
+                ToolIds =
+                [
+                    "memory_search",
+                    "memory_save",
+                    "memory_get",
+                    "web_search",
+                    "read",
+                    "write"
+                ],
+                Metadata = new Dictionary<string, object?> { ["role"] = "planner" }
+            },
+
+            new AgentDescriptor
+            {
+                AgentId = AgentId.From("reviewer"),
+                DisplayName = "Reviewer",
+                Emoji = "🔎",
+                Description = "Code review, PR analysis, and quality checks. Read-only file and shell access.",
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot",
+                IsolationStrategy = "in-process",
+                SystemPrompt = "You are Reviewer 🔎, a focused code-review agent. Your job is to analyse code, identify issues, and provide clear actionable feedback. You are read-only — you do not modify files directly.",
+                ToolIds =
+                [
+                    "read",
+                    "glob",
+                    "grep",
+                    "shell",
+                    "web_fetch",
+                    "memory_search"
+                ],
+                Metadata = new Dictionary<string, object?> { ["role"] = "reviewer" }
+            },
+
+            new AgentDescriptor
+            {
+                AgentId = AgentId.From("writer"),
+                DisplayName = "Writer",
+                Emoji = "✍️",
+                Description = "Documentation, changelogs, summaries, and content. File write access.",
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot",
+                IsolationStrategy = "in-process",
+                SystemPrompt = "You are Writer ✍️, a focused documentation and content agent. Your job is to produce clear, well-structured written content: docs, changelogs, summaries, and guides. Write for your audience.",
+                ToolIds =
+                [
+                    "read",
+                    "write",
+                    "edit",
+                    "glob",
+                    "grep",
+                    "web_search",
+                    "web_fetch",
+                    "memory_search"
+                ],
+                Metadata = new Dictionary<string, object?> { ["role"] = "writer" }
+            },
+
+            new AgentDescriptor
+            {
+                AgentId = AgentId.From("analyst"),
+                DisplayName = "Analyst",
+                Emoji = "📊",
+                Description = "Data analysis, log triage, and metrics. Read and shell access.",
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot",
+                IsolationStrategy = "in-process",
+                SystemPrompt = "You are Analyst 📊, a focused data and log analysis agent. Your job is to triage logs, analyse data, surface metrics, and summarise findings. Be systematic and data-driven.",
+                ToolIds =
+                [
+                    "read",
+                    "glob",
+                    "grep",
+                    "shell",
+                    "exec",
+                    "web_fetch"
+                ],
+                Metadata = new Dictionary<string, object?> { ["role"] = "analyst" }
+            }
+        ];
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -173,6 +173,10 @@ public static class GatewayServiceCollectionExtensions
         // Built-in tools
         services.AddBotNexusTools();
 
+        // Built-in platform agents (researcher, coder, planner, reviewer, writer, analyst)
+        services.AddSingleton<IAgentConfigurationSource, BuiltInAgentConfigurationSource>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
+
         // Gateway host
         services.TryAddSingleton<GatewayHost>();
         services.TryAddSingleton<IChannelDispatcher>(serviceProvider => serviceProvider.GetRequiredService<GatewayHost>());

--- a/tests/agent/BotNexus.Agent.Core.Tests/Loop/ToolExecutorTimeoutTests.cs
+++ b/tests/agent/BotNexus.Agent.Core.Tests/Loop/ToolExecutorTimeoutTests.cs
@@ -248,26 +248,26 @@ public sealed class ToolExecutorTimeoutTests
     [Fact]
     public async Task ToolDefaultTimeout_SmallerThanSafetyCap_SafetyCapWins()
     {
-        // Tool declares 50ms default but safety cap is 500ms
-        // Tool runs for 200ms — should complete fine (both limits are above 200ms is wrong)
-        // Actually: safety cap 500ms > tool default 50ms → safety cap wins → tool gets 500ms
-        // Tool finishes in 200ms → success
+        // Tool declares 100ms default but safety cap is 2000ms
+        // Tool runs for 400ms — should complete fine (safety cap wins)
+        // Actually: safety cap 2000ms > tool default 100ms → safety cap wins → tool gets 2000ms
+        // Tool finishes in 400ms → success
         var completedNormally = false;
-        var tool = CreateToolWithDefaultTimeout("quick-tool", TimeSpan.FromMilliseconds(50), async ct =>
+        var tool = CreateToolWithDefaultTimeout("quick-tool", TimeSpan.FromMilliseconds(100), async ct =>
         {
-            await Task.Delay(200, ct);
+            await Task.Delay(400, ct);
             completedNormally = true;
             return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "done")]);
         });
 
         var msg = CreateAssistant("tc-1", "quick-tool");
-        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(500));
+        var config = TestHelpers.CreateTestConfig(toolTimeout: TimeSpan.FromMilliseconds(2000));
         var context = new AgentContext(null, [], [tool]);
 
         var results = await ToolExecutor.ExecuteAsync(
             context, msg, config, _ => Task.CompletedTask, CancellationToken.None);
 
-        // Safety cap (500ms) > tool default (50ms) → executor uses 500ms → 200ms tool succeeds
+        // Safety cap (2000ms) > tool default (100ms) → executor uses 2000ms → 400ms tool succeeds
         completedNormally.ShouldBeTrue();
         results[0].IsError.ShouldBeFalse();
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/BuiltInAgentConfigurationSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/BuiltInAgentConfigurationSourceTests.cs
@@ -1,0 +1,132 @@
+using BotNexus.Gateway.Configuration;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="BuiltInAgentConfigurationSource"/>.
+/// </summary>
+public sealed class BuiltInAgentConfigurationSourceTests
+{
+    private readonly BuiltInAgentConfigurationSource _source = new();
+
+    [Fact]
+    public async Task LoadAsync_ReturnsAllSixBuiltInAgents()
+    {
+        var agents = await _source.LoadAsync();
+
+        agents.Count.ShouldBe(6);
+    }
+
+    [Theory]
+    [InlineData("researcher")]
+    [InlineData("coder")]
+    [InlineData("planner")]
+    [InlineData("reviewer")]
+    [InlineData("writer")]
+    [InlineData("analyst")]
+    public async Task LoadAsync_ContainsExpectedAgentId(string agentId)
+    {
+        var agents = await _source.LoadAsync();
+
+        agents.ShouldContain(a => a.AgentId.Value == agentId,
+            $"built-in agents must include '{agentId}'");
+    }
+
+    [Theory]
+    [InlineData("researcher")]
+    [InlineData("coder")]
+    [InlineData("planner")]
+    [InlineData("reviewer")]
+    [InlineData("writer")]
+    [InlineData("analyst")]
+    public async Task LoadAsync_EachAgentHasRoleMetadataMatchingId(string agentId)
+    {
+        var agents = await _source.LoadAsync();
+        var agent = agents.Single(a => a.AgentId.Value == agentId);
+
+        agent.Metadata.ShouldContainKey("role",
+            $"agent '{agentId}' must have a 'role' metadata entry");
+        agent.Metadata["role"].ShouldBe(agentId,
+            $"agent '{agentId}' role metadata must equal its ID for SubAgentRoles matching");
+    }
+
+    [Theory]
+    [InlineData("researcher", "web_search")]
+    [InlineData("researcher", "web_fetch")]
+    [InlineData("researcher", "memory_search")]
+    [InlineData("coder", "shell")]
+    [InlineData("coder", "exec")]
+    [InlineData("coder", "write")]
+    [InlineData("planner", "memory_save")]
+    [InlineData("reviewer", "shell")]
+    [InlineData("writer", "write")]
+    [InlineData("analyst", "shell")]
+    [InlineData("analyst", "exec")]
+    public async Task LoadAsync_AgentHasExpectedToolInToolIds(string agentId, string toolId)
+    {
+        var agents = await _source.LoadAsync();
+        var agent = agents.Single(a => a.AgentId.Value == agentId);
+
+        agent.ToolIds.ShouldContain(toolId,
+            $"agent '{agentId}' must have tool '{toolId}'");
+    }
+
+    [Theory]
+    [InlineData("researcher", "shell")]
+    [InlineData("researcher", "exec")]
+    [InlineData("researcher", "write")]
+    [InlineData("researcher", "edit")]
+    [InlineData("reviewer", "write")]
+    [InlineData("reviewer", "edit")]
+    public async Task LoadAsync_ReadOnlyAgentsDoNotHaveMutatingTools(string agentId, string mutatingTool)
+    {
+        var agents = await _source.LoadAsync();
+        var agent = agents.Single(a => a.AgentId.Value == agentId);
+
+        agent.ToolIds.ShouldNotContain(mutatingTool,
+            $"read-only agent '{agentId}' must NOT have mutating tool '{mutatingTool}'");
+    }
+
+    [Fact]
+    public async Task LoadAsync_AllAgentsHaveSystemPrompt()
+    {
+        var agents = await _source.LoadAsync();
+
+        foreach (var agent in agents)
+        {
+            agent.SystemPrompt.ShouldNotBeNullOrWhiteSpace(
+                $"built-in agent '{agent.AgentId}' must have a system prompt");
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_AllAgentsHaveDisplayNameAndDescription()
+    {
+        var agents = await _source.LoadAsync();
+
+        foreach (var agent in agents)
+        {
+            agent.DisplayName.ShouldNotBeNullOrWhiteSpace(
+                $"built-in agent '{agent.AgentId}' must have a display name");
+            agent.Description.ShouldNotBeNullOrWhiteSpace(
+                $"built-in agent '{agent.AgentId}' must have a description");
+        }
+    }
+
+    [Fact]
+    public void Watch_ReturnsNull_BecauseBuiltInsAreStatic()
+    {
+        var watcher = _source.Watch(_ => { });
+
+        watcher.ShouldBeNull("built-in agents never change at runtime");
+    }
+
+    [Fact]
+    public void AgentIds_ContainsAllSixRoles()
+    {
+        BuiltInAgentConfigurationSource.AgentIds.ShouldBe(
+            ["researcher", "coder", "planner", "reviewer", "writer", "analyst"],
+            ignoreOrder: true);
+    }
+}


### PR DESCRIPTION
Closes #467

## Changes

Adds `BuiltInAgentConfigurationSource` providing 6 always-available platform agents:

| Agent | Role | Tools |
|-------|------|-------|
| `researcher` | researcher | web_search, web_fetch, memory_search, read, glob, grep |
| `coder` | coder | read, write, edit, glob, grep, shell, exec, process, watch_file |
| `planner` | planner | memory_search, memory_save, memory_get, web_search, read, write |
| `reviewer` | reviewer | read, glob, grep, shell, web_fetch, memory_search |
| `writer` | writer | read, write, edit, glob, grep, web_search, web_fetch, memory_search |
| `analyst` | analyst | read, glob, grep, shell, exec, web_fetch |

Each agent has `metadata.role` matching its ID, making it grantable via `SubAgentRoles`.

Registered in `AddBotNexusGateway()` alongside the `AgentConfigurationHostedService`, before file/platform config sources. The code-based agent guard in `AgentConfigurationHostedService.StartAsync` ensures config-file agents with the same ID are skipped.

## Tests

34 new unit tests covering:
- All 6 agents present
- Tool inclusion and exclusion (researcher/reviewer read-only)
- Role metadata matches agent ID
- System prompt + description completeness
- `Watch()` returns null (static source)