### PR TITLE
feat(domain): introduce Citizen abstraction and migrate SessionParticipant

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Security;
 
 namespace BotNexus.Gateway.Abstractions.Models;
@@ -7,13 +8,20 @@ namespace BotNexus.Gateway.Abstractions.Models;
 /// Describes a registered agent — its identity, default configuration, and capabilities.
 /// This is the static descriptor; runtime state lives in <see cref="AgentInstance"/>.
 /// </summary>
-public sealed record AgentDescriptor
+public sealed record AgentDescriptor : ICitizen
 {
     /// <summary>Unique agent identifier (e.g., "coding-agent", "chat-assistant").</summary>
     public required AgentId AgentId { get; init; }
 
     /// <summary>Human-readable display name.</summary>
     public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Discriminated citizen identity. Always <see cref="CitizenId.Of(AgentId)"/> for an agent —
+    /// satisfies <see cref="ICitizen"/> so the descriptor can flow through cross-cutting code
+    /// that addresses users and agents uniformly without losing the typed <see cref="AgentId"/>.
+    /// </summary>
+    CitizenId ICitizen.Id => CitizenId.Of(AgentId);
 
     /// <summary>Optional emoji that visually identifies this agent in user interfaces.</summary>
     public string? Emoji { get; init; }

--- a/src/domain/BotNexus.Domain/Primitives/SessionParticipant.cs
+++ b/src/domain/BotNexus.Domain/Primitives/SessionParticipant.cs
@@ -1,33 +1,192 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Domain.World;
+
 namespace BotNexus.Domain.Primitives;
 
 /// <summary>
-/// Represents session participant.
+/// A participant in a <see cref="BotNexus.Gateway.Abstractions.Models.GatewaySession"/> —
+/// either a user (human) or an agent identified via the discriminated <see cref="CitizenId"/>
+/// union. The optional <see cref="Role"/> distinguishes initiator from peer, caller from
+/// callee, etc.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Persistence note: existing session stores (<c>SqliteSessionStore.participants_json</c> and
+/// <c>FileSessionStore</c> metadata sidecars) may contain blobs written before Phase 1.5 in
+/// the legacy shape <c>{ "type": 0|1|"User"|"Agent", "id": "...", "worldId": "...", "role": "..." }</c>.
+/// The custom <see cref="SessionParticipantJsonConverter"/> reads both shapes and, during the
+/// transition window, writes both shapes so a rollback can still read participants written by
+/// post-migration code. The legacy <see cref="ParticipantType"/> enum remains for read
+/// back-compat only.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(SessionParticipantJsonConverter))]
 public sealed record SessionParticipant
 {
-    /// <summary>
-    /// Gets or sets the type.
-    /// </summary>
-    public required ParticipantType Type { get; init; }
-    /// <summary>
-    /// Gets or sets the id.
-    /// </summary>
-    public required string Id { get; init; }
-    /// <summary>
-    /// Gets or sets the world id.
-    /// </summary>
-    public string? WorldId { get; init; }
-    /// <summary>
-    /// Gets or sets the role.
-    /// </summary>
+    /// <summary>The discriminated citizen identity of this participant.</summary>
+    public required CitizenId CitizenId { get; init; }
+
+    /// <summary>Optional role label (e.g., <c>"initiator"</c>, <c>"caller"</c>, <c>"peer"</c>).</summary>
     public string? Role { get; init; }
 }
 
 /// <summary>
-/// Specifies supported values for participant type.
+/// Legacy discriminator for <see cref="SessionParticipant"/> persisted before Phase 1.5
+/// introduced <see cref="CitizenId"/>. Retained for one release so existing session blobs
+/// continue to deserialise; new code should consume <see cref="CitizenKind"/> via
+/// <see cref="SessionParticipant.CitizenId"/>.
 /// </summary>
 public enum ParticipantType
 {
+    /// <summary>The participant is a human user. Maps to <see cref="CitizenKind.User"/>.</summary>
     User,
-    Agent
+    /// <summary>The participant is a named agent. Maps to <see cref="CitizenKind.Agent"/>.</summary>
+    Agent,
+}
+
+/// <summary>
+/// System.Text.Json converter for <see cref="SessionParticipant"/>. Handles two wire formats:
+/// <list type="bullet">
+///   <item>New shape: <c>{ "citizenId": { "kind": "User"|"Agent", "id": "..." }, "role": "..." }</c>.</item>
+///   <item>Legacy shape: <c>{ "type": 0|1|"User"|"Agent", "id": "...", "worldId": "...", "role": "..." }</c>.</item>
+/// </list>
+/// Reads either shape (property names case-insensitive). For one release the converter writes
+/// <em>both</em> shapes so a rollback to pre-Phase-1.5 code can still read newly-persisted
+/// participants. After the rollback window, the legacy write path will be removed; readers
+/// will keep handling the legacy shape until the back-compat window closes.
+/// </summary>
+internal sealed class SessionParticipantJsonConverter : JsonConverter<SessionParticipant>
+{
+    public override SessionParticipant Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected start of object for SessionParticipant.");
+
+        CitizenId? citizenIdFromNewShape = null;
+        CitizenKind? legacyKind = null;
+        string? legacyId = null;
+        string? role = null;
+        var sawLegacyType = false;
+        var sawLegacyId = false;
+        var sawNewCitizenId = false;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                break;
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected property name in SessionParticipant.");
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            if (string.Equals(propertyName, "citizenId", StringComparison.OrdinalIgnoreCase))
+            {
+                sawNewCitizenId = true;
+                citizenIdFromNewShape = JsonSerializer.Deserialize<CitizenId>(ref reader, options);
+            }
+            else if (string.Equals(propertyName, "type", StringComparison.OrdinalIgnoreCase))
+            {
+                sawLegacyType = true;
+                legacyKind = ReadLegacyType(ref reader);
+            }
+            else if (string.Equals(propertyName, "id", StringComparison.OrdinalIgnoreCase))
+            {
+                sawLegacyId = true;
+                if (reader.TokenType == JsonTokenType.Null)
+                    throw new JsonException("SessionParticipant.id cannot be null.");
+                legacyId = reader.GetString();
+            }
+            else if (string.Equals(propertyName, "role", StringComparison.OrdinalIgnoreCase))
+            {
+                role = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+            }
+            else
+            {
+                // Tolerate and skip unknown fields (e.g. legacy "worldId").
+                reader.Skip();
+            }
+        }
+
+        if (sawNewCitizenId && (sawLegacyType || sawLegacyId))
+        {
+            var fromLegacy = TryBuildLegacy(legacyKind, legacyId);
+            if (fromLegacy is null || !fromLegacy.Equals(citizenIdFromNewShape!.Value))
+                throw new JsonException("SessionParticipant has both new and legacy identity shapes and they disagree.");
+        }
+
+        var resolvedCitizenId = sawNewCitizenId
+            ? citizenIdFromNewShape!.Value
+            : TryBuildLegacy(legacyKind, legacyId)
+                ?? throw new JsonException("SessionParticipant requires either 'citizenId' or legacy 'type'+'id'.");
+
+        return new SessionParticipant { CitizenId = resolvedCitizenId, Role = role };
+    }
+
+    private static CitizenKind ReadLegacyType(ref Utf8JsonReader reader)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                var raw = reader.GetString();
+                if (string.IsNullOrWhiteSpace(raw))
+                    throw new JsonException("SessionParticipant.type string cannot be empty.");
+                if (Enum.TryParse<ParticipantType>(raw, ignoreCase: true, out var parsed))
+                    return ToCitizenKind(parsed);
+                throw new JsonException($"SessionParticipant.type '{raw}' is not a known ParticipantType.");
+            case JsonTokenType.Number:
+                if (!reader.TryGetInt32(out var asInt))
+                    throw new JsonException("SessionParticipant.type number must be a 32-bit integer.");
+                if (!Enum.IsDefined(typeof(ParticipantType), asInt))
+                    throw new JsonException($"SessionParticipant.type numeric value {asInt} is not a known ParticipantType.");
+                return ToCitizenKind((ParticipantType)asInt);
+            default:
+                throw new JsonException("SessionParticipant.type must be a string or number.");
+        }
+    }
+
+    private static CitizenKind ToCitizenKind(ParticipantType type) => type switch
+    {
+        ParticipantType.User => CitizenKind.User,
+        ParticipantType.Agent => CitizenKind.Agent,
+        _ => throw new JsonException($"ParticipantType '{type}' has no CitizenKind mapping."),
+    };
+
+    private static CitizenId? TryBuildLegacy(CitizenKind? kind, string? id)
+    {
+        if (kind is null || id is null)
+            return null;
+
+        return kind.Value switch
+        {
+            CitizenKind.User => CitizenId.Of(UserId.From(id)),
+            CitizenKind.Agent => CitizenId.Of(AgentId.From(id)),
+            _ => null,
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, SessionParticipant value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        writer.WritePropertyName("citizenId");
+        JsonSerializer.Serialize(writer, value.CitizenId, options);
+
+        // Legacy fields are emitted for one-release rollback safety; readers prefer "citizenId".
+        writer.WriteString("type", ToParticipantType(value.CitizenId.Kind).ToString());
+        writer.WriteString("id", value.CitizenId.Value);
+
+        if (value.Role is not null)
+            writer.WriteString("role", value.Role);
+
+        writer.WriteEndObject();
+    }
+
+    private static ParticipantType ToParticipantType(CitizenKind kind) => kind switch
+    {
+        CitizenKind.User => ParticipantType.User,
+        CitizenKind.Agent => ParticipantType.Agent,
+        _ => throw new JsonException($"CitizenKind '{kind}' cannot be persisted as a ParticipantType."),
+    };
 }

