### PR TITLE
fix(gateway): require admin scope for config write endpoints

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConfigController.cs
@@ -1,5 +1,7 @@
+using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Api.Models;
 using BotNexus.Gateway.Configuration;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -86,6 +88,10 @@ public sealed class ConfigController : ControllerBase
         [FromServices] PlatformConfigWriter writer,
         CancellationToken ct)
     {
+        var adminCheck = RequireAdminScope();
+        if (adminCheck is not null)
+            return adminCheck;
+
         // Prevent updating agents via this endpoint (use /api/agents instead)
         if (section.Equals("agents", StringComparison.OrdinalIgnoreCase))
             return BadRequest("Use /api/agents for agent management.");
@@ -105,6 +111,10 @@ public sealed class ConfigController : ControllerBase
         [FromServices] PlatformConfigWriter writer,
         CancellationToken ct)
     {
+        var adminCheck = RequireAdminScope();
+        if (adminCheck is not null)
+            return adminCheck;
+
         await writer.UpdateSectionEntryAsync(section, key, value, ct);
         return Ok(new { message = $"Entry '{key}' in section '{section}' updated." });
     }
@@ -119,6 +129,10 @@ public sealed class ConfigController : ControllerBase
         [FromServices] PlatformConfigWriter writer,
         CancellationToken ct)
     {
+        var adminCheck = RequireAdminScope();
+        if (adminCheck is not null)
+            return adminCheck;
+
         await writer.RemoveSectionEntryAsync(section, key, ct);
         return Ok(new { message = $"Entry '{key}' removed from section '{section}'." });
     }
@@ -346,6 +360,26 @@ public sealed class ConfigController : ControllerBase
                 : ex.Message;
             return Ok(new ConfigValidationResponse(false, resolvedPath, [], [$"Invalid JSON in config file: {parseMessage}"]));
         }
+    }
+
+    /// <summary>
+    /// Returns a 403 ObjectResult if the caller identity is present but is not an admin.
+    /// Returns <see langword="null"/> to allow the request through (admin, or no identity = dev mode).
+    /// </summary>
+    private ObjectResult? RequireAdminScope()
+    {
+        if (HttpContext?.Items is not { } items)
+            return null;
+
+        if (items[GatewayAuthMiddleware.CallerIdentityItemKey] is not GatewayCallerIdentity identity)
+            return null; // no identity present — dev mode / auth disabled
+
+        if (identity.IsAdmin)
+            return null;
+
+        return StatusCode(
+            StatusCodes.Status403Forbidden,
+            new { error = "forbidden", message = "Admin scope required for config write operations." });
     }
 
     private static string ResolveConfiguredPath(IConfiguration configuration)

