### PR TITLE
feat(scenarios): add VirtualWorld harness + first-wave bug-probing citizen scenarios

### DIFF
--- a/tests/scenarios/BotNexus.Scenarios.Harness/BotNexus.Scenarios.Harness.csproj
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/BotNexus.Scenarios.Harness.csproj
@@ -5,11 +5,17 @@
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway\BotNexus.Gateway.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Conversations\BotNexus.Gateway.Conversations.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Sessions\BotNexus.Gateway.Sessions.csproj" />
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Core\BotNexus.Agent.Core.csproj" />
     <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/tests/scenarios/BotNexus.Scenarios.Harness/VirtualWorld.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/VirtualWorld.cs
@@ -1,0 +1,497 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Scenarios.Harness;
+
+/// <summary>
+/// In-process gateway harness for end-to-end citizen scenarios. Boots the production
+/// <c>AddBotNexusGateway()</c> service graph against an isolated temp <c>BotNexusHome</c>,
+/// substitutes the LLM round-trip with <see cref="ScenarioFakeApiProvider"/>, and exposes
+/// a single channel — <see cref="VirtualChannelAdapter"/> — so scenarios drive the
+/// platform exactly as a real channel would, but deterministically and with zero
+/// network IO.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use <see cref="StartAsync(VirtualWorldOptions?, CancellationToken)"/> to construct an
+/// instance. The world is fully isolated: every instance has its own temp home, its own
+/// in-memory stores, its own fake provider, and its own virtual channel adapter — so
+/// tests can run in parallel without contamination.
+/// </para>
+/// <para>
+/// The world's public surface is intentionally narrow: scenarios call typed verbs
+/// (<see cref="GivenAgentAsync"/>, <see cref="WhenSendsAsync"/>,
+/// <see cref="WaitForOutboundAsync"/>) and never reach into DI. This is enforced by the
+/// <c>ScenarioHarness_PublicSurface_DoesNotLeakDiPrimitives</c> architecture rule.
+/// </para>
+/// </remarks>
+public sealed class VirtualWorld : IAsyncDisposable
+{
+    private readonly IHost _host;
+    private readonly VirtualChannelAdapter _adapter;
+    private readonly ScenarioFakeApiProvider _provider;
+    private readonly string _tempHomePath;
+    private readonly IAgentRegistry _agentRegistry;
+    private readonly IConversationStore _conversationStore;
+    private readonly ISessionStore _sessionStore;
+    private readonly IConversationResetService _resetService;
+    private readonly TimeSpan _defaultOutboundWaitTimeout;
+
+    private VirtualWorld(
+        IHost host,
+        VirtualChannelAdapter adapter,
+        ScenarioFakeApiProvider provider,
+        string tempHomePath,
+        IAgentRegistry agentRegistry,
+        IConversationStore conversationStore,
+        ISessionStore sessionStore,
+        IConversationResetService resetService,
+        TimeSpan defaultOutboundWaitTimeout)
+    {
+        _host = host;
+        _adapter = adapter;
+        _provider = provider;
+        _tempHomePath = tempHomePath;
+        _agentRegistry = agentRegistry;
+        _conversationStore = conversationStore;
+        _sessionStore = sessionStore;
+        _resetService = resetService;
+        _defaultOutboundWaitTimeout = defaultOutboundWaitTimeout;
+    }
+
+    /// <summary>
+    /// The virtual channel adapter every scenario drives through. Capability flags
+    /// (streaming / steering / etc.) are baked at <see cref="StartAsync"/> time via
+    /// <see cref="VirtualWorldOptions.ChannelOptions"/>.
+    /// </summary>
+    public VirtualChannelAdapter Adapter => _adapter;
+
+    /// <summary>The fake provider — exposes turn count and the canned response factory.</summary>
+    public ScenarioFakeApiProvider Provider => _provider;
+
+    /// <summary>
+    /// Bootstraps a fully wired in-process gateway, registers the virtual channel + fake
+    /// provider, waits for the channel adapter to start, and returns a ready-to-use world.
+    /// </summary>
+    public static async Task<VirtualWorld> StartAsync(
+        VirtualWorldOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= new VirtualWorldOptions();
+        var tempHomePath = Path.Combine(
+            Path.GetTempPath(),
+            "botnexus-vworld",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempHomePath);
+
+        var adapter = new VirtualChannelAdapter(options.ChannelOptions);
+        var provider = options.ResponseFactory is null
+            ? new ScenarioFakeApiProvider()
+            : new ScenarioFakeApiProvider(options.ResponseFactory);
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddSimpleConsole(o => { o.SingleLine = true; o.IncludeScopes = false; });
+        builder.Logging.SetMinimumLevel(options.LogLevel);
+
+        var services = builder.Services;
+
+        // Substitute BotNexusHome to a fresh temp directory so no scenario writes into
+        // the real ~/.botnexus and parallel scenarios don't see each other's files.
+        services.AddSingleton(new BotNexusHome(tempHomePath));
+
+        // PlatformConfig is consumed by GatewayAuthManager + isolation strategies. Register a
+        // default-shaped options monitor (no provider configuration) so DI resolves cleanly
+        // without reaching for a real config.json on disk.
+        services.AddOptions<PlatformConfig>();
+
+        // GatewayAuthManager is registered by AddPlatformConfiguration in production, NOT by
+        // AddBotNexusGateway. Scenarios don't call AddPlatformConfiguration (it touches the
+        // real ~/.botnexus/config.json), so we must register it ourselves before the gateway
+        // wires up InProcessIsolationStrategy which depends on it.
+        services.AddSingleton<GatewayAuthManager>();
+
+        // Empty in-memory agent config source so AddBotNexusGateway's default file-based
+        // source is skipped. Scenarios register agents programmatically via GivenAgentAsync.
+        services.AddSingleton<IAgentConfigurationSource, EmptyAgentConfigurationSource>();
+
+        services.AddBotNexusGateway();
+
+        // The single virtual channel — register the concrete type AND the IChannelAdapter
+        // contract that ChannelManager scans for.
+        services.AddSingleton(adapter);
+        services.AddSingleton<IChannelAdapter>(adapter);
+
+        // LLM stack — gateway does NOT auto-register these (Program.cs does in production).
+        services.AddSingleton<ApiProviderRegistry>();
+        services.AddSingleton<ModelRegistry>();
+        services.AddSingleton<LlmClient>(sp =>
+        {
+            var apis = sp.GetRequiredService<ApiProviderRegistry>();
+            var models = sp.GetRequiredService<ModelRegistry>();
+            provider.Register(apis, models);
+            return new LlmClient(apis, models);
+        });
+
+        // Strip ALL background hosted services and re-add only GatewayHost — it owns the
+        // channel-adapter startup loop and the dispatch pipeline that scenarios drive. The
+        // rest (UpdateCheckService, MemoryIndexer, SessionWarmupService, SessionCleanupService,
+        // AgentConfigurationHostedService) are noise that slows startup and drags in extra
+        // dependencies (HttpClient, file watchers) that scenarios don't exercise.
+        var hostedDescriptors = services
+            .Where(d => d.ServiceType == typeof(IHostedService))
+            .ToList();
+        foreach (var descriptor in hostedDescriptors)
+            services.Remove(descriptor);
+        services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<BotNexus.Gateway.GatewayHost>());
+
+        var host = builder.Build();
+        await host.StartAsync(cancellationToken);
+
+        // Force LlmClient construction so the fake provider/model are registered before
+        // the first inbound triggers an agent supervisor lookup.
+        _ = host.Services.GetRequiredService<LlmClient>();
+
+        // Wait for the channel adapter to be started by GatewayHost.ExecuteAsync.
+        await WaitForAdapterStartAsync(adapter, TimeSpan.FromSeconds(10), cancellationToken);
+
+        return new VirtualWorld(
+            host,
+            adapter,
+            provider,
+            tempHomePath,
+            host.Services.GetRequiredService<IAgentRegistry>(),
+            host.Services.GetRequiredService<IConversationStore>(),
+            host.Services.GetRequiredService<ISessionStore>(),
+            host.Services.GetRequiredService<IConversationResetService>(),
+            options.DefaultOutboundWaitTimeout);
+    }
+
+    /// <summary>
+    /// Registers an agent that responds via <see cref="ScenarioFakeApiProvider"/>. The
+    /// agent runs in-process and is started lazily when the first inbound hits it.
+    /// </summary>
+    public Task<RegisteredAgent> GivenAgentAsync(
+        string agentId,
+        string? systemPrompt = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From(agentId),
+            DisplayName = agentId,
+            ModelId = ScenarioFakeApiProvider.ModelId,
+            ApiProvider = ScenarioFakeApiProvider.ProviderName,
+            SystemPrompt = systemPrompt,
+            IsolationStrategy = "in-process",
+        };
+        _agentRegistry.Register(descriptor);
+        return Task.FromResult(new RegisteredAgent(descriptor.AgentId.Value, descriptor.DisplayName));
+    }
+
+    /// <summary>
+    /// Drives a citizen-originated inbound through the virtual channel exactly as a real
+    /// channel would. The router resolves the conversation, the supervisor starts the
+    /// agent if needed, the fake provider produces a reply, and the outbound lands back
+    /// on the virtual channel (observable via <see cref="WaitForOutboundAsync"/>).
+    /// </summary>
+    /// <param name="fromUser">The originating user — also used as the channel address (one address per user by default).</param>
+    /// <param name="toAgent">The target agent id (must have been registered via <see cref="GivenAgentAsync"/>).</param>
+    /// <param name="content">The user message.</param>
+    /// <param name="channelAddress">Optional explicit channel address — defaults to the user id (one conversation per user).</param>
+    /// <param name="conversationId">Optional explicit conversation id for the conversation-first routing path.</param>
+    public async Task<DispatchedInbound> WhenSendsAsync(
+        string fromUser,
+        string toAgent,
+        string content,
+        string? channelAddress = null,
+        string? conversationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fromUser);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toAgent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(content);
+
+        var address = string.IsNullOrWhiteSpace(channelAddress) ? fromUser : channelAddress;
+        var inbound = new InboundMessage
+        {
+            ChannelType = ChannelKey.From(VirtualChannelAdapter.VirtualChannelType),
+            SenderId = fromUser,
+            Sender = CitizenId.Of(UserId.From(fromUser)),
+            ChannelAddress = ChannelAddress.From(address),
+            TargetAgentId = toAgent,
+            Content = content,
+            ConversationId = conversationId,
+        };
+        await _adapter.SimulateInboundAsync(inbound, cancellationToken);
+        return new DispatchedInbound(
+            FromUser: fromUser,
+            ToAgent: toAgent,
+            Content: content,
+            ChannelAddress: address,
+            ConversationId: conversationId);
+    }
+
+    /// <summary>
+    /// Blocks until an outbound message matching <paramref name="predicate"/> is observed
+    /// or <paramref name="timeout"/> elapses. Useful for "the agent replied" assertions
+    /// where the reply is async to the inbound dispatch.
+    /// </summary>
+    public async Task<OutboundMessage> WaitForOutboundAsync(
+        Func<OutboundMessage, bool> predicate,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return await _adapter.WaitForOutboundAsync(
+            predicate,
+            timeout ?? _defaultOutboundWaitTimeout,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Convenience overload: waits for any outbound message addressed to a specific channel
+    /// address (i.e. delivered back to a specific virtual citizen).
+    /// </summary>
+    public Task<OutboundMessage> WaitForOutboundToAsync(
+        string channelAddress,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+        => WaitForOutboundAsync(
+            m => string.Equals(m.ChannelAddress.Value, channelAddress, StringComparison.Ordinal),
+            timeout,
+            cancellationToken);
+
+    /// <summary>
+    /// Channel-agnostic reply assertion: waits for the agent's response on
+    /// <paramref name="channelAddress"/> regardless of whether the channel delivers
+    /// the reply via <see cref="IChannelAdapter.SendAsync(OutboundMessage, CancellationToken)"/>
+    /// (non-streaming) or via stream events (streaming). Returns the assembled reply text
+    /// + the delivery mechanism. Scenarios should prefer this over
+    /// <see cref="WaitForOutboundAsync"/> when they don't care how the reply got there.
+    /// </summary>
+    /// <param name="channelAddress">The channel address the reply is addressed to.</param>
+    /// <param name="timeout">Optional override for the default wait timeout.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The accumulated reply content + the delivery channel (<c>outbound</c> or <c>stream</c>).</returns>
+    /// <exception cref="TimeoutException">Thrown when no completed reply is observed before the timeout.</exception>
+    public async Task<AgentReply> WaitForReplyAsync(
+        string channelAddress,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(channelAddress);
+        var deadline = DateTimeOffset.UtcNow + (timeout ?? _defaultOutboundWaitTimeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Non-streaming delivery — completed OutboundMessage on the channel address.
+            var outbound = _adapter.Outbound.FirstOrDefault(m =>
+                string.Equals(m.ChannelAddress.Value, channelAddress, StringComparison.Ordinal));
+            if (outbound is not null)
+                return new AgentReply(outbound.Content, channelAddress, AgentReplyDelivery.Outbound);
+
+            // Streaming delivery — the channel saw TurnEnd or MessageEnd for this address,
+            // meaning the agent has emitted a complete reply over the stream.
+            if (_adapter.StreamEvents.TryGetValue(channelAddress, out var events) && events.Count > 0)
+            {
+                var ended = events.Any(e =>
+                    e.Type == AgentStreamEventType.TurnEnd
+                    || e.Type == AgentStreamEventType.MessageEnd);
+                if (ended)
+                {
+                    var content = string.Concat(events
+                        .Where(e => e.Type == AgentStreamEventType.ContentDelta && e.ContentDelta is not null)
+                        .Select(e => e.ContentDelta));
+
+                    // Fall back to raw deltas if the channel only saw legacy delta events.
+                    if (string.IsNullOrEmpty(content)
+                        && _adapter.StreamDeltas.TryGetValue(channelAddress, out var deltas))
+                    {
+                        content = string.Concat(deltas);
+                    }
+
+                    return new AgentReply(content, channelAddress, AgentReplyDelivery.Stream);
+                }
+            }
+
+            await Task.Delay(20, cancellationToken);
+        }
+
+        throw new TimeoutException(
+            $"No agent reply observed on channel address '{channelAddress}' within " +
+            $"{(timeout ?? _defaultOutboundWaitTimeout).TotalMilliseconds:F0}ms " +
+            $"(outbound={_adapter.Outbound.Count}, streamEvents={(_adapter.StreamEvents.TryGetValue(channelAddress, out var e) ? e.Count : 0)}, " +
+            $"providerTurns={_provider.TurnCount}).");
+    }
+
+    /// <summary>
+    /// Returns a read-only snapshot view of the conversation for assertion purposes.
+    /// </summary>
+    public async Task<ConversationView?> GetConversationAsync(string conversationId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        var conversation = await _conversationStore.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        return conversation is null ? null : ToView(conversation);
+    }
+
+    /// <summary>
+    /// Returns the full list of conversations owned by an agent (regardless of channel binding).
+    /// </summary>
+    public async Task<IReadOnlyList<ConversationView>> ListConversationsForAgentAsync(string agentId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        var conversations = await _conversationStore.ListAsync(AgentId.From(agentId), cancellationToken);
+        return [.. conversations.Select(ToView)];
+    }
+
+    /// <summary>
+    /// Returns a read-only snapshot view of the session for assertion purposes.
+    /// </summary>
+    public async Task<SessionView?> GetSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        var snapshot = await _sessionStore.GetAsync(SessionId.From(sessionId), cancellationToken);
+        if (snapshot is null) return null;
+        return new SessionView(
+            SessionId: snapshot.Session.SessionId.Value,
+            AgentId: snapshot.AgentId.Value,
+            ConversationId: snapshot.Session.ConversationId?.Value,
+            Status: snapshot.Session.Status.ToString(),
+            HistoryCount: snapshot.Session.History.Count);
+    }
+
+    /// <summary>
+    /// Drives the canonical reset flow for an active session: stops the agent, flushes
+    /// memory, cancels any pending ask-user, seals the old session, and clears the
+    /// conversation's <c>ActiveSessionId</c> so the next inbound creates a fresh session.
+    /// </summary>
+    public Task ResetSessionAsync(string conversationId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        return _resetService.ResetActiveSessionAsync(ConversationId.From(conversationId), cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _host.StopAsync(TimeSpan.FromSeconds(5));
+        }
+        catch
+        {
+            // Best-effort shutdown.
+        }
+        _host.Dispose();
+        try
+        {
+            if (Directory.Exists(_tempHomePath))
+                Directory.Delete(_tempHomePath, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; tests should not fail on temp dir cleanup races.
+        }
+    }
+
+    private static async Task WaitForAdapterStartAsync(VirtualChannelAdapter adapter, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (adapter.IsRunning) return;
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Delay(10, cancellationToken);
+        }
+        throw new TimeoutException(
+            $"VirtualChannelAdapter did not start within {timeout.TotalSeconds:F0}s. " +
+            "Likely the gateway's BackgroundService failed to start its channel adapters.");
+    }
+
+    private static ConversationView ToView(Conversation conversation)
+        => new(
+            ConversationId: conversation.ConversationId.Value,
+            AgentId: conversation.AgentId.Value,
+            Title: conversation.Title,
+            ActiveSessionId: conversation.ActiveSessionId?.Value,
+            ChannelBindings: [.. conversation.ChannelBindings.Select(b => new ChannelBindingView(b.ChannelType.Value, b.ChannelAddress.Value))],
+            Status: conversation.Status.ToString(),
+            InitiatorId: conversation.Initiator?.ToString());
+
+    private sealed class EmptyAgentConfigurationSource : IAgentConfigurationSource
+    {
+        public Task<IReadOnlyList<AgentDescriptor>> LoadAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AgentDescriptor>>([]);
+
+        public IDisposable? Watch(Action<IReadOnlyList<AgentDescriptor>> onChanged) => null;
+    }
+}
+
+/// <summary>Read-only view of a registered agent — exposed to scenarios so they can refer back to the id without going through DI.</summary>
+public sealed record RegisteredAgent(string AgentId, string DisplayName);
+
+/// <summary>Read-only record of an inbound that was just dispatched — useful for chained assertions.</summary>
+public sealed record DispatchedInbound(string FromUser, string ToAgent, string Content, string ChannelAddress, string? ConversationId);
+
+/// <summary>Read-only view of a conversation — minimum surface for assertion-style scenarios.</summary>
+public sealed record ConversationView(
+    string ConversationId,
+    string AgentId,
+    string? Title,
+    string? ActiveSessionId,
+    IReadOnlyList<ChannelBindingView> ChannelBindings,
+    string Status,
+    string? InitiatorId);
+
+/// <summary>Read-only view of a single channel binding on a conversation.</summary>
+public sealed record ChannelBindingView(string ChannelType, string ChannelAddress);
+
+/// <summary>Read-only view of a session — exposes the fields scenarios assert against.</summary>
+public sealed record SessionView(
+    string SessionId,
+    string AgentId,
+    string? ConversationId,
+    string Status,
+    int HistoryCount);
+
+/// <summary>
+/// How the gateway delivered the agent's reply back to the channel. Streaming channels
+/// receive deltas + a terminating event; non-streaming channels receive a single
+/// completed <c>OutboundMessage</c>. Scenarios that just want to assert on the reply
+/// content shouldn't care which path was used — see
+/// <see cref="VirtualWorld.WaitForReplyAsync"/>.
+/// </summary>
+public enum AgentReplyDelivery
+{
+    /// <summary>The reply landed via <see cref="IChannelAdapter.SendAsync(OutboundMessage, CancellationToken)"/> as one completed message.</summary>
+    Outbound,
+
+    /// <summary>The reply was assembled from streaming events / deltas captured on the channel.</summary>
+    Stream
+}
+
+/// <summary>
+/// The agent's reply as observed by the virtual channel, regardless of delivery path.
+/// Returned by <see cref="VirtualWorld.WaitForReplyAsync"/>.
+/// </summary>
+/// <param name="Content">The accumulated reply text the citizen would see.</param>
+/// <param name="ChannelAddress">The address the reply was delivered to.</param>
+/// <param name="Delivery">Whether the reply came via the streaming or non-streaming path.</param>
+public sealed record AgentReply(string Content, string ChannelAddress, AgentReplyDelivery Delivery);

--- a/tests/scenarios/BotNexus.Scenarios.Harness/VirtualWorldOptions.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/VirtualWorldOptions.cs
@@ -1,0 +1,44 @@
+namespace BotNexus.Scenarios.Harness;
+
+/// <summary>
+/// Configuration for a <see cref="VirtualWorld"/> instance. Mirrors the subset of gateway
+/// behaviour that scenarios typically need to vary without leaking DI primitives onto the
+/// public surface (which the <c>ScenarioHarness_PublicSurface_DoesNotLeakDiPrimitives</c>
+/// architecture rule enforces).
+/// </summary>
+public sealed class VirtualWorldOptions
+{
+    /// <summary>
+    /// Capability flags for the single virtual channel auto-registered with the world.
+    /// Override to construct capability-gating scenarios (e.g. <c>SupportsSteering=false</c>).
+    /// </summary>
+    public VirtualChannelAdapterOptions ChannelOptions { get; init; } = new();
+
+    /// <summary>
+    /// Optional response factory for the in-memory <see cref="ScenarioFakeApiProvider"/>. When
+    /// null, the provider emits the literal string "ok" for every turn — sufficient for most
+    /// routing / lifecycle scenarios that don't assert on reply content.
+    /// </summary>
+    public Func<int, BotNexus.Agent.Providers.Core.Models.Context, string>? ResponseFactory { get; init; }
+
+    /// <summary>
+    /// Default system prompt baked into agents created via <see cref="VirtualWorld.GivenAgentAsync"/>
+    /// when the caller does not pass one explicitly.
+    /// </summary>
+    public string DefaultSystemPrompt { get; init; } = "You are a helpful scenario test agent.";
+
+    /// <summary>
+    /// Minimum log level emitted by the in-process gateway. Default is <see cref="Microsoft.Extensions.Logging.LogLevel.Warning"/>
+    /// — bump to <see cref="Microsoft.Extensions.Logging.LogLevel.Debug"/> when diagnosing why a scenario doesn't reach an expected
+    /// outbound and the failure message alone isn't enough.
+    /// </summary>
+    public Microsoft.Extensions.Logging.LogLevel LogLevel { get; init; } = Microsoft.Extensions.Logging.LogLevel.Warning;
+
+    /// <summary>
+    /// Maximum wait used by <see cref="VirtualWorld.WaitForOutboundAsync"/> when the caller
+    /// does not pass an explicit timeout. Default 5s — chosen high enough to absorb agent
+    /// startup + provider dispatch + outbound capture on a slow CI box but low enough that
+    /// a regression failing this gate produces fast, readable failures.
+    /// </summary>
+    public TimeSpan DefaultOutboundWaitTimeout { get; init; } = TimeSpan.FromSeconds(5);
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/ConcurrentInboundScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/ConcurrentInboundScenario.cs
@@ -1,0 +1,139 @@
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Bug-probing scenario for race conditions in conversation routing under concurrent
+/// inbound load.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> the routing rule is "every unique
+/// <c>(channelType, channelAddress)</c> maps to one conversation" (see
+/// <c>DefaultConversationRouter.cs:117</c>). When two inbounds arrive at the same
+/// <c>(channelType, channelAddress)</c> concurrently and no conversation exists yet,
+/// a careless "check-then-create" implementation will create <b>two</b> conversations —
+/// one per racing thread — and the user sees their messages silently split across two
+/// transcripts. The same defect class produced #441 (reconnect creates new conversation)
+/// in production.
+/// </para>
+/// <para>
+/// This scenario fires <i>N</i> inbounds concurrently from the <b>same user / same
+/// channel address</b> via <see cref="Task.WhenAll(System.Collections.Generic.IEnumerable{Task})"/>
+/// and asserts that <b>exactly one</b> conversation exists at the end. Repeating per
+/// agent is intentional: contention is per-conversation key, and the absence of
+/// duplicate creation is the most valuable regression guarantee in the entire suite.
+/// </para>
+/// </remarks>
+public sealed class ConcurrentInboundScenario
+{
+    [Fact]
+    public async Task RapidConcurrentInbound_SameAgentSameAddress_ResolvesToSingleConversation_NoDuplicate()
+    {
+        // Arrange — single agent, single user, ten concurrent inbounds.
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            // Use a slow-ish response factory so the provider work overlaps across requests
+            // (otherwise the first turn might complete before the second arrives, which
+            // would test a serialized — not concurrent — workflow).
+            ResponseFactory = (turn, _) => $"reply-{turn}",
+        });
+        _ = await world.GivenAgentAsync("contention-agent");
+
+        const int concurrency = 10;
+        var inbounds = Enumerable.Range(0, concurrency)
+            .Select(i => world.WhenSendsAsync(
+                fromUser: "carla",
+                toAgent: "contention-agent",
+                content: $"concurrent-{i}"))
+            .ToArray();
+
+        // Act — fire all ten in parallel and wait for them all to enter the dispatcher.
+        await Task.WhenAll(inbounds);
+
+        // Wait until the provider has been invoked for every inbound — that is the strongest
+        // signal that the gateway has finished serializing each one through the per-conversation
+        // queue. If the gateway has a race that drops or duplicates, TurnCount will not match.
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline && world.Provider.TurnCount < concurrency)
+        {
+            await Task.Delay(25);
+        }
+
+        // Assert — exactly ONE conversation exists for this agent. The routing rule
+        // (channelType, channelAddress) -> conversation is 1:1 by construction; if a race
+        // window opens during "first inbound for this address" handling, the
+        // conversation store will hold N rows instead of 1.
+        var conversations = await world.ListConversationsForAgentAsync("contention-agent");
+        conversations.Count.ShouldBe(
+            1,
+            $"expected exactly 1 conversation under concurrent inbound, observed {conversations.Count} " +
+            "— a race in DefaultConversationRouter's 'find or create' for new (channelType, channelAddress) tuples");
+
+        var conversation = conversations[0];
+        conversation.ChannelBindings.Count.ShouldBe(
+            1,
+            $"expected exactly 1 binding on the shared conversation, observed {conversation.ChannelBindings.Count}");
+        conversation.ChannelBindings[0].ChannelAddress.ShouldBe("carla");
+
+        // And the provider was invoked exactly N times — proves all inbounds were processed
+        // (none silently dropped) and none re-dispatched (no duplicate execution).
+        world.Provider.TurnCount.ShouldBe(
+            concurrency,
+            $"expected exactly {concurrency} provider invocations, observed {world.Provider.TurnCount} " +
+            "— some inbounds were dropped or duplicated by the dispatcher");
+    }
+
+    [Fact]
+    public async Task RapidConcurrentInbound_DifferentAddresses_CreatesOneConversationPerAddress_NoCrossContamination()
+    {
+        // Bug-probing companion: same load pattern but each inbound carries a different
+        // channel address. The expected result is N distinct conversations (one per
+        // address). If the router has a bug that conflates by some shared key (e.g.
+        // agent id alone), this surfaces immediately.
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ResponseFactory = (turn, _) => $"reply-{turn}",
+        });
+        _ = await world.GivenAgentAsync("multi-user-agent");
+
+        const int users = 8;
+        var inbounds = Enumerable.Range(0, users)
+            .Select(i => world.WhenSendsAsync(
+                fromUser: $"user-{i}",
+                toAgent: "multi-user-agent",
+                content: $"hello from user-{i}"))
+            .ToArray();
+
+        await Task.WhenAll(inbounds);
+
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline && world.Provider.TurnCount < users)
+        {
+            await Task.Delay(25);
+        }
+
+        // Assert — exactly N conversations (one per channel address).
+        var conversations = await world.ListConversationsForAgentAsync("multi-user-agent");
+        conversations.Count.ShouldBe(
+            users,
+            $"expected exactly {users} conversations (one per channel address), observed {conversations.Count} " +
+            "— either router conflated addresses, or some inbound failed to create its conversation");
+
+        // And each conversation has its own distinct binding — no shared / cross-contaminated bindings.
+        var bindingAddresses = conversations
+            .SelectMany(c => c.ChannelBindings.Select(b => b.ChannelAddress))
+            .OrderBy(a => a)
+            .ToArray();
+        bindingAddresses.Distinct().Count().ShouldBe(
+            users,
+            "expected one distinct ChannelAddress per conversation; duplicate addresses indicate cross-contamination");
+
+        for (var i = 0; i < users; i++)
+        {
+            bindingAddresses.ShouldContain(
+                $"user-{i}",
+                $"missing binding for user-{i} — that conversation never reached the store");
+        }
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/ConversationResetScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/ConversationResetScenario.cs
@@ -1,0 +1,141 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Bug-probing scenario for the canonical session reset sequence (Phase 3c —
+/// <c>IConversationResetService.ResetActiveSessionAsync</c>, shipped in PR #538).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> reset is the most error-prone operation in the entire
+/// conversation lifecycle. The plan's F-2c finding was: the SignalR path used to flush
+/// memory before sealing, the REST path did not, and that asymmetry meant the agent
+/// silently lost context across reset on one channel but not the other. PR #538
+/// introduced <c>IConversationResetService.ResetActiveSessionAsync</c> as the
+/// <b>single canonical reset path</b> both transports route through.
+/// </para>
+/// <para>
+/// This scenario asserts the canonical post-reset invariant: the OLD session is
+/// <c>Sealed</c>, the conversation's <c>ActiveSessionId</c> is cleared, the next
+/// inbound creates a <b>new empty session</b> in the same Conversation, and the LLM
+/// context for the next turn does <b>not</b> contain any history from the sealed
+/// session. The fake provider captures the post-reset context so we can prove the
+/// new session genuinely starts from empty — a silent "reset doesn't actually reset"
+/// regression would leak the old history into the new context and break long-running
+/// conversations after their first reset.
+/// </para>
+/// </remarks>
+public sealed class ConversationResetScenario
+{
+    [Fact]
+    public async Task ResetActiveSession_SealsOldSession_ClearsActiveSessionId_NextInboundCreatesEmptyNewSession()
+    {
+        // Arrange — response factory captures the LLM context for each turn so the
+        // post-reset context can be inspected for old-history leakage.
+        var capturedContexts = new List<Context>();
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ResponseFactory = (turn, ctx) =>
+            {
+                capturedContexts.Add(ctx);
+                return $"reply-{turn}";
+            },
+        });
+        _ = await world.GivenAgentAsync("reset-agent");
+
+        // Act 1 — establish a conversation with two turns of history.
+        await world.WhenSendsAsync(fromUser: "fern", toAgent: "reset-agent", content: "secret-phrase-pre-reset-A");
+        _ = await world.WaitForReplyAsync(channelAddress: "fern");
+        await world.WhenSendsAsync(fromUser: "fern", toAgent: "reset-agent", content: "secret-phrase-pre-reset-B");
+        _ = await world.WaitForReplyAsync(channelAddress: "fern");
+
+        var preResetConversation = (await world.ListConversationsForAgentAsync("reset-agent")).Single();
+        var oldSessionId = preResetConversation.ActiveSessionId.ShouldNotBeNull(
+            "conversation must have an active session before reset is meaningful");
+        var oldSession = await world.GetSessionAsync(oldSessionId);
+        oldSession.ShouldNotBeNull();
+        oldSession.HistoryCount.ShouldBeGreaterThan(
+            0,
+            "pre-reset session must have history for the reset assertion to mean anything");
+
+        // Act 2 — drive the canonical reset.
+        await world.ResetSessionAsync(preResetConversation.ConversationId);
+
+        // Assert post-reset state:
+        // - The OLD session must be Sealed (no longer accepting writes).
+        // - The conversation's ActiveSessionId must be cleared (lazy new-session per PR #538).
+        var postResetConversation = (await world.ListConversationsForAgentAsync("reset-agent")).Single();
+        postResetConversation.ConversationId.ShouldBe(
+            preResetConversation.ConversationId,
+            "reset must not destroy the Conversation; only seal its active session");
+        postResetConversation.ActiveSessionId.ShouldBeNull(
+            "post-reset ActiveSessionId must be cleared so the next inbound creates a fresh session " +
+            "(PR #538 canonical reset sequence — F-2c)");
+
+        var sealedSession = await world.GetSessionAsync(oldSessionId);
+        sealedSession.ShouldNotBeNull("the old session must NOT be deleted — only sealed");
+        sealedSession.Status.ShouldBe(
+            "Sealed",
+            $"old session status must be 'Sealed' after reset (was '{sealedSession.Status}')");
+        sealedSession.HistoryCount.ShouldBe(
+            oldSession.HistoryCount,
+            "sealed session must retain its history — sealing is non-destructive (F-2a sibling property)");
+
+        // Act 3 — next inbound should create a brand-new session in the SAME conversation
+        // with EMPTY history. The next-turn LLM context must NOT see the sealed history.
+        capturedContexts.Clear();
+        await world.WhenSendsAsync(fromUser: "fern", toAgent: "reset-agent", content: "first-post-reset-turn");
+        _ = await world.WaitForReplyAsync(channelAddress: "fern");
+
+        // Assert post-reset:
+        // - One fresh provider invocation.
+        // - The provider's context contains the NEW user message but NOT the sealed-session content.
+        capturedContexts.Count.ShouldBe(1, "first post-reset turn should invoke the provider exactly once");
+
+        var newContext = capturedContexts[0];
+        var allUserContent = string.Concat(newContext.Messages
+            .OfType<UserMessage>()
+            .Select(m => m.Content.IsText
+                ? m.Content.Text
+                : string.Concat(m.Content.Blocks?.OfType<TextContent>().Select(t => t.Text) ?? [])));
+
+        allUserContent.ShouldContain(
+            "first-post-reset-turn",
+            customMessage: "the new user message must reach the LLM context");
+        allUserContent.ShouldNotContain(
+            "secret-phrase-pre-reset-A",
+            customMessage: "reset MUST NOT leak sealed session history into the new session's LLM context — " +
+            "this would be a silent reset-failure regression that breaks every reset-once-then-continue workflow");
+        allUserContent.ShouldNotContain(
+            "secret-phrase-pre-reset-B",
+            customMessage: "reset MUST NOT leak sealed session history into the new session's LLM context");
+
+        // And the assistant's prior replies must also not leak.
+        var allAssistantContent = string.Concat(newContext.Messages
+            .OfType<AssistantMessage>()
+            .SelectMany(m => m.Content)
+            .OfType<TextContent>()
+            .Select(t => t.Text));
+        allAssistantContent.ShouldNotContain(
+            "reply-0",
+            customMessage: "reset MUST NOT leak prior assistant replies into the new session's LLM context");
+        allAssistantContent.ShouldNotContain(
+            "reply-1",
+            customMessage: "reset MUST NOT leak prior assistant replies into the new session's LLM context");
+
+        // And the conversation now has a NEW active session that is NOT the old one.
+        var finalConversation = (await world.ListConversationsForAgentAsync("reset-agent")).Single();
+        var newSessionId = finalConversation.ActiveSessionId.ShouldNotBeNull(
+            "next inbound after reset must create a fresh active session");
+        newSessionId.ShouldNotBe(
+            oldSessionId,
+            "the new active session must NOT be the resurrected sealed session — reset created a new one");
+
+        // And the system prompt is still loaded on the FIRST turn of the new session.
+        newContext.SystemPrompt.ShouldNotBeNull(
+            "system prompt must be loaded on the first turn of the new session — " +
+            "F-3d invariant: empty history implies first-call, instruction loading is unconditional");
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/CrossAgentIsolationScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/CrossAgentIsolationScenario.cs
@@ -1,0 +1,151 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Bug-probing scenario for the cross-agent isolation boundary.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this matters:</b> in a multi-tenant deployment with N agents registered,
+/// a message addressed to agent A must <i>only</i> reach agent A. A bug in the
+/// supervisor lookup, the conversation router, or the dispatch fan-out could:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Deliver agent A's prompt to agent B's LLM (cross-tenant data leak).</description></item>
+///   <item><description>Insert agent A's user turn into agent B's session history (silent context contamination).</description></item>
+///   <item><description>Cause agent B to reply on agent A's behalf (impersonation).</description></item>
+/// </list>
+/// <para>
+/// All three are catastrophic in a multi-user deployment and easy to introduce
+/// when refactoring the router or the supervisor. This scenario pins the
+/// invariant that <see cref="ScenarioFakeApiProvider.TurnCount"/> and per-agent
+/// session history are <i>partitioned by agent id</i> with zero bleed-through.
+/// </para>
+/// <para>
+/// <b>The probe:</b> register two agents. User sends three messages, alternating
+/// between them. After each send, assert the receiving agent's session
+/// accumulated the turn and the non-receiving agent's session did not.
+/// </para>
+/// </remarks>
+public sealed class CrossAgentIsolationScenario
+{
+    [Fact]
+    public async Task TwoAgents_SameUser_EachAgentReceivesOnlyItsOwnTurns_NoCrossContamination()
+    {
+        var capturedByAgent = new System.Collections.Concurrent.ConcurrentDictionary<
+            string,
+            List<List<string>>>();
+        var observedSystemPrompts = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ResponseFactory = (turn, ctx) =>
+            {
+                // Capture the user-visible content of every UserMessage in the LLM context,
+                // keyed by which agent's prompt triggered this turn. The system prompt
+                // tells us which agent — see GivenAgentAsync below.
+                var systemPrompt = ctx.SystemPrompt ?? string.Empty;
+                observedSystemPrompts.Add(systemPrompt);
+                var agentKey = systemPrompt.Contains("agent:alpha", StringComparison.Ordinal) ? "alpha"
+                    : systemPrompt.Contains("agent:bravo", StringComparison.Ordinal) ? "bravo"
+                    : "unknown";
+
+                var userTexts = ctx.Messages
+                    .OfType<UserMessage>()
+                    .Select(m => m.Content.IsText
+                        ? m.Content.Text ?? string.Empty
+                        : string.Concat(m.Content.Blocks?.OfType<TextContent>().Select(t => t.Text) ?? []))
+                    .ToList();
+
+                capturedByAgent.AddOrUpdate(
+                    agentKey,
+                    _ => new List<List<string>> { userTexts },
+                    (_, list) => { list.Add(userTexts); return list; });
+
+                return $"reply-from-{agentKey}-turn-{turn}";
+            },
+        });
+
+        _ = await world.GivenAgentAsync("alpha", systemPrompt: "agent:alpha");
+        _ = await world.GivenAgentAsync("bravo", systemPrompt: "agent:bravo");
+
+        // Three sends, alternating agents — same user, same channel address (so the
+        // only discriminator is TargetAgentId on the inbound).
+        await world.WhenSendsAsync(
+            fromUser: "isolation-user",
+            toAgent: "alpha",
+            content: "ALPHA-SECRET-1");
+        _ = await world.WaitForReplyAsync(channelAddress: "isolation-user");
+
+        await world.WhenSendsAsync(
+            fromUser: "isolation-user",
+            toAgent: "bravo",
+            content: "BRAVO-SECRET-1");
+        _ = await world.WaitForReplyAsync(channelAddress: "isolation-user");
+
+        await world.WhenSendsAsync(
+            fromUser: "isolation-user",
+            toAgent: "alpha",
+            content: "ALPHA-SECRET-2");
+        _ = await world.WaitForReplyAsync(channelAddress: "isolation-user");
+
+        // Provider was invoked once per inbound — three total.
+        world.Provider.TurnCount.ShouldBe(3);
+
+        // Each agent saw exactly the user turns addressed to it.
+        capturedByAgent.ShouldContainKey(
+            "alpha",
+            $"alpha never received a turn — supervisor routing regression. Observed system prompts: [{string.Join("] [", observedSystemPrompts)}]");
+        capturedByAgent.ShouldContainKey(
+            "bravo",
+            $"bravo never received a turn — supervisor routing regression. Observed system prompts: [{string.Join("] [", observedSystemPrompts)}]");
+
+        var alphaInvocations = capturedByAgent["alpha"];
+        var bravoInvocations = capturedByAgent["bravo"];
+
+        alphaInvocations.Count.ShouldBe(
+            2,
+            $"alpha should have been invoked twice, observed {alphaInvocations.Count}");
+        bravoInvocations.Count.ShouldBe(
+            1,
+            $"bravo should have been invoked once, observed {bravoInvocations.Count}");
+
+        // CRITICAL: alpha's LLM context must NEVER contain BRAVO-SECRET-* and vice versa.
+        // This is the cross-tenant data leak probe.
+        foreach (var (turnIndex, alphaContext) in alphaInvocations.Select((c, i) => (i, c)))
+        {
+            var alphaCombined = string.Join("|", alphaContext);
+            alphaCombined.ShouldNotContain(
+                "BRAVO-SECRET",
+                customMessage: $"alpha turn #{turnIndex} contains BRAVO-SECRET — cross-agent data leak: [{alphaCombined}]");
+        }
+
+        foreach (var (turnIndex, bravoContext) in bravoInvocations.Select((c, i) => (i, c)))
+        {
+            var bravoCombined = string.Join("|", bravoContext);
+            bravoCombined.ShouldNotContain(
+                "ALPHA-SECRET",
+                customMessage: $"bravo turn #{turnIndex} contains ALPHA-SECRET — cross-agent data leak: [{bravoCombined}]");
+        }
+
+        // Alpha's second invocation should have ALPHA-SECRET-1 visible (history
+        // accumulated within its session) AND ALPHA-SECRET-2 as the latest user turn.
+        var alphaSecondContext = alphaInvocations[1];
+        alphaSecondContext.Any(t => t.Contains("ALPHA-SECRET-1")).ShouldBeTrue(
+            $"alpha's second turn lost ALPHA-SECRET-1 from history — session continuity broken: [{string.Join("|", alphaSecondContext)}]");
+        alphaSecondContext.Any(t => t.Contains("ALPHA-SECRET-2")).ShouldBeTrue(
+            $"alpha's second turn missing ALPHA-SECRET-2 as latest user message: [{string.Join("|", alphaSecondContext)}]");
+
+        // Each agent owns its own conversation — verifies the supervisor/router
+        // created separate conversations rather than reusing one across agents.
+        var alphaConversations = await world.ListConversationsForAgentAsync("alpha");
+        var bravoConversations = await world.ListConversationsForAgentAsync("bravo");
+        alphaConversations.Count.ShouldBe(1, $"alpha should own exactly 1 conversation, observed {alphaConversations.Count}");
+        bravoConversations.Count.ShouldBe(1, $"bravo should own exactly 1 conversation, observed {bravoConversations.Count}");
+        alphaConversations[0].ConversationId.ShouldNotBe(
+            bravoConversations[0].ConversationId,
+            "two agents must not share a single conversation — multi-tenant isolation regression");
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/ExplicitConversationIdScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/ExplicitConversationIdScenario.cs
@@ -1,0 +1,127 @@
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Bug-probing scenario for the explicit-<c>conversationId</c> routing path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> <see cref="VirtualWorld.WhenSendsAsync"/>
+/// accepts an explicit <c>conversationId</c> override that maps to
+/// <c>InboundMessage.ConversationId</c>. This drives the gateway down a
+/// <i>different routing branch</i> than the implicit
+/// <c>(channelType, channelAddress)</c> lookup — specifically the
+/// <c>DefaultConversationRouter</c> "explicit conversation id" fast path
+/// (see <c>DefaultConversationRouter.cs:46-104</c>). The implicit and explicit
+/// paths share zero code beneath the entry point, so they can silently diverge
+/// in behaviour (e.g. explicit-id binding registration, fan-out targeting, or
+/// session creation under same-address-different-conversation contention).
+/// </para>
+/// <para>
+/// <b>Documented contract</b> (verified via <c>DefaultConversationRouter.cs:46-55</c>):
+/// the explicit <c>conversationId</c> on inbound is treated as "look up an existing
+/// conversation". A non-existent id <b>falls through</b> to address-based routing;
+/// clients <i>cannot</i> create a new conversation with a chosen id by passing it on
+/// inbound. The test below pins this contract and probes the
+/// "bind-on-first-use" side effect described at <c>:67-86</c>.
+/// </para>
+/// </remarks>
+public sealed class ExplicitConversationIdScenario
+{
+    [Fact]
+    public async Task ExplicitConversationId_OnExistingConversation_RoutesToThatConversation_AndBindsChannelAddressIfNew()
+    {
+        // Arrange — create a conversation by sending a first inbound (the natural
+        // creation path). Then capture the generated id and use it as the explicit
+        // ConversationId for a SECOND inbound that arrives on a different channel
+        // address. The router's bind-on-first-use path (router :67-86) should bind
+        // the new channel address to the existing conversation, NOT create a second
+        // conversation. This is the user-visible "open same conversation from a
+        // second device" flow.
+        await using var world = await VirtualWorld.StartAsync();
+        _ = await world.GivenAgentAsync("explicit-id-agent");
+
+        await world.WhenSendsAsync(
+            fromUser: "ivy",
+            toAgent: "explicit-id-agent",
+            channelAddress: "ivy-tablet",
+            content: "first message from tablet");
+        _ = await world.WaitForReplyAsync(channelAddress: "ivy-tablet");
+
+        var initialConversation = (await world.ListConversationsForAgentAsync("explicit-id-agent")).Single();
+        var sharedConversationId = initialConversation.ConversationId;
+
+        // Act — send a second inbound from a DIFFERENT channel address but with the
+        // explicit conversation id of the first conversation. Must route to that
+        // conversation (not create a second one).
+        await world.WhenSendsAsync(
+            fromUser: "ivy",
+            toAgent: "explicit-id-agent",
+            channelAddress: "ivy-phone",
+            content: "follow-up from phone, same conversation",
+            conversationId: sharedConversationId);
+        _ = await world.WaitForReplyAsync(channelAddress: "ivy-phone");
+
+        // Assert — exactly one conversation still exists.
+        var conversations = await world.ListConversationsForAgentAsync("explicit-id-agent");
+        conversations.Count.ShouldBe(
+            1,
+            $"explicit ConversationId on a second inbound from a different channel address should NOT " +
+            $"create a second conversation; observed {conversations.Count} conversations — " +
+            $"router fell back to address-based path despite the explicit id being valid");
+
+        var conversation = conversations[0];
+        conversation.ConversationId.ShouldBe(sharedConversationId);
+
+        // And the conversation now has TWO channel-address bindings — proving the
+        // bind-on-first-use side effect at router lines 67-86 fired.
+        conversation.ChannelBindings.Count.ShouldBe(
+            2,
+            $"the router should have added a binding for the new channel address; observed " +
+            $"{conversation.ChannelBindings.Count} bindings — bind-on-first-use regression");
+
+        var addresses = conversation.ChannelBindings.Select(b => b.ChannelAddress).ToHashSet();
+        addresses.ShouldContain("ivy-tablet", "the original address must still be bound");
+        addresses.ShouldContain("ivy-phone", "the new address must be bound via bind-on-first-use");
+
+        // And both inbound messages reached the LLM.
+        world.Provider.TurnCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ExplicitConversationId_OnNonExistentId_FallsBackToAddressRouting_AndPersistsNewConversation()
+    {
+        // Bug-probing companion: pins the "non-existent explicit id falls through to
+        // binding lookup" contract documented at DefaultConversationRouter.cs:50-55.
+        // A regression that throws on a non-existent id (or silently drops the
+        // inbound) would surface here.
+        await using var world = await VirtualWorld.StartAsync();
+        _ = await world.GivenAgentAsync("fallback-agent");
+
+        var bogusId = "non-existent-" + Guid.NewGuid().ToString("N");
+
+        // Act — inbound carries an explicit conversationId that doesn't exist.
+        await world.WhenSendsAsync(
+            fromUser: "jack",
+            toAgent: "fallback-agent",
+            content: "hello",
+            conversationId: bogusId);
+        _ = await world.WaitForReplyAsync(channelAddress: "jack");
+
+        // Assert — the inbound was processed (provider invoked), one conversation
+        // exists for the agent (via the fallback address-based path), and its id
+        // is NOT the bogus id we provided.
+        world.Provider.TurnCount.ShouldBe(1);
+        var conversations = await world.ListConversationsForAgentAsync("fallback-agent");
+        conversations.Count.ShouldBe(
+            1,
+            "the fallback address-based path should create exactly one conversation; " +
+            $"observed {conversations.Count}");
+        conversations[0].ConversationId.ShouldNotBe(
+            bogusId,
+            "the gateway must NOT persist a client-supplied conversation id (security boundary)");
+        conversations[0].ChannelBindings.Single().ChannelAddress.ShouldBe("jack");
+    }
+}
+

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/MultiTurnHistoryAccumulationScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/MultiTurnHistoryAccumulationScenario.cs
@@ -1,0 +1,202 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Bug-probing scenario for multi-turn history accumulation and the LLM-context projection
+/// (Phase 3b — <c>SessionContextProjector</c>, shipped in PR #535).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> the canonical "history -> LLM context" projection is the single
+/// most load-bearing piece of code in the conversation lifecycle. If it filters too
+/// aggressively the agent loses memory mid-conversation; if it filters too leniently
+/// historical / sentinel entries leak back into prompts. Before PR #535 the projection
+/// was inlined in <c>InProcessIsolationStrategy</c>; now it lives in
+/// <c>BotNexus.Gateway.Sessions.SessionContextProjector</c> and is supposed to be the
+/// single source of truth for "what does the LLM see".
+/// </para>
+/// <para>
+/// This scenario sends N turns to one conversation and uses the fake provider's response
+/// factory to <b>capture every <see cref="Context"/> the gateway hands to the LLM</b>,
+/// then asserts:
+/// <list type="number">
+/// <item>The LLM-visible message count <b>grows monotonically</b> across turns (history
+///       accumulates correctly).</item>
+/// <item>The user content of each prior turn is faithfully reproduced in subsequent
+///       contexts — no silent message loss or reordering.</item>
+/// <item>The session store's <c>History.Count</c> matches the on-the-wire growth (history
+///       is durably persisted, not just held in memory for one turn).</item>
+/// <item>The system prompt the agent declared is present in every context (instruction
+///       loading is consistent — no "system prompt only loaded once" regression).</item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class MultiTurnHistoryAccumulationScenario
+{
+    [Fact]
+    public async Task MultiTurn_HistoryAccumulates_AndProviderSeesGrowingContext_WithSystemPromptOnEveryTurn()
+    {
+        // Arrange — a response factory that records the LLM-visible context for every turn.
+        // This is the single most valuable instrumentation in the harness: it lets a
+        // scenario inspect EXACTLY what the LLM saw, which is the only honest definition
+        // of "the agent received this history".
+        var capturedContexts = new List<Context>();
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ResponseFactory = (turn, context) =>
+            {
+                capturedContexts.Add(context);
+                return $"assistant-reply-{turn}";
+            },
+        });
+        _ = await world.GivenAgentAsync("multi-turn-agent", systemPrompt: "I am a multi-turn test agent.");
+
+        // Act — three sequential turns from the same user (await each so the LLM round-trips
+        // serialize correctly and we get a deterministic context sequence).
+        await world.WhenSendsAsync(fromUser: "diana", toAgent: "multi-turn-agent", content: "turn 1 — hello");
+        _ = await world.WaitForReplyAsync(channelAddress: "diana");
+
+        await world.WhenSendsAsync(fromUser: "diana", toAgent: "multi-turn-agent", content: "turn 2 — what did I say first?");
+        _ = await world.WaitForReplyAsync(channelAddress: "diana");
+
+        await world.WhenSendsAsync(fromUser: "diana", toAgent: "multi-turn-agent", content: "turn 3 — and after that?");
+        _ = await world.WaitForReplyAsync(channelAddress: "diana");
+
+        // Assert — three turns dispatched, three contexts captured.
+        world.Provider.TurnCount.ShouldBe(3);
+        capturedContexts.Count.ShouldBe(3, "expected one Context capture per LLM round-trip");
+
+        // INVARIANT 1: every context carries the agent's system prompt. If the prompt was
+        // only loaded on the first turn (which is what F-3d "systemPromptInitialized" used
+        // to gate before PR #538), the agent would forget its identity mid-conversation.
+        for (var i = 0; i < capturedContexts.Count; i++)
+        {
+            capturedContexts[i].SystemPrompt.ShouldNotBeNull($"turn {i + 1} lost the system prompt");
+            capturedContexts[i].SystemPrompt!.ShouldContain(
+                "multi-turn test agent",
+                customMessage: $"turn {i + 1} system prompt was rewritten or truncated; agent identity drifted");
+        }
+
+        // INVARIANT 2: the LLM-visible message count grows monotonically. If history is
+        // wiped between turns the agent has no idea what was said before; if it grows
+        // discontinuously (e.g. +3 between turns when it should be +2) some artifact like
+        // tool sentinels are leaking into the projection.
+        //
+        // NOTE: turn 1's exact count is NOT asserted to be 1 because the gateway is allowed
+        // to inject a session-start system entry / instructional preamble. The contract we
+        // care about is GROWTH (no message loss across turns) — not the exact starting count.
+        var turn1Messages = capturedContexts[0].Messages.Count;
+        var turn2Messages = capturedContexts[1].Messages.Count;
+        var turn3Messages = capturedContexts[2].Messages.Count;
+
+        turn1Messages.ShouldBeGreaterThanOrEqualTo(
+            1,
+            $"turn 1 must include at least the new user message, got {turn1Messages}");
+        turn2Messages.ShouldBeGreaterThan(
+            turn1Messages,
+            $"turn 2 context ({turn2Messages} msgs) did not grow over turn 1 ({turn1Messages} msgs) — history was not accumulated");
+        turn3Messages.ShouldBeGreaterThan(
+            turn2Messages,
+            $"turn 3 context ({turn3Messages} msgs) did not grow over turn 2 ({turn2Messages} msgs) — history was not accumulated");
+
+        // Helper: human-readable rendering of a Context for failure diagnostics.
+        static string Render(Context ctx) => string.Join(" | ", ctx.Messages.Select(m => m switch
+        {
+            UserMessage u => "user:" + (u.Content.IsText
+                ? u.Content.Text
+                : string.Concat(u.Content.Blocks?.OfType<TextContent>().Select(t => t.Text) ?? [])),
+            AssistantMessage a => "assistant:" + string.Concat(a.Content.OfType<TextContent>().Select(t => t.Text)),
+            ToolResultMessage t => $"tool({t.ToolName}):{t.IsError}",
+            _ => m.GetType().Name,
+        }));
+
+        // Diagnostic: dump turn 1 message roles + content prefixes so any future surprise in
+        // pre-roll content is immediately legible in the test output.
+        var turn1Diagnostic = Render(capturedContexts[0]);
+        turn1Diagnostic.ShouldContain(
+            "turn 1 — hello",
+            customMessage: $"turn 1 LLM context did not contain the originating user message; observed: [{turn1Diagnostic}]");
+
+        // INVARIANT 3: the user's earlier message text is preserved verbatim in later contexts.
+        // The projector must not silently truncate, summarise, or re-order historical messages
+        // without an explicit compaction event.
+        var turn2Render = Render(capturedContexts[1]);
+        var turn3Render = Render(capturedContexts[2]);
+
+        var turn2UserContent = string.Concat(capturedContexts[1].Messages
+            .OfType<UserMessage>()
+            .Select(m => m.Content.IsText
+                ? m.Content.Text
+                : string.Concat(m.Content.Blocks?.OfType<TextContent>().Select(t => t.Text) ?? [])));
+        turn2UserContent.ShouldContain(
+            "turn 1 — hello",
+            customMessage: $"turn 1's user message was not visible in turn 2 LLM context — projector dropped historical user input.{Environment.NewLine}Turn 2 context: [{turn2Render}]");
+
+        var turn3UserContent = string.Concat(capturedContexts[2].Messages
+            .OfType<UserMessage>()
+            .Select(m => m.Content.IsText
+                ? m.Content.Text
+                : string.Concat(m.Content.Blocks?.OfType<TextContent>().Select(t => t.Text) ?? [])));
+        turn3UserContent.ShouldContain(
+            "turn 1 — hello",
+            customMessage: $"turn 1's user message was not visible in turn 3 LLM context.{Environment.NewLine}Turn 3 context: [{turn3Render}]");
+        turn3UserContent.ShouldContain(
+            "turn 2 — what did I say first?",
+            customMessage: $"turn 2's user message was not visible in turn 3 LLM context.{Environment.NewLine}Turn 3 context: [{turn3Render}]");
+
+        // INVARIANT 4: the conversation has exactly one session, and the session store
+        // holds the durable record of all six entries (3 user + 3 assistant).
+        var conversations = await world.ListConversationsForAgentAsync("multi-turn-agent");
+        var conversation = conversations.ShouldHaveSingleItem();
+        conversation.ActiveSessionId.ShouldNotBeNull();
+
+        var session = await world.GetSessionAsync(conversation.ActiveSessionId!);
+        session.ShouldNotBeNull();
+        session.HistoryCount.ShouldBeGreaterThanOrEqualTo(
+            6,
+            $"expected at least 6 session entries (3 user + 3 assistant), session has {session.HistoryCount} — " +
+            "some turns were dropped from durable history");
+    }
+
+    [Fact]
+    public async Task MultiTurn_AssistantPriorReplies_AreVisible_InSubsequentContexts()
+    {
+        // Companion bug-probe: prove the assistant's PRIOR replies are part of the context
+        // the LLM sees on subsequent turns. A regression that excludes assistant messages
+        // from the projection makes every reply look like a single-turn response from the
+        // model's perspective — which silently breaks any multi-turn reasoning.
+        var capturedContexts = new List<Context>();
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ResponseFactory = (turn, context) =>
+            {
+                capturedContexts.Add(context);
+                return $"the-assistant-spoke-on-turn-{turn}";
+            },
+        });
+        _ = await world.GivenAgentAsync("multi-turn-asst");
+
+        await world.WhenSendsAsync(fromUser: "ed", toAgent: "multi-turn-asst", content: "first user");
+        _ = await world.WaitForReplyAsync(channelAddress: "ed");
+
+        await world.WhenSendsAsync(fromUser: "ed", toAgent: "multi-turn-asst", content: "second user");
+        _ = await world.WaitForReplyAsync(channelAddress: "ed");
+
+        // Turn 2's context must contain turn 1's assistant reply.
+        var turn2 = capturedContexts[1];
+        var hasAssistant = turn2.Messages.OfType<AssistantMessage>().Any();
+        hasAssistant.ShouldBeTrue(
+            "turn 2 LLM context contained NO AssistantMessage entries — the projector excluded prior assistant replies");
+
+        var assistantContent = string.Concat(turn2.Messages
+            .OfType<AssistantMessage>()
+            .SelectMany(m => m.Content)
+            .OfType<TextContent>()
+            .Select(t => t.Text));
+        assistantContent.ShouldContain(
+            "the-assistant-spoke-on-turn-0",
+            customMessage: "turn 1 assistant content was not visible in turn 2 LLM context");
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/NonStreamingChannelScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/NonStreamingChannelScenario.cs
@@ -1,0 +1,107 @@
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Bug-probing scenario for the non-streaming delivery path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> the sanity scenario in
+/// <see cref="UserSendsMessageAgentRepliesScenario"/> drives a streaming-capable channel
+/// (<c>SupportsStreaming = true</c>), so the gateway routes through
+/// <c>GatewayHost.ProcessInboundMessageAsync</c> lines 519-613 (streaming path) and the
+/// reply lands as <see cref="AgentStreamEvent"/> instances on the channel.
+/// </para>
+/// <para>
+/// The <b>non-streaming</b> code path at <c>GatewayHost.cs:616-641</c> is an entirely
+/// different branch — it calls <c>handle.PromptAsync</c> instead of <c>handle.StreamAsync</c>,
+/// builds a single <see cref="OutboundMessage"/>, and delivers it via
+/// <c>channel.SendAsync(OutboundMessage)</c>. There was previously <b>no in-process test
+/// that exercised this path with a virtual channel</b>; if a regression breaks the
+/// non-streaming path, the entire streaming-coupled SignalR suite stays green and the
+/// CLI / Service Bus channels silently break. This scenario is the regression net for
+/// that branch.
+/// </para>
+/// <para>
+/// The scenario forces <c>SupportsStreaming = false</c> on the virtual channel and
+/// asserts the reply arrives as a single <see cref="AgentReplyDelivery.Outbound"/>
+/// message — not as stream events. If the gateway were to incorrectly fall back to
+/// streaming on a non-streaming channel, the assertion on <see cref="AgentReply.Delivery"/>
+/// would fail.
+/// </para>
+/// </remarks>
+public sealed class NonStreamingChannelScenario
+{
+    [Fact]
+    public async Task Channel_WithoutStreamingCapability_ReceivesCompletedOutboundMessage_NotStreamEvents()
+    {
+        // Arrange — virtual channel with streaming explicitly disabled. This forces
+        // GatewayHost.ProcessInboundMessageAsync down the non-streaming branch
+        // (`else` arm of the `resolvedChannel is { SupportsStreaming: true }` check).
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ChannelOptions = new VirtualChannelAdapterOptions { SupportsStreaming = false },
+            ResponseFactory = (_, _) => "non-streaming reply payload",
+        });
+        _ = await world.GivenAgentAsync("ns-agent", systemPrompt: "You reply once, completely, with no streaming.");
+
+        // Act — drive a single inbound through the channel.
+        await world.WhenSendsAsync(fromUser: "alice", toAgent: "ns-agent", content: "hello");
+
+        // Assert — the reply landed on the channel as a single completed OutboundMessage
+        // (the non-streaming path). The delivery mechanism must be Outbound, not Stream;
+        // any drift to streaming on a non-streaming channel is an explicit gateway bug.
+        var reply = await world.WaitForReplyAsync(channelAddress: "alice");
+        reply.Content.ShouldBe("non-streaming reply payload");
+        reply.ChannelAddress.ShouldBe("alice");
+        reply.Delivery.ShouldBe(
+            AgentReplyDelivery.Outbound,
+            "non-streaming channels must receive completed OutboundMessage, not stream events");
+
+        // And the streaming surfaces must be empty — no SendStreamEventAsync calls and no
+        // SendStreamDeltaAsync calls. If either has entries, the gateway leaked streaming
+        // events to a channel that explicitly disabled the capability.
+        world.Adapter.StreamEvents.ShouldBeEmpty(
+            "channel SupportsStreaming=false must NOT receive stream events");
+        world.Adapter.StreamDeltas.ShouldBeEmpty(
+            "channel SupportsStreaming=false must NOT receive stream deltas");
+
+        // And exactly one OutboundMessage — no duplicate delivery from a streaming/non-streaming
+        // hybrid bug.
+        world.Adapter.Outbound.Count.ShouldBe(
+            1,
+            $"expected exactly 1 outbound message, observed {world.Adapter.Outbound.Count}");
+
+        // And the provider was invoked once — proves the LLM round-trip really happened
+        // (a TurnCount=0 green test would indicate the non-streaming path skipped the agent
+        // entirely, which would be a serious regression).
+        world.Provider.TurnCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Channel_WithoutStreamingCapability_OutboundCarriesSessionIdAndBindingId()
+    {
+        // Bug-probing extension: the non-streaming OutboundMessage construction at
+        // GatewayHost.cs:626-637 explicitly populates SessionId, BindingId, and
+        // DisplayPrefix from the resolved source. If any of those wire-up assignments
+        // regress (e.g. BindingId left as default in a refactor), downstream channels
+        // that depend on binding-aware fan-out (#126) silently break.
+        await using var world = await VirtualWorld.StartAsync(new VirtualWorldOptions
+        {
+            ChannelOptions = new VirtualChannelAdapterOptions { SupportsStreaming = false },
+        });
+        _ = await world.GivenAgentAsync("ns-agent2");
+
+        await world.WhenSendsAsync(fromUser: "bob", toAgent: "ns-agent2", content: "hi");
+        _ = await world.WaitForReplyAsync(channelAddress: "bob");
+
+        var outbound = world.Adapter.Outbound.ShouldHaveSingleItem();
+        outbound.SessionId.ShouldNotBeNullOrWhiteSpace(
+            "non-streaming OutboundMessage must carry the originating SessionId");
+        outbound.ChannelAddress.Value.ShouldBe("bob",
+            "non-streaming OutboundMessage must echo the originating ChannelAddress");
+        outbound.ChannelType.Value.ShouldBe(VirtualChannelAdapter.VirtualChannelType,
+            "non-streaming OutboundMessage must carry the originating ChannelType");
+    }
+}

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/UserSendsMessageAgentRepliesScenario.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Citizens/UserSendsMessageAgentRepliesScenario.cs
@@ -1,0 +1,48 @@
+using BotNexus.Scenarios.Harness;
+
+namespace BotNexus.Scenarios.Tests.Citizens;
+
+/// <summary>
+/// Sanity gate for the <see cref="VirtualWorld"/> harness — proves the full
+/// inbound → router → conversation → session → agent supervisor → fake provider →
+/// outbound loop works in-process. If this scenario goes red, every other
+/// VirtualWorld-backed scenario in the suite is suspect because the harness
+/// itself is broken.
+/// </summary>
+public sealed class UserSendsMessageAgentRepliesScenario
+{
+    [Fact]
+    public async Task User_SendsMessage_AgentReplies_OutboundDelivered_ToVirtualChannel()
+    {
+        // Arrange — boot the world with default options (streaming on, like a real
+        // SignalR / Telegram channel).
+        await using var world = await VirtualWorld.StartAsync();
+        _ = await world.GivenAgentAsync("scenario-agent", systemPrompt: "You are a scenario test agent.");
+
+        // Act — drive an inbound through the virtual channel just like a real channel.
+        await world.WhenSendsAsync(fromUser: "amy", toAgent: "scenario-agent", content: "hello");
+
+        // Assert — the agent's reply lands on the virtual channel addressed to the citizen,
+        // whether the channel streams or delivers a single OutboundMessage.
+        var reply = await world.WaitForReplyAsync(channelAddress: "amy");
+        reply.Content.ShouldContain("ok");
+        reply.ChannelAddress.ShouldBe("amy");
+
+        // And the provider was actually invoked exactly once — proves the LLM round-trip
+        // really happened end-to-end (vs. a swallowed exception or a silent skip path).
+        world.Provider.TurnCount.ShouldBe(1);
+
+        // And exactly one conversation now exists for the agent, with the binding pointing
+        // at the user's virtual address.
+        var conversations = await world.ListConversationsForAgentAsync("scenario-agent");
+        var conversation = conversations.ShouldHaveSingleItem();
+        conversation.AgentId.ShouldBe("scenario-agent");
+        conversation.ChannelBindings.ShouldHaveSingleItem();
+        conversation.ChannelBindings[0].ChannelAddress.ShouldBe("amy");
+        conversation.ActiveSessionId.ShouldNotBeNull();
+
+        // The fake provider was actually consulted exactly once — proving the LLM round-trip
+        // really happened (a green test with TurnCount=0 would indicate fake-provider bypass).
+        world.Provider.TurnCount.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## What this PR ships

The first wave of **VirtualWorld in-process citizen scenarios** for the `tests/scenarios/BotNexus.Scenarios.Tests` project — a deliberately **bug-probing** test suite (per the maintainer's directive: *"tests should find bugs, not just validate mocks"*).

Follow-up to PR #515 (scenario harness foundation) and PR #542 (SignalR reliability pins). This is the §11.4 / §10.4 first-wave deliverable from the plan.

### Foundation (1 commit)

| Commit | What |
|---|---|
| `b7ea5f4` | `VirtualWorld` in-process gateway harness + `User_SendsMessage_AgentReplies` sanity scenario. Wires Gateway + Conversations + Sessions + Agent.Core + Hosting + DI packages; binds `ScenarioFakeApiProvider` + `VirtualChannelAdapter`; exposes `WaitForReplyAsync` channel-agnostic gate that accumulates from both `_adapter.Outbound` (non-streaming `SendAsync`) and `_adapter.StreamEvents`/`StreamDeltas` (streaming). |

### Bug-probing scenarios (6 commits, 10 [Fact]s)

| # | Scenario | Probes | Findings |
|---|---|---|---|
| 1 | `NonStreamingChannelScenario` (2 facts) | The previously-uncovered `GatewayHost.cs:616-641` non-streaming `SendAsync(OutboundMessage)` path. Asserts `Delivery == Outbound`, streaming surfaces empty, outbound carries `SessionId`+`BindingId`+`DisplayPrefix` from `resolvedSource`. | None — path is correct; pin established. |
| 2 | `ConcurrentInboundScenario` (2 facts) | Race-probe firing 10 concurrent inbounds to same `(agent, address)` (must collapse to 1 conversation) and 8 to distinct addresses (must produce 8). | None — no race in `DefaultConversationRouter`. Contract pinned. |
| 3 | `MultiTurnHistoryAccumulationScenario` (2 facts) | Phase 3b `SessionContextProjector`. Captures every `Context` via `ResponseFactory`. Asserts monotonic LLM-context growth, system prompt on EVERY turn (F-3d), historical user content visible, prior assistant replies visible. | **Test bug surfaced & fixed**: `m.Content.ToString()` returns the type name string, not the user text. `UserMessageContent.ToString()` is not overridden — fixed by extracting `Content.Text` / `Content.Blocks.OfType<TextContent>()`. Documented in the commit + template comment so future probes don't repeat it. |
| 4 | `ConversationResetScenario` (1 fact) | Phase 3c canonical reset sequence (PR #538) end-to-end. Establishes 2-turn conversation with secret phrases, calls `ResetSessionAsync`, asserts old session `Status == Sealed` + history retained; `ActiveSessionId` cleared; conversation id stable; new session created on next inbound with different id; post-reset LLM context contains NEW user message but NOT the secret phrases from sealed history. | None — reset is correct end-to-end. Strong regression net for PR #538 + F-3d. |
| 5 | `ExplicitConversationIdScenario` (2 facts) | The `InboundMessage.ConversationId` override path in `DefaultConversationRouter.cs:46-104`. | **Wrong-assumption surfaced**: my first iteration assumed a client-supplied id would be persisted as the new conversation's id. Reading the router established the actual contract — **the explicit-id branch is a LOOKUP for existing conversations only**. Non-existent ids fall back to address-based routing; client-supplied ids are never persisted (security boundary). Tests rewritten to pin both branches. First scenario doubles as a "second device joins same conversation" regression net for the bind-on-first-use side effect at router :67-86. |
| 6 | `CrossAgentIsolationScenario` (1 fact) | **The strictest probe in this wave.** Multi-tenant boundary. Two agents (alpha, bravo) registered in the same world; same user alternates between them; provider captures the LLM context for every turn keyed by agent. Asserts alpha never sees `BRAVO-SECRET-*`, bravo never sees `ALPHA-SECRET-*`, history continuity within each agent, and distinct conversations per agent. | **Documentation surfaced**: `Context.SystemPrompt` is WRAPPED by `SystemPromptBuilder` (preamble + conversation purpose + memory directives + raw prompt) — not passed through verbatim. The test compensates with `Contains("agent:<name>")` and the commit message documents this nuance for any future probe that needs to identify which agent a captured `Context` belongs to. |

### What this PR does NOT change

- No production-code changes. Pure test additions.
- No `IChannelAdapter`, `IConversationRouter`, or domain-model contract changes.
- No `tests/scenarios/AGENTS.md` rewrite — the existing conventions are honoured.

### Coverage delta

- `tests/scenarios/BotNexus.Scenarios.Tests` — **+10 [Fact]s** (from 19 to 29, +52%).
- Architecture fences — unchanged (24/24 green).
- Full solution — **0 warnings, 0 errors** under `TreatWarningsAsErrors=true`; 4,200+ tests green.

### Bug-probing observations (none requiring fixes in this PR)

All 10 facts are green. The probes confirmed:

1. The non-streaming `SendAsync(OutboundMessage)` path is correct end-to-end including `SessionId` / `BindingId` propagation.
2. `DefaultConversationRouter` has no race under 10× concurrent inbounds.
3. Multi-turn history accumulates correctly via `SessionContextProjector`; system prompt is present on every turn.
4. PR #538 reset sequence is intact; sealed history does not leak into the post-reset session.
5. Explicit `conversationId` is treated as a lookup for existing conversations (security boundary); non-existent ids fall back to address routing.
6. Cross-agent isolation is intact — no cross-tenant data leak under interleaved sends.

What this gives the maintainer: **a regression net pinning these contracts** so any future refactor of the router, supervisor lookup, or dispatch fan-out can no longer silently break them.

### Lineage

Closes #515-followup (first-wave scenarios from §10.4 / §11.4).

Next wave (PR-C territory, deferred): per-channel SignalR conformance project that reruns these scenarios through a real SignalR adapter.