--- a/src/domain/BotNexus.Domain/Primitives/UserId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/UserId.cs
@@ -1,0 +1,27 @@
+using Vogen;
+
+namespace BotNexus.Domain.Primitives;
+
+/// <summary>
+/// Identifies a user (human citizen) inside a BotNexus world. Construct via
+/// <see cref="From(string)"/>; the value must be non-null, non-empty, non-whitespace
+/// and is stored trimmed.
+/// </summary>
+/// <remarks>
+/// The validation floor is intentionally permissive (non-empty after trim). Sender
+/// strings are channel-specific — Telegram numeric ids, TUI <see cref="Environment.UserName"/>,
+/// composite <c>channel:address</c> tokens — and a stricter rule would block legitimate
+/// channels before a real user registry exists (Phase 2). Stricter shape rules belong on
+/// channel-specific user identity types, not on the canonical <c>UserId</c>.
+/// </remarks>
+[ValueObject<string>(conversions: Conversions.SystemTextJson)]
+public readonly partial struct UserId
+{
+    private static Validation Validate(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? Validation.Invalid("UserId cannot be null, empty, or whitespace.")
+            : Validation.Ok;
+
+    private static string NormalizeInput(string input) =>
+        input is null ? input! : input.Trim();
+}

--- a/src/domain/BotNexus.Domain/World/CitizenId.cs
+++ b/src/domain/BotNexus.Domain/World/CitizenId.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// A discriminated-union identity for a <see cref="ICitizen"/> — carries either a
+/// <see cref="UserId"/> or an <see cref="AgentId"/>. Used by cross-cutting code
+/// (channel routing, permissions, audit, session participants) so a single typed
+/// identity can refer to either species without losing the species discriminator.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="CitizenId"/> is a sum type, not a Vogen value object: it wraps two
+/// distinct inner identities and chooses between them via <see cref="Kind"/>. The
+/// inner <see cref="UserId"/> and <see cref="AgentId"/> are themselves Vogen-typed
+/// value objects.
+/// </para>
+/// <para>
+/// Constructed only via <see cref="Of(UserId)"/> / <see cref="Of(AgentId)"/> — there is
+/// no public constructor and no public init-property surface that could yield a
+/// mixed-arm record. <c>default(CitizenId)</c> has <see cref="Kind"/> equal to
+/// <see cref="CitizenKind.Unknown"/> and is rejected by <see cref="Match{T}"/> and
+/// <see cref="Value"/>; equality of two well-formed <c>CitizenId</c> instances depends
+/// only on <see cref="Kind"/> and the populated arm.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(CitizenIdJsonConverter))]
+public readonly struct CitizenId : IEquatable<CitizenId>
+{
+    private readonly UserId? _asUser;
+    private readonly AgentId? _asAgent;
+
+    private CitizenId(CitizenKind kind, UserId? asUser, AgentId? asAgent)
+    {
+        Kind = kind;
+        _asUser = asUser;
+        _asAgent = asAgent;
+    }
+
+    /// <summary>The species of this citizen.</summary>
+    public CitizenKind Kind { get; }
+
+    /// <summary>The user identity when <see cref="Kind"/> is <see cref="CitizenKind.User"/>; otherwise <c>null</c>.</summary>
+    public UserId? AsUser => Kind == CitizenKind.User ? _asUser : null;
+
+    /// <summary>The agent identity when <see cref="Kind"/> is <see cref="CitizenKind.Agent"/>; otherwise <c>null</c>.</summary>
+    public AgentId? AsAgent => Kind == CitizenKind.Agent ? _asAgent : null;
+
+    /// <summary>True when this is a well-formed citizen (i.e. not <c>default(CitizenId)</c>).</summary>
+    public bool IsValid => Kind != CitizenKind.Unknown;
+
+    /// <summary>
+    /// The underlying identifier string for the populated arm. Use with care — discards the
+    /// <see cref="Kind"/> discriminator so two citizens of different species with the same
+    /// inner string compare equal at the string level. Persistence and indexing should prefer
+    /// <see cref="ToString"/>, which includes the kind prefix, or serialise <see cref="Kind"/>
+    /// separately.
+    /// </summary>
+    public string Value => Kind switch
+    {
+        CitizenKind.User => _asUser!.Value.Value,
+        CitizenKind.Agent => _asAgent!.Value.Value,
+        _ => throw new InvalidOperationException("CitizenId is uninitialized; use Of(UserId) or Of(AgentId) to construct one."),
+    };
+
+    /// <summary>Creates a <see cref="CitizenId"/> for a user citizen.</summary>
+    public static CitizenId Of(UserId id) => new(CitizenKind.User, id, null);
+
+    /// <summary>Creates a <see cref="CitizenId"/> for an agent citizen.</summary>
+    public static CitizenId Of(AgentId id) => new(CitizenKind.Agent, null, id);
+
+    /// <summary>
+    /// Folds this citizen identity into a single result, dispatching on <see cref="Kind"/>.
+    /// Throws <see cref="InvalidOperationException"/> for <c>default(CitizenId)</c>.
+    /// </summary>
+    public T Match<T>(Func<UserId, T> onUser, Func<AgentId, T> onAgent)
+    {
+        ArgumentNullException.ThrowIfNull(onUser);
+        ArgumentNullException.ThrowIfNull(onAgent);
+
+        return Kind switch
+        {
+            CitizenKind.User => onUser(_asUser!.Value),
+            CitizenKind.Agent => onAgent(_asAgent!.Value),
+            _ => throw new InvalidOperationException("CitizenId is uninitialized; use Of(UserId) or Of(AgentId) to construct one."),
+        };
+    }
+
+    /// <summary>Diagnostic / persistence-key form: <c>user:&lt;id&gt;</c> or <c>agent:&lt;id&gt;</c>.</summary>
+    public override string ToString() => Kind switch
+    {
+        CitizenKind.User => $"user:{_asUser!.Value.Value}",
+        CitizenKind.Agent => $"agent:{_asAgent!.Value.Value}",
+        _ => "citizen:<uninitialized>",
+    };
+
+    /// <inheritdoc/>
+    public bool Equals(CitizenId other) => Kind switch
+    {
+        CitizenKind.User => other.Kind == CitizenKind.User && _asUser!.Value == other._asUser!.Value,
+        CitizenKind.Agent => other.Kind == CitizenKind.Agent && _asAgent!.Value == other._asAgent!.Value,
+        _ => other.Kind == CitizenKind.Unknown,
+    };
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is CitizenId other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Kind switch
+    {
+        CitizenKind.User => HashCode.Combine(CitizenKind.User, _asUser!.Value),
+        CitizenKind.Agent => HashCode.Combine(CitizenKind.Agent, _asAgent!.Value),
+        _ => 0,
+    };
+
+    /// <summary>Equality operator.</summary>
+    public static bool operator ==(CitizenId left, CitizenId right) => left.Equals(right);
+
+    /// <summary>Inequality operator.</summary>
+    public static bool operator !=(CitizenId left, CitizenId right) => !left.Equals(right);
+}
+
+/// <summary>
+/// System.Text.Json converter for <see cref="CitizenId"/>. Wire format:
+/// <c>{ "kind": "User", "id": "alice" }</c> or <c>{ "kind": "Agent", "id": "coding-agent" }</c>.
+/// Property names are read case-insensitively; <see cref="CitizenKind"/> tolerates both string
+/// and numeric (legacy) forms.
+/// </summary>
+internal sealed class CitizenIdJsonConverter : JsonConverter<CitizenId>
+{
+    public override CitizenId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected start of object for CitizenId.");
+
+        CitizenKind? kind = null;
+        string? id = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                break;
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected property name in CitizenId.");
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            if (string.Equals(propertyName, "kind", StringComparison.OrdinalIgnoreCase))
+            {
+                kind = ReadKind(ref reader);
+            }
+            else if (string.Equals(propertyName, "id", StringComparison.OrdinalIgnoreCase))
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    throw new JsonException("CitizenId.id cannot be null.");
+                id = reader.GetString();
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+
+        if (kind is null)
+            throw new JsonException("CitizenId requires a 'kind' property.");
+        if (id is null)
+            throw new JsonException("CitizenId requires an 'id' property.");
+
+        return kind.Value switch
+        {
+            CitizenKind.User => CitizenId.Of(UserId.From(id)),
+            CitizenKind.Agent => CitizenId.Of(AgentId.From(id)),
+            _ => throw new JsonException($"CitizenId.kind '{kind}' is not a valid citizen species."),
+        };
+    }
+
+    private static CitizenKind ReadKind(ref Utf8JsonReader reader) => reader.TokenType switch
+    {
+        JsonTokenType.String => ParseKind(reader.GetString()),
+        JsonTokenType.Number => (CitizenKind)reader.GetInt32(),
+        _ => throw new JsonException("CitizenId.kind must be a string or number."),
+    };
+
+    private static CitizenKind ParseKind(string? value) =>
+        Enum.TryParse<CitizenKind>(value, ignoreCase: true, out var parsed)
+            ? parsed
+            : throw new JsonException($"CitizenId.kind '{value}' is not a known CitizenKind.");
+
+    public override void Write(Utf8JsonWriter writer, CitizenId value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("kind", value.Kind.ToString());
+        writer.WriteString("id", value.Value);
+        writer.WriteEndObject();
+    }
+}