--- a/src/gateway/BotNexus.Gateway.Api/GatewayAuthMiddleware.cs
+++ b/src/gateway/BotNexus.Gateway.Api/GatewayAuthMiddleware.cs
@@ -13,7 +13,8 @@ namespace BotNexus.Gateway.Api;
 /// </summary>
 public sealed class GatewayAuthMiddleware
 {
-    internal const string CallerIdentityItemKey = "BotNexus.Gateway.CallerIdentity";
+    /// <summary>The <see cref="Microsoft.AspNetCore.Http.HttpContext"/> item key for the authenticated <see cref="GatewayCallerIdentity"/>.</summary>
+    public const string CallerIdentityItemKey = "BotNexus.Gateway.CallerIdentity";
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ConfigControllerAdminScopeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConfigControllerAdminScopeTests.cs
@@ -1,0 +1,132 @@
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Api;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json.Nodes;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests that config write endpoints enforce admin scope.
+/// </summary>
+public sealed class ConfigControllerAdminScopeTests
+{
+    private static ConfigController CreateController(GatewayCallerIdentity? identity)
+    {
+        var controller = new ConfigController();
+        var httpContext = new DefaultHttpContext();
+        if (identity is not null)
+            httpContext.Items[GatewayAuthMiddleware.CallerIdentityItemKey] = identity;
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+        return controller;
+    }
+
+    private static PlatformConfigWriter CreateWriter()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"bn-admin-scope-{Guid.NewGuid():N}.json");
+        File.WriteAllText(tempPath, "{}");
+        return new PlatformConfigWriter(tempPath, new System.IO.Abstractions.FileSystem());
+    }
+
+    private static GatewayCallerIdentity AdminIdentity() => new()
+    {
+        CallerId = "admin-key",
+        IsAdmin = true
+    };
+
+    private static GatewayCallerIdentity NonAdminIdentity() => new()
+    {
+        CallerId = "agent-key",
+        IsAdmin = false
+    };
+
+    // --- UpdateSection ---
+
+    [Fact]
+    public async Task UpdateSection_WhenCallerIsAdmin_Returns200()
+    {
+        var controller = CreateController(AdminIdentity());
+        var writer = CreateWriter();
+
+        var result = await controller.UpdateSection("gateway", new JsonObject(), writer, CancellationToken.None);
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task UpdateSection_WhenCallerIsNotAdmin_Returns403()
+    {
+        var controller = CreateController(NonAdminIdentity());
+        var writer = CreateWriter();
+
+        var result = await controller.UpdateSection("gateway", new JsonObject(), writer, CancellationToken.None);
+
+        result.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSection_WhenNoIdentityPresent_Returns200()
+    {
+        // No identity = dev mode / auth disabled — allow through
+        var controller = CreateController(identity: null);
+        var writer = CreateWriter();
+
+        var result = await controller.UpdateSection("gateway", new JsonObject(), writer, CancellationToken.None);
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+
+    // --- UpdateSectionEntry ---
+
+    [Fact]
+    public async Task UpdateSectionEntry_WhenCallerIsNotAdmin_Returns403()
+    {
+        var controller = CreateController(NonAdminIdentity());
+        var writer = CreateWriter();
+
+        var result = await controller.UpdateSectionEntry("providers", "my-provider", new JsonObject(), writer, CancellationToken.None);
+
+        result.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSectionEntry_WhenCallerIsAdmin_Returns200()
+    {
+        var controller = CreateController(AdminIdentity());
+        var writer = CreateWriter();
+
+        var result = await controller.UpdateSectionEntry("providers", "my-provider", new JsonObject(), writer, CancellationToken.None);
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+
+    // --- DeleteSectionEntry ---
+
+    [Fact]
+    public async Task DeleteSectionEntry_WhenCallerIsNotAdmin_Returns403()
+    {
+        var controller = CreateController(NonAdminIdentity());
+        var writer = CreateWriter();
+
+        var result = await controller.DeleteSectionEntry("providers", "my-provider", writer, CancellationToken.None);
+
+        result.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task DeleteSectionEntry_WhenCallerIsAdmin_Returns200()
+    {
+        var controller = CreateController(AdminIdentity());
+        var writer = CreateWriter();
+
+        // Entry doesn't exist — that's OK, just verify the 200 path (writer will no-op)
+        var result = await controller.DeleteSectionEntry("providers", "missing-provider", writer, CancellationToken.None);
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+}


### PR DESCRIPTION
Closes #506

## Changes

- `ConfigController.UpdateSection`, `UpdateSectionEntry`, `DeleteSectionEntry` now call `RequireAdminScope()` before proceeding
- Non-admin `GatewayCallerIdentity` returns **403 Forbidden** with `{error: "forbidden", message: "Admin scope required for config write operations."}`
- Callers with no identity in `HttpContext.Items` (dev mode / auth disabled) are allowed through — backward compatible
- `GatewayAuthMiddleware.CallerIdentityItemKey` promoted from `internal` to `public const` so tests and future consumers can reference it without string literals
- 7 new unit tests: admin 200, non-admin 403, no-identity 200 for each write method

## Test Results

7 new tests pass. 1513/1513 gateway tests pass (no regressions).