### PR TITLE
feat(portal): add conversation bindings management panel

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ConversationBindingsPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ConversationBindingsPanel.razor
@@ -1,0 +1,379 @@
+@page "/conversations/{ConversationId}/bindings"
+@inject NavigationManager Nav
+@inject HttpClient Http
+@implements IDisposable
+
+<div class="bindings-panel">
+    <header class="bindings-toolbar">
+        <h3>🔗 Channel Bindings</h3>
+        <div class="bindings-toolbar-actions">
+            @if (!string.IsNullOrEmpty(_statusMessage))
+            {
+                <span class="bindings-status @_statusClass" role="status">@_statusMessage</span>
+            }
+            <button class="toolbar-btn" @onclick="LoadAsync" disabled="@_loading" title="Refresh">↻ Reload</button>
+            <button class="toolbar-btn primary add-binding-btn" @onclick="ShowAddForm" disabled="@(_loading || _showForm)" title="Add a channel binding">+ Add Binding</button>
+        </div>
+    </header>
+
+    @if (_loading)
+    {
+        <div class="bindings-loading" aria-live="polite">
+            <div class="loading-spinner small"></div>
+            <span>Loading bindings…</span>
+        </div>
+    }
+    else if (_error is not null)
+    {
+        <div class="bindings-error" role="alert">⚠️ Failed to load bindings: @_error</div>
+    }
+    else
+    {
+        @* Add Binding form *@
+        @if (_showForm)
+        {
+            <div class="binding-form-card">
+                <h4>Add Channel Binding</h4>
+                <div class="binding-form-grid">
+                    <label for="channel-type-input">Channel Type <span class="required">*</span></label>
+                    <div>
+                        <input id="channel-type-input"
+                               class="cfg-input @(HasFieldError("ChannelType") ? "field-error" : "")"
+                               value="@_addChannelType"
+                               @oninput="OnChannelTypeInput"
+                               placeholder="e.g. telegram, signalr" aria-required="true" />
+                        @if (HasFieldError("ChannelType"))
+                        {
+                            <span class="bindings-field-error" role="alert">@GetFieldError("ChannelType")</span>
+                        }
+                    </div>
+
+                    <label for="channel-address-input">Channel Address <span class="required">*</span></label>
+                    <div>
+                        <input id="channel-address-input"
+                               class="cfg-input @(HasFieldError("ChannelAddress") ? "field-error" : "")"
+                               value="@_addChannelAddress"
+                               @oninput="OnChannelAddressInput"
+                               placeholder="e.g. chat ID, user ID" aria-required="true" />
+                        @if (HasFieldError("ChannelAddress"))
+                        {
+                            <span class="bindings-field-error" role="alert">@GetFieldError("ChannelAddress")</span>
+                        }
+                    </div>
+
+                    <label for="thread-id-input">Thread ID</label>
+                    <input id="thread-id-input" class="cfg-input"
+                           value="@_addThreadId"
+                           @oninput="OnThreadIdInput"
+                           placeholder="optional" />
+
+                    <label for="mode-input">Mode</label>
+                    <select id="mode-input" class="cfg-input"
+                            value="@_addMode"
+                            @onchange="OnModeChange">
+                        <option value="Interactive">Interactive</option>
+                        <option value="Notify">Notify</option>
+                        <option value="ReadOnly">ReadOnly</option>
+                    </select>
+                </div>
+                @if (!string.IsNullOrEmpty(_formError))
+                {
+                    <div class="bindings-form-error" role="alert">⚠️ @_formError</div>
+                }
+                <div class="binding-form-actions">
+                    <button class="toolbar-btn primary" @onclick="SaveAddFormAsync" disabled="@_saving">
+                        @(_saving ? "Saving…" : "✓ Add Binding")
+                    </button>
+                    <button class="toolbar-btn cancel-add-btn" @onclick="CancelForm" disabled="@_saving">Cancel</button>
+                </div>
+            </div>
+        }
+
+        @* Delete confirmation dialog *@
+        @if (_confirmDeleteId is not null)
+        {
+            <div class="binding-confirm-overlay" @onclick="CancelDelete">
+                <div class="binding-confirm-dialog" @onclick:stopPropagation="true" role="alertdialog"
+                     aria-labelledby="binding-delete-title">
+                    <h4 id="binding-delete-title">Remove Binding</h4>
+                    <p>Remove this channel binding from the conversation? The channel address will no longer route to this conversation.</p>
+                    <div class="binding-confirm-actions">
+                        <button class="toolbar-btn danger confirm-delete-btn" @onclick="ConfirmDeleteAsync" disabled="@_deleting">
+                            @(_deleting ? "Removing…" : "Remove")
+                        </button>
+                        <button class="toolbar-btn" @onclick="CancelDelete" disabled="@_deleting">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        }
+
+        @* Bindings list *@
+        @if (_bindings.Count == 0 && !_showForm)
+        {
+            <div class="bindings-empty">
+                <p>No channel bindings for this conversation. Click <strong>+ Add Binding</strong> to add one.</p>
+            </div>
+        }
+        else if (_bindings.Count > 0)
+        {
+            <table class="bindings-table" aria-label="Channel bindings">
+                <thead>
+                    <tr>
+                        <th>Channel Type</th>
+                        <th>Address</th>
+                        <th>Thread ID</th>
+                        <th>Mode</th>
+                        <th>Bound At</th>
+                        <th><span class="sr-only">Actions</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var b in _bindings)
+                    {
+                        var bId = b.BindingId;
+                        <tr data-binding-id="@b.BindingId">
+                            <td class="binding-channel-type">@b.ChannelType</td>
+                            <td class="binding-address mono">@b.ChannelAddress</td>
+                            <td>@(b.ThreadId ?? "—")</td>
+                            <td>@b.Mode</td>
+                            <td>@b.BoundAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</td>
+                            <td class="binding-actions">
+                                <button class="agents-btn-delete delete-binding-btn"
+                                        @onclick="() => RequestDelete(bId)"
+                                        title="Remove binding @b.BindingId"
+                                        aria-label="Remove binding">🗑️</button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public string ConversationId { get; set; } = default!;
+
+    // ── Form state (flat fields instead of a record to avoid Razor lambda issues) ─────
+    private string _addChannelType = "";
+    private string _addChannelAddress = "";
+    private string? _addThreadId;
+    private string _addMode = "Interactive";
+
+    private List<BindingRow> _bindings = [];
+    private bool _loading = true;
+    private string? _error;
+    private string? _statusMessage;
+    private string _statusClass = "";
+    private bool _showForm;
+    private bool _saving;
+    private bool _deleting;
+    private string? _formError;
+    private string? _confirmDeleteId;
+    private Dictionary<string, string> _fieldErrors = new();
+    private CancellationTokenSource? _statusDismissCts;
+
+    private sealed record BindingRow(
+        string BindingId,
+        string ChannelType,
+        string ChannelAddress,
+        string? ThreadId,
+        string Mode,
+        DateTimeOffset BoundAt);
+
+    private bool HasFieldError(string field) => _fieldErrors.ContainsKey(field);
+    private string GetFieldError(string field) => _fieldErrors.GetValueOrDefault(field, "");
+
+    private void OnChannelTypeInput(ChangeEventArgs e)    => _addChannelType    = e.Value?.ToString() ?? "";
+    private void OnChannelAddressInput(ChangeEventArgs e) => _addChannelAddress = e.Value?.ToString() ?? "";
+    private void OnThreadIdInput(ChangeEventArgs e)       => _addThreadId       = e.Value?.ToString();
+    private void OnModeChange(ChangeEventArgs e)          => _addMode           = e.Value?.ToString() ?? "Interactive";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    public void Dispose()
+    {
+        _statusDismissCts?.Cancel();
+        _statusDismissCts?.Dispose();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _error = null;
+        StateHasChanged();
+
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/conversations/{ConversationId}";
+            var opts = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var response = await Http.GetAsync(url);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _error = $"HTTP {(int)response.StatusCode}";
+                return;
+            }
+
+            var conv = await response.Content.ReadFromJsonAsync<ConversationDetail>(opts);
+            _bindings = conv?.Bindings?.Select(b => new BindingRow(
+                b.BindingId ?? "",
+                b.ChannelType ?? "",
+                b.ChannelAddress ?? "",
+                b.ThreadId,
+                b.Mode ?? "Interactive",
+                b.BoundAt)).ToList() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void ShowAddForm()
+    {
+        _addChannelType = "";
+        _addChannelAddress = "";
+        _addThreadId = null;
+        _addMode = "Interactive";
+        _fieldErrors.Clear();
+        _formError = null;
+        _showForm = true;
+    }
+
+    private void CancelForm()
+    {
+        _showForm = false;
+        _fieldErrors.Clear();
+        _formError = null;
+    }
+
+    private bool ValidateAddForm()
+    {
+        _fieldErrors.Clear();
+        if (string.IsNullOrWhiteSpace(_addChannelType))
+            _fieldErrors["ChannelType"] = "Channel Type is required.";
+        if (string.IsNullOrWhiteSpace(_addChannelAddress))
+            _fieldErrors["ChannelAddress"] = "Channel Address is required.";
+        return _fieldErrors.Count == 0;
+    }
+
+    private async Task SaveAddFormAsync()
+    {
+        _formError = null;
+        if (!ValidateAddForm()) return;
+
+        _saving = true;
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/conversations/{ConversationId}/bindings";
+            var payload = new
+            {
+                channelType = _addChannelType,
+                channelAddress = _addChannelAddress,
+                threadId = string.IsNullOrWhiteSpace(_addThreadId) ? null : _addThreadId,
+                mode = _addMode,
+                threadingMode = "Single"
+            };
+            var response = await Http.PostAsJsonAsync(url, payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                _formError = $"Error {(int)response.StatusCode}: {body}";
+                return;
+            }
+
+            _showForm = false;
+            SetStatus("Binding added.", "success");
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            _formError = ex.Message;
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private void RequestDelete(string bindingId) => _confirmDeleteId = bindingId;
+    private void CancelDelete() => _confirmDeleteId = null;
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (_confirmDeleteId is null) return;
+
+        _deleting = true;
+        var id = _confirmDeleteId;
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/conversations/{ConversationId}/bindings/{id}";
+            var response = await Http.DeleteAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                SetStatus($"Delete failed: {(int)response.StatusCode}", "error");
+                return;
+            }
+            SetStatus("Binding removed.", "success");
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Error: {ex.Message}", "error");
+        }
+        finally
+        {
+            _deleting = false;
+            _confirmDeleteId = null;
+        }
+    }
+
+    private void SetStatus(string msg, string cssClass)
+    {
+        _statusMessage = msg;
+        _statusClass = cssClass;
+        _statusDismissCts?.Cancel();
+        _statusDismissCts?.Dispose();
+        _statusDismissCts = new CancellationTokenSource();
+        var token = _statusDismissCts.Token;
+        _ = DismissStatusAfterDelay(token);
+    }
+
+    private async Task DismissStatusAfterDelay(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(4000, token);
+            _statusMessage = null;
+            _statusClass = "";
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    // ── Local DTOs for deserialization ─────────────────────────────────────
+
+    private sealed class ConversationDetail
+    {
+        public List<BindingDetail>? Bindings { get; init; }
+    }
+
+    private sealed class BindingDetail
+    {
+        public string? BindingId { get; init; }
+        public string? ChannelType { get; init; }
+        public string? ChannelAddress { get; init; }
+        public string? ThreadId { get; init; }
+        public string? Mode { get; init; }
+        public DateTimeOffset BoundAt { get; init; }
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationBindingsPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationBindingsPanelTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class ConversationBindingsPanelTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly TestMockHttpHandler _httpHandler = new();
+
+    private const string TestConvId = "conv-123";
+
+    public ConversationBindingsPanelTests()
+    {
+        var httpClient = new HttpClient(_httpHandler) { BaseAddress = new Uri("http://localhost/") };
+        _ctx.Services.AddSingleton(httpClient);
+        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private static string BuildConversationJson(IEnumerable<object>? bindings = null)
+    {
+        var bindingArray = bindings ?? Array.Empty<object>();
+        return JsonSerializer.Serialize(new
+        {
+            conversationId = TestConvId,
+            agentId = "agent-1",
+            title = "Test Conv",
+            isDefault = false,
+            status = "Active",
+            activeSessionId = (string?)null,
+            bindings = bindingArray,
+            createdAt = DateTimeOffset.UtcNow,
+            updatedAt = DateTimeOffset.UtcNow
+        });
+    }
+
+    private static object MakeBinding(string bindingId = "b-1", string channelType = "signalr", string channelAddress = "addr-1") =>
+        new
+        {
+            bindingId,
+            channelType,
+            channelAddress,
+            threadId = (string?)null,
+            mode = "Interactive",
+            threadingMode = "Single",
+            displayPrefix = (string?)null,
+            boundAt = DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public void Shows_loading_spinner_initially()
+    {
+        _httpHandler.SetupGet($"/api/conversations/{TestConvId}", BuildConversationJson());
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        // At time of render the loading spinner should be visible
+        // (we can't easily race this, but we can verify it loads correctly)
+        cut.WaitForState(() => !cut.Markup.Contains("Loading bindings"));
+        Assert.DoesNotContain("Loading bindings", cut.Markup);
+    }
+
+    [Fact]
+    public void Shows_empty_state_when_no_bindings()
+    {
+        _httpHandler.SetupGet($"/api/conversations/{TestConvId}", BuildConversationJson());
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.Markup.Contains("No channel bindings"));
+
+        Assert.Contains("No channel bindings", cut.Markup);
+    }
+
+    [Fact]
+    public void Displays_bindings_in_table()
+    {
+        _httpHandler.SetupGet(
+            $"/api/conversations/{TestConvId}",
+            BuildConversationJson([MakeBinding("b-1", "telegram", "chat-42")]));
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.Markup.Contains("telegram"));
+
+        Assert.Contains("telegram", cut.Markup);
+        Assert.Contains("chat-42", cut.Markup);
+    }
+
+    [Fact]
+    public void Shows_add_binding_form_when_add_button_clicked()
+    {
+        _httpHandler.SetupGet($"/api/conversations/{TestConvId}", BuildConversationJson());
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.FindAll(".add-binding-btn").Count > 0);
+
+        cut.Find(".add-binding-btn").Click();
+
+        Assert.Contains("Channel Type", cut.Markup);
+        Assert.Contains("Channel Address", cut.Markup);
+    }
+
+    [Fact]
+    public void Cancel_add_form_hides_form()
+    {
+        _httpHandler.SetupGet($"/api/conversations/{TestConvId}", BuildConversationJson());
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.FindAll(".add-binding-btn").Count > 0);
+        cut.Find(".add-binding-btn").Click();
+
+        Assert.Contains("Channel Type", cut.Markup);
+
+        cut.Find(".cancel-add-btn").Click();
+
+        Assert.DoesNotContain("Channel Type", cut.Markup);
+    }
+
+    [Fact]
+    public void Delete_button_shows_confirmation_dialog()
+    {
+        _httpHandler.SetupGet(
+            $"/api/conversations/{TestConvId}",
+            BuildConversationJson([MakeBinding("b-del", "signalr", "portal")]));
+        _httpHandler.SetupDelete($"/api/conversations/{TestConvId}/bindings/b-del");
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.FindAll(".delete-binding-btn").Count > 0);
+
+        cut.Find(".delete-binding-btn").Click();
+
+        // Confirm dialog should appear
+        cut.WaitForState(() => cut.FindAll(".binding-confirm-overlay").Count > 0);
+        Assert.Contains("Remove Binding", cut.Markup);
+        Assert.NotEmpty(cut.FindAll(".confirm-delete-btn"));
+    }
+
+    [Fact]
+    public void Shows_error_when_load_fails()
+    {
+        _httpHandler.SetupErrorGet($"/api/conversations/{TestConvId}", HttpStatusCode.NotFound);
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.Markup.Contains("Failed") || cut.Markup.Contains("Error") || cut.Markup.Contains("error"));
+
+        Assert.Contains("Failed", cut.Markup);
+    }
+
+    [Fact]
+    public void Add_binding_form_validation_shows_errors()
+    {
+        _httpHandler.SetupGet($"/api/conversations/{TestConvId}", BuildConversationJson());
+
+        var cut = _ctx.Render<ConversationBindingsPanel>(p =>
+            p.Add(c => c.ConversationId, TestConvId));
+
+        cut.WaitForState(() => cut.FindAll(".add-binding-btn").Count > 0);
+        cut.Find(".add-binding-btn").Click();
+
+        // Click save without filling in fields
+        cut.Find(".binding-form-actions button.primary").Click();
+
+        Assert.Contains("Channel Type is required", cut.Markup);
+        Assert.Contains("Channel Address is required", cut.Markup);
+    }
+
+    // ── Private helper mock ────────────────────────────────────────────────
+
+    internal sealed class TestMockHttpHandler : HttpMessageHandler
+    {
+        private readonly List<(string Method, string Path, HttpResponseMessage Response)> _routes = [];
+
+        public void SetupGet(string path, string json)
+        {
+            _routes.Add(("GET", path, new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            }));
+        }
+
+        public void SetupErrorGet(string path, HttpStatusCode status)
+        {
+            _routes.Add(("GET", path, new HttpResponseMessage(status)
+            {
+                Content = new StringContent("Error", System.Text.Encoding.UTF8, "text/plain")
+            }));
+        }
+
+        public void SetupDelete(string path, HttpStatusCode status = HttpStatusCode.NoContent)
+        {
+            _routes.Add(("DELETE", path, new HttpResponseMessage(status)));
+        }
+
+        public void SetupPost(string path, string json = "{}", HttpStatusCode status = HttpStatusCode.Created)
+        {
+            _routes.Add(("POST", path, new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            }));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? "";
+            var method = request.Method.Method;
+
+            // Try method-specific match first
+            foreach (var (m, p, r) in _routes)
+            {
+                if (string.Equals(m, method, StringComparison.OrdinalIgnoreCase) &&
+                    path.Contains(p, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(r);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}


### PR DESCRIPTION
Closes #140

## Changes

### `ConversationBindingsPanel.razor`
New Blazor component at `Components/ConversationBindingsPanel.razor`:
- Renders all channel bindings for a conversation in a table (channel type, address, thread ID, mode, bound-at)
- **Add Binding** form with channel type, address, optional thread ID, mode select (Interactive/Notify/ReadOnly)
- Form validation: both channel type and channel address required before POST
- **Remove Binding** with confirmation dialog before DELETE
- Status notifications (auto-dismiss 4s) for add/remove outcomes
- Error handling: loading failure shows human-readable error, retry via Reload button
- Accessible: `aria-label`, `aria-required`, `role=alertdialog`, `role=alert`, `role=status`

### Tests (8 tests)
- `Shows_loading_spinner_initially`
- `Shows_empty_state_when_no_bindings`
- `Displays_bindings_in_table`
- `Shows_add_binding_form_when_add_button_clicked`
- `Cancel_add_form_hides_form`
- `Delete_button_shows_confirmation_dialog`
- `Shows_error_when_load_fails`
- `Add_binding_form_validation_shows_errors`

**Note:** This PR covers the portal UI portion of #140. The REST API (POST /bindings, DELETE /bindings/{id}, POST /bindings/{id}/move) is already implemented and merged in PR #488. The `move` UI is a follow-up.