--- a/src/domain/BotNexus.Domain/World/CitizenKind.cs
+++ b/src/domain/BotNexus.Domain/World/CitizenKind.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Discriminates the species of a <see cref="CitizenId"/>. Citizens of a BotNexus world
+/// are either users (humans) or agents.
+/// </summary>
+/// <remarks>
+/// <see cref="Unknown"/> is the explicit default value so that <c>default(CitizenId)</c>
+/// is unambiguously invalid (rather than masquerading as a malformed user). Code that
+/// receives a <c>CitizenId</c> can assert <c>Kind != CitizenKind.Unknown</c> to detect
+/// uninitialised inputs.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<CitizenKind>))]
+public enum CitizenKind
+{
+    /// <summary>Sentinel value reserved for <c>default(CitizenId)</c>; never a valid citizen.</summary>
+    Unknown = 0,
+
+    /// <summary>The citizen is a human user.</summary>
+    User = 1,
+
+    /// <summary>The citizen is a named agent.</summary>
+    Agent = 2,
+}

--- a/src/domain/BotNexus.Domain/World/ICitizen.cs
+++ b/src/domain/BotNexus.Domain/World/ICitizen.cs
@@ -1,0 +1,30 @@
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Marker for any citizen of a BotNexus world. Both <c>User</c> (Phase 2) and
+/// <see cref="BotNexus.Gateway.Abstractions.Models.AgentDescriptor"/> implement this so
+/// cross-cutting code (channel routing, permissions, participant lists, audit) can
+/// address either species through a single typed lens.
+/// </summary>
+/// <remarks>
+/// <para>Phase 1.5 keeps the surface deliberately narrow:</para>
+/// <list type="bullet">
+///   <item><see cref="Id"/> — the discriminated <see cref="CitizenId"/>.</item>
+///   <item><see cref="DisplayName"/> — short, human-readable label suitable for UI.</item>
+/// </list>
+/// <para>
+/// Other plausible members — <c>WorldIdentity World</c>, profile/avatar, last-seen
+/// timestamp — are intentionally deferred. Agents do not yet carry a back-reference to
+/// their <see cref="WorldDescriptor"/> (world membership is denormalised through
+/// <see cref="WorldDescriptor.HostedAgents"/>); the interface stays minimal so adoption
+/// is mechanical and Phase 7 can lift <c>World</c> when worlds become first-class.
+/// </para>
+/// </remarks>
+public interface ICitizen
+{
+    /// <summary>The citizen's typed identity (user or agent).</summary>
+    CitizenId Id { get; }
+
+    /// <summary>Short, human-readable display name (UI lists, participant tags, audit lines).</summary>
+    string DisplayName { get; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -8,11 +8,12 @@ using BotNexus.Gateway.Dispatching;
 using BotNexus.Gateway.Abstractions.Services;
 using AgentId = BotNexus.Domain.Primitives.AgentId;
 using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
-using ParticipantType = BotNexus.Domain.Primitives.ParticipantType;
 using SessionId = BotNexus.Domain.Primitives.SessionId;
+using UserId = BotNexus.Domain.Primitives.UserId;
 using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
+using BotNexus.Domain.World;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 using Microsoft.AspNetCore.SignalR;
@@ -141,8 +142,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         {
             session.Participants.Add(new SessionParticipant
             {
-                Type = ParticipantType.User,
-                Id = Context.ConnectionId
+                CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
             });
             needsSave = true;
         }
@@ -717,8 +717,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         {
             session.Participants.Add(new SessionParticipant
             {
-                Type = ParticipantType.User,
-                Id = Context.ConnectionId
+                CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
             });
             needsSave = true;
         }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -71,20 +72,17 @@ public sealed class CrossWorldFederationController(
         session.Participants.Clear();
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.Agent,
-            Id = request.SourceAgentId,
-            WorldId = request.SourceWorldId,
+            CitizenId = CitizenId.Of(AgentId.From(request.SourceAgentId)),
             Role = "initiator"
         });
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.Agent,
-            Id = targetAgentId.Value,
-            WorldId = _localWorldId,
+            CitizenId = CitizenId.Of(targetAgentId),
             Role = "target"
         });
         session.Metadata["conversationId"] = request.ConversationId;
         session.Metadata["sourceWorldId"] = request.SourceWorldId;
