### PR TITLE
test(scenarios): add citizen scenario suite and virtual channel adapter (foundation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,24 @@ structurally prevent regressions.
 
 See `src/domain/AGENTS.md` for the full convention and a worked example.
 
+### Scenario Test Suite
+
+Channel-agnostic acceptance tests for the citizen → conversation → session model live under
+`tests/scenarios/`. The harness (`BotNexus.Scenarios.Harness`) and the spec project
+(`BotNexus.Scenarios.Tests`) are governed by `tests/scenarios/AGENTS.md` and four
+architecture fitness functions in
+`tests/architecture/BotNexus.Architecture.Tests/ScenarioSuiteArchitectureTests.cs`:
+
+- Scenario tests must not reference any `BotNexus.Extensions.Channels.*` assembly.
+- The harness must not reference any channel extension either.
+- `VirtualChannelAdapter` must implement `IChannelAdapter`.
+- Scenario tests must drive the platform through the harness DSL, never through
+  `IServiceProvider` directly.
+
+If a future PR adds scenarios or extends the harness, read `tests/scenarios/AGENTS.md`
+first — the conventions there are the answer to "how do I add a new scenario without
+recreating the slop?"
+
 ### Memory Tool Naming
 
 - The agent-facing tool for persisting notes is **`memory_save`**. Do not call it "memory store."

--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -67,6 +67,10 @@
   <Folder Name="/tests/domain/">
     <Project Path="tests/domain/BotNexus.Domain.Tests/BotNexus.Domain.Tests.csproj" />
   </Folder>
+  <Folder Name="/tests/scenarios/">
+    <Project Path="tests/scenarios/BotNexus.Scenarios.Harness/BotNexus.Scenarios.Harness.csproj" />
+    <Project Path="tests/scenarios/BotNexus.Scenarios.Tests/BotNexus.Scenarios.Tests.csproj" />
+  </Folder>
   <Folder Name="/tests/extensions/">
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.ExecTool.Tests/BotNexus.Extensions.ExecTool.Tests.csproj" />

--- a/tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj
+++ b/tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj
@@ -20,6 +20,9 @@
     <ProjectReference Include="..\..\..\src\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+    <ProjectReference Include="..\..\scenarios\BotNexus.Scenarios.Harness\BotNexus.Scenarios.Harness.csproj" />
+    <ProjectReference Include="..\..\scenarios\BotNexus.Scenarios.Tests\BotNexus.Scenarios.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/architecture/BotNexus.Architecture.Tests/ScenarioSuiteArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ScenarioSuiteArchitectureTests.cs
@@ -1,0 +1,149 @@
+using System.Reflection;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Scenarios.Harness;
+using NetArchTest.Rules;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions for the scenario test suite. These rules structurally enforce
+/// the channel-agnostic / production-shaped conventions documented in <c>tests/scenarios/AGENTS.md</c>
+/// (plan §10.6). If a future change pulls a channel-extension reference into the scenarios project,
+/// or reaches past the harness DSL into the gateway's <c>IServiceProvider</c>, the build fails
+/// before the change lands. This is the antidote to slop accumulating in the suite over time.
+/// </summary>
+public sealed class ScenarioSuiteArchitectureTests
+{
+    private static readonly Assembly HarnessAssembly = typeof(VirtualChannelAdapter).Assembly;
+    private static readonly Assembly ScenarioTestsAssembly =
+        Assembly.Load("BotNexus.Scenarios.Tests");
+
+    /// <summary>
+    /// Scenario tests must remain channel-agnostic: a scenario that references any
+    /// <c>BotNexus.Extensions.Channels.*</c> assembly is a tight coupling to a single
+    /// transport and defeats the channel-conformance role of the suite.
+    /// </summary>
+    [Fact]
+    public void ScenarioTests_DoNotReferenceAnyChannelExtension()
+    {
+        var referenced = ScenarioTestsAssembly
+            .GetReferencedAssemblies()
+            .Select(name => name.Name!)
+            .Where(name => name.StartsWith("BotNexus.Extensions.Channels.", StringComparison.Ordinal))
+            .ToArray();
+
+        referenced.ShouldBeEmpty(
+            "Scenario tests must remain channel-agnostic. Found channel-extension references: " +
+            string.Join(", ", referenced));
+    }
+
+    /// <summary>
+    /// The scenario harness is consumed by the test project and (later) per-channel conformance
+    /// projects, so it must not pull in any channel-extension dependency that would force
+    /// adopters of the harness to also drag in unrelated transports.
+    /// </summary>
+    [Fact]
+    public void ScenarioHarness_DoesNotReferenceAnyChannelExtension()
+    {
+        var referenced = HarnessAssembly
+            .GetReferencedAssemblies()
+            .Select(name => name.Name!)
+            .Where(name => name.StartsWith("BotNexus.Extensions.Channels.", StringComparison.Ordinal))
+            .ToArray();
+
+        referenced.ShouldBeEmpty(
+            "BotNexus.Scenarios.Harness must remain channel-agnostic. Found references: " +
+            string.Join(", ", referenced));
+    }
+
+    /// <summary>
+    /// <see cref="VirtualChannelAdapter"/> must remain a real <see cref="IChannelAdapter"/>
+    /// implementation. If a future refactor breaks that contract (e.g. by inheriting from a
+    /// stub that no longer satisfies the interface), every scenario silently loses fidelity.
+    /// </summary>
+    [Fact]
+    public void VirtualChannelAdapter_ImplementsIChannelAdapter()
+    {
+        typeof(IChannelAdapter).IsAssignableFrom(typeof(VirtualChannelAdapter))
+            .ShouldBeTrue($"{nameof(VirtualChannelAdapter)} must implement {nameof(IChannelAdapter)}.");
+    }
+
+    /// <summary>
+    /// Scenario tests must drive the platform through the harness DSL (the virtual adapter
+    /// and supporting helpers), never by reaching into <see cref="IServiceProvider"/> directly.
+    /// Direct DI access from a scenario test is a smell — the DSL exposes the right level of
+    /// abstraction. If the DSL is missing a verb, add the verb; don't reach past it.
+    /// </summary>
+    [Fact]
+    public void ScenarioTests_DoNotDependOnIServiceProvider()
+    {
+        var result = Types.InAssembly(ScenarioTestsAssembly)
+            .Should()
+            .NotHaveDependencyOn("Microsoft.Extensions.DependencyInjection")
+            .And()
+            .NotHaveDependencyOn("System.IServiceProvider")
+            .GetResult();
+
+        var failing = result.FailingTypeNames ?? [];
+        failing.ShouldBeEmpty(
+            "Scenario tests must drive the platform through the harness DSL, not by resolving from DI directly. " +
+            "Offending types: " + string.Join(", ", failing));
+    }
+
+    /// <summary>
+    /// The harness's public surface must not leak DI primitives (<see cref="IServiceProvider"/>,
+    /// <see cref="IServiceCollection"/>, hosting types). A future <c>VirtualWorld</c> harness will
+    /// build its own DI graph internally — that's fine — but it must expose only typed verbs
+    /// (e.g. <c>Adapter</c>, <c>AsUser</c>, <c>WaitForReplyAsync</c>) so that scenarios stay at
+    /// spec level and do not devolve into service-location tests.
+    /// </summary>
+    [Fact]
+    public void ScenarioHarness_PublicSurface_DoesNotLeakDiPrimitives()
+    {
+        var disallowed = new[]
+        {
+            "System.IServiceProvider",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            "Microsoft.Extensions.DependencyInjection.IServiceScopeFactory",
+            "Microsoft.Extensions.DependencyInjection.IServiceScope",
+            "Microsoft.Extensions.Hosting.IHost",
+            "Microsoft.Extensions.Hosting.IHostBuilder",
+            "Microsoft.Extensions.Hosting.IHostedService",
+        };
+
+        var leaks = new List<string>();
+
+        foreach (var type in HarnessAssembly.GetExportedTypes())
+        {
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            {
+                if (disallowed.Contains(prop.PropertyType.FullName))
+                    leaks.Add($"{type.FullName}.{prop.Name} : {prop.PropertyType.FullName}");
+            }
+
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            {
+                if (disallowed.Contains(method.ReturnType.FullName))
+                    leaks.Add($"{type.FullName}.{method.Name}() : {method.ReturnType.FullName}");
+                foreach (var parameter in method.GetParameters())
+                {
+                    if (disallowed.Contains(parameter.ParameterType.FullName))
+                        leaks.Add($"{type.FullName}.{method.Name}({parameter.Name}) : {parameter.ParameterType.FullName}");
+                }
+            }
+
+            foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                foreach (var parameter in ctor.GetParameters())
+                {
+                    if (disallowed.Contains(parameter.ParameterType.FullName))
+                        leaks.Add($"{type.FullName}.ctor({parameter.Name}) : {parameter.ParameterType.FullName}");
+                }
+            }
+        }
+
+        leaks.ShouldBeEmpty(
+            "BotNexus.Scenarios.Harness must not expose DI primitives on its public surface. " +
+            "Found: " + string.Join("; ", leaks));
+    }
+}

