### PR TITLE
feat(gateway): canonical IConversationResetService + delete systemPromptInitialized flag (#536, #537)

### DIFF
--- a/docs/development/llm-request-lifecycle.md
+++ b/docs/development/llm-request-lifecycle.md
@@ -185,6 +185,22 @@ private static IReadOnlyList<AgentMessage> CompactForOverflow(IReadOnlyList<Agen
 }
 ```
 
+## Conversation Reset (`IConversationResetService`)
+
+In-session compaction keeps the conversation in the **same session**. A user-initiated `/reset` (REST `POST /api/conversations/{id}/reset`, SignalR `ResetSession`, or REST archive) is different: it **seals the active session in place** and lets the next inbound message start a **fresh empty session in the same conversation**, with the system prompt naturally reloaded from workspace files. Memory persists across the boundary via an explicit memory-bridge step.
+
+The canonical reset sequence is owned by **`IConversationResetService.ResetActiveSessionAsync`** (default impl `DefaultConversationResetService`) so REST and SignalR cannot drift. The five steps are:
+
+1. **Stop the agent supervisor handle** for the active session — best-effort. Drops any in-memory handle so the next `GetOrCreateAsync` starts a fresh isolation strategy with a freshly-built system prompt.
+2. **Flush memory via `ISessionEndMemoryFlusher`** — best-effort. The agent gets one final synthetic turn to write a memory bridge (what it learned, decisions made, follow-ups) before the session is sealed, so the next session inherits the agent's intent without inheriting the raw turn history.
+3. **Cancel pending ask-user prompts** — any conversation-scoped `ask_user` waiters are cancelled so they don't block the new session.
+4. **Seal the active session in place** — set `Status = Sealed` and persist. Sessions are *not* archived (`ArchiveAsync` would delete from `InMemorySessionStore` and rename out of lookup in `FileSessionStore`); they remain readable via the session store for transcript/audit, just no longer Active.
+5. **Clear `Conversation.ActiveSessionId`** — persist the conversation. The next inbound through `DefaultConversationRouter` sees no active session and creates a new one.
+
+REST `Archive` runs the same canonical sequence on the active session before archiving the conversation, so both archive and reset paths get the memory-flush bridge.
+
+An architecture fitness function — `NoDirect_ISessionEndMemoryFlusher_FlushAsync_OutsideAllowlist` — fails the build if any file in `src/gateway/` outside the 3-file allowlist (`DefaultConversationResetService.cs` + `SessionEndMemoryFlusher.cs` + the `ISessionEndMemoryFlusher.cs` interface declaration) references both `ISessionEndMemoryFlusher` and `FlushAsync(`. New callers that need to reset must route through `IConversationResetService`.
+
 ## System Prompt Assembly
 
 The system prompt is the largest fixed cost per LLM call. `SystemPromptBuilder.Build()` assembles it from:
@@ -197,6 +213,15 @@ The system prompt is the largest fixed cost per LLM call. `SystemPromptBuilder.B
 6. **Behavioral rules** — silent reply rules, reply tags, messaging guidance
 
 A **cache boundary marker** (`<!-- BOTNEXUS_CACHE_BOUNDARY -->`) separates stable content from dynamic content. Providers that support prompt caching (Anthropic) can cache the stable portion across calls, reducing cost for the repeated system prompt.
+
+### When the system prompt is (re)loaded
+
+`GatewayHost.ShouldInitializeSystemPrompt(session)` returns true exactly when `session.History.Count == 0`. That's the only signal needed — and it's safe because:
+
+- **In-session compaction** marks older entries as `IsHistory = true` rather than deleting them, so a compacted session still has `History.Count > 0` and the prompt is *not* re-initialised mid-conversation.
+- **Conversation reset** (see above) creates a brand-new session in the same conversation with empty `History`, so the prompt *is* re-loaded on the next dispatch, picking up any changes to workspace files (AGENTS.md, SOUL.md, etc.).
+
+There is intentionally no metadata flag: the natural invariant on `Session.History` is the source of truth, enforced by the `NoCode_References_systemPromptInitialized_Literal` architecture fence.
 
 ## Session Warmup and Resumption
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -43,7 +43,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     private readonly IConversationStore? _conversationStore;
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
     private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
-    private readonly ISessionEndMemoryFlusher? _sessionEndFlusher;
+    private readonly IConversationResetService? _resetService;
     private readonly ILogger<GatewayHub> _logger;
 
     public GatewayHub(
@@ -60,7 +60,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         ILogger<GatewayHub> logger,
         IConversationStore? conversationStore = null,
         IAskUserResponseRegistry? askUserResponseRegistry = null,
-        ISessionEndMemoryFlusher? sessionEndFlusher = null)
+        IConversationResetService? resetService = null)
     {
         _supervisor = supervisor;
         _registry = registry;
@@ -75,7 +75,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         _logger = logger;
         _conversationStore = conversationStore;
         _askUserResponseRegistry = askUserResponseRegistry;
-        _sessionEndFlusher = sessionEndFlusher;
+        _resetService = resetService;
     }
 
     /// <summary>
@@ -472,36 +472,55 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     }
 
     /// <summary>
-    /// Executes reset session.
+    /// Resets the caller's active session: stops the agent, flushes session-end memory,
+    /// cancels any pending ask-user prompts, seals the session, and clears the
+    /// conversation's <see cref="Conversation.ActiveSessionId"/> so the next inbound
+    /// message creates a fresh session inside the same conversation.
     /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="IConversationResetService"/> when a conversation is bound,
+    /// guarding against stale <paramref name="sessionId"/> values by passing it as the
+    /// expected active session. Sessions without a conversation (legacy/orphans) are
+    /// sealed in place — no transcript-destroying <see cref="ISessionStore.ArchiveAsync"/>.
+    /// </remarks>
     /// <param name="agentId">The agent id.</param>