+        session.Metadata["targetWorldId"] = _localWorldId;
         session.Metadata["sourceSessionId"] = request.SourceSessionId;
         session.Status = GatewaySessionStatus.Active;
         session.AddEntry(new SessionEntry

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
@@ -3,6 +3,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Triggers;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using Microsoft.Extensions.Logging;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
@@ -128,14 +129,12 @@ public sealed class SoulTrigger(
         session.Status = GatewaySessionStatus.Active;
         session.Metadata["soulDate"] = soulDate.ToString("yyyy-MM-dd");
 
-        if (!session.Participants.Any(participant =>
-                participant.Type == ParticipantType.Agent &&
-                string.Equals(participant.Id, agentId.Value, StringComparison.OrdinalIgnoreCase)))
+        var agentCitizenId = CitizenId.Of(agentId);
+        if (!session.Participants.Any(participant => participant.CitizenId == agentCitizenId))
         {
             session.Participants.Add(new SessionParticipant
             {
-                Type = ParticipantType.Agent,
-                Id = agentId.Value
+                CitizenId = agentCitizenId
             });
         }
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -104,6 +105,8 @@ public abstract class SessionStoreBase : ISessionStore
         => agentId is null ? sessions : sessions.Where(session => session.AgentId == agentId);
 
     private static bool IsParticipant(GatewaySession session, AgentId agentId)
-        => session.Participants.Any(participant =>
-            string.Equals(participant.Id, agentId.Value, StringComparison.OrdinalIgnoreCase));
+    {
+        var citizenId = CitizenId.Of(agentId);
+        return session.Participants.Any(participant => participant.CitizenId == citizenId);
+    }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -1,5 +1,6 @@
 using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Channels;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
@@ -85,14 +86,12 @@ public sealed class AgentExchangeService : IAgentExchangeService
         session.Participants.Clear();
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.Agent,
-            Id = request.InitiatorId.Value,
+            CitizenId = CitizenId.Of(request.InitiatorId),
             Role = "initiator"
         });
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.Agent,
-            Id = request.TargetId.Value,
+            CitizenId = CitizenId.Of(request.TargetId),
             Role = "target"
         });
 
@@ -182,16 +181,12 @@ public sealed class AgentExchangeService : IAgentExchangeService
         session.Participants.Clear();
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.Agent,
-            Id = request.InitiatorId.Value,
-            WorldId = _sourceWorldId,
+            CitizenId = CitizenId.Of(request.InitiatorId),
             Role = "initiator"
         });
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.Agent,
-            Id = resolvedTarget.AgentId.Value,
-            WorldId = resolvedTarget.WorldId,
+            CitizenId = CitizenId.Of(resolvedTarget.AgentId),
             Role = "target"
         });
 
@@ -201,6 +196,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
             .ToArray();
         session.Metadata["objective"] = request.Objective;
         session.Metadata["maxTurns"] = request.MaxTurns;
+        session.Metadata["sourceWorldId"] = _sourceWorldId;
         session.Metadata["targetWorldId"] = resolvedTarget.WorldId;
         session.Metadata["conversationId"] = conversationId;
 

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -17,9 +17,10 @@ using BotNexus.Gateway.Dispatching;
 using AgentId = BotNexus.Domain.Primitives.AgentId;
 using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
 using MessageRole = BotNexus.Domain.Primitives.MessageRole;
-using ParticipantType = BotNexus.Domain.Primitives.ParticipantType;
 using SessionId = BotNexus.Domain.Primitives.SessionId;
+using UserId = BotNexus.Domain.Primitives.UserId;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
+using BotNexus.Domain.World;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using BotNexus.Gateway.Diagnostics;
@@ -1041,13 +1042,13 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         if (string.IsNullOrWhiteSpace(callerId))
             return;
 
-        if (session.Participants.Any(p => p.Type == ParticipantType.User && string.Equals(p.Id, callerId, StringComparison.Ordinal)))
+        var callerCitizenId = CitizenId.Of(UserId.From(callerId));
+        if (session.Participants.Any(p => p.CitizenId == callerCitizenId))
             return;
 
         session.Participants.Add(new SessionParticipant
         {
-            Type = ParticipantType.User,
-            Id = callerId
+            CitizenId = callerCitizenId
         });
     }
 

--- a/tests/architecture/BotNexus.Architecture.Tests/DomainArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/DomainArchitectureTests.cs
@@ -176,6 +176,40 @@ public sealed class DomainArchitectureTests
             "Implicit operators found: " + string.Join(", ", implicitOperators));
     }
 
+    /// <summary>
+    /// UserId is the canonical Vogen value object for a human user identifier introduced in Phase 1.5
+    /// alongside the Citizen abstraction. Mirrors the AgentId rule — Vogen owns construction, JSON,
+    /// and equality.
+    /// </summary>
+    [Fact]
+    public void UserId_IsVogenValueObject()
+    {
+        var attribute = typeof(UserId).GetCustomAttributes()
+            .FirstOrDefault(a => a.GetType().Name.StartsWith("ValueObjectAttribute", StringComparison.Ordinal));
+
+        attribute.ShouldNotBeNull(
+            "UserId must be annotated with [ValueObject<string>] so Vogen generates the converters and analyser checks.");
+    }
+
+    /// <summary>
+    /// UserId must not expose an implicit conversion to/from string. Phase 1.5 introduced UserId as
+    /// a typed identity for the User species; allowing implicit string conversions would defeat the
+    /// purpose just like it did for the original hand-rolled AgentId / SessionId.
+    /// </summary>
+    [Fact]
+    public void UserId_HasNoImplicitStringConversion()
+    {
+        var implicitOperators = typeof(UserId)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.Name == "op_Implicit")
+            .Select(m => $"{m.ReturnType.Name}<-{m.GetParameters()[0].ParameterType.Name}")
+            .ToArray();
+
+        implicitOperators.ShouldBeEmpty(
+            "UserId must not expose implicit conversions to/from string. Use .Value and .From() explicitly. " +
+            "Implicit operators found: " + string.Join(", ", implicitOperators));
+    }
+
     private static bool IsFrameworkAssembly(string assemblyName)
         => assemblyName.StartsWith("System.", StringComparison.Ordinal)
         || assemblyName.StartsWith("Microsoft.", StringComparison.Ordinal)