--- a/tests/scenarios/AGENTS.md
+++ b/tests/scenarios/AGENTS.md
@@ -1,0 +1,167 @@
+# Scenario Test Suite
+
+This folder hosts the **channel-agnostic scenario test suite** for BotNexus. It is the executable
+specification of the citizen → conversation → session model documented in `plan.md §10` and
+`docs/architecture/domain-model.md` (when that ships in Phase 0).
+
+## Why this exists
+
+The user's directive (2026-05-22) is the charter:
+
+> "I want good TDD validation and emulation of the platform using virtual test channel
+> adapters to emulate the different citizen scenarios in agent creation, conversation
+> creation and interactions as well as how this impacts sessions. These will also stop slop
+> coming in in the future as they articulate the core scenarios and will allow it to work
+> no matter what channel implementations there are."
+
+The three roles this suite plays:
+
+1. **Spec.** Each scenario reads as plain English: "a citizen starts a conversation,
+   exchanges three turns, compaction fires, conversation continues with history hidden
+   from the LLM but preserved in the store." If the implementation can't make that pass,
+   the implementation is wrong — not the spec.
+2. **Regression net.** Today's slop happened because the inbound→router→session→adapter
+   path had transport-coupled tests and zero contract-level tests. This suite is the
+   contract-level net that survives any channel-implementation change.
+3. **Channel-conformance gate.** A future SignalR/Telegram/Teams/CLI channel that wants
+   to claim "I am a BotNexus channel" runs the same scenarios with its own adapter and
+   passes — or it isn't a BotNexus channel.
+
+## Folder layout
+
+```
+tests/scenarios/
+├── BotNexus.Scenarios.Harness/        # class library — reusable across future per-channel
+│   │                                    conformance projects (not a test project itself)
+│   ├── VirtualChannelAdapter.cs       # full IChannelAdapter implementation; captures
+│   │                                    outbound; pushes inbound on demand
+│   ├── VirtualChannelAdapterOptions.cs  # per-instance capability flags + AdapterId
+│   └── ScenarioFakeApiProvider.cs     # deterministic IApiProvider; scripted responses
+│
+└── BotNexus.Scenarios.Tests/          # the only test project under tests/scenarios/
+    ├── Adapter/                       # harness conformance — proves the harness itself works
+    │   ├── VirtualChannelAdapterConformance.cs
+    │   └── ScenarioFakeApiProviderConformance.cs
+    ├── Citizens/                      # (future) end-to-end citizen scenarios
+    ├── Conversations/                 # (future) conversation lifecycle scenarios
+    └── Sessions/                      # (future) session lifecycle + compaction scenarios
+```
+
+## The three layers
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  tests/scenarios/BotNexus.Scenarios.Tests                    │  ← scenario specs (xUnit)
+│  - citizen scenarios (User↔Agent, Agent↔Agent, Agent↔Sub)   │
+│  - conversation lifecycle (create, list, switch, end, reset)│
+│  - session lifecycle (turn, compact, seal, new-in-same-conv) │
+│  - channel-binding scenarios (multi-channel, fan-out)        │
+│  - capability gating (steering / streaming / images)         │
+└──────────────────────────────────────────────────────────────┘
+              uses ↓
+┌──────────────────────────────────────────────────────────────┐
+│  tests/scenarios/BotNexus.Scenarios.Harness                  │  ← reusable test fixture
+│  - VirtualChannelAdapter (IChannelAdapter impl)              │     (class library)
+│  - VirtualWorld (in-process gateway harness — coming next)   │
+│  - ScenarioFakeApiProvider (deterministic LLM)               │
+│  - Given/When/Then DSL (coming next)                         │
+└──────────────────────────────────────────────────────────────┘
+              uses ↓
+┌──────────────────────────────────────────────────────────────┐
+│  src/gateway + src/extensions/* (production code)            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The harness is a class library, not a test project, so that any future channel adapter
+(Telegram, ServiceBus, Teams, CLI) can reference it as a test dep and rerun the same
+flows with its own adapter substituted in.
+
+## Conventions
+
+These conventions are **structurally enforced** by four architecture fitness functions
+in `tests/architecture/BotNexus.Architecture.Tests/ScenarioSuiteArchitectureTests.cs`.
+Violations fail the build.
+
+1. **Every scenario is a `[Fact]` with a prose-shaped name.**
+   Use `WhatHappens_When_Setup` not `Method_Scenario_Result` — these are spec tests, not
+   unit tests. Examples:
+   - `User_OpensConversation_WithAgent_AndReceivesReply_OnSingleTurn`
+   - `Session_Compacts_WhenBudgetExceeded_AndConversationContinues_InSameSession`
+   - `OneConversation_TwoVirtualChannels_BothReceiveOutbound_FromSameAgentTurn`
+
+2. **No references to channel-extension projects.** A scenario test that does
+   `using BotNexus.Extensions.Channels.SignalR;` (or any other concrete channel) is
+   rejected by `ScenarioTests_DoNotReferenceAnyChannelExtension`. The whole point is
+   channel-agnostic.
+
+3. **Use the DSL or nothing.** Direct DI access from a scenario test is a smell — the
+   DSL exposes the right level of abstraction. If the DSL is missing a verb, add the
+   verb; don't reach past it. The
+   `ScenarioTests_DoNotDependOnIServiceProvider` rule rejects any
+   `Microsoft.Extensions.DependencyInjection` or `System.IServiceProvider` dependency
+   from the scenarios project.
+
+4. **Deterministic time.** When the `VirtualWorld` ships, it will provide
+   `FakeTimeProvider`. Tests advance time explicitly via the DSL — no `await Task.Delay`.
+
+5. **Deterministic LLM.** `ScenarioFakeApiProvider` takes a scripted
+   `Func<int turnIndex, Context, string> respond` so every scenario's LLM behaviour is
+   reproducible. Random replies are banned — they break the regression-net property.
+
+6. **The harness is production-shaped.** `BotNexus.Scenarios.Harness` is a class library,
+   not a test project. It must remain re-usable by any future per-channel conformance
+   project. The
+   `ScenarioHarness_DoesNotReferenceAnyChannelExtension` rule prevents accidentally
+   coupling the harness to a single transport.
+
+## Scenario inventory and phasing
+
+The first wave of 12 scenarios is documented in `plan.md §10.4`. They are sequenced so
+that:
+
+- **Conformance tests** (this PR, 16 [Fact]s) prove the harness itself works end-to-end:
+  the virtual adapter implements `IChannelAdapter` correctly, captures outbound and
+  receives inbound, honours capability flags, and the fake API provider produces
+  observable, deterministic LLM responses.
+- **End-to-end citizen scenarios** land in follow-up PRs together with the
+  `VirtualWorld` host harness and the fluent DSL. The detailed scenario list is in
+  `plan.md §10.4` (first wave) and `plan.md §10.5` (later waves that depend on model
+  evolution — Citizen abstraction, mark-as-history compaction, ThreadId removal,
+  isolation strategies).
+
+Each behaviour-changing phase tightens scenarios from "today's behaviour" to "target
+behaviour" within the same PR — see `plan.md §9.5` for the per-phase TDD outline.
+
+## How to add a scenario
+
+1. Pick the folder under `BotNexus.Scenarios.Tests/` that matches the area
+   (Citizens, Conversations, Sessions, ...) — create the folder if needed.
+2. Name the file after the actor-and-outcome (e.g. `UserOpensConversation.cs`,
+   `CompactionPreservesHistory.cs`). One file per scenario family.
+3. Write a `[Fact]` with a prose-shaped name. The body must be readable as English —
+   if you find yourself reaching for DI, switch to the harness DSL or extend the DSL.
+4. Use `ScenarioFakeApiProvider` and `VirtualChannelAdapter` (once `VirtualWorld` is
+   in place, prefer the world-level DSL).
+5. Run the architecture fitness functions:
+   `dotnet test tests/architecture/BotNexus.Architecture.Tests/ --filter ScenarioSuiteArchitectureTests`.
+
+## Running
+
+```shell
+# All scenario tests
+dotnet test tests/scenarios/BotNexus.Scenarios.Tests/BotNexus.Scenarios.Tests.csproj --nologo --tl:off
+
+# Just the harness conformance
+dotnet test tests/scenarios/BotNexus.Scenarios.Tests/BotNexus.Scenarios.Tests.csproj --nologo --tl:off --filter "FullyQualifiedName~Adapter"
+
+# Architecture rules for the suite
+dotnet test tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj --nologo --tl:off --filter "FullyQualifiedName~ScenarioSuiteArchitectureTests"
+```
+
+## Related docs
+
+- `plan.md §10` — the full scenario-suite design and scenario inventory.
+- `plan.md §9` — the broader TDD strategy these scenarios sit inside.
+- `tests/architecture/BotNexus.Architecture.Tests/ScenarioSuiteArchitectureTests.cs` —
+  the four fitness functions that keep the suite honest.
+- Root `AGENTS.md` (Test Enforcement, Value Objects Use Vogen) — global conventions.

--- a/tests/scenarios/BotNexus.Scenarios.Harness/BotNexus.Scenarios.Harness.csproj
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/BotNexus.Scenarios.Harness.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>
+

--- a/tests/scenarios/BotNexus.Scenarios.Harness/ScenarioFakeApiProvider.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/ScenarioFakeApiProvider.cs
@@ -1,0 +1,130 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+
+namespace BotNexus.Scenarios.Harness;
+
+/// <summary>
+/// Deterministic <see cref="IApiProvider"/> used by scenario tests so the LLM round-trip
+/// becomes a scripted function of <c>(turnIndex, context)</c>. Removes flakiness from the
+/// suite — citizens always receive the same reply for the same turn, every run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Construct with a <c>responseFactory</c> that returns the text to emit for a given turn,
+/// or a constant <c>response</c>. The factory sees the zero-based turn index and the gateway-
+/// assembled <see cref="Context"/> (system prompt, message history, tools) so tests can
+/// assert on the LLM-facing projection if they choose.
+/// </para>
+/// <para>
+/// Register via <see cref="Register(ApiProviderRegistry, ModelRegistry)"/> which both
+/// registers the provider under <see cref="ApiName"/> and registers a matching scenario
+/// model under <see cref="ModelId"/>. Scenarios point their agents at <see cref="ModelId"/>
+/// + <see cref="ProviderName"/> and the gateway resolves through this fake.
+/// </para>
+/// </remarks>
+public sealed class ScenarioFakeApiProvider : IApiProvider
+{
+    /// <summary>The API key under which the fake is registered with <see cref="ApiProviderRegistry"/>.</summary>
+    public const string ApiName = "scenario-test-api";
+
+    /// <summary>The provider key under which the fake's model is registered with <see cref="ModelRegistry"/>.</summary>
+    public const string ProviderName = "scenario-test-provider";
+
+    /// <summary>The model id scenarios assign to their agents to route LLM calls to this fake.</summary>
+    public const string ModelId = "scenario-test-model";
+
+    private readonly Func<int, Context, string> _responseFactory;
+    private int _turnIndex;
+
+    /// <summary>
+    /// Creates a fake provider that emits <paramref name="response"/> for every turn.
+    /// </summary>
+    public ScenarioFakeApiProvider(string response = "ok")
+        : this((_, _) => response)
+    {
+    }
+
+    /// <summary>
+    /// Creates a fake provider that emits the text returned by <paramref name="responseFactory"/>
+    /// for each turn. The factory receives the zero-based turn index and the gateway-assembled
+    /// <see cref="Context"/>.
+    /// </summary>
+    public ScenarioFakeApiProvider(Func<int, Context, string> responseFactory)
+    {
+        _responseFactory = responseFactory ?? throw new ArgumentNullException(nameof(responseFactory));
+    }
+
+    /// <inheritdoc />
+    public string Api => ApiName;
+
+    /// <summary>The total number of stream/streamSimple calls observed by this provider.</summary>
+    public int TurnCount => Volatile.Read(ref _turnIndex);
+
+    /// <inheritdoc />
+    public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+        => BuildStream(NextTurn(), context, model);
+
+    /// <inheritdoc />
+    public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+        => BuildStream(NextTurn(), context, model);
+
+    /// <summary>
+    /// Registers this provider with <paramref name="apiProviderRegistry"/> and registers a matching
+    /// scenario model with <paramref name="modelRegistry"/> so the gateway can resolve LLM calls
+    /// from agents that point at <see cref="ModelId"/> and <see cref="ProviderName"/>.
+    /// </summary>
+    public void Register(ApiProviderRegistry apiProviderRegistry, ModelRegistry modelRegistry)
+    {
+        ArgumentNullException.ThrowIfNull(apiProviderRegistry);
+        ArgumentNullException.ThrowIfNull(modelRegistry);
+
+        apiProviderRegistry.Register(this, sourceId: ApiName);
+        modelRegistry.Register(ProviderName, CreateModel());
+    }
+
+    /// <summary>The scenario-test <see cref="LlmModel"/> registered alongside this provider.</summary>
+    public static LlmModel CreateModel() => new(
+        Id: ModelId,
+        Name: "Scenario Test Model",
+        Api: ApiName,
+        Provider: ProviderName,
+        BaseUrl: "https://scenario.test.invalid",
+        Reasoning: false,
+        Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 128_000,
+        MaxTokens: 32_000);
+
+    private int NextTurn() => Interlocked.Increment(ref _turnIndex) - 1;
+
+    private LlmStream BuildStream(int turn, Context context, LlmModel model)
+    {
+        var text = _responseFactory(turn, context) ?? string.Empty;
+        var stream = new LlmStream();
+        var message = new AssistantMessage(
+            Content: [new TextContent(text)],
+            Api: ApiName,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: new Usage
+            {
+                Input = 10,
+                Output = Math.Max(1, text.Length / 4),
+                TotalTokens = 10 + Math.Max(1, text.Length / 4)
+            },
+            StopReason: StopReason.Stop,
+            ErrorMessage: null,
+            ResponseId: $"scenario-{turn:D6}",
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new StartEvent(message));
+        stream.Push(new TextStartEvent(0, message));
+        stream.Push(new TextDeltaEvent(0, text, message));
+        stream.Push(new TextEndEvent(0, text, message));
+        stream.Push(new DoneEvent(StopReason.Stop, message));
+        stream.End(message);
+        return stream;
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Harness/VirtualChannelAdapter.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/VirtualChannelAdapter.cs
@@ -1,0 +1,213 @@
+using System.Collections.Concurrent;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Scenarios.Harness;
+
+/// <summary>
+/// A fully in-memory <see cref="IChannelAdapter"/> used by scenario tests to drive citizen
+/// interactions without bringing up a real channel (SignalR, Telegram, Service Bus, ...).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The adapter is intentionally passive: it carries inbound <see cref="ChannelAddress"/> verbatim
+/// from the test, so multi-binding / multi-conversation scenarios are driven from the test
+/// rather than faked inside the adapter. It captures every outbound message and stream event
+/// into ordered logs that scenario assertions read from.
+/// </para>
+/// <para>
+/// Each capability flag (streaming, steering, follow-up, thinking, tool, inbound images) is
+/// configurable per instance via <see cref="VirtualChannelAdapterOptions"/> so capability-gating
+/// scenarios can drive the router with a channel that lacks a specific capability.
+/// </para>
+/// <para>
+/// Use <see cref="SimulateInboundAsync(InboundMessage, CancellationToken)"/> to drive an
+/// inbound message through the gateway's <see cref="IChannelDispatcher"/>. The adapter must be
+/// started (<see cref="ChannelAdapterBase.StartAsync"/>) before inbound dispatch will succeed.
+/// </para>
+/// <para>
+/// Re-listing <see cref="IChannelAdapter"/> in the class declaration is intentional: it allows
+/// the explicit-interface implementation of <see cref="IChannelAdapter.AdapterId"/> below to
+/// override the interface's default implementation. <see cref="ChannelAdapterBase"/> does not
+/// itself override <see cref="IChannelAdapter.AdapterId"/>, so the explicit impl is currently
+/// the only way for a scenario to set a stable adapter id when standing up more than one virtual
+/// adapter under the same channel type. If a future refactor adds a virtual or abstract
+/// <c>AdapterId</c> to <see cref="ChannelAdapterBase"/>, replace this pattern with a normal
+/// override -- the <c>VirtualChannelAdapter_ExposesAdapterId_ViaInterface</c> conformance test
+/// will fail loudly if the two surfaces drift.
+/// </para>
+/// </remarks>
+public sealed class VirtualChannelAdapter : ChannelAdapterBase, IChannelAdapter, IStreamEventChannelAdapter
+{
+    /// <summary>The canonical channel type identifier used by all virtual adapters.</summary>
+    public const string VirtualChannelType = "virtual";
+
+    private static readonly ChannelKey VirtualChannelKey = ChannelKey.From(VirtualChannelType);
+
+    private readonly ConcurrentQueue<OutboundMessage> _outbound = new();
+    private readonly ConcurrentQueue<InboundMessage> _inbound = new();
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _streamDeltas = new();
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<AgentStreamEvent>> _streamEvents = new();
+    private readonly VirtualChannelAdapterOptions _options;
+    private int _dispatchCount;
+
+    /// <summary>
+    /// Creates a virtual channel adapter with default capabilities (streaming, steering,
+    /// follow-up on; thinking, tool, inbound images off).
+    /// </summary>
+    public VirtualChannelAdapter()
+        : this(new VirtualChannelAdapterOptions(), NullLogger<VirtualChannelAdapter>.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Creates a virtual channel adapter with explicit capability and identity options.
+    /// </summary>
+    public VirtualChannelAdapter(VirtualChannelAdapterOptions options, ILogger<VirtualChannelAdapter>? logger = null)
+        : base(logger ?? NullLogger<VirtualChannelAdapter>.Instance)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public override ChannelKey ChannelType => VirtualChannelKey;
+
+    /// <inheritdoc />
+    public override string DisplayName => string.IsNullOrWhiteSpace(_options.DisplayName)
+        ? "Virtual"
+        : _options.DisplayName;
+
+    /// <summary>
+    /// Optional adapter instance identifier. Set via <see cref="VirtualChannelAdapterOptions.AdapterId"/>
+    /// when a single scenario stands up multiple virtual adapters under the same channel type.
+    /// </summary>
+    string? IChannelAdapter.AdapterId => _options.AdapterId;
+
+    /// <inheritdoc />
+    public override bool SupportsStreaming => _options.SupportsStreaming;
+
+    /// <inheritdoc />
+    public override bool SupportsSteering => _options.SupportsSteering;
+
+    /// <inheritdoc />
+    public override bool SupportsFollowUp => _options.SupportsFollowUp;
+
+    /// <inheritdoc />
+    public override bool SupportsThinkingDisplay => _options.SupportsThinkingDisplay;
+
+    /// <inheritdoc />
+    public override bool SupportsToolDisplay => _options.SupportsToolDisplay;
+
+    /// <inheritdoc />
+    public override bool SupportsInboundImages => _options.SupportsInboundImages;
+
+    /// <summary>Ordered snapshot of every outbound <see cref="OutboundMessage"/> the gateway sent through this adapter.</summary>
+    public IReadOnlyList<OutboundMessage> Outbound => [.. _outbound];
+
+    /// <summary>Ordered snapshot of every inbound <see cref="InboundMessage"/> the test dispatched through this adapter.</summary>
+    public IReadOnlyList<InboundMessage> InboundDispatched => [.. _inbound];
+
+    /// <summary>The total number of times <see cref="SimulateInboundAsync"/> reached the gateway dispatcher.</summary>
+    public int InboundDispatchCount => Volatile.Read(ref _dispatchCount);
+
+    /// <summary>Stream deltas grouped by the channel-level conversation routing key the gateway used.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> StreamDeltas
+        => _streamDeltas.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<string>)kvp.Value.ToArray());
+
+    /// <summary>Structured stream events grouped by the channel-level conversation routing key the gateway used.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<AgentStreamEvent>> StreamEvents
+        => _streamEvents.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<AgentStreamEvent>)kvp.Value.ToArray());
+
+    /// <summary>
+    /// Drives <paramref name="message"/> through the gateway's <see cref="IChannelDispatcher"/>
+    /// as if it had arrived from a real channel. The adapter must be started before this is invoked.
+    /// </summary>
+    /// <param name="message">The inbound message to dispatch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the adapter has not been started.</exception>
+    public async Task SimulateInboundAsync(InboundMessage message, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (!IsRunning)
+            throw new InvalidOperationException(
+                $"{nameof(VirtualChannelAdapter)} must be started via {nameof(StartAsync)} before {nameof(SimulateInboundAsync)} can be used.");
+
+        _inbound.Enqueue(message);
+        Interlocked.Increment(ref _dispatchCount);
+        await DispatchInboundAsync(message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits until at least one outbound message matches <paramref name="predicate"/> or the
+    /// <paramref name="timeout"/> elapses. Returns the first matching message.
+    /// </summary>
+    /// <param name="predicate">Selector for the outbound message of interest.</param>
+    /// <param name="timeout">Maximum time to wait before giving up.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="TimeoutException">Thrown when no matching message is observed before the timeout.</exception>
+    public async Task<OutboundMessage> WaitForOutboundAsync(
+        Func<OutboundMessage, bool> predicate,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var match = _outbound.FirstOrDefault(predicate);
+            if (match is not null)
+                return match;
+            await Task.Delay(TimeSpan.FromMilliseconds(20), cancellationToken);
+        }
+
+        throw new TimeoutException(
+            $"No outbound message matching predicate observed within {timeout.TotalMilliseconds:F0}ms (observed {_outbound.Count}).");
+    }
+
+    /// <summary>Clears every captured outbound, inbound, stream-delta and stream-event log.</summary>
+    public void Reset()
+    {
+        _outbound.Clear();
+        _inbound.Clear();
+        _streamDeltas.Clear();
+        _streamEvents.Clear();
+        Interlocked.Exchange(ref _dispatchCount, 0);
+    }
+
+    /// <inheritdoc />
+    protected override Task OnStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    protected override Task OnStopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public override Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        _outbound.Enqueue(message);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(conversationId);
+        ArgumentNullException.ThrowIfNull(delta);
+        _streamDeltas.GetOrAdd(conversationId, _ => new ConcurrentQueue<string>()).Enqueue(delta);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(conversationId);
+        ArgumentNullException.ThrowIfNull(streamEvent);
+        _streamEvents.GetOrAdd(conversationId, _ => new ConcurrentQueue<AgentStreamEvent>()).Enqueue(streamEvent);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Harness/VirtualChannelAdapterOptions.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/VirtualChannelAdapterOptions.cs
@@ -1,0 +1,37 @@
+namespace BotNexus.Scenarios.Harness;
+
+/// <summary>
+/// Configuration for a <see cref="VirtualChannelAdapter"/> instance. Defaults match a
+/// modern interactive channel (streaming on, steering on, follow-up on) so the common path
+/// "just works" without ceremony; capability-gating scenarios opt into a narrower set.
+/// </summary>
+public sealed record VirtualChannelAdapterOptions
+{
+    /// <summary>
+    /// Optional adapter instance identifier. Required when multiple virtual adapters of the
+    /// same channel type live in one scenario (e.g. proving multi-channel fan-out).
+    /// Returns <c>null</c> when only one virtual adapter is registered.
+    /// </summary>
+    public string? AdapterId { get; init; }
+
+    /// <summary>Human-readable display name for the adapter. Defaults to "Virtual".</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Whether the adapter advertises streaming-delta support to the router.</summary>
+    public bool SupportsStreaming { get; init; } = true;
+
+    /// <summary>Whether the adapter advertises mid-response steering support to the router.</summary>
+    public bool SupportsSteering { get; init; } = true;
+
+    /// <summary>Whether the adapter advertises follow-up message controls to the router.</summary>
+    public bool SupportsFollowUp { get; init; } = true;
+
+    /// <summary>Whether the adapter advertises thinking/progress rendering to the router.</summary>
+    public bool SupportsThinkingDisplay { get; init; }
+
+    /// <summary>Whether the adapter advertises tool-call activity rendering to the router.</summary>
+    public bool SupportsToolDisplay { get; init; }
+
+    /// <summary>Whether the adapter advertises inbound image attachment support to the router.</summary>
+    public bool SupportsInboundImages { get; init; }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Adapter/ScenarioFakeApiProviderConformance.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Adapter/ScenarioFakeApiProviderConformance.cs
@@ -1,0 +1,104 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Adapter;
+
+/// <summary>
+/// Conformance scenarios for <see cref="ScenarioFakeApiProvider"/>: proves the deterministic
+/// LLM driver behaves as the scenario suite expects (turn counting, scripted replies,
+/// per-turn context observation, registry wiring).
+/// </summary>
+public sealed class ScenarioFakeApiProviderConformance
+{
+    private static readonly LlmModel Model = ScenarioFakeApiProvider.CreateModel();
+    private static readonly Context EmptyContext = new(SystemPrompt: null, Messages: []);
+
+    [Fact]
+    public async Task Constant_Response_IsReturnedForEveryTurn()
+    {
+        var provider = new ScenarioFakeApiProvider("hello citizen");
+
+        var first = await provider.Stream(Model, EmptyContext).GetResultAsync();
+        var second = await provider.StreamSimple(Model, EmptyContext).GetResultAsync();
+
+        TextOf(first).ShouldBe("hello citizen");
+        TextOf(second).ShouldBe("hello citizen");
+        provider.TurnCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ScriptedFactory_SeesZeroBasedTurnIndex_AndReturnsPerTurnText()
+    {
+        var observed = new List<int>();
+        var provider = new ScenarioFakeApiProvider((turn, _) =>
+        {
+            observed.Add(turn);
+            return $"turn-{turn}";
+        });
+
+        var t0 = await provider.StreamSimple(Model, EmptyContext).GetResultAsync();
+        var t1 = await provider.StreamSimple(Model, EmptyContext).GetResultAsync();
+        var t2 = await provider.StreamSimple(Model, EmptyContext).GetResultAsync();
+
+        observed.ShouldBe([0, 1, 2]);
+        TextOf(t0).ShouldBe("turn-0");
+        TextOf(t1).ShouldBe("turn-1");
+        TextOf(t2).ShouldBe("turn-2");
+    }
+
+    [Fact]
+    public async Task Provider_TagsAssistantMessage_WithScenarioApiAndModelMetadata()
+    {
+        var provider = new ScenarioFakeApiProvider("anything");
+
+        var message = await provider.StreamSimple(Model, EmptyContext).GetResultAsync();
+
+        message.Api.ShouldBe(ScenarioFakeApiProvider.ApiName);
+        message.ModelId.ShouldBe(ScenarioFakeApiProvider.ModelId);
+        message.Provider.ShouldBe(ScenarioFakeApiProvider.ProviderName);
+        message.StopReason.ShouldBe(StopReason.Stop);
+    }
+
+    [Fact]
+    public async Task Register_WiresProviderAndModel_IntoRegistries_AndIsRoutedByLlmClient()
+    {
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        var provider = new ScenarioFakeApiProvider("registered reply");
+
+        provider.Register(providers, models);
+
+        providers.Get(ScenarioFakeApiProvider.ApiName).ShouldNotBeNull();
+        var resolvedModel = models.GetModel(ScenarioFakeApiProvider.ProviderName, ScenarioFakeApiProvider.ModelId);
+        resolvedModel.ShouldNotBeNull();
+        resolvedModel.Api.ShouldBe(ScenarioFakeApiProvider.ApiName);
+
+        var llmClient = new LlmClient(providers, models);
+        var reply = await llmClient.CompleteSimpleAsync(resolvedModel, EmptyContext);
+
+        TextOf(reply).ShouldBe("registered reply");
+    }
+
+    [Fact]
+    public async Task Factory_ReceivesGatewayAssembledContext_SoScenariosCanAssertOnSystemPromptAndHistory()
+    {
+        Context? captured = null;
+        var provider = new ScenarioFakeApiProvider((_, ctx) =>
+        {
+            captured = ctx;
+            return "ack";
+        });
+
+        var context = new Context(SystemPrompt: "you are agent-a", Messages: []);
+        _ = await provider.StreamSimple(Model, context).GetResultAsync();
+
+        captured.ShouldNotBeNull();
+        captured.SystemPrompt.ShouldBe("you are agent-a");
+    }
+
+    private static string TextOf(AssistantMessage message)
+        => string.Concat(message.Content.OfType<TextContent>().Select(t => t.Text));
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Adapter/VirtualChannelAdapterConformance.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Adapter/VirtualChannelAdapterConformance.cs
@@ -1,0 +1,217 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Adapter;
+
+/// <summary>
+/// Conformance scenarios for <see cref="VirtualChannelAdapter"/>: the foundational
+/// piece of the scenario suite. If this adapter does not behave like a real
+/// <see cref="IChannelAdapter"/>, every higher-level scenario built on top is suspect.
+/// </summary>
+public sealed class VirtualChannelAdapterConformance
+{
+    [Fact]
+    public void VirtualChannelAdapter_ImplementsIChannelAdapter_AndReportsVirtualChannelType()
+    {
+        var adapter = new VirtualChannelAdapter();
+
+        adapter.ShouldBeAssignableTo<IChannelAdapter>();
+        adapter.ChannelType.ShouldBe(ChannelKey.From(VirtualChannelAdapter.VirtualChannelType));
+        adapter.DisplayName.ShouldBe("Virtual");
+        adapter.IsRunning.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void VirtualChannelAdapter_DefaultCapabilities_MatchInteractiveChannelExpectations()
+    {
+        var adapter = new VirtualChannelAdapter();
+
+        adapter.SupportsStreaming.ShouldBeTrue();
+        adapter.SupportsSteering.ShouldBeTrue();
+        adapter.SupportsFollowUp.ShouldBeTrue();
+        adapter.SupportsThinkingDisplay.ShouldBeFalse();
+        adapter.SupportsToolDisplay.ShouldBeFalse();
+        adapter.SupportsInboundImages.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void VirtualChannelAdapter_CapabilityOverrides_AreReflectedOnTheInterface()
+    {
+        var adapter = new VirtualChannelAdapter(new VirtualChannelAdapterOptions
+        {
+            SupportsStreaming = false,
+            SupportsSteering = false,
+            SupportsFollowUp = false,
+            SupportsThinkingDisplay = true,
+            SupportsToolDisplay = true,
+            SupportsInboundImages = true,
+            DisplayName = "Telegram-Like"
+        });
+
+        IChannelAdapter contract = adapter;
+        contract.SupportsStreaming.ShouldBeFalse();
+        contract.SupportsSteering.ShouldBeFalse();
+        contract.SupportsFollowUp.ShouldBeFalse();
+        contract.SupportsThinkingDisplay.ShouldBeTrue();
+        contract.SupportsToolDisplay.ShouldBeTrue();
+        contract.SupportsInboundImages.ShouldBeTrue();
+        contract.DisplayName.ShouldBe("Telegram-Like");
+    }
+
+    [Fact]
+    public void VirtualChannelAdapter_AdapterId_IsHonoredThroughInterfaceContract()
+    {
+        var adapter = new VirtualChannelAdapter(new VirtualChannelAdapterOptions { AdapterId = "vc-east" });
+
+        IChannelAdapter contract = adapter;
+        contract.AdapterId.ShouldBe("vc-east");
+
+        var unset = new VirtualChannelAdapter();
+        IChannelAdapter unsetContract = unset;
+        unsetContract.AdapterId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SimulateInbound_BeforeStart_Throws_BecauseDispatcherIsNotBound()
+    {
+        var adapter = new VirtualChannelAdapter();
+        var inbound = NewInbound("hello");
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => adapter.SimulateInboundAsync(inbound));
+    }
+
+    [Fact]
+    public async Task SimulateInbound_AfterStart_DispatchesExactlyOnce_ThroughTheChannelDispatcher()
+    {
+        var adapter = new VirtualChannelAdapter();
+        var dispatcher = new RecordingDispatcher();
+        await adapter.StartAsync(dispatcher);
+
+        var inbound = NewInbound("hello");
+        await adapter.SimulateInboundAsync(inbound);
+
+        dispatcher.Calls.Count.ShouldBe(1);
+        dispatcher.Calls[0].ShouldBeSameAs(inbound);
+        adapter.InboundDispatchCount.ShouldBe(1);
+        adapter.InboundDispatched.ShouldHaveSingleItem().ShouldBeSameAs(inbound);
+    }
+
+    [Fact]
+    public async Task SendAsync_RecordsOutboundMessages_InTheOrderTheyWereSent()
+    {
+        var adapter = new VirtualChannelAdapter();
+        var first = NewOutbound("first");
+        var second = NewOutbound("second");
+
+        await adapter.SendAsync(first);
+        await adapter.SendAsync(second);
+
+        adapter.Outbound.Count.ShouldBe(2);
+        adapter.Outbound[0].Content.ShouldBe("first");
+        adapter.Outbound[1].Content.ShouldBe("second");
+    }
+
+    [Fact]
+    public async Task SendStreamDelta_GroupsDeltas_ByConversationRoutingKey()
+    {
+        var adapter = new VirtualChannelAdapter();
+        await adapter.SendStreamDeltaAsync("conv-a", "Hel");
+        await adapter.SendStreamDeltaAsync("conv-a", "lo");
+        await adapter.SendStreamDeltaAsync("conv-b", "Hi");
+
+        adapter.StreamDeltas["conv-a"].ShouldBe(["Hel", "lo"]);
+        adapter.StreamDeltas["conv-b"].ShouldBe(["Hi"]);
+    }
+
+    [Fact]
+    public async Task SendStreamEvent_GroupsStructuredEvents_ByConversationRoutingKey()
+    {
+        var adapter = new VirtualChannelAdapter();
+        IStreamEventChannelAdapter contract = adapter;
+
+        var start = new AgentStreamEvent { Type = AgentStreamEventType.MessageStart };
+        var delta = new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Hi" };
+        var end = new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd };
+
+        await contract.SendStreamEventAsync("conv-a", start);
+        await contract.SendStreamEventAsync("conv-a", delta);
+        await contract.SendStreamEventAsync("conv-b", end);
+
+        adapter.StreamEvents["conv-a"].Select(e => e.Type)
+            .ShouldBe([AgentStreamEventType.MessageStart, AgentStreamEventType.ContentDelta]);
+        adapter.StreamEvents["conv-b"].Select(e => e.Type)
+            .ShouldBe([AgentStreamEventType.MessageEnd]);
+    }
+
+    [Fact]
+    public async Task WaitForOutbound_ResolvesAsSoonAsAMatchingMessageArrives()
+    {
+        var adapter = new VirtualChannelAdapter();
+        var match = NewOutbound("important");
+        var unrelated = NewOutbound("noise");
+        await adapter.SendAsync(unrelated);
+
+        var pending = adapter.WaitForOutboundAsync(m => m.Content == "important", TimeSpan.FromSeconds(1));
+        await adapter.SendAsync(match);
+        var resolved = await pending;
+
+        resolved.ShouldBeSameAs(match);
+    }
+
+    [Fact]
+    public async Task WaitForOutbound_TimesOut_WhenNoMatchingMessageArrives()
+    {
+        var adapter = new VirtualChannelAdapter();
+
+        await Should.ThrowAsync<TimeoutException>(
+            () => adapter.WaitForOutboundAsync(_ => false, TimeSpan.FromMilliseconds(50)));
+    }
+
+    [Fact]
+    public async Task Reset_ClearsAllCapturedTraffic()
+    {
+        var adapter = new VirtualChannelAdapter();
+        var dispatcher = new RecordingDispatcher();
+        await adapter.StartAsync(dispatcher);
+
+        await adapter.SimulateInboundAsync(NewInbound("in"));
+        await adapter.SendAsync(NewOutbound("out"));
+        await adapter.SendStreamDeltaAsync("conv-a", "delta");
+
+        adapter.Reset();
+
+        adapter.Outbound.ShouldBeEmpty();
+        adapter.InboundDispatched.ShouldBeEmpty();
+        adapter.StreamDeltas.ShouldBeEmpty();
+        adapter.InboundDispatchCount.ShouldBe(0);
+    }
+
+    private static InboundMessage NewInbound(string content) => new()
+    {
+        ChannelType = ChannelKey.From(VirtualChannelAdapter.VirtualChannelType),
+        SenderId = "alice",
+        ChannelAddress = ChannelAddress.From("virtual:alice"),
+        Content = content
+    };
+
+    private static OutboundMessage NewOutbound(string content) => new()
+    {
+        ChannelType = ChannelKey.From(VirtualChannelAdapter.VirtualChannelType),
+        ChannelAddress = ChannelAddress.From("virtual:alice"),
+        Content = content
+    };
+
+    private sealed class RecordingDispatcher : IChannelDispatcher
+    {
+        public List<InboundMessage> Calls { get; } = [];
+
+        public Task DispatchAsync(InboundMessage message, CancellationToken cancellationToken = default)
+        {
+            Calls.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/BotNexus.Scenarios.Tests.csproj
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/BotNexus.Scenarios.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BotNexus.Scenarios.Harness\BotNexus.Scenarios.Harness.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Conversations\BotNexus.Gateway.Conversations.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Sessions\BotNexus.Gateway.Sessions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/CitizenMessageThroughVirtualAdapterScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/CitizenMessageThroughVirtualAdapterScenario.cs
@@ -1,0 +1,113 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Scenarios.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Spec for the minimal citizen → router → conversation/session loop driven through the
+/// <see cref="VirtualChannelAdapter"/>. This is the smallest possible "scenario" that proves
+/// the suite delivers behavioural value on top of the conformance tests: a citizen message
+/// arriving on a virtual channel ends up creating a real <see cref="Conversation"/> and
+/// <see cref="Session"/> via the production <see cref="DefaultConversationRouter"/>.
+/// </summary>
+/// <remarks>
+/// This scenario deliberately bypasses <c>GatewayHost</c> / <c>IAgentSupervisor</c> /
+/// <c>LlmClient</c> — those land with the <c>VirtualWorld</c> harness in a follow-up PR.
+/// What it locks down today is the contract between the inbound channel surface and the
+/// router/store layer, so future PRs that change session shape, binding shape, or routing
+/// semantics have to acknowledge this behaviour and update the scenario explicitly.
+/// </remarks>
+public sealed class CitizenMessageThroughVirtualAdapterScenario
+{
+    [Fact]
+    public async Task CitizenMessage_ThroughVirtualAdapter_CreatesConversationAndSession_BoundToTheVirtualChannel()
+    {
+        // Arrange — wire real router + real in-memory stores against a virtual channel.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = new DefaultConversationRouter(
+            conversationStore,
+            sessionStore,
+            NullLogger<DefaultConversationRouter>.Instance);
+
+        var agentId = AgentId.From("scenario-agent");
+        var adapter = new VirtualChannelAdapter();
+        var dispatcher = new RouterDispatcher(router, agentId);
+        await adapter.StartAsync(dispatcher);
+
+        var inbound = new InboundMessage
+        {
+            ChannelType = ChannelKey.From(VirtualChannelAdapter.VirtualChannelType),
+            SenderId = "alice",
+            ChannelAddress = ChannelAddress.From("virtual:alice"),
+            Content = "hello agent",
+        };
+
+        // Act — drive the inbound through the adapter just like a real channel would.
+        await adapter.SimulateInboundAsync(inbound);
+
+        // Assert — the router created one conversation for this agent and bound it to the
+        // (channel, address) pair the virtual adapter carried.
+        adapter.InboundDispatchCount.ShouldBe(1);
+
+        var conversations = await conversationStore.ListAsync(agentId);
+        var conversation = conversations.ShouldHaveSingleItem();
+        conversation.AgentId.ShouldBe(agentId);
+        conversation.ActiveSessionId.ShouldNotBeNull();
+
+        conversation.ChannelBindings.ShouldHaveSingleItem();
+        var binding = conversation.ChannelBindings[0];
+        binding.ChannelType.ShouldBe(ChannelKey.From(VirtualChannelAdapter.VirtualChannelType));
+        binding.ChannelAddress.ShouldBe(ChannelAddress.From("virtual:alice"));
+
+        // And the session the router created is reachable from the session store and
+        // points back at the conversation that owns it.
+        var session = await sessionStore.GetAsync(conversation.ActiveSessionId!.Value);
+        session.ShouldNotBeNull();
+        session!.AgentId.ShouldBe(agentId);
+        session.Session.ConversationId.ShouldBe(conversation.ConversationId);
+
+        // Routing decision was the result of the dispatcher actually hitting the router.
+        dispatcher.LastResult.ShouldNotBeNull();
+        dispatcher.LastResult!.IsNewSession.ShouldBeTrue();
+        dispatcher.LastResult.Conversation.ConversationId.ShouldBe(conversation.ConversationId);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IChannelDispatcher"/> that forwards inbound messages straight into
+    /// the production router. This is the seam the future <c>VirtualWorld</c> harness will
+    /// replace with the real <c>GatewayHost</c> dispatcher; until then it gives scenario
+    /// tests an honest path from "virtual channel inbound" to "router + store" without
+    /// needing the full hosted runtime.
+    /// </summary>
+    private sealed class RouterDispatcher : IChannelDispatcher
+    {
+        private readonly IConversationRouter _router;
+        private readonly AgentId _agentId;
+
+        public RouterDispatcher(IConversationRouter router, AgentId agentId)
+        {
+            _router = router;
+            _agentId = agentId;
+        }
+
+        public ConversationRoutingResult? LastResult { get; private set; }
+
+        public async Task DispatchAsync(InboundMessage message, CancellationToken cancellationToken = default)
+        {
+            LastResult = await _router.ResolveInboundAsync(
+                _agentId,
+                message.ChannelType,
+                message.ChannelAddress,
+                message.ThreadId,
+                message.ConversationId,
+                cancellationToken);
+        }
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/xunit.runner.json
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}


### PR DESCRIPTION
Lands the **foundation** for the channel-agnostic citizen scenario suite described in
`plan.md` section 10. Subsequent behavioural scenarios (compaction-mark, reset-flush,
multi-binding fan-out, citizen-aware variants, ThreadId-removal regression) ship in
their phase PRs and reuse this harness.

Closes #514

## What ships

- `tests/scenarios/BotNexus.Scenarios.Harness` (class library): `VirtualChannelAdapter`
  (full `IChannelAdapter` + `IStreamEventChannelAdapter`), `VirtualChannelAdapterOptions`
  (per-instance capability flags), `ScenarioFakeApiProvider` (deterministic LLM script).
- `tests/scenarios/BotNexus.Scenarios.Tests` (xUnit + Shouldly): 17 conformance tests
  (12 adapter + 5 fake provider) + 1 thin behavioural scenario driving the production
  `DefaultConversationRouter` end to end through the virtual adapter. 18 tests total,
  all green.
- 5 architecture fitness functions in `BotNexus.Architecture.Tests` (plan section 10.7)
  - channel-agnostic enforcement for both the test project and harness, `IChannelAdapter`
  drift guard, `IServiceProvider` ban in scenarios, and a reflection-based public-surface
  scan that prevents DI primitives leaking through the harness API.
- `tests/scenarios/AGENTS.md` documenting conventions; root `AGENTS.md` cross-link.

## Why a thin first wave

§10.4 lists 12 first-wave scenarios. Most of them require model changes that have not
shipped yet (`SessionEntry.IsHistory` per F-2a, the `/reset` REST symmetry per F-2c,
the `ChannelAddress`-only routing per F-12, the `CitizenId` abstraction per Phase 1.5).
Writing them now would either (a) lock in today's wrong behaviour as the "spec", or
(b) require a parallel `VirtualWorld` host harness whose right shape only becomes
obvious once Phase 3a/3c/6b/1.5 land. Instead, this PR ships the **infrastructure** plus
the conformance bar that proves the infrastructure is sound, and each model-evolution
PR then adds its own scenarios on top.

## Rubber-duck-guided fixes already applied in this PR

1. `VirtualChannelAdapter` re-lists `IChannelAdapter` and implements
   `IStreamEventChannelAdapter` so `SendStreamEvent` capture is honest against
   `GatewayHost`'s actual interface check.
2. Stream-event and stream-delta buffers use `ConcurrentDictionary<string,
   ConcurrentQueue<T>>` rather than `...<string, List<T>>` (the latter is not
   thread-safe; `ConcurrentDictionary` only protects the dictionary, not its values).
3. `ScenarioHarness_PublicSurface_DoesNotLeakDiPrimitives` added so future harness
   evolution can't accidentally expose `IServiceProvider` / `IHost*` through a
   `VirtualWorld` API.
4. Harness deps trimmed to Domain + Gateway Contracts/Abstractions/Channels +
   Agent.Providers.Core + Logging.Abstractions only - no Hosting/DI/Gateway/Memory.

## Validation

`dotnet build BotNexus.slnx --nologo --tl:off` - **clean (0 warnings, 0 errors).**

`dotnet test BotNexus.slnx --nologo --tl:off --no-build` - **all suites green, full
run reported `Passed: 1633` for `BotNexus.Gateway.Tests` and 18/18 + 10/10 for the
new scenarios + architecture projects.** (One subsequent run produced two flaky failures
in `BotNexus.Gateway.Tests` under concurrent `dotnet test` parallelism; re-running
that project in isolation passed 1633/1633. The scenarios harness is fully in-memory -
no SQLite, no temp files - so it can't be the source. Pre-existing flakiness in the
parallel runner, unrelated to this change.)

## Reviewer note

If you'd prefer the foundation to land alongside a wider first-wave end-to-end scenario
set built on a real `VirtualWorld` (rather than the in-place
`DefaultConversationRouter` wiring used by the one behavioural scenario here), say
so on the PR and I'll extend before merge - I held back because that work benefits
materially from landing alongside the model-evolution PRs it would exercise.