### PR TITLE
refactor(domain): introduce JobId/RunId Vogen value objects

### DIFF
--- a/src/domain/BotNexus.Domain/Primitives/JobId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/JobId.cs
@@ -1,0 +1,26 @@
+using Vogen;
+
+namespace BotNexus.Domain.Primitives;
+
+/// <summary>
+/// Identifies a cron job (scheduled task) inside the BotNexus world. Construct via
+/// <see cref="From(string)"/>; the value must be non-null, non-empty, non-whitespace
+/// and is stored trimmed.
+/// </summary>
+/// <remarks>
+/// Cron job ids are persisted as TEXT in the SQLite cron store and carried as
+/// strings over the SignalR/REST wire formats — this value object guarantees a
+/// single canonical shape (trimmed, non-empty) without changing the storage or
+/// network representation. Part of the Phase 2 Vogen rollout (#501).
+/// </remarks>
+[ValueObject<string>(conversions: Conversions.SystemTextJson)]
+public readonly partial struct JobId
+{
+    private static Validation Validate(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? Validation.Invalid("JobId cannot be null, empty, or whitespace.")
+            : Validation.Ok;
+
+    private static string NormalizeInput(string input) =>
+        input is null ? input! : input.Trim();
+}

--- a/src/domain/BotNexus.Domain/Primitives/RunId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/RunId.cs
@@ -1,0 +1,34 @@
+using Vogen;
+
+namespace BotNexus.Domain.Primitives;
+
+/// <summary>
+/// Identifies a single execution (run) of a cron <see cref="JobId"/>. Construct via
+/// <see cref="From(string)"/> for existing values or <see cref="Create"/> for a new
+/// run; the value must be non-null, non-empty, non-whitespace and is stored trimmed.
+/// </summary>
+/// <remarks>
+/// Each invocation of a cron job — whether scheduled or triggered via "run now" —
+/// produces a fresh <see cref="RunId"/>. The id is persisted in the cron store
+/// alongside the originating <see cref="JobId"/>, run status, and the
+/// <see cref="SessionId"/> opened by the action. Part of the Phase 2 Vogen rollout
+/// (#501).
+/// </remarks>
+[ValueObject<string>(conversions: Conversions.SystemTextJson)]
+public readonly partial struct RunId
+{
+    /// <summary>
+    /// Creates a new unique <see cref="RunId"/> using a 32-character N-formatted GUID.
+    /// Matches the format that <c>SqliteCronStore.RecordRunStartAsync</c> has
+    /// historically generated, so existing rows are still round-trippable.
+    /// </summary>
+    public static RunId Create() => From(Guid.NewGuid().ToString("N"));
+
+    private static Validation Validate(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? Validation.Invalid("RunId cannot be null, empty, or whitespace.")
+            : Validation.Ok;
+
+    private static string NormalizeInput(string input) =>
+        input is null ? input! : input.Trim();
+}

--- a/src/gateway/BotNexus.Cli/Commands/CronCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/CronCommands.cs
@@ -141,10 +141,10 @@ internal sealed class CronCommands
             {
                 var enabledMark = job.Enabled ? "[green]\u2713[/]" : "[red]\u2717[/]";
                 table.AddRow(
-                    Markup.Escape(job.Id ?? "-"),
+                    Markup.Escape(job.Id.Value),
                     Markup.Escape(job.Name ?? "-"),
                     Markup.Escape(job.Schedule ?? "-"),
-                    Markup.Escape(job.AgentId ?? "-"),
+                    Markup.Escape(job.AgentId?.Value ?? "-"),
                     enabledMark,
                     Markup.Escape(job.ActionType ?? "-"));
             }
@@ -262,7 +262,7 @@ internal sealed class CronCommands
             }
 
             var run = await response.Content.ReadFromJsonAsync<CronRun>(JsonOpts, ct);
-            AnsiConsole.MarkupLine($"[green]\u2713[/] Cron job [yellow]{Markup.Escape(jobId)}[/] triggered. Run ID: [dim]{Markup.Escape(run?.Id ?? "?")}[/]");
+            AnsiConsole.MarkupLine($"[green]\u2713[/] Cron job [yellow]{Markup.Escape(jobId)}[/] triggered. Run ID: [dim]{Markup.Escape(run?.Id.Value ?? "?")}[/]");
             return 0;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
@@ -334,11 +334,11 @@ internal sealed class CronCommands
 
     private static void PrintJob(CronJob job)
     {
-        AnsiConsole.MarkupLine($"[bold]ID:[/]       {Markup.Escape(job.Id ?? "-")}");
+        AnsiConsole.MarkupLine($"[bold]ID:[/]       {Markup.Escape(job.Id.Value)}");
         AnsiConsole.MarkupLine($"[bold]Name:[/]     {Markup.Escape(job.Name ?? "-")}");
         AnsiConsole.MarkupLine($"[bold]Schedule:[/] {Markup.Escape(job.Schedule ?? "-")}");
         AnsiConsole.MarkupLine($"[bold]Type:[/]     {Markup.Escape(job.ActionType ?? "-")}");
-        AnsiConsole.MarkupLine($"[bold]Agent:[/]    {Markup.Escape(job.AgentId ?? "-")}");
+        AnsiConsole.MarkupLine($"[bold]Agent:[/]    {Markup.Escape(job.AgentId?.Value ?? "-")}");
         AnsiConsole.MarkupLine($"[bold]Enabled:[/]  {(job.Enabled ? "[green]yes[/]" : "[red]no[/]")}");
         if (!string.IsNullOrWhiteSpace(job.TimeZone))
             AnsiConsole.MarkupLine($"[bold]TimeZone:[/] {Markup.Escape(job.TimeZone)}");

--- a/src/gateway/BotNexus.Cli/Commands/PromptCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/PromptCommands.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text.Json;
 using BotNexus.Cron;
 using BotNexus.Cron.Prompts;
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Options;
 using Spectre.Console;
@@ -201,7 +202,7 @@ internal sealed class PromptCommands
         try
         {
             var resolver = CreateTemplateResolver(config);
-            if (!resolver.TryRender(resolvedAgentId, templateName, parameters, out var rendered, out var error))
+            if (!resolver.TryRender(AgentId.From(resolvedAgentId!), templateName, parameters, out var rendered, out var error))
             {
                 if (!string.IsNullOrWhiteSpace(error))
                     AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(error)}");
@@ -248,7 +249,7 @@ internal sealed class PromptCommands
         try
         {
             var resolver = CreateTemplateResolver(config);
-            var templates = resolver.ListTemplateNames(resolvedAgentId);
+            var templates = resolver.ListTemplateNames(AgentId.From(resolvedAgentId!));
             foreach (var template in templates)
                 Console.WriteLine(template);
             return 0;
@@ -293,7 +294,7 @@ internal sealed class PromptCommands
         try
         {
             var resolver = CreateTemplateResolver(config);
-            if (!resolver.TryRender(resolvedAgentId, templateName, parameters, out renderedPrompt, out var renderError))
+            if (!resolver.TryRender(AgentId.From(resolvedAgentId!), templateName, parameters, out renderedPrompt, out var renderError))
             {
                 if (!string.IsNullOrWhiteSpace(renderError))
                     AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(renderError)}");

--- a/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
+++ b/src/gateway/BotNexus.Cron/ActionStubs/AgentPromptActionStub.cs
@@ -20,9 +20,8 @@ public sealed class AgentPromptAction : ICronAction
     public async Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
-        var agentId = context.Job.AgentId;
-        if (string.IsNullOrWhiteSpace(agentId))
-            throw new InvalidOperationException("Cron job must define an agent id for agent-prompt actions.");
+        var agentId = context.Job.AgentId
+            ?? throw new InvalidOperationException("Cron job must define an agent id for agent-prompt actions.");
 
         var message = context.Job.Message;
         if (!string.IsNullOrWhiteSpace(context.Job.TemplateName))
@@ -40,7 +39,7 @@ public sealed class AgentPromptAction : ICronAction
             throw new InvalidOperationException("Cron job must define either a message or a templateName for agent-prompt actions.");
 
         var registry = context.Services.GetService<IAgentRegistry>();
-        var descriptor = registry?.Get(AgentId.From(agentId));
+        var descriptor = registry?.Get(agentId);
 
         var preferredTriggerType = descriptor?.Soul?.Enabled == true
             ? TriggerType.Soul
@@ -62,18 +61,18 @@ public sealed class AgentPromptAction : ICronAction
         };
         var sessionId = await trigger
             .CreateSessionAsync(
-                AgentId.From(agentId),
+                agentId,
                 message,
                 cancellationToken,
                 triggerRequest)
             .ConfigureAwait(false);
 
-        context.RecordSessionId(sessionId.Value);
+        context.RecordSessionId(sessionId);
 
         // Surface the resolved conversation ID back to the execution context so the
         // scheduler can persist it to the job record, eliminating the lookup on future runs.
-        if (!string.IsNullOrWhiteSpace(triggerRequest.ResolvedConversationId))
-            context.RecordConversationId(triggerRequest.ResolvedConversationId);
+        if (triggerRequest.ResolvedConversationId is { } resolvedConversationId)
+            context.RecordConversationId(resolvedConversationId);
     }
 
     private static bool IsInQuietHours(QuietHoursConfig config, string timezoneId)

--- a/src/gateway/BotNexus.Cron/Actions/HeartbeatAction.cs
+++ b/src/gateway/BotNexus.Cron/Actions/HeartbeatAction.cs
@@ -24,13 +24,12 @@ public sealed class HeartbeatAction : ICronAction
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var agentId = context.Job.AgentId;
-        if (string.IsNullOrWhiteSpace(agentId))
-            throw new InvalidOperationException("Heartbeat cron job must define an agent id.");
+        var agentId = context.Job.AgentId
+            ?? throw new InvalidOperationException("Heartbeat cron job must define an agent id.");
 
         var logger = context.Services.GetService<ILogger<HeartbeatAction>>();
         var registry = context.Services.GetService<IAgentRegistry>();
-        var descriptor = registry?.Get(AgentId.From(agentId));
+        var descriptor = registry?.Get(agentId);
 
         // Pre-flight: quiet hours
         var quietHours = descriptor?.Heartbeat?.QuietHours;
@@ -64,7 +63,7 @@ public sealed class HeartbeatAction : ICronAction
 
         var sessionId = await trigger
             .CreateSessionAsync(
-                AgentId.From(agentId),
+                agentId,
                 prompt,
                 cancellationToken,
                 new InternalTriggerRequest
@@ -75,7 +74,7 @@ public sealed class HeartbeatAction : ICronAction
                 })
             .ConfigureAwait(false);
 
-        context.RecordSessionId(sessionId.Value);
+        context.RecordSessionId(sessionId);
     }
 
     /// <summary>
@@ -84,12 +83,12 @@ public sealed class HeartbeatAction : ICronAction
     /// </summary>
     public static async Task<string?> ReadHeartbeatFileAsync(
         IAgentWorkspaceManager workspaceManager,
-        string agentId,
+        AgentId agentId,
         CancellationToken cancellationToken)
     {
         try
         {
-            var workspacePath = workspaceManager.GetWorkspacePath(agentId);
+            var workspacePath = workspaceManager.GetWorkspacePath(agentId.Value);
             var heartbeatPath = Path.Combine(workspacePath, "HEARTBEAT.md");
             if (!File.Exists(heartbeatPath))
                 return null;

--- a/src/gateway/BotNexus.Cron/CronJob.cs
+++ b/src/gateway/BotNexus.Cron/CronJob.cs
@@ -1,12 +1,14 @@
+using BotNexus.Domain.Primitives;
+
 namespace BotNexus.Cron;
 
 public sealed record CronJob
 {
-    public required string Id { get; init; }
+    public required JobId Id { get; init; }
     public required string Name { get; init; }
     public required string Schedule { get; init; }
     public required string ActionType { get; init; }
-    public string? AgentId { get; init; }
+    public AgentId? AgentId { get; init; }
     public string? Message { get; init; }
     /// <summary>
     /// Optional named prompt template reference for agent-prompt jobs.
@@ -36,6 +38,6 @@ public sealed record CronJob
     /// When set, every run is linked to this conversation regardless of routing.
     /// When null, a stable per-job conversation is created automatically using the job ID.
     /// </summary>
-    public string? ConversationId { get; init; }
+    public ConversationId? ConversationId { get; init; }
     public IReadOnlyDictionary<string, object?>? Metadata { get; init; }
 }

--- a/src/gateway/BotNexus.Cron/CronRun.cs
+++ b/src/gateway/BotNexus.Cron/CronRun.cs
@@ -1,12 +1,14 @@
+using BotNexus.Domain.Primitives;
+
 namespace BotNexus.Cron;
 
 public sealed record CronRun
 {
-    public required string Id { get; init; }
-    public required string JobId { get; init; }
+    public required RunId Id { get; init; }
+    public required JobId JobId { get; init; }
     public DateTimeOffset StartedAt { get; init; }
     public DateTimeOffset? CompletedAt { get; init; }
     public required string Status { get; init; }
     public string? Error { get; init; }
-    public string? SessionId { get; init; }
+    public SessionId? SessionId { get; init; }
 }

--- a/src/gateway/BotNexus.Cron/CronScheduler.cs
+++ b/src/gateway/BotNexus.Cron/CronScheduler.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using Cronos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,9 +22,8 @@ public sealed class CronScheduler(
         .GroupBy(action => action.ActionType, StringComparer.OrdinalIgnoreCase)
         .ToDictionary(group => group.Key, group => group.Last(), StringComparer.OrdinalIgnoreCase);
 
-    public async Task<CronRun> RunNowAsync(string jobId, CancellationToken cancellationToken = default)
+    public async Task<CronRun> RunNowAsync(JobId jobId, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         await _cronStore.InitializeAsync(cancellationToken).ConfigureAwait(false);
 
         var job = await _cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
@@ -147,9 +147,9 @@ public sealed class CronScheduler(
             // Persist the resolved conversation ID back to the job record so subsequent
             // runs skip the conversation lookup and use the fast path directly.
             var resolvedConversationId = context.ConversationId;
-            var needsConversationPinback = !string.IsNullOrWhiteSpace(resolvedConversationId)
-                && (string.IsNullOrWhiteSpace(latest.ConversationId)
-                    || latest.ConversationId != resolvedConversationId);
+            var needsConversationPinback = resolvedConversationId.HasValue
+                && (!latest.ConversationId.HasValue
+                    || latest.ConversationId.Value != resolvedConversationId.Value);
 
             await _cronStore.UpdateAsync(latest with
             {
@@ -224,15 +224,15 @@ public sealed class CronScheduler(
         if (options.Jobs is null || options.Jobs.Count == 0)
             return;
 
-        foreach (var (jobId, configuredJob) in options.Jobs)
+        foreach (var (jobIdString, configuredJob) in options.Jobs)
         {
-            if (string.IsNullOrWhiteSpace(jobId) ||
+            if (string.IsNullOrWhiteSpace(jobIdString) ||
                 string.IsNullOrWhiteSpace(configuredJob.Schedule) ||
                 string.IsNullOrWhiteSpace(configuredJob.ActionType))
             {
                 _logger.LogWarning(
                     "Skipping configured cron job '{JobId}' due to missing required fields (schedule/actionType).",
-                    jobId);
+                    jobIdString);
                 continue;
             }
 
@@ -241,7 +241,7 @@ public sealed class CronScheduler(
             {
                 _logger.LogWarning(
                     "Skipping configured cron job '{JobId}' because action type '{ActionType}' is not registered.",
-                    jobId,
+                    jobIdString,
                     configuredJob.ActionType);
                 continue;
             }
@@ -252,9 +252,14 @@ public sealed class CronScheduler(
             {
                 _logger.LogWarning(
                     "Skipping configured cron job '{JobId}' because agent-prompt jobs require agentId and either message or templateName.",
-                    jobId);
+                    jobIdString);
                 continue;
             }
+
+            var jobId = JobId.From(jobIdString);
+            var agentId = string.IsNullOrWhiteSpace(configuredJob.AgentId)
+                ? (AgentId?)null
+                : AgentId.From(configuredJob.AgentId);
 
             var existing = await _cronStore.GetAsync(jobId, ct).ConfigureAwait(false);
             if (existing is null)
@@ -262,10 +267,10 @@ public sealed class CronScheduler(
                 var seeded = new CronJob
                 {
                     Id = jobId,
-                    Name = configuredJob.Name ?? jobId,
+                    Name = configuredJob.Name ?? jobIdString,
                     Schedule = configuredJob.Schedule,
                     ActionType = normalizedActionType,
-                    AgentId = configuredJob.AgentId,
+                    AgentId = agentId,
                     Message = configuredJob.Message,
                     TemplateName = configuredJob.TemplateName,
                     TemplateParameters = configuredJob.TemplateParameters,
@@ -288,7 +293,7 @@ public sealed class CronScheduler(
                 Name = configuredJob.Name ?? existing.Name,
                 Schedule = configuredJob.Schedule,
                 ActionType = normalizedActionType,
-                AgentId = configuredJob.AgentId,
+                AgentId = agentId,
                 Message = configuredJob.Message,
                 TemplateName = configuredJob.TemplateName,
                 TemplateParameters = configuredJob.TemplateParameters,

--- a/src/gateway/BotNexus.Cron/HeartbeatCronProvisioner.cs
+++ b/src/gateway/BotNexus.Cron/HeartbeatCronProvisioner.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using Microsoft.Extensions.Hosting;
@@ -46,7 +47,7 @@ public sealed class HeartbeatCronProvisioner : IHostedService, IHeartbeatProvisi
     public async Task ProvisionAsync(AgentDescriptor descriptor, CancellationToken cancellationToken)
     {
         var heartbeat = descriptor.Heartbeat;
-        var jobId = $"heartbeat:{descriptor.AgentId}";
+        var jobId = JobId.From($"heartbeat:{descriptor.AgentId.Value}");
 
         if (heartbeat is not { Enabled: true })
         {
@@ -86,7 +87,7 @@ public sealed class HeartbeatCronProvisioner : IHostedService, IHeartbeatProvisi
                 Name = $"Heartbeat \u2014 {descriptor.DisplayName}",
                 Schedule = cronExpression,
                 ActionType = "heartbeat",
-                AgentId = descriptor.AgentId.Value,
+                AgentId = descriptor.AgentId,
                 Message = prompt,
                 Enabled = true,
                 System = true,

--- a/src/gateway/BotNexus.Cron/ICronAction.cs
+++ b/src/gateway/BotNexus.Cron/ICronAction.cs
@@ -1,3 +1,5 @@
+using BotNexus.Domain.Primitives;
+
 namespace BotNexus.Cron;
 
 public interface ICronAction
@@ -9,21 +11,20 @@ public interface ICronAction
 public sealed record CronExecutionContext
 {
     public required CronJob Job { get; init; }
-    public required string RunId { get; init; }
+    public required RunId RunId { get; init; }
     public required DateTimeOffset TriggeredAt { get; init; }
     public required CronTriggerType TriggerType { get; init; }
     public required IServiceProvider Services { get; init; }
-    public string? SessionId { get; private set; }
+    public SessionId? SessionId { get; private set; }
 
     /// <summary>
     /// The conversation ID resolved or created by the trigger for this run.
     /// Set by the trigger so the scheduler can persist it back to the job record.
     /// </summary>
-    public string? ConversationId { get; private set; }
+    public ConversationId? ConversationId { get; private set; }
 
-    public void RecordSessionId(string sessionId)
+    public void RecordSessionId(SessionId sessionId)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
         SessionId = sessionId;
     }
 
@@ -32,9 +33,8 @@ public sealed record CronExecutionContext
     /// Called by the trigger after conversation creation or lookup so the scheduler
     /// can persist the value back to the job for fast-path reuse on subsequent runs.
     /// </summary>
-    public void RecordConversationId(string conversationId)
+    public void RecordConversationId(ConversationId conversationId)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ConversationId = conversationId;
     }
 }

--- a/src/gateway/BotNexus.Cron/ICronStore.cs
+++ b/src/gateway/BotNexus.Cron/ICronStore.cs
@@ -1,14 +1,16 @@
+using BotNexus.Domain.Primitives;
+
 namespace BotNexus.Cron;
 
 public interface ICronStore
 {
     Task InitializeAsync(CancellationToken ct = default);
     Task<CronJob> CreateAsync(CronJob job, CancellationToken ct = default);
-    Task<CronJob?> GetAsync(string jobId, CancellationToken ct = default);
-    Task<IReadOnlyList<CronJob>> ListAsync(string? agentId = null, CancellationToken ct = default);
+    Task<CronJob?> GetAsync(JobId jobId, CancellationToken ct = default);
+    Task<IReadOnlyList<CronJob>> ListAsync(AgentId? agentId = null, CancellationToken ct = default);
     Task<CronJob> UpdateAsync(CronJob job, CancellationToken ct = default);
-    Task DeleteAsync(string jobId, CancellationToken ct = default);
-    Task<CronRun> RecordRunStartAsync(string jobId, CancellationToken ct = default);
-    Task RecordRunCompleteAsync(string runId, string status, string? error = null, string? sessionId = null, CancellationToken ct = default);
-    Task<IReadOnlyList<CronRun>> GetRunHistoryAsync(string jobId, int limit = 20, CancellationToken ct = default);
+    Task DeleteAsync(JobId jobId, CancellationToken ct = default);
+    Task<CronRun> RecordRunStartAsync(JobId jobId, CancellationToken ct = default);
+    Task RecordRunCompleteAsync(RunId runId, string status, string? error = null, SessionId? sessionId = null, CancellationToken ct = default);
+    Task<IReadOnlyList<CronRun>> GetRunHistoryAsync(JobId jobId, int limit = 20, CancellationToken ct = default);
 }

--- a/src/gateway/BotNexus.Cron/Prompts/CronOptionsPromptTemplateResolver.cs
+++ b/src/gateway/BotNexus.Cron/Prompts/CronOptionsPromptTemplateResolver.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using System.Text.Json;
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using Microsoft.Extensions.Options;
 
@@ -18,11 +19,8 @@ public sealed class CronOptionsPromptTemplateResolver(
     private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystem();
 
     /// <inheritdoc />
-    public IReadOnlyList<string> ListTemplateNames(string agentId)
+    public IReadOnlyList<string> ListTemplateNames(AgentId agentId)
     {
-        if (string.IsNullOrWhiteSpace(agentId))
-            return [];
-
         var templates = DiscoverTemplates(agentId);
         return templates.Keys
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
@@ -31,19 +29,12 @@ public sealed class CronOptionsPromptTemplateResolver(
 
     /// <inheritdoc />
     public bool TryRender(
-        string agentId,
+        AgentId agentId,
         string templateName,
         IReadOnlyDictionary<string, string?>? parameters,
         out string renderedPrompt,
         out string? error)
     {
-        if (string.IsNullOrWhiteSpace(agentId))
-        {
-            renderedPrompt = string.Empty;
-            error = "Agent id is required.";
-            return false;
-        }
-
         if (string.IsNullOrWhiteSpace(templateName))
         {
             renderedPrompt = string.Empty;
@@ -85,7 +76,7 @@ public sealed class CronOptionsPromptTemplateResolver(
             out error);
     }
 
-    private IReadOnlyDictionary<string, ResolvedPromptTemplate> DiscoverTemplates(string agentId)
+    private IReadOnlyDictionary<string, ResolvedPromptTemplate> DiscoverTemplates(AgentId agentId)
     {
         var templates = LoadOptionTemplates();
         foreach (var (directory, source) in ResolveTemplateDirectories(agentId, highestFirst: false))
@@ -151,7 +142,7 @@ public sealed class CronOptionsPromptTemplateResolver(
     }
 
     private bool TryResolveFileTemplate(
-        string agentId,
+        AgentId agentId,
         string templateName,
         out ResolvedPromptTemplate template,
         out string? error)
@@ -229,18 +220,18 @@ public sealed class CronOptionsPromptTemplateResolver(
         return false;
     }
 
-    private IReadOnlyList<(string Directory, TemplateSource Source)> ResolveTemplateDirectories(string agentId, bool highestFirst)
+    private IReadOnlyList<(string Directory, TemplateSource Source)> ResolveTemplateDirectories(AgentId agentId, bool highestFirst)
     {
         var homePath = ResolveBotNexusHomePath();
         var ordered = new List<(string Directory, TemplateSource Source)>
         {
             (_fileSystem.Path.Combine(homePath, "prompts"), TemplateSource.Shared),
-            (_fileSystem.Path.Combine(homePath, "agents", agentId, "prompts"), TemplateSource.Agent)
+            (_fileSystem.Path.Combine(homePath, "agents", agentId.Value, "prompts"), TemplateSource.Agent)
         };
 
         if (_workspaceManager is not null)
         {
-            var workspacePath = _workspaceManager.GetWorkspacePath(agentId);
+            var workspacePath = _workspaceManager.GetWorkspacePath(agentId.Value);
             ordered.Add((_fileSystem.Path.Combine(workspacePath, "prompts"), TemplateSource.Workspace));
         }
 

--- a/src/gateway/BotNexus.Cron/Prompts/IPromptTemplateResolver.cs
+++ b/src/gateway/BotNexus.Cron/Prompts/IPromptTemplateResolver.cs
@@ -1,3 +1,5 @@
+using BotNexus.Domain.Primitives;
+
 namespace BotNexus.Cron.Prompts;
 
 /// <summary>
@@ -10,7 +12,7 @@ public interface IPromptTemplateResolver
     /// </summary>
     /// <param name="agentId">Agent identifier used for per-agent and workspace template discovery.</param>
     /// <returns>Sorted template names.</returns>
-    IReadOnlyList<string> ListTemplateNames(string agentId);
+    IReadOnlyList<string> ListTemplateNames(AgentId agentId);
 
     /// <summary>
     /// Renders a named template for the specified agent.
@@ -22,7 +24,7 @@ public interface IPromptTemplateResolver
     /// <param name="error">Deterministic error message when render fails.</param>
     /// <returns><c>true</c> when the template was rendered successfully; otherwise <c>false</c>.</returns>
     bool TryRender(
-        string agentId,
+        AgentId agentId,
         string templateName,
         IReadOnlyDictionary<string, string?>? parameters,
         out string renderedPrompt,

--- a/src/gateway/BotNexus.Cron/SqliteCronStore.cs
+++ b/src/gateway/BotNexus.Cron/SqliteCronStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BotNexus.Domain.Primitives;
 using Microsoft.Data.Sqlite;
 using System.IO.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -140,7 +141,6 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         {
             var created = job with
             {
-                Id = string.IsNullOrWhiteSpace(job.Id) ? Guid.NewGuid().ToString("N") : job.Id,
                 CreatedAt = job.CreatedAt == default ? DateTimeOffset.UtcNow : job.CreatedAt
             };
 
@@ -174,9 +174,8 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         }
     }
 
-    public async Task<CronJob?> GetAsync(string jobId, CancellationToken ct = default)
+    public async Task<CronJob?> GetAsync(JobId jobId, CancellationToken ct = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         await InitializeAsync(ct).ConfigureAwait(false);
 
         await using var connection = CreateConnection();
@@ -188,7 +187,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             FROM cron_jobs
             WHERE id = $id
             """;
-        command.Parameters.AddWithValue("$id", jobId);
+        command.Parameters.AddWithValue("$id", jobId.Value);
 
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
         return await reader.ReadAsync(ct).ConfigureAwait(false)
@@ -196,7 +195,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             : null;
     }
 
-    public async Task<IReadOnlyList<CronJob>> ListAsync(string? agentId = null, CancellationToken ct = default)
+    public async Task<IReadOnlyList<CronJob>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
     {
         await InitializeAsync(ct).ConfigureAwait(false);
 
@@ -210,7 +209,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             WHERE $agentId IS NULL OR agent_id = $agentId
             ORDER BY created_at DESC
             """;
-        command.Parameters.AddWithValue("$agentId", (object?)agentId ?? DBNull.Value);
+        command.Parameters.AddWithValue("$agentId", agentId.HasValue ? (object)agentId.Value.Value : DBNull.Value);
 
         List<CronJob> jobs = [];
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -277,9 +276,8 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         }
     }
 
-    public async Task DeleteAsync(string jobId, CancellationToken ct = default)
+    public async Task DeleteAsync(JobId jobId, CancellationToken ct = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         await InitializeAsync(ct).ConfigureAwait(false);
 
         await _writeLock.WaitAsync(ct).ConfigureAwait(false);
@@ -290,12 +288,12 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
 
             await using var deleteRuns = connection.CreateCommand();
             deleteRuns.CommandText = "DELETE FROM cron_runs WHERE job_id = $jobId";
-            deleteRuns.Parameters.AddWithValue("$jobId", jobId);
+            deleteRuns.Parameters.AddWithValue("$jobId", jobId.Value);
             await deleteRuns.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
             await using var deleteJob = connection.CreateCommand();
             deleteJob.CommandText = "DELETE FROM cron_jobs WHERE id = $jobId";
-            deleteJob.Parameters.AddWithValue("$jobId", jobId);
+            deleteJob.Parameters.AddWithValue("$jobId", jobId.Value);
             await deleteJob.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
             _logger.LogInformation("Deleted cron job '{JobId}'.", jobId);
         }
@@ -305,9 +303,8 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         }
     }
 
-    public async Task<CronRun> RecordRunStartAsync(string jobId, CancellationToken ct = default)
+    public async Task<CronRun> RecordRunStartAsync(JobId jobId, CancellationToken ct = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         await InitializeAsync(ct).ConfigureAwait(false);
 
         await _writeLock.WaitAsync(ct).ConfigureAwait(false);
@@ -316,7 +313,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             var now = DateTimeOffset.UtcNow;
             var run = new CronRun
             {
-                Id = Guid.NewGuid().ToString("N"),
+                Id = RunId.Create(),
                 JobId = jobId,
                 StartedAt = now,
                 Status = "running"
@@ -330,8 +327,8 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
                 INSERT INTO cron_runs (id, job_id, started_at, completed_at, status, error, session_id)
                 VALUES ($id, $jobId, $startedAt, $completedAt, $status, $error, $sessionId)
                 """;
-            insertRun.Parameters.AddWithValue("$id", run.Id);
-            insertRun.Parameters.AddWithValue("$jobId", run.JobId);
+            insertRun.Parameters.AddWithValue("$id", run.Id.Value);
+            insertRun.Parameters.AddWithValue("$jobId", run.JobId.Value);
             insertRun.Parameters.AddWithValue("$startedAt", run.StartedAt.ToString("O"));
             insertRun.Parameters.AddWithValue("$completedAt", DBNull.Value);
             insertRun.Parameters.AddWithValue("$status", run.Status);
@@ -348,7 +345,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
                 WHERE id = $jobId
                 """;
             updateJob.Parameters.AddWithValue("$lastRunAt", now.ToString("O"));
-            updateJob.Parameters.AddWithValue("$jobId", jobId);
+            updateJob.Parameters.AddWithValue("$jobId", jobId.Value);
             await updateJob.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
             return run;
@@ -360,13 +357,12 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
     }
 
     public async Task RecordRunCompleteAsync(
-        string runId,
+        RunId runId,
         string status,
         string? error = null,
-        string? sessionId = null,
+        SessionId? sessionId = null,
         CancellationToken ct = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
         ArgumentException.ThrowIfNullOrWhiteSpace(status);
         await InitializeAsync(ct).ConfigureAwait(false);
 
@@ -388,8 +384,8 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             command.Parameters.AddWithValue("$completedAt", DateTimeOffset.UtcNow.ToString("O"));
             command.Parameters.AddWithValue("$status", status);
             command.Parameters.AddWithValue("$error", (object?)error ?? DBNull.Value);
-            command.Parameters.AddWithValue("$sessionId", (object?)sessionId ?? DBNull.Value);
-            command.Parameters.AddWithValue("$runId", runId);
+            command.Parameters.AddWithValue("$sessionId", sessionId.HasValue ? (object)sessionId.Value.Value : DBNull.Value);
+            command.Parameters.AddWithValue("$runId", runId.Value);
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
         finally
@@ -398,9 +394,8 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         }
     }
 
-    public async Task<IReadOnlyList<CronRun>> GetRunHistoryAsync(string jobId, int limit = 20, CancellationToken ct = default)
+    public async Task<IReadOnlyList<CronRun>> GetRunHistoryAsync(JobId jobId, int limit = 20, CancellationToken ct = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         await InitializeAsync(ct).ConfigureAwait(false);
 
         var cappedLimit = Math.Clamp(limit, 1, int.MaxValue);
@@ -414,7 +409,7 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
             ORDER BY started_at DESC
             LIMIT $limit
             """;
-        command.Parameters.AddWithValue("$jobId", jobId);
+        command.Parameters.AddWithValue("$jobId", jobId.Value);
         command.Parameters.AddWithValue("$limit", cappedLimit);
 
         List<CronRun> runs = [];
@@ -429,11 +424,11 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
 
     private static void BindJob(SqliteCommand command, CronJob job)
     {
-        command.Parameters.AddWithValue("$id", job.Id);
+        command.Parameters.AddWithValue("$id", job.Id.Value);
         command.Parameters.AddWithValue("$name", job.Name);
         command.Parameters.AddWithValue("$schedule", job.Schedule);
         command.Parameters.AddWithValue("$actionType", job.ActionType);
-        command.Parameters.AddWithValue("$agentId", (object?)job.AgentId ?? DBNull.Value);
+        command.Parameters.AddWithValue("$agentId", job.AgentId.HasValue ? (object)job.AgentId.Value.Value : DBNull.Value);
         command.Parameters.AddWithValue("$message", (object?)job.Message ?? DBNull.Value);
         command.Parameters.AddWithValue("@templateName", (object?)job.TemplateName ?? DBNull.Value);
         command.Parameters.AddWithValue("@templateParametersJson", SerializeTemplateParameters(job.TemplateParameters));
@@ -458,11 +453,11 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
         var metadataJson = reader.IsDBNull(20) ? null : reader.GetString(20);
         return new CronJob
         {
-            Id = reader.GetString(0),
+            Id = JobId.From(reader.GetString(0)),
             Name = reader.GetString(1),
             Schedule = reader.GetString(2),
             ActionType = reader.GetString(3),
-            AgentId = reader.IsDBNull(4) ? null : reader.GetString(4),
+            AgentId = reader.IsDBNull(4) ? null : AgentId.From(reader.GetString(4)),
             Message = reader.IsDBNull(5) ? null : reader.GetString(5),
             TemplateName = reader.IsDBNull(6) ? null : reader.GetString(6),
             TemplateParameters = DeserializeTemplateParameters(templateParametersJson),
@@ -486,13 +481,13 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
     {
         return new CronRun
         {
-            Id = reader.GetString(0),
-            JobId = reader.GetString(1),
+            Id = RunId.From(reader.GetString(0)),
+            JobId = JobId.From(reader.GetString(1)),
             StartedAt = ParseDate(reader.GetString(2)),
             CompletedAt = reader.IsDBNull(3) ? null : ParseDate(reader.GetString(3)),
             Status = reader.GetString(4),
             Error = reader.IsDBNull(5) ? null : reader.GetString(5),
-            SessionId = reader.IsDBNull(6) ? null : reader.GetString(6)
+            SessionId = reader.IsDBNull(6) ? null : SessionId.From(reader.GetString(6))
         };
     }
 

--- a/src/gateway/BotNexus.Cron/Tools/CronTool.cs
+++ b/src/gateway/BotNexus.Cron/Tools/CronTool.cs
@@ -2,18 +2,17 @@ using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Domain.Primitives;
 
 namespace BotNexus.Cron.Tools;
 
 public sealed class CronTool(
     ICronStore cronStore,
     CronScheduler scheduler,
-    string agentId,
+    AgentId agentId,
     bool allowCrossAgentCron = false) : IAgentTool
 {
-    private readonly string _agentId = string.IsNullOrWhiteSpace(agentId)
-        ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
-        : agentId;
+    private readonly AgentId _agentId = agentId;
 
     public string Name => "cron";
     public string Label => "Cron Job Manager";
@@ -106,8 +105,8 @@ public sealed class CronTool(
         var visible = allowCrossAgentCron
             ? filtered.ToList()
             : filtered.Where(job =>
-                string.Equals(job.CreatedBy, _agentId, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(job.AgentId, _agentId, StringComparison.OrdinalIgnoreCase)).ToList();
+                string.Equals(job.CreatedBy, _agentId.Value, StringComparison.OrdinalIgnoreCase)
+                || (job.AgentId.HasValue && job.AgentId.Value == _agentId)).ToList();
 
         return TextResult(JsonSerializer.Serialize(visible, JsonOptions));
     }
@@ -130,20 +129,25 @@ public sealed class CronTool(
         }
         catch { /* invalid schedule — will be caught by scheduler */ }
 
+        var targetAgentIdString = ReadString(arguments, "agentId");
+        var targetAgentId = string.IsNullOrWhiteSpace(targetAgentIdString)
+            ? _agentId
+            : AgentId.From(targetAgentIdString);
+
         var job = new CronJob
         {
-            Id = Guid.NewGuid().ToString("N"),
+            Id = JobId.From(Guid.NewGuid().ToString("N")),
             Name = ReadRequired(arguments, "name"),
             Schedule = schedule,
             ActionType = "agent-prompt",
-            AgentId = ReadString(arguments, "agentId") ?? _agentId,
+            AgentId = targetAgentId,
             Message = message,
             TemplateName = templateName,
             TemplateParameters = ReadStringMap(arguments, "templateParameters"),
             Model = ReadString(arguments, "model"),
             Enabled = arguments.TryGetValue("enabled", out var enabled) && enabled is bool boolEnabled ? boolEnabled : true,
             TimeZone = timeZone,
-            CreatedBy = _agentId,
+            CreatedBy = _agentId.Value,
             CreatedAt = now,
             NextRunAt = nextRunAt,
             Metadata = new Dictionary<string, object?>()
@@ -155,9 +159,9 @@ public sealed class CronTool(
 
     private async Task<AgentToolResult> UpdateAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken cancellationToken)
     {
-        var jobId = ReadRequired(arguments, "jobId");
+        var jobId = JobId.From(ReadRequired(arguments, "jobId"));
         var existing = await cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
-            ?? throw new KeyNotFoundException($"Cron job '{jobId}' was not found.");
+            ?? throw new KeyNotFoundException($"Cron job '{jobId.Value}' was not found.");
 
         EnsureCanManage(existing);
 
@@ -169,6 +173,12 @@ public sealed class CronTool(
             ? ReadStringMap(arguments, "templateParameters")
             : existing.TemplateParameters;
         EnsurePromptSource(newMessage, newTemplateName);
+
+        var newAgentIdString = ReadString(arguments, "agentId");
+        var newAgentId = string.IsNullOrWhiteSpace(newAgentIdString)
+            ? existing.AgentId
+            : AgentId.From(newAgentIdString);
+
         var updated = existing with
         {
             Name = ReadString(arguments, "name") ?? existing.Name,
@@ -178,7 +188,7 @@ public sealed class CronTool(
             TemplateName = newTemplateName,
             TemplateParameters = newTemplateParameters,
             Model = ReadString(arguments, "model") ?? existing.Model,
-            AgentId = ReadString(arguments, "agentId") ?? existing.AgentId,
+            AgentId = newAgentId,
             Enabled = arguments.TryGetValue("enabled", out var enabled) && enabled is bool boolEnabled ? boolEnabled : existing.Enabled
         };
 
@@ -204,20 +214,20 @@ public sealed class CronTool(
 
     private async Task<AgentToolResult> DeleteAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken cancellationToken)
     {
-        var jobId = ReadRequired(arguments, "jobId");
+        var jobId = JobId.From(ReadRequired(arguments, "jobId"));
         var existing = await cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
-            ?? throw new KeyNotFoundException($"Cron job '{jobId}' was not found.");
+            ?? throw new KeyNotFoundException($"Cron job '{jobId.Value}' was not found.");
 
         EnsureCanManage(existing);
         await cronStore.DeleteAsync(jobId, cancellationToken).ConfigureAwait(false);
-        return TextResult($"Deleted cron job '{jobId}'.");
+        return TextResult($"Deleted cron job '{jobId.Value}'.");
     }
 
     private async Task<AgentToolResult> RunAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken cancellationToken)
     {
-        var jobId = ReadRequired(arguments, "jobId");
+        var jobId = JobId.From(ReadRequired(arguments, "jobId"));
         var existing = await cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
-            ?? throw new KeyNotFoundException($"Cron job '{jobId}' was not found.");
+            ?? throw new KeyNotFoundException($"Cron job '{jobId.Value}' was not found.");
 
         EnsureCanManage(existing);
         var run = await scheduler.RunNowAsync(jobId, cancellationToken).ConfigureAwait(false);
@@ -229,8 +239,8 @@ public sealed class CronTool(
         if (allowCrossAgentCron)
             return;
 
-        var isCreator = string.Equals(job.CreatedBy, _agentId, StringComparison.OrdinalIgnoreCase);
-        var isTarget = string.Equals(job.AgentId, _agentId, StringComparison.OrdinalIgnoreCase);
+        var isCreator = string.Equals(job.CreatedBy, _agentId.Value, StringComparison.OrdinalIgnoreCase);
+        var isTarget = job.AgentId.HasValue && job.AgentId.Value == _agentId;
         if (!isCreator && !isTarget)
             throw new UnauthorizedAccessException("You can only manage cron jobs created by or targeting this agent.");
     }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CronController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CronController.cs
@@ -1,4 +1,5 @@
 using BotNexus.Cron;
+using BotNexus.Domain.Primitives;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -28,7 +29,7 @@ public sealed class CronController(
     public async Task<ActionResult<IReadOnlyList<CronJob>>> List(CancellationToken cancellationToken)
     {
         var persisted = await store.ListAsync(ct: cancellationToken);
-        var merged = persisted.ToDictionary(job => job.Id, StringComparer.OrdinalIgnoreCase);
+        var merged = persisted.ToDictionary(job => job.Id.Value, StringComparer.OrdinalIgnoreCase);
         var configuredJobs = cronOptions.CurrentValue?.Jobs;
         if (configuredJobs is not null)
         {
@@ -46,11 +47,11 @@ public sealed class CronController(
 
                 merged[jobId] = new CronJob
                 {
-                    Id = jobId,
+                    Id = JobId.From(jobId),
                     Name = configured.Name ?? jobId,
                     Schedule = configured.Schedule,
                     ActionType = NormalizeActionType(configured.ActionType),
-                    AgentId = configured.AgentId,
+                    AgentId = string.IsNullOrWhiteSpace(configured.AgentId) ? null : AgentId.From(configured.AgentId),
                     Message = configured.Message,
                     TemplateName = configured.TemplateName,
                     TemplateParameters = configured.TemplateParameters,
@@ -80,7 +81,7 @@ public sealed class CronController(
     [HttpGet("{jobId}")]
     public async Task<ActionResult<CronJob>> Get(string jobId, CancellationToken cancellationToken)
     {
-        var job = await store.GetAsync(jobId, cancellationToken);
+        var job = await store.GetAsync(JobId.From(jobId), cancellationToken);
         return job is null ? NotFound() : Ok(job);
     }
 
@@ -96,14 +97,13 @@ public sealed class CronController(
     {
         var toCreate = request with
         {
-            Id = string.IsNullOrWhiteSpace(request.Id) ? Guid.NewGuid().ToString("N") : request.Id,
             ActionType = NormalizeActionType(request.ActionType),
             CreatedAt = request.CreatedAt == default ? DateTimeOffset.UtcNow : request.CreatedAt
         };
 
         var created = await store.CreateAsync(toCreate, cancellationToken);
-        logger.LogInformation("Cron job created via API: {JobId} ({ActionType})", created.Id, created.ActionType);
-        return CreatedAtAction(nameof(Get), new { jobId = created.Id }, created);
+        logger.LogInformation("Cron job created via API: {JobId} ({ActionType})", created.Id.Value, created.ActionType);
+        return CreatedAtAction(nameof(Get), new { jobId = created.Id.Value }, created);
     }
 
     /// <summary>Updates a cron job.</summary>
@@ -117,19 +117,20 @@ public sealed class CronController(
     [HttpPut("{jobId}")]
     public async Task<ActionResult<CronJob>> Update(string jobId, [FromBody] CronJob request, CancellationToken cancellationToken)
     {
-        var existing = await store.GetAsync(jobId, cancellationToken);
+        var typedJobId = JobId.From(jobId);
+        var existing = await store.GetAsync(typedJobId, cancellationToken);
         if (existing is null)
             return NotFound();
 
         var updated = request with
         {
-            Id = jobId,
+            Id = typedJobId,
             ActionType = NormalizeActionType(request.ActionType),
             CreatedAt = existing.CreatedAt
         };
 
         var saved = await store.UpdateAsync(updated, cancellationToken);
-        logger.LogInformation("Cron job updated via API: {JobId} ({ActionType})", saved.Id, saved.ActionType);
+        logger.LogInformation("Cron job updated via API: {JobId} ({ActionType})", saved.Id.Value, saved.ActionType);
         return Ok(saved);
     }
 
@@ -143,7 +144,7 @@ public sealed class CronController(
     [HttpDelete("{jobId}")]
     public async Task<IActionResult> Delete(string jobId, CancellationToken cancellationToken)
     {
-        await store.DeleteAsync(jobId, cancellationToken);
+        await store.DeleteAsync(JobId.From(jobId), cancellationToken);
         logger.LogInformation("Cron job deleted via API: {JobId}", jobId);
         return NoContent();
     }
@@ -158,11 +159,12 @@ public sealed class CronController(
     [HttpPost("{jobId}/run")]
     public async Task<ActionResult<CronRun>> Run(string jobId, CancellationToken cancellationToken)
     {
-        var existing = await store.GetAsync(jobId, cancellationToken);
+        var typedJobId = JobId.From(jobId);
+        var existing = await store.GetAsync(typedJobId, cancellationToken);
         if (existing is null)
             return NotFound();
 
-        var run = await scheduler.RunNowAsync(jobId, cancellationToken);
+        var run = await scheduler.RunNowAsync(typedJobId, cancellationToken);
         return Accepted(run);
     }
 
@@ -177,11 +179,12 @@ public sealed class CronController(
     [HttpGet("{jobId}/runs")]
     public async Task<ActionResult<IReadOnlyList<CronRun>>> Runs(string jobId, [FromQuery] int limit = 20, CancellationToken cancellationToken = default)
     {
-        var existing = await store.GetAsync(jobId, cancellationToken);
+        var typedJobId = JobId.From(jobId);
+        var existing = await store.GetAsync(typedJobId, cancellationToken);
         if (existing is null)
             return NotFound();
 
-        return Ok(await store.GetRunHistoryAsync(jobId, limit, cancellationToken));
+        return Ok(await store.GetRunHistoryAsync(typedJobId, limit, cancellationToken));
     }
 
     private static string NormalizeActionType(string? actionType)

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -57,19 +57,19 @@ public sealed class CronTrigger(
         else
             session.Metadata["modelOverride"] = request!.ModelOverride;
 
-        if (string.IsNullOrWhiteSpace(request?.CronJobId))
+        if (request?.CronJobId is null)
             session.Metadata.Remove("cronJobId");
         else
-            session.Metadata["cronJobId"] = request!.CronJobId;
+            session.Metadata["cronJobId"] = request.CronJobId.Value.Value;
 
         // Resolve the conversation for this run:
         // 1. Explicit ConversationId on the job — always use that conversation
         // 2. Otherwise find/create a stable per-job conversation keyed by job ID
         //    so every run of the same job lands in the same conversation.
         Conversation conversation;
-        if (!string.IsNullOrWhiteSpace(request?.ConversationId))
+        if (request?.ConversationId is { } explicitConversationId)
         {
-            conversation = await conversations.GetAsync(ConversationId.From(request.ConversationId), ct).ConfigureAwait(false)
+            conversation = await conversations.GetAsync(explicitConversationId, ct).ConfigureAwait(false)
                 ?? await GetOrCreateCronConversationAsync(agentId, request.CronJobId, request.JobName, ct).ConfigureAwait(false);
         }
         else
@@ -79,8 +79,8 @@ public sealed class CronTrigger(
 
         // Write back the resolved conversation ID so the caller (e.g. scheduler) can persist it to the job
         // record, enabling subsequent runs to skip the lookup entirely.
-        if (request is not null && string.IsNullOrWhiteSpace(request.ResolvedConversationId))
-            request.ResolvedConversationId = conversation.ConversationId.Value;
+        if (request is not null && request.ResolvedConversationId is null)
+            request.ResolvedConversationId = conversation.ConversationId;
 
         if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
             session.Session.ConversationId = conversation.ConversationId;
@@ -117,14 +117,15 @@ public sealed class CronTrigger(
     /// All runs of the same job land in the same conversation.
     /// The conversation is identified by its title "cron:{jobId}" or "cron:unnamed" for jobs without an ID.
     /// </summary>
-    private async Task<Conversation> GetOrCreateCronConversationAsync(AgentId agentId, string? jobId, string? jobName, CancellationToken ct)
+    private async Task<Conversation> GetOrCreateCronConversationAsync(AgentId agentId, JobId? jobId, string? jobName, CancellationToken ct)
     {
+        var jobIdString = jobId?.Value;
         // Use human-readable job name as title when available; fall back to job-id slug.
         var title = !string.IsNullOrWhiteSpace(jobName)
             ? jobName
-            : string.IsNullOrWhiteSpace(jobId)
+            : string.IsNullOrWhiteSpace(jobIdString)
                 ? $"cron:{agentId.Value}"
-                : $"cron:{SanitizeSessionIdPart(jobId) ?? agentId.Value}";
+                : $"cron:{SanitizeSessionIdPart(jobIdString) ?? agentId.Value}";
         var stableConversationId = BuildCronConversationId(agentId, jobId);
 
         // Prefer deterministic lookup by stable conversation id.
@@ -252,11 +253,11 @@ public sealed class CronTrigger(
             canonical.ConversationId);
     }
 
-    private static SessionId BuildCronSessionId(string? jobId)
+    private static SessionId BuildCronSessionId(JobId? jobId)
     {
         var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmss");
         var suffix = Guid.NewGuid().ToString("N");
-        var safeJobId = SanitizeSessionIdPart(jobId);
+        var safeJobId = SanitizeSessionIdPart(jobId?.Value);
         return string.IsNullOrWhiteSpace(safeJobId)
             ? SessionId.From($"cron:{timestamp}:{suffix}")
             : SessionId.From($"cron:{safeJobId}:{timestamp}:{suffix}");
@@ -286,10 +287,10 @@ public sealed class CronTrigger(
         return new string(buffer[..length]).Trim('-');
     }
 
-    private static ConversationId BuildCronConversationId(AgentId agentId, string? jobId)
+    private static ConversationId BuildCronConversationId(AgentId agentId, JobId? jobId)
     {
         var safeAgentId = SanitizeSessionIdPart(agentId.Value) ?? "agent";
-        var safeJobId = SanitizeSessionIdPart(jobId) ?? safeAgentId;
+        var safeJobId = SanitizeSessionIdPart(jobId?.Value) ?? safeAgentId;
         return ConversationId.From($"cronconv:{safeAgentId}:{safeJobId}");
     }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
@@ -104,10 +104,10 @@ public sealed class HeartbeatTrigger(
         else
             session.Metadata["modelOverride"] = request!.ModelOverride;
 
-        if (string.IsNullOrWhiteSpace(request?.CronJobId))
+        if (request?.CronJobId is null)
             session.Metadata.Remove("cronJobId");
         else
-            session.Metadata["cronJobId"] = request!.CronJobId;
+            session.Metadata["cronJobId"] = request.CronJobId.Value.Value;
 
         if (conversation.ActiveSessionId != sessionId)
         {

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
@@ -65,10 +65,10 @@ public sealed class SoulTrigger(
         else
             session.Metadata["modelOverride"] = request!.ModelOverride;
 
-        if (string.IsNullOrWhiteSpace(request?.CronJobId))
+        if (request?.CronJobId is null)
             session.Metadata.Remove("cronJobId");
         else
-            session.Metadata["cronJobId"] = request!.CronJobId;
+            session.Metadata["cronJobId"] = request.CronJobId.Value.Value;
 
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = prompt });
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Triggers/IInternalTrigger.cs
@@ -35,7 +35,7 @@ public sealed record InternalTriggerRequest
     /// <summary>
     /// Optional cron job identifier used for traceability and session-id composition.
     /// </summary>
-    public string? CronJobId { get; init; }
+    public JobId? CronJobId { get; init; }
 
     /// <summary>
     /// Optional model override for this trigger execution.
@@ -47,7 +47,7 @@ public sealed record InternalTriggerRequest
     /// Optional explicit conversation ID to route this trigger run into.
     /// When null, the trigger determines the conversation (e.g. per-job stable conversation for cron).
     /// </summary>
-    public string? ConversationId { get; init; }
+    public ConversationId? ConversationId { get; init; }
 
     /// <summary>
     /// Optional human-readable job name used as the conversation title when the trigger creates a new conversation.
@@ -59,5 +59,5 @@ public sealed record InternalTriggerRequest
     /// Written back by the trigger after the conversation for this run has been resolved or created.
     /// Callers can read this value to persist the conversation ID for fast-path reuse on subsequent runs.
     /// </summary>
-    public string? ResolvedConversationId { get; set; }
+    public ConversationId? ResolvedConversationId { get; set; }
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -151,7 +151,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             if (cronStore is not null && cronScheduler is not null)
             {
                 var allowCrossAgentCron = ResolveAllowCrossAgentCron(descriptor);
-                tools.Add(new CronTool(cronStore, cronScheduler, descriptor.AgentId.Value, allowCrossAgentCron));
+                tools.Add(new CronTool(cronStore, cronScheduler, descriptor.AgentId, allowCrossAgentCron));
             }
         }
 

--- a/src/gateway/BotNexus.Gateway/Sessions/PreCompactionMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/PreCompactionMemoryFlusher.cs
@@ -69,7 +69,7 @@ public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
                 timeoutCt.Token,
                 new InternalTriggerRequest
                 {
-                    ConversationId = session.ConversationId?.Value
+                    ConversationId = session.ConversationId
                 }).ConfigureAwait(false);
 
             // Record that a flush has run for this compaction cycle.

--- a/src/gateway/BotNexus.Gateway/Sessions/SessionEndMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/SessionEndMemoryFlusher.cs
@@ -66,7 +66,7 @@ public sealed class SessionEndMemoryFlusher : ISessionEndMemoryFlusher
                 timeoutCts.Token,
                 new InternalTriggerRequest
                 {
-                    ConversationId = session.ConversationId?.Value
+                    ConversationId = session.ConversationId
                 }).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/tests/architecture/BotNexus.Architecture.Tests/JobIdRunIdArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/JobIdRunIdArchitectureTests.cs
@@ -1,0 +1,93 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the PR #501 (Vogen Phase 2) invariant:
+/// the Cron module and its triggers no longer accept primitive <c>string</c>
+/// identifiers named <c>jobId</c> or <c>runId</c>. They use the typed value
+/// objects <c>BotNexus.Domain.Primitives.JobId</c> and
+/// <c>BotNexus.Domain.Primitives.RunId</c> instead.
+/// </summary>
+/// <remarks>
+/// Phase 1 of the Vogen rollout (PR #513) typed <c>AgentId</c>,
+/// <c>ConversationId</c>, and <c>SessionId</c>. Phase 2 (PR #501) extends the
+/// same treatment to scheduled-job identifiers. JSON / REST / SignalR boundaries
+/// still take <c>string</c> from the wire (where Vogen runs its validation on
+/// <c>From(...)</c>); only public method parameters and field declarations are
+/// fenced here.
+/// </remarks>
+public sealed class JobIdRunIdArchitectureTests
+{
+    // Cron-domain files that own the wire ↔ typed boundary. They take strings from
+    // REST/CLI inputs and convert via JobId.From / RunId.From; the fence would
+    // otherwise force them to take the typed value before the conversion has run.
+    private static readonly string[] AllowedFiles =
+    {
+        // REST controller accepts {jobId} as a route segment string and wraps with JobId.From.
+        "CronController.cs",
+        // CLI commands accept string CLI arguments and wrap them at the boundary.
+        "CronCommands.cs",
+        // Cron tool accepts JSON-encoded arguments and wraps them at the boundary.
+        "CronTool.cs",
+    };
+
+    // Folders that must use typed JobId / RunId on every public surface.
+    private static readonly string[] ScopedFolders =
+    {
+        Path.Combine("gateway", "BotNexus.Cron"),
+        Path.Combine("gateway", "BotNexus.Gateway.Api", "Triggers"),
+    };
+
+    /// <summary>
+    /// No public method in the Cron module or its triggers may declare a
+    /// parameter or field named <c>jobId</c> / <c>runId</c> of type
+    /// <c>string</c>. Use <c>JobId</c> / <c>RunId</c> instead.
+    /// </summary>
+    [Fact]
+    public void NoStringJobIdOrRunId_InCronModule()
+    {
+        var srcRoot = FindSourceRoot();
+        // Matches `string jobId`, `string? jobId`, `string  runId`, etc. — but not
+        // `JobId jobId` or `RunId runId` (typed parameters).
+        var pattern = new Regex(@"\bstring\??\s+(jobId|runId)\b", RegexOptions.Compiled);
+
+        var offenders = ScopedFolders
+            .Select(folder => Path.Combine(srcRoot, folder))
+            .Where(Directory.Exists)
+            .SelectMany(folder => Directory.EnumerateFiles(folder, "*.cs", SearchOption.AllDirectories))
+            .Where(IsProductionSource)
+            .Where(path => !AllowedFiles.Contains(Path.GetFileName(path), StringComparer.Ordinal))
+            .Where(path => pattern.IsMatch(File.ReadAllText(path)))
+            .Select(path => Path.GetRelativePath(srcRoot, path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            "Files under src/gateway/BotNexus.Cron/ or src/gateway/BotNexus.Gateway.Api/Triggers/ " +
+            "declare a 'string jobId' or 'string runId' parameter / field. PR #501 (Vogen Phase 2) " +
+            "introduced the typed JobId and RunId value objects — public API must use them. " +
+            "Boundary adapters (REST controllers, CLI commands, tool JSON parsing) are allowlisted " +
+            "because they convert the wire string with JobId.From(...) / RunId.From(...).\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static bool IsProductionSource(string path)
+        => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        && !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/domain/BotNexus.Domain.Tests/JobIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/JobIdTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using Vogen;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class JobIdTests
+{
+    [Fact]
+    public void From_TrimsLeadingAndTrailingWhitespace()
+    {
+        var result = JobId.From(" job-1 ");
+
+        result.Value.ShouldBe("job-1");
+    }
+
+    [Fact]
+    public void From_RejectsNull()
+    {
+        Action act = () => JobId.From(null!);
+
+        act.ShouldThrow<ValueObjectValidationException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("   \n   ")]
+    public void From_RejectsEmptyOrWhitespace(string value)
+    {
+        Action act = () => JobId.From(value);
+
+        var ex = act.ShouldThrow<ValueObjectValidationException>();
+        ex.Message.ShouldContain("JobId");
+    }
+
+    [Fact]
+    public void Equality_MatchesByValue()
+    {
+        JobId.From("job-1").ShouldBe(JobId.From("job-1"));
+        JobId.From("job-1").ShouldNotBe(JobId.From("job-2"));
+    }
+
+    [Fact]
+    public void ToString_ReturnsRawValue()
+    {
+        JobId.From("job-1").ToString().ShouldBe("job-1");
+    }
+
+    [Fact]
+    public void Json_SerializesAsBareString()
+    {
+        var json = JsonSerializer.Serialize(JobId.From("job-1"));
+
+        json.ShouldBe("\"job-1\"");
+    }
+
+    [Fact]
+    public void Json_DeserializesFromBareString()
+    {
+        var id = JsonSerializer.Deserialize<JobId>("\"job-1\"");
+
+        id.ShouldBe(JobId.From("job-1"));
+    }
+
+    [Fact]
+    public void Json_RoundTripPreservesValue()
+    {
+        var original = JobId.From("job-1");
+
+        var roundTrip = JsonSerializer.Deserialize<JobId>(JsonSerializer.Serialize(original));
+
+        roundTrip.ShouldBe(original);
+    }
+
+    [Fact]
+    public void Json_PropertyOnDtoUsesBareStringWithCamelCase()
+    {
+        var dto = new { job = JobId.From("job-1"), label = "scheduled" };
+
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        json.ShouldBe("{\"job\":\"job-1\",\"label\":\"scheduled\"}");
+    }
+}

--- a/tests/domain/BotNexus.Domain.Tests/RunIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/RunIdTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using Vogen;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class RunIdTests
+{
+    [Fact]
+    public void Create_GeneratesUnique32CharacterGuid()
+    {
+        var a = RunId.Create();
+        var b = RunId.Create();
+
+        a.Value.Length.ShouldBe(32);
+        a.ShouldNotBe(b);
+    }
+
+    [Fact]
+    public void From_TrimsLeadingAndTrailingWhitespace()
+    {
+        var result = RunId.From(" run-1 ");
+
+        result.Value.ShouldBe("run-1");
+    }
+
+    [Fact]
+    public void From_RejectsNull()
+    {
+        Action act = () => RunId.From(null!);
+
+        act.ShouldThrow<ValueObjectValidationException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("   \n   ")]
+    public void From_RejectsEmptyOrWhitespace(string value)
+    {
+        Action act = () => RunId.From(value);
+
+        var ex = act.ShouldThrow<ValueObjectValidationException>();
+        ex.Message.ShouldContain("RunId");
+    }
+
+    [Fact]
+    public void Equality_MatchesByValue()
+    {
+        RunId.From("run-1").ShouldBe(RunId.From("run-1"));
+        RunId.From("run-1").ShouldNotBe(RunId.From("run-2"));
+    }
+
+    [Fact]
+    public void ToString_ReturnsRawValue()
+    {
+        RunId.From("run-1").ToString().ShouldBe("run-1");
+    }
+
+    [Fact]
+    public void Json_SerializesAsBareString()
+    {
+        var json = JsonSerializer.Serialize(RunId.From("run-1"));
+
+        json.ShouldBe("\"run-1\"");
+    }
+
+    [Fact]
+    public void Json_DeserializesFromBareString()
+    {
+        var id = JsonSerializer.Deserialize<RunId>("\"run-1\"");
+
+        id.ShouldBe(RunId.From("run-1"));
+    }
+
+    [Fact]
+    public void Json_RoundTripPreservesValue()
+    {
+        var original = RunId.From("run-1");
+
+        var roundTrip = JsonSerializer.Deserialize<RunId>(JsonSerializer.Serialize(original));
+
+        roundTrip.ShouldBe(original);
+    }
+
+    [Fact]
+    public void Json_PropertyOnDtoUsesBareStringWithCamelCase()
+    {
+        var dto = new { run = RunId.From("run-1"), label = "in-progress" };
+
+        var json = JsonSerializer.Serialize(
+            dto,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        json.ShouldBe("{\"run\":\"run-1\",\"label\":\"in-progress\"}");
+    }
+}

--- a/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTemplateTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTemplateTests.cs
@@ -20,8 +20,8 @@ public sealed class AgentPromptActionTemplateTests
         trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
             .Callback<AgentId, string, CancellationToken, InternalTriggerRequest?>((_, prompt, _, _) => capturedPrompt = prompt)
             .ReturnsAsync(SessionId.From("cron:template:run-1"));
-        resolver.Setup(value => value.TryRender("agent-a", "daily-status", It.IsAny<IReadOnlyDictionary<string, string?>?>(), out It.Ref<string>.IsAny, out It.Ref<string?>.IsAny))
-            .Returns((string _, string __, IReadOnlyDictionary<string, string?>? ___, out string rendered, out string? error) =>
+        resolver.Setup(value => value.TryRender(AgentId.From("agent-a"), "daily-status", It.IsAny<IReadOnlyDictionary<string, string?>?>(), out It.Ref<string>.IsAny, out It.Ref<string?>.IsAny))
+            .Returns((AgentId _, string __, IReadOnlyDictionary<string, string?>? ___, out string rendered, out string? error) =>
             {
                 rendered = "Rendered prompt";
                 error = null;
@@ -77,18 +77,18 @@ public sealed class AgentPromptActionTemplateTests
         {
             Job = new CronJob
             {
-                Id = "job-1",
+                Id = JobId.From("job-1"),
                 Name = "Cron prompt",
                 Schedule = "*/1 * * * *",
                 ActionType = "agent-prompt",
-                AgentId = "agent-a",
+                AgentId = AgentId.From("agent-a"),
                 Message = message,
                 TemplateName = templateName,
                 TemplateParameters = new Dictionary<string, string?> { ["owner"] = "Hermes" },
                 CreatedAt = DateTimeOffset.UtcNow,
                 Enabled = true
             },
-            RunId = "run-1",
+            RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
             TriggerType = CronTriggerType.Scheduled,
             Services = services

--- a/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/AgentPromptActionTests.cs
@@ -41,9 +41,9 @@ public sealed class AgentPromptActionTests
         capturedAgentId.ShouldBe(AgentId.From("agent-a"));
         capturedPrompt.ShouldBe("Ping from cron");
         capturedRequest.ShouldNotBeNull();
-        capturedRequest!.CronJobId.ShouldBe("job-1");
+        capturedRequest!.CronJobId!.Value.Value.ShouldBe("job-1");
         capturedRequest.ModelOverride.ShouldBe("openai/gpt-4.1");
-        context.SessionId.ShouldBe(createdSession.Value);
+        context.SessionId!.Value.ShouldBe(createdSession);
         trigger.Verify(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
     }
 
@@ -110,18 +110,18 @@ public sealed class AgentPromptActionTests
         {
             Job = new CronJob
             {
-                Id = "job-1",
+                Id = JobId.From("job-1"),
                 Name = "Cron prompt",
                 Schedule = "*/1 * * * *",
                 ActionType = "agent-prompt",
-                AgentId = "agent-a",
+                AgentId = AgentId.From("agent-a"),
                 Message = "Ping from cron",
                 Model = model,
                 CreatedBy = "tester",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Enabled = true
             },
-            RunId = "run-1",
+            RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
             TriggerType = CronTriggerType.Scheduled,
             Services = services
@@ -148,17 +148,17 @@ public sealed class AgentPromptActionTests
         {
             Job = new CronJob
             {
-                Id = "job-pinned",
+                Id = JobId.From("job-pinned"),
                 Name = "Pinned conversation job",
                 Schedule = "*/1 * * * *",
                 ActionType = "agent-prompt",
-                AgentId = "agent-a",
+                AgentId = AgentId.From("agent-a"),
                 Message = "Run in pinned conversation",
-                ConversationId = "conv-explicit-123",
+                ConversationId = ConversationId.From("conv-explicit-123"),
                 CreatedAt = DateTimeOffset.UtcNow,
                 Enabled = true
             },
-            RunId = "run-1",
+            RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
             TriggerType = CronTriggerType.Scheduled,
             Services = services
@@ -167,8 +167,8 @@ public sealed class AgentPromptActionTests
         await action.ExecuteAsync(context);
 
         capturedRequest.ShouldNotBeNull();
-        capturedRequest!.ConversationId.ShouldBe("conv-explicit-123");
-        capturedRequest.CronJobId.ShouldBe("job-pinned");
+        capturedRequest!.ConversationId!.Value.Value.ShouldBe("conv-explicit-123");
+        capturedRequest.CronJobId!.Value.Value.ShouldBe("job-pinned");
     }
 
     [Fact]
@@ -184,8 +184,8 @@ public sealed class AgentPromptActionTests
         trigger.Setup(value => value.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
             .Callback<AgentId, string, CancellationToken, InternalTriggerRequest?>((_, prompt, _, _) => capturedPrompt = prompt)
             .ReturnsAsync(SessionId.From("cron:templated:run-1"));
-        resolver.Setup(value => value.TryRender("agent-a", "daily-summary", It.IsAny<IReadOnlyDictionary<string, string?>?>(), out It.Ref<string>.IsAny, out It.Ref<string?>.IsAny))
-            .Returns((string _, string __, IReadOnlyDictionary<string, string?>? ___, out string renderedPrompt, out string? error) =>
+        resolver.Setup(value => value.TryRender(AgentId.From("agent-a"), "daily-summary", It.IsAny<IReadOnlyDictionary<string, string?>?>(), out It.Ref<string>.IsAny, out It.Ref<string?>.IsAny))
+            .Returns((AgentId _, string __, IReadOnlyDictionary<string, string?>? ___, out string renderedPrompt, out string? error) =>
             {
                 renderedPrompt = "Rendered prompt";
                 error = null;

--- a/tests/gateway/BotNexus.Cron.Tests/CronJobSystemFlagTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronJobSystemFlagTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Cron.Tools;
+using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -15,7 +16,7 @@ public sealed class CronJobSystemFlagTests
     {
         var job = new CronJob
         {
-            Id = "job-1",
+            Id = JobId.From("job-1"),
             Name = "Job 1",
             Schedule = "*/1 * * * *",
             ActionType = "agent-prompt",
@@ -31,7 +32,7 @@ public sealed class CronJobSystemFlagTests
     {
         var job = new CronJob
         {
-            Id = "job-1",
+            Id = JobId.From("job-1"),
             Name = "Job 1",
             Schedule = "*/1 * * * *",
             ActionType = "agent-prompt",
@@ -53,7 +54,7 @@ public sealed class CronJobSystemFlagTests
                 CreateJob("job-1", createdBy: "agent-a", system: false),
                 CreateJob("heartbeat:agent-a", createdBy: "system:heartbeat", system: true)
             ]);
-        var tool = new CronTool(store.Object, scheduler, "agent-a", allowCrossAgentCron: true);
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"), allowCrossAgentCron: true);
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
         var jobs = JsonSerializer.Deserialize<List<CronJobDto>>(ReadText(result), JsonOptions);
@@ -81,11 +82,11 @@ public sealed class CronJobSystemFlagTests
     private static CronJob CreateJob(string id, string createdBy, bool system)
         => new()
         {
-            Id = id,
+            Id = JobId.From(id),
             Name = $"Job {id}",
             Schedule = "*/1 * * * *",
             ActionType = "agent-prompt",
-            AgentId = "agent-a",
+            AgentId = AgentId.From("agent-a"),
             Message = "Hello",
             Enabled = true,
             System = system,

--- a/tests/gateway/BotNexus.Cron.Tests/CronOptionsPromptTemplateResolverTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronOptionsPromptTemplateResolverTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Cron.Prompts;
+using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using Microsoft.Extensions.Options;
 using System.IO.Abstractions.TestingHelpers;
@@ -19,7 +20,7 @@ public sealed class CronOptionsPromptTemplateResolverTests
             }
         });
 
-        resolver.ListTemplateNames("farnsworth").ShouldBe(["Alpha", "zebra"]);
+        resolver.ListTemplateNames(AgentId.From("farnsworth")).ShouldBe(["Alpha", "zebra"]);
     }
 
     [Fact]
@@ -27,7 +28,7 @@ public sealed class CronOptionsPromptTemplateResolverTests
     {
         var resolver = CreateResolver(new CronOptions());
 
-        var ok = resolver.TryRender("farnsworth", "does-not-exist", null, out var rendered, out var error);
+        var ok = resolver.TryRender(AgentId.From("farnsworth"), "does-not-exist", null, out var rendered, out var error);
 
         ok.ShouldBeFalse();
         rendered.ShouldBeEmpty();
@@ -52,8 +53,7 @@ public sealed class CronOptionsPromptTemplateResolverTests
             }
         });
 
-        var ok = resolver.TryRender(
-            "farnsworth",
+        var ok = resolver.TryRender(AgentId.From("farnsworth"),
             "DAILY-STATUS",
             new Dictionary<string, string?> { ["owner"] = "Hermes" },
             out var rendered,
@@ -92,7 +92,7 @@ public sealed class CronOptionsPromptTemplateResolverTests
                 fileSystem,
                 new StubWorkspaceManager(workspacePath));
 
-            var ok = resolver.TryRender("farnsworth", "daily-status", new Dictionary<string, string?> { ["owner"] = "Hermes" }, out var rendered, out var error);
+            var ok = resolver.TryRender(AgentId.From("farnsworth"), "daily-status", new Dictionary<string, string?> { ["owner"] = "Hermes" }, out var rendered, out var error);
 
             ok.ShouldBeTrue();
             error.ShouldBeNull();

--- a/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronSchedulerTests.cs
@@ -26,7 +26,7 @@ public sealed class CronSchedulerTests
         await InvokeProcessTickAsync(scheduler);
 
         action.ExecutionCount.ShouldBe(1);
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
         history.ShouldHaveSingleItem().Status.ShouldBe("ok");
     }
 
@@ -45,7 +45,7 @@ public sealed class CronSchedulerTests
         await InvokeProcessTickAsync(scheduler);
 
         action.ExecutionCount.ShouldBe(0);
-        (await context.Store.GetRunHistoryAsync("job-1")).ShouldBeEmpty();
+        (await context.Store.GetRunHistoryAsync(JobId.From("job-1"))).ShouldBeEmpty();
     }
 
     [Fact]
@@ -57,13 +57,13 @@ public sealed class CronSchedulerTests
         await context.Store.CreateAsync(job);
         var scheduler = CreateScheduler(context.Store, [action]);
 
-        var run = await scheduler.RunNowAsync("job-1");
+        var run = await scheduler.RunNowAsync(JobId.From("job-1"));
 
         run.Status.ShouldBe("ok");
-        var updated = await context.Store.GetAsync("job-1");
+        var updated = await context.Store.GetAsync(JobId.From("job-1"));
         updated!.LastRunStatus.ShouldBe("ok");
         updated.LastRunError.ShouldBeNull();
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
         history.ShouldHaveSingleItem().Status.ShouldBe("ok");
     }
 
@@ -76,12 +76,12 @@ public sealed class CronSchedulerTests
         await context.Store.CreateAsync(job);
         var scheduler = CreateScheduler(context.Store, [action]);
 
-        var run = await scheduler.RunNowAsync("job-1");
+        var run = await scheduler.RunNowAsync(JobId.From("job-1"));
 
         run.Status.ShouldBe("ok");
-        run.SessionId.ShouldBe("cron:job-1:session-1");
-        var history = await context.Store.GetRunHistoryAsync("job-1");
-        history.ShouldHaveSingleItem().SessionId.ShouldBe("cron:job-1:session-1");
+        run.SessionId!.Value.Value.ShouldBe("cron:job-1:session-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
+        history.ShouldHaveSingleItem().SessionId!.Value.Value.ShouldBe("cron:job-1:session-1");
     }
 
     [Fact]
@@ -93,15 +93,15 @@ public sealed class CronSchedulerTests
         await context.Store.CreateAsync(job);
         var scheduler = CreateScheduler(context.Store, [action]);
 
-        var run = await scheduler.RunNowAsync("job-1");
+        var run = await scheduler.RunNowAsync(JobId.From("job-1"));
 
         run.Status.ShouldBe("error");
         run.Error.ShouldBe("boom");
-        var updated = await context.Store.GetAsync("job-1");
+        var updated = await context.Store.GetAsync(JobId.From("job-1"));
         updated!.LastRunStatus.ShouldBe("error");
         updated.LastRunError.ShouldNotBeNull();
         updated.LastRunError.ShouldContain("boom");
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
         var entry = history.ShouldHaveSingleItem();
         entry.Status.ShouldBe("error");
         entry.Error.ShouldBe("boom");
@@ -118,12 +118,12 @@ public sealed class CronSchedulerTests
         await context.Store.CreateAsync(job);
         var scheduler = CreateScheduler(context.Store, [new WebhookAction()]);
 
-        var run = await scheduler.RunNowAsync("job-1");
+        var run = await scheduler.RunNowAsync(JobId.From("job-1"));
 
         run.Status.ShouldBe("error");
         run.Error.ShouldNotBeNull();
         run.Error!.ToLowerInvariant().ShouldContain("not implemented");
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
         history.ShouldHaveSingleItem().Status.ShouldBe("error");
     }
 
@@ -147,7 +147,7 @@ public sealed class CronSchedulerTests
         // Scheduler should detect the mismatch and correct NextRunAt.
         await InvokeProcessTickAsync(scheduler);
 
-        var updated = await context.Store.GetAsync("job-1");
+        var updated = await context.Store.GetAsync(JobId.From("job-1"));
         updated!.NextRunAt.ShouldNotBeNull();
         updated.NextRunAt!.Value.ShouldBe(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(2),
             "NextRunAt should be corrected to the next occurrence from now");
@@ -173,7 +173,7 @@ public sealed class CronSchedulerTests
         action.ExecutionCount.ShouldBe(0, "corrected NextRunAt is still in the future");
 
         // Simulate time passing: set NextRunAt to the past.
-        var corrected = await context.Store.GetAsync("job-1");
+        var corrected = await context.Store.GetAsync(JobId.From("job-1"));
         corrected.ShouldNotBeNull();
         corrected!.NextRunAt.ShouldNotBeNull();
         corrected.NextRunAt!.Value.ShouldBeLessThan(DateTimeOffset.UtcNow.AddDays(364),
@@ -208,7 +208,7 @@ public sealed class CronSchedulerTests
         await InvokeProcessTickAsync(scheduler);
 
         action.ExecutionCount.ShouldBe(0, "job is not due yet");
-        var updated = await context.Store.GetAsync("job-1");
+        var updated = await context.Store.GetAsync(JobId.From("job-1"));
         updated!.NextRunAt.ShouldBe(nextJan1, "NextRunAt should not change when it matches the schedule");
     }
 
@@ -230,7 +230,7 @@ public sealed class CronSchedulerTests
 
         await InvokeProcessTickAsync(scheduler);
 
-        var updated = await context.Store.GetAsync("job-1");
+        var updated = await context.Store.GetAsync(JobId.From("job-1"));
         updated!.NextRunAt.ShouldNotBeNull();
 
         // The next occurrence in Pacific should be at noon Pacific time.
@@ -257,7 +257,7 @@ public sealed class CronSchedulerTests
 
         await InvokeProcessTickAsync(scheduler);
 
-        var updated = await context.Store.GetAsync("job-1");
+        var updated = await context.Store.GetAsync(JobId.From("job-1"));
         updated!.NextRunAt.ShouldNotBeNull();
         // With UTC fallback, the next occurrence should be at 12:00 UTC
         updated.NextRunAt!.Value.Hour.ShouldBe(12);
@@ -286,9 +286,9 @@ public sealed class CronSchedulerTests
         await context.Store.UpdateAsync(updated);
 
         // Manual run should not clobber the updated NextRunAt
-        await scheduler.RunNowAsync("job-1");
+        await scheduler.RunNowAsync(JobId.From("job-1"));
 
-        var afterRun = await context.Store.GetAsync("job-1");
+        var afterRun = await context.Store.GetAsync(JobId.From("job-1"));
         afterRun!.LastRunStatus.ShouldBe("ok");
         // NextRunAt should reflect the updated "0 0 1 1 *" schedule, not the old "*/5"
         afterRun.NextRunAt.ShouldNotBeNull();
@@ -320,7 +320,7 @@ public sealed class CronSchedulerTests
 
         okAction.ExecutionCount.ShouldBe(1,
             "the second job should still run even though the first threw");
-        var failedRun = await context.Store.GetRunHistoryAsync("job-fail");
+        var failedRun = await context.Store.GetRunHistoryAsync(JobId.From("job-fail"));
         failedRun.ShouldHaveSingleItem().Status.ShouldBe("error");
     }
 
@@ -367,7 +367,7 @@ public sealed class CronSchedulerTests
         await InvokeProcessTickAsync(scheduler);
 
         action.ExecutionCount.ShouldBe(1, "valid job should still fire");
-        var goodHistory = await context.Store.GetRunHistoryAsync("good-job");
+        var goodHistory = await context.Store.GetRunHistoryAsync(JobId.From("good-job"));
         goodHistory.ShouldHaveSingleItem().Status.ShouldBe("ok");
     }
 
@@ -399,7 +399,7 @@ public sealed class CronSchedulerTests
         var action = new RecordingAction("test-action");
         var scheduler = CreateScheduler(context.Store, [action]);
 
-        var act = () => scheduler.RunNowAsync("nonexistent-job");
+        var act = () => scheduler.RunNowAsync(JobId.From("nonexistent-job"));
 
         await act.ShouldThrowAsync<KeyNotFoundException>();
     }
@@ -416,7 +416,7 @@ public sealed class CronSchedulerTests
         await context.Store.CreateAsync(job);
         var scheduler = CreateScheduler(context.Store, [action]);
 
-        var run = await scheduler.RunNowAsync("job-1");
+        var run = await scheduler.RunNowAsync(JobId.From("job-1"));
 
         run.Status.ShouldBe("ok");
         action.ExecutionCount.ShouldBe(1);
@@ -448,7 +448,7 @@ public sealed class CronSchedulerTests
         await InvokeProcessTickAsync(scheduler);
 
         // ProcessTickAsync should detect the mismatch and correct NextRunAt
-        var updated = await context.Store.GetAsync("config-job");
+        var updated = await context.Store.GetAsync(JobId.From("config-job"));
         updated!.NextRunAt.ShouldNotBeNull();
         updated.NextRunAt!.Value.ShouldBe(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(2),
             "scheduler should correct stale NextRunAt after config sync");
@@ -479,7 +479,7 @@ public sealed class CronSchedulerTests
 
         await InvokeSyncConfiguredJobsAsync(scheduler, options);
 
-        var stored = await context.Store.GetAsync("config-job");
+        var stored = await context.Store.GetAsync(JobId.From("config-job"));
         stored.ShouldNotBeNull();
         stored!.ActionType.ShouldBe("agent-prompt");
         stored.Model.ShouldBe("openai/gpt-4.1");
@@ -510,7 +510,7 @@ public sealed class CronSchedulerTests
 
         await InvokeSyncConfiguredJobsAsync(scheduler, options);
 
-        var stored = await context.Store.GetAsync("config-job");
+        var stored = await context.Store.GetAsync(JobId.From("config-job"));
         stored.ShouldNotBeNull();
         stored!.TemplateName.ShouldBe("daily-status");
         stored.TemplateParameters.ShouldNotBeNull();
@@ -624,11 +624,11 @@ public sealed class CronSchedulerTests
         await InvokeProcessTickAsync(scheduler);
 
         okAction.ExecutionCount.ShouldBe(2, "both ok jobs should run despite the first job failing");
-        var failHistory = await context.Store.GetRunHistoryAsync("job-fail");
+        var failHistory = await context.Store.GetRunHistoryAsync(JobId.From("job-fail"));
         failHistory.ShouldHaveSingleItem().Status.ShouldBe("error");
-        var ok1History = await context.Store.GetRunHistoryAsync("job-ok-1");
+        var ok1History = await context.Store.GetRunHistoryAsync(JobId.From("job-ok-1"));
         ok1History.ShouldHaveSingleItem().Status.ShouldBe("ok");
-        var ok2History = await context.Store.GetRunHistoryAsync("job-ok-2");
+        var ok2History = await context.Store.GetRunHistoryAsync(JobId.From("job-ok-2"));
         ok2History.ShouldHaveSingleItem().Status.ShouldBe("ok");
     }
 
@@ -654,7 +654,7 @@ public sealed class CronSchedulerTests
         action.ExecutionCount.ShouldBe(3);
         for (var i = 1; i <= 3; i++)
         {
-            var updated = await context.Store.GetAsync($"job-{i}");
+            var updated = await context.Store.GetAsync(JobId.From($"job-{i}"));
             updated.ShouldNotBeNull();
             updated!.NextRunAt.ShouldNotBeNull(
                 $"job-{i} NextRunAt should be updated after concurrent run");
@@ -736,7 +736,7 @@ public sealed class CronSchedulerTests
 
         public Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
         {
-            context.RecordSessionId(sessionId);
+            context.RecordSessionId(SessionId.From(sessionId));
             return Task.CompletedTask;
         }
     }

--- a/tests/gateway/BotNexus.Cron.Tests/CronToolTemplateTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronToolTemplateTests.cs
@@ -1,5 +1,6 @@
 using BotNexus.Agent.Core.Types;
 using BotNexus.Cron.Tools;
+using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -18,7 +19,7 @@ public sealed class CronToolTemplateTests
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -45,7 +46,7 @@ public sealed class CronToolTemplateTests
         var tool = new CronTool(
             Mock.Of<ICronStore>(),
             CreateScheduler(),
-            "agent-a");
+            AgentId.From("agent-a"));
 
         var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {

--- a/tests/gateway/BotNexus.Cron.Tests/CronToolTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronToolTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Cron.Tools;
+using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -20,7 +21,7 @@ public sealed class CronToolTests
                 CreateJob("job-1", createdBy: "agent-a"),
                 CreateJobWithTarget("job-2", createdBy: "agent-b", agentId: "agent-b")
             ]);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
         var jobs = JsonSerializer.Deserialize<List<CronJobDto>>(ReadText(result), JsonOptions);
@@ -41,7 +42,7 @@ public sealed class CronToolTests
                     Model = "openai/gpt-4.1"
                 }
             ]);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
         var jobs = JsonSerializer.Deserialize<List<CronJobDto>>(ReadText(result), JsonOptions);
@@ -59,7 +60,7 @@ public sealed class CronToolTests
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -73,7 +74,7 @@ public sealed class CronToolTests
         created.ShouldNotBeNull();
         created!.ActionType.ShouldBe("agent-prompt");
         created.CreatedBy.ShouldBe("agent-a");
-        created.AgentId.ShouldBe("agent-a");
+        created.AgentId!.Value.Value.ShouldBe("agent-a");
         created.Model.ShouldBe("openai/gpt-4.1");
         ReadText(result).ShouldContain("Daily summary");
     }
@@ -87,7 +88,7 @@ public sealed class CronToolTests
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -110,7 +111,7 @@ public sealed class CronToolTests
     {
         var store = new Mock<ICronStore>();
         var scheduler = CreateScheduler();
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -128,11 +129,11 @@ public sealed class CronToolTests
     {
         var store = new Mock<ICronStore>();
         var scheduler = CreateScheduler();
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateJob("job-1", createdBy: "agent-a"));
-        store.Setup(value => value.DeleteAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.DeleteAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -141,7 +142,7 @@ public sealed class CronToolTests
         });
 
         ReadText(result).ShouldContain("Deleted cron job 'job-1'");
-        store.Verify(value => value.DeleteAsync("job-1", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(value => value.DeleteAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -149,9 +150,9 @@ public sealed class CronToolTests
     {
         var store = new Mock<ICronStore>();
         var scheduler = CreateScheduler();
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateJobWithTarget("job-1", createdBy: "other-agent", agentId: "other-agent"));
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -172,13 +173,13 @@ public sealed class CronToolTests
             Schedule = "0 0 1 1 *",
             NextRunAt = DateTimeOffset.UtcNow.AddDays(365)
         };
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         CronJob? saved = null;
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => saved = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -205,13 +206,13 @@ public sealed class CronToolTests
             Schedule = "*/5 * * * *",
             NextRunAt = originalNext
         };
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         CronJob? saved = null;
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => saved = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -234,7 +235,7 @@ public sealed class CronToolTests
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -265,13 +266,13 @@ public sealed class CronToolTests
             Schedule = "0 12 * * *",
             NextRunAt = DateTimeOffset.UtcNow.AddHours(2)
         };
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         CronJob? saved = null;
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => saved = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -298,7 +299,7 @@ public sealed class CronToolTests
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -323,13 +324,13 @@ public sealed class CronToolTests
             Schedule = "*/5 * * * *",
             NextRunAt = DateTimeOffset.UtcNow.AddMinutes(3)
         };
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         CronJob? saved = null;
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => saved = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -351,13 +352,13 @@ public sealed class CronToolTests
         {
             Model = "copilot/gpt-4o-mini"
         };
-        store.Setup(value => value.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         CronJob? saved = null;
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => saved = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "agent-a");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -384,7 +385,7 @@ public sealed class CronToolTests
                 CreateJobWithTarget("job-1", createdBy: "nova", agentId: "farnsworth"),
                 CreateJobWithTarget("job-2", createdBy: "other-agent", agentId: "other-agent")
             ]);
-        var tool = new CronTool(store.Object, scheduler, "farnsworth");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("farnsworth"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
         var jobs = JsonSerializer.Deserialize<List<CronJobDto>>(ReadText(result), JsonOptions);
@@ -403,7 +404,7 @@ public sealed class CronToolTests
                 CreateJobWithTarget("job-1", createdBy: "nova", agentId: "nova"),
                 CreateJobWithTarget("job-2", createdBy: "other", agentId: "other")
             ]);
-        var tool = new CronTool(store.Object, scheduler, "farnsworth");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("farnsworth"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
         var jobs = JsonSerializer.Deserialize<List<CronJobDto>>(ReadText(result), JsonOptions);
@@ -417,11 +418,11 @@ public sealed class CronToolTests
     {
         var store = new Mock<ICronStore>();
         var scheduler = CreateScheduler();
-        store.Setup(s => s.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(s => s.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateJobWithTarget("job-1", createdBy: "nova", agentId: "farnsworth"));
-        store.Setup(s => s.DeleteAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(s => s.DeleteAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        var tool = new CronTool(store.Object, scheduler, "farnsworth");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("farnsworth"));
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -430,7 +431,7 @@ public sealed class CronToolTests
         });
 
         ReadText(result).ShouldContain("Deleted cron job 'job-1'");
-        store.Verify(s => s.DeleteAsync("job-1", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.DeleteAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -438,9 +439,9 @@ public sealed class CronToolTests
     {
         var store = new Mock<ICronStore>();
         var scheduler = CreateScheduler();
-        store.Setup(s => s.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(s => s.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateJobWithTarget("job-1", createdBy: "nova", agentId: "nova"));
-        var tool = new CronTool(store.Object, scheduler, "farnsworth");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("farnsworth"));
 
         var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -457,13 +458,13 @@ public sealed class CronToolTests
         var store = new Mock<ICronStore>();
         var scheduler = CreateScheduler();
         var existingJob = CreateJobWithTarget("job-1", createdBy: "nova", agentId: "farnsworth");
-        store.Setup(s => s.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(s => s.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         CronJob? saved = null;
         store.Setup(s => s.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => saved = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
-        var tool = new CronTool(store.Object, scheduler, "farnsworth");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("farnsworth"));
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
         {
@@ -481,7 +482,7 @@ public sealed class CronToolTests
     {
         var store = new Mock<ICronStore>();
         var existingJob = CreateJobWithTarget("job-1", createdBy: "nova", agentId: "farnsworth");
-        store.Setup(s => s.GetAsync("job-1", It.IsAny<CancellationToken>()))
+        store.Setup(s => s.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingJob);
         store.Setup(s => s.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
@@ -498,7 +499,7 @@ public sealed class CronToolTests
             options,
             NullLogger<CronScheduler>.Instance);
 
-        var tool = new CronTool(store.Object, scheduler, "farnsworth");
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("farnsworth"));
 
         // run is permitted for target agent even when created by another
         var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
@@ -530,11 +531,11 @@ public sealed class CronToolTests
     private static CronJob CreateJobWithTarget(string id, string createdBy, string agentId)
         => new()
         {
-            Id = id,
+            Id = JobId.From(id),
             Name = $"Job {id}",
             Schedule = "*/1 * * * *",
             ActionType = "agent-prompt",
-            AgentId = agentId,
+            AgentId = AgentId.From(agentId),
             Message = "Hello",
             Enabled = true,
             CreatedBy = createdBy,
@@ -543,11 +544,11 @@ public sealed class CronToolTests
     private static CronJob CreateJob(string id, string createdBy)
         => new()
         {
-            Id = id,
+            Id = JobId.From(id),
             Name = $"Job {id}",
             Schedule = "*/1 * * * *",
             ActionType = "agent-prompt",
-            AgentId = "agent-a",
+            AgentId = AgentId.From("agent-a"),
             Message = "Hello",
             Enabled = true,
             CreatedBy = createdBy,

--- a/tests/gateway/BotNexus.Cron.Tests/HeartbeatActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/HeartbeatActionTests.cs
@@ -102,7 +102,7 @@ public sealed class HeartbeatActionTests
         await action.ExecuteAsync(context);
 
         trigger.Verify(v => v.CreateSessionAsync(AgentId.From("agent-a"), "Heartbeat ping", It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
-        context.SessionId.ShouldBe(sessionId.Value);
+        context.SessionId!.Value.ShouldBe(sessionId);
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public sealed class HeartbeatActionTests
         await action.ExecuteAsync(context);
 
         cronTrigger.Verify(v => v.CreateSessionAsync(It.IsAny<AgentId>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
-        context.SessionId.ShouldBe(sessionId.Value);
+        context.SessionId!.Value.ShouldBe(sessionId);
     }
 
     [Fact]
@@ -233,11 +233,11 @@ public sealed class HeartbeatActionTests
         {
             Job = new CronJob
             {
-                Id = "heartbeat:agent-a",
+                Id = JobId.From("heartbeat:agent-a"),
                 Name = "Heartbeat",
                 Schedule = "*/30 * * * *",
                 ActionType = "heartbeat",
-                AgentId = "agent-a",
+                AgentId = AgentId.From("agent-a"),
                 Message = "Heartbeat ping",
                 Model = "openai/gpt-4.1",
                 Enabled = true,
@@ -245,7 +245,7 @@ public sealed class HeartbeatActionTests
                 CreatedBy = "system:heartbeat",
                 CreatedAt = DateTimeOffset.UtcNow
             },
-            RunId = "run-1",
+            RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
             TriggerType = CronTriggerType.Scheduled,
             Services = services
@@ -254,7 +254,7 @@ public sealed class HeartbeatActionTests
         await action.ExecuteAsync(context);
 
         captured.ShouldNotBeNull();
-        captured!.CronJobId.ShouldBe("heartbeat:agent-a");
+        captured!.CronJobId!.Value.Value.ShouldBe("heartbeat:agent-a");
         captured.ModelOverride.ShouldBe("openai/gpt-4.1");
     }
 
@@ -379,7 +379,7 @@ public sealed class HeartbeatActionTests
         workspace.Setup(v => v.GetWorkspacePath("agent-a"))
             .Returns(Path.Combine(Path.GetTempPath(), "botnexus-test-nonexistent-" + Guid.NewGuid()));
 
-        var result = await HeartbeatAction.ReadHeartbeatFileAsync(workspace.Object, "agent-a", CancellationToken.None);
+        var result = await HeartbeatAction.ReadHeartbeatFileAsync(workspace.Object, AgentId.From("agent-a"), CancellationToken.None);
 
         result.ShouldBeNull();
     }
@@ -397,7 +397,7 @@ public sealed class HeartbeatActionTests
 
         try
         {
-            var result = await HeartbeatAction.ReadHeartbeatFileAsync(workspace.Object, "agent-a", CancellationToken.None);
+            var result = await HeartbeatAction.ReadHeartbeatFileAsync(workspace.Object, AgentId.From("agent-a"), CancellationToken.None);
             result.ShouldBe("- [ ] Deploy the thing");
         }
         finally
@@ -418,18 +418,18 @@ public sealed class HeartbeatActionTests
         {
             Job = new CronJob
             {
-                Id = "heartbeat:agent-a",
+                Id = JobId.From("heartbeat:agent-a"),
                 Name = "Heartbeat",
                 Schedule = "*/30 * * * *",
                 ActionType = "heartbeat",
-                AgentId = agentId,
+                AgentId = agentId is null ? null : AgentId.From(agentId),
                 Message = message,
                 Enabled = true,
                 System = true,
                 CreatedBy = "system:heartbeat",
                 CreatedAt = DateTimeOffset.UtcNow
             },
-            RunId = "run-1",
+            RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
             TriggerType = CronTriggerType.Scheduled,
             Services = services

--- a/tests/gateway/BotNexus.Cron.Tests/HeartbeatCronProvisionerTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/HeartbeatCronProvisionerTests.cs
@@ -18,7 +18,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
@@ -28,7 +28,7 @@ public sealed class HeartbeatCronProvisionerTests
         await provisioner.StartAsync(CancellationToken.None);
 
         created.ShouldNotBeNull();
-        created!.Id.ShouldBe("heartbeat:agent-a");
+        created!.Id.Value.ShouldBe("heartbeat:agent-a");
         created.Schedule.ShouldBe("*/30 * * * *");
         created.System.ShouldBeTrue();
     }
@@ -42,7 +42,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
 
         var provisioner = new HeartbeatCronProvisioner(registry.Object, store.Object, NullLogger<HeartbeatCronProvisioner>.Instance);
 
@@ -59,11 +59,11 @@ public sealed class HeartbeatCronProvisionerTests
         var descriptor = CreateDescriptor("agent-a", new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 15 });
         var existing = new CronJob
         {
-            Id = "heartbeat:agent-a",
+            Id = JobId.From("heartbeat:agent-a"),
             Name = "Heartbeat \u2014 Agent A",
             Schedule = "*/30 * * * *",
             ActionType = "heartbeat",
-            AgentId = "agent-a",
+            AgentId = AgentId.From("agent-a"),
             Message = "old",
             Enabled = true,
             System = true,
@@ -74,7 +74,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync(existing);
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => updated = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
@@ -95,11 +95,11 @@ public sealed class HeartbeatCronProvisionerTests
         var descriptor = CreateDescriptor("agent-a", null);
         var existing = new CronJob
         {
-            Id = "heartbeat:agent-a",
+            Id = JobId.From("heartbeat:agent-a"),
             Name = "Heartbeat \u2014 Agent A",
             Schedule = "*/30 * * * *",
             ActionType = "heartbeat",
-            AgentId = "agent-a",
+            AgentId = AgentId.From("agent-a"),
             Message = "test",
             Enabled = true,
             System = true,
@@ -109,14 +109,14 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
-        store.Setup(value => value.DeleteAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        store.Setup(value => value.DeleteAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         var provisioner = new HeartbeatCronProvisioner(registry.Object, store.Object, NullLogger<HeartbeatCronProvisioner>.Instance);
 
         await provisioner.StartAsync(CancellationToken.None);
 
-        store.Verify(value => value.DeleteAsync("heartbeat:agent-a", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(value => value.DeleteAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
@@ -157,7 +157,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
         store.Setup(value => value.CreateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => created = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);
@@ -185,7 +185,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync((CronJob?)null);
 
         var provisioner = new HeartbeatCronProvisioner(registry.Object, store.Object, NullLogger<HeartbeatCronProvisioner>.Instance);
 
@@ -207,11 +207,11 @@ public sealed class HeartbeatCronProvisionerTests
         });
         var existing = new CronJob
         {
-            Id = "heartbeat:agent-a",
+            Id = JobId.From("heartbeat:agent-a"),
             Name = "Heartbeat \u2014 Agent A",
             Schedule = "*/30 * * * *",
             ActionType = "heartbeat",
-            AgentId = "agent-a",
+            AgentId = AgentId.From("agent-a"),
             Message = "Read HEARTBEAT.md if it exists and execute any pending tasks. If nothing needs attention, reply HEARTBEAT_OK.",
             Enabled = true,
             System = true,
@@ -223,7 +223,7 @@ public sealed class HeartbeatCronProvisionerTests
 
         registry.Setup(value => value.GetAll()).Returns([descriptor]);
         store.Setup(value => value.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        store.Setup(value => value.GetAsync("heartbeat:agent-a", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        store.Setup(value => value.GetAsync(JobId.From("heartbeat:agent-a"), It.IsAny<CancellationToken>())).ReturnsAsync(existing);
         store.Setup(value => value.UpdateAsync(It.IsAny<CronJob>(), It.IsAny<CancellationToken>()))
             .Callback<CronJob, CancellationToken>((job, _) => updated = job)
             .ReturnsAsync((CronJob job, CancellationToken _) => job);

--- a/tests/gateway/BotNexus.Cron.Tests/QuietHoursTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/QuietHoursTests.cs
@@ -68,7 +68,7 @@ public sealed class QuietHoursTests
         await action.ExecuteAsync(context);
 
         trigger.Verify(value => value.CreateSessionAsync(AgentId.From("agent-a"), "Ping from heartbeat", It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()), Times.Once);
-        context.SessionId.ShouldBe(sessionId.Value);
+        context.SessionId!.Value.ShouldBe(sessionId);
     }
 
     private static CronExecutionContext CreateHeartbeatContext(IServiceProvider services)
@@ -76,18 +76,18 @@ public sealed class QuietHoursTests
         {
             Job = new CronJob
             {
-                Id = "heartbeat:agent-a",
+                Id = JobId.From("heartbeat:agent-a"),
                 Name = "Heartbeat",
                 Schedule = "*/30 * * * *",
                 ActionType = "heartbeat",
-                AgentId = "agent-a",
+                AgentId = AgentId.From("agent-a"),
                 Message = "Ping from heartbeat",
                 Enabled = true,
                 System = true,
                 CreatedBy = "system:heartbeat",
                 CreatedAt = DateTimeOffset.UtcNow
             },
-            RunId = "run-1",
+            RunId = RunId.From("run-1"),
             TriggeredAt = DateTimeOffset.UtcNow,
             TriggerType = CronTriggerType.Scheduled,
             Services = services

--- a/tests/gateway/BotNexus.Cron.Tests/SqliteCronStoreTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/SqliteCronStoreTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Cron.Tests.TestInfrastructure;
+using BotNexus.Domain.Primitives;
 using Microsoft.Data.Sqlite;
 
 namespace BotNexus.Cron.Tests;
@@ -37,12 +38,12 @@ public sealed class SqliteCronStoreTests
         var job = CronStoreTestContext.CreateJob("job-1");
 
         await context.Store.CreateAsync(job);
-        var loaded = await context.Store.GetAsync("job-1");
+        var loaded = await context.Store.GetAsync(JobId.From("job-1"));
 
         loaded.ShouldNotBeNull();
-        loaded!.Id.ShouldBe("job-1");
+        loaded!.Id.Value.ShouldBe("job-1");
         loaded.Name.ShouldBe(job.Name);
-        loaded.AgentId.ShouldBe("agent-a");
+        loaded.AgentId.ShouldBe(AgentId.From("agent-a"));
     }
 
     [Fact]
@@ -55,7 +56,7 @@ public sealed class SqliteCronStoreTests
         var jobs = await context.Store.ListAsync();
 
         jobs.Count().ShouldBe(2);
-        jobs.Select(job => job.Id).OrderBy(id => id).ShouldBe(["job-1", "job-2"]);
+        jobs.Select(job => job.Id.Value).OrderBy(id => id).ShouldBe(["job-1", "job-2"]);
     }
 
     [Fact]
@@ -65,10 +66,10 @@ public sealed class SqliteCronStoreTests
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1", "agent-a"));
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-2", "agent-b"));
 
-        var filtered = await context.Store.ListAsync("agent-a");
+        var filtered = await context.Store.ListAsync(AgentId.From("agent-a"));
 
         filtered.ShouldHaveSingleItem();
-        filtered[0].Id.ShouldBe("job-1");
+        filtered[0].Id.Value.ShouldBe("job-1");
     }
 
     [Fact]
@@ -85,7 +86,7 @@ public sealed class SqliteCronStoreTests
         };
         await context.Store.UpdateAsync(updated);
 
-        var loaded = await context.Store.GetAsync("job-1");
+        var loaded = await context.Store.GetAsync(JobId.From("job-1"));
         loaded.ShouldNotBeNull();
         loaded!.Name.ShouldBe("Updated Name");
         loaded.Enabled.ShouldBeFalse();
@@ -102,7 +103,7 @@ public sealed class SqliteCronStoreTests
         };
 
         await context.Store.CreateAsync(job);
-        var loaded = await context.Store.GetAsync("job-1");
+        var loaded = await context.Store.GetAsync(JobId.From("job-1"));
 
         loaded.ShouldNotBeNull();
         loaded!.Model.ShouldBe("openai/gpt-4.1");
@@ -123,7 +124,7 @@ public sealed class SqliteCronStoreTests
         };
 
         await context.Store.CreateAsync(job);
-        var loaded = await context.Store.GetAsync("job-1");
+        var loaded = await context.Store.GetAsync(JobId.From("job-1"));
 
         loaded.ShouldNotBeNull();
         loaded!.TemplateName.ShouldBe("daily-status");
@@ -138,9 +139,9 @@ public sealed class SqliteCronStoreTests
         await using var context = await CronStoreTestContext.CreateAsync();
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
 
-        await context.Store.DeleteAsync("job-1");
+        await context.Store.DeleteAsync(JobId.From("job-1"));
 
-        (await context.Store.GetAsync("job-1")).ShouldBeNull();
+        (await context.Store.GetAsync(JobId.From("job-1"))).ShouldBeNull();
     }
 
     [Fact]
@@ -149,11 +150,11 @@ public sealed class SqliteCronStoreTests
         await using var context = await CronStoreTestContext.CreateAsync();
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
 
-        var run = await context.Store.RecordRunStartAsync("job-1");
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
 
-        run.JobId.ShouldBe("job-1");
+        run.JobId.Value.ShouldBe("job-1");
         run.Status.ShouldBe("running");
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
         var entry = history.ShouldHaveSingleItem();
         entry.Id.ShouldBe(run.Id);
         entry.Status.ShouldBe("running");
@@ -164,14 +165,14 @@ public sealed class SqliteCronStoreTests
     {
         await using var context = await CronStoreTestContext.CreateAsync();
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
-        var run = await context.Store.RecordRunStartAsync("job-1");
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
 
-        await context.Store.RecordRunCompleteAsync(run.Id, "ok", sessionId: "session-1");
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        await context.Store.RecordRunCompleteAsync(run.Id, "ok", sessionId: SessionId.From("session-1"));
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
 
         history.ShouldHaveSingleItem();
         history[0].Status.ShouldBe("ok");
-        history[0].SessionId.ShouldBe("session-1");
+        history[0].SessionId!.Value.Value.ShouldBe("session-1");
         history[0].CompletedAt.ShouldNotBeNull();
     }
 
@@ -182,15 +183,15 @@ public sealed class SqliteCronStoreTests
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
         await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-2"));
 
-        var run1 = await context.Store.RecordRunStartAsync("job-1");
+        var run1 = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
         await context.Store.RecordRunCompleteAsync(run1.Id, "ok");
-        var run2 = await context.Store.RecordRunStartAsync("job-2");
+        var run2 = await context.Store.RecordRunStartAsync(JobId.From("job-2"));
         await context.Store.RecordRunCompleteAsync(run2.Id, "error", "boom");
 
-        var history = await context.Store.GetRunHistoryAsync("job-1");
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
 
         history.ShouldHaveSingleItem();
-        history[0].JobId.ShouldBe("job-1");
+        history[0].JobId.Value.ShouldBe("job-1");
         history[0].Status.ShouldBe("ok");
     }
 }

--- a/tests/gateway/BotNexus.Cron.Tests/TestInfrastructure/CronStoreTestContext.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/TestInfrastructure/CronStoreTestContext.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.Primitives;
 using Microsoft.Data.Sqlite;
 using System.IO.Abstractions;
 
@@ -33,11 +34,11 @@ internal sealed class CronStoreTestContext : IAsyncDisposable
     {
         return new CronJob
         {
-            Id = id,
+            Id = JobId.From(id),
             Name = $"Job {id}",
             Schedule = "*/1 * * * *",
             ActionType = actionType,
-            AgentId = agentId,
+            AgentId = AgentId.From(agentId),
             Message = "Run scheduled task",
             Enabled = enabled,
             CreatedBy = "test-agent",

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -41,7 +41,7 @@ public sealed class CronTriggerTests
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task",
-            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance", ModelOverride = "openai/gpt-4.1" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "Scheduled Maintenance", ModelOverride = "openai/gpt-4.1" });
 
         // Assert: conversation created with human-readable job name as title
         createdConversation.ShouldNotBeNull();
@@ -91,7 +91,7 @@ public sealed class CronTriggerTests
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task run 2",
-            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "Scheduled Maintenance" });
 
         // Assert: no new conversation created — existing one reused
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -132,7 +132,7 @@ public sealed class CronTriggerTests
         await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Pinned task",
-            request: new InternalTriggerRequest { CronJobId = "job-2", ConversationId = "conv-pinned" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-2"), ConversationId = ConversationId.From("conv-pinned") });
 
         // Assert: no ListAsync (bypassed), no CreateAsync
         conversationStore.Verify(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -181,9 +181,9 @@ public sealed class CronTriggerTests
         var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
 
         var first = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 1",
-            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "Scheduled Maintenance" });
         var second = await trigger.CreateSessionAsync(AgentId.From("agent-a"), "Run 2",
-            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "Scheduled Maintenance" });
 
         // Different session IDs per run
         first.ShouldNotBe(second);
@@ -225,7 +225,7 @@ public sealed class CronTriggerTests
         var sessionId = await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task",
-            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "Scheduled Maintenance" });
 
         sessionId.Value.ShouldStartWith("cron:job-1:");
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -280,7 +280,7 @@ public sealed class CronTriggerTests
         await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Scheduled task",
-            request: new InternalTriggerRequest { CronJobId = "job-1", JobName = "Scheduled Maintenance" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "Scheduled Maintenance" });
 
         conversationStore.Verify(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
         conversationStore.Verify(s => s.ArchiveAsync(duplicate.ConversationId, It.IsAny<CancellationToken>()), Times.Once);
@@ -312,7 +312,7 @@ public sealed class CronTriggerTests
         await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Run task",
-            request: new InternalTriggerRequest { CronJobId = "job-abc", JobName = "Autonomous Issue and PR Maintenance" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-abc"), JobName = "Autonomous Issue and PR Maintenance" });
 
         // Assert: conversation title is human-readable job name, not the job-id slug
         createdConversation.ShouldNotBeNull();
@@ -340,7 +340,7 @@ public sealed class CronTriggerTests
         await trigger.CreateSessionAsync(
             AgentId.From("agent-a"),
             "Run task",
-            request: new InternalTriggerRequest { CronJobId = "job-1" });
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-1") });
 
         // Assert: falls back to slug-based title
         createdConversation.ShouldNotBeNull();
@@ -364,7 +364,7 @@ public sealed class CronTriggerTests
 
         var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
 
-        var request = new InternalTriggerRequest { CronJobId = "job-1", JobName = "My Job" };
+        var request = new InternalTriggerRequest { CronJobId = JobId.From("job-1"), JobName = "My Job" };
 
         // Act
         await trigger.CreateSessionAsync(
@@ -373,9 +373,9 @@ public sealed class CronTriggerTests
             request: request);
 
         // Assert: ResolvedConversationId is set so the scheduler can pin it back to the job
-        request.ResolvedConversationId.ShouldNotBeNullOrWhiteSpace();
+        request.ResolvedConversationId!.Value.Value.ShouldNotBeNullOrWhiteSpace();
         createdConversation.ShouldNotBeNull();
-        request.ResolvedConversationId.ShouldBe(createdConversation!.ConversationId.Value);
+        request.ResolvedConversationId!.Value.Value.ShouldBe(createdConversation!.ConversationId.Value);
     }
     // ── Helpers ─────────────────────────────────────────────────────────────
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
@@ -113,7 +113,7 @@ public sealed class HeartbeatTriggerTests
         await trigger.CreateSessionAsync(agentId, "Heartbeat ping",
             request: new InternalTriggerRequest
             {
-                CronJobId = "heartbeat:agent-a",
+                CronJobId = JobId.From("heartbeat:agent-a"),
                 ModelOverride = "openai/gpt-4.1"
             });
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/SoulTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/SoulTriggerTests.cs
@@ -184,7 +184,7 @@ public sealed class SoulTriggerTests
             "first prompt",
             request: new BotNexus.Gateway.Abstractions.Triggers.InternalTriggerRequest
             {
-                CronJobId = "job-1",
+                CronJobId = JobId.From("job-1"),
                 ModelOverride = "openai/gpt-4.1"
             });
         var second = await trigger.CreateSessionAsync(agentId, "second prompt");

--- a/tests/gateway/BotNexus.Gateway.Tests/CronControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CronControllerTests.cs
@@ -36,7 +36,7 @@ public sealed class CronControllerTests
 
         var job = (result.Result as OkObjectResult)?.Value as CronJob;
         job.ShouldNotBeNull();
-        job!.Id.ShouldBe("job-1");
+        job!.Id.Value.ShouldBe("job-1");
     }
 
     [Fact]
@@ -44,13 +44,13 @@ public sealed class CronControllerTests
     {
         var store = new FakeCronStore();
         var controller = CreateController(store, new RecordingAction(), new CronOptions());
-        var request = CreateJob(string.Empty) with { Id = string.Empty };
+        var request = CreateJob("job-create");
 
         var result = await controller.Create(request, CancellationToken.None);
 
         var created = (result.Result as CreatedAtActionResult)?.Value as CronJob;
         created.ShouldNotBeNull();
-        created!.Id.ShouldNotBeNullOrWhiteSpace();
+        created!.Id.Value.ShouldBe("job-create");
         (await store.GetAsync(created.Id)).ShouldNotBeNull();
     }
 
@@ -64,7 +64,7 @@ public sealed class CronControllerTests
         var result = await controller.Delete("job-1", CancellationToken.None);
 
         result.ShouldBeOfType<NoContentResult>();
-        (await store.GetAsync("job-1")).ShouldBeNull();
+        (await store.GetAsync(JobId.From("job-1"))).ShouldBeNull();
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public sealed class CronControllerTests
 
         var jobs = (result.Result as OkObjectResult)?.Value as IReadOnlyList<CronJob>;
         jobs.ShouldNotBeNull();
-        var configured = jobs!.Single(job => job.Id == "config-job");
+        var configured = jobs!.Single(job => job.Id.Value == "config-job");
         configured.ActionType.ShouldBe("agent-prompt");
         configured.Model.ShouldBe("openai/gpt-4.1");
     }
@@ -119,9 +119,8 @@ public sealed class CronControllerTests
     {
         var store = new FakeCronStore();
         var controller = CreateController(store, new RecordingAction(), new CronOptions());
-        var request = CreateJob(string.Empty) with
+        var request = CreateJob("job-norm") with
         {
-            Id = string.Empty,
             ActionType = "agent-chat",
             Model = "openai/gpt-4.1"
         };
@@ -148,11 +147,11 @@ public sealed class CronControllerTests
     private static CronJob CreateJob(string id, string actionType = "agent-prompt")
         => new()
         {
-            Id = id,
+            Id = JobId.From(id),
             Name = "Test Job",
             Schedule = "*/1 * * * *",
             ActionType = actionType,
-            AgentId = "agent-a",
+            AgentId = AgentId.From("agent-a"),
             Message = "run",
             Enabled = true,
             CreatedBy = "tester",
@@ -182,56 +181,55 @@ public sealed class CronControllerTests
         {
             var created = job with
             {
-                Id = string.IsNullOrWhiteSpace(job.Id) ? Guid.NewGuid().ToString("N") : job.Id,
                 CreatedAt = job.CreatedAt == default ? DateTimeOffset.UtcNow : job.CreatedAt
             };
-            _jobs[created.Id] = created;
+            _jobs[created.Id.Value] = created;
             return Task.FromResult(created);
         }
 
-        public Task<CronJob?> GetAsync(string jobId, CancellationToken ct = default)
-            => Task.FromResult(_jobs.GetValueOrDefault(jobId));
+        public Task<CronJob?> GetAsync(JobId jobId, CancellationToken ct = default)
+            => Task.FromResult(_jobs.GetValueOrDefault(jobId.Value));
 
-        public Task<IReadOnlyList<CronJob>> ListAsync(string? agentId = null, CancellationToken ct = default)
+        public Task<IReadOnlyList<CronJob>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
         {
-            IReadOnlyList<CronJob> jobs = agentId is null
+            IReadOnlyList<CronJob> jobs = !agentId.HasValue
                 ? [.. _jobs.Values]
-                : _jobs.Values.Where(job => string.Equals(job.AgentId, agentId, StringComparison.OrdinalIgnoreCase)).ToList();
+                : _jobs.Values.Where(job => job.AgentId.HasValue && job.AgentId.Value == agentId.Value).ToList();
             return Task.FromResult(jobs);
         }
 
         public Task<CronJob> UpdateAsync(CronJob job, CancellationToken ct = default)
         {
-            _jobs[job.Id] = job;
+            _jobs[job.Id.Value] = job;
             return Task.FromResult(job);
         }
 
-        public Task DeleteAsync(string jobId, CancellationToken ct = default)
+        public Task DeleteAsync(JobId jobId, CancellationToken ct = default)
         {
-            _jobs.Remove(jobId);
-            foreach (var runId in _runs.Values.Where(run => run.JobId == jobId).Select(run => run.Id).ToList())
+            _jobs.Remove(jobId.Value);
+            foreach (var runId in _runs.Values.Where(run => run.JobId == jobId).Select(run => run.Id.Value).ToList())
                 _runs.Remove(runId);
             return Task.CompletedTask;
         }
 
-        public Task<CronRun> RecordRunStartAsync(string jobId, CancellationToken ct = default)
+        public Task<CronRun> RecordRunStartAsync(JobId jobId, CancellationToken ct = default)
         {
             var run = new CronRun
             {
-                Id = Guid.NewGuid().ToString("N"),
+                Id = RunId.Create(),
                 JobId = jobId,
                 StartedAt = DateTimeOffset.UtcNow,
                 Status = "running"
             };
-            _runs[run.Id] = run;
+            _runs[run.Id.Value] = run;
             return Task.FromResult(run);
         }
 
-        public Task RecordRunCompleteAsync(string runId, string status, string? error = null, string? sessionId = null, CancellationToken ct = default)
+        public Task RecordRunCompleteAsync(RunId runId, string status, string? error = null, SessionId? sessionId = null, CancellationToken ct = default)
         {
-            if (_runs.TryGetValue(runId, out var run))
+            if (_runs.TryGetValue(runId.Value, out var run))
             {
-                _runs[runId] = run with
+                _runs[runId.Value] = run with
                 {
                     Status = status,
                     Error = error,
@@ -242,7 +240,7 @@ public sealed class CronControllerTests
             return Task.CompletedTask;
         }
 
-        public Task<IReadOnlyList<CronRun>> GetRunHistoryAsync(string jobId, int limit = 20, CancellationToken ct = default)
+        public Task<IReadOnlyList<CronRun>> GetRunHistoryAsync(JobId jobId, int limit = 20, CancellationToken ct = default)
         {
             var runs = _runs.Values
                 .Where(run => run.JobId == jobId)


### PR DESCRIPTION
## Summary

Phase 2 of the Vogen primitive-obsession audit (#425). Introduces `JobId` and `RunId` as Vogen-typed value objects, joining `AgentId`/`ConversationId`/`SessionId` from Phase 1 (#500/#513). The BotNexus.Cron module's public surface (`ICronStore`, `ICronAction`, `CronScheduler`, `CronRun`, `CronJob`) is now strongly typed end-to-end; the SQLite boundary uses `.Value` (write) and `.From()` (read) for the round-trip.

Closes #501.

## What changed

### New Vogen value objects
- `BotNexus.Domain.Primitives.JobId` — required, non-empty, non-whitespace; trimmed on construction.
- `BotNexus.Domain.Primitives.RunId` — same validation shape; adds a static `Create()` factory matching `SqliteCronStore.RecordRunStartAsync`'s historical 32-char `Guid.NewGuid().ToString("N")` format.
- 19 dedicated tests across `JobIdTests` (9) and `RunIdTests` (10), covering validation, equality, JSON round-trip, and the factory.

### Cron module typed throughout
- `CronJob`: `required JobId Id`, `AgentId? AgentId`, `ConversationId? ConversationId`.
- `CronRun`: `RunId Id`, `JobId JobId`, `SessionId? SessionId`.
- `ICronStore`: all five method signatures typed (`GetAsync`, `ListAsync`, `DeleteAsync`, `RecordRunStartAsync`, `RecordRunCompleteAsync`, `GetRunHistoryAsync`).
- `ICronAction`: typed `CronExecutionContext.RunId/SessionId/ConversationId`, typed `RecordSessionId`/`RecordConversationId`.
- `SqliteCronStore`: typed reads/writes via the `.Value` / `.From()` round-trip; uses `RunId.Create()` for fresh run ids.
- `CronScheduler`: `RunNowAsync(JobId)`; config-parse boundary wraps strings.
- `CronTool`: `AgentId` ctor parameter, JSON-arg `JobId.From` boundary, Vogen `==` in `EnsureCanManage` for typed agent ownership checks.

### Triggers + memory flushers
- `InternalTriggerRequest`: `CronJobId: JobId?`, `ConversationId: ConversationId?`, `ResolvedConversationId: ConversationId?`.
- `CronTrigger`, `HeartbeatTrigger`, `SoulTrigger`: typed metadata pass-through.
- `PreCompactionMemoryFlusher`, `SessionEndMemoryFlusher`: typed pass-through.
- `InProcessIsolationStrategy`: typed `CronTool` construction at the single CronTool registration site.

### REST/CLI consumer updates
- `CronController` — wraps the JSON `{jobId}` route parameter with `JobId.From(jobId)` at every public endpoint; uses `job.Id.Value` for dictionary keys; `AgentId.From(...)` for `CronOptions.AgentId` parsing. Auto-generate-Id-on-empty path removed because Vogen rejects `default(JobId)`; REST callers must supply an id (which the typed-from-JSON shape enforces structurally). CronTool keeps generating fresh ids internally.
- `CronCommands` (CLI) — `job.Id.Value` for display (struct, never null), `job.AgentId?.Value ?? "-"` for the nullable Vogen field, `run?.Id.Value` for runs.
- `PromptCommands` (CLI) — three sites wrap `resolvedAgentId!` (string after null-check) with `AgentId.From(...)`.

### Phase 1 leftovers bundled in
The same Cron module had five `string agentId`/`sessionId` parameters Phase 1 missed:
- `HeartbeatAction.ReadHeartbeatFileAsync(IAgentWorkspaceManager, AgentId, ...)`
- `ICronAction.RecordSessionId(SessionId)`
- `CronOptionsPromptTemplateResolver` and `IPromptTemplateResolver`
- `CronTool` constructor (`AgentId`)

Bundled because they live in the same module — a single-pass cleanup was lower risk than two separate PRs.

## ChannelId from #501 — does not apply

The issue lists `JobId`, `ChannelId`, and `RunId`. BotNexus has no `string ChannelId` / `string channelId` parameter in `src/`: `ChannelKey` (already Vogen) and `ChannelAddress` (already Vogen) cover the conceptual space. The only `ChannelId` references in the repo are in `examples/teams-proxy/`, where they refer to Bot Framework's `Activity.ChannelId` (a Microsoft.Bot.Builder SDK type, out of scope). PR ships `JobId` + `RunId` only.

## Architecture fence

New `JobIdRunIdArchitectureTests.NoStringJobIdOrRunId_InCronModule` source-scans `src/gateway/BotNexus.Cron/**` and `src/gateway/BotNexus.Gateway.Api/Triggers/**` for `string jobId` / `string runId` parameter or field declarations. Three boundary files are allowlisted because they receive wire-level strings and wrap with `JobId.From(...)` at the entry:
- `CronController.cs` — REST route parameters
- `CronCommands.cs` — CLI argument strings
- `CronTool.cs` — JSON tool-argument parsing

Follows the existing `NoCode_References_ThreadId_Type` pattern from #539.

## Validation

- Full solution build: **clean** (0 warnings / 0 errors under `TreatWarningsAsErrors=true`).
- Full solution test suite: **all green**.
  - `BotNexus.Gateway.Tests`: 1,724 passed
  - `BotNexus.Cron.Tests`: 129 passed
  - `BotNexus.Domain.Tests`: 308 passed (was 289 + 19 new value-object tests)
  - `BotNexus.Architecture.Tests`: 24 passed (was 23 + new fence)
  - All other suites: passing.
- 4,200+ tests total across the solution, 0 failures.

## Notes on follow-up work (not in this PR)

- `SessionId`'s ad-hoc substring-encoded structural meaning (`::subagent::`, `::agent-agent::`, `::soul::`) remains; in scope for Phase 5 (Agent kinds) and Phase 7 (Session shape) per the domain-model plan.
- Vogen Phase 3 (#502) — `ToolName`, `WorkingDir`, `ConversationTitle` — separate PR.