--- a/tests/domain/BotNexus.Domain.Tests/CitizenIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/CitizenIdTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class CitizenIdTests
+{
+    [Fact]
+    public void Of_UserId_ProducesUserKind()
+    {
+        var citizen = CitizenId.Of(UserId.From("alice"));
+
+        citizen.Kind.ShouldBe(CitizenKind.User);
+        citizen.AsUser.ShouldNotBeNull();
+        citizen.AsUser!.Value.Value.ShouldBe("alice");
+        citizen.AsAgent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Of_AgentId_ProducesAgentKind()
+    {
+        var citizen = CitizenId.Of(AgentId.From("coding-agent"));
+
+        citizen.Kind.ShouldBe(CitizenKind.Agent);
+        citizen.AsAgent.ShouldNotBeNull();
+        citizen.AsAgent!.Value.Value.ShouldBe("coding-agent");
+        citizen.AsUser.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Match_DispatchesOnKind()
+    {
+        var user = CitizenId.Of(UserId.From("alice"));
+        var agent = CitizenId.Of(AgentId.From("bob"));
+
+        user.Match(u => $"u:{u.Value}", a => $"a:{a.Value}").ShouldBe("u:alice");
+        agent.Match(u => $"u:{u.Value}", a => $"a:{a.Value}").ShouldBe("a:bob");
+    }
+
+    [Fact]
+    public void Match_OnDefault_Throws()
+    {
+        var uninitialized = default(CitizenId);
+
+        Action act = () => uninitialized.Match(u => 1, a => 2);
+
+        act.ShouldThrow<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Default_IsUnknownAndInvalid()
+    {
+        var d = default(CitizenId);
+
+        d.Kind.ShouldBe(CitizenKind.Unknown);
+        d.IsValid.ShouldBeFalse();
+        d.AsUser.ShouldBeNull();
+        d.AsAgent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Value_OnDefault_Throws()
+    {
+        var d = default(CitizenId);
+
+        Action act = () => _ = d.Value;
+
+        act.ShouldThrow<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ToString_PrefixesByKind()
+    {
+        CitizenId.Of(UserId.From("alice")).ToString().ShouldBe("user:alice");
+        CitizenId.Of(AgentId.From("bob")).ToString().ShouldBe("agent:bob");
+    }
+
+    [Fact]
+    public void Equality_SameKindAndId_AreEqual()
+    {
+        var a = CitizenId.Of(UserId.From("alice"));
+        var b = CitizenId.Of(UserId.From("alice"));
+
+        (a == b).ShouldBeTrue();
+        a.Equals(b).ShouldBeTrue();
+        a.GetHashCode().ShouldBe(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_DifferentKindSameInner_AreNotEqual()
+    {
+        var asUser = CitizenId.Of(UserId.From("shared-name"));
+        var asAgent = CitizenId.Of(AgentId.From("shared-name"));
+
+        (asUser == asAgent).ShouldBeFalse();
+        (asUser != asAgent).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equality_TwoDefaults_AreEqual()
+    {
+        (default(CitizenId) == default(CitizenId)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Json_WritesKindAndId_AsObject()
+    {
+        var json = JsonSerializer.Serialize(CitizenId.Of(UserId.From("alice")));
+
+        json.ShouldBe("{\"kind\":\"User\",\"id\":\"alice\"}");
+    }
+
+    [Fact]
+    public void Json_ReadsCanonicalShape()
+    {
+        var citizen = JsonSerializer.Deserialize<CitizenId>("{\"kind\":\"Agent\",\"id\":\"coding-agent\"}");
+
+        citizen.Kind.ShouldBe(CitizenKind.Agent);
+        citizen.AsAgent!.Value.Value.ShouldBe("coding-agent");
+    }
+
+    [Theory]
+    [InlineData("{\"Kind\":\"User\",\"Id\":\"alice\"}")]
+    [InlineData("{\"kind\":\"user\",\"id\":\"alice\"}")]
+    [InlineData("{\"KIND\":\"USER\",\"ID\":\"alice\"}")]
+    public void Json_PropertyNamesAreCaseInsensitive(string json)
+    {
+        var citizen = JsonSerializer.Deserialize<CitizenId>(json);
+
+        citizen.Kind.ShouldBe(CitizenKind.User);
+        citizen.AsUser!.Value.Value.ShouldBe("alice");
+    }
+
+    [Theory]
+    [InlineData("{\"kind\":1,\"id\":\"alice\"}", CitizenKind.User)]
+    [InlineData("{\"kind\":2,\"id\":\"agent-1\"}", CitizenKind.Agent)]
+    public void Json_KindAcceptsNumericValues(string json, CitizenKind expected)
+    {
+        var citizen = JsonSerializer.Deserialize<CitizenId>(json);
+
+        citizen.Kind.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Json_RoundTripPreservesValue()
+    {
+        var original = CitizenId.Of(AgentId.From("agent-x"));
+
+        var roundTrip = JsonSerializer.Deserialize<CitizenId>(JsonSerializer.Serialize(original));
+
+        roundTrip.ShouldBe(original);
+    }
+
+    [Fact]
+    public void Json_MissingKind_Throws()
+    {
+        Action act = () => JsonSerializer.Deserialize<CitizenId>("{\"id\":\"alice\"}");
+
+        act.ShouldThrow<JsonException>();
+    }
+
+    [Fact]
+    public void Json_MissingId_Throws()
+    {
+        Action act = () => JsonSerializer.Deserialize<CitizenId>("{\"kind\":\"User\"}");
+
+        act.ShouldThrow<JsonException>();
+    }
+
+    [Fact]
+    public void Json_UnknownKind_Throws()
+    {
+        Action act = () => JsonSerializer.Deserialize<CitizenId>("{\"kind\":\"Cat\",\"id\":\"whiskers\"}");
+
+        act.ShouldThrow<JsonException>();
+    }
+}

--- a/tests/domain/BotNexus.Domain.Tests/SessionParticipantTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/SessionParticipantTests.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class SessionParticipantTests
+{
+    [Fact]
+    public void Json_NewShape_RoundTrips()
+    {
+        var participant = new SessionParticipant
+        {
+            CitizenId = CitizenId.Of(UserId.From("alice")),
+            Role = "caller",
+        };
+
+        var json = JsonSerializer.Serialize(participant);
+        var roundTrip = JsonSerializer.Deserialize<SessionParticipant>(json);
+
+        roundTrip.ShouldNotBeNull();
+        roundTrip!.CitizenId.ShouldBe(participant.CitizenId);
+        roundTrip.Role.ShouldBe("caller");
+    }
+
+    [Fact]
+    public void Json_WritesBothNewAndLegacyShape_ForRollbackSafety()
+    {
+        var participant = new SessionParticipant
+        {
+            CitizenId = CitizenId.Of(AgentId.From("agent-1")),
+            Role = "target",
+        };
+
+        var json = JsonSerializer.Serialize(participant);
+
+        json.ShouldContain("\"citizenId\":");
+        json.ShouldContain("\"type\":\"Agent\"");
+        json.ShouldContain("\"id\":\"agent-1\"");
+        json.ShouldContain("\"role\":\"target\"");
+    }
+
+    [Theory]
+    [InlineData("{\"type\":\"User\",\"id\":\"alice\"}", CitizenKind.User, "alice")]
+    [InlineData("{\"type\":\"Agent\",\"id\":\"bot\"}", CitizenKind.Agent, "bot")]
+    [InlineData("{\"type\":0,\"id\":\"alice\"}", CitizenKind.User, "alice")]
+    [InlineData("{\"type\":1,\"id\":\"bot\"}", CitizenKind.Agent, "bot")]
+    public void Json_ReadsLegacyShape(string legacyJson, CitizenKind expectedKind, string expectedId)
+    {
+        var participant = JsonSerializer.Deserialize<SessionParticipant>(legacyJson);
+
+        participant.ShouldNotBeNull();
+        participant!.CitizenId.Kind.ShouldBe(expectedKind);
+        participant.CitizenId.Value.ShouldBe(expectedId);
+    }
+
+    [Fact]
+    public void Json_LegacyShape_PreservesRole()
+    {
+        var participant = JsonSerializer.Deserialize<SessionParticipant>(
+            "{\"type\":\"Agent\",\"id\":\"agent-1\",\"role\":\"target\"}");
+
+        participant.ShouldNotBeNull();
+        participant!.CitizenId.Kind.ShouldBe(CitizenKind.Agent);
+        participant.Role.ShouldBe("target");
+    }
+
+    [Fact]
+    public void Json_LegacyShape_IgnoresWorldId()
+    {
+        var participant = JsonSerializer.Deserialize<SessionParticipant>(
+            "{\"type\":\"Agent\",\"id\":\"agent-1\",\"worldId\":\"world-a\",\"role\":\"initiator\"}");
+
+        participant.ShouldNotBeNull();
+        participant!.CitizenId.Kind.ShouldBe(CitizenKind.Agent);
+        participant.CitizenId.Value.ShouldBe("agent-1");
+        participant.Role.ShouldBe("initiator");
+    }
+
+    [Fact]
+    public void Json_PropertyNamesAreCaseInsensitive()
+    {
+        var participant = JsonSerializer.Deserialize<SessionParticipant>(
+            "{\"Type\":\"User\",\"ID\":\"alice\",\"ROLE\":\"caller\"}");
+
+        participant.ShouldNotBeNull();
+        participant!.CitizenId.Kind.ShouldBe(CitizenKind.User);
+        participant.CitizenId.Value.ShouldBe("alice");
+        participant.Role.ShouldBe("caller");
+    }
+
+    [Fact]
+    public void Json_MissingBothShapes_Throws()
+    {
+        Action act = () => JsonSerializer.Deserialize<SessionParticipant>("{\"role\":\"caller\"}");
+
+        act.ShouldThrow<JsonException>();
+    }
+
+    [Fact]
+    public void Json_BothShapesPresentAndAgree_DeserializesSuccessfully()
+    {
+        var both = "{\"citizenId\":{\"kind\":\"Agent\",\"id\":\"agent-1\"},\"type\":\"Agent\",\"id\":\"agent-1\"}";
+
+        var participant = JsonSerializer.Deserialize<SessionParticipant>(both);
+
+        participant.ShouldNotBeNull();
+        participant!.CitizenId.Kind.ShouldBe(CitizenKind.Agent);
+        participant.CitizenId.Value.ShouldBe("agent-1");
+    }
+
+    [Fact]
+    public void Json_BothShapesPresentAndDisagree_Throws()
+    {
+        var conflicting = "{\"citizenId\":{\"kind\":\"User\",\"id\":\"alice\"},\"type\":\"Agent\",\"id\":\"agent-1\"}";
+
+        Action act = () => JsonSerializer.Deserialize<SessionParticipant>(conflicting);
+
+        act.ShouldThrow<JsonException>();
+    }
+
+    [Fact]
+    public void Json_UnknownFieldsAreTolerated()
+    {
+        var withExtras = "{\"type\":\"User\",\"id\":\"alice\",\"capabilityLevel\":3,\"tags\":[\"vip\"]}";
+
+        var participant = JsonSerializer.Deserialize<SessionParticipant>(withExtras);
+
+        participant.ShouldNotBeNull();
+        participant!.CitizenId.Value.ShouldBe("alice");
+    }
+
+    [Fact]
+    public void Json_ListOfMixedShapes_DeserializesAll()
+    {
+        var json = "[" +
+                   "{\"type\":\"User\",\"id\":\"alice\"}," +
+                   "{\"citizenId\":{\"kind\":\"Agent\",\"id\":\"bot\"},\"role\":\"target\"}" +
+                   "]";
+
+        var participants = JsonSerializer.Deserialize<List<SessionParticipant>>(json);
+
+        participants.ShouldNotBeNull();
+        participants!.Count.ShouldBe(2);
+        participants[0].CitizenId.Kind.ShouldBe(CitizenKind.User);
+        participants[1].CitizenId.Kind.ShouldBe(CitizenKind.Agent);
+        participants[1].Role.ShouldBe("target");
+    }
+}

--- a/tests/domain/BotNexus.Domain.Tests/UserIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/UserIdTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using Vogen;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class UserIdTests
+{
+    [Fact]
+    public void From_TrimsLeadingAndTrailingWhitespace()
+    {
+        var result = UserId.From(" alice ");
+
+        result.Value.ShouldBe("alice");
+    }
+
+    [Fact]
+    public void From_RejectsNull()
+    {
+        Action act = () => UserId.From(null!);
+
+        act.ShouldThrow<ValueObjectValidationException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("   \n   ")]
+    public void From_RejectsEmptyOrWhitespace(string value)
+    {
+        Action act = () => UserId.From(value);
+
+        var ex = act.ShouldThrow<ValueObjectValidationException>();
+        ex.Message.ShouldContain("UserId");
+    }
+
+    [Fact]
+    public void Equality_MatchesByValue()
+    {
+        UserId.From("alice").ShouldBe(UserId.From("alice"));
+        UserId.From("alice").ShouldNotBe(UserId.From("bob"));
+    }
+
+    [Fact]
+    public void ToString_ReturnsRawValue()
+    {
+        UserId.From("alice").ToString().ShouldBe("alice");
+    }
+
+    [Fact]
+    public void Json_SerializesAsBareString()
+    {
+        var json = JsonSerializer.Serialize(UserId.From("alice"));
+
+        json.ShouldBe("\"alice\"");
+    }
+
+    [Fact]
+    public void Json_DeserializesFromBareString()
+    {
+        var id = JsonSerializer.Deserialize<UserId>("\"alice\"");
+
+        id.ShouldBe(UserId.From("alice"));
+    }
+
+    [Fact]
+    public void Json_RoundTripPreservesValue()
+    {
+        var original = UserId.From("alice");
+
+        var roundTrip = JsonSerializer.Deserialize<UserId>(JsonSerializer.Serialize(original));
+
+        roundTrip.ShouldBe(original);
+    }
+
+    [Fact]
+    public void Json_PropertyOnDtoUsesBareStringWithCamelCase()
+    {
+        var dto = new { user = UserId.From("alice"), label = "hello" };
+
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        json.ShouldBe("{\"user\":\"alice\",\"label\":\"hello\"}");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentDescriptorCitizenTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentDescriptorCitizenTests.cs
@@ -1,0 +1,55 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class AgentDescriptorCitizenTests
+{
+    [Fact]
+    public void ImplementsICitizen()
+    {
+        var descriptor = CreateDescriptor();
+
+        descriptor.ShouldBeAssignableTo<ICitizen>();
+    }
+
+    [Fact]
+    public void ICitizenId_WrapsAgentIdAsAgentCitizen()
+    {
+        ICitizen descriptor = CreateDescriptor();
+
+        descriptor.Id.Kind.ShouldBe(CitizenKind.Agent);
+        descriptor.Id.AsAgent.ShouldNotBeNull();
+        descriptor.Id.AsAgent!.Value.Value.ShouldBe("agent-a");
+        descriptor.Id.AsUser.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ICitizenDisplayName_MatchesDescriptorDisplayName()
+    {
+        ICitizen descriptor = CreateDescriptor();
+
+        descriptor.DisplayName.ShouldBe("Agent A");
+    }
+
+    [Fact]
+    public void TwoDescriptorsWithSameAgentId_ExposeEqualCitizenIds()
+    {
+        ICitizen a = CreateDescriptor();
+        ICitizen b = CreateDescriptor();
+
+        a.Id.ShouldBe(b.Id);
+    }
+
+    private static AgentDescriptor CreateDescriptor()
+        => new()
+        {
+            AgentId = AgentId.From("agent-a"),
+            DisplayName = "Agent A",
+            ModelId = "model",
+            ApiProvider = "provider",
+            SystemPrompt = "Prompt",
+            MaxConcurrentSessions = 1,
+        };
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -1,5 +1,6 @@
 using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Channels;
 using System.Net;
 using System.Net.Http.Json;
@@ -57,8 +58,8 @@ public sealed class AgentExchangeServiceTests
         session.ShouldNotBeNull();
         session!.SessionType.ShouldBe(SessionType.AgentAgent);
         session.Status.ShouldBe(GatewaySessionStatus.Sealed);
-        session.Participants.Where(p => p.Type == ParticipantType.Agent && p.Id == "test-agent" && p.Role == "initiator").ShouldHaveSingleItem();
-        session.Participants.Where(p => p.Type == ParticipantType.Agent && p.Id == "agent-c" && p.Role == "target").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
 
         var initiatorExistence = await sessionStore.GetExistenceAsync(initiator, new ExistenceQuery());
         var targetExistence = await sessionStore.GetExistenceAsync(target, new ExistenceQuery());
@@ -216,8 +217,10 @@ public sealed class AgentExchangeServiceTests
         var session = await sessionStore.GetAsync(result.SessionId);
         session.ShouldNotBeNull();
         session!.ChannelType.ShouldBe(ChannelKey.From("cross-world"));
-        session.Participants.Where(p => p.Id == "test-agent" && p.WorldId == "world-a").ShouldHaveSingleItem();
-        session.Participants.Where(p => p.Id == "agent-c" && p.WorldId == "world-b").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
+        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
+        session.Metadata["sourceWorldId"].ShouldBe("world-a");
+        session.Metadata["targetWorldId"].ShouldBe("world-b");
 
         capturedRequest.ShouldNotBeNull();
         capturedRequest!.Headers.TryGetValues("X-Cross-World-Key", out var keys).ShouldBeTrue();

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Api.Controllers;
@@ -87,8 +88,10 @@ public sealed class CrossWorldFederationControllerTests
         var savedSession = await sessions.GetAsync(SessionId.From(payload.SessionId));
         savedSession.ShouldNotBeNull();
         savedSession!.ChannelType.ShouldBe(ChannelKey.From("cross-world"));
-        savedSession.Participants.Where(p => p.Id == "test-agent" && p.WorldId == "world-a").ShouldHaveSingleItem();
-        savedSession.Participants.Where(p => p.Id == "agent-c" && p.WorldId == "world-b").ShouldHaveSingleItem();
+        savedSession.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
+        savedSession.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
+        savedSession.Metadata["sourceWorldId"].ShouldBe("world-a");
+        savedSession.Metadata["targetWorldId"].ShouldBe("world-b");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Sessions;
@@ -277,7 +278,7 @@ public sealed class FileSessionStoreTests
             SessionType = BotNexus.Domain.Primitives.SessionType.Cron,
             Participants =
             [
-                new BotNexus.Domain.Primitives.SessionParticipant { Type = BotNexus.Domain.Primitives.ParticipantType.Agent, Id = "agent-a" }
+                new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }
             ],
             CreatedAt = now.AddDays(-1)
         });

--- a/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Sessions;
 
 namespace BotNexus.Gateway.Tests;
@@ -164,7 +165,7 @@ public sealed class InMemorySessionStoreTests
             SessionType = SessionType.Cron,
             Participants =
             [
-                new SessionParticipant { Type = ParticipantType.Agent, Id = "agent-a" }
+                new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }
             ],
             CreatedAt = now.AddDays(-1)
         });

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Sessions;
@@ -175,8 +176,7 @@ public sealed class SessionStoreExistenceQueryTests
             [
                 new SessionParticipant
                 {
-                    Type = ParticipantType.Agent,
-                    Id = "agent-a"
+                    CitizenId = CitizenId.Of(AgentId.From("agent-a"))
                 }
             ],
             CreatedAt = now.AddDays(-2),
@@ -191,8 +191,7 @@ public sealed class SessionStoreExistenceQueryTests
             [
                 new SessionParticipant
                 {
-                    Type = ParticipantType.Agent,
-                    Id = "agent-a"
+                    CitizenId = CitizenId.Of(AgentId.From("agent-a"))
                 }
             ],
             CreatedAt = now.AddDays(-1),

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionModelWave2Tests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionModelWave2Tests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -132,8 +133,8 @@ public sealed class SessionModelWave2Tests
     {
         var session = CreateSession();
         session.CallerId = "user-123";
-        session.Participants.Add(new SessionParticipant { Type = ParticipantType.User, Id = "user-123" });
-        session.Participants.Add(new SessionParticipant { Type = ParticipantType.Agent, Id = "agent-a" });
+        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("user-123")) });
+        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) });
 
         session.CallerId.ShouldBe("user-123");
         session.Participants.Count().ShouldBe(2);
@@ -144,12 +145,12 @@ public sealed class SessionModelWave2Tests
     {
         var session = CreateSession();
         session.CallerId = "caller-1";
-        session.Participants.Add(new SessionParticipant { Type = ParticipantType.User, Id = "caller-1" });
-        session.Participants.Add(new SessionParticipant { Type = ParticipantType.Agent, Id = "agent-a" });
+        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("caller-1")) });
+        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) });
 
