### PR TITLE
fix(sessions): use system prompt and fallback model for compaction

### DIFF
--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -177,47 +177,72 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         return (toSummarize, toPreserve);
     }
 
-    private static string BuildSummarizationPrompt(List<SessionEntry> entries, int maxChars)
+    private static (string systemPrompt, string userMessage) BuildSummarizationPrompt(List<SessionEntry> entries, int maxChars)
     {
-        var builder = new StringBuilder();
-        builder.AppendLine("Summarize the following conversation history. Preserve critical information in a structured format.");
-        builder.AppendLine();
-        builder.AppendLine("Required sections:");
-        builder.AppendLine("## Decisions - Key decisions made");
-        builder.AppendLine("## Open TODOs - Incomplete tasks and follow-ups");
-        builder.AppendLine("## Constraints - Rules or constraints established");
-        builder.AppendLine("## Key Identifiers - File paths, UUIDs, URLs, hashes that must be preserved exactly");
-        builder.AppendLine();
-        builder.AppendLine($"Keep the summary under {maxChars} characters.");
-        builder.AppendLine();
-        builder.AppendLine("Conversation:");
+        var systemPrompt =
+            "You are a concise conversation summarizer. When asked, produce a structured summary of the provided conversation. " +
+            "Required sections: ## Decisions, ## Open TODOs, ## Constraints, ## Key Identifiers. " +
+            $"Keep the summary under {maxChars} characters. Output only the summary — no preamble, no markdown fences.";
 
+        var historyBuilder = new StringBuilder();
+        historyBuilder.AppendLine("Summarize the following conversation history:");
+        historyBuilder.AppendLine();
         foreach (var entry in entries)
         {
-            builder.AppendLine($"[{entry.Role}]: {entry.Content}");
+            historyBuilder.AppendLine($"[{entry.Role}]: {entry.Content}");
         }
 
-        return builder.ToString();
+        return (systemPrompt, historyBuilder.ToString());
     }
 
     private async Task<string> CallLlmForSummaryAsync(
-        string summaryPrompt,
+        (string systemPrompt, string userMessage) prompt,
         CompactionOptions options,
         CancellationToken cancellationToken)
     {
         var model = ResolveModel(options.SummarizationModel, options.SummarizationProvider);
+        var result = await TryGetSummaryAsync(model, prompt, cancellationToken).ConfigureAwait(false);
 
-        // Bug 3: log the resolved model so failures are diagnosable.
+        if (!string.IsNullOrWhiteSpace(result))
+            return result;
+
+        // Primary model returned empty — attempt fallback auto-selection
+        _logger.LogWarning(
+            "Model {ModelId} returned no usable content for compaction summary. Attempting fallback model.",
+            model.Id);
+
+        var fallback = ResolveFallbackModel(model);
+        if (fallback is null)
+        {
+            _logger.LogWarning(
+                "No fallback model available. Compaction aborted for session.");
+            return string.Empty;
+        }
+
+        _logger.LogInformation(
+            "Retrying compaction summary with fallback model {ModelId} (provider {Provider})",
+            fallback.Id,
+            fallback.Provider);
+
+        result = await TryGetSummaryAsync(fallback, prompt, cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<string> TryGetSummaryAsync(
+        LlmModel model,
+        (string systemPrompt, string userMessage) prompt,
+        CancellationToken cancellationToken)
+    {
         _logger.LogDebug(
             "Requesting compaction summary via model {ModelId} (provider {Provider})",
             model.Id,
             model.Provider);
 
         var context = new Context(
-            SystemPrompt: null,
+            SystemPrompt: prompt.systemPrompt,
             Messages:
             [
-                new UserMessage(new UserMessageContent(summaryPrompt), DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+                new UserMessage(new UserMessageContent(prompt.userMessage), DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
             ]);
 
         var completion = await _llmClient
@@ -225,11 +250,12 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Bug 3: log what actually came back before filtering.
         _logger.LogDebug(
-            "Compaction LLM response: {ContentItemCount} content item(s), TextContent items: {TextCount}",
+            "Compaction LLM response from {ModelId}: {ContentItemCount} item(s), TextContent: {TextCount}, types: {Types}",
+            model.Id,
             completion.Content.Count,
-            completion.Content.OfType<TextContent>().Count());
+            completion.Content.OfType<TextContent>().Count(),
+            string.Join(", ", completion.Content.Select(c => c.GetType().Name)));
 
         var result = string.Join(
             Environment.NewLine,
@@ -248,6 +274,30 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Resolves a fallback model when the primary returns empty content.
+    /// Excludes the primary model and prefers the first available from the default list.
+    /// </summary>
+    private LlmModel? ResolveFallbackModel(LlmModel primary)
+    {
+        foreach (var modelId in DefaultSummaryModelIds)
+        {
+            if (string.Equals(modelId, primary.Id, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var candidate = FindModel(modelId);
+            if (candidate is not null)
+                return candidate;
+        }
+
+        // Last resort: any registered model that isn't the primary
+        return _llmClient.Models
+            .GetProviders()
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .SelectMany(p => _llmClient.Models.GetModels(p))
+            .FirstOrDefault(m => !string.Equals(m.Id, primary.Id, StringComparison.OrdinalIgnoreCase));
     }
 
     private LlmModel ResolveModel(string? requestedModelId, string? preferredProvider = null)

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -355,4 +355,129 @@ public sealed class LlmSessionCompactorTests
         // 1200 chars / 4 = 300 tokens; threshold = 1200 * 1.0 = 1200; 300 > 1200 = false
         compactor.ShouldCompact(session.Session, options).ShouldBeFalse();
     }
+
+    /// <summary>
+    /// #496: Compaction context must include a system prompt so models like gpt-4.1
+    /// do not refuse the summarization request with empty content.
+    /// </summary>
+    [Fact]
+    public async Task CompactAsync_ContextHasSystemPrompt()
+    {
+        Context? capturedContext = null;
+        var session = CreateSession(
+            ("user", "older"),
+            ("assistant", "older-response"),
+            ("user", "recent"));
+
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        models.Register(TestModel.Provider, TestModel);
+
+        var provider = new Mock<IApiProvider>();
+        provider.SetupGet(item => item.Api).Returns(TestModel.Api);
+        provider.Setup(item => item.StreamSimple(
+                It.IsAny<LlmModel>(),
+                It.IsAny<Context>(),
+                It.IsAny<SimpleStreamOptions?>()))
+            .Callback<LlmModel, Context, SimpleStreamOptions?>((_, ctx, _) => capturedContext = ctx)
+            .Returns(() => CreateStream("summary"));
+
+        providers.Register(provider.Object);
+        var llmClient = new LlmClient(providers, models);
+        var compactor = new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
+
+        await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        capturedContext.ShouldNotBeNull();
+        capturedContext!.SystemPrompt.ShouldNotBeNullOrWhiteSpace("system prompt must be set for compaction");
+    }
+
+    /// <summary>
+    /// #496: When primary model returns empty content, retry with fallback model.
+    /// </summary>
+    [Fact]
+    public async Task CompactAsync_PrimaryReturnsEmpty_RetriesWithFallbackModel()
+    {
+        var session = CreateSession(
+            ("user", "older"),
+            ("assistant", "older-response"),
+            ("user", "recent"));
+
+        var fallbackModel = new LlmModel(
+            Id: "fallback-model",
+            Name: "Fallback Model",
+            Api: "test-api",
+            Provider: "test-provider",
+            BaseUrl: "https://example.com",
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 32000,
+            MaxTokens: 4096);
+
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        models.Register(TestModel.Provider, TestModel);
+        models.Register(fallbackModel.Provider, fallbackModel);
+
+        var callCount = 0;
+        var provider = new Mock<IApiProvider>();
+        provider.SetupGet(item => item.Api).Returns(TestModel.Api);
+        provider.Setup(item => item.StreamSimple(
+                It.IsAny<LlmModel>(),
+                It.IsAny<Context>(),
+                It.IsAny<SimpleStreamOptions?>()))
+            .Returns(() =>
+            {
+                callCount++;
+                // First call (primary) returns empty; second call (fallback) returns real summary
+                return callCount == 1 ? CreateStream("") : CreateStream("fallback summary");
+            });
+
+        providers.Register(provider.Object);
+        var llmClient = new LlmClient(providers, models);
+        var compactor = new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
+
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeTrue("fallback model should produce a successful compaction");
+        result.Summary.ShouldBe("fallback summary");
+        callCount.ShouldBe(2, "should have called LLM twice (primary + fallback)");
+    }
+
+    /// <summary>
+    /// #496: When primary returns empty AND no fallback is available, compaction aborts cleanly.
+    /// </summary>
+    [Fact]
+    public async Task CompactAsync_PrimaryAndNoFallback_AbortsCleanly()
+    {
+        var session = CreateSession(
+            ("user", "older"),
+            ("assistant", "older-response"),
+            ("user", "recent"));
+        var originalHistory = session.GetHistorySnapshot().ToList();
+
+        // CreateCompactor uses a single model (TestModel) — no fallback available
+        var compactor = CreateCompactor(summary: "");
+
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeFalse();
+        result.Summary.ShouldBeEmpty();
+        result.CompactedHistory.ShouldBeNull();
+        // History must be unchanged
+        session.GetHistorySnapshot().Count.ShouldBe(originalHistory.Count);
+    }
 }


### PR DESCRIPTION
Closes #496

## Problem

`gpt-4.1` via the `copilot` provider returns structurally empty content on every compaction attempt. The `#366` abort guard fires correctly (history is preserved), but compaction never succeeds — sessions grow indefinitely.

Root cause: `CallLlmForSummaryAsync` sent `SystemPrompt: null` in the `Context`. Models like `gpt-4.1` that require a system-role directive for summarization refuse the user-only prompt and return 0 content items.

## Changes

### `LlmSessionCompactor.cs`
- **System prompt**: `BuildSummarizationPrompt` now returns a `(systemPrompt, userMessage)` tuple instead of a single string. The summarization instruction is sent as `Context.SystemPrompt`, not as part of the user message.
- **Fallback model retry**: When the primary model returns empty content, `CallLlmForSummaryAsync` calls `ResolveFallbackModel` and retries with the first available alternative from `DefaultSummaryModelIds` (excluding the primary). Last-resort fallback to any registered model that isn't the primary.
- **Improved logging**: `TryGetSummaryAsync` now logs all content type names (not just count) for easier diagnosis of future empty-response events.

### `LlmSessionCompactorTests.cs`
- `CompactAsync_ContextHasSystemPrompt` — asserts `Context.SystemPrompt` is non-null/non-empty
- `CompactAsync_PrimaryReturnsEmpty_RetriesWithFallbackModel` — verifies fallback model is called and produces successful compaction
- `CompactAsync_PrimaryAndNoFallback_AbortsCleanly` — verifies clean abort when no fallback available (history unchanged)

1639/1639 gateway tests pass.