-    /// <param name="sessionId">The session id.</param>
-    /// <returns>The reset session result.</returns>
+    /// <param name="sessionId">The session id known to the caller.</param>
+    /// <returns>A task that completes when the caller has been notified.</returns>
     public async Task ResetSession(AgentId agentId, SessionId sessionId)
     {
         var typedAgentId = NormalizeAgentId(agentId);
         var typedSessionId = NormalizeSessionId(sessionId);
-        await _supervisor.StopAsync(typedAgentId, typedSessionId, CancellationToken.None);
 
-        // Phase 2: session-end memory flush before archiving
-        if (_sessionEndFlusher is not null)
+        var gatewaySession = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
+
+        if (gatewaySession?.Session.ConversationId is { } conversationId && _resetService is not null)
         {
-            var gatewaySession = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
-            if (gatewaySession is not null && _sessionEndFlusher.ShouldFlush(gatewaySession.Session, _compactionOptions.CurrentValue))
+            await _resetService.ResetActiveSessionAsync(
+                conversationId,
+                expectedActiveSessionId: typedSessionId,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        else if (gatewaySession is not null)
+        {
+            // Orphan/legacy session with no conversation link: stop the agent and seal
+            // the session in place (Status=Sealed + SaveAsync). Deliberately avoids
+            // ArchiveAsync because the InMemory implementation deletes the row and the
+            // file store renames files out of normal lookup — both destroy transcript
+            // readability for any UI that lists historical sessions.
+            try
             {
-                try
-                {
-                    await _sessionEndFlusher.FlushAsync(typedAgentId, gatewaySession.Session, _compactionOptions.CurrentValue, CancellationToken.None)
-                        .ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Session-end memory flush failed for session {SessionId}, reset will proceed.", typedSessionId);
-                }
+                await _supervisor.StopAsync(typedAgentId, typedSessionId, CancellationToken.None).ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Supervisor stop failed for orphan session {SessionId}; reset will proceed.", typedSessionId);
+            }
+
+            gatewaySession.Session.Status = GatewaySessionStatus.Sealed;
+            gatewaySession.Session.UpdatedAt = DateTimeOffset.UtcNow;
+            await _sessions.SaveAsync(gatewaySession, CancellationToken.None).ConfigureAwait(false);
         }
 
-        await _sessions.ArchiveAsync(typedSessionId, CancellationToken.None);
         await Clients.Caller.SessionReset(new SessionResetPayload(typedAgentId.Value, typedSessionId.Value));
     }
 

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
@@ -47,6 +47,15 @@ public sealed record BindingResponse(
     string? DisplayPrefix,
     DateTimeOffset BoundAt);
 
+/// <summary>Response returned by <c>POST /api/conversations/{id}/reset</c>.</summary>
+/// <param name="ConversationId">The conversation that was reset.</param>
+/// <param name="Outcome">The reset outcome: <c>Reset</c>, <c>NoActiveSession</c>, <c>NotFound</c>, or <c>StaleSessionId</c>.</param>
+/// <param name="SealedSessionId">The session id that was sealed, when <paramref name="Outcome"/> is <c>Reset</c>; otherwise <c>null</c>.</param>
+public sealed record ConversationResetResponse(
+    string ConversationId,
+    string Outcome,
+    string? SealedSessionId);
+
 /// <summary>Paginated conversation history response.</summary>
 public sealed record ConversationHistoryResponse(
     string ConversationId,

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -26,6 +26,7 @@ public sealed class ConversationsController : ControllerBase
     private readonly IReadOnlyList<IConversationChangeNotifier> _conversationChangeNotifiers;
     private readonly ILogger<ConversationsController> _logger;
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
+    private readonly IConversationResetService? _resetService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConversationsController"/> class.
@@ -35,18 +36,24 @@ public sealed class ConversationsController : ControllerBase
     /// <param name="conversationChangeNotifiers">Publishes conversation lifecycle notifications to connected channel clients.</param>
     /// <param name="logger">Logs best-effort transport notification failures.</param>
     /// <param name="askUserResponseRegistry">Optional registry used to cancel pending ask_user prompts on archive.</param>
+    /// <param name="resetService">Canonical reset service. When supplied (the default in production DI), Archive
+    /// and Reset endpoints delegate the active-session seal + memory flush + ask-user cancel to it. When omitted,
+    /// the controller falls back to a best-effort in-place seal — used only by tests that construct the controller
+    /// directly without DI.</param>
     public ConversationsController(
         IConversationStore conversations,
         ISessionStore sessions,
         IEnumerable<IConversationChangeNotifier>? conversationChangeNotifiers = null,
         ILogger<ConversationsController>? logger = null,
-        IAskUserResponseRegistry? askUserResponseRegistry = null)
+        IAskUserResponseRegistry? askUserResponseRegistry = null,
+        IConversationResetService? resetService = null)
     {
         _conversations = conversations;
         _sessions = sessions;
         _conversationChangeNotifiers = conversationChangeNotifiers?.ToArray() ?? [];
         _logger = logger ?? NullLogger<ConversationsController>.Instance;
         _askUserResponseRegistry = askUserResponseRegistry;
+        _resetService = resetService;
     }
 
     /// <summary>
@@ -337,6 +344,13 @@ public sealed class ConversationsController : ControllerBase
     /// Archived conversations are hidden from active listings and can be reopened automatically
     /// if a bound channel or explicit conversation id starts activity again.
     /// </summary>
+    /// <remarks>
+    /// Performs the canonical reset on the active session (flush memory, cancel pending ask_user
+    /// prompts, seal the session via <c>Status=Sealed + SaveAsync</c>, clear <see cref="Conversation.ActiveSessionId"/>)
+    /// before archiving the conversation. This closes F-2c — the REST archive path used to skip
+    /// the memory flush, so the agent had no chance to write a memory bridge before the session
+    /// was sealed.
+    /// </remarks>
     [HttpDelete("{conversationId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -367,16 +381,65 @@ public sealed class ConversationsController : ControllerBase
         if (virtualCronSessionId.HasValue)
             await SealSessionAsync(virtualCronSessionId.Value, cancellationToken);
 
-        if (conversation.ActiveSessionId is { } activeSessionId)
-            if (!virtualCronSessionId.HasValue || virtualCronSessionId.Value != activeSessionId)
+        // Canonical reset of the active session (stop supervisor + flush memory bridge +
+        // cancel pending ask_user prompts + seal via SaveAsync + clear ActiveSessionId).
+        // No expectedActiveSessionId — the REST caller doesn't know which session is active.
+        if (_resetService is not null)
+        {
+            await _resetService.ResetActiveSessionAsync(conversation.ConversationId, cancellationToken: cancellationToken);
+        }
+        else
+        {
+            // Defensive fallback used only when DI omitted the service (legacy test harnesses).
+            // Misses the memory-flush bridge, which is the F-2c bug — production DI must wire it.
+            if (conversation.ActiveSessionId is { } activeSessionId &&
+                (!virtualCronSessionId.HasValue || virtualCronSessionId.Value != activeSessionId))
+            {
                 await SealSessionAsync(activeSessionId, cancellationToken);
+            }
 
-        await SealConversationSessionsAsync(conversation.ConversationId, cancellationToken);
+            _askUserResponseRegistry?.CancelAllForConversation(conversation.ConversationId);
+        }
 
         await _conversations.ArchiveAsync(conversation.ConversationId, cancellationToken);
-        _askUserResponseRegistry?.CancelAllForConversation(conversation.ConversationId);
         await NotifyConversationChangedBestEffortAsync("archived", conversation.AgentId.Value, conversation.ConversationId.Value, cancellationToken);
         return NoContent();
+    }
+
+    /// <summary>
+    /// Resets the active session of a conversation without archiving the conversation itself.
+    /// Equivalent to the SignalR <c>ResetSession</c> hub method: stops the supervisor, flushes
+    /// the session-end memory bridge, cancels pending ask_user prompts, seals the active session
+    /// in place, and clears <see cref="Conversation.ActiveSessionId"/> so the next inbound message
+    /// starts a fresh session inside the same conversation with the system prompt re-injected.
+    /// </summary>
+    /// <param name="conversationId">The conversation to reset.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <list type="bullet">
+    ///   <item><description><c>200 OK</c> with the reset outcome and (when applicable) the sealed session id.</description></item>
+    ///   <item><description><c>404 NotFound</c> when the conversation does not exist.</description></item>
+    ///   <item><description><c>503 ServiceUnavailable</c> when the reset service is not registered (DI misconfiguration).</description></item>
+    /// </list>
+    /// </returns>
+    [HttpPost("{conversationId}/reset")]
+    [ProducesResponseType(typeof(ConversationResetResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult> Reset(string conversationId, CancellationToken cancellationToken)
+    {
+        if (_resetService is null)
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Conversation reset service is not configured.");
+
+        var result = await _resetService.ResetActiveSessionAsync(ConversationId.From(conversationId), cancellationToken: cancellationToken);
+
+        if (result.Outcome == ConversationResetOutcome.NotFound)
+            return NotFound();
+
+        return Ok(new ConversationResetResponse(
+            ConversationId: conversationId,
+            Outcome: result.Outcome.ToString(),
+            SealedSessionId: result.SealedSessionId?.Value));
     }
 
     // ΓöÇΓöÇ Notification helpers ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
@@ -443,19 +506,6 @@ public sealed class ConversationsController : ControllerBase
         session.Status = SessionStatus.Sealed;
         session.UpdatedAt = DateTimeOffset.UtcNow;
         await _sessions.SaveAsync(session, cancellationToken);
-    }
-
-    private async Task SealConversationSessionsAsync(ConversationId conversationId, CancellationToken cancellationToken)
-    {
-        var allSessions = await _sessions.ListAsync(cancellationToken: cancellationToken);
-        var linkedSessionIds = allSessions
-            .Where(session => session.Session.ConversationId is { } linkedConversationId &&
-                              linkedConversationId == conversationId)
-            .Select(session => session.SessionId)
-            .ToList();
-
-        foreach (var sessionId in linkedSessionIds)
-            await SealSessionAsync(sessionId, cancellationToken);
     }
 
     private async Task<ActionResult> GetVirtualCronHistoryAsync(

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationResetService.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationResetService.cs
@@ -1,0 +1,94 @@
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Conversations;
+
+/// <summary>
+/// Outcome of a <see cref="IConversationResetService.ResetActiveSessionAsync"/> call.
+/// </summary>
+public enum ConversationResetOutcome
+{
+    /// <summary>The active session was sealed and (where applicable) memory was flushed
+    /// and pending <c>ask_user</c> waits were cancelled.</summary>
+    Reset,
+
+    /// <summary>The conversation exists but has no <see cref="Conversation.ActiveSessionId"/>;
+    /// nothing to reset. Treated as a successful no-op by callers.</summary>
+    NoActiveSession,
+
+    /// <summary>The conversation was not found in the store.</summary>
+    NotFound,
+
+    /// <summary>The caller passed an <c>expectedActiveSessionId</c> that does not match the
+    /// conversation's current <see cref="Conversation.ActiveSessionId"/>; the current session
+    /// is intentionally left untouched. This protects channels that hold a stale session id
+    /// (e.g. SignalR clients) from clobbering a newer session that was created in the meantime.</summary>
+    StaleSessionId,
+}
+
+/// <summary>
+/// Result of a conversation reset attempt.
+/// </summary>
+/// <param name="Outcome">The classification of what happened.</param>
+/// <param name="SealedSessionId">The session id that was sealed when <see cref="Outcome"/>
+/// is <see cref="ConversationResetOutcome.Reset"/>; otherwise <c>null</c>.</param>
+/// <param name="AgentId">The agent that owned the sealed session, for caller convenience
+/// (e.g. emitting <c>SessionReset</c> notifications) when <see cref="Outcome"/> is
+/// <see cref="ConversationResetOutcome.Reset"/>; otherwise <c>null</c>.</param>
+public sealed record ConversationResetResult(
+    ConversationResetOutcome Outcome,
+    SessionId? SealedSessionId,
+    AgentId? AgentId);
+
+/// <summary>
+/// Canonical "reset the active session of a conversation" operation.
+/// </summary>
+/// <remarks>
+/// <para>This service is the single source of truth for the reset sequence shared by
+/// REST (<c>ConversationsController</c>: both <c>DELETE</c>/archive and <c>POST .../reset</c>)
+/// and SignalR (<c>GatewayHub.ResetSession</c>). It exists to close a historical defect
+/// (REST archive used to seal sessions but never invoke
+/// <see cref="Sessions.ISessionEndMemoryFlusher"/>, silently losing the session-end memory
+/// bridge that SignalR users received).</para>
+///
+/// <para>The canonical sequence is:</para>
+/// <list type="number">
+///   <item>Load the conversation; emit <see cref="ConversationResetOutcome.NotFound"/> if missing.</item>
+///   <item>If <see cref="Conversation.ActiveSessionId"/> is <c>null</c>, return
+///         <see cref="ConversationResetOutcome.NoActiveSession"/>.</item>
+///   <item>If <paramref name="expectedActiveSessionId"/> is supplied and does not match the
+///         conversation's current active session, return
+///         <see cref="ConversationResetOutcome.StaleSessionId"/> (do not touch the current session).</item>
+///   <item>Stop the agent supervisor handle for the session.</item>
+///   <item>Best-effort invoke <see cref="Sessions.ISessionEndMemoryFlusher.FlushAsync"/>
+///         (skipped for non-interactive sessions; exceptions logged, not thrown).</item>
+///   <item>Cancel any pending <c>ask_user</c> waits for the conversation so the next inbound
+///         is not consumed by the stale <c>PendingAskUserInterceptor</c>.</item>
+///   <item>Seal the session: <c>Status = Sealed</c>, <c>UpdatedAt = now</c>, persist via
+///         <see cref="Sessions.ISessionStore.SaveAsync"/>. (Deliberately not
+///         <c>ArchiveAsync</c>, whose semantics vary by store implementation — some delete
+///         the row outright.)</item>
+///   <item>Clear <see cref="Conversation.ActiveSessionId"/> and persist the conversation.
+///         The next inbound message will create a fresh session via the router.</item>
+/// </list>
+///
+/// <para>A new session is intentionally <b>not</b> created eagerly — the router materialises
+/// one on the next inbound, at which point the session's empty history naturally signals
+/// system-prompt re-initialisation (Phase 3d invariant).</para>
+/// </remarks>
+public interface IConversationResetService
+{
+    /// <summary>
+    /// Resets the conversation's active session.
+    /// </summary>
+    /// <param name="conversationId">The conversation to reset.</param>
+    /// <param name="expectedActiveSessionId">Optional guard: if supplied, the reset proceeds
+    /// only when <see cref="Conversation.ActiveSessionId"/> matches; otherwise returns
+    /// <see cref="ConversationResetOutcome.StaleSessionId"/>. Pass the caller's last-known
+    /// session id (e.g. the one delivered on a SignalR <c>ResetSession</c> call) to avoid
+    /// clobbering a newer session that was created by a concurrent inbound.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<ConversationResetResult> ResetActiveSessionAsync(
+        ConversationId conversationId,
+        SessionId? expectedActiveSessionId = null,
+        CancellationToken ct = default);
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationResetService.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationResetService.cs
@@ -86,9 +86,9 @@ public interface IConversationResetService
     /// <see cref="ConversationResetOutcome.StaleSessionId"/>. Pass the caller's last-known
     /// session id (e.g. the one delivered on a SignalR <c>ResetSession</c> call) to avoid
     /// clobbering a newer session that was created by a concurrent inbound.</param>
-    /// <param name="ct">Cancellation token.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<ConversationResetResult> ResetActiveSessionAsync(
         ConversationId conversationId,
         SessionId? expectedActiveSessionId = null,
-        CancellationToken ct = default);
+        CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationResetService.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationResetService.cs
@@ -1,0 +1,180 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Services;
+using BotNexus.Gateway.Abstractions.Sessions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
+
+namespace BotNexus.Gateway.Conversations;
+
+/// <summary>
+/// Canonical implementation of <see cref="IConversationResetService"/>.
+/// </summary>
+/// <remarks>
+/// <para>This is the single owner of the reset sequence shared by REST
+/// (<c>ConversationsController.Archive</c> and <c>POST .../reset</c>) and SignalR
+/// (<c>GatewayHub.ResetSession</c>). The architecture test
+/// <c>NoDirect_ISessionEndMemoryFlusher_FlushAsync_OutsideAllowlist</c> fences against
+/// other code regressing into bypassing this service to call
+/// <see cref="ISessionEndMemoryFlusher.FlushAsync"/> directly.</para>
+///
+/// <para>The step ordering is deliberate:</para>
+/// <list type="number">
+///   <item><b>Stop supervisor first.</b> Quiesces any in-flight agent turn for the session
+///         so the subsequent flush isn't racing the current handle.</item>
+///   <item><b>Flush memory next.</b> The flusher spawns a separate internal-trigger session
+///         (<c>SessionEndMemoryFlusher</c>), so stopping the original handle does not
+///         interfere with its execution.</item>
+///   <item><b>Cancel pending <c>ask_user</c> waits.</b> Otherwise the next inbound for this
+///         conversation is consumed by <c>PendingAskUserInterceptor</c> as a stale response.</item>
+///   <item><b>Seal the session (Status = Sealed; SaveAsync).</b> Deliberately not
+///         <c>ISessionStore.ArchiveAsync</c>: <c>InMemorySessionStore.ArchiveAsync</c> deletes
+///         the row outright; <c>FileSessionStore.ArchiveAsync</c> renames the file out of the
+///         normal lookup directory. Sealing preserves history for transcript readers.</item>
+///   <item><b>Clear <see cref="Conversation.ActiveSessionId"/>.</b> The router's resolution
+///         path creates a fresh session on the next inbound when <c>ActiveSessionId</c> is
+///         null; the new session starts with empty history, which is exactly the signal the
+///         Phase 3d invariant uses to re-initialise the system prompt.</item>
+/// </list>
+/// </remarks>
+internal sealed class DefaultConversationResetService : IConversationResetService
+{
+    private readonly IConversationStore _conversations;
+    private readonly ISessionStore _sessions;
+    private readonly IAgentSupervisor _supervisor;
+    private readonly ISessionEndMemoryFlusher? _sessionEndFlusher;
+    private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
+    private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
+    private readonly ILogger<DefaultConversationResetService> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    public DefaultConversationResetService(
+        IConversationStore conversations,
+        ISessionStore sessions,
+        IAgentSupervisor supervisor,
+        IOptionsMonitor<CompactionOptions> compactionOptions,
+        ILogger<DefaultConversationResetService> logger,
+        ISessionEndMemoryFlusher? sessionEndFlusher = null,
+        IAskUserResponseRegistry? askUserResponseRegistry = null,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(conversations);
+        ArgumentNullException.ThrowIfNull(sessions);
+        ArgumentNullException.ThrowIfNull(supervisor);
+        ArgumentNullException.ThrowIfNull(compactionOptions);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _conversations = conversations;
+        _sessions = sessions;
+        _supervisor = supervisor;
+        _sessionEndFlusher = sessionEndFlusher;
+        _askUserResponseRegistry = askUserResponseRegistry;
+        _compactionOptions = compactionOptions;
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public async Task<ConversationResetResult> ResetActiveSessionAsync(
+        ConversationId conversationId,
+        SessionId? expectedActiveSessionId = null,
+        CancellationToken ct = default)
+    {
+        var conversation = await _conversations.GetAsync(conversationId, ct).ConfigureAwait(false);
+        if (conversation is null)
+        {
+            _logger.LogDebug("Reset requested for unknown conversation {ConversationId}; returning NotFound.", conversationId);
+            return new ConversationResetResult(ConversationResetOutcome.NotFound, SealedSessionId: null, AgentId: null);
+        }
+
+        if (conversation.ActiveSessionId is not { } activeSessionId)
+        {
+            _logger.LogDebug("Reset requested for conversation {ConversationId} with no active session; no-op.", conversationId);
+            return new ConversationResetResult(ConversationResetOutcome.NoActiveSession, SealedSessionId: null, AgentId: conversation.AgentId);
+        }
+
+        if (expectedActiveSessionId is { } expected && expected != activeSessionId)
+        {
+            _logger.LogInformation(
+                "Reset for conversation {ConversationId} requested with stale session id {Expected}; current ActiveSessionId is {Actual}. Leaving current session untouched.",
+                conversationId, expected, activeSessionId);
+            return new ConversationResetResult(ConversationResetOutcome.StaleSessionId, SealedSessionId: null, AgentId: conversation.AgentId);
+        }
+
+        var agentId = conversation.AgentId;
+        var gatewaySession = await _sessions.GetAsync(activeSessionId, ct).ConfigureAwait(false);
+        if (gatewaySession is null)
+        {
+            _logger.LogWarning(
+                "Conversation {ConversationId} pointed at session {SessionId} which is no longer in the store. Clearing ActiveSessionId defensively.",
+                conversationId, activeSessionId);
+            conversation.ActiveSessionId = null;
+            conversation.UpdatedAt = _timeProvider.GetUtcNow();
+            await _conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
+            return new ConversationResetResult(ConversationResetOutcome.NoActiveSession, SealedSessionId: null, AgentId: agentId);
+        }
+
+        // Step 1: stop the supervisor handle for this session (idempotent — safe if not running).
+        try
+        {
+            await _supervisor.StopAsync(agentId, activeSessionId, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Supervisor stop failed for session {SessionId}; reset will proceed.",
+                activeSessionId);
+        }
+
+        // Step 2: best-effort session-end memory flush. Skipped for non-interactive sessions
+        // via ShouldFlush. FlushAsync swallows its own exceptions, but we wrap defensively.
+        if (_sessionEndFlusher is not null)
+        {
+            var compactionOptions = _compactionOptions.CurrentValue;
+            if (_sessionEndFlusher.ShouldFlush(gatewaySession.Session, compactionOptions))
+            {
+                try
+                {
+                    await _sessionEndFlusher.FlushAsync(agentId, gatewaySession.Session, compactionOptions, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Session-end memory flush failed for session {SessionId}; reset will proceed.",
+                        activeSessionId);
+                }
+            }
+        }
+
+        // Step 3: cancel pending ask_user waits so the next inbound is not consumed as a stale response.
+        try
+        {
+            _askUserResponseRegistry?.CancelAllForConversation(conversationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Cancelling pending ask_user waits failed for conversation {ConversationId}; reset will proceed.",
+                conversationId);
+        }
+
+        // Step 4: seal the session (Status = Sealed; SaveAsync). Not ArchiveAsync — see class docs.
+        gatewaySession.Session.Status = SessionStatus.Sealed;
+        gatewaySession.Session.UpdatedAt = _timeProvider.GetUtcNow();
+        await _sessions.SaveAsync(gatewaySession, ct).ConfigureAwait(false);
+
+        // Step 5: clear ActiveSessionId. The router creates a fresh session on next inbound.
+        conversation.ActiveSessionId = null;
+        conversation.UpdatedAt = _timeProvider.GetUtcNow();
+        await _conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Reset conversation {ConversationId}: sealed session {SessionId}, cleared ActiveSessionId.",
+            conversationId, activeSessionId);
+
+        return new ConversationResetResult(ConversationResetOutcome.Reset, SealedSessionId: activeSessionId, AgentId: agentId);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationResetService.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationResetService.cs
@@ -81,9 +81,9 @@ internal sealed class DefaultConversationResetService : IConversationResetServic
     public async Task<ConversationResetResult> ResetActiveSessionAsync(
         ConversationId conversationId,
         SessionId? expectedActiveSessionId = null,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
-        var conversation = await _conversations.GetAsync(conversationId, ct).ConfigureAwait(false);
+        var conversation = await _conversations.GetAsync(conversationId, cancellationToken).ConfigureAwait(false);
         if (conversation is null)
         {
             _logger.LogDebug("Reset requested for unknown conversation {ConversationId}; returning NotFound.", conversationId);
@@ -105,7 +105,7 @@ internal sealed class DefaultConversationResetService : IConversationResetServic
         }
 
         var agentId = conversation.AgentId;
-        var gatewaySession = await _sessions.GetAsync(activeSessionId, ct).ConfigureAwait(false);
+        var gatewaySession = await _sessions.GetAsync(activeSessionId, cancellationToken).ConfigureAwait(false);
         if (gatewaySession is null)
         {
             _logger.LogWarning(
@@ -113,14 +113,14 @@ internal sealed class DefaultConversationResetService : IConversationResetServic
                 conversationId, activeSessionId);
             conversation.ActiveSessionId = null;
             conversation.UpdatedAt = _timeProvider.GetUtcNow();
-            await _conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
+            await _conversations.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
             return new ConversationResetResult(ConversationResetOutcome.NoActiveSession, SealedSessionId: null, AgentId: agentId);
         }
 
         // Step 1: stop the supervisor handle for this session (idempotent — safe if not running).
         try
         {
-            await _supervisor.StopAsync(agentId, activeSessionId, ct).ConfigureAwait(false);
+            await _supervisor.StopAsync(agentId, activeSessionId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -138,7 +138,7 @@ internal sealed class DefaultConversationResetService : IConversationResetServic
             {
                 try
                 {
-                    await _sessionEndFlusher.FlushAsync(agentId, gatewaySession.Session, compactionOptions, ct).ConfigureAwait(false);
+                    await _sessionEndFlusher.FlushAsync(agentId, gatewaySession.Session, compactionOptions, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -164,12 +164,12 @@ internal sealed class DefaultConversationResetService : IConversationResetServic
         // Step 4: seal the session (Status = Sealed; SaveAsync). Not ArchiveAsync — see class docs.
         gatewaySession.Session.Status = SessionStatus.Sealed;
         gatewaySession.Session.UpdatedAt = _timeProvider.GetUtcNow();
-        await _sessions.SaveAsync(gatewaySession, ct).ConfigureAwait(false);
+        await _sessions.SaveAsync(gatewaySession, cancellationToken).ConfigureAwait(false);
 
         // Step 5: clear ActiveSessionId. The router creates a fresh session on next inbound.
         conversation.ActiveSessionId = null;
         conversation.UpdatedAt = _timeProvider.GetUtcNow();
-        await _conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
+        await _conversations.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Reset conversation {ConversationId}: sealed session {SessionId}, cleared ActiveSessionId.",

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -146,6 +146,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<ISessionCompactor, LlmSessionCompactor>();
         services.AddSingleton<IPreCompactionMemoryFlusher, PreCompactionMemoryFlusher>();
         services.AddSingleton<ISessionEndMemoryFlusher, SessionEndMemoryFlusher>();
+        services.AddSingleton<IConversationResetService, DefaultConversationResetService>();
         services.AddSingleton<IMediaPipeline, MediaPipeline>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICommandContributor, BuiltInCommandContributor>());
         services.TryAddSingleton<CommandRegistry>();

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -42,7 +42,6 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private const string BusyMessage = "Session is busy processing messages. Please retry shortly.";
     private const string ControlSteer = "steer";
     private const string ControlCompact = "compact";
-    private const string SystemPromptInitializedMetadataKey = "systemPromptInitialized";
 
     private readonly IAgentSupervisor _supervisor;
     private readonly IMessageRouter _router;
@@ -371,7 +370,6 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             EnsureCallerParticipant(session, message.Sender);
             if (ShouldInitializeSystemPrompt(session))
             {
-                session.Metadata[SystemPromptInitializedMetadataKey] = true;
                 // Force fresh handle creation so isolation strategy rebuilds system prompt from workspace files.
                 var stopTask = _supervisor.StopAsync(AgentId.From(agentId), SessionId.From(sessionId), cancellationToken);
                 if (stopTask is not null)
@@ -863,18 +861,19 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         return !string.IsNullOrWhiteSpace(command);
     }
 
+    /// <summary>
+    /// Indicates whether the system prompt should be (re)loaded for this session's
+    /// next agent invocation. Returns true exactly when the session has no history
+    /// entries — the natural invariant for "no LLM call has been made yet against
+    /// this session." Phase 3d (issue #537) replaced an explicit prompt-initialised
+    /// metadata flag with this invariant; it is safe because compaction now
+    /// <em>marks</em> historical entries rather than deleting them (Phase 3a, #531)
+    /// and reset creates a fresh empty session in the same conversation (Phase 3c,
+    /// #536), so a non-empty <c>History</c> is a reliable signal that prompt
+    /// initialisation has already happened.
+    /// </summary>
     private static bool ShouldInitializeSystemPrompt(GatewaySession session)
-    {
-        if (!session.Metadata.TryGetValue(SystemPromptInitializedMetadataKey, out var value) || value is null)
-            return true;
-
-        return value switch
-        {
-            bool boolValue => !boolValue,
-            string stringValue when bool.TryParse(stringValue, out var parsed) => !parsed,
-            _ => true
-        };
-    }
+        => session.History.Count == 0;
 
     private static bool IsHeartbeatAck(string? response)
     {

--- a/tests/architecture/BotNexus.Architecture.Tests/ConversationResetServiceArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ConversationResetServiceArchitectureTests.cs
@@ -1,0 +1,84 @@
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 3c invariant (#536):
+/// the canonical "seal active session + flush memory + cancel ask-user" sequence
+/// is owned by <c>DefaultConversationResetService</c>, and callers that need to
+/// reset a conversation session must go through <c>IConversationResetService</c>
+/// rather than invoking <c>ISessionEndMemoryFlusher.FlushAsync</c> directly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// F-2c — the original defect this phase closes — was that the REST and SignalR
+/// reset paths each rolled their own seal sequence and only one of them
+/// remembered to call the memory flusher. Centralising the sequence in one
+/// service only helps if new callers cannot quietly reach past it to invoke the
+/// flusher themselves. This fence makes that drift a compile-time-discovered
+/// architecture failure.
+/// </para>
+/// </remarks>
+public sealed class ConversationResetServiceArchitectureTests
+{
+    /// <summary>
+    /// No file in <c>src/gateway/</c> outside the allowlist may invoke
+    /// <c>FlushAsync(</c> while also referencing <c>ISessionEndMemoryFlusher</c>.
+    /// The combination is the strongest grep-style signal of a direct flusher
+    /// invocation that bypasses the canonical reset service.
+    /// </summary>
+    [Fact]
+    public void NoDirect_ISessionEndMemoryFlusher_FlushAsync_OutsideAllowlist()
+    {
+        var gatewayRoot = FindGatewaySourceRoot();
+        var allowlist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // The canonical orchestrator — the only legitimate caller of
+            // ISessionEndMemoryFlusher.FlushAsync in production code.
+            "DefaultConversationResetService.cs",
+            // The flusher implementation itself, where the method body lives.
+            "SessionEndMemoryFlusher.cs",
+            // The interface declaration — contains the FlushAsync( method signature,
+            // not an invocation.
+            "ISessionEndMemoryFlusher.cs",
+        };
+
+        var offenders = Directory
+            .EnumerateFiles(gatewayRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !allowlist.Contains(Path.GetFileName(path)))
+            .Where(path =>
+            {
+                var text = File.ReadAllText(path);
+                return text.Contains("ISessionEndMemoryFlusher", StringComparison.Ordinal)
+                    && text.Contains("FlushAsync(", StringComparison.Ordinal);
+            })
+            .Select(path => Path.GetRelativePath(gatewayRoot, path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            "Files outside the canonical reset-service allowlist reference both " +
+            "ISessionEndMemoryFlusher and FlushAsync(, indicating a direct memory-flush " +
+            "invocation that bypasses IConversationResetService. Route the call through " +
+            "IConversationResetService.ResetActiveSessionAsync instead — it owns the full " +
+            "canonical sequence (stop supervisor, flush memory, cancel ask-user, seal session, " +
+            "clear ActiveSessionId).\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static string FindGatewaySourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var gatewayRoot = Path.Combine(current.FullName, "src", "gateway");
+        Directory.Exists(gatewayRoot).ShouldBeTrue("Expected src/gateway under " + current.FullName);
+        return gatewayRoot;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SystemPromptInitMetadataArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SystemPromptInitMetadataArchitectureTests.cs
@@ -1,0 +1,71 @@
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 3d invariant (#537):
+/// the <c>systemPromptInitialized</c> session-metadata flag has been deleted
+/// in favour of the natural <c>session.History.Count == 0</c> invariant. No
+/// production code may reintroduce the literal — doing so would mean a future
+/// change went looking for the flag, didn't find it, and silently invented its
+/// own re-implementation of "has this session been initialised?", drifting from
+/// the canonical <c>GatewayHost.ShouldInitializeSystemPrompt</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The metadata flag existed because the pre-3a compactor <em>deleted</em>
+/// summarised turns, so the natural "history is non-empty" signal would have
+/// flipped back to false after every compaction and re-initialised the system
+/// prompt mid-conversation. Phase 3a fixed compaction to mark-not-delete, which
+/// closed the only remaining ambiguity and made the flag redundant. Phase 3d
+/// removed it.
+/// </para>
+/// </remarks>
+public sealed class SystemPromptInitMetadataArchitectureTests
+{
+    /// <summary>
+    /// No file under <c>src/</c> may contain the literal <c>"systemPromptInitialized"</c>.
+    /// The flag was deleted in Phase 3d (#537); any reappearance is almost certainly an
+    /// accidental reintroduction of the deprecated metadata gate.
+    /// </summary>
+    [Fact]
+    public void NoCode_References_systemPromptInitialized_Literal()
+    {
+        var srcRoot = FindSourceRoot();
+
+        var offenders = Directory
+            .EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path =>
+            {
+                var text = File.ReadAllText(path);
+                return text.Contains("systemPromptInitialized", StringComparison.Ordinal);
+            })
+            .Select(path => Path.GetRelativePath(srcRoot, path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            "Files under src/ reference the literal \"systemPromptInitialized\" — a session-metadata " +
+            "key that was deleted in Phase 3d (#537) in favour of the natural " +
+            "session.History.Count == 0 invariant in GatewayHost.ShouldInitializeSystemPrompt. " +
+            "Remove the reference; if you need to gate behaviour on \"has the system prompt been " +
+            "loaded?\", route through GatewayHost or use session.History.Count directly.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Conversations/ConversationsControllerResetTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Conversations/ConversationsControllerResetTests.cs
@@ -1,0 +1,207 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Services;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Sessions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+/// <summary>
+/// Behavioural tests for <see cref="ConversationsController.Archive"/> and
+/// <see cref="ConversationsController.Reset"/>, focused on the F-2c bug (REST archive used to
+/// skip the memory-flush bridge) and the new <see cref="IConversationResetService"/> delegation.
+/// </summary>
+public sealed class ConversationsControllerResetTests
+{
+    private static readonly AgentId TestAgent = AgentId.From("agent-a");
+
+    [Fact]
+    public async Task Archive_DelegatesToResetService_BeforeArchivingConversation()
+    {
+        var conversationId = ConversationId.From("conv-archive-1");
+        var sessions = new InMemorySessionStore();
+        var conversationStore = new Mock<IConversationStore>();
+        var conversation = new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = TestAgent,
+            ActiveSessionId = SessionId.From("session-active"),
+        };
+        conversationStore.Setup(c => c.GetAsync(conversationId, It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
+        conversationStore.Setup(c => c.ArchiveAsync(conversationId, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var resetService = new Mock<IConversationResetService>();
+        resetService
+            .Setup(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.Reset, SessionId.From("session-active"), TestAgent));
+
+        var sequence = new List<string>();
+        resetService
+            .Setup(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add("reset"))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.Reset, SessionId.From("session-active"), TestAgent));
+        conversationStore
+            .Setup(c => c.ArchiveAsync(conversationId, It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add("archive"))
+            .Returns(Task.CompletedTask);
+
+        var controller = new ConversationsController(
+            conversationStore.Object,
+            sessions,
+            resetService: resetService.Object);
+
+        var result = await controller.Archive(conversationId.Value, CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+        sequence.ShouldBe(new[] { "reset", "archive" });
+        resetService.Verify(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()), Times.Once);
+        conversationStore.Verify(c => c.ArchiveAsync(conversationId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Archive_DoesNotCallSessionStoreListAsync()
+    {
+        var conversationId = ConversationId.From("conv-no-walk");
+        var conversation = new Conversation { ConversationId = conversationId, AgentId = TestAgent, ActiveSessionId = SessionId.From("session-active") };
+        var conversationStore = new Mock<IConversationStore>();
+        conversationStore.Setup(c => c.GetAsync(conversationId, It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
+        conversationStore.Setup(c => c.ArchiveAsync(conversationId, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var sessions = new Mock<ISessionStore>(MockBehavior.Strict);
+        // GetAsync may be called for virtual cron lookup; permit it returning null.
+        sessions.Setup(s => s.GetAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>())).ReturnsAsync((GatewaySession?)null);
+
+        var resetService = new Mock<IConversationResetService>();
+        resetService.Setup(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.Reset, SessionId.From("session-active"), TestAgent));
+
+        var controller = new ConversationsController(conversationStore.Object, sessions.Object, resetService: resetService.Object);
+        var result = await controller.Archive(conversationId.Value, CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+        // The old SealConversationSessionsAsync walked every session in the store via ListAsync.
+        // The new flow trusts ActiveSessionId via the reset service — verify the walk is gone.
+        sessions.Verify(
+            s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Archive_UnknownConversationAndNotVirtualCron_Returns404()
+    {
+        var conversationStore = new Mock<IConversationStore>();
+        conversationStore.Setup(c => c.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>())).ReturnsAsync((Conversation?)null);
+        var sessions = new InMemorySessionStore();
+        var resetService = new Mock<IConversationResetService>(MockBehavior.Strict);
+
+        var controller = new ConversationsController(conversationStore.Object, sessions, resetService: resetService.Object);
+        var result = await controller.Archive("nope", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+        resetService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Archive_VirtualCronSessionWithoutLinkedConversation_SealsVirtualSession_AndDoesNotCallResetService()
+    {
+        var sessions = new InMemorySessionStore();
+        var virtualSessionId = SessionId.From("cron-session-1");
+        var virtualSession = await sessions.GetOrCreateAsync(virtualSessionId, TestAgent);
+        virtualSession.Session.SessionType = SessionType.Heartbeat;
+        await sessions.SaveAsync(virtualSession);
+
+        var conversationStore = new Mock<IConversationStore>();
+        conversationStore.Setup(c => c.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>())).ReturnsAsync((Conversation?)null);
+        var resetService = new Mock<IConversationResetService>(MockBehavior.Strict);
+
+        var controller = new ConversationsController(conversationStore.Object, sessions, resetService: resetService.Object);
+        // Virtual cron conversation ids are encoded as "cron-session:<sessionId>" — matches TryParseVirtualCronConversationId.
+        var result = await controller.Archive($"cron-session:{virtualSessionId.Value}", CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+        var reloaded = await sessions.GetAsync(virtualSessionId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(SessionStatus.Sealed);
+        resetService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Reset_ExistingConversation_Returns200_WithOutcomeAndSealedSessionId()
+    {
+        var conversationId = ConversationId.From("conv-reset-1");
+        var sealedSessionId = SessionId.From("session-being-sealed");
+        var resetService = new Mock<IConversationResetService>();
+        resetService.Setup(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.Reset, sealedSessionId, TestAgent));
+
+        var controller = new ConversationsController(
+            new Mock<IConversationStore>().Object,
+            new InMemorySessionStore(),
+            resetService: resetService.Object);
+
+        var result = await controller.Reset(conversationId.Value, CancellationToken.None);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<ConversationResetResponse>();
+        payload.ConversationId.ShouldBe(conversationId.Value);
+        payload.Outcome.ShouldBe("Reset");
+        payload.SealedSessionId.ShouldBe(sealedSessionId.Value);
+    }
+
+    [Fact]
+    public async Task Reset_NoActiveSession_Returns200_WithNullSealedSessionId()
+    {
+        var conversationId = ConversationId.From("conv-quiet");
+        var resetService = new Mock<IConversationResetService>();
+        resetService.Setup(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.NoActiveSession, null, TestAgent));
+
+        var controller = new ConversationsController(
+            new Mock<IConversationStore>().Object,
+            new InMemorySessionStore(),
+            resetService: resetService.Object);
+
+        var result = await controller.Reset(conversationId.Value, CancellationToken.None);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<ConversationResetResponse>();
+        payload.Outcome.ShouldBe("NoActiveSession");
+        payload.SealedSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_UnknownConversation_Returns404()
+    {
+        var conversationId = ConversationId.From("conv-nope");
+        var resetService = new Mock<IConversationResetService>();
+        resetService.Setup(r => r.ResetActiveSessionAsync(conversationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.NotFound, null, null));
+
+        var controller = new ConversationsController(
+            new Mock<IConversationStore>().Object,
+            new InMemorySessionStore(),
+            resetService: resetService.Object);
+
+        var result = await controller.Reset(conversationId.Value, CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Reset_ResetServiceNotRegistered_Returns503()
+    {
+        var controller = new ConversationsController(
+            new Mock<IConversationStore>().Object,
+            new InMemorySessionStore()); // resetService omitted
+
+        var result = await controller.Reset("anything", CancellationToken.None);
+
+        var status = result.ShouldBeOfType<ObjectResult>();
+        status.StatusCode.ShouldBe(StatusCodes.Status503ServiceUnavailable);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Conversations/DefaultConversationResetServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Conversations/DefaultConversationResetServiceTests.cs
@@ -1,0 +1,375 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Services;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using SessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+/// <summary>
+/// Behavioural tests for <see cref="DefaultConversationResetService"/>. Covers every outcome
+/// branch (Reset / NoActiveSession / NotFound / StaleSessionId), the canonical step ordering
+/// (Stop → Flush → CancelAskUser → Seal → ClearActiveSessionId), and best-effort error
+/// behaviour around the supervisor, flusher, and ask-user cancellation.
+/// </summary>
+public sealed class DefaultConversationResetServiceTests
+{
+    private static readonly AgentId TestAgent = AgentId.From("agent-a");
+    private static readonly ConversationId TestConversation = ConversationId.From("conv-1");
+    private static readonly SessionId TestSession = SessionId.From("session-1");
+
+    // ─── Outcome branches ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reset_UnknownConversation_ReturnsNotFound()
+    {
+        var fixture = new Fixture();
+        // No conversation set up.
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.NotFound);
+        result.SealedSessionId.ShouldBeNull();
+        result.AgentId.ShouldBeNull();
+        fixture.Supervisor.Verify(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Reset_ConversationWithNoActiveSession_ReturnsNoActiveSession_AndIsIdempotent()
+    {
+        var fixture = new Fixture();
+        var conversation = new Conversation { ConversationId = TestConversation, AgentId = TestAgent, ActiveSessionId = null };
+        fixture.SetupConversation(conversation);
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.NoActiveSession);
+        result.SealedSessionId.ShouldBeNull();
+        result.AgentId.ShouldBe(TestAgent);
+        fixture.Supervisor.Verify(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        fixture.Conversations.Verify(c => c.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Reset_StaleExpectedActiveSessionId_ReturnsStaleSessionId_AndDoesNotTouchAnything()
+    {
+        var fixture = new Fixture();
+        var newerSession = SessionId.From("session-2");
+        var conversation = new Conversation { ConversationId = TestConversation, AgentId = TestAgent, ActiveSessionId = newerSession };
+        fixture.SetupConversation(conversation);
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation, expectedActiveSessionId: TestSession);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.StaleSessionId);
+        result.SealedSessionId.ShouldBeNull();
+        result.AgentId.ShouldBe(TestAgent);
+        fixture.Supervisor.Verify(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        fixture.Conversations.Verify(c => c.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+        fixture.Sessions.Verify(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Reset_MatchingExpectedActiveSessionId_ProceedsAsNormal()
+    {
+        var fixture = new Fixture();
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation, expectedActiveSessionId: TestSession);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        result.SealedSessionId.ShouldBe(TestSession);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_MissingSessionInStore_DefensivelyClearsActiveSessionId_AndReturnsNoActiveSession()
+    {
+        var fixture = new Fixture();
+        var conversation = new Conversation { ConversationId = TestConversation, AgentId = TestAgent, ActiveSessionId = TestSession };
+        fixture.SetupConversation(conversation);
+        // SessionStore returns null for TestSession (not set up).
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.NoActiveSession);
+        result.AgentId.ShouldBe(TestAgent);
+        conversation.ActiveSessionId.ShouldBeNull();
+        fixture.Conversations.Verify(c => c.SaveAsync(conversation, It.IsAny<CancellationToken>()), Times.Once);
+        fixture.Supervisor.Verify(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ─── Canonical sequence ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reset_InteractiveSession_ExecutesCanonicalSequence_InOrder()
+    {
+        var fixture = new Fixture();
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+        var sequence = new MockSequence();
+
+        // We can't put SaveAsync on the sequence reliably because the same mock is reused
+        // for both conversation+session saves. Instead, assert ordering via a manual list.
+        var callOrder = new List<string>();
+        fixture.Supervisor.Setup(s => s.StopAsync(TestAgent, TestSession, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("stop"))
+            .Returns(Task.CompletedTask);
+        fixture.Flusher.Setup(f => f.FlushAsync(TestAgent, session.Session, It.IsAny<CompactionOptions>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("flush"))
+            .Returns(Task.CompletedTask);
+        fixture.AskUserRegistry.Setup(a => a.CancelAllForConversation(TestConversation))
+            .Callback(() => callOrder.Add("cancel-ask-user"));
+        fixture.Sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("save-session"))
+            .Returns(Task.CompletedTask);
+        fixture.Conversations.Setup(c => c.SaveAsync(conversation, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("save-conversation"))
+            .Returns(Task.CompletedTask);
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        callOrder.ShouldBe(new[] { "stop", "flush", "cancel-ask-user", "save-session", "save-conversation" });
+    }
+
+    [Fact]
+    public async Task Reset_SealsSession_WithStatusSealedAndUpdatedTimestamp_NotArchiveAsync()
+    {
+        var fixture = new Fixture();
+        var fixedNow = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        fixture.TimeProvider = new FixedTimeProvider(fixedNow);
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+
+        await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        session.Session.UpdatedAt.ShouldBe(fixedNow);
+        // Critical: ArchiveAsync is intentionally NOT used (it deletes in InMemorySessionStore,
+        // renames in FileSessionStore — both destroy transcript readability).
+        fixture.Sessions.Verify(s => s.ArchiveAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        fixture.Sessions.Verify(s => s.SaveAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Reset_ClearsActiveSessionId_AndUpdatesConversationTimestamp()
+    {
+        var fixture = new Fixture();
+        var fixedNow = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        fixture.TimeProvider = new FixedTimeProvider(fixedNow);
+        var (conversation, _) = fixture.SetupInteractiveConversationWithSession();
+
+        await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        conversation.ActiveSessionId.ShouldBeNull();
+        conversation.UpdatedAt.ShouldBe(fixedNow);
+        fixture.Conversations.Verify(c => c.SaveAsync(conversation, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─── Best-effort error handling ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Reset_FlushFailure_IsSwallowed_AndResetCompletes()
+    {
+        var fixture = new Fixture();
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+        fixture.Flusher.Setup(f => f.FlushAsync(It.IsAny<AgentId>(), It.IsAny<Session>(), It.IsAny<CompactionOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("memory backend down"));
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_SupervisorStopFailure_IsSwallowed_AndResetCompletes()
+    {
+        var fixture = new Fixture();
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+        fixture.Supervisor.Setup(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("handle already disposed"));
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_AskUserCancelFailure_IsSwallowed_AndResetCompletes()
+    {
+        var fixture = new Fixture();
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+        fixture.AskUserRegistry.Setup(a => a.CancelAllForConversation(It.IsAny<ConversationId>()))
+            .Throws(new InvalidOperationException("registry corrupt"));
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    // ─── Conditional invocation ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reset_NonInteractiveSession_SkipsFlush_StillSealsAndClears()
+    {
+        var fixture = new Fixture();
+        var conversation = new Conversation { ConversationId = TestConversation, AgentId = TestAgent, ActiveSessionId = TestSession };
+        var session = BuildSession(SessionType.Heartbeat); // ShouldFlush returns false.
+        fixture.SetupConversation(conversation);
+        fixture.SetupSession(session);
+        // Default Flusher.ShouldFlush mock returns based on real semantics; for Heartbeat the
+        // real flusher would say false. We mirror that here.
+        fixture.Flusher.Setup(f => f.ShouldFlush(session.Session, It.IsAny<CompactionOptions>())).Returns(false);
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        fixture.Flusher.Verify(f => f.FlushAsync(It.IsAny<AgentId>(), It.IsAny<Session>(), It.IsAny<CompactionOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_NullFlusher_StillCompletes()
+    {
+        var fixture = new Fixture { IncludeFlusher = false };
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_NullAskUserRegistry_StillCompletes()
+    {
+        var fixture = new Fixture { IncludeAskUserRegistry = false };
+        var (conversation, session) = fixture.SetupInteractiveConversationWithSession();
+
+        var result = await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        result.Outcome.ShouldBe(ConversationResetOutcome.Reset);
+        session.Session.Status.ShouldBe(SessionStatus.Sealed);
+        conversation.ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Reset_CancelsAskUserOncePerConversation()
+    {
+        var fixture = new Fixture();
+        fixture.SetupInteractiveConversationWithSession();
+
+        await fixture.Service.ResetActiveSessionAsync(TestConversation);
+
+        fixture.AskUserRegistry.Verify(a => a.CancelAllForConversation(TestConversation), Times.Once);
+    }
+
+    // ─── Fixture & helpers ──────────────────────────────────────────────────
+
+    private static GatewaySession BuildSession(SessionType type)
+    {
+        var session = new GatewaySession
+        {
+            SessionId = TestSession,
+            AgentId = TestAgent,
+        };
+        session.Session.SessionType = type;
+        session.Session.ConversationId = TestConversation;
+        session.Session.History.Add(new SessionEntry { Role = MessageRole.User, Content = "hello" });
+        return session;
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTimeProvider(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class Fixture
+    {
+        public Mock<IConversationStore> Conversations { get; } = new(MockBehavior.Strict);
+        public Mock<ISessionStore> Sessions { get; } = new(MockBehavior.Strict);
+        public Mock<IAgentSupervisor> Supervisor { get; } = new(MockBehavior.Strict);
+        public Mock<ISessionEndMemoryFlusher> Flusher { get; } = new(MockBehavior.Strict);
+        public Mock<IAskUserResponseRegistry> AskUserRegistry { get; } = new(MockBehavior.Strict);
+        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+        public bool IncludeFlusher { get; init; } = true;
+        public bool IncludeAskUserRegistry { get; init; } = true;
+
+        public Fixture()
+        {
+            // Default lenient setups for "looks up missing things returns null" so NotFound paths work.
+            Conversations.Setup(c => c.GetAsync(It.IsAny<ConversationId>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Conversation?)null);
+            Conversations.Setup(c => c.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            Sessions.Setup(s => s.GetAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((GatewaySession?)null);
+            Sessions.Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            Supervisor.Setup(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            // Default Flusher: interactive sessions are flushable, non-interactive aren't —
+            // individual tests can override. Calls to FlushAsync return completed by default.
+            Flusher.Setup(f => f.ShouldFlush(It.IsAny<Session>(), It.IsAny<CompactionOptions>()))
+                .Returns<Session, CompactionOptions>((s, _) => s.IsInteractive && s.History.Any(e => e.Role == MessageRole.User));
+            Flusher.Setup(f => f.FlushAsync(It.IsAny<AgentId>(), It.IsAny<Session>(), It.IsAny<CompactionOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            AskUserRegistry.Setup(a => a.CancelAllForConversation(It.IsAny<ConversationId>()));
+        }
+
+        public IConversationResetService Service => new DefaultConversationResetService(
+            Conversations.Object,
+            Sessions.Object,
+            Supervisor.Object,
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } }),
+            NullLogger<DefaultConversationResetService>.Instance,
+            IncludeFlusher ? Flusher.Object : null,
+            IncludeAskUserRegistry ? AskUserRegistry.Object : null,
+            TimeProvider);
+
+        public void SetupConversation(Conversation conversation)
+        {
+            Conversations.Setup(c => c.GetAsync(conversation.ConversationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(conversation);
+        }
+
+        public void SetupSession(GatewaySession session)
+        {
+            Sessions.Setup(s => s.GetAsync(session.SessionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(session);
+        }
+
+        public (Conversation, GatewaySession) SetupInteractiveConversationWithSession()
+        {
+            var conversation = new Conversation { ConversationId = TestConversation, AgentId = TestAgent, ActiveSessionId = TestSession };
+            var session = BuildSession(SessionType.UserAgent);
+            SetupConversation(conversation);
+            SetupSession(session);
+            return (conversation, session);
+        }
+    }
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T> where T : class, new()
+    {
+        public TestOptionsMonitor(T value) => CurrentValue = value;
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -250,20 +250,25 @@ public sealed class ConversationsControllerHistoryTests
     }
 
     [Fact]
-    public async Task Archive_SealsAllSessionsLinkedToConversation()
+    public async Task Archive_SealsOnlyActiveSession_LeavesOtherSessionsUntouched()
     {
-        var conversationId = ConversationId.From("c_archive_seals_all_linked_sessions");
+        // Phase 3c contract: Archive trusts Conversation.ActiveSessionId and only seals that
+        // session via the reset service. Older sessions in a conversation are already sealed
+        // by the normal lifecycle; unrelated sessions belong to other conversations and must
+        // not be touched. The pre-3c "walk every session matching ConversationId and seal"
+        // pass was a workaround for not trusting ActiveSessionId and is intentionally removed.
+        var conversationId = ConversationId.From("c_archive_seals_active_only");
         var sessions = new InMemorySessionStore();
 
-        var firstLinked = await sessions.GetOrCreateAsync(SessionId.From("s-linked-1"), AgentId.From("assistant"));
-        firstLinked.Session.ConversationId = conversationId;
-        firstLinked.Status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Active;
-        await sessions.SaveAsync(firstLinked);
+        var activeSession = await sessions.GetOrCreateAsync(SessionId.From("s-active"), AgentId.From("assistant"));
+        activeSession.Session.ConversationId = conversationId;
+        activeSession.Status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Active;
+        await sessions.SaveAsync(activeSession);
 
-        var secondLinked = await sessions.GetOrCreateAsync(SessionId.From("s-linked-2"), AgentId.From("assistant"));
-        secondLinked.Session.ConversationId = conversationId;
-        secondLinked.Status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Suspended;
-        await sessions.SaveAsync(secondLinked);
+        var previouslySealed = await sessions.GetOrCreateAsync(SessionId.From("s-old-sealed"), AgentId.From("assistant"));
+        previouslySealed.Session.ConversationId = conversationId;
+        previouslySealed.Status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed;
+        await sessions.SaveAsync(previouslySealed);
 
         var unrelated = await sessions.GetOrCreateAsync(SessionId.From("s-unrelated"), AgentId.From("assistant"));
         unrelated.Session.ConversationId = ConversationId.From("c_other");
@@ -271,15 +276,22 @@ public sealed class ConversationsControllerHistoryTests
         await sessions.SaveAsync(unrelated);
 
         var conversationStore = new InMemoryConversationStore();
-        await conversationStore.CreateAsync(CreateConversation(conversationId, "assistant", activeSessionId: SessionId.From("s-linked-1")));
+        await conversationStore.CreateAsync(CreateConversation(conversationId, "assistant", activeSessionId: SessionId.From("s-active")));
         var controller = new ConversationsController(conversationStore, sessions);
 
         var result = await controller.Archive(conversationId.Value, CancellationToken.None);
 
         result.ShouldBeOfType<NoContentResult>();
-        (await sessions.GetAsync(SessionId.From("s-linked-1")))!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
-        (await sessions.GetAsync(SessionId.From("s-linked-2")))!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
+        (await sessions.GetAsync(SessionId.From("s-active")))!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
+        (await sessions.GetAsync(SessionId.From("s-old-sealed")))!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
         (await sessions.GetAsync(SessionId.From("s-unrelated")))!.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Active);
+
+        // ActiveSessionId is cleared after archive (next inbound would create a fresh session
+        // if the conversation were re-opened — but archived conversations are hidden from listing).
+        var archivedConversation = await conversationStore.GetAsync(conversationId);
+        archivedConversation.ShouldNotBeNull();
+        archivedConversation!.ActiveSessionId.ShouldBeNull();
+        archivedConversation.Status.ShouldBe(ConversationStatus.Archived);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -432,8 +432,12 @@ public sealed class GatewayHostTests
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenSystemPromptNotInitialized_StopsExistingHandleBeforePrompt()
+    public async Task DispatchAsync_WhenSessionHasNoHistory_StopsExistingHandleBeforePrompt()
     {
+        // Phase 3d invariant (#537): system prompt is initialised exactly when
+        // session.History.Count == 0. A brand-new session has no entries, so we
+        // expect the supervisor to be told to drop any stale handle so the next
+        // GetOrCreateAsync rebuilds the prompt from workspace files.
         var router = new Mock<IMessageRouter>();
         router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(["agent-a"]);
@@ -465,8 +469,12 @@ public sealed class GatewayHostTests
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenSystemPromptInitialized_DoesNotStopExistingHandle()
+    public async Task DispatchAsync_WhenSessionHasHistory_DoesNotStopExistingHandle()
     {
+        // Phase 3d invariant (#537): a session with any history entries has already
+        // had its system prompt initialised on a prior turn, so the supervisor handle
+        // must be reused — re-stopping would force the isolation strategy to rebuild
+        // the prompt from disk and clobber any in-memory continuation state.
         var router = new Mock<IMessageRouter>();
         router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(["agent-a"]);
@@ -477,7 +485,78 @@ public sealed class GatewayHostTests
             .ReturnsAsync(handle.Object);
 
         var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a") };
-        session.Metadata["systemPromptInitialized"] = true;
+        // Pre-existing turn from a previous dispatch — proves the session is not fresh.
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "earlier turn",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1)
+        });
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetAsync(SessionId.From("session-1"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await using var host = CreateHost(
+            supervisor.Object,
+            router.Object,
+            sessions.Object,
+            new RecordingActivityBroadcaster(),
+            CreateChannelManager());
+
+        await host.DispatchAsync(CreateMessage("hello", sessionId: "session-1"));
+
+        supervisor.Verify(s => s.StopAsync(It.IsAny<BotNexus.Domain.Primitives.AgentId>(), It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenCompactedSessionHasMarkedHistoryAndSummary_DoesNotStopExistingHandle()
+    {
+        // Phase 3a + Phase 3d interaction (#531 + #537): after in-session compaction,
+        // older turns are marked IsHistory=true (not deleted) and a summary entry is
+        // inserted at the boundary. The session is no longer "fresh" — History.Count > 0 —
+        // so the prompt-init force-stop must not fire, even though the LLM-visible
+        // projection only sees the summary + preserved tail.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+
+        var handle = CreatePromptHandle("agent-a", "session-1", "ok");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a") };
+        // Reproduce the canonical post-compaction shape: [historical..., summary, preserved tail].
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "summarised user turn",
+            IsHistory = true,
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-10)
+        });
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "summarised assistant turn",
+            IsHistory = true,
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-9)
+        });
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.System,
+            Content = "compaction summary",
+            IsCompactionSummary = true,
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-8)
+        });
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "preserved tail user turn",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1)
+        });
+
         var sessions = new Mock<ISessionStore>();
         sessions.Setup(s => s.GetAsync(SessionId.From("session-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionResumeIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionResumeIntegrationTests.cs
@@ -82,7 +82,7 @@ public sealed class SessionResumeIntegrationTests : IDisposable
     }
 
     [Fact]
-    public async Task ResetSession_ArchivesOldSession_NewSessionIsEmpty()
+    public async Task ResetSession_SealsOldSessionInPlace_PreservingHistory()
     {
         var storePath = CreateStorePath();
         var sessionId = "reset-session";
@@ -99,11 +99,19 @@ public sealed class SessionResumeIntegrationTests : IDisposable
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         await connection.InvokeAsync("ResetSession", TestAgentId, sessionId, cts.Token);
-        var newSession = await store.GetOrCreateAsync(SessionId.From(sessionId), AgentId.From(TestAgentId), cts.Token);
 
-        newSession.History.ShouldBeEmpty();
-        Directory.GetFiles(storePath, $"{encodedSessionId}.jsonl.archived.*").ShouldHaveSingleItem();
-        Directory.GetFiles(storePath, $"{encodedSessionId}.meta.json.archived.*").ShouldHaveSingleItem();
+        // The session is sealed in place (Status=Sealed + SaveAsync) so transcript readers
+        // can still see what happened. ArchiveAsync is intentionally NOT used because the
+        // file-store implementation renames files out of normal lookup, breaking history APIs.
+        var reloaded = await store.GetAsync(SessionId.From(sessionId), cts.Token);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(SessionStatus.Sealed);
+        reloaded.History.Count.ShouldBe(10);
+        reloaded.History.Select(e => e.Content).ShouldBe(Enumerable.Range(0, 10).Select(i => $"old-{i}"));
+
+        // No archived-files side-effect — the file remains under its normal name.
+        Directory.GetFiles(storePath, $"{encodedSessionId}.jsonl.archived.*").ShouldBeEmpty();
+        Directory.GetFiles(storePath, $"{encodedSessionId}.meta.json.archived.*").ShouldBeEmpty();
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -622,7 +622,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task Hub_ResetSession_DeletesSessionAndNotifiesClient()
+    public async Task Hub_ResetSession_SealsSessionAndNotifiesClient()
     {
         await using var factory = CreateTestFactory();
         using var cts = CreateTimeout();
@@ -640,9 +640,13 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         resetPayload.GetProperty("sessionId").GetString().ShouldBe(sessionId);
         resetPayload.GetProperty("agentId").GetString().ShouldBe(TestAgentId);
 
+        // Session is sealed in place — Status flips to Sealed, the row stays in the store so
+        // transcript readers still see the conversation history. ArchiveAsync is intentionally
+        // not used (it deletes in InMemorySessionStore, hides files in FileSessionStore).
         var store = factory.Services.GetRequiredService<ISessionStore>();
         var session = await store.GetAsync(SessionId.From(sessionId), cts.Token);
-        session.ShouldBeNull();
+        session.ShouldNotBeNull();
+        session!.Status.ShouldBe(SessionStatus.Sealed);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -424,26 +424,90 @@ public sealed class SignalRHubTests
     }
 
     [Fact]
-    public async Task ResetSession_ArchivesInsteadOfDeleting()
+    public async Task ResetSession_WithConversation_DelegatesToResetService_WithExpectedSessionId()
     {
         var caller = new Mock<IGatewayHubClient>();
-        caller.Setup(proxy => proxy.SessionReset(It.IsAny<SessionResetPayload>()))
-            .Returns(Task.CompletedTask);
+        caller.Setup(proxy => proxy.SessionReset(It.IsAny<SessionResetPayload>())).Returns(Task.CompletedTask);
+        var clients = new Mock<IHubCallerClients<IGatewayHubClient>>();
+        clients.SetupGet(value => value.Caller).Returns(caller.Object);
+
+        var conversationId = ConversationId.From("conv-1");
+        var sessionId = SessionId.From("session-1");
+        var agentId = AgentId.From("agent-a");
+
+        var session = new GatewaySession { SessionId = sessionId, AgentId = agentId };
+        session.Session.ConversationId = conversationId;
+
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetAsync(sessionId, CancellationToken.None)).ReturnsAsync(session);
+
+        var resetService = new Mock<IConversationResetService>();
+        resetService.Setup(s => s.ResetActiveSessionAsync(conversationId, sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationResetResult(ConversationResetOutcome.Reset, sessionId, agentId));
+
+        var supervisor = new Mock<IAgentSupervisor>(MockBehavior.Strict);
+
+        var hub = CreateHub(clients: clients.Object, sessions: sessions.Object, supervisor: supervisor.Object, resetService: resetService.Object);
+
+        await hub.ResetSession(agentId, sessionId);
+
+        resetService.Verify(s => s.ResetActiveSessionAsync(conversationId, sessionId, It.IsAny<CancellationToken>()), Times.Once);
+        sessions.Verify(s => s.ArchiveAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        sessions.Verify(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()), Times.Never);
+        supervisor.Verify(s => s.StopAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        caller.Verify(c => c.SessionReset(It.Is<SessionResetPayload>(p => p.AgentId == "agent-a" && p.SessionId == "session-1")), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResetSession_OrphanSession_NoConversation_SealsInPlace_DoesNotArchive()
+    {
+        var caller = new Mock<IGatewayHubClient>();
+        caller.Setup(proxy => proxy.SessionReset(It.IsAny<SessionResetPayload>())).Returns(Task.CompletedTask);
+        var clients = new Mock<IHubCallerClients<IGatewayHubClient>>();
+        clients.SetupGet(value => value.Caller).Returns(caller.Object);
+
+        var sessionId = SessionId.From("session-orphan");
+        var agentId = AgentId.From("agent-a");
+        var session = new GatewaySession { SessionId = sessionId, AgentId = agentId };
+        // No ConversationId — simulates legacy orphan.
+
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetAsync(sessionId, CancellationToken.None)).ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, CancellationToken.None)).Returns(Task.CompletedTask);
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.StopAsync(agentId, sessionId, CancellationToken.None)).Returns(Task.CompletedTask);
+
+        var resetService = new Mock<IConversationResetService>(MockBehavior.Strict);
+
+        var hub = CreateHub(clients: clients.Object, sessions: sessions.Object, supervisor: supervisor.Object, resetService: resetService.Object);
+
+        await hub.ResetSession(agentId, sessionId);
+
+        sessions.Verify(s => s.ArchiveAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        sessions.Verify(s => s.SaveAsync(session, CancellationToken.None), Times.Once);
+        supervisor.Verify(s => s.StopAsync(agentId, sessionId, CancellationToken.None), Times.Once);
+        resetService.Verify(s => s.ResetActiveSessionAsync(It.IsAny<ConversationId>(), It.IsAny<SessionId?>(), It.IsAny<CancellationToken>()), Times.Never);
+        session.Session.Status.ShouldBe(BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed);
+    }
+
+    [Fact]
+    public async Task ResetSession_UnknownSession_NotifiesCallerWithoutFailing()
+    {
+        var caller = new Mock<IGatewayHubClient>();
+        caller.Setup(proxy => proxy.SessionReset(It.IsAny<SessionResetPayload>())).Returns(Task.CompletedTask);
         var clients = new Mock<IHubCallerClients<IGatewayHubClient>>();
         clients.SetupGet(value => value.Caller).Returns(caller.Object);
 
         var sessions = new Mock<ISessionStore>();
-        sessions.Setup(value => value.ArchiveAsync(SessionId.From("session-1"), CancellationToken.None)).Returns(Task.CompletedTask);
+        sessions.Setup(s => s.GetAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>())).ReturnsAsync((GatewaySession?)null);
 
-        var supervisor = new Mock<IAgentSupervisor>();
-        supervisor.Setup(value => value.StopAsync(BotNexus.Domain.Primitives.AgentId.From("agent-a"), BotNexus.Domain.Primitives.SessionId.From("session-1"), CancellationToken.None)).Returns(Task.CompletedTask);
+        var hub = CreateHub(clients: clients.Object, sessions: sessions.Object);
 
-        var hub = CreateHub(clients: clients.Object, sessions: sessions.Object, supervisor: supervisor.Object);
+        await hub.ResetSession(AgentId.From("agent-a"), SessionId.From("missing"));
 
-        await hub.ResetSession(AgentId.From("agent-a"), SessionId.From("session-1"));
-
-        sessions.Verify(value => value.ArchiveAsync(SessionId.From("session-1"), CancellationToken.None), Times.Once);
-        sessions.Verify(value => value.DeleteAsync(It.IsAny<BotNexus.Domain.Primitives.SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+        caller.Verify(c => c.SessionReset(It.IsAny<SessionResetPayload>()), Times.Once);
+        sessions.Verify(s => s.ArchiveAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -505,6 +569,7 @@ public sealed class SignalRHubTests
         IConversationDispatcher? conversationDispatcher = null,
         IConversationStore? conversationStore = null,
         IAskUserResponseRegistry? askUserResponseRegistry = null,
+        IConversationResetService? resetService = null,
         string connectionId = "conn-test")
     {
         var sessionStore = sessions ?? new InMemorySessionStore();
@@ -528,7 +593,8 @@ public sealed class SignalRHubTests
             compactionOptions ?? new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
             NullLogger<GatewayHub>.Instance,
             convStore,
-            askUserResponseRegistry)
+            askUserResponseRegistry,
+            resetService)
         {
             Clients = clients ?? Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = groups ?? Mock.Of<IGroupManager>(),


### PR DESCRIPTION
## Summary

Bundles **Phase 3c (#536)** and **Phase 3d (#537)** of the domain-model refactor (#523):

- **Phase 3c** introduces IConversationResetService as the single canonical "reset active session" sequence shared by REST archive, REST reset, and SignalR `ResetSession`. Closes finding **F-2c**: the REST archive path used to skip `ISessionEndMemoryFlusher` so the agent never got a chance to write a memory bridge before the session was sealed.
- **Phase 3d** deletes the `systemPromptInitialized` session-metadata flag in favour of the natural `session.History.Count == 0` invariant — safe now that compaction marks-not-deletes (#531) and reset creates a fresh empty session (#536).

Both phases were bundled per maintainer choice because 3d builds directly on the reset behaviour from 3c.

## What changed

### Phase 3c (#536) ━ canonical reset service

**New contract** `IConversationResetService.ResetActiveSessionAsync(conversationId, expectedActiveSessionId?, ct)` with outcomes `Reset` / `NoActiveSession` / `NotFound` / `StaleSessionId`.

**Canonical 5-step sequence** (now in one place):

1. Stop the agent supervisor handle (best-effort).
2. Flush memory via `ISessionEndMemoryFlusher` (best-effort) — the memory bridge.
3. Cancel pending conversation-scoped `ask_user` waiters (best-effort).
4. Set `Session.Status = Sealed` and save (sessions are **not archived** — `ArchiveAsync` would delete in `InMemorySessionStore` and rename out of lookup in `FileSessionStore`).
5. Clear `Conversation.ActiveSessionId` and save.

**Wiring**:
- `GatewayHub.ResetSession` delegates when the session has a bound conversation; for orphan sessions falls back to a direct in-place seal.
- `ConversationsController.Archive` delegates the active-session seal to the reset service, then archives the conversation — the REST + SignalR archive/reset paths now share the canonical sequence.
- New `POST /api/conversations/{id}/reset` endpoint returns `ConversationResetResponse` with the outcome and sealed session id.
- Deleted `ConversationsController.SealConversationSessionsAsync` walk-all-sessions hack — the new flow trusts `Conversation.ActiveSessionId`.

### Phase 3d (#537) ━ delete the prompt-init metadata flag

Replaces the `systemPromptInitialized` metadata write/read with the natural invariant `session.History.Count == 0` in `GatewayHost.ShouldInitializeSystemPrompt`.

Safe because:
- Phase 3a (#531) made compaction mark-not-delete, so a compacted session keeps `History.Count > 0`.
- Phase 3c (#536) makes reset create a fresh empty session in the same conversation, so a post-reset inbound naturally lands `History.Count == 0`.

## Architecture fences (CI-enforced)

- `NoDirect_ISessionEndMemoryFlusher_FlushAsync_OutsideAllowlist` — fails the build if any file in `src/gateway/` outside the 3-file allowlist (`DefaultConversationResetService.cs` + `SessionEndMemoryFlusher.cs` + `ISessionEndMemoryFlusher.cs`) references both `ISessionEndMemoryFlusher` and `FlushAsync(`.
- `NoCode_References_systemPromptInitialized_Literal` — fails the build if any file in `src/` contains the deprecated literal.

## Tests

- 15 new unit tests for `DefaultConversationResetService` covering all four outcomes, best-effort error handling, and `TimeProvider` usage.
- 8 new controller tests for `ConversationsController` Archive delegation + Reset endpoint variants + virtual-cron fallback preservation + no-walk-all-sessions regression.
- 3 new `GatewayHub` tests for the conversation / orphan / unknown-session reset paths.
- 3 migrated/new `GatewayHostTests` for the Phase 3d invariant: empty history initialises, non-empty history does not, and the critical post-compaction state (mixed `IsHistory=true` entries + summary + preserved tail) does not.
- Migrated `ResetSession_ArchivesOldSession_NewSessionIsEmpty` to assert seal-in-place behaviour (no archive files, history preserved, `Status=Sealed`).
- Migrated `Archive_SealsAllSessionsLinkedToConversation` to `Archive_SealsOnlyActiveSession_LeavesOtherSessionsUntouched` — locks the new contract: only the active session is sealed; pre-sealed sessions stay sealed; unrelated conversations are untouched.

## Validation

`dotnet build BotNexus.slnx` ━ 0 warnings, 0 errors.
`dotnet test BotNexus.slnx` ━ 0 failures across the full solution (Gateway.Tests 1699, Gateway.Conversations.Tests 100, Architecture.Tests 20 incl. 2 new fences, Scenarios.Tests 18, CodingAgent.Tests 206, all extensions + providers green).

## Docs

`docs/development/llm-request-lifecycle.md` gains a top-level "Conversation Reset" section describing the canonical sequence + fence, and a "When the system prompt is (re)loaded" subsection under System Prompt Assembly documenting the Phase 3d invariant.

Closes #536.
Closes #537.
Refs #523.