-        var firstUser = session.Participants.First(p => p.Type == ParticipantType.User);
+        var firstUser = session.Participants.First(p => p.CitizenId.Kind == CitizenKind.User);
 
-        firstUser.Id.ShouldBe(session.CallerId);
+        firstUser.CitizenId.AsUser!.Value.Value.ShouldBe(session.CallerId);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
@@ -1,0 +1,128 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Back-compat integration tests for <see cref="SessionParticipant"/> persistence.
+/// Verifies that sessions written before Phase 1.5 (legacy <c>{type,id,worldId}</c> shape)
+/// still deserialise into the new CitizenId-based shape when re-read by the current store.
+/// </summary>
+public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
+{
+    [Fact]
+    public async Task GetAsync_WithLegacyParticipantJson_DeserializesAsCitizenId()
+    {
+        using var fixture = new StoreFixture();
+
+        // Bootstrap the schema by opening the store once and saving a placeholder
+        // session — this ensures all tables, columns, and migrations are in place
+        // before we hand-inject legacy JSON.
+        var bootstrap = fixture.CreateStore();
+        var placeholder = await bootstrap.GetOrCreateAsync(SessionId.From("placeholder"), AgentId.From("agent-a"));
+        await bootstrap.SaveAsync(placeholder);
+
+        const string legacyParticipantsJson = """
+            [
+              { "type": "User", "id": "alice", "worldId": "world-a", "role": "caller" },
+              { "type": 1, "id": "agent-b", "worldId": "world-b", "role": "target" }
+            ]
+            """;
+
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var insert = connection.CreateCommand();
+            insert.CommandText = """
+                INSERT INTO sessions
+                  (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at)
+                VALUES
+                  ($id, $agentId, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt)
+                """;
+            insert.Parameters.AddWithValue("$id", "legacy-session");
+            insert.Parameters.AddWithValue("$agentId", "agent-a");
+            insert.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
+            insert.Parameters.AddWithValue("$participants", legacyParticipantsJson);
+            insert.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
+            insert.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToString("O"));
+            insert.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("legacy-session"));
+
+        reloaded.ShouldNotBeNull();
+        reloaded!.Participants.Count.ShouldBe(2);
+
+        var caller = reloaded.Participants[0];
+        caller.CitizenId.Kind.ShouldBe(CitizenKind.User);
+        caller.CitizenId.AsUser!.Value.Value.ShouldBe("alice");
+        caller.Role.ShouldBe("caller");
+
+        var target = reloaded.Participants[1];
+        target.CitizenId.Kind.ShouldBe(CitizenKind.Agent);
+        target.CitizenId.AsAgent!.Value.Value.ShouldBe("agent-b");
+        target.Role.ShouldBe("target");
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsParticipants_InDualShape_ForRollbackSafety()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var session = await store.GetOrCreateAsync(SessionId.From("dual-shape"), AgentId.From("agent-a"));
+        session.Participants.Add(new SessionParticipant
+        {
+            CitizenId = CitizenId.Of(UserId.From("alice")),
+            Role = "caller",
+        });
+        await store.SaveAsync(session);
+
+        string? participantsJson;
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var read = connection.CreateCommand();
+            read.CommandText = "SELECT participants_json FROM sessions WHERE id = $id";
+            read.Parameters.AddWithValue("$id", "dual-shape");
+            participantsJson = (string?)await read.ExecuteScalarAsync();
+        }
+
+        participantsJson.ShouldNotBeNull();
+        participantsJson!.ShouldContain("\"citizenId\"");
+        participantsJson.ShouldContain("\"type\":\"User\"");
+        participantsJson.ShouldContain("\"id\":\"alice\"");
+    }
+
+    private sealed class StoreFixture : IDisposable
+    {
+        public StoreFixture()
+        {
+            DirectoryPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "SqliteSessionStoreSessionParticipantBackCompatTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(DirectoryPath);
+            DatabasePath = Path.Combine(DirectoryPath, "sessions.db");
+            ConnectionString = $"Data Source={DatabasePath};Pooling=False";
+        }
+
+        public string DirectoryPath { get; }
+        public string DatabasePath { get; }
+        public string ConnectionString { get; }
+
+        public SqliteSessionStore CreateStore()
+            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(DirectoryPath))
+                Directory.Delete(DirectoryPath, recursive: true);
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -371,7 +372,7 @@ public sealed class SqliteSessionStoreTests
             SessionType = BotNexus.Domain.Primitives.SessionType.Cron,
             Participants =
             [
-                new BotNexus.Domain.Primitives.SessionParticipant { Type = BotNexus.Domain.Primitives.ParticipantType.Agent, Id = "agent-a" }
+                new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }
             ],
             CreatedAt = now.AddDays(-1)
         });


