### PR TITLE
feat(gateway): add Conversation.Initiator + ListForCitizenAsync (Phase 2b)

### DIFF
--- a/docs/architecture/gateway-flow.md
+++ b/docs/architecture/gateway-flow.md
@@ -68,8 +68,8 @@ flowchart TD
     C --> E{Conversation\nfound?}
     D --> E
 
-    E -- No  --> F[Create new Conversation + ChannelBinding]
-    E -- Yes --> G[Use existing Conversation]
+    E -- No  --> F[Create new Conversation + ChannelBinding\nstamp Initiator = inbound.Sender]
+    E -- Yes --> G[Use existing Conversation\nInitiator preserved write-once]
     F --> G
 
     G --> H{ActiveSessionId\npresent?}
@@ -167,3 +167,32 @@ All channel-addressing fields have been migrated to strong types (completed in P
 | `InboundMessage.SenderId` | `InboundMessage` | Wire-level audit/allow-list token (channel-native, e.g. SignalR connection id). Phase 2c (#526) added the companion `InboundMessage.Sender` of typed `CitizenId`; the legacy hand-rolled `SenderId` value-object struct was deleted in the same change since the typed identity now lives on `Sender`. |
 | `CrossWorldRelayRequest.ChannelAddress` | DTO | Intentionally string for HTTP wire format |
 | Streaming `conversationId` | `IStreamEventChannelAdapter` | Channel-specific encoding; strong type would need format changes |
+
+---
+
+## Conversation.Initiator (provenance)
+
+Phase 2b (#529) added `Conversation.Initiator` of type `CitizenId?` to record **who first
+caused the conversation to be created**. Distinct from `Conversation.AgentId` (current
+agent owner): `Initiator` is **write-once at creation time** and never overwritten — even
+when an archived conversation is re-opened or the agent assignment changes.
+
+**Stamping path:**
+
+| Producer | Initiator value | Source |
+|---|---|---|
+| Channel-driven inbound (SignalR, Telegram, ServiceBus, TUI, ...) | `inbound.Sender` (always a `CitizenId`) | `DefaultConversationRouter` via `GatewayHost` / `DefaultConversationDispatcher` |
+| `ConversationTool.NewAsync` (agent-initiated) | `CitizenId.Of(agentId)` | `ConversationTool` |
+| `HeartbeatTrigger` / `CronTrigger` (system-initiated for an agent) | `CitizenId.Of(agentId)` | trigger code |
+| `ConversationsController.Create` (REST admin path) | `null` (no trustworthy citizen until #527 lands) | controller; left explicit with `// pending SignalR claims-based auth (#527)` |
+
+**Write-once discipline:** the router only stamps `Initiator` on the create-new-conversation
+branch (Diagram 2 box F). Existing conversations — including the archived-reopen and
+`explicit-ConversationId` fast-path branches — preserve the original `Initiator` even if
+the current inbound message carries a different `Sender`.
+
+**Query path:** `IConversationStore.ListForCitizenAsync(CitizenId)` returns the **union**
+of `Initiator == citizen` and (when the citizen is an agent) `AgentId == citizen.AsAgent`.
+For user citizens the predicate degenerates to the initiator leg only — users do not own
+conversations. SQLite implements this with a single `WHERE` clause so duplicates are
+naturally deduplicated by the row identity.

--- a/docs/development/message-flow.md
+++ b/docs/development/message-flow.md
@@ -98,6 +98,16 @@ may differ in shape — for example the sub-agent wake-up uses `SenderId = "suba
 for audit while `Sender` carries the typed child agent id (`CitizenId.Of(agentId)`).
 Downstream code must NEVER re-parse `SenderId` to infer species; use `Sender.Kind`.
 
+**Sender → Initiator (Phase 2b, #529):** when the router creates a **new** Conversation,
+`inbound.Sender` is stamped onto `Conversation.Initiator` as the write-once provenance of
+who first caused the conversation to exist. `Initiator` is **never** overwritten — archived-
+reopen and explicit-ConversationId branches preserve the original value even when the
+inbound `Sender` differs. Agent-initiated conversations (`ConversationTool.NewAsync`,
+`HeartbeatTrigger`, `CronTrigger`) set `Initiator = CitizenId.Of(agentId)` directly;
+`ConversationsController.Create` leaves it `null` pending SignalR claims-based auth (#527).
+`IConversationStore.ListForCitizenAsync(citizen)` returns the union of conversations the
+citizen initiated and (for agents only) those they currently own.
+
 ### 4. Agent Resolution
 
 ```text

--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 
 namespace BotNexus.Gateway.Abstractions.Models;
 
@@ -46,4 +47,20 @@ public sealed record Conversation
 
     /// <summary>Gets or sets conversation-scoped instructions injected into the system prompt on session start.</summary>
     public string? Instructions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the citizen that opened this conversation — the user who sent the first
+    /// inbound message, or the agent that programmatically created it (via <c>conversation_new</c>
+    /// tool calls, heartbeats, cron triggers, etc.). Set by the router on creation and treated as
+    /// write-once provenance; producers must not overwrite it on subsequent saves. <c>null</c> for
+    /// legacy conversations created before this field existed and for paths where the creator's
+    /// identity is not yet authenticated (see issue #527 for the HTTP create-endpoint follow-up).
+    /// </summary>
+    /// <remarks>
+    /// This is distinct from <see cref="AgentId"/>, which is the agent that <em>owns</em> the
+    /// conversation. For agent-initiated conversations the two are typically the same citizen, but
+    /// they are not required to be — e.g. a heartbeat-triggered conversation may be initiated by a
+    /// system agent yet owned by the target user-facing agent.
+    /// </remarks>
+    public CitizenId? Initiator { get; set; }
 }

--- a/src/domain/BotNexus.Domain/World/CitizenId.cs
+++ b/src/domain/BotNexus.Domain/World/CitizenId.cs
@@ -96,6 +96,52 @@ public readonly struct CitizenId : IEquatable<CitizenId>
         _ => "citizen:<uninitialized>",
     };
 
+    /// <summary>
+    /// Attempts to parse a citizen identity from the canonical persistence-key form produced
+    /// by <see cref="ToString"/> — <c>user:&lt;id&gt;</c> or <c>agent:&lt;id&gt;</c>. The kind
+    /// prefix is matched case-insensitively; the inner identifier is preserved verbatim and
+    /// must be valid for the corresponding inner value object. Returns <c>false</c> for
+    /// <c>null</c>, empty/whitespace, missing-separator, empty-kind, empty-id, unknown kind,
+    /// and the <c>citizen:&lt;uninitialized&gt;</c> sentinel emitted by <c>default(CitizenId)</c>.
+    /// </summary>
+    public static bool TryParse(string? value, out CitizenId citizen)
+    {
+        citizen = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var separator = value.IndexOf(':');
+        if (separator <= 0 || separator == value.Length - 1)
+            return false;
+
+        var kindPart = value[..separator];
+        var idPart = value[(separator + 1)..];
+
+        if (string.IsNullOrWhiteSpace(kindPart) || string.IsNullOrWhiteSpace(idPart))
+            return false;
+
+        try
+        {
+            if (string.Equals(kindPart, "user", StringComparison.OrdinalIgnoreCase))
+            {
+                citizen = Of(UserId.From(idPart));
+                return true;
+            }
+            if (string.Equals(kindPart, "agent", StringComparison.OrdinalIgnoreCase))
+            {
+                citizen = Of(AgentId.From(idPart));
+                return true;
+            }
+        }
+        catch (Vogen.ValueObjectValidationException)
+        {
+            // Inner value-object validation rejected the id portion.
+            return false;
+        }
+
+        return false;
+    }
+
     /// <inheritdoc/>
     public bool Equals(CitizenId other) => Kind switch
     {

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -111,7 +111,11 @@ public sealed class ConversationsController : ControllerBase
             Instructions = NormalizeInstructions(request.Instructions),
             Status = ConversationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,
-            UpdatedAt = DateTimeOffset.UtcNow
+            UpdatedAt = DateTimeOffset.UtcNow,
+            // Initiator left null: this endpoint is currently unauthenticated, so we cannot
+            // determine which user/agent created the conversation. Once SignalR/portal claims-based
+            // auth lands (see issue #527) this should be populated from the request principal.
+            Initiator = null
         };
 
         var created = await _conversations.CreateAsync(conversation, cancellationToken);

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -4,6 +4,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Triggers;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using Microsoft.Extensions.Logging;
 
 namespace BotNexus.Gateway.Api.Triggers;
@@ -173,7 +174,10 @@ public sealed class CronTrigger(
             ConversationId = stableConversationId,
             AgentId = agentId,
             Title = title,
-            IsDefault = false
+            IsDefault = false,
+            // Cron triggers schedule work for the target agent on its own behalf, so the
+            // initiating citizen is that agent.
+            Initiator = CitizenId.Of(agentId)
         };
         try
         {

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
@@ -4,6 +4,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Triggers;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using Microsoft.Extensions.Logging;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
@@ -216,7 +217,9 @@ public sealed class HeartbeatTrigger(
             ConversationId = stableId,
             AgentId = agentId,
             Title = $"heartbeat:{agentId.Value}",
-            IsDefault = false
+            IsDefault = false,
+            // Heartbeat is a self-initiated system flow; the agent itself is the initiator.
+            Initiator = CitizenId.Of(agentId)
         };
         try
         {

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 
 namespace BotNexus.Gateway.Abstractions.Conversations;
@@ -16,13 +17,28 @@ public interface IConversationRouter
     /// Every channel gets its own conversation on first contact regardless of address.
     /// Stamps Session.ConversationId when creating/resolving sessions.
     /// </summary>
+    /// <param name="agentId">The owning agent for the resolved conversation.</param>
+    /// <param name="channelType">Channel species (e.g. signalr, telegram, tui).</param>
+    /// <param name="channelAddress">Channel-specific address — opaque to the router.</param>
+    /// <param name="threadId">Native sub-thread id when the channel exposes one (deprecated; see #523 Phase 6b).</param>
+    /// <param name="conversationId">Explicit conversation id to bypass binding lookup.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="initiator">
+    /// The citizen who triggered this resolution — typically the inbound message's resolved
+    /// <see cref="Domain.World.CitizenId"/> sender. Stamped onto <see cref="Conversation.Initiator"/>
+    /// when a new conversation is created; ignored for existing conversations to preserve the
+    /// write-once provenance invariant. Pass <c>null</c> when the initiator is unknown (legacy /
+    /// system-system paths); existing conversations also remain <c>null</c> until they are next
+    /// created fresh.
+    /// </param>
     Task<ConversationRoutingResult> ResolveInboundAsync(
         AgentId agentId,
         ChannelKey channelType,
         ChannelAddress channelAddress,
         ThreadId? threadId,
         string? conversationId = null,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        CitizenId? initiator = null);
 
     /// <summary>
     /// Returns channel bindings that should receive outbound fan-out for a session.

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 
 namespace BotNexus.Gateway.Abstractions.Conversations;
@@ -26,6 +27,27 @@ public interface IConversationStore
     /// Lists all active conversations, optionally filtered by agent.
     /// </summary>
     Task<IReadOnlyList<Conversation>> ListAsync(AgentId? agentId = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists conversations <em>relevant to</em> the given citizen, in any status (including
+    /// <see cref="ConversationStatus.Archived"/>) to match <see cref="ListAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>The set is the union of:</para>
+    /// <list type="bullet">
+    ///   <item><b>Initiator-match</b>: <c>Conversation.Initiator == citizen</c> — conversations
+    ///     this citizen <em>opened</em>. Applies to both User and Agent species.</item>
+    ///   <item><b>Owner-match</b>: when <c>citizen.Kind == Agent</c>, <c>Conversation.AgentId == citizen.AsAgent</c> —
+    ///     conversations <em>owned</em> by this agent. There is no symmetric owner relationship
+    ///     for User citizens (owning-by-user is not modelled), which makes this method
+    ///     intentionally asymmetric across species.</item>
+    /// </list>
+    /// <para>"Any session participant" semantics — which would require iterating each conversation's
+    /// active session participants — are not provided here; that query lives one layer up.</para>
+    /// </remarks>
+    /// <param name="citizen">The citizen identity to query for; must be <see cref="CitizenId.IsValid"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default);
 
     /// <summary>
     /// Creates a new conversation. Throws if the ConversationId already exists.

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -38,7 +39,8 @@ public sealed class DefaultConversationRouter : IConversationRouter
         ChannelAddress channelAddress,
         ThreadId? threadId,
         string? conversationId = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        CitizenId? initiator = null)
     {
         // When the caller knows the exact conversation (e.g. portal with active conversation tab),
         // skip binding lookup entirely. This is the fast path that eliminates the thread-binding hack.
@@ -125,7 +127,8 @@ public sealed class DefaultConversationRouter : IConversationRouter
                 ConversationId = ConversationId.Create(),
                 AgentId = agentId,
                 Title = title,
-                IsDefault = false
+                IsDefault = false,
+                Initiator = initiator?.IsValid == true ? initiator : null
             };
             var binding = new ChannelBinding
             {

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using Microsoft.Extensions.Logging;
@@ -56,6 +57,38 @@ public sealed class FileConversationStore : IConversationStore
         await _lock.WaitAsync(ct).ConfigureAwait(false);
         try { return await EnumerateAsync(agentId, ct).ConfigureAwait(false); }
         finally { _lock.Release(); }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default)
+    {
+        if (!citizen.IsValid)
+            throw new ArgumentException("Citizen must be a valid (non-default) CitizenId.", nameof(citizen));
+
+        // Scope: when the citizen is an Agent we can narrow the enumeration to that agent's
+        // directory because owner-match guarantees AgentId == citizen.AsAgent. For User citizens
+        // we have to scan everything since they could have initiated conversations under any agent.
+        AgentId? scope = citizen.Kind == CitizenKind.Agent ? citizen.AsAgent : null;
+
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var all = await EnumerateAsync(scope, ct).ConfigureAwait(false);
+            IReadOnlyList<Conversation> filtered = [.. all.Where(c => MatchesCitizen(c, citizen))];
+            return filtered;
+        }
+        finally { _lock.Release(); }
+    }
+
+    private static bool MatchesCitizen(Conversation conversation, CitizenId citizen)
+    {
+        if (conversation.Initiator is { IsValid: true } init && init == citizen)
+            return true;
+
+        if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
+            return true;
+
+        return false;
     }
 
     public async Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 
@@ -25,6 +26,28 @@ public sealed class InMemoryConversationStore : IConversationStore
             ? [.. _conversations.Values]
             : [.. _conversations.Values.Where(c => c.AgentId == agentId.Value)];
         return Task.FromResult(results);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default)
+    {
+        if (!citizen.IsValid)
+            throw new ArgumentException("Citizen must be a valid (non-default) CitizenId.", nameof(citizen));
+
+        IReadOnlyList<Conversation> results = [.. _conversations.Values.Where(c => MatchesCitizen(c, citizen))];
+        return Task.FromResult(results);
+    }
+
+    private static bool MatchesCitizen(Conversation conversation, CitizenId citizen)
+    {
+        if (conversation.Initiator is { IsValid: true } init && init == citizen)
+            return true;
+
+        // Owner-match: only agent-species citizens own conversations.
+        if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
+            return true;
+
+        return false;
     }
 
     public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using Microsoft.Data.Sqlite;
@@ -84,6 +85,57 @@ public sealed class SqliteConversationStore : IConversationStore
             : "SELECT id FROM conversations WHERE agent_id = $agentId ORDER BY updated_at DESC";
         if (agentId is not null)
             command.Parameters.AddWithValue("$agentId", agentId.Value.Value);
+
+        var conversations = new List<Conversation>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var id = reader.GetString(0);
+            Conversation conversation;
+            if (_cache.TryGetValue(id, out var cached))
+            {
+                conversation = CloneConversation(cached);
+            }
+            else
+            {
+                conversation = await LoadConversationAsync(connection, ConversationId.From(id), ct).ConfigureAwait(false)
+                    ?? throw new InvalidOperationException($"Conversation '{id}' disappeared during enumeration.");
+                _cache[id] = CloneConversation(conversation);
+            }
+
+            conversations.Add(conversation);
+        }
+
+        return conversations;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default)
+    {
+        if (!citizen.IsValid)
+            throw new ArgumentException("Citizen must be a valid (non-default) CitizenId.", nameof(citizen));
+
+        using var activity = ActivitySource.StartActivity("conversation.list_for_citizen", ActivityKind.Internal);
+        activity?.SetTag("botnexus.citizen.kind", citizen.Kind.ToString());
+        activity?.SetTag("botnexus.citizen", citizen.ToString());
+
+        await EnsureCreatedAsync(ct).ConfigureAwait(false);
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        // Union semantics: rows whose initiator matches, plus (only for Agent species) rows
+        // whose owning agent matches. The $isAgent flag short-circuits the owner-match for users.
+        command.CommandText = """
+            SELECT id FROM conversations
+            WHERE initiator = $initiator
+               OR ($isAgent = 1 AND agent_id = $agentMatch)
+            ORDER BY updated_at DESC
+            """;
+        command.Parameters.AddWithValue("$initiator", citizen.ToString());
+        command.Parameters.AddWithValue("$isAgent", citizen.Kind == CitizenKind.Agent ? 1 : 0);
+        command.Parameters.AddWithValue("$agentMatch",
+            citizen.Kind == CitizenKind.Agent ? (object)citizen.AsAgent!.Value.Value : DBNull.Value);
 
         var conversations = new List<Conversation>();
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -381,6 +433,7 @@ public sealed class SqliteConversationStore : IConversationStore
             await EnsurePurposeColumnAsync(connection, ct).ConfigureAwait(false);
             await EnsureInstructionsColumnAsync(connection, ct).ConfigureAwait(false);
             await EnsureCanvasHtmlColumnAsync(connection, ct).ConfigureAwait(false);
+            await EnsureInitiatorColumnAsync(connection, ct).ConfigureAwait(false);
 
             // One-time migration: archive stale signalr:connection-id conversations created
             // before binding-first routing (#148). Those conversations have a title matching
@@ -488,6 +541,58 @@ public sealed class SqliteConversationStore : IConversationStore
         await canvasAlterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
+    private static async Task EnsureInitiatorColumnAsync(SqliteConnection connection, CancellationToken ct)
+    {
+        await using var tableInfoCommand = connection.CreateCommand();
+        tableInfoCommand.CommandText = "PRAGMA table_info(conversations);";
+
+        var hasColumn = false;
+        await using (var reader = await tableInfoCommand.ExecuteReaderAsync(ct).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                if (string.Equals(reader.GetString(1), "initiator", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasColumn)
+        {
+            await using var alterCommand = connection.CreateCommand();
+            alterCommand.CommandText = "ALTER TABLE conversations ADD COLUMN initiator TEXT;";
+            await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        // Always ensure the index exists (cheap when present).
+        await using var indexCommand = connection.CreateCommand();
+        indexCommand.CommandText = "CREATE INDEX IF NOT EXISTS idx_conversations_initiator ON conversations(initiator);";
+        await indexCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Persistence form for <see cref="Conversation.Initiator"/>. <c>null</c> in returns <c>null</c>;
+    /// a present-but-invalid <see cref="CitizenId"/> (i.e. <c>default(CitizenId)</c>) is a programming
+    /// error and throws — the router contract requires either <c>null</c> or a well-formed citizen.
+    /// </summary>
+    internal static string? SerializeInitiator(CitizenId? initiator)
+    {
+        if (initiator is null)
+            return null;
+        if (!initiator.Value.IsValid)
+            throw new InvalidOperationException("Conversation.Initiator must be null or a valid CitizenId; got default(CitizenId).");
+        return initiator.Value.ToString();
+    }
+
+    private static CitizenId? DeserializeInitiator(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+        return CitizenId.TryParse(raw, out var citizen) ? citizen : null;
+    }
+
     private async Task<Conversation?> LoadConversationAsync(ConversationId conversationId, CancellationToken ct)
     {
         await using var connection = CreateConnection();
@@ -499,7 +604,7 @@ public sealed class SqliteConversationStore : IConversationStore
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html
+            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator
             FROM conversations
             WHERE id = $id
             """;
@@ -521,7 +626,8 @@ public sealed class SqliteConversationStore : IConversationStore
             CreatedAt = ParseTimestamp(reader.GetString(8)),
             UpdatedAt = ParseTimestamp(reader.GetString(9)),
             Instructions = reader.IsDBNull(10) ? null : reader.GetString(10),
-            CanvasHtml = reader.FieldCount > 11 && !reader.IsDBNull(11) ? reader.GetString(11) : null
+            CanvasHtml = reader.FieldCount > 11 && !reader.IsDBNull(11) ? reader.GetString(11) : null,
+            Initiator = reader.FieldCount > 12 ? DeserializeInitiator(reader.IsDBNull(12) ? null : reader.GetString(12)) : null
         };
         if (!reader.IsDBNull(6))
             conversation.ActiveSessionId = SessionId.From(reader.GetString(6));
@@ -572,8 +678,8 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Transaction = transaction;
         conversationCommand.CommandText = upsert
             ? """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator)
                 ON CONFLICT(id) DO UPDATE SET
                     agent_id = excluded.agent_id,
                     title = excluded.title,
@@ -585,11 +691,12 @@ public sealed class SqliteConversationStore : IConversationStore
                     created_at = excluded.created_at,
                     updated_at = excluded.updated_at,
                     instructions = excluded.instructions,
-                    canvas_html = excluded.canvas_html
+                    canvas_html = excluded.canvas_html,
+                    initiator = excluded.initiator
                 """
             : """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator)
                 """;
         conversationCommand.Parameters.AddWithValue("$id", conversation.ConversationId.Value);
         conversationCommand.Parameters.AddWithValue("$agentId", conversation.AgentId.Value);
@@ -603,6 +710,7 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Parameters.AddWithValue("$updatedAt", conversation.UpdatedAt.ToString("O"));
         conversationCommand.Parameters.AddWithValue("$instructions", conversation.Instructions is null ? (object)DBNull.Value : conversation.Instructions);
         conversationCommand.Parameters.AddWithValue("$canvasHtml", conversation.CanvasHtml is null ? (object)DBNull.Value : conversation.CanvasHtml);
+        conversationCommand.Parameters.AddWithValue("$initiator", (object?)SerializeInitiator(conversation.Initiator) ?? DBNull.Value);
         await conversationCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         await using var deleteBindingsCommand = connection.CreateCommand();
@@ -675,6 +783,7 @@ public sealed class SqliteConversationStore : IConversationStore
             Purpose = conversation.Purpose,
             Instructions = conversation.Instructions,
             CanvasHtml = conversation.CanvasHtml,
+            Initiator = conversation.Initiator,
             IsDefault = conversation.IsDefault,
             Status = conversation.Status,
             CreatedAt = conversation.CreatedAt,

--- a/src/gateway/BotNexus.Gateway.Dispatching/DefaultConversationDispatcher.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/DefaultConversationDispatcher.cs
@@ -38,7 +38,8 @@ public sealed class DefaultConversationDispatcher : IConversationDispatcher
             context.Source.ChannelAddress,
             context.Source.ThreadId,
             context.RequestedConversationId,
-            cancellationToken);
+            cancellationToken,
+            initiator: context.Message.Sender);
 
         var resolvedSource = routingResult.OriginatingBinding is null
             ? context.Source

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -323,7 +323,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     message.ChannelAddress,
                     threadId: message.ThreadId,
                     conversationId: message.ConversationId,
-                    cancellationToken);
+                    cancellationToken,
+                    initiator: message.Sender);
                 sessionId = routingResult.SessionId.Value;
                 var originatingBinding = routingResult.OriginatingBinding;
                 resolvedSource = originatingBinding is null

--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -246,7 +246,10 @@ public sealed class ConversationTool(
             Purpose = string.IsNullOrWhiteSpace(purpose) ? null : purpose.Trim(),
             Status = ConversationStatus.Active,
             CreatedAt = now,
-            UpdatedAt = now
+            UpdatedAt = now,
+            // The conversation_new tool is invoked by an agent (the caller of this tool), so the
+            // initiating citizen is always the calling agent.
+            Initiator = CitizenId.Of(agentId)
         };
 
         var created = await conversationStore.CreateAsync(conversation, ct).ConfigureAwait(false);

--- a/tests/domain/BotNexus.Domain.Tests/CitizenIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/CitizenIdTests.cs
@@ -175,4 +175,55 @@ public sealed class CitizenIdTests
 
         act.ShouldThrow<JsonException>();
     }
+
+    [Theory]
+    [InlineData("user:alice", CitizenKind.User, "alice")]
+    [InlineData("agent:coding-agent", CitizenKind.Agent, "coding-agent")]
+    [InlineData("USER:alice", CitizenKind.User, "alice")]
+    [InlineData("Agent:bob", CitizenKind.Agent, "bob")]
+    public void TryParse_AcceptsCanonicalFormatCaseInsensitively(string input, CitizenKind expectedKind, string expectedId)
+    {
+        var ok = CitizenId.TryParse(input, out var citizen);
+
+        ok.ShouldBeTrue();
+        citizen.Kind.ShouldBe(expectedKind);
+        citizen.Value.ShouldBe(expectedId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("user")]
+    [InlineData("user:")]
+    [InlineData(":alice")]
+    [InlineData("alice")]
+    [InlineData("cat:whiskers")]
+    [InlineData("citizen:<uninitialized>")]
+    [InlineData("user: ")]
+    public void TryParse_RejectsMalformedInput(string? input)
+    {
+        var ok = CitizenId.TryParse(input, out var citizen);
+
+        ok.ShouldBeFalse();
+        citizen.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_RoundTripsWithToString_ForUser()
+    {
+        var original = CitizenId.Of(UserId.From("alice"));
+
+        CitizenId.TryParse(original.ToString(), out var parsed).ShouldBeTrue();
+        parsed.ShouldBe(original);
+    }
+
+    [Fact]
+    public void TryParse_RoundTripsWithToString_ForAgent()
+    {
+        var original = CitizenId.Of(AgentId.From("coding-agent"));
+
+        CitizenId.TryParse(original.ToString(), out var parsed).ShouldBeTrue();
+        parsed.ShouldBe(original);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -457,5 +457,118 @@ public sealed class DefaultConversationRouterTests
 
         ex.ShouldBeNull();
     }
+
+    // ── Initiator (CitizenId) ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveInbound_NewConversation_StampsInitiator_WhenCitizenProvided()
+    {
+        var store = new InMemoryConversationStore();
+        var router = CreateRouter(store);
+        var user = BotNexus.Domain.World.CitizenId.Of(BotNexus.Domain.Primitives.UserId.From("alice"));
+
+        var result = await router.ResolveInboundAsync(
+            Agent(),
+            Channel(),
+            ChannelAddress.From("chat-init-1"),
+            null,
+            ct: default,
+            initiator: user);
+
+        result.Conversation.Initiator.ShouldNotBeNull();
+        result.Conversation.Initiator!.Value.ShouldBe(user);
+
+        var roundTrip = await store.GetAsync(result.Conversation.ConversationId);
+        roundTrip!.Initiator.ShouldNotBeNull();
+        roundTrip.Initiator!.Value.ShouldBe(user);
+    }
+
+    [Fact]
+    public async Task ResolveInbound_NewConversation_LeavesInitiatorNull_WhenNoCitizenProvided()
+    {
+        var store = new InMemoryConversationStore();
+        var router = CreateRouter(store);
+
+        var result = await router.ResolveInboundAsync(Agent(), Channel(), ChannelAddress.From("chat-init-2"), null);
+
+        result.Conversation.Initiator.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ResolveInbound_ReopensArchivedConversation_DoesNotOverwriteInitiator()
+    {
+        // Initiator is write-once: when the router reopens an archived conversation, it must
+        // preserve the original Initiator even if a different citizen sends the reopening message.
+        var store = new InMemoryConversationStore();
+        var router = CreateRouter(store);
+        var agentId = Agent();
+        var original = BotNexus.Domain.World.CitizenId.Of(BotNexus.Domain.Primitives.UserId.From("alice"));
+        var different = BotNexus.Domain.World.CitizenId.Of(BotNexus.Domain.Primitives.UserId.From("bob"));
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "archived",
+            Status = ConversationStatus.Archived,
+            Initiator = original,
+            ChannelBindings =
+            [
+                new ChannelBinding
+                {
+                    ChannelType = Channel("telegram"),
+                    ChannelAddress = ChannelAddress.From("chat-reopen")
+                }
+            ]
+        };
+        await store.CreateAsync(conversation);
+
+        var result = await router.ResolveInboundAsync(
+            agentId,
+            Channel("telegram"),
+            ChannelAddress.From("chat-reopen"),
+            null,
+            ct: default,
+            initiator: different);
+
+        result.Conversation.Initiator.ShouldNotBeNull();
+        result.Conversation.Initiator!.Value.ShouldBe(original);
+
+        var roundTrip = await store.GetAsync(conversation.ConversationId);
+        roundTrip!.Initiator!.Value.ShouldBe(original);
+    }
+
+    [Fact]
+    public async Task ResolveInbound_WithExplicitConversationId_DoesNotOverwriteInitiator()
+    {
+        // The explicit-conversationId fast path must also preserve the existing Initiator,
+        // even when a citizen is supplied on the call.
+        var store = new InMemoryConversationStore();
+        var router = CreateRouter(store);
+        var agentId = Agent();
+        var original = BotNexus.Domain.World.CitizenId.Of(BotNexus.Domain.Primitives.UserId.From("alice"));
+        var different = BotNexus.Domain.World.CitizenId.Of(BotNexus.Domain.Primitives.UserId.From("bob"));
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = "explicit",
+            Initiator = original
+        };
+        await store.CreateAsync(conversation);
+
+        var result = await router.ResolveInboundAsync(
+            agentId,
+            Channel(),
+            ChannelAddress.From("unused"),
+            null,
+            conversation.ConversationId.Value,
+            ct: default,
+            initiator: different);
+
+        result.Conversation.ConversationId.ShouldBe(conversation.ConversationId);
+        result.Conversation.Initiator!.Value.ShouldBe(original);
+    }
 }
 

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -60,7 +60,7 @@ public sealed class GatewayHostBindingRoutingTests
         convRouter
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
-                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>(), It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
@@ -134,7 +134,7 @@ public sealed class GatewayHostBindingRoutingTests
         convRouter
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
-                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>(), It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))
@@ -224,7 +224,7 @@ public sealed class GatewayHostBindingRoutingTests
         convRouter
             .Setup(r => r.ResolveInboundAsync(
                 It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
-                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>(), It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(routingResult);
         convRouter
             .Setup(r => r.GetOutboundBindingsAsync(It.IsAny<SessionId>(), It.IsAny<BindingId?>(), It.IsAny<CancellationToken>()))

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/ThreadIdRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/ThreadIdRoutingTests.cs
@@ -117,7 +117,8 @@ internal sealed class CapturingConversationRouter : IConversationRouter
 
     public Task<ConversationRoutingResult> ResolveInboundAsync(
         AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress,
-        ThreadId? threadId, string? conversationId = null, CancellationToken ct = default)
+        ThreadId? threadId, string? conversationId = null, CancellationToken ct = default,
+        BotNexus.Domain.World.CitizenId? initiator = null)
     {
         CapturedThreadId = threadId;
         var conv = new Conversation { AgentId = agentId };

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/InMemoryConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/InMemoryConversationStoreTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Conversations;
 
@@ -236,5 +237,110 @@ public sealed class InMemoryConversationStoreTests
         summaries.Count.ShouldBe(1);
         summaries[0].BindingCount.ShouldBe(1);
         summaries[0].AgentId.ShouldBe("summary-agent");
+    }
+
+    // ── Initiator + ListForCitizenAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task Initiator_NullByDefault_AndRoundTrips_WhenSet()
+    {
+        var store = new InMemoryConversationStore();
+        var agent = Agent();
+        var user = CitizenId.Of(UserId.From("alice"));
+
+        var withoutInitiator = MakeConversation(agent, "no-init");
+        var withInitiator = MakeConversation(agent, "with-init") with { Initiator = user };
+
+        await store.CreateAsync(withoutInitiator);
+        await store.CreateAsync(withInitiator);
+
+        (await store.GetAsync(withoutInitiator.ConversationId))!.Initiator.ShouldBeNull();
+        (await store.GetAsync(withInitiator.ConversationId))!.Initiator!.Value.ShouldBe(user);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_Throws_OnInvalidCitizen()
+    {
+        var store = new InMemoryConversationStore();
+        await Should.ThrowAsync<ArgumentException>(() => store.ListForCitizenAsync(default));
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_User_ReturnsOnly_ConversationsTheyInitiated()
+    {
+        var store = new InMemoryConversationStore();
+        var alice = CitizenId.Of(UserId.From("alice"));
+        var bob = CitizenId.Of(UserId.From("bob"));
+
+        var aliceConv = MakeConversation(Agent(), "alice-1") with { Initiator = alice };
+        var bobConv = MakeConversation(Agent(), "bob-1") with { Initiator = bob };
+        var noOne = MakeConversation(Agent(), "no-init");
+
+        await store.CreateAsync(aliceConv);
+        await store.CreateAsync(bobConv);
+        await store.CreateAsync(noOne);
+
+        var aliceList = await store.ListForCitizenAsync(alice);
+        aliceList.Select(c => c.ConversationId).ShouldBe(new[] { aliceConv.ConversationId }, ignoreOrder: true);
+
+        var bobList = await store.ListForCitizenAsync(bob);
+        bobList.Select(c => c.ConversationId).ShouldBe(new[] { bobConv.ConversationId }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_Agent_ReturnsUnion_OfInitiatedAndOwned()
+    {
+        var store = new InMemoryConversationStore();
+        var helper = AgentId.From("helper");
+        var other = AgentId.From("other");
+        var alice = CitizenId.Of(UserId.From("alice"));
+        var helperCitizen = CitizenId.Of(helper);
+
+        // Owned by helper, initiated by a user
+        var owned = MakeConversation(helper, "owned-by-helper") with { Initiator = alice };
+        // Owned by other agent, but initiated by helper (agent-to-agent)
+        var initiatedByHelper = MakeConversation(other, "initiated-by-helper") with { Initiator = helperCitizen };
+        // Unrelated to helper entirely
+        var unrelated = MakeConversation(other, "unrelated") with { Initiator = alice };
+
+        await store.CreateAsync(owned);
+        await store.CreateAsync(initiatedByHelper);
+        await store.CreateAsync(unrelated);
+
+        var helperList = await store.ListForCitizenAsync(helperCitizen);
+
+        helperList.Select(c => c.ConversationId).ShouldBe(
+            new[] { owned.ConversationId, initiatedByHelper.ConversationId },
+            ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_DeduplicatesWhenInitiatorAndOwnerAreSameAgent()
+    {
+        var store = new InMemoryConversationStore();
+        var helper = AgentId.From("helper");
+        var helperCitizen = CitizenId.Of(helper);
+
+        var selfStarted = MakeConversation(helper, "self") with { Initiator = helperCitizen };
+        await store.CreateAsync(selfStarted);
+
+        var list = await store.ListForCitizenAsync(helperCitizen);
+        list.Count.ShouldBe(1);
+        list[0].ConversationId.ShouldBe(selfStarted.ConversationId);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_IncludesArchivedConversations()
+    {
+        var store = new InMemoryConversationStore();
+        var alice = CitizenId.Of(UserId.From("alice"));
+
+        var conv = MakeConversation(Agent(), "archived") with { Initiator = alice };
+        await store.CreateAsync(conv);
+        await store.ArchiveAsync(conv.ConversationId);
+
+        var list = await store.ListForCitizenAsync(alice);
+        list.Count.ShouldBe(1);
+        list[0].Status.ShouldBe(ConversationStatus.Archived);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
@@ -1,7 +1,9 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Conversations;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BotNexus.Gateway.Conversations.Tests;
@@ -326,6 +328,174 @@ public sealed class SqliteConversationStoreTests
     }
 
     private static AgentId Agent(string id) => AgentId.From(id);
+
+    // ── Initiator + ListForCitizenAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task Initiator_RoundTrips_Null_User_And_Agent()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var alice = CitizenId.Of(UserId.From("alice"));
+        var helper = CitizenId.Of(Agent("helper"));
+
+        var noInit = CreateConversation(Agent("agent-a"), "no-init");
+        var userInit = CreateConversation(Agent("agent-a"), "user-init");
+        userInit.Initiator = alice;
+        var agentInit = CreateConversation(Agent("agent-b"), "agent-init");
+        agentInit.Initiator = helper;
+
+        await store.CreateAsync(noInit);
+        await store.CreateAsync(userInit);
+        await store.CreateAsync(agentInit);
+
+        var fresh = fixture.CreateStore();
+        (await fresh.GetAsync(noInit.ConversationId))!.Initiator.ShouldBeNull();
+        (await fresh.GetAsync(userInit.ConversationId))!.Initiator!.Value.ShouldBe(alice);
+        (await fresh.GetAsync(agentInit.ConversationId))!.Initiator!.Value.ShouldBe(helper);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_Throws_OnInvalidCitizen()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        await Should.ThrowAsync<ArgumentException>(() => store.ListForCitizenAsync(default));
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_User_ReturnsOnly_ConversationsTheyInitiated()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var alice = CitizenId.Of(UserId.From("alice"));
+        var bob = CitizenId.Of(UserId.From("bob"));
+
+        var aliceConv = CreateConversation(Agent("a1"), "alice-conv");
+        aliceConv.Initiator = alice;
+        var bobConv = CreateConversation(Agent("a1"), "bob-conv");
+        bobConv.Initiator = bob;
+        var noInit = CreateConversation(Agent("a1"), "no-init");
+
+        await store.CreateAsync(aliceConv);
+        await store.CreateAsync(bobConv);
+        await store.CreateAsync(noInit);
+
+        var fresh = fixture.CreateStore();
+        var aliceList = await fresh.ListForCitizenAsync(alice);
+        aliceList.Select(c => c.ConversationId).ShouldBe(new[] { aliceConv.ConversationId }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_Agent_ReturnsUnion_OfInitiatedAndOwned()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var helper = Agent("helper");
+        var other = Agent("other");
+        var alice = CitizenId.Of(UserId.From("alice"));
+        var helperCitizen = CitizenId.Of(helper);
+
+        var owned = CreateConversation(helper, "owned-by-helper");
+        owned.Initiator = alice;
+        var initiatedByHelper = CreateConversation(other, "initiated-by-helper");
+        initiatedByHelper.Initiator = helperCitizen;
+        var unrelated = CreateConversation(other, "unrelated");
+        unrelated.Initiator = alice;
+
+        await store.CreateAsync(owned);
+        await store.CreateAsync(initiatedByHelper);
+        await store.CreateAsync(unrelated);
+
+        var fresh = fixture.CreateStore();
+        var list = await fresh.ListForCitizenAsync(helperCitizen);
+
+        list.Select(c => c.ConversationId).ShouldBe(
+            new[] { owned.ConversationId, initiatedByHelper.ConversationId },
+            ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_IncludesArchivedConversations()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var alice = CitizenId.Of(UserId.From("alice"));
+
+        var conv = CreateConversation(Agent("a1"), "archived");
+        conv.Initiator = alice;
+        await store.CreateAsync(conv);
+        await store.ArchiveAsync(conv.ConversationId);
+
+        var list = await fixture.CreateStore().ListForCitizenAsync(alice);
+        list.Count.ShouldBe(1);
+        list[0].Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    [Fact]
+    public async Task Migration_AddsInitiatorColumn_ToPreExistingDatabase_WithoutDataLoss()
+    {
+        // Seed a database with the schema as it existed before the initiator column was added
+        // (the canvas_html column was the prior-most migration). The store must add the column
+        // on first access and not lose any existing conversation rows.
+        using var fixture = new StoreFixture();
+
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var seed = connection.CreateCommand();
+            seed.CommandText = """
+                CREATE TABLE conversations (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    purpose TEXT,
+                    is_default INTEGER NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL DEFAULT 'Active',
+                    active_session_id TEXT,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    instructions TEXT,
+                    canvas_html TEXT
+                );
+
+                CREATE TABLE conversation_bindings (
+                    binding_id TEXT PRIMARY KEY,
+                    conversation_id TEXT NOT NULL,
+                    channel_type TEXT NOT NULL,
+                    channel_address TEXT NOT NULL,
+                    thread_id TEXT,
+                    mode TEXT NOT NULL DEFAULT 'Interactive',
+                    threading_mode TEXT NOT NULL DEFAULT 'Single',
+                    display_prefix TEXT,
+                    bound_at TEXT NOT NULL,
+                    last_inbound_at TEXT,
+                    last_outbound_at TEXT
+                );
+
+                INSERT INTO conversations (id, agent_id, title, status, metadata, created_at, updated_at)
+                VALUES ('legacy-1', 'agent-a', 'pre-migration', 'Active', '{}', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z');
+                """;
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        var store = fixture.CreateStore();
+        // First access triggers EnsureCreatedAsync -> EnsureInitiatorColumnAsync.
+        var loaded = await store.GetAsync(ConversationId.From("legacy-1"));
+
+        loaded.ShouldNotBeNull();
+        loaded!.Title.ShouldBe("pre-migration");
+        loaded.Initiator.ShouldBeNull();
+
+        // Save with an Initiator to prove the new column is writable + readable end-to-end.
+        var alice = CitizenId.Of(UserId.From("alice"));
+        loaded.Initiator = alice;
+        await store.SaveAsync(loaded);
+
+        var roundTrip = await fixture.CreateStore().GetAsync(ConversationId.From("legacy-1"));
+        roundTrip!.Initiator!.Value.ShouldBe(alice);
+    }
 
     private static string TempDb()
         => Path.Combine(Path.GetTempPath(), $"bn-conv-test-{Guid.NewGuid():N}.db");

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -389,5 +389,8 @@ public sealed class ConversationsControllerHistoryTests
 
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
             => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(BotNexus.Domain.World.CitizenId citizen, CancellationToken ct = default)
+            => throw new NotSupportedException();
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FanOutStaleBindingTests.cs
@@ -131,7 +131,7 @@ public sealed class FanOutStaleBindingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>(), It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
 
         // Return the stale binding for fan-out
@@ -199,7 +199,7 @@ public sealed class FanOutStaleBindingTests
         var convRouter = new Mock<IConversationRouter>();
         convRouter
             .Setup(r => r.ResolveInboundAsync(
-                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AgentId>(), It.IsAny<ChannelKey>(), It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(), It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>(), It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(new ConversationRoutingResult(conversation, SessionId.From(sessionId), false));
 
         // Empty list = already muted / no fan-out targets

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1780,7 +1780,8 @@ public sealed class GatewayHostTests
                 It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
                 It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(),
                 It.IsAny<string?>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<CancellationToken>(),
+                It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(new ConversationRoutingResult(routingConversation, BotNexus.Domain.Primitives.SessionId.From("session-1"), false));
         conversationRouter.Setup(r => r.GetOutboundBindingsAsync(
                 It.IsAny<BotNexus.Domain.Primitives.SessionId>(),
@@ -1871,7 +1872,8 @@ public sealed class GatewayHostTests
                 It.IsAny<BotNexus.Domain.Primitives.ChannelAddress>(),
                 It.IsAny<BotNexus.Domain.Primitives.ThreadId?>(),
                 It.IsAny<string?>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<CancellationToken>(),
+                It.IsAny<BotNexus.Domain.World.CitizenId?>()))
             .ReturnsAsync(new ConversationRoutingResult(routingConversation2, BotNexus.Domain.Primitives.SessionId.From("session-1"), false));
         conversationRouter.Setup(r => r.GetOutboundBindingsAsync(
                 It.IsAny<BotNexus.Domain.Primitives.SessionId>(),


### PR DESCRIPTION
Closes #529. Part of umbrella #523.

## What

Adds `Conversation.Initiator` (`CitizenId?`) — the **write-once provenance** of who first caused
a conversation to exist — and `IConversationStore.ListForCitizenAsync(CitizenId)` — the symmetric
"all conversations for a citizen" query (union of initiated + agent-owned).

Distinct from `Conversation.AgentId` (current owner): `Initiator` records who *started* the
conversation and is never overwritten — even when an archived conversation is re-opened or the
agent assignment changes.

## Why

Phase 2c (#528) put a typed `CitizenId Sender` on every inbound message resolution path. That
gives us, at long last, a trustworthy citizen identity at the moment the router creates a
conversation. Stamping it onto `Conversation.Initiator` makes the provenance queryable instead
of inferring it from session-participant joins after the fact. `ListForCitizenAsync` is the
first consumer.

## How

**Domain (b1d2c36f):**
- `Conversation.Initiator : CitizenId?` added — XML-documented as write-once provenance.
- `CitizenId.TryParse` added (mirrors the canonical `user:<id>` / `agent:<id>` format) for the
  SQLite deserialiser, which must tolerate parse failure without losing the row.

**Contracts (e543b29b):**
- `IConversationRouter.ResolveInboundAsync` gains a trailing `CitizenId? initiator = null` parameter
  (additive — existing call sites compile unchanged).
- `IConversationStore.ListForCitizenAsync(CitizenId)` declared; XML doc locks the union semantics
  so each backing store implements identical behaviour.

**Router + stores (f037e724):**
- `DefaultConversationRouter` stamps `Initiator` **only** on the create-new-conversation branch.
  Archived-reopen and explicit-ConversationId fast-path branches preserve the original — covered by
  dedicated tests.
- `InMemoryConversationStore`, `FileConversationStore`, `SqliteConversationStore` all implement
  `ListForCitizenAsync` with the union: `Initiator == citizen OR (citizen.IsAgent AND AgentId == citizen.AsAgent)`.
- SQLite: `EnsureInitiatorColumnAsync` migration (mirrors `EnsurePurposeColumnAsync` shape),
  `idx_conversations_initiator` index, column propagated through all four read/write paths
  (LOAD, INSERT, UPSERT, CloneConversation), `SerializeInitiator`/`DeserializeInitiator` helpers.

**Producers (90a80639):**
- `GatewayHost` + `DefaultConversationDispatcher`: forward `inbound.Sender` via the new arg.
- `ConversationTool.NewAsync` + `HeartbeatTrigger` + `CronTrigger`: stamp `Initiator = CitizenId.Of(agentId)`.
- `ConversationsController.Create`: explicitly leaves `Initiator = null` with a comment referencing #527.
  Without authenticated principals the controller has no trustworthy citizen to record.

**Tests (085a397a):**
- **4 router tests** — new-conv stamping, null-initiator passthrough, archived-reopen
  preservation, explicit-ConversationId preservation under a *different* sender.
- **5 InMemory store tests** — round-trip null/User/Agent; `ArgumentException` on `default(CitizenId)`;
  user-only and agent-union variants of `ListForCitizenAsync` with dedup; archived included.
- **5 SQLite store tests** — same shape, plus a **migration test** that seeds the pre-initiator
  schema directly via raw `SqliteConnection` and proves the column is added on first access with
  no data loss.
- Existing Moq stub stores patched for the new interface method (one stub: `StubConversationStore`
  in `ConversationsControllerHistoryTests.cs`).

**Docs (e97f9f25):**
- `docs/architecture/gateway-flow.md` — Diagram 2 annotated; new "Conversation.Initiator (provenance)"
  section explains the provenance-vs-ownership distinction, the union semantics, and the #527-pending
  REST `null` carve-out.
- `docs/development/message-flow.md` — Sender→Initiator paragraph added next to the two-field
  `SenderId`/`Sender` invariant.

## Verification

- `dotnet build BotNexus.slnx`: 0 warnings, 0 errors.
- `dotnet test BotNexus.slnx`: all projects green.
  - `BotNexus.Gateway.Conversations.Tests`: 100/100
  - `BotNexus.Gateway.Tests`: 1662/1662
  - `BotNexus.Domain.Tests`: 283/283
  - `BotNexus.Architecture.Tests`: 16/16
  - `BotNexus.Scenarios.Tests`: 18/18
  - No regressions anywhere; E2E and Conversation.Tests intentionally skipped (unchanged).

## Out of scope (deferred)

- Exposing `Initiator` on `ConversationResponse` DTO — no consumer needs it yet.
- Backfilling `Initiator` on archived-reopen from session participants — explicitly **NO**.
  Write-once at router only.
- REST `Initiator` stamping — blocked on #527 (SignalR/REST claims-based auth).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
