### PR TITLE
feat(portal): add clone action to agent list

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Agents.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Agents.razor
@@ -189,6 +189,7 @@
                             <td>@agent.ModelId</td>
                             <td class="agents-actions">
                                 <button class="agents-btn-edit" @onclick="() => EditAgent(agent)" title="Edit @agent.AgentId" aria-label="Edit @agent.AgentId">✏️</button>
+                                <button class="agents-btn-clone" @onclick="() => CloneAgent(agent)" title="Clone @agent.AgentId" aria-label="Clone @agent.AgentId">📋</button>
                                 <button class="agents-btn-delete" @onclick="() => RequestDelete(agent.AgentId!)" title="Delete @agent.AgentId" aria-label="Delete @agent.AgentId">🗑️</button>
                             </td>
                         </tr>
@@ -386,6 +387,25 @@
         _models = [];
         if (!string.IsNullOrEmpty(agent.ApiProvider))
             await LoadModelsAsync(agent.ApiProvider);
+        _showForm = true;
+    }
+
+    private async Task CloneAgent(AgentRow source)
+    {
+        _editingId = null; // Clone always creates a new agent
+        _form = new AgentFormModel(
+            AgentId: "",
+            DisplayName: $"Copy of {source.DisplayName}",
+            Description: source.Description ?? "",
+            ApiProvider: source.ApiProvider,
+            ModelId: source.ModelId,
+            SystemPrompt: source.SystemPrompt);
+        _originalForm = _form with { DisplayName = "" }; // Force IsDirty = true so Save is enabled
+        _formError = null;
+        _fieldErrors.Clear();
+        _models = [];
+        if (!string.IsNullOrEmpty(source.ApiProvider))
+            await LoadModelsAsync(source.ApiProvider);
         _showForm = true;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentsPageTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentsPageTests.cs
@@ -250,6 +250,83 @@ public sealed class AgentsPageTests : IDisposable
         Assert.Equal("Agent list", table.GetAttribute("aria-label"));
     }
 
+    [Fact]
+    public void Clone_button_renders_in_agent_row()
+    {
+        var agents = JsonSerializer.Serialize(new[]
+        {
+            new { agentId = "bot-1", displayName = "Bot One", description = "", apiProvider = "openai", modelId = "gpt-4", systemPrompt = "" }
+        });
+        _httpHandler.SetupResponse("/api/agents", agents);
+        _httpHandler.SetupResponse("/api/providers", "[]");
+
+        var cut = _ctx.Render<Agents>();
+        cut.WaitForState(() => cut.Markup.Contains("bot-1"));
+
+        Assert.Contains("agents-btn-clone", cut.Markup);
+    }
+
+    [Fact]
+    public void Clone_button_opens_form_with_copy_display_name()
+    {
+        var agents = JsonSerializer.Serialize(new[]
+        {
+            new { agentId = "bot-1", displayName = "Bot One", description = "A bot", apiProvider = "openai", modelId = "gpt-4", systemPrompt = "Be helpful." }
+        });
+        _httpHandler.SetupResponse("/api/agents", agents);
+        _httpHandler.SetupResponse("/api/providers", "[]");
+
+        var cut = _ctx.Render<Agents>();
+        cut.WaitForState(() => cut.Markup.Contains("bot-1"));
+
+        cut.Find("button.agents-btn-clone").Click();
+
+        cut.WaitForState(() => cut.Markup.Contains("Copy of Bot One"));
+        Assert.Contains("Copy of Bot One", cut.Markup);
+    }
+
+    [Fact]
+    public void Clone_form_has_empty_agent_id_field()
+    {
+        var agents = JsonSerializer.Serialize(new[]
+        {
+            new { agentId = "bot-1", displayName = "Bot One", description = "", apiProvider = "openai", modelId = "gpt-4", systemPrompt = "" }
+        });
+        _httpHandler.SetupResponse("/api/agents", agents);
+        _httpHandler.SetupResponse("/api/providers", "[]");
+
+        var cut = _ctx.Render<Agents>();
+        cut.WaitForState(() => cut.Markup.Contains("bot-1"));
+
+        cut.Find("button.agents-btn-clone").Click();
+
+        cut.WaitForState(() => cut.Markup.Contains("Copy of Bot One"));
+        var agentIdInput = cut.Find("#agent-id-input");
+        Assert.Equal("", agentIdInput.GetAttribute("value"));
+        // Agent ID must be editable when cloning (not disabled)
+        Assert.Null(agentIdInput.GetAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Clone_form_copies_provider_and_model()
+    {
+        var agents = JsonSerializer.Serialize(new[]
+        {
+            new { agentId = "bot-1", displayName = "Bot One", description = "", apiProvider = "copilot", modelId = "gpt-4o", systemPrompt = "" }
+        });
+        _httpHandler.SetupResponse("/api/agents", agents);
+        _httpHandler.SetupResponse("/api/providers", "[]");
+
+        var cut = _ctx.Render<Agents>();
+        cut.WaitForState(() => cut.Markup.Contains("bot-1"));
+
+        cut.Find("button.agents-btn-clone").Click();
+
+        cut.WaitForState(() => cut.Markup.Contains("Copy of Bot One"));
+        Assert.Contains("copilot", cut.Markup);
+        Assert.Contains("gpt-4o", cut.Markup);
+    }
+
     private void RaiseAgentsChanged(AgentsChangedPayload payload)
     {
         var field = typeof(GatewayHubConnection).GetField("OnAgentsChanged", BindingFlags.Instance | BindingFlags.NonPublic);


### PR DESCRIPTION
Closes #290

## Changes

### `Agents.razor`
- Added 📋 **Clone** button to each row in the agents table (between Edit and Delete)
- New `CloneAgent(AgentRow)` method:
  - `_editingId = null` — clone always creates a new agent (POST path)
  - `AgentId` cleared (editable, required)
  - `DisplayName` pre-filled as `Copy of {source display name}`
  - `Description`, `ApiProvider`, `ModelId`, `SystemPrompt` copied from source
  - `_originalForm` set with empty DisplayName so `IsDirty = true` — Save button immediately enabled
  - Loads provider models for the copied provider

### Tests (4 new in `AgentsPageTests.cs`)
- `Clone_button_renders_in_agent_row` — verifies `agents-btn-clone` class present in table row
- `Clone_button_opens_form_with_copy_display_name` — DisplayName is `Copy of Bot One`
- `Clone_form_has_empty_agent_id_field` — AgentId input is empty and not disabled
- `Clone_form_copies_provider_and_model` — provider/model values preserved

341/341 BlazorClient tests pass.

## Notes
- This implements the Clone action from #290 scope
- Remaining #290 scope (Soul, Access Controls, Runtime, Tool Policy sections) depends on #494 (AgentDetailPanel) merging first