### PR DESCRIPTION
Closes #521.

Introduces the **Citizen** abstraction over the two species in a World (User and Agent) and migrates `SessionParticipant` to the new shape. This is Phase 1.5 of the domain-model refactor (plan §4 in the session); Phase 2 (full `User` entity + `IUserRegistry` + inbound `CitizenId` resolution + `Conversation.Initiator` + `ListByCitizenAsync`) is the next ticket and depends only on the types this PR ships.

## What ships

**New types** (`src/domain/BotNexus.Domain`):
- `Primitives/UserId.cs` — Vogen value object, mirrors the `AgentId`/`ConversationId`/`SessionId` shape (non-null, non-empty, no whitespace; no implicit string conversion).
- `World/CitizenKind.cs` — `{ Unknown = 0, User = 1, Agent = 2 }`. `Unknown` is load-bearing: `default(CitizenId)` is invalid by construction.
- `World/CitizenId.cs` — sum type (User | Agent), hand-written because Vogen targets single-value wrappers. Private ctor + `Of(UserId)` / `Of(AgentId)` factories, defensive `AsUser` / `AsAgent` accessors, equality only on the populated arm, embedded STJ converter that reads both numeric and string enum kinds, case-insensitive props, with unknown-field tolerance and conflict-throws.
- `World/ICitizen.cs` — marker interface (`CitizenId Id`, `string DisplayName`). `World` is deferred to Phase 7 because agents don't yet know their world directly.

