### PR TITLE
feat(channels): add test channel extension for integration testing

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -1,4 +1,4 @@
-<Solution>
+﻿<Solution>
   <Folder Name="/src/extensions/">
     <Project Path="src/extensions/BotNexus.Extensions.AudioTranscription/BotNexus.Extensions.AudioTranscription.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Skills/BotNexus.Extensions.Skills.csproj" />
@@ -12,6 +12,7 @@
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj" />
+    <Project Path="src/extensions/BotNexus.Extensions.Channels.Test/BotNexus.Extensions.Channels.Test.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Tui/BotNexus.Extensions.Channels.Tui.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.ServiceBus/BotNexus.Extensions.Channels.ServiceBus.csproj" />
   </Folder>
@@ -73,6 +74,7 @@
     <Project Path="tests/extensions/BotNexus.Extensions.Skills.Tests/BotNexus.Extensions.Skills.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.WebTools.Tests/BotNexus.Extensions.WebTools.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj" />
+    <Project Path="tests/extensions/BotNexus.Extensions.Channels.Test.Tests/BotNexus.Extensions.Channels.Test.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/gateway/">
     <Project Path="tests/gateway/BotNexus.Cli.Tests/BotNexus.Cli.Tests.csproj" />

--- a/src/extensions/BotNexus.Extensions.Channels.Test/BotNexus.Extensions.Channels.Test.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/BotNexus.Extensions.Channels.Test.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Content Include="botnexus-extension.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+</Project>

