### PR TITLE
refactor(gateway): centralise LLM-visible session-history projection (#534)

### DIFF
--- a/docs/development/llm-request-lifecycle.md
+++ b/docs/development/llm-request-lifecycle.md
@@ -163,6 +163,15 @@ After compaction (LLM-visible projection):
 
 On the next compaction cycle the previous `summary` entry is itself folded into the new summary and marked `IsHistory = true` — only the latest summary is ever sent to the LLM, but the chain of summaries (and every original turn) stays in the store.
 
+### 1a. Where the projection lives (`SessionContextProjector`)
+
+The "which session entries reach the LLM" rule is **owned by a single type**: `SessionContextProjector` in `BotNexus.Gateway.Sessions`. Two predicates make explicit what was previously two divergent inline filters:
+
+- **`IsVisibleOnResume`** — the strict filter used by isolation strategies when hydrating a cold-resumed session into the initial LLM message list. Excludes `IsHistory`, `IsCrashSentinel`, raw `System` entries, and (importantly) `Tool` entries. Tool entries are dropped on resume because the persisted Assistant `SessionEntry` only carries response text, not the structured `tool_use` blocks that would pair with the following `tool_result`. Without the pair, the `tool_result` becomes orphaned and the Anthropic Messages API rejects the request.
+- **`IsVisibleInLiveContext`** — the broader filter used by `LlmSessionCompactor` for sizing the token budget. Counts `Tool` and non-summary `System` entries because in continuous mid-session operation those *are* sent to the LLM — the agent's in-memory message list still has the tool calls paired with their Assistant `tool_use` blocks, and the provider client serialises them correctly.
+
+Future isolation strategies (sandbox, container, remote) and any other code that turns session history into LLM messages must route through `SessionContextProjector`. An architecture test (`SessionContextProjectorArchitectureTests`) fails the build if a file outside the small allowlist contains both `IsHistory` and `IsCrashSentinel` — that is the canonical signature of an inline re-implementation drifting from the projector.
+
 ### 2. Emergency Overflow Recovery
 
 If the provider rejects a call with a context overflow error (detected by `ContextOverflowDetector`), `AgentLoopRunner.ExecuteWithRetryAsync` does an emergency compact: keeps the last 1/3 of messages (minimum 8) and retries.

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs
@@ -1,0 +1,82 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// Canonical projections from full session history into the slices the LLM runtime
+/// actually sees. Two predicates that look similar but are <em>deliberately</em>
+/// distinct: one for cold-start resume hydration, one for in-flight token budgeting.
+/// Both isolation strategies and the compactor must route through this type so the
+/// rules cannot drift.
+/// </summary>
+/// <remarks>
+/// Phase 3b (#534). Before this type existed, the resume filter lived inline in
+/// <c>InProcessIsolationStrategy</c> and the budget filter lived as a private
+/// predicate on <c>LlmSessionCompactor</c>. Any future isolation strategy that
+/// hydrated a session would have had to re-invent the rules.
+/// </remarks>
+public static class SessionContextProjector
+{
+    /// <summary>
+    /// Strict filter applied when hydrating a cold-resumed session into the initial
+    /// LLM message list. Excludes:
+    /// <list type="bullet">
+    /// <item><see cref="SessionEntry.IsHistory"/> = true (folded into a later summary).</item>
+    /// <item><see cref="SessionEntry.IsCrashSentinel"/> = true (recovery placeholder).</item>
+    /// <item>Raw <see cref="MessageRole.System"/> entries (the agent's system prompt is
+    /// rebuilt separately by <c>SystemPromptBuilder</c>); compaction-summary system
+    /// entries are kept because they carry the folded context.</item>
+    /// <item><see cref="MessageRole.Tool"/> entries. On cold-start resume, the
+    /// Assistant <see cref="SessionEntry"/> only persists the response text and not
+    /// the structured <c>tool_use</c> blocks, so the following Tool entry would
+    /// become an orphaned <c>tool_result</c> with no paired call — Anthropic rejects
+    /// that. In live continuous operation Tool entries are present in the agent's
+    /// in-memory message list and are sent correctly; that is the
+    /// <see cref="IsVisibleInLiveContext"/> case.</item>
+    /// </list>
+    /// </summary>
+    public static bool IsVisibleOnResume(SessionEntry entry)
+    {
+        if (entry.IsCrashSentinel || entry.IsHistory)
+            return false;
+
+        return entry.Role.Equals(MessageRole.User)
+            || entry.Role.Equals(MessageRole.Assistant)
+            || (entry.Role.Equals(MessageRole.System) && entry.IsCompactionSummary);
+    }
+
+    /// <summary>
+    /// Broad filter applied when estimating the in-flight LLM token budget for the
+    /// <em>next</em> call in a continuous session. Counts every entry that will be
+    /// sent on that call — Tool and non-summary System entries included, because in
+    /// a continuous run they sit beside their paired Assistant <c>tool_use</c> (and
+    /// the agent's system prompt) in the live message list. Only entries that the
+    /// compactor itself or a crash has already removed from the LLM view are
+    /// excluded.
+    /// </summary>
+    public static bool IsVisibleInLiveContext(SessionEntry entry) =>
+        !entry.IsHistory && !entry.IsCrashSentinel;
+
+    /// <summary>
+    /// Eager projection used by isolation strategies to build the initial LLM
+    /// message list on cold-start resume. Materialised so callers cannot be
+    /// surprised by deferred enumeration over a <see cref="GatewaySession.History"/>
+    /// list that is mutated concurrently.
+    /// </summary>
+    public static IReadOnlyList<SessionEntry> ProjectForResume(IEnumerable<SessionEntry> history)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+        return history.Where(IsVisibleOnResume).ToList();
+    }
+
+    /// <summary>
+    /// Eager projection used by the compactor when sizing the token budget. Same
+    /// materialisation rationale as <see cref="ProjectForResume"/>.
+    /// </summary>
+    public static IReadOnlyList<SessionEntry> ProjectForLiveContext(IEnumerable<SessionEntry> history)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+        return history.Where(IsVisibleInLiveContext).ToList();
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -23,6 +23,7 @@ using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Security;
+using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Tools;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
@@ -329,22 +330,14 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         List<AgentMessage>? initialMessages = null;
         if (context.History.Count > 0)
         {
-            // Inject compaction summary entries as system messages so the LLM retains
-            // summarised context when the handle is recreated (e.g. after a gateway restart).
-            // Tool-role entries are excluded: they become orphaned ToolResultMessages
-            // (no matching tool_use in the preceding assistant message) which causes
-            // LLM provider rejection. Regular system entries (IsCompactionSummary=false)
-            // are also excluded — the agent's system prompt is set separately.
-            // Phase 3a (#531): historical entries (IsHistory=true) are preserved in the
-            // session store for transcript fidelity but excluded from LLM context — that
-            // is what the summary entry replaces. Phase 3b will centralise this filter
-            // into a SessionContextProjector.
-            initialMessages = context.History
-                .Where(e => !e.IsCrashSentinel
-                         && !e.IsHistory
-                         && (e.Role == Domain.Primitives.MessageRole.User
-                         || e.Role == Domain.Primitives.MessageRole.Assistant
-                         || (e.Role == Domain.Primitives.MessageRole.System && e.IsCompactionSummary)))
+            // The cold-start resume projection — what survives a session hydration without
+            // breaking the LLM provider — is owned by SessionContextProjector. Tool entries
+            // are dropped there because Anthropic rejects orphaned tool_result blocks
+            // (the Assistant SessionEntry persists response text but not the paired
+            // tool_use). Phase 3a/#531 added IsHistory; Phase 3b/#534 centralised the
+            // filter so all isolation strategies share it.
+            initialMessages = SessionContextProjector
+                .ProjectForResume(context.History)
                 .Select(ConvertSessionEntryToAgentMessage)
                 .ToList();
 

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -58,8 +58,9 @@ public sealed class LlmSessionCompactor : ISessionCompactor
 
         // Phase 3a: compaction operates on the "LLM-visible" projection only. Already-historical
         // entries from prior compactions, and crash sentinels, are passed through verbatim and
-        // must never be re-summarised.
-        var visible = history.Where(IsVisibleToLlm).ToList();
+        // must never be re-summarised. The visibility predicate is centralised in
+        // SessionContextProjector (Phase 3b, #534).
+        var visible = history.Where(SessionContextProjector.IsVisibleInLiveContext).ToList();
         var (toSummarize, toPreserve) = SplitHistory(visible, options.PreservedTurns);
         if (toSummarize.Count == 0)
         {
@@ -171,8 +172,6 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             TokensAfter = tokensAfter
         };
     }
-
-    private static bool IsVisibleToLlm(SessionEntry entry) => !entry.IsHistory && !entry.IsCrashSentinel;
 
     private static (List<SessionEntry> toSummarize, List<SessionEntry> toPreserve) SplitHistory(
         IReadOnlyList<SessionEntry> history,
@@ -351,7 +350,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     private static int EstimateVisibleTokenCount(Session session)
     {
         var totalChars = session.History
-            .Where(IsVisibleToLlm)
+            .Where(SessionContextProjector.IsVisibleInLiveContext)
             .Sum(entry => (long)(entry.Content?.Length ?? 0));
         return (int)Math.Min(totalChars / 4, int.MaxValue);
     }
@@ -359,7 +358,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     private static int EstimateVisibleTokenCountFromEntries(IEnumerable<SessionEntry> entries)
     {
         var totalChars = entries
-            .Where(IsVisibleToLlm)
+            .Where(SessionContextProjector.IsVisibleInLiveContext)
             .Sum(entry => (long)(entry.Content?.Length ?? 0));
         return (int)Math.Min(totalChars / 4, int.MaxValue);
     }

--- a/tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj
+++ b/tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Sessions\BotNexus.Gateway.Sessions.csproj" />
     <ProjectReference Include="..\..\scenarios\BotNexus.Scenarios.Harness\BotNexus.Scenarios.Harness.csproj" />
     <ProjectReference Include="..\..\scenarios\BotNexus.Scenarios.Tests\BotNexus.Scenarios.Tests.csproj" />
   </ItemGroup>

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionContextProjectorArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionContextProjectorArchitectureTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using BotNexus.Gateway.Sessions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 3b invariant (#534):
+/// the canonical "session history → LLM-visible entries" projection lives in
+/// exactly one place — <see cref="SessionContextProjector"/> in the
+/// <c>BotNexus.Gateway.Sessions</c> assembly — and is not re-invented inline
+/// anywhere else in <c>src/gateway/</c>.
+/// </summary>
+public sealed class SessionContextProjectorArchitectureTests
+{
+    /// <summary>
+    /// The projector must live in the <c>BotNexus.Gateway.Sessions</c> assembly so
+    /// every isolation strategy and the compactor can depend on it without taking
+    /// on a wider runtime dependency. A namespace-only check is insufficient because
+    /// <c>BotNexus.Gateway.Sessions</c> is also used by types compiled into the
+    /// <c>BotNexus.Gateway</c> assembly (e.g. <c>LlmSessionCompactor</c>).
+    /// </summary>
+    [Fact]
+    public void SessionContextProjector_LivesInGatewaySessionsAssembly()
+    {
+        var assemblyName = typeof(SessionContextProjector).Assembly.GetName().Name;
+
+        assemblyName.ShouldBe("BotNexus.Gateway.Sessions",
+            "SessionContextProjector is the single source of truth for the LLM-visible " +
+            "projection. It must live in BotNexus.Gateway.Sessions so isolation strategies " +
+            "(in BotNexus.Gateway and future projects) and the compactor can share it.");
+    }
+
+    /// <summary>
+    /// No file in <c>src/gateway/</c> outside the allowlist may contain a compound
+    /// boolean expression that references both <c>IsHistory</c> and
+    /// <c>IsCrashSentinel</c>. This is the canonical projection-filter pattern, and
+    /// any new occurrence is almost certainly an inline re-implementation drifting
+    /// from <see cref="SessionContextProjector"/>.
+    /// </summary>
+    /// <remarks>
+    /// The scan is intentionally narrow: it looks for the substrings
+    /// <c>IsHistory</c> and <c>IsCrashSentinel</c> appearing in the same file, which
+    /// is the strongest grep-style signal of an inline projection that does not
+    /// suffer the brittleness of matching a specific predicate formatting.
+    /// </remarks>
+    [Fact]
+    public void NoInlineProjectionFilter_OutsideAllowlist()
+    {
+        var gatewayRoot = FindGatewaySourceRoot();
+        var allowlist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // The canonical filter — the one and only place that combines IsHistory and
+            // IsCrashSentinel in projection logic.
+            "SessionContextProjector.cs",
+            // Storage layer: persists both flags on the SessionEntry row. The projection
+            // happens elsewhere; here we just round-trip the raw state.
+            "SqliteSessionStore.cs",
+            // Documentation comment only; the actual projection is delegated to the
+            // projector via SessionCompaction.ApplyLegacyHistoryProjection.
+            "FileSessionStore.cs",
+        };
+
+        var offenders = Directory
+            .EnumerateFiles(gatewayRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !allowlist.Contains(Path.GetFileName(path)))
+            .Where(path =>
+            {
+                var text = File.ReadAllText(path);
+                return text.Contains("IsHistory", StringComparison.Ordinal)
+                    && text.Contains("IsCrashSentinel", StringComparison.Ordinal);
+            })
+            .Select(path => Path.GetRelativePath(gatewayRoot, path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            "Files outside the SessionContextProjector allowlist contain both IsHistory " +
+            "and IsCrashSentinel, indicating an inline re-implementation of the projection " +
+            "filter. Route the call through SessionContextProjector instead.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static string FindGatewaySourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var gatewayRoot = Path.Combine(current.FullName, "src", "gateway");
+        Directory.Exists(gatewayRoot).ShouldBeTrue("Expected src/gateway under " + current.FullName);
+        return gatewayRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Sessions.Tests/SessionContextProjectorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Sessions.Tests/SessionContextProjectorTests.cs
@@ -1,0 +1,247 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+
+namespace BotNexus.Gateway.Sessions.Tests;
+
+/// <summary>
+/// Phase 3b (#534). Behaviour tests for the canonical "history → LLM-visible entries"
+/// projection. The two predicates are deliberately distinct — see the
+/// <see cref="SessionContextProjector"/> XML docs for the orphaned-tool-result rationale.
+/// </summary>
+public sealed class SessionContextProjectorTests
+{
+    private static SessionEntry User(string content = "u") => new()
+    {
+        Role = MessageRole.User,
+        Content = content,
+    };
+
+    private static SessionEntry Assistant(string content = "a") => new()
+    {
+        Role = MessageRole.Assistant,
+        Content = content,
+    };
+
+    private static SessionEntry Tool(string content = "t") => new()
+    {
+        Role = MessageRole.Tool,
+        Content = content,
+        ToolName = "test_tool",
+        ToolCallId = "call_1",
+    };
+
+    private static SessionEntry RawSystem(string content = "s") => new()
+    {
+        Role = MessageRole.System,
+        Content = content,
+    };
+
+    private static SessionEntry Summary(string content = "summary") => new()
+    {
+        Role = MessageRole.System,
+        Content = content,
+        IsCompactionSummary = true,
+    };
+
+    [Fact]
+    public void IsVisibleOnResume_ExcludesIsHistory()
+    {
+        var entry = User() with { IsHistory = true };
+
+        SessionContextProjector.IsVisibleOnResume(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_ExcludesCrashSentinel()
+    {
+        var entry = Assistant() with { IsCrashSentinel = true };
+
+        SessionContextProjector.IsVisibleOnResume(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_IncludesUser()
+    {
+        SessionContextProjector.IsVisibleOnResume(User()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_IncludesAssistant()
+    {
+        SessionContextProjector.IsVisibleOnResume(Assistant()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_IncludesCompactionSummary_AsSystem()
+    {
+        SessionContextProjector.IsVisibleOnResume(Summary()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_ExcludesNonSummarySystem()
+    {
+        SessionContextProjector.IsVisibleOnResume(RawSystem()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_ExcludesToolRole_DocumentingOrphanCase()
+    {
+        // Tool entries are dropped on cold-start resume because the Assistant
+        // SessionEntry only persists response text and not the tool_use blocks
+        // that would pair with this tool_result. Including them would cause an
+        // orphaned tool_result rejection by Anthropic.
+        SessionContextProjector.IsVisibleOnResume(Tool()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVisibleOnResume_HistoryWins_OverEverythingElse()
+    {
+        var entry = Summary() with { IsHistory = true };
+
+        SessionContextProjector.IsVisibleOnResume(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_IncludesUser()
+    {
+        SessionContextProjector.IsVisibleInLiveContext(User()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_IncludesAssistant()
+    {
+        SessionContextProjector.IsVisibleInLiveContext(Assistant()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_IncludesToolRole()
+    {
+        // Live context counts Tool entries — they ARE sent in a continuous run
+        // because the agent's in-memory message list has them paired with the
+        // Assistant tool_use that produced them.
+        SessionContextProjector.IsVisibleInLiveContext(Tool()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_IncludesNonSummarySystem()
+    {
+        // Non-summary System entries count too — the compactor's budget needs to
+        // reflect everything the LLM will see, including any in-conversation
+        // system messages the agent injected.
+        SessionContextProjector.IsVisibleInLiveContext(RawSystem()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_IncludesCompactionSummary()
+    {
+        SessionContextProjector.IsVisibleInLiveContext(Summary()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_ExcludesIsHistory()
+    {
+        var entry = Assistant() with { IsHistory = true };
+
+        SessionContextProjector.IsVisibleInLiveContext(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVisibleInLiveContext_ExcludesCrashSentinel()
+    {
+        var entry = User() with { IsCrashSentinel = true };
+
+        SessionContextProjector.IsVisibleInLiveContext(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ProjectForResume_PreservesOrder()
+    {
+        var history = new[]
+        {
+            User("u1"),
+            Assistant("a1"),
+            Tool("t1"),
+            User("u2"),
+            Assistant("a2"),
+        };
+
+        var projected = SessionContextProjector.ProjectForResume(history);
+
+        projected.Select(e => e.Content).ShouldBe(["u1", "a1", "u2", "a2"]);
+    }
+
+    [Fact]
+    public void ProjectForResume_MultiCycleHistory_KeepsOnlyActiveSummary()
+    {
+        // Post-Phase-3a invariant: older summaries are already IsHistory=true.
+        // The projector trusts the flag — it does NOT discover "latest" itself.
+        // That's SessionCompaction.ApplyLegacyHistoryProjection's job.
+        var history = new[]
+        {
+            User("u1") with { IsHistory = true },
+            Assistant("a1") with { IsHistory = true },
+            Summary("s1") with { IsHistory = true },
+            User("u2") with { IsHistory = true },
+            Assistant("a2") with { IsHistory = true },
+            Summary("s2"),
+            User("u3"),
+            Assistant("a3"),
+        };
+
+        var projected = SessionContextProjector.ProjectForResume(history);
+
+        projected.Select(e => e.Content).ShouldBe(["s2", "u3", "a3"]);
+    }
+
+    [Fact]
+    public void ProjectForResume_IsMaterialised_NotLazy()
+    {
+        var history = new List<SessionEntry> { User("u1"), Assistant("a1") };
+
+        var projected = SessionContextProjector.ProjectForResume(history);
+
+        history.Clear();
+        projected.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ProjectForLiveContext_PreservesOrder_AndIncludesTool()
+    {
+        var history = new[]
+        {
+            User("u1"),
+            Assistant("a1"),
+            Tool("t1"),
+            Assistant("a2"),
+            User("u2"),
+        };
+
+        var projected = SessionContextProjector.ProjectForLiveContext(history);
+
+        projected.Select(e => e.Content).ShouldBe(["u1", "a1", "t1", "a2", "u2"]);
+    }
+
+    [Fact]
+    public void ProjectForLiveContext_IsMaterialised_NotLazy()
+    {
+        var history = new List<SessionEntry> { User("u1"), Tool("t1") };
+
+        var projected = SessionContextProjector.ProjectForLiveContext(history);
+
+        history.Clear();
+        projected.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ProjectForResume_ThrowsOnNull()
+    {
+        Should.Throw<ArgumentNullException>(() => SessionContextProjector.ProjectForResume(null!));
+    }
+
+    [Fact]
+    public void ProjectForLiveContext_ThrowsOnNull()
+    {
+        Should.Throw<ArgumentNullException>(() => SessionContextProjector.ProjectForLiveContext(null!));
+    }
+}


### PR DESCRIPTION
## What

Phase 3b of the domain-model refactor (umbrella #523). Introduces `SessionContextProjector` as the single source of truth for "session history → LLM-visible entries" and replaces the previously inline filters in `InProcessIsolationStrategy` and `LlmSessionCompactor` with calls to it.

> Closes #534. Refs umbrella #523. Builds on #531 / PR #533 (Phase 3a).

## Why

Before this PR, three would-be call sites needed to know the rules of "what reaches the LLM":

1. **`InProcessIsolationStrategy.cs:329-354`** — strict resume filter (excludes Tool to avoid orphaned `tool_result` rejection by Anthropic).
2. **`LlmSessionCompactor.IsVisibleToLlm`** (private) — broader budget filter (counts Tool because it IS sent in continuous operation).
3. **Sandbox / Container / Remote isolation strategies** — none inject history *yet*, so the day they do, the rules would be re-invented from scratch.

Two existing filters, deliberately different but uncoordinated, uncommented at the type level, and untestable as a unit. Phase 3b makes them explicit, paired, and reusable.

## How

### Production

`src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs` (new):

```csharp
public static class SessionContextProjector
{
    public static bool IsVisibleOnResume(SessionEntry entry);       // strict (excludes Tool, raw System)
    public static bool IsVisibleInLiveContext(SessionEntry entry);  // broad  (!IsHistory && !IsCrashSentinel)

    public static IReadOnlyList<SessionEntry> ProjectForResume(IEnumerable<SessionEntry> history);
    public static IReadOnlyList<SessionEntry> ProjectForLiveContext(IEnumerable<SessionEntry> history);
}
```

Two predicates, two eager (materialised) convenience projections that protect callers from deferred enumeration over `GatewaySession.History` (a mutable `List<SessionEntry>`).

### Call-site changes

- **`InProcessIsolationStrategy.cs:329-345`** — inline `Where(e => ...)` replaced by `SessionContextProjector.ProjectForResume(context.History).Select(ConvertSessionEntryToAgentMessage).ToList()`. Comment trimmed to point at the projector.
- **`LlmSessionCompactor.cs`** — private `IsVisibleToLlm` predicate removed. `EstimateVisibleTokenCount` / `EstimateVisibleTokenCountFromEntries` / the `visible = history.Where(...)` site in `CompactAsync` all delegate to `SessionContextProjector.IsVisibleInLiveContext`. Predicate expression is textually identical → zero behaviour change.

### Architecture fences

`tests/architecture/BotNexus.Architecture.Tests/SessionContextProjectorArchitectureTests.cs` (new):

1. **`SessionContextProjector_LivesInGatewaySessionsAssembly`** — asserts the projector is compiled into the `BotNexus.Gateway.Sessions` assembly. Per rubber-duck critique we check assembly, not namespace, because `LlmSessionCompactor` already uses the `BotNexus.Gateway.Sessions` namespace from inside the `BotNexus.Gateway` assembly — a namespace-only check would let a misplaced copy slip past.
2. **`NoInlineProjectionFilter_OutsideAllowlist`** — walks `src/gateway/**/*.cs` and fails if any non-allowlisted file contains both `IsHistory` and `IsCrashSentinel` (the canonical signature of an inline projection re-implementation). Allowlist is intentionally small:
   - `SessionContextProjector.cs` — the canonical filter.
   - `SqliteSessionStore.cs` — persists both flags as columns.
   - `FileSessionStore.cs` — documentation comment only; delegates to `SessionCompaction.ApplyLegacyHistoryProjection`.

### Docs

`docs/development/llm-request-lifecycle.md` gains a "1a. Where the projection lives (`SessionContextProjector`)" subsection between the compaction and overflow-recovery sections. Names both predicates, explains the resume-vs-live split, surfaces the orphaned-tool-result rationale, and mentions the architecture fence.

## Tests

| Project | Before | After | Delta | Result |
| --- | --- | --- | --- | --- |
| `BotNexus.Gateway.Sessions.Tests` | 7 | **29** | +22 | ✅ |
| `BotNexus.Architecture.Tests` | 16 | **18** | +2 | ✅ |
| `BotNexus.Gateway.Tests` | 1673 | 1673 | 0 | ✅ |
| `BotNexus.Domain.Tests` | 283 | 283 | 0 | ✅ |
| `BotNexus.Gateway.Conversations.Tests` | 100 | 100 | 0 | ✅ |
| All other projects | unchanged | unchanged | — | ✅ |

**New unit tests (22 in `SessionContextProjectorTests`):**

- `IsVisibleOnResume_ExcludesIsHistory`
- `IsVisibleOnResume_ExcludesCrashSentinel`
- `IsVisibleOnResume_IncludesUser`
- `IsVisibleOnResume_IncludesAssistant`
- `IsVisibleOnResume_IncludesCompactionSummary_AsSystem`
- `IsVisibleOnResume_ExcludesNonSummarySystem`
- `IsVisibleOnResume_ExcludesToolRole_DocumentingOrphanCase`
- `IsVisibleOnResume_HistoryWins_OverEverythingElse`
- `IsVisibleInLiveContext_IncludesUser`
- `IsVisibleInLiveContext_IncludesAssistant`
- `IsVisibleInLiveContext_IncludesToolRole`
- `IsVisibleInLiveContext_IncludesNonSummarySystem`
- `IsVisibleInLiveContext_IncludesCompactionSummary`
- `IsVisibleInLiveContext_ExcludesIsHistory`
- `IsVisibleInLiveContext_ExcludesCrashSentinel`
- `ProjectForResume_PreservesOrder`
- `ProjectForResume_MultiCycleHistory_KeepsOnlyActiveSummary` (per rubber-duck: starts with `IsHistory=true` already set; projector trusts the flag rather than discovering "latest")
- `ProjectForResume_IsMaterialised_NotLazy`
- `ProjectForLiveContext_PreservesOrder_AndIncludesTool`
- `ProjectForLiveContext_IsMaterialised_NotLazy`
- `ProjectForResume_ThrowsOnNull`
- `ProjectForLiveContext_ThrowsOnNull`

**No existing tests modified.** The compactor and isolation tests pass unchanged because the predicate semantics are preserved.

## Rubber-duck critique adopted

A pre-implementation critique surfaced four findings; all were adopted:

| # | Finding | Resolution |
| --- | --- | --- |
| 1 | Architecture test must assert **assembly**, not namespace (LlmSessionCompactor uses `BotNexus.Gateway.Sessions` namespace inside the `BotNexus.Gateway` assembly) | `typeof(SessionContextProjector).Assembly.GetName().Name.ShouldBe("BotNexus.Gateway.Sessions")` |
| 2 | `IsBudgetVisible` is too narrow a name; future readers may invent a third filter for "live context" | Renamed to **`IsVisibleInLiveContext`** (and the projection helper to `ProjectForLiveContext`) |
| 3 | Lazy `IEnumerable` projections are unsafe against mutable `History` | `ProjectForResume` / `ProjectForLiveContext` return `IReadOnlyList<SessionEntry>` via eager `.ToList()` |
| 4 | Multi-cycle projector test should not "discover" the latest summary; that's `SessionCompaction.ApplyLegacyHistoryProjection`'s job | Test now starts with older summaries already `IsHistory=true`; projector merely trusts the flag |

Plus a useful side note (#5): added a source-scan architecture rule, narrowly scoped via allowlist, that fences against drift.

## Backwards compatibility

- **No public API change** on existing types. `SessionContextProjector` is a new static class.
- **No behaviour change**. Both predicates produce identical results to the pre-existing filters they replace. Three of the targeted compaction / isolation test suites pass unmodified.
- **No persistence change**. Storage layout untouched.

## Out of scope

- **Tool-role orphan repair** — properly re-pairing Tool entries with their preceding Assistant `tool_use` on cold-start resume requires capturing the `tool_use` block on the Assistant `SessionEntry` (a schema change). The projector documents the orphaning rationale; fixing it is a separate, larger piece of work.
- **#532** — snapshot-then-await race in `LlmSessionCompactor.CompactAsync`. Pre-existing.
- **Phase 3c** (`/reset` REST↔SignalR memory-flush parity, F-2c) and **Phase 3d** (delete the `systemPromptInitialized` metadata gate). Separate issues will be filed.

## Acceptance checklist

- [x] `SessionContextProjector` lives in `BotNexus.Gateway.Sessions`.
- [x] `InProcessIsolationStrategy` and `LlmSessionCompactor` route through the projector; no inline projection filters remain in either file.
- [x] Architecture tests fail-fast on drift (assembly location + source scan).
- [x] 22 new unit tests + 2 new architecture tests; existing suites green.
- [x] Build: 0 warnings, 0 errors. Full suite green.
- [x] `docs/development/llm-request-lifecycle.md` updated.
