### PR TITLE
feat(gateway): convert compaction to mark-not-delete with SessionEntry.IsHistory (#531)

### DIFF
--- a/docs/development/llm-request-lifecycle.md
+++ b/docs/development/llm-request-lifecycle.md
@@ -141,20 +141,27 @@ Since the full timeline is sent every call, context grows with every turn. BotNe
 
 ### 1. Session Compaction (`LlmSessionCompactor`)
 
-When the estimated token count exceeds a threshold (default: 60% of context window), the compactor:
+When the estimated token count of the **LLM-visible** projection exceeds a threshold (default: 60% of context window), the compactor:
 
-1. **Splits** the history into old entries and recent entries (preserves last N user turns, default: 3)
-2. **Summarizes** the old entries using a cheaper model (e.g., `gpt-4.1-mini`) with a structured prompt requesting decisions, TODOs, constraints, and key identifiers
-3. **Replaces** the old entries with a single system message containing the summary
-4. Subsequent LLM calls send: system prompt + compaction summary + recent messages
+1. **Projects** the session history to the LLM-visible subset: everything that is not already historical (`SessionEntry.IsHistory == false`) and not a crash sentinel. Already-historical entries from earlier compactions are not re-summarised.
+2. **Splits** the visible portion into old entries and recent entries (preserves last N user turns, default: 3).
+3. **Summarises** the old entries using a cheaper model (e.g., `gpt-4.1-mini`) with a structured prompt requesting decisions, TODOs, constraints, and key identifiers.
+4. **Marks** every summarised entry with `IsHistory = true` and **inserts** the new summary entry at the historical→preserved boundary. The original turns remain in the session store for the full-fidelity transcript.
+5. Subsequent LLM calls send: system prompt + latest compaction summary + recent messages. Historical entries are excluded from the projection.
 
 ```text
-Before compaction:
-  [system prompt] + [msg1] + [msg2] + ... + [msg47] + [msg48]  → ~90K tokens
+Before compaction (stored history):
+  [u1] [a1] [u2] [a2] ... [u47] [a47] [u48] [a48]
 
-After compaction:
-  [system prompt] + [compaction summary] + [msg46] + [msg47] + [msg48]  → ~25K tokens
+After compaction (stored history — full transcript preserved):
+  [u1*] [a1*] ... [u45*] [a45*] [summary] [u46] [a46] [u47] [a47] [u48] [a48]
+  *IsHistory = true; excluded from LLM context but visible in the UI transcript
+
+After compaction (LLM-visible projection):
+  [system prompt] + [summary] + [u46] [a46] [u47] [a47] [u48] [a48]  → ~25K tokens
 ```
+
+On the next compaction cycle the previous `summary` entry is itself folded into the new summary and marked `IsHistory = true` — only the latest summary is ever sent to the LLM, but the chain of summaries (and every original turn) stays in the store.
 
 ### 2. Emergency Overflow Recovery
 

--- a/docs/development/session-stores.md
+++ b/docs/development/session-stores.md
@@ -132,7 +132,9 @@ CREATE TABLE IF NOT EXISTS session_history (
     timestamp TEXT,
     tool_name TEXT,
     tool_call_id TEXT,
-    is_compaction_summary INTEGER NOT NULL DEFAULT 0
+    is_compaction_summary INTEGER NOT NULL DEFAULT 0,
+    is_crash_sentinel INTEGER NOT NULL DEFAULT 0,
+    is_history INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
@@ -142,6 +144,18 @@ CREATE INDEX idx_sessions_created_at ON sessions(created_at);
 ```
 
 **Key behaviors:** Parameterized queries throughout, `INSERT OR REPLACE` for upserts, JSON serialization for complex fields (`participants_json`, `metadata`). Session history stored in the separate `session_history` table. Lazy schema initialization via `EnsureSchemaAsync`, and ISO 8601 date formatting.
+
+### History entry flags
+
+The `session_history` table stores the full transcript — *nothing is ever deleted by compaction*. Three boolean flags determine how the runtime interprets each entry:
+
+| Flag | Set when | Effect |
+| --- | --- | --- |
+| `is_compaction_summary` | Compactor inserts the synthetic summary entry that folds older turns | Sent to the LLM as a `system` message so the model still has the compressed context |
+| `is_crash_sentinel` | Gateway is mid-turn at shutdown and writes a placeholder so the next start can recover | Excluded from the LLM context projection and from any future summarisation prompt |
+| `is_history` | Compactor marks summarised entries — they remain in the store for the transcript but are hidden from the LLM | Excluded from the LLM context projection; not eligible for re-summarisation on later compaction cycles |
+
+On load, `SessionCompaction.ApplyLegacyHistoryProjection` collapses pre-Phase-3a databases forward — any session that has multiple `is_compaction_summary=true` rows with `is_history=false` (the old code applied a load-time slice to hide older summaries) gets all-but-latest summary flipped to `is_history=true` in memory, and the new state persists on the next save. The migration is idempotent.
 
 See [SqliteSessionStore.cs](../../src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs)
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -283,6 +283,16 @@ public sealed record SessionEntry
     /// Sentinels are removed on clean turn completion and must not be forwarded to the LLM.
     /// </summary>
     public bool IsCrashSentinel { get; init; }
+
+    /// <summary>
+    /// True if this entry has been folded into a later compaction summary and must NOT be
+    /// projected into LLM context. Historical entries remain in the session store for
+    /// transcript fidelity, replay, audit, and UI fold/collapse. Orthogonal to
+    /// <see cref="IsCompactionSummary"/>: a compaction summary itself becomes
+    /// <c>IsHistory = true</c> once a newer summary supersedes it, at which point only
+    /// the most recent summary stays LLM-visible.
+    /// </summary>
+    public bool IsHistory { get; init; }
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ChannelHistoryController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ChannelHistoryController.cs
@@ -119,7 +119,9 @@ public sealed class ChannelHistoryController : ControllerBase
                     entry.Timestamp,
                     EmptyMetadata,
                     entry.ToolName,
-                    entry.ToolCallId));
+                    entry.ToolCallId,
+                    entry.IsHistory,
+                    entry.IsCompactionSummary));
                 messageIndex++;
             }
         }
@@ -204,7 +206,11 @@ public sealed record ChannelHistoryResponse(
     IReadOnlyList<ChannelHistorySessionBoundary> SessionBoundaries);
 
 /// <summary>
-/// Channel history message payload.
+/// Channel history message payload. <paramref name="IsHistory"/> and
+/// <paramref name="IsCompactionSummary"/> are populated from the underlying
+/// <c>SessionEntry</c> flags so the UI can render historical (folded) ranges and
+/// compaction-summary markers distinctly from live turns. Both default to <c>false</c>
+/// for backward compatibility with consumers that ignore the new fields.
 /// </summary>
 public sealed record ChannelHistoryMessage(
     string Id,
@@ -214,7 +220,9 @@ public sealed record ChannelHistoryMessage(
     DateTimeOffset Timestamp,
     IReadOnlyDictionary<string, object?> Metadata,
     string? ToolName = null,
-    string? ToolCallId = null);
+    string? ToolCallId = null,
+    bool IsHistory = false,
+    bool IsCompactionSummary = false);
 
 /// <summary>
 /// Session boundary marker in a history page.

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionResult.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionResult.cs
@@ -18,20 +18,28 @@ public sealed record CompactionResult
     public bool Succeeded { get; init; }
 
     /// <summary>
-    /// The new session history to apply when <see cref="Succeeded"/> is true.
+    /// The new session history to apply when <see cref="Succeeded"/> is true. After Phase 3a
+    /// (#531) this contains the FULL original history with the summarised range marked
+    /// <c>IsHistory = true</c>, plus the new summary entry inserted at the historical→preserved
+    /// boundary, plus the preserved tail. The list grows on every cycle — historical fidelity
+    /// is preserved in the session store while only the LLM-visible projection shrinks.
     /// Null when <see cref="Succeeded"/> is false.
     /// </summary>
     public IReadOnlyList<SessionEntry>? CompactedHistory { get; init; }
 
-    /// <summary>Number of entries that were summarized (removed).</summary>
+    /// <summary>
+    /// Number of entries that were folded into the new summary and marked
+    /// <c>IsHistory = true</c>. They remain present in <see cref="CompactedHistory"/> for
+    /// transcript fidelity but are excluded from the LLM context projection.
+    /// </summary>
     public int EntriesSummarized { get; init; }
 
-    /// <summary>Number of entries preserved verbatim.</summary>
+    /// <summary>Number of entries preserved verbatim in the LLM-visible tail.</summary>
     public int EntriesPreserved { get; init; }
 
-    /// <summary>Approximate token count before compaction.</summary>
+    /// <summary>Approximate LLM-visible token count before compaction.</summary>
     public int TokensBefore { get; init; }
 
-    /// <summary>Approximate token count after compaction.</summary>
+    /// <summary>Approximate LLM-visible token count after compaction.</summary>
     public int TokensAfter { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -210,7 +210,10 @@ public sealed class FileSessionStore : SessionStoreBase
             cancellationToken).ConfigureAwait(false);
         if (entries.Count > 0)
         {
-            session.AddEntries(SessionCompaction.KeepFromLastCompaction(entries));
+            // Phase 3a (#531): preserve every entry; collapse pre-Phase-3a multi-summary
+            // state forward via SessionCompaction.ApplyLegacyHistoryProjection. The LLM-visible
+            // filter (IsHistory + IsCrashSentinel) is applied downstream by the projector.
+            session.AddEntries(SessionCompaction.ApplyLegacyHistoryProjection(entries));
             session.UpdatedAt = meta.UpdatedAt;
         }
 

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionCompaction.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionCompaction.cs
@@ -3,22 +3,44 @@ using BotNexus.Gateway.Abstractions.Models;
 namespace BotNexus.Gateway.Sessions;
 
 /// <summary>
-/// Represents session compaction.
+/// Helpers for projecting and migrating session history with respect to compaction state.
+/// After Phase 3a (#531) the canonical model is "preserve all entries in storage, mark older
+/// summarised entries with <see cref="SessionEntry.IsHistory"/> = true, project to the LLM
+/// elsewhere". This class owns the legacy-to-new forward migration applied at load time.
 /// </summary>
 public static class SessionCompaction
 {
     /// <summary>
-    /// Executes keep from last compaction.
+    /// Forward-migrates session histories written by the pre-Phase-3a compactor, which
+    /// produced multiple <see cref="SessionEntry.IsCompactionSummary"/> rows on disk all
+    /// with <see cref="SessionEntry.IsHistory"/> = false (the old code applied a load-time
+    /// slice to hide them from the runtime). Returns a new list where every summary except
+    /// the latest is marked <c>IsHistory = true</c>; non-summary entries are unchanged. The
+    /// projection is idempotent — running it on already-migrated history is a no-op because
+    /// older summaries are already <c>IsHistory = true</c> and are skipped.
     /// </summary>
-    /// <param name="entries">The entries.</param>
-    /// <returns>The keep from last compaction result.</returns>
-    public static IReadOnlyList<SessionEntry> KeepFromLastCompaction(IEnumerable<SessionEntry> entries)
+    /// <param name="entries">Raw entries loaded from the session store.</param>
+    /// <returns>A new list with legacy multi-summary state collapsed forward.</returns>
+    public static List<SessionEntry> ApplyLegacyHistoryProjection(IEnumerable<SessionEntry> entries)
     {
         var materialized = entries.ToList();
-        var lastCompactionIndex = materialized.FindLastIndex(static entry => entry.IsCompactionSummary);
-        if (lastCompactionIndex < 0)
+
+        var activeSummaries = new List<int>();
+        for (var i = 0; i < materialized.Count; i++)
+        {
+            if (materialized[i].IsCompactionSummary && !materialized[i].IsHistory)
+                activeSummaries.Add(i);
+        }
+
+        if (activeSummaries.Count <= 1)
             return materialized;
 
-        return materialized.GetRange(lastCompactionIndex, materialized.Count - lastCompactionIndex);
+        for (var i = 0; i < activeSummaries.Count - 1; i++)
+        {
+            var idx = activeSummaries[i];
+            materialized[idx] = materialized[idx] with { IsHistory = true };
+        }
+
+        return materialized;
     }
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -264,7 +264,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
                     tool_name TEXT,
                     tool_call_id TEXT,
                     is_compaction_summary INTEGER NOT NULL DEFAULT 0,
-                    is_crash_sentinel INTEGER NOT NULL DEFAULT 0
+                    is_crash_sentinel INTEGER NOT NULL DEFAULT 0,
+                    is_history INTEGER NOT NULL DEFAULT 0
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_session_history_session_id ON session_history(session_id);
@@ -297,7 +298,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
                      ("is_compaction_summary", "INTEGER NOT NULL DEFAULT 0"),
                      ("tool_args", "TEXT"),
                      ("tool_is_error", "INTEGER NOT NULL DEFAULT 0"),
-                     ("is_crash_sentinel", "INTEGER NOT NULL DEFAULT 0")
+                     ("is_crash_sentinel", "INTEGER NOT NULL DEFAULT 0"),
+                     ("is_history", "INTEGER NOT NULL DEFAULT 0")
                  })
         {
             try
@@ -487,7 +489,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
         await using var historyCommand = connection.CreateCommand();
         historyCommand.CommandText = """
-            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel
+            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history
             FROM session_history
             WHERE session_id = $sessionId
             ORDER BY id ASC
@@ -508,13 +510,17 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 IsCompactionSummary = !historyReader.IsDBNull(5) && historyReader.GetInt64(5) != 0,
                 ToolArgs = historyReader.FieldCount > 6 && !historyReader.IsDBNull(6) ? historyReader.GetString(6) : null,
                 ToolIsError = historyReader.FieldCount > 7 && !historyReader.IsDBNull(7) && historyReader.GetInt64(7) != 0,
-                IsCrashSentinel = historyReader.FieldCount > 8 && !historyReader.IsDBNull(8) && historyReader.GetInt64(8) != 0
+                IsCrashSentinel = historyReader.FieldCount > 8 && !historyReader.IsDBNull(8) && historyReader.GetInt64(8) != 0,
+                IsHistory = historyReader.FieldCount > 9 && !historyReader.IsDBNull(9) && historyReader.GetInt64(9) != 0
             });
         }
 
-        var lastCompactionIndex = entries.FindLastIndex(entry => entry.IsCompactionSummary);
-        if (lastCompactionIndex >= 0)
-            entries = entries.GetRange(lastCompactionIndex, entries.Count - lastCompactionIndex);
+        // Phase 3a (#531): the full transcript is preserved in storage; the LLM-visible
+        // projection is computed at runtime via IsHistory/IsCrashSentinel flags. Legacy
+        // pre-Phase-3a databases may contain multiple IsCompactionSummary rows all with
+        // IsHistory=false because the old code applied a load-time slice to hide them;
+        // collapse those forward so only the latest summary is LLM-visible after migration.
+        entries = SessionCompaction.ApplyLegacyHistoryProjection(entries);
 
         if (entries.Count > 0)
             session.AddEntries(entries);
@@ -571,8 +577,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
             await using var insertCommand = connection.CreateCommand();
             insertCommand.Transaction = transaction;
             insertCommand.CommandText = """
-                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel)
-                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError, $isCrashSentinel)
+                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history)
+                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError, $isCrashSentinel, $isHistory)
                 """;
             insertCommand.Parameters.AddWithValue("$sessionId", session.SessionId.Value);
             insertCommand.Parameters.AddWithValue("$role", entry.Role.Value);
@@ -584,6 +590,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
             insertCommand.Parameters.AddWithValue("$toolArgs", (object?)entry.ToolArgs ?? DBNull.Value);
             insertCommand.Parameters.AddWithValue("$toolIsError", entry.ToolIsError ? 1 : 0);
             insertCommand.Parameters.AddWithValue("$isCrashSentinel", entry.IsCrashSentinel ? 1 : 0);
+            insertCommand.Parameters.AddWithValue("$isHistory", entry.IsHistory ? 1 : 0);
             await insertCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -334,9 +334,14 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             // Tool-role entries are excluded: they become orphaned ToolResultMessages
             // (no matching tool_use in the preceding assistant message) which causes
             // LLM provider rejection. Regular system entries (IsCompactionSummary=false)
-            // are also excluded ΓÇö the agent's system prompt is set separately.
+            // are also excluded — the agent's system prompt is set separately.
+            // Phase 3a (#531): historical entries (IsHistory=true) are preserved in the
+            // session store for transcript fidelity but excluded from LLM context — that
+            // is what the summary entry replaces. Phase 3b will centralise this filter
+            // into a SessionContextProjector.
             initialMessages = context.History
                 .Where(e => !e.IsCrashSentinel
+                         && !e.IsHistory
                          && (e.Role == Domain.Primitives.MessageRole.User
                          || e.Role == Domain.Primitives.MessageRole.Assistant
                          || (e.Role == Domain.Primitives.MessageRole.System && e.IsCompactionSummary)))

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -32,7 +32,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
 
     public bool ShouldCompact(Session session, CompactionOptions options)
     {
-        var estimatedTokens = EstimateTokenCount(session);
+        var estimatedTokens = EstimateVisibleTokenCount(session);
         var threshold = (int)(options.ContextWindowTokens * options.TokenThresholdRatio);
         return estimatedTokens > threshold;
     }
@@ -56,7 +56,11 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             };
         }
 
-        var (toSummarize, toPreserve) = SplitHistory(history, options.PreservedTurns);
+        // Phase 3a: compaction operates on the "LLM-visible" projection only. Already-historical
+        // entries from prior compactions, and crash sentinels, are passed through verbatim and
+        // must never be re-summarised.
+        var visible = history.Where(IsVisibleToLlm).ToList();
+        var (toSummarize, toPreserve) = SplitHistory(visible, options.PreservedTurns);
         if (toSummarize.Count == 0)
         {
             return new CompactionResult
@@ -65,12 +69,12 @@ public sealed class LlmSessionCompactor : ISessionCompactor
                 Succeeded = false,
                 EntriesSummarized = 0,
                 EntriesPreserved = toPreserve.Count,
-                TokensBefore = EstimateTokenCount(session),
-                TokensAfter = EstimateTokenCount(session)
+                TokensBefore = EstimateVisibleTokenCount(session),
+                TokensAfter = EstimateVisibleTokenCount(session)
             };
         }
 
-        var tokensBefore = EstimateTokenCount(session);
+        var tokensBefore = EstimateVisibleTokenCount(session);
         var summaryPrompt = BuildSummarizationPrompt(toSummarize, options.MaxSummaryChars);
         var summary = await CallLlmForSummaryAsync(summaryPrompt, options, cancellationToken).ConfigureAwait(false);
 
@@ -79,7 +83,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         {
             _logger.LogWarning(
                 "Compaction aborted for session {SessionId}: LLM returned an empty summary. " +
-                "History is unchanged. Summarized {Count} entries would have been deleted.",
+                "History is unchanged. Summarized {Count} entries would have been marked as historical.",
                 session.SessionId,
                 toSummarize.Count);
 
@@ -111,16 +115,44 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             Timestamp = DateTimeOffset.UtcNow
         };
 
-        // Bug 4: do NOT assign session.History directly — return the new list so the caller
-        // can apply it via GatewaySession.ReplaceHistory() which routes through the runtime lock.
-        var newHistory = new List<SessionEntry> { compactionEntry };
-        newHistory.AddRange(toPreserve);
+        // Phase 3a: build the new history by walking the ORIGINAL history. Entries in toSummarize
+        // are marked IsHistory=true (folded); all other entries — pre-existing historical entries
+        // from prior compactions, crash sentinels, and the preserved tail — pass through verbatim.
+        // The new summary is inserted at the index immediately AFTER the last toSummarize entry's
+        // original position so chronological order is preserved for transcript readers.
+        var toSummarizeSet = new HashSet<SessionEntry>(toSummarize, ReferenceEqualityComparer.Instance);
+        var newHistory = new List<SessionEntry>(history.Count + 1);
+        var summaryInserted = false;
+        var summarizedSeen = 0;
+        for (var i = 0; i < history.Count; i++)
+        {
+            var entry = history[i];
+            if (toSummarizeSet.Contains(entry))
+            {
+                newHistory.Add(entry with { IsHistory = true });
+                summarizedSeen++;
+                if (summarizedSeen == toSummarize.Count && !summaryInserted)
+                {
+                    newHistory.Add(compactionEntry);
+                    summaryInserted = true;
+                }
+            }
+            else
+            {
+                newHistory.Add(entry);
+            }
+        }
 
-        var tokensAfter = EstimateTokenCountFromEntries(newHistory);
+        // Defensive: if for any reason the summary wasn't inserted (shouldn't happen — toSummarize
+        // comes from the iteration above) prepend it so it's still LLM-visible.
+        if (!summaryInserted)
+            newHistory.Insert(0, compactionEntry);
+
+        var tokensAfter = EstimateVisibleTokenCountFromEntries(newHistory);
 
         _logger.LogInformation(
-            "Compacted session {SessionId}: {Summarized} entries summarized, {Preserved} preserved, " +
-            "tokens {Before}→{After} (delta {Delta})",
+            "Compacted session {SessionId}: {Summarized} entries marked historical, {Preserved} preserved, " +
+            "tokens {Before}→{After} (delta {Delta}) — full history retained in store",
             session.SessionId,
             toSummarize.Count,
             toPreserve.Count,
@@ -139,6 +171,8 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             TokensAfter = tokensAfter
         };
     }
+
+    private static bool IsVisibleToLlm(SessionEntry entry) => !entry.IsHistory && !entry.IsCrashSentinel;
 
     private static (List<SessionEntry> toSummarize, List<SessionEntry> toPreserve) SplitHistory(
         IReadOnlyList<SessionEntry> history,
@@ -314,15 +348,19 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         return null;
     }
 
-    private static int EstimateTokenCount(Session session)
+    private static int EstimateVisibleTokenCount(Session session)
     {
-        var totalChars = session.History.Sum(entry => (long)(entry.Content?.Length ?? 0));
+        var totalChars = session.History
+            .Where(IsVisibleToLlm)
+            .Sum(entry => (long)(entry.Content?.Length ?? 0));
         return (int)Math.Min(totalChars / 4, int.MaxValue);
     }
 
-    private static int EstimateTokenCountFromEntries(IEnumerable<SessionEntry> entries)
+    private static int EstimateVisibleTokenCountFromEntries(IEnumerable<SessionEntry> entries)
     {
-        var totalChars = entries.Sum(entry => (long)(entry.Content?.Length ?? 0));
+        var totalChars = entries
+            .Where(IsVisibleToLlm)
+            .Sum(entry => (long)(entry.Content?.Length ?? 0));
         return (int)Math.Min(totalChars / 4, int.MaxValue);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Sessions.Tests/SessionPrimitivesTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Sessions.Tests/SessionPrimitivesTests.cs
@@ -56,20 +56,76 @@ public sealed class SessionPrimitivesTests
     }
 
     [Fact]
-    public void SessionCompaction_KeepFromLastCompaction_ReturnsSuffix()
+    public void SessionCompaction_ApplyLegacyHistoryProjection_NoSummaries_ReturnsUnchanged()
     {
         var entries = new[]
         {
             new SessionEntry { Role = MessageRole.User, Content = "one" },
-            new SessionEntry { Role = MessageRole.Assistant, Content = "summary", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.Assistant, Content = "two" }
+        };
+
+        var projected = SessionCompaction.ApplyLegacyHistoryProjection(entries);
+
+        projected.Count.ShouldBe(2);
+        projected.ShouldAllBe(e => !e.IsHistory);
+    }
+
+    [Fact]
+    public void SessionCompaction_ApplyLegacyHistoryProjection_SingleSummary_ReturnsUnchanged()
+    {
+        var entries = new[]
+        {
+            new SessionEntry { Role = MessageRole.User, Content = "one" },
+            new SessionEntry { Role = MessageRole.System, Content = "summary", IsCompactionSummary = true },
             new SessionEntry { Role = MessageRole.User, Content = "two" }
         };
 
-        var compacted = SessionCompaction.KeepFromLastCompaction(entries);
+        var projected = SessionCompaction.ApplyLegacyHistoryProjection(entries);
 
-        compacted.Count().ShouldBe(2);
-        compacted[0].IsCompactionSummary.ShouldBeTrue();
-        compacted[1].Content.ShouldBe("two");
+        projected.Count.ShouldBe(3);
+        projected.ShouldAllBe(e => !e.IsHistory);
+    }
+
+    [Fact]
+    public void SessionCompaction_ApplyLegacyHistoryProjection_MultipleSummaries_MarksAllButLatestAsHistory()
+    {
+        var entries = new[]
+        {
+            new SessionEntry { Role = MessageRole.User, Content = "before-1" },
+            new SessionEntry { Role = MessageRole.System, Content = "summary-1", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.User, Content = "between" },
+            new SessionEntry { Role = MessageRole.System, Content = "summary-2", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.Assistant, Content = "after" }
+        };
+
+        var projected = SessionCompaction.ApplyLegacyHistoryProjection(entries);
+
+        projected.Count.ShouldBe(5);
+        projected[0].IsHistory.ShouldBeFalse();
+        projected[1].IsCompactionSummary.ShouldBeTrue();
+        projected[1].IsHistory.ShouldBeTrue();
+        projected[2].IsHistory.ShouldBeFalse();
+        projected[3].IsCompactionSummary.ShouldBeTrue();
+        projected[3].IsHistory.ShouldBeFalse();
+        projected[4].IsHistory.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SessionCompaction_ApplyLegacyHistoryProjection_AlreadyMigrated_IsIdempotent()
+    {
+        var entries = new[]
+        {
+            new SessionEntry { Role = MessageRole.System, Content = "summary-1", IsCompactionSummary = true, IsHistory = true },
+            new SessionEntry { Role = MessageRole.User, Content = "between" },
+            new SessionEntry { Role = MessageRole.System, Content = "summary-2", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.User, Content = "after" }
+        };
+
+        var projected = SessionCompaction.ApplyLegacyHistoryProjection(entries);
+
+        projected.Count.ShouldBe(4);
+        projected[0].IsHistory.ShouldBeTrue();
+        projected[2].IsHistory.ShouldBeFalse();
     }
 
     private sealed record TestMetadata(string SessionId, string AgentId, DateTimeOffset UpdatedAt);

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
@@ -56,14 +56,14 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
 
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("compaction-persist"));
 
+        // Phase 3a (#531): full transcript preserved; single active summary stays LLM-visible.
         reloaded.ShouldNotBeNull();
-        reloaded!.History.Count().ShouldBe(11);
-        reloaded.History[0].IsCompactionSummary.ShouldBeTrue();
-        reloaded.History[0].Content.ShouldBe("compaction-summary");
+        reloaded!.History.Count.ShouldBe(21);
+        reloaded.History.Single(e => e.IsCompactionSummary).Content.ShouldBe("compaction-summary");
     }
 
     [Fact]
-    public async Task MultipleCompactions_OnlyLastSummaryKept()
+    public async Task MultipleCompactions_OnlyLatestSummaryRemainsLlmVisible()
     {
         using var fixture = new MockFileStoreFixture();
         var store = fixture.CreateStore();
@@ -84,10 +84,12 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         await store.SaveAsync(session);
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("multi-compaction"));
 
+        // Phase 3a (#531): legacy multi-summary state is forward-migrated — all-but-latest summary marked IsHistory.
         reloaded.ShouldNotBeNull();
-        reloaded!.History.Select(entry => entry.Content)
-            .ShouldBe(new[] { "summary-2", "tail-1", "tail-2" }, ignoreOrder: false);
-        reloaded.History.Count().ShouldBe(3);
+        reloaded!.History.Count.ShouldBe(8);
+        reloaded.History.Single(e => e.Content == "summary-1").IsHistory.ShouldBeTrue();
+        reloaded.History.Single(e => e.Content == "summary-2").IsHistory.ShouldBeFalse();
+        reloaded.History.Single(e => e.Content == "summary-2").IsCompactionSummary.ShouldBeTrue();
     }
 
     [Fact]
@@ -145,10 +147,10 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         await store.SaveAsync(session);
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("sqlite-compaction"));
 
+        // Phase 3a (#531): full transcript preserved through SQLite roundtrip.
         reloaded.ShouldNotBeNull();
-        reloaded!.History.Count().ShouldBe(11);
-        reloaded.History[0].IsCompactionSummary.ShouldBeTrue();
-        reloaded.History[0].Content.ShouldBe("sqlite-summary");
+        reloaded!.History.Count.ShouldBe(21);
+        reloaded.History.Single(e => e.IsCompactionSummary).Content.ShouldBe("sqlite-summary");
     }
 
     [Fact]
@@ -175,13 +177,14 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         session.ReplaceHistory(result.CompactedHistory!);
 
         var history = session.GetHistorySnapshot();
-        history.Count().ShouldBe(7);
-        history[0].IsCompactionSummary.ShouldBeTrue();
-        history.Skip(1).Select(entry => entry.Content)
+        // Phase 3a (#531): original 20 entries preserved + 1 summary appended at boundary = 21 total.
+        history.Count.ShouldBe(21);
+        // Summarised entries (14) marked historical, then summary, then 6 preserved.
+        history.Take(14).ShouldAllBe(e => e.IsHistory);
+        history[14].IsCompactionSummary.ShouldBeTrue();
+        history[14].IsHistory.ShouldBeFalse();
+        history.Skip(15).Select(entry => entry.Content)
             .ShouldBe(new[] { "user-8", "assistant-8", "user-9", "assistant-9", "user-10", "assistant-10" }, ignoreOrder: false);
-
-        history.Skip(1).Select(entry => entry.Content)
-            .ShouldBe(originalEntries.Skip(14).Select(entry => entry.Content));
     }
 
     [Fact]
@@ -209,8 +212,9 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         result.CompactedHistory.ShouldNotBeNull();
         session.ReplaceHistory(result.CompactedHistory!);
 
+        // Phase 3a (#531): summarised entries preserved as historical; summary at boundary; preserved tail after.
         session.GetHistorySnapshot().Select(entry => entry.Content)
-            .ShouldBe(new[] { "tool-summary", "u2", "a2", "tool-call", "tool-result" }, ignoreOrder: false);
+            .ShouldBe(new[] { "u1", "a1", "tool-summary", "u2", "a2", "tool-call", "tool-result" }, ignoreOrder: false);
     }
 
     [Fact]
@@ -239,8 +243,76 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u3" });
         session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a3" });
 
+        // Phase 3a (#531): full transcript including newly-historical entries remains coherent.
         session.GetHistorySnapshot().Select(entry => entry.Content)
-            .ShouldBe(new[] { "coherent-summary", "u2", "a2", "u3", "a3" }, ignoreOrder: false);
+            .ShouldBe(new[] { "u1", "a1", "coherent-summary", "u2", "a2", "u3", "a3" }, ignoreOrder: false);
+    }
+
+    [Fact]
+    public async Task MultiCycleCompaction_PreservesAllOriginalTurns_InStore()
+    {
+        // Phase 3a (#531): the canonical promise. After N compaction cycles every
+        // originally-inserted turn must still exist in the session store — only the
+        // LLM-visible projection shrinks via IsHistory marking.
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("multi-cycle"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+
+        var insertedContents = new List<string>();
+        for (var i = 1; i <= 4; i++)
+        {
+            var u = $"cycle0-u{i}";
+            var a = $"cycle0-a{i}";
+            session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = u });
+            session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = a });
+            insertedContents.Add(u);
+            insertedContents.Add(a);
+        }
+
+        // Cycle 1.
+        var compactor1 = CreateCompactor("summary-c1");
+        var result1 = await compactor1.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+        result1.Succeeded.ShouldBeTrue();
+        session.ReplaceHistory(result1.CompactedHistory!);
+
+        // Add more turns to drive cycle 2.
+        for (var i = 1; i <= 4; i++)
+        {
+            var u = $"cycle1-u{i}";
+            var a = $"cycle1-a{i}";
+            session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = u });
+            session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = a });
+            insertedContents.Add(u);
+            insertedContents.Add(a);
+        }
+
+        // Cycle 2.
+        var compactor2 = CreateCompactor("summary-c2");
+        var result2 = await compactor2.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+        result2.Succeeded.ShouldBeTrue();
+        session.ReplaceHistory(result2.CompactedHistory!);
+
+        var snapshot = session.GetHistorySnapshot();
+
+        // Every originally-inserted turn is still present.
+        foreach (var content in insertedContents)
+            snapshot.Select(e => e.Content).ShouldContain(content,
+                $"original turn '{content}' must survive across compaction cycles");
+
+        // Two summaries on disk; older one is historical.
+        snapshot.Single(e => e.Content == "summary-c1").IsHistory.ShouldBeTrue();
+        snapshot.Single(e => e.Content == "summary-c2").IsHistory.ShouldBeFalse();
+        snapshot.Single(e => e.Content == "summary-c2").IsCompactionSummary.ShouldBeTrue();
     }
 
     [Fact]
@@ -384,8 +456,9 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         }
 
         history.Count(entry => entry.IsCompactionSummary).ShouldBeLessThanOrEqualTo(1);
+        // Phase 3a (#531): summary no longer sits at index 0; check it exists and is not marked historical.
         if (history.Any(entry => entry.IsCompactionSummary))
-            history.First().IsCompactionSummary.ShouldBeTrue();
+            history.Single(entry => entry.IsCompactionSummary).IsHistory.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/CompactionModelTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/CompactionModelTests.cs
@@ -83,7 +83,54 @@ public sealed class CompactionModelTests
     }
 
     [Fact]
-    public async Task FileSessionStore_LoadWithCompactionEntry_SkipsBefore()
+    public void SessionEntry_IsHistory_DefaultFalse()
+    {
+        var entry = new SessionEntry { Role = MessageRole.User, Content = "hello" };
+
+        entry.IsHistory.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SessionEntry_IsHistory_SerializesCorrectly()
+    {
+        var original = new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "historicized",
+            IsHistory = true
+        };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var roundTrip = JsonSerializer.Deserialize<SessionEntry>(json, JsonOptions);
+
+        roundTrip.ShouldNotBeNull();
+        roundTrip!.IsHistory.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SessionEntry_IsHistory_OrthogonalTo_IsCompactionSummary()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.System,
+            Content = "old summary folded into newer one",
+            IsCompactionSummary = true,
+            IsHistory = true
+        };
+
+        entry.IsCompactionSummary.ShouldBeTrue();
+        entry.IsHistory.ShouldBeTrue();
+
+        var json = JsonSerializer.Serialize(entry, JsonOptions);
+        var roundTrip = JsonSerializer.Deserialize<SessionEntry>(json, JsonOptions);
+
+        roundTrip.ShouldNotBeNull();
+        roundTrip!.IsCompactionSummary.ShouldBeTrue();
+        roundTrip.IsHistory.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task FileSessionStore_LoadWithCompactionEntry_PreservesAllEntries()
     {
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
@@ -98,13 +145,16 @@ public sealed class CompactionModelTests
 
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s1"));
 
+        // Phase 3a (#531): the full transcript is preserved in storage. With a single
+        // active summary, no legacy projection is applied.
         reloaded.ShouldNotBeNull();
         reloaded!.GetHistorySnapshot().Select(entry => entry.Content)
-            .ShouldBe(new[] { "summary", "after-1" }, ignoreOrder: false);
+            .ShouldBe(new[] { "before-1", "before-2", "summary", "after-1" }, ignoreOrder: false);
+        reloaded.GetHistorySnapshot().ShouldAllBe(e => !e.IsHistory);
     }
 
     [Fact]
-    public async Task FileSessionStore_LoadWithMultipleCompactions_UsesLastOne()
+    public async Task FileSessionStore_LoadWithMultipleCompactions_MarksOlderSummariesAsHistory()
     {
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
@@ -120,9 +170,13 @@ public sealed class CompactionModelTests
 
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s1"));
 
+        // Phase 3a (#531): legacy multi-summary state migrates forward — all-but-latest summary marked IsHistory.
         reloaded.ShouldNotBeNull();
-        reloaded!.GetHistorySnapshot().Select(entry => entry.Content)
-            .ShouldBe(new[] { "summary-2", "after" }, ignoreOrder: false);
+        var snapshot = reloaded!.GetHistorySnapshot();
+        snapshot.Select(entry => entry.Content).ShouldBe(
+            new[] { "before-1", "summary-1", "between", "summary-2", "after" }, ignoreOrder: false);
+        snapshot.Single(e => e.Content == "summary-1").IsHistory.ShouldBeTrue();
+        snapshot.Single(e => e.Content == "summary-2").IsHistory.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -70,8 +70,12 @@ public sealed class LlmSessionCompactorTests
         result.CompactedHistory.ShouldNotBeNull();
         session.ReplaceHistory(result.CompactedHistory!);
 
+        // Phase 3a (#531): summarised entries are kept in the session store with IsHistory=true,
+        // the summary entry sits at the boundary, then the preserved tail follows.
         session.GetHistorySnapshot().Select(entry => entry.Content).ToList().ShouldBe(
-            new[] { "summary-u1", "u2", "a2", "t2", "u3", "a3" }, ignoreOrder: false);
+            new[] { "u1", "a1", "t1", "summary-u1", "u2", "a2", "t2", "u3", "a3" }, ignoreOrder: false);
+        session.GetHistorySnapshot().Take(3).ShouldAllBe(e => e.IsHistory);
+        session.GetHistorySnapshot().Skip(3).ShouldAllBe(e => !e.IsHistory);
     }
 
     [Fact]
@@ -98,7 +102,11 @@ public sealed class LlmSessionCompactorTests
         session.ReplaceHistory(result.CompactedHistory!);
 
         session.GetHistorySnapshot().Select(entry => entry.Content)
-            .ToList().ShouldBe(new[] { "structured summary", "recent", "recent-response" }, ignoreOrder: false);
+            .ToList().ShouldBe(new[] { "older", "older-response", "structured summary", "recent", "recent-response" }, ignoreOrder: false);
+        session.GetHistorySnapshot()[0].IsHistory.ShouldBeTrue();
+        session.GetHistorySnapshot()[1].IsHistory.ShouldBeTrue();
+        session.GetHistorySnapshot()[2].IsCompactionSummary.ShouldBeTrue();
+        session.GetHistorySnapshot()[2].IsHistory.ShouldBeFalse();
     }
 
     [Fact]
@@ -161,9 +169,12 @@ public sealed class LlmSessionCompactorTests
         result.CompactedHistory.ShouldNotBeNull();
         session.ReplaceHistory(result.CompactedHistory!);
 
-        var summaryEntry = session.GetHistorySnapshot().First();
+        // Phase 3a (#531): summary entry now sits at the historical→preserved boundary, not at index 0.
+        var summaryEntry = session.GetHistorySnapshot().Single(e => e.IsCompactionSummary);
         summaryEntry.Role.ShouldBe(MessageRole.System);
         summaryEntry.IsCompactionSummary.ShouldBeTrue();
+        summaryEntry.IsHistory.ShouldBeFalse();
+        summaryEntry.Content.ShouldBe("compacted");
     }
 
     [Fact]
@@ -187,7 +198,7 @@ public sealed class LlmSessionCompactorTests
         result.Summary.Length.ShouldBe(40);
 
         session.ReplaceHistory(result.CompactedHistory!);
-        session.GetHistorySnapshot().First().Content.Length.ShouldBe(40);
+        session.GetHistorySnapshot().Single(e => e.IsCompactionSummary).Content.Length.ShouldBe(40);
     }
 
     /// <summary>
@@ -355,5 +366,176 @@ public sealed class LlmSessionCompactorTests
         var options = new CompactionOptions { ContextWindowTokens = 1200, TokenThresholdRatio = 1.0 };
         // 1200 chars / 4 = 300 tokens; threshold = 1200 * 1.0 = 1200; 300 > 1200 = false
         compactor.ShouldCompact(session.Session, options).ShouldBeFalse();
+    }
+
+    // ─── Phase 3a (#531): mark-not-delete behaviour ─────────────────────────────
+
+    [Fact]
+    public async Task CompactAsync_KeepsSummarisedEntries_WithIsHistoryTrue()
+    {
+        var session = CreateSession(
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("user", "u2"),
+            ("assistant", "a2"));
+        var compactor = CreateCompactor("summary");
+        var originalCount = session.GetHistorySnapshot().Count;
+
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        result.CompactedHistory!.Count.ShouldBe(originalCount + 1,
+            "every original entry must remain in the store; only the summary is appended");
+
+        var historyEntries = result.CompactedHistory.Where(e => e.IsHistory).ToList();
+        historyEntries.Count.ShouldBe(2);
+        historyEntries.Select(e => e.Content).ShouldBe(new[] { "u1", "a1" });
+    }
+
+    [Fact]
+    public async Task CompactAsync_OldSummary_BecomesIsHistory_OnNextCompaction()
+    {
+        // Cycle 1: produce a summary at index 2 (after u1,a1 are marked historical)
+        var session = CreateSession(
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("user", "u2"),
+            ("assistant", "a2"));
+        var compactor = CreateCompactor("summary-1");
+
+        var result1 = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+        session.ReplaceHistory(result1.CompactedHistory!);
+
+        // Add more turns
+        session.AddEntries(new[]
+        {
+            new SessionEntry { Role = MessageRole.User, Content = "u3" },
+            new SessionEntry { Role = MessageRole.Assistant, Content = "a3" }
+        });
+
+        // Cycle 2: summary-1 is now LLM-visible (IsHistory=false). It must be folded into summary-2 and marked historical.
+        var compactor2 = CreateCompactor("summary-2");
+        var result2 = await compactor2.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result2.Succeeded.ShouldBeTrue();
+        session.ReplaceHistory(result2.CompactedHistory!);
+
+        var snapshot = session.GetHistorySnapshot();
+        snapshot.Where(e => e.Content == "summary-1").Single().IsHistory.ShouldBeTrue();
+        snapshot.Where(e => e.Content == "summary-2").Single().IsHistory.ShouldBeFalse();
+        // u1/a1/u2/a2 all preserved
+        snapshot.Select(e => e.Content).ShouldContain("u1");
+        snapshot.Select(e => e.Content).ShouldContain("a1");
+        snapshot.Select(e => e.Content).ShouldContain("u2");
+        snapshot.Select(e => e.Content).ShouldContain("a2");
+    }
+
+    [Fact]
+    public async Task CompactAsync_AlreadyHistoricalEntries_NotReSummarised()
+    {
+        var session = CreateSession(
+            ("user", "u1"),
+            ("assistant", "a1"));
+        // Mark u1/a1 as historical to simulate post-cycle-1 state
+        var snapshotEntries = session.GetHistorySnapshot()
+            .Select(e => e with { IsHistory = true })
+            .Concat(new[]
+            {
+                new SessionEntry { Role = MessageRole.User, Content = "u2" },
+                new SessionEntry { Role = MessageRole.Assistant, Content = "a2" },
+                new SessionEntry { Role = MessageRole.User, Content = "u3" },
+                new SessionEntry { Role = MessageRole.Assistant, Content = "a3" }
+            })
+            .ToList();
+        session.ReplaceHistory(snapshotEntries);
+
+        var compactor = CreateCompactor("summary");
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeTrue();
+        // The already-historical u1/a1 must remain IsHistory=true and not be folded again.
+        // Only u2/a2 should be newly marked historical (PreservedTurns=1 keeps the u3/a3 turn).
+        result.EntriesSummarized.ShouldBe(2, "only u2/a2 are newly summarised — u1/a1 were already historical");
+
+        var newHistory = result.CompactedHistory!;
+        newHistory.Single(e => e.Content == "u1").IsHistory.ShouldBeTrue();
+        newHistory.Single(e => e.Content == "a1").IsHistory.ShouldBeTrue();
+        newHistory.Single(e => e.Content == "u2").IsHistory.ShouldBeTrue();
+        newHistory.Single(e => e.Content == "a2").IsHistory.ShouldBeTrue();
+        newHistory.Single(e => e.Content == "u3").IsHistory.ShouldBeFalse();
+        newHistory.Single(e => e.Content == "a3").IsHistory.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CompactAsync_CrashSentinels_ExcludedFromSummarisationPrompt()
+    {
+        var session = CreateSession(
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("user", "u2"),
+            ("assistant", "a2"));
+
+        // Insert a crash sentinel in the middle to simulate a survived gateway restart.
+        var entries = session.GetHistorySnapshot().ToList();
+        entries.Insert(2, new SessionEntry
+        {
+            Role = MessageRole.System,
+            Content = "[agent turn in progress — gateway restarted]",
+            IsCrashSentinel = true
+        });
+        session.ReplaceHistory(entries);
+
+        var compactor = CreateCompactor("summary");
+        var result = await compactor.CompactAsync(session.Session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeTrue();
+        // Crash sentinel must remain present in the store, unchanged, never marked IsHistory.
+        var newHistory = result.CompactedHistory!;
+        var sentinel = newHistory.Single(e => e.IsCrashSentinel);
+        sentinel.IsHistory.ShouldBeFalse();
+        // u1/a1 are summarised, marked IsHistory; sentinel and the preserved u2/a2 turn remain LLM-visible.
+        result.EntriesSummarized.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ShouldCompact_OnlyCountsLlmVisibleEntries_HistoricalEntriesExcluded()
+    {
+        // Massive historical entries should NOT trigger compaction — they're hidden from the LLM.
+        var session = CreateSession(("user", "tiny"));
+        var entries = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = new string('a', 1_000_000), IsHistory = true },
+            new() { Role = MessageRole.Assistant, Content = new string('b', 1_000_000), IsHistory = true },
+            new() { Role = MessageRole.System, Content = "summary", IsCompactionSummary = true },
+            new() { Role = MessageRole.User, Content = "tiny" }
+        };
+        session.ReplaceHistory(entries);
+
+        var compactor = CreateCompactor("summary");
+        var options = new CompactionOptions { ContextWindowTokens = 100_000, TokenThresholdRatio = 0.5 };
+
+        compactor.ShouldCompact(session.Session, options).ShouldBeFalse(
+            "historical entries must not contribute to the token budget");
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -300,6 +300,7 @@ public sealed class SqliteSessionStoreTests
             columns.Add(columnReader.GetString(1));
 
         columns.ShouldContain("is_compaction_summary");
+        columns.ShouldContain("is_history");
     }
 
     [Fact]
@@ -350,6 +351,63 @@ public sealed class SqliteSessionStoreTests
             columns.Add(columnReader.GetString(1));
 
         columns.ShouldContain("is_compaction_summary");
+        // Phase 3a (#531): legacy DBs must gain the new is_history column on first open.
+        columns.ShouldContain("is_history");
+    }
+
+    [Fact]
+    public async Task GetAsync_PreservesIsHistoryFlag_AcrossRoundTrip()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync(SessionId.From("history-roundtrip"), AgentId.From("agent-a"));
+        session.AddEntries(new[]
+        {
+            new SessionEntry { Role = MessageRole.User, Content = "old-user", IsHistory = true },
+            new SessionEntry { Role = MessageRole.Assistant, Content = "old-assistant", IsHistory = true },
+            new SessionEntry { Role = MessageRole.System, Content = "summary", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.User, Content = "fresh" }
+        });
+        await store.SaveAsync(session);
+
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("history-roundtrip"));
+
+        reloaded.ShouldNotBeNull();
+        var snapshot = reloaded!.GetHistorySnapshot();
+        snapshot.Count.ShouldBe(4);
+        snapshot.Single(e => e.Content == "old-user").IsHistory.ShouldBeTrue();
+        snapshot.Single(e => e.Content == "old-assistant").IsHistory.ShouldBeTrue();
+        snapshot.Single(e => e.Content == "summary").IsHistory.ShouldBeFalse();
+        snapshot.Single(e => e.Content == "summary").IsCompactionSummary.ShouldBeTrue();
+        snapshot.Single(e => e.Content == "fresh").IsHistory.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetAsync_LegacyMultipleSummaries_ForwardMigratesAllButLatest()
+    {
+        // Phase 3a (#531): legacy DBs with multiple IsCompactionSummary rows and IsHistory=false
+        // (because the old code applied a load-time slice) must forward-migrate on load —
+        // all-but-latest summary marked IsHistory=true.
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var session = await store.GetOrCreateAsync(SessionId.From("legacy-multi"), AgentId.From("agent-a"));
+        session.AddEntries(new[]
+        {
+            new SessionEntry { Role = MessageRole.User, Content = "before-1" },
+            new SessionEntry { Role = MessageRole.System, Content = "summary-1", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.User, Content = "middle" },
+            new SessionEntry { Role = MessageRole.System, Content = "summary-2", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.User, Content = "after" }
+        });
+        await store.SaveAsync(session);
+
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("legacy-multi"));
+
+        reloaded.ShouldNotBeNull();
+        var snapshot = reloaded!.GetHistorySnapshot();
+        snapshot.Count.ShouldBe(5);
+        snapshot.Single(e => e.Content == "summary-1").IsHistory.ShouldBeTrue();
+        snapshot.Single(e => e.Content == "summary-2").IsHistory.ShouldBeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## What

Phase 3a of the domain-model refactor (umbrella #523). Converts in-session compaction from **delete-and-summarise** to **mark-as-history**: summarised turns stay in the session store for the full transcript and are excluded from the LLM context projection.

> Closes #531. Refs umbrella #523. Defers concurrency race to #532.

## Why

Before this PR, `LlmSessionCompactor.CompactAsync` discarded summarised entries entirely. The user-facing transcript lost them, the session store lost them, only the LLM-facing prompt benefited. The intended model is the opposite (see plan §4 Phase 3a / F-2a): preserve the full history in the store, hide only from the LLM. This is the standard "context-engineering" mark-not-delete pattern used by Claude Code's `/compact` and Codex auto-compaction (see plan §7).

## How

### Domain
- `SessionEntry.IsHistory` (`bool`, defaults to `false`).

### Compactor (`LlmSessionCompactor`)
- New `IsVisibleToLlm` predicate: `!IsHistory && !IsCrashSentinel`.
- `ShouldCompact` and the budget calculation now use `EstimateVisibleTokenCount` / `EstimateVisibleTokenCountFromEntries` so already-historical entries do not push the compactor into a no-op loop.
- `CompactAsync` algorithm:
  ```
  visible = history.Where(IsVisibleToLlm)
  (toSummarize, toPreserve) = SplitHistory(visible, preservedTurns)
  newHistory = []
  for each entry in original history:
      if toSummarize contains entry → emit (entry with IsHistory = true)
          if last toSummarize → also emit summaryEntry
      else → emit entry verbatim
  ```
- Result shape: `[historical..., summary, preserved tail]` where the historical prefix may include pre-existing `IsHistory=true` entries, prior summaries that become historical, and crash sentinels passing through unchanged.
- `EntriesSummarized` now means "entries newly marked as historical in this cycle".

### Persistence
- SQLite `session_history` gains `is_history INTEGER NOT NULL DEFAULT 0` with a non-destructive `ALTER TABLE` migration. Reader, writer, and schema bootstrap all flow `IsHistory` end-to-end.
- `SessionCompaction.KeepFromLastCompaction` (the load-time slice that silently dropped older summaries) is replaced by `ApplyLegacyHistoryProjection` — an **idempotent forward migration** that marks all-but-latest active summary as `IsHistory=true` in memory. Both file and SQLite stores invoke it on load; legacy databases converge to the new shape on the next save without any explicit migration script.

### Isolation
- `InProcessIsolationStrategy` filter gains `!e.IsHistory &&` alongside the existing `!IsCrashSentinel` guard. A follow-up phase (3b) will centralise this in a shared `SessionContextProjector` so all isolation strategies (in-process, sandbox, container, remote) share one projection.

### Channel-history API
- `ChannelHistoryMessage` record gains two optional positional fields `IsHistory = false, IsCompactionSummary = false`. The controller mapper populates them. Optional positional record params with defaults are source-compatible for keyword construction; existing positional call sites stop at `ToolCallId` so no downstream code breaks.

### Docs
- `docs/development/llm-request-lifecycle.md` rewrites the compaction section for the visible-projection model + multi-cycle behaviour.
- `docs/development/session-stores.md` updates the SQLite schema, adds a "history entry flags" table, and explains the lazy `ApplyLegacyHistoryProjection` forward migration.

## Tests

Build clean (0 warnings, 0 errors). Full solution test run green:

| Project | Tests | Result |
| --- | --- | --- |
| `BotNexus.Domain.Tests` | 283 | ✅ |
| `BotNexus.Gateway.Tests` | **1673** (+11) | ✅ |
| `BotNexus.Gateway.Sessions.Tests` | 7 (3 net-new after replacing the dropped slice test) | ✅ |
| `BotNexus.Gateway.Conversations.Tests` | 100 | ✅ |
| `BotNexus.Architecture.Tests` | 16 | ✅ |
| `BotNexus.Scenarios.Tests` | 18 | ✅ |
| All others | unchanged | ✅ |

**New tests** (11 in Gateway.Tests, 3 in Gateway.Sessions.Tests, 2 in CompactionModelTests, 2 in SqliteSessionStoreTests, 1 multi-cycle integration):

- `SessionEntry.IsHistory_*` (×3) — default/`with`/serialisation.
- `SessionCompaction.ApplyLegacyHistoryProjection_*` (×4) — 0/1/N-summary + idempotency.
- `LlmSessionCompactor_*KeepsSummarisedEntries_WithIsHistoryTrue`, `_OldSummary_BecomesIsHistory_OnNextCompaction`, `_AlreadyHistoricalEntries_NotReSummarised`, `_CrashSentinels_ExcludedFromSummarisationPrompt`, `ShouldCompact_OnlyCountsLlmVisibleEntries_HistoricalEntriesExcluded`.
- `SqliteSessionStore_GetAsync_PreservesIsHistoryFlag_AcrossRoundTrip`, `_LegacyMultipleSummaries_ForwardMigratesAllButLatest`.
- `MultiCycleCompaction_PreservesAllOriginalTurns_InStore`.

**Existing tests updated** for new ordering (preserved + extended assertions, none net-deleted): `PreservesRecentTurns`, `SummarizesOlderEntries`, `SetsIsCompactionSummaryFlag`, `TruncatesSummaryIfTooLong`, `CompactedSession_PersistsAcrossStoreRecreation`, `MultipleCompactions_OnlyLatestSummaryRemainsLlmVisible` (renamed), `CompactedSession_SqliteStore_SameLoadBehavior`, `LlmSessionCompactor_SplitHistory_PreservesExactTurns`, `LlmSessionCompactor_WithToolEntries_GroupsCorrectly`, `CompactThenSendMessage_HistoryIsCoherent`, `CompactAsync_ConcurrentAccess_NoCorruption`.

## Backwards compatibility

- **Schema**: `ALTER TABLE` adds `is_history` non-destructively, defaulting to `0` for existing rows.
- **Shape convergence**: pre-Phase-3a databases with multiple active summary entries collapse to the new shape lazily at load. Idempotent — running the projection twice has no further effect.
- **DTO**: optional positional record fields with defaults; no compile breaks anywhere.
- **No data loss on rollback**: the previous code only ever wrote `is_history = false`, so a downgrade would simply ignore the column.

## Out of scope (deferred)

- **#532** — concurrency race in `CompactAsync`: snapshot history → await LLM → return new list → caller `ReplaceHistory` under lock. Any `AddEntry` between snapshot and apply is dropped. Pre-existing; tracked separately.
- **Phase 3b** — centralise the LLM-context projection in a shared `SessionContextProjector` so all isolation strategies share one filter. This PR keeps the one-line filter change next to the existing projection in `InProcessIsolationStrategy`.
- **Phase 3c** — REST `/reset` memory-flush parity with the SignalR path (F-2c).
- **Phase 3d** — delete the `systemPromptInitialized` metadata gate.

---

Plan §4 Phase 3a — see [docs/architecture/domain-model.md](https://github.com/sytone/botnexus/blob/main/docs/architecture/domain-model.md) (the canonical refactor plan tracked in this repo).
