### PR TITLE
feat(gateway): add botnexus_admin tool for safe platform management

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -238,6 +238,17 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 || effectiveToolIds.Contains("list_agents", StringComparer.OrdinalIgnoreCase);
             if (includeListAgents)
                 tools.Add(new ListAgentsTool(agentRegistry, descriptor.AgentId));
+
+            var includeAdminTool = effectiveToolIds.Count == 0
+                || effectiveToolIds.Contains("botnexus_admin", StringComparer.OrdinalIgnoreCase);
+            if (includeAdminTool)
+            {
+                var adminSupervisor = _serviceProvider.GetService<IAgentSupervisor>();
+                var adminConfigWriter = _serviceProvider.GetService<IAgentConfigurationWriter>();
+                var adminPlatformConfig = _serviceProvider.GetService<IOptionsMonitor<PlatformConfig>>();
+                if (adminSupervisor is not null && adminConfigWriter is not null && adminPlatformConfig is not null)
+                    tools.Add(new PlatformAdminTool(agentRegistry, adminSupervisor, adminConfigWriter, adminPlatformConfig));
+            }
         }
 
         var includeCanvas = effectiveToolIds.Count == 0

--- a/src/gateway/BotNexus.Gateway/Tools/PlatformAdminTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/PlatformAdminTool.cs
@@ -1,0 +1,322 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Agent.Providers.Core.Models;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Tools;
+
+/// <summary>
+/// Platform admin tool that provides safe, validated access to Gateway management operations.
+/// Agents use this tool instead of writing directly to config.json or agent files.
+/// </summary>
+/// <remarks>
+/// Operations: get_config, list_agents, get_platform_status, create_agent, update_agent, delete_agent.
+/// All mutating operations go through <see cref="IAgentRegistry"/> and
+/// <see cref="IAgentConfigurationWriter"/> — they never touch files directly.
+/// </remarks>
+public sealed class PlatformAdminTool(
+    IAgentRegistry agentRegistry,
+    IAgentSupervisor agentSupervisor,
+    IAgentConfigurationWriter configWriter,
+    IOptionsMonitor<PlatformConfig> platformConfig) : IAgentTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    public string Name => "botnexus_admin";
+    public string Label => "BotNexus Platform Admin";
+
+    public Tool Definition => new(
+        Name,
+        """
+        Safe agent-facing API for BotNexus platform management.
+        Use this tool instead of writing config.json or agent files directly.
+        All mutations are validated and committed through the Gateway's own config layer.
+
+        Actions:
+        - get_config: Read current effective platform configuration summary (secrets redacted)
+        - list_agents: List all registered agents with metadata and running status
+        - get_platform_status: Get gateway agent counts and server time
+        - create_agent: Register a new agent (requires agentId, displayName, modelId, apiProvider)
+        - update_agent: Update an existing agent's properties (only provided fields are changed)
+        - delete_agent: Unregister an agent (does not stop a running instance)
+        """,
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": ["get_config", "list_agents", "get_platform_status", "create_agent", "update_agent", "delete_agent"],
+                  "description": "The management operation to perform."
+                },
+                "agentId": {
+                  "type": "string",
+                  "description": "Agent ID (required for create_agent, update_agent, delete_agent)."
+                },
+                "displayName": {
+                  "type": "string",
+                  "description": "Human-readable agent display name (for create_agent / update_agent)."
+                },
+                "modelId": {
+                  "type": "string",
+                  "description": "Model identifier (for create_agent / update_agent)."
+                },
+                "apiProvider": {
+                  "type": "string",
+                  "description": "API provider name, e.g. 'github-copilot', 'openai', 'anthropic' (for create_agent / update_agent)."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Agent description (for create_agent / update_agent)."
+                },
+                "emoji": {
+                  "type": "string",
+                  "description": "Emoji avatar for the agent (for create_agent / update_agent)."
+                },
+                "systemPrompt": {
+                  "type": "string",
+                  "description": "System prompt for the agent (for create_agent / update_agent)."
+                }
+              },
+              "required": ["action"]
+            }
+            """).RootElement.Clone());
+
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(arguments);
+    }
+
+    public async Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var action = ReadString(arguments, "action");
+        if (string.IsNullOrWhiteSpace(action))
+            return Fail("Missing required parameter: action");
+
+        return action.ToLowerInvariant() switch
+        {
+            "get_config" => GetConfig(),
+            "list_agents" => ListAgents(),
+            "get_platform_status" => GetPlatformStatus(),
+            "create_agent" => await CreateAgentAsync(arguments, cancellationToken),
+            "update_agent" => await UpdateAgentAsync(arguments, cancellationToken),
+            "delete_agent" => await DeleteAgentAsync(arguments, cancellationToken),
+            _ => Fail($"Unknown action '{action}'. Valid actions: get_config, list_agents, get_platform_status, create_agent, update_agent, delete_agent")
+        };
+    }
+
+    // ─── Read-only operations ────────────────────────────────────────────────
+
+    private AgentToolResult GetConfig()
+    {
+        var config = platformConfig.CurrentValue;
+        var summary = new
+        {
+            version = config.Version,
+            gateway = new
+            {
+                listenUrl = config.Gateway?.ListenUrl,
+                defaultAgentId = config.Gateway?.DefaultAgentId,
+                defaultTimezone = config.Gateway?.DefaultTimezone
+            },
+            agentCount = config.Agents?.Count ?? 0,
+            providerCount = config.Providers?.Count ?? 0,
+            channelCount = config.Channels?.Count ?? 0
+        };
+        return Ok(JsonSerializer.Serialize(summary, JsonOptions));
+    }
+
+    private AgentToolResult ListAgents()
+    {
+        var runningInstances = agentSupervisor.GetAllInstances()
+            .Select(i => i.AgentId.ToString())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var agents = agentRegistry.GetAll()
+            .Select(d => new AgentSummary(
+                AgentId: d.AgentId.ToString(),
+                DisplayName: d.DisplayName,
+                Description: d.Description,
+                Emoji: d.Emoji,
+                ModelId: d.ModelId,
+                ApiProvider: d.ApiProvider,
+                IsRunning: runningInstances.Contains(d.AgentId.ToString())))
+            .OrderBy(a => a.AgentId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return Ok(JsonSerializer.Serialize(agents, JsonOptions));
+    }
+
+    private AgentToolResult GetPlatformStatus()
+    {
+        var allAgents = agentRegistry.GetAll();
+        var runningCount = agentSupervisor.GetAllInstances().Count;
+
+        var status = new
+        {
+            totalAgents = allAgents.Count,
+            runningAgents = runningCount,
+            idleAgents = allAgents.Count - runningCount,
+            serverTime = DateTimeOffset.UtcNow.ToString("O")
+        };
+        return Ok(JsonSerializer.Serialize(status, JsonOptions));
+    }
+
+    // ─── Mutating operations ─────────────────────────────────────────────────
+
+    private async Task<AgentToolResult> CreateAgentAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        var agentId = ReadString(arguments, "agentId");
+        var displayName = ReadString(arguments, "displayName");
+        var modelId = ReadString(arguments, "modelId");
+        var apiProvider = ReadString(arguments, "apiProvider");
+
+        if (string.IsNullOrWhiteSpace(agentId))
+            return Fail("create_agent requires agentId");
+        if (string.IsNullOrWhiteSpace(displayName))
+            return Fail("create_agent requires displayName");
+        if (string.IsNullOrWhiteSpace(modelId))
+            return Fail("create_agent requires modelId");
+        if (string.IsNullOrWhiteSpace(apiProvider))
+            return Fail("create_agent requires apiProvider");
+
+        var id = AgentId.From(agentId);
+        if (agentRegistry.Contains(id))
+            return Fail($"Agent '{agentId}' already exists. Use update_agent to modify it.");
+
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = id,
+            DisplayName = displayName,
+            ModelId = modelId,
+            ApiProvider = apiProvider,
+            Description = ReadString(arguments, "description"),
+            Emoji = ReadString(arguments, "emoji"),
+            SystemPrompt = ReadString(arguments, "systemPrompt")
+        };
+
+        try
+        {
+            agentRegistry.Register(descriptor);
+            await configWriter.SaveAsync(descriptor, cancellationToken);
+            return Ok($"Agent '{agentId}' created successfully.");
+        }
+        catch (Exception ex)
+        {
+            return Fail($"Failed to create agent '{agentId}': {ex.Message}");
+        }
+    }
+
+    private async Task<AgentToolResult> UpdateAgentAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        var agentId = ReadString(arguments, "agentId");
+        if (string.IsNullOrWhiteSpace(agentId))
+            return Fail("update_agent requires agentId");
+
+        var id = AgentId.From(agentId);
+        var existing = agentRegistry.Get(id);
+        if (existing is null)
+            return Fail($"Agent '{agentId}' not found. Use create_agent to register a new agent.");
+
+        var updated = existing with
+        {
+            DisplayName = ReadString(arguments, "displayName") ?? existing.DisplayName,
+            ModelId = ReadString(arguments, "modelId") ?? existing.ModelId,
+            ApiProvider = ReadString(arguments, "apiProvider") ?? existing.ApiProvider,
+            Description = ReadString(arguments, "description") ?? existing.Description,
+            Emoji = ReadString(arguments, "emoji") ?? existing.Emoji,
+            SystemPrompt = ReadString(arguments, "systemPrompt") ?? existing.SystemPrompt
+        };
+
+        try
+        {
+            var wasUpdated = agentRegistry.Update(id, updated);
+            if (!wasUpdated)
+                return Fail($"Failed to update agent '{agentId}': registry update returned false.");
+            await configWriter.SaveAsync(updated, cancellationToken);
+            return Ok($"Agent '{agentId}' updated successfully.");
+        }
+        catch (Exception ex)
+        {
+            return Fail($"Failed to update agent '{agentId}': {ex.Message}");
+        }
+    }
+
+    private async Task<AgentToolResult> DeleteAgentAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        var agentId = ReadString(arguments, "agentId");
+        if (string.IsNullOrWhiteSpace(agentId))
+            return Fail("delete_agent requires agentId");
+
+        var id = AgentId.From(agentId);
+        if (!agentRegistry.Contains(id))
+            return Fail($"Agent '{agentId}' not found.");
+
+        try
+        {
+            agentRegistry.Unregister(id);
+            await configWriter.DeleteAsync(agentId, cancellationToken);
+            return Ok($"Agent '{agentId}' deleted successfully.");
+        }
+        catch (Exception ex)
+        {
+            return Fail($"Failed to delete agent '{agentId}': {ex.Message}");
+        }
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static AgentToolResult Ok(string text) =>
+        new([new AgentToolContent(AgentToolContentType.Text, text)]);
+
+    private static AgentToolResult Fail(string message) =>
+        new([new AgentToolContent(AgentToolContentType.Text, $"Error: {message}")]);
+
+    private static string? ReadString(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value))
+            return null;
+        if (value is JsonElement elem && elem.ValueKind == JsonValueKind.String)
+            return elem.GetString();
+        if (value is string s)
+            return s;
+        return null;
+    }
+
+    // ─── Internal DTOs ────────────────────────────────────────────────────────
+
+    private sealed record AgentSummary(
+        string AgentId,
+        string DisplayName,
+        string? Description,
+        string? Emoji,
+        string ModelId,
+        string ApiProvider,
+        bool IsRunning);
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/PlatformAdminToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/PlatformAdminToolTests.cs
@@ -1,0 +1,261 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Tools;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Tools;
+
+public sealed class PlatformAdminToolTests
+{
+    private static AgentDescriptor MakeAgent(string id) => new()
+    {
+        AgentId = AgentId.From(id),
+        DisplayName = id.ToUpperInvariant(),
+        ModelId = "test-model",
+        ApiProvider = "test-provider"
+    };
+
+    private static (PlatformAdminTool tool, Mock<IAgentRegistry> registry, Mock<IAgentSupervisor> supervisor, Mock<IAgentConfigurationWriter> writer)
+        MakeTool(params AgentDescriptor[] agents)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns(agents.ToList());
+        foreach (var a in agents)
+        {
+            registry.Setup(r => r.Get(a.AgentId)).Returns(a);
+            registry.Setup(r => r.Contains(a.AgentId)).Returns(true);
+        }
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        // override for registered agents
+        foreach (var a in agents)
+        {
+            registry.Setup(r => r.Get(a.AgentId)).Returns(a);
+            registry.Setup(r => r.Contains(a.AgentId)).Returns(true);
+        }
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetAllInstances()).Returns([]);
+
+        var writer = new Mock<IAgentConfigurationWriter>();
+        writer.Setup(w => w.SaveAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        writer.Setup(w => w.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var config = new PlatformConfig { Version = 1 };
+        var monitor = new TestOptionsMonitor<PlatformConfig>(config);
+
+        var tool = new PlatformAdminTool(registry.Object, supervisor.Object, writer.Object, monitor);
+        return (tool, registry, supervisor, writer);
+    }
+
+    private static Dictionary<string, object?> Args(string action, params (string key, string value)[] extras)
+    {
+        var d = new Dictionary<string, object?> { ["action"] = JsonDocument.Parse($"\"{action}\"").RootElement };
+        foreach (var (k, v) in extras)
+            d[k] = JsonDocument.Parse($"\"{v}\"").RootElement;
+        return d;
+    }
+
+    private static bool IsSuccess(AgentToolResult r) =>
+        !r.Content[0].Value.StartsWith("Error:", StringComparison.Ordinal);
+
+    private static bool IsError(AgentToolResult r) =>
+        r.Content[0].Value.StartsWith("Error:", StringComparison.Ordinal);
+
+    // ─── Tool metadata ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Tool_HasExpectedNameAndLabel()
+    {
+        var (tool, _, _, _) = MakeTool();
+        tool.Name.ShouldBe("botnexus_admin");
+        tool.Label.ShouldBe("BotNexus Platform Admin");
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_ReturnsArgumentsUnchanged()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var args = new Dictionary<string, object?> { ["action"] = "list_agents" };
+        var result = await tool.PrepareArgumentsAsync(args);
+        result.ShouldBe(args);
+    }
+
+    // ─── get_config ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetConfig_ReturnsConfigSummary()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var result = await tool.ExecuteAsync("t1", Args("get_config"));
+        IsSuccess(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("version");
+    }
+
+    // ─── list_agents ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAgents_ReturnsAllAgentsOrdered()
+    {
+        var (tool, _, _, _) = MakeTool(MakeAgent("zebra"), MakeAgent("alpha"), MakeAgent("mango"));
+        var result = await tool.ExecuteAsync("t1", Args("list_agents"));
+        IsSuccess(result).ShouldBeTrue();
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.Count.ShouldBe(3);
+        list[0].GetProperty("agentId").GetString().ShouldBe("alpha");
+        list[2].GetProperty("agentId").GetString().ShouldBe("zebra");
+    }
+
+    [Fact]
+    public async Task ListAgents_RunningAgentFlaggedCorrectly()
+    {
+        var agent = MakeAgent("worker");
+        var (tool, _, supervisor, _) = MakeTool(agent);
+        var instance = new AgentInstance
+        {
+            InstanceId = "inst-1",
+            AgentId = agent.AgentId,
+            SessionId = SessionId.Create(),
+            Status = AgentInstanceStatus.Running,
+            IsolationStrategy = "in-process"
+        };
+        supervisor.Setup(s => s.GetAllInstances()).Returns([instance]);
+
+        var result = await tool.ExecuteAsync("t1", Args("list_agents"));
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list[0].GetProperty("isRunning").GetBoolean().ShouldBeTrue();
+    }
+
+    // ─── get_platform_status ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPlatformStatus_ReturnsCountsAndServerTime()
+    {
+        var (tool, _, _, _) = MakeTool(MakeAgent("a"), MakeAgent("b"));
+        var result = await tool.ExecuteAsync("t1", Args("get_platform_status"));
+        IsSuccess(result).ShouldBeTrue();
+        var obj = JsonSerializer.Deserialize<JsonElement>(result.Content[0].Value);
+        obj.GetProperty("totalAgents").GetInt32().ShouldBe(2);
+        obj.GetProperty("runningAgents").GetInt32().ShouldBe(0);
+        obj.GetProperty("serverTime").GetString().ShouldNotBeNullOrEmpty();
+    }
+
+    // ─── create_agent ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAgent_RegistersAndPersists()
+    {
+        var (tool, registry, _, writer) = MakeTool();
+        var args = Args("create_agent",
+            ("agentId", "new-bot"),
+            ("displayName", "New Bot"),
+            ("modelId", "gpt-4o"),
+            ("apiProvider", "openai"));
+        var result = await tool.ExecuteAsync("t1", args);
+        IsSuccess(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("new-bot");
+        registry.Verify(r => r.Register(It.Is<AgentDescriptor>(d => d.AgentId.ToString() == "new-bot")), Times.Once);
+        writer.Verify(w => w.SaveAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAgent_MissingRequiredField_ReturnsError()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var args = Args("create_agent",
+            ("agentId", "new-bot"),
+            ("displayName", "New Bot"));
+        // missing modelId and apiProvider
+        var result = await tool.ExecuteAsync("t1", args);
+        IsError(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("requires modelId");
+    }
+
+    [Fact]
+    public async Task CreateAgent_DuplicateId_ReturnsError()
+    {
+        var (tool, _, _, _) = MakeTool(MakeAgent("existing"));
+        var args = Args("create_agent",
+            ("agentId", "existing"),
+            ("displayName", "Existing"),
+            ("modelId", "m"),
+            ("apiProvider", "p"));
+        var result = await tool.ExecuteAsync("t1", args);
+        IsError(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("already exists");
+    }
+
+    // ─── update_agent ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAgent_UpdatesAndPersists()
+    {
+        var existing = MakeAgent("bot1");
+        var (tool, registry, _, writer) = MakeTool(existing);
+        registry.Setup(r => r.Update(existing.AgentId, It.IsAny<AgentDescriptor>())).Returns(true);
+
+        var args = Args("update_agent",
+            ("agentId", "bot1"),
+            ("displayName", "Updated Bot"));
+        var result = await tool.ExecuteAsync("t1", args);
+        IsSuccess(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("updated successfully");
+        writer.Verify(w => w.SaveAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAgent_NotFound_ReturnsError()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var result = await tool.ExecuteAsync("t1", Args("update_agent", ("agentId", "ghost")));
+        IsError(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("not found");
+    }
+
+    // ─── delete_agent ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAgent_UnregistersAndDeletes()
+    {
+        var agent = MakeAgent("old-bot");
+        var (tool, registry, _, writer) = MakeTool(agent);
+
+        var result = await tool.ExecuteAsync("t1", Args("delete_agent", ("agentId", "old-bot")));
+        IsSuccess(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("deleted successfully");
+        registry.Verify(r => r.Unregister(agent.AgentId), Times.Once);
+        writer.Verify(w => w.DeleteAsync("old-bot", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAgent_NotFound_ReturnsError()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var result = await tool.ExecuteAsync("t1", Args("delete_agent", ("agentId", "ghost")));
+        IsError(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("not found");
+    }
+
+    // ─── unknown action ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UnknownAction_ReturnsError()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var result = await tool.ExecuteAsync("t1", Args("nuke_everything"));
+        IsError(result).ShouldBeTrue();
+        result.Content[0].Value.ShouldContain("Unknown action");
+    }
+
+    [Fact]
+    public async Task MissingAction_ReturnsError()
+    {
+        var (tool, _, _, _) = MakeTool();
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+        IsError(result).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Closes #370

## Changes

Adds a new botnexus_admin IAgentTool that provides a safe, validated gateway management API for agents.

### Why
Agents were writing directly to config.json via write/edit tools. This caused production incidents. This tool routes all mutations through the Gateway's own validated code paths.

### Operations
- get_config: Read effective platform config summary (secrets redacted)
- list_agents: List all registered agents with running status
- get_platform_status: Get agent counts and server time
- create_agent: Register a new agent (validated required fields)
- update_agent: Update agent properties (only provided fields changed)
- delete_agent: Unregister an agent

### Implementation
- New PlatformAdminTool in BotNexus.Gateway.Tools
- Wired into InProcessIsolationStrategy.CreateAsync alongside list_agents
- Mutations go through IAgentRegistry and IAgentConfigurationWriter -- never direct file access
- 15 new tests covering happy paths and all sad/error paths

### Not in this PR (follow-up work)
- Audit log for mutations
- Privilege scoping per agent
- Portal UI for audit trail