--- a/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelAdapter.cs
@@ -1,0 +1,172 @@
+﻿using System.Collections.Concurrent;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Channels.Test;
+
+/// <summary>
+/// In-memory test channel adapter for integration testing of multi-channel scenarios.
+/// Stores inbound/outbound messages and captured log entries in memory.
+/// Exposes HTTP endpoints via <see cref="TestChannelEndpoints"/> for test orchestration.
+/// </summary>
+/// <remarks>
+/// This adapter is opt-in only. It must be explicitly registered and should never
+/// be loaded in production configurations. The <c>botnexus-extension.json</c> manifest
+/// has <c>"enabled": false</c> to prevent accidental auto-loading.
+/// </remarks>
+public sealed class TestChannelAdapter : ChannelAdapterBase
+{
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<OutboundMessage>> _outbound =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, System.Text.StringBuilder> _streamBuffers =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentQueue<TestLogEntry> _logs = new();
+
+    public TestChannelAdapter(ILogger<TestChannelAdapter> logger) : base(logger)
+    {
+    }
+
+    /// <inheritdoc />
+    public override ChannelKey ChannelType => ChannelKey.From("test");
+
+    /// <inheritdoc />
+    public override string DisplayName => "Test Channel";
+
+    /// <inheritdoc />
+    public override bool SupportsStreaming => true;
+
+    /// <summary>
+    /// Enqueues an outbound message to the per-channel queue.
+    /// </summary>
+    public override Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
+    {
+        var queue = _outbound.GetOrAdd(message.ChannelAddress.Value, _ => new ConcurrentQueue<OutboundMessage>());
+        queue.Enqueue(message);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Accumulates streaming deltas per conversation. Deltas are buffered and
+    /// exposed via <see cref="GetOutbound"/> as a single synthetic message on flush.
+    /// </summary>
+    public override Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    {
+        var buf = _streamBuffers.GetOrAdd(conversationId, _ => new System.Text.StringBuilder());
+        lock (buf)
+            buf.Append(delta);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Flushes any accumulated streaming buffer for <paramref name="conversationId"/>
+    /// into the outbound queue and clears the buffer.
+    /// </summary>
+    public void FlushStreamBuffer(string conversationId)
+    {
+        if (!_streamBuffers.TryGetValue(conversationId, out var buf))
+            return;
+
+        string content;
+        lock (buf)
+        {
+            content = buf.ToString();
+            buf.Clear();
+        }
+
+        if (string.IsNullOrEmpty(content))
+            return;
+
+        var queue = _outbound.GetOrAdd(conversationId, _ => new ConcurrentQueue<OutboundMessage>());
+        queue.Enqueue(new OutboundMessage
+        {
+            ChannelType = ChannelType,
+            ChannelAddress = ChannelAddress.From(conversationId),
+            Content = content,
+            Metadata = new Dictionary<string, object?> { ["source"] = "stream-flush" }
+        });
+    }
+
+    /// <summary>
+    /// Returns and dequeues all outbound messages for the given channel address.
+    /// </summary>
+    public IReadOnlyList<OutboundMessage> GetOutbound(string channelId)
+    {
+        if (!_outbound.TryGetValue(channelId, out var queue))
+            return [];
+
+        var result = new List<OutboundMessage>();
+        while (queue.TryDequeue(out var msg))
+            result.Add(msg);
+        return result;
+    }
+
+    /// <summary>
+    /// Clears all outbound messages for the given channel address.
+    /// </summary>
+    public void ClearOutbound(string channelId)
+    {
+        if (_outbound.TryGetValue(channelId, out var queue))
+            while (queue.TryDequeue(out _)) { }
+    }
+
+    /// <summary>
+    /// Returns all captured log entries (does not clear).
+    /// </summary>
+    public IReadOnlyList<TestLogEntry> GetLogs()
+    {
+        return _logs.ToArray();
+    }
+
+    /// <summary>
+    /// Clears the log buffer.
+    /// </summary>
+    public void ClearLogs()
+    {
+        while (_logs.TryDequeue(out _)) { }
+    }
+
+    /// <summary>
+    /// Injects an inbound message into the gateway pipeline as if it arrived on this channel.
+    /// </summary>
+    public Task InjectInboundAsync(
+        string channelId,
+        string content,
+        string senderId,
+        string? targetAgentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var message = new InboundMessage
+        {
+            ChannelType = ChannelType,
+            ChannelAddress = ChannelAddress.From(channelId),
+            SenderId = senderId,
+            Content = content,
+            TargetAgentId = targetAgentId
+        };
+
+        return DispatchInboundAsync(message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Captures a log entry into the internal log buffer.
+    /// Called by <see cref="TestChannelLoggerProvider"/>.
+    /// </summary>
+    public void CaptureLog(TestLogEntry entry) => _logs.Enqueue(entry);
+
+    /// <inheritdoc />
+    protected override Task OnStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    protected override Task OnStopAsync(CancellationToken cancellationToken)
+    {
+        _outbound.Clear();
+        _streamBuffers.Clear();
+        while (_logs.TryDequeue(out _)) { }
+        return Task.CompletedTask;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelEndpoints.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelEndpoints.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace BotNexus.Extensions.Channels.Test;
+
+/// <summary>
+/// Minimal API endpoints for the test channel HTTP interface.
+/// Map these endpoints in your test host startup via <see cref="MapTestChannelEndpoints"/>.
+/// </summary>
+public static class TestChannelEndpoints
+{
+    /// <summary>
+    /// Maps the test channel HTTP endpoints to the given route builder.
+    /// </summary>
+    /// <remarks>
+    /// Endpoints:
+    /// <list type="bullet">
+    ///   <item><c>POST /test-channel/{channelId}/inbound</c> — inject inbound message</item>
+    ///   <item><c>GET /test-channel/{channelId}/outbound</c> — poll outbound messages</item>
+    ///   <item><c>DELETE /test-channel/{channelId}/outbound</c> — clear outbound queue</item>
+    ///   <item><c>GET /test-channel/logs</c> — get captured log entries</item>
+    ///   <item><c>DELETE /test-channel/logs</c> — clear log buffer</item>
+    /// </list>
+    /// </remarks>
+    public static IEndpointRouteBuilder MapTestChannelEndpoints(
+        this IEndpointRouteBuilder app,
+        TestChannelAdapter adapter)
+    {
+        var group = app.MapGroup("/test-channel");
+
+        // POST /test-channel/{channelId}/inbound
+        group.MapPost("{channelId}/inbound", async (string channelId, InboundMessageRequest req, CancellationToken ct) =>
+        {
+            await adapter.InjectInboundAsync(channelId, req.Content, req.SenderId, req.TargetAgentId, ct);
+            return Results.Ok(new { channelId, injected = true });
+        });
+
+        // GET /test-channel/{channelId}/outbound
+        group.MapGet("{channelId}/outbound", (string channelId) =>
+        {
+            var messages = adapter.GetOutbound(channelId);
+            return Results.Ok(messages.Select(m => new
+            {
+                channelAddress = m.ChannelAddress.Value,
+                content = m.Content,
+                metadata = m.Metadata
+            }));
+        });
+
+        // DELETE /test-channel/{channelId}/outbound
+        group.MapDelete("{channelId}/outbound", (string channelId) =>
+        {
+            adapter.ClearOutbound(channelId);
+            return Results.NoContent();
+        });
+
+        // GET /test-channel/logs
+        group.MapGet("logs", () =>
+        {
+            var logs = adapter.GetLogs();
+            return Results.Ok(logs.Select(l => new
+            {
+                timestamp = l.Timestamp,
+                level = l.Level,
+                message = l.Message,
+                properties = l.Properties
+            }));
+        });
+
+        // DELETE /test-channel/logs
+        group.MapDelete("logs", () =>
+        {
+            adapter.ClearLogs();
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+
+    /// <summary>
+    /// Request body for injecting an inbound message.
+    /// </summary>
+    public sealed record InboundMessageRequest(
+        string Content,
+        string SenderId,
+        string? TargetAgentId = null);
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelLoggerProvider.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelLoggerProvider.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Channels.Test;
+
+/// <summary>
+/// An <see cref="ILoggerProvider"/> that captures all log entries to the
+/// <see cref="TestChannelAdapter"/> log buffer, making them queryable via the
+/// <c>/test-channel/logs</c> HTTP endpoint.
+/// </summary>
+public sealed class TestChannelLoggerProvider : ILoggerProvider
+{
+    private readonly TestChannelAdapter _adapter;
+
+    public TestChannelLoggerProvider(TestChannelAdapter adapter)
+    {
+        _adapter = adapter;
+    }
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName) => new TestChannelLogger(categoryName, _adapter);
+
+    /// <inheritdoc />
+    public void Dispose() { }
+}
+
+/// <summary>
+/// Logger implementation that writes to the <see cref="TestChannelAdapter"/> log buffer.
+/// </summary>
+public sealed class TestChannelLogger : ILogger
+{
+    private readonly string _category;
+    private readonly TestChannelAdapter _adapter;
+
+    public TestChannelLogger(string category, TestChannelAdapter adapter)
+    {
+        _category = category;
+        _adapter = adapter;
+    }
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    /// <inheritdoc />
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+            return;
+
+        var message = formatter(state, exception);
+        if (exception is not null)
+            message = $"{message} | Exception: {exception.Message}";
+
+        var properties = new Dictionary<string, object?>
+        {
+            ["category"] = _category,
+            ["eventId"] = eventId.Id,
+            ["eventName"] = eventId.Name
+        };
+
+        // Extract structured log properties from IReadOnlyList<KeyValuePair<string, object?>> state
+        if (state is IEnumerable<KeyValuePair<string, object?>> kvps)
+        {
+            foreach (var (key, val) in kvps)
+            {
+                if (key != "{OriginalFormat}")
+                    properties[key] = val;
+            }
+        }
+
+        _adapter.CaptureLog(new TestLogEntry(
+            Timestamp: DateTimeOffset.UtcNow,
+            Level: logLevel.ToString(),
+            Message: message,
+            Properties: properties));
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelServiceCollectionExtensions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/TestChannelServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using BotNexus.Gateway.Abstractions.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Channels.Test;
+
+/// <summary>
+/// Dependency-injection extensions for registering the test channel adapter.
+/// </summary>
+public static class TestChannelServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the test channel adapter and its log capture provider.
+    /// </summary>
+    /// <remarks>
+    /// This method is opt-in only. Never call it in production configurations.
+    /// The test channel is designed exclusively for integration testing.
+    /// </remarks>
+    public static IServiceCollection AddBotNexusTestChannel(this IServiceCollection services)
+    {
+        services.AddSingleton<TestChannelAdapter>();
+        services.AddSingleton<IChannelAdapter>(sp => sp.GetRequiredService<TestChannelAdapter>());
+        services.AddSingleton<ILoggerProvider>(sp =>
+            new TestChannelLoggerProvider(sp.GetRequiredService<TestChannelAdapter>()));
+        return services;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Test/TestLogEntry.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/TestLogEntry.cs
@@ -1,0 +1,10 @@
+namespace BotNexus.Extensions.Channels.Test;
+
+/// <summary>
+/// A captured log entry from the test channel log sink.
+/// </summary>
+public sealed record TestLogEntry(
+    DateTimeOffset Timestamp,
+    string Level,
+    string Message,
+    Dictionary<string, object?> Properties);

--- a/src/extensions/BotNexus.Extensions.Channels.Test/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.Test/botnexus-extension.json
@@ -1,0 +1,9 @@
+{
+  "id": "botnexus-test-channel",
+  "name": "Test Channel",
+  "description": "In-memory test channel adapter for integration testing of multi-channel scenarios. Never load in production.",
+  "version": "1.0.0",
+  "entryAssembly": "BotNexus.Extensions.Channels.Test.dll",
+  "extensionTypes": ["channel"],
+  "enabled": false
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.Test.Tests/BotNexus.Extensions.Channels.Test.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Channels.Test.Tests/BotNexus.Extensions.Channels.Test.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.Test\BotNexus.Extensions.Channels.Test.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/extensions/BotNexus.Extensions.Channels.Test.Tests/TestChannelAdapterTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.Test.Tests/TestChannelAdapterTests.cs
@@ -1,0 +1,195 @@
+﻿using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Extensions.Channels.Test;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Extensions.Channels.Test.Tests;
+
+public sealed class TestChannelAdapterTests
+{
+    private static TestChannelAdapter CreateAdapter() =>
+        new TestChannelAdapter(NullLogger<TestChannelAdapter>.Instance);
+
+    // 1. ChannelType returns "test"
+    [Fact]
+    public void ChannelType_IsTest()
+    {
+        var adapter = CreateAdapter();
+        Assert.Equal(ChannelKey.From("test"), adapter.ChannelType);
+    }
+
+    // 2. GetOutbound returns empty list when no messages sent
+    [Fact]
+    public void GetOutbound_ReturnsEmpty_WhenNoMessages()
+    {
+        var adapter = CreateAdapter();
+        var result = adapter.GetOutbound("chan-1");
+        Assert.Empty(result);
+    }
+
+    // 3. SendAsync enqueues message, GetOutbound returns it
+    [Fact]
+    public async Task SendAsync_EnqueuesMessage_GetOutboundReturnsIt()
+    {
+        var adapter = CreateAdapter();
+        var msg = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("chan-1"),
+            Content = "hello world",
+            Metadata = new Dictionary<string, object?>()
+        };
+
+        await adapter.SendAsync(msg);
+
+        var result = adapter.GetOutbound("chan-1");
+        Assert.Single(result);
+        Assert.Equal("hello world", result[0].Content);
+    }
+
+    // 4. ClearOutbound empties the queue
+    [Fact]
+    public async Task ClearOutbound_EmptiesQueue()
+    {
+        var adapter = CreateAdapter();
+        var msg = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("chan-2"),
+            Content = "test",
+            Metadata = new Dictionary<string, object?>()
+        };
+        await adapter.SendAsync(msg);
+
+        adapter.ClearOutbound("chan-2");
+
+        Assert.Empty(adapter.GetOutbound("chan-2"));
+    }
+
+    // 5. GetOutbound dequeues messages (subsequent call returns empty)
+    [Fact]
+    public async Task GetOutbound_DequeuesMessages_SubsequentCallReturnsEmpty()
+    {
+        var adapter = CreateAdapter();
+        var msg = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("chan-3"),
+            Content = "msg",
+            Metadata = new Dictionary<string, object?>()
+        };
+        await adapter.SendAsync(msg);
+
+        var first = adapter.GetOutbound("chan-3");
+        var second = adapter.GetOutbound("chan-3");
+
+        Assert.Single(first);
+        Assert.Empty(second);
+    }
+
+    // 6. GetLogs returns captured log entries
+    [Fact]
+    public void GetLogs_ReturnsCapturedEntries()
+    {
+        var adapter = CreateAdapter();
+        adapter.CaptureLog(new TestLogEntry(DateTimeOffset.UtcNow, "Information", "Test message", []));
+
+        var logs = adapter.GetLogs();
+
+        Assert.Single(logs);
+        Assert.Equal("Test message", logs[0].Message);
+    }
+
+    // 7. ClearLogs empties the log buffer
+    [Fact]
+    public void ClearLogs_EmptiesLogBuffer()
+    {
+        var adapter = CreateAdapter();
+        adapter.CaptureLog(new TestLogEntry(DateTimeOffset.UtcNow, "Warning", "warn", []));
+        adapter.CaptureLog(new TestLogEntry(DateTimeOffset.UtcNow, "Error", "err", []));
+
+        adapter.ClearLogs();
+
+        Assert.Empty(adapter.GetLogs());
+    }
+
+    // 8. Logger provider creates a logger that captures log messages
+    [Fact]
+    public void LoggerProvider_CreatesLogger_ThatCapturesMessages()
+    {
+        var adapter = CreateAdapter();
+        var provider = new TestChannelLoggerProvider(adapter);
+        var logger = provider.CreateLogger("TestCategory");
+
+        logger.LogInformation("Hello from test");
+
+        var logs = adapter.GetLogs();
+        Assert.Single(logs);
+        Assert.Equal("Information", logs[0].Level);
+        Assert.Contains("Hello from test", logs[0].Message);
+        Assert.Equal("TestCategory", logs[0].Properties["category"]);
+    }
+
+    // 9. SendStreamDeltaAsync accumulates and FlushStreamBuffer enqueues
+    [Fact]
+    public async Task SendStreamDeltaAsync_AccumulatesDeltas_FlushEnqueues()
+    {
+        var adapter = CreateAdapter();
+        await adapter.SendStreamDeltaAsync("conv-1", "Hello ");
+        await adapter.SendStreamDeltaAsync("conv-1", "World");
+
+        adapter.FlushStreamBuffer("conv-1");
+
+        var msgs = adapter.GetOutbound("conv-1");
+        Assert.Single(msgs);
+        Assert.Equal("Hello World", msgs[0].Content);
+    }
+
+    // 10. InjectInboundAsync with no dispatcher registered does not throw
+    [Fact]
+    public async Task InjectInboundAsync_WithNoDispatcher_DoesNotThrow()
+    {
+        var adapter = CreateAdapter();
+        // Adapter not started — dispatcher is null. Should not throw.
+        await adapter.InjectInboundAsync("chan-test", "hello", "sender-1");
+    }
+
+    // 11. Multiple channels are independent
+    [Fact]
+    public async Task MultipleChannels_AreIndependent()
+    {
+        var adapter = CreateAdapter();
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("chan-a"),
+            Content = "for-a",
+            Metadata = new Dictionary<string, object?>()
+        });
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("chan-b"),
+            Content = "for-b",
+            Metadata = new Dictionary<string, object?>()
+        });
+
+        var outboundA = adapter.GetOutbound("chan-a");
+        var outboundB = adapter.GetOutbound("chan-b");
+        Assert.Single(outboundA);
+        Assert.Single(outboundB);
+        Assert.Equal("for-a", outboundA[0].Content);
+        Assert.Equal("for-b", outboundB[0].Content);
+    }
+
+    // 12. DisplayName is "Test Channel"
+    [Fact]
+    public void DisplayName_IsTestChannel()
+    {
+        var adapter = CreateAdapter();
+        Assert.Equal("Test Channel", adapter.DisplayName);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.Test.Tests/xunit.runner.json
+++ b/tests/extensions/BotNexus.Extensions.Channels.Test.Tests/xunit.runner.json
@@ -1,0 +1,1 @@
+{"parallelizeAssembly": false, "parallelizeTestCollections": true}


### PR DESCRIPTION
Closes #326

## Changes
- New `BotNexus.Extensions.Channels.Test` extension project
- `TestChannelAdapter`: in-memory message queues, `ChannelKey = test`, opt-in only (manifest `enabled: false`)
- `SendAsync` / `SendStreamDeltaAsync` / `FlushStreamBuffer` for outbound message capture
- `InjectInboundAsync` dispatches into the real gateway pipeline
- `CaptureLog` / `GetLogs` / `ClearLogs` for structured log buffer
- `TestChannelLoggerProvider` / `TestChannelLogger` for structured log capture from gateway logs
- `TestChannelEndpoints`: minimal API group (`/test-channel/...`) for HTTP-based test orchestration
- `TestChannelServiceCollectionExtensions`: DI registration (`AddBotNexusTestChannel()`)
- Added both projects to `BotNexus.slnx`

## Test coverage (12 tests)
- ChannelType returns `test`
- GetOutbound empty when no messages
- SendAsync enqueues, GetOutbound returns message
- ClearOutbound empties queue
- GetOutbound dequeues (subsequent call returns empty)
- GetLogs returns captured entries
- ClearLogs empties buffer
- Logger provider captures log messages with category and level
- SendStreamDeltaAsync accumulates, FlushStreamBuffer enqueues
- InjectInboundAsync with no dispatcher does not throw
- Multiple channels are independent
- DisplayName is Test Channel