**Adopted**:
- `AgentDescriptor : ICitizen` via explicit interface implementation; no shape change.

**Migrated**:
- `SessionParticipant` is now `{ CitizenId, Role }` instead of `{ Type, Id, WorldId }`.
- Embedded STJ converter does **dual-shape write** (emits both the new `citizenId` object AND the legacy flat `{type, id, role}` fields) so a rolled-back gateway in the one-release window can still read forward-written rows.
- Reader prefers `citizenId` when present, falls back to `{type, id}`; tolerates numeric or string enum kinds, case-insensitive props, unknown fields. Throws on conflict between the two shapes.
- Legacy `WorldId` on participants is dropped — verified write-only across the codebase. Cross-world signal is preserved by writing `session.Metadata[""sourceWorldId""|""targetWorldId""]` in `AgentExchangeService` and `CrossWorldFederationController` instead.

**Call-site sweep** (9 production + 6 test files, all in the gateway commit): every `SessionParticipant` constructor now uses `CitizenId.Of(...)`.

## Back-compat strategy

- New writes contain both shapes (dual-write). After one release, the legacy fields can be dropped from the writer.
- Reads of legacy rows (pre-Phase-1.5) silently upgrade to `CitizenId`; the dropped `worldId` is ignored.
- A dedicated SQLite integration test (`SqliteSessionStoreSessionParticipantBackCompatTests`) hand-injects a legacy `participants_json` blob and verifies the current store reads it correctly, plus asserts new writes contain both keys.

## Tests added

| Project | File | Facts |
|---|---|---|
| Domain.Tests | `UserIdTests.cs` | 10 |
| Domain.Tests | `CitizenIdTests.cs` | 18 |
| Domain.Tests | `SessionParticipantTests.cs` | 11 |
| Gateway.Tests | `AgentDescriptorCitizenTests.cs` | 4 |
| Gateway.Tests | `SqliteSessionStoreSessionParticipantBackCompatTests.cs` | 2 |
| Architecture.Tests | `DomainArchitectureTests.cs` | +2 facts |

Full suite: build 0 warnings / 0 errors, all tests green.

## Commits (Conventional Commits)

1. `feat(domain): add UserId Vogen value object`
2. `feat(domain): add Citizen abstraction (CitizenKind, CitizenId, ICitizen)`
3. `refactor(domain): adopt ICitizen on AgentDescriptor`
4. `refactor(domain): migrate SessionParticipant to CitizenId with dual-shape persistence`
5. `refactor(gateway): switch SessionParticipant call sites to CitizenId; preserve world info in session metadata`
6. `test(architecture): extend Vogen fitness functions to UserId`

## Out of scope (Phase 2 ticket)

- `User` record + `IUserRegistry` + `ICitizenRegistry` implementation.
- `InboundMessage.SenderId` -> `CitizenId` resolution at the channel boundary.
- `Conversation.Initiator` field migration.
- `IConversationStore.ListByCitizenAsync(CitizenId)`.
- `WorldDescriptor.HostedUsers`.

## Reviewer notes

- `CitizenId.Value` (`""kind:value""`) is provided for single-column persistence keys but discards `Kind` on parse-back — the XML docs flag that and recommend `ToString()` + parse for round-trip uses.
- SignalR BlazorClient: I greped for any direct consumer of the `SessionParticipant` wire shape and found none; worth confirming during review if you know of any.
