### PR TITLE
feat(sessions): add ISessionStore.ListByConversationAsync + fix FileSessionStore orphan-on-restart bug (Phase 4.3 / F-7)

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -279,14 +279,11 @@ public sealed class ConversationsController : ControllerBase
         if (conversation is null)
             return NotFound();
 
-        // Get all sessions belonging to this conversation, ordered by CreatedAt ascending
-        var allSessions = await _sessions.ListAsync(cancellationToken: cancellationToken);
+        // Get all sessions belonging to this conversation, ordered by CreatedAt ascending.
+        // ListByConversationAsync guarantees Active+Sealed inclusion + the ordering contract,
+        // and goes through the indexed Sqlite path -- no full-table scan (F-7).
         var convId = ConversationId.From(conversationId);
-        var linkedSessions = allSessions
-            .Where(s => s.Session.ConversationId.HasValue &&
-                        s.Session.ConversationId.Value == convId)
-            .OrderBy(s => s.CreatedAt)
-            .ToList();
+        var linkedSessions = await _sessions.ListByConversationAsync(convId, cancellationToken: cancellationToken);
 
         // Assemble flat list of history entries with boundary markers between sessions
         var allEntries = new List<ConversationHistoryEntry>();

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -222,10 +222,14 @@ public sealed class CronTrigger(
         if (duplicateActive.Count == 0)
             return;
 
-        var agentSessions = await sessions.ListAsync(agentId, ct).ConfigureAwait(false);
+        // Per-duplicate: only fetch sessions in that conversation -- avoids loading the full
+        // agent-scoped session table just to filter it down to one conversation (F-7).
         foreach (var duplicate in duplicateActive)
         {
-            foreach (var session in agentSessions.Where(s => s.Session.ConversationId == duplicate.ConversationId))
+            var duplicateSessions = await sessions
+                .ListByConversationAsync(duplicate.ConversationId, agentId, ct)
+                .ConfigureAwait(false);
+            foreach (var session in duplicateSessions)
             {
                 session.Session.ConversationId = canonical.ConversationId;
                 await sessions.SaveAsync(session, ct).ConfigureAwait(false);
@@ -234,8 +238,13 @@ public sealed class CronTrigger(
             await conversations.ArchiveAsync(duplicate.ConversationId, ct).ConfigureAwait(false);
         }
 
-        var latestLinked = agentSessions
-            .Where(s => s.Session.ConversationId == canonical.ConversationId)
+        // After rewriting, find the newest session linked to canonical to pin ActiveSessionId.
+        // ListByConversationAsync orders ASC by CreatedAt; we want the latest by UpdatedAt
+        // (sessions may have been re-pointed; CreatedAt won't necessarily match recency).
+        var canonicalSessions = await sessions
+            .ListByConversationAsync(canonical.ConversationId, agentId, ct)
+            .ConfigureAwait(false);
+        var latestLinked = canonicalSessions
             .OrderByDescending(s => s.UpdatedAt)
             .FirstOrDefault();
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
@@ -67,6 +67,41 @@ public interface ISessionStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists sessions belonging to a specific conversation, in chronological
+    /// (ascending CreatedAt) order. Includes both Active and Sealed sessions
+    /// — conversation history requires the full timeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the canonical "give me the sessions for conversation X" API.
+    /// Replaces the previous load-all-then-filter pattern
+    /// (<c>ListAsync(...).Where(s =&gt; s.ConversationId == ...)</c>) which was
+    /// pinned by issue F-7.
+    /// </para>
+    /// <para>
+    /// Behavioural contract (must be honoured by every implementation):
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>Returns an empty list (never <c>null</c>) when no sessions match.</item>
+    ///   <item>Excludes sessions whose <c>ConversationId</c> is <c>null</c>.</item>
+    ///   <item>Ordered by <c>CreatedAt</c> ascending; ties broken by
+    ///   <c>SessionId</c> ascending so the order is fully deterministic.</item>
+    ///   <item>Includes sessions with <c>Status == Sealed</c> and
+    ///   <c>Status == Active</c> alike; conversation history needs the full sequence.</item>
+    /// </list>
+    /// </remarks>
+    /// <param name="conversationId">The conversation to query.</param>
+    /// <param name="agentId">
+    /// Optional agent filter. When set, only sessions owned by this agent are returned.
+    /// Useful for access-control-shaped callers and cron normalisation.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<GatewaySession>> ListByConversationAsync(
+        ConversationId conversationId,
+        AgentId? agentId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Lists sessions where the agent either owns the session or is listed as a participant.
     /// </summary>
     Task<IReadOnlyList<GatewaySession>> GetExistenceAsync(

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -6,6 +6,7 @@ using SessionId = BotNexus.Domain.Primitives.SessionId;
 using ChannelKey = BotNexus.Domain.Primitives.ChannelKey;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
+using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -193,7 +194,8 @@ public sealed class FileSessionStore : SessionStoreBase
             CreatedAt = meta.CreatedAt,
             UpdatedAt = meta.UpdatedAt,
             Status = meta.Status,
-            ExpiresAt = meta.ExpiresAt
+            ExpiresAt = meta.ExpiresAt,
+            ConversationId = meta.ConversationId
         }, _redactor)
         {
             CallerId = meta.CallerId
@@ -242,7 +244,8 @@ public sealed class FileSessionStore : SessionStoreBase
             session.Status,
             session.ExpiresAt,
             session.NextSequenceId,
-            [.. session.GetStreamEventSnapshot()]);
+            [.. session.GetStreamEventSnapshot()],
+            session.Session.ConversationId);
         await SessionMetadataSidecar.WriteAsync(
             _fileSystem,
             metaPath,
@@ -265,5 +268,6 @@ public sealed class FileSessionStore : SessionStoreBase
         SessionStatus Status = SessionStatus.Active,
         DateTimeOffset? ExpiresAt = null,
         long NextSequenceId = 1,
-        List<GatewaySessionStreamEvent>? StreamEvents = null);
+        List<GatewaySessionStreamEvent>? StreamEvents = null,
+        ConversationId? ConversationId = null);
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -52,6 +52,25 @@ public abstract class SessionStoreBase : ISessionStore
             .ToList();
     }
 
+    public virtual async Task<IReadOnlyList<GatewaySession>> ListByConversationAsync(
+        ConversationId conversationId,
+        AgentId? agentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var sessions = await EnumerateSessionsAsync(cancellationToken).ConfigureAwait(false);
+        IEnumerable<GatewaySession> result = sessions
+            .Where(session => session.Session.ConversationId is not null
+                && session.Session.ConversationId.Value == conversationId);
+        if (agentId is not null)
+        {
+            result = result.Where(session => session.AgentId == agentId);
+        }
+        return result
+            .OrderBy(session => session.CreatedAt)
+            .ThenBy(session => session.SessionId.Value, StringComparer.Ordinal)
+            .ToList();
+    }
+
     public async Task<IReadOnlyList<GatewaySession>> GetExistenceAsync(
         AgentId agentId,
         ExistenceQuery query,

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -223,6 +223,49 @@ public sealed class SqliteSessionStore : SessionStoreBase
         return sessions;
     }
 
+    /// <summary>
+    /// Returns sessions for a single conversation, using the
+    /// <c>idx_sessions_conversation_agent</c> index to avoid loading the
+    /// full session table. Honours the same chronological-ascending /
+    /// SessionId-tiebreaker contract as <see cref="SessionStoreBase.ListByConversationAsync"/>.
+    /// </summary>
+    public override async Task<IReadOnlyList<GatewaySession>> ListByConversationAsync(
+        ConversationId conversationId,
+        AgentId? agentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT id
+            FROM sessions
+            WHERE conversation_id = $conversationId
+              AND ($agentId IS NULL OR agent_id = $agentId)
+            ORDER BY created_at ASC, id ASC
+            """;
+        command.Parameters.AddWithValue("$conversationId", conversationId.Value);
+        command.Parameters.AddWithValue("$agentId", (object?)agentId?.Value ?? DBNull.Value);
+
+        var sessions = new List<GatewaySession>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var sessionId = SessionId.From(reader.GetString(0));
+            var session = _cache.GetValueOrDefault(sessionId)
+                ?? await LoadSessionAsync(connection, sessionId, _redactor, cancellationToken).ConfigureAwait(false);
+            if (session is not null)
+            {
+                _cache[sessionId] = session;
+                sessions.Add(session);
+            }
+        }
+
+        return sessions;
+    }
+
     private async Task EnsureCreatedAsync(CancellationToken cancellationToken)
     {
         if (_initialized) return;
@@ -276,6 +319,13 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
             // Migrate: add tool columns to existing databases
             await MigrateAsync(connection, cancellationToken).ConfigureAwait(false);
+
+            // Conversation-routing index. MUST run AFTER MigrateAsync because legacy
+            // schemas may lack the conversation_id column until migration adds it.
+            await using var convIndexCmd = connection.CreateCommand();
+            convIndexCmd.CommandText =
+                "CREATE INDEX IF NOT EXISTS idx_sessions_conversation_agent ON sessions(conversation_id, agent_id, created_at);";
+            await convIndexCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
             // Migrate: link orphaned sessions to their agent's default conversation
             if (_conversationStore is not null)

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionConversationFilterArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionConversationFilterArchitectureTests.cs
@@ -1,0 +1,210 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function enforcing the F-7 invariant: callers must
+/// use <c>ISessionStore.ListByConversationAsync(ConversationId, AgentId?)</c>
+/// to retrieve sessions for a conversation, NOT load the full session table
+/// and filter by <c>Session.ConversationId</c> in memory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The load-all-then-filter pattern (<c>sessions.ListAsync(...).Where(s =&gt; s.ConversationId == ...)</c>)
+/// has two well-documented problems:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///   On Sqlite-backed deployments it loads the entire session table per
+///   request — a real perf issue once a deployment accrues thousands of
+///   sessions.
+///   </item>
+///   <item>
+///   Every caller reimplements the filter/order/orphan-exclusion contract
+///   and silently diverges. F-7 was a direct consequence of this — the
+///   FileSessionStore ConversationId-drop bug was invisible until every
+///   call site happened to fail the same way.
+///   </item>
+/// </list>
+/// <para>
+/// This fence is intentionally narrow: it only flags methods whose body
+/// contains ALL of the three telltales (<c>.ListAsync(</c>, <c>.Where(</c>,
+/// <c>.ConversationId</c>). It will not catch sufficiently obfuscated
+/// rewrites — but it catches the specific shape that has historically
+/// reappeared at code-review time.
+/// </para>
+/// <para>
+/// The fence runs on every cs file under <c>src/</c>. To resolve a failure:
+/// rewrite the offending method to use
+/// <see cref="BotNexus.Gateway.Abstractions.Sessions.ISessionStore.ListByConversationAsync"/>.
+/// If you genuinely need every session in the store (e.g. orphan migration,
+/// memory backfill, TTL cleanup), the lookup is not the F-7 pattern — add
+/// the file to <see cref="AllowedFiles"/> with a short rationale comment.
+/// </para>
+/// </remarks>
+public sealed class SessionConversationFilterArchitectureTests
+{
+    // Files genuinely doing a cross-conversation walk (orphan migration, memory backfill,
+    // TTL cleanup, broader access-controlled listing) are NOT F-7 offenders. Add new
+    // entries here only after confirming the caller really must see every session.
+    private static readonly string[] AllowedFiles =
+    {
+        // Sqlite orphan migration: must see every conversation-less session to repair it.
+        "SqliteSessionStore.cs",
+        // Memory backfill: indexes every session by design.
+        "MemoryIndexer.cs",
+        // Access-controlled listing tool used by agents — not conversation-scoped.
+        "SessionTool.cs",
+        // Per-agent warmup — not conversation-scoped.
+        "SessionWarmupService.cs",
+        // Cross-conversation TTL scan.
+        "SessionCleanupService.cs",
+        // CronTrigger.NormalizeDuplicateCronConversationsAsync calls
+        // _conversations.ListAsync(agentId) (Conversations, not Sessions) and dedupes by
+        // Conversation.ConversationId. Its session-by-conversation lookups already use
+        // ISessionStore.ListByConversationAsync. False positive at the file-grain because
+        // the fence checks "any .ListAsync(" + ".Where(...ConversationId...)" in the same file.
+        "CronTrigger.cs",
+    };
+
+    /// <summary>
+    /// No method body under <c>src/</c> may contain the F-7 anti-pattern:
+    /// <c>sessions.ListAsync(...)</c> followed by a <c>.Where(...)</c> that
+    /// filters on <c>.ConversationId</c>.
+    /// </summary>
+    [Fact]
+    public void NoMethod_LoadsAllSessions_AndFiltersByConversationId()
+    {
+        var srcRoot = FindSourceRoot();
+
+        // The F-7 fingerprint: a .Where(...) whose lambda directly accesses .ConversationId
+        // with no intervening parens. This precisely matches the historic shape
+        //   .Where(s => s.Session.ConversationId == x)
+        //   .Where(s => s.Session.ConversationId.HasValue && s.Session.ConversationId.Value == x)
+        // and (correctly) does NOT match downstream .Select(...) that exposes ConversationId
+        // as a response field, because there's a closing/opening paren in the chain
+        // between .Where(...) and that .ConversationId access.
+        var whereByConvIdPattern = new Regex(
+            @"\.Where\([^()]*?\.ConversationId",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
+        var offenders = new List<string>();
+        foreach (var path in Directory
+                     .EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+                     .Where(IsProductionSource)
+                     .Where(p => !AllowedFiles.Contains(Path.GetFileName(p), StringComparer.Ordinal)))
+        {
+            var source = StripCommentsAndStrings(File.ReadAllText(path));
+
+            // Require BOTH a .ListAsync(...) call AND a .Where(...) that filters
+            // on .ConversationId in the SAME file. The .ListAsync requirement
+            // distinguishes "load-from-store" from in-memory chained filters.
+            if (!source.Contains(".ListAsync(", StringComparison.Ordinal))
+                continue;
+            if (!whereByConvIdPattern.IsMatch(source))
+                continue;
+
+            offenders.Add(Path.GetRelativePath(srcRoot, path));
+        }
+
+        offenders.Sort(StringComparer.Ordinal);
+        offenders.ShouldBeEmpty(
+            "Files under src/ contain the F-7 anti-pattern: a .ListAsync(...) call " +
+            "in the same file as a .Where(...) lambda that filters on .ConversationId. " +
+            "Use ISessionStore.ListByConversationAsync(conversationId, agentId?) instead — " +
+            "it goes through the idx_sessions_conversation_agent SQLite index and " +
+            "guarantees the Active+Sealed inclusion and CreatedAt-ascending ordering " +
+            "contract. If the .ListAsync call is on IConversationStore (loading " +
+            "conversations, not sessions) the false positive can be resolved by adding " +
+            "the file to AllowedFiles with a short rationale.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static bool IsProductionSource(string path)
+        => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        && !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+
+    // Replace comments and string/char literals with whitespace so the .Where(...).ConversationId
+    // pattern match isn't fooled by text appearing inside an error-message string literal
+    // (e.g., this very test file's failure message). Cheap and deterministic; not a full lexer.
+    private static string StripCommentsAndStrings(string source)
+    {
+        var buffer = new char[source.Length];
+        var i = 0;
+        while (i < source.Length)
+        {
+            // Line comment
+            if (i + 1 < source.Length && source[i] == '/' && source[i + 1] == '/')
+            {
+                while (i < source.Length && source[i] != '\n') { buffer[i] = ' '; i++; }
+                continue;
+            }
+            // Block comment
+            if (i + 1 < source.Length && source[i] == '/' && source[i + 1] == '*')
+            {
+                while (i + 1 < source.Length && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    buffer[i] = source[i] == '\n' ? '\n' : ' ';
+                    i++;
+                }
+                if (i + 1 < source.Length) { buffer[i] = ' '; buffer[i + 1] = ' '; i += 2; }
+                continue;
+            }
+            // Verbatim/interpolated/raw string-prefix tokens — fall through to the
+            // regular string handler; we don't need 100% correctness, just brace neutralisation.
+            // String literal
+            if (source[i] == '"')
+            {
+                buffer[i] = ' ';
+                i++;
+                while (i < source.Length && source[i] != '"')
+                {
+                    if (source[i] == '\\' && i + 1 < source.Length)
+                    {
+                        buffer[i] = ' '; buffer[i + 1] = ' '; i += 2; continue;
+                    }
+                    buffer[i] = source[i] == '\n' ? '\n' : ' ';
+                    i++;
+                }
+                if (i < source.Length) { buffer[i] = ' '; i++; }
+                continue;
+            }
+            // Char literal
+            if (source[i] == '\'')
+            {
+                buffer[i] = ' ';
+                i++;
+                while (i < source.Length && source[i] != '\'')
+                {
+                    if (source[i] == '\\' && i + 1 < source.Length)
+                    {
+                        buffer[i] = ' '; buffer[i + 1] = ' '; i += 2; continue;
+                    }
+                    buffer[i] = ' ';
+                    i++;
+                }
+                if (i < source.Length) { buffer[i] = ' '; i++; }
+                continue;
+            }
+
+            buffer[i] = source[i];
+            i++;
+        }
+        return new string(buffer);
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -272,8 +272,15 @@ public sealed class CronTriggerTests
             .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Conversation> { canonical, duplicate });
         sessionStore
-            .Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.ListByConversationAsync(duplicate.ConversationId, It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<GatewaySession> { legacySession });
+        // After SaveAsync rewrites ConversationId, the canonical lookup should return the
+        // (now-rewritten) session so latestLinked is the legacy session.
+        sessionStore
+            .Setup(s => s.ListByConversationAsync(canonical.ConversationId, It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => legacySession.Session.ConversationId == canonical.ConversationId
+                ? new List<GatewaySession> { legacySession }
+                : new List<GatewaySession>());
 
         var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
 

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -300,6 +300,115 @@ public sealed class FileSessionStoreTests
         reloaded.ShouldNotBeNull();
     }
 
+    // --- ListByConversationAsync: F-7 contract pins (FileSessionStore) ---
+    //
+    // These exercise the SAME 5 invariants as InMemorySessionStoreTests but go through
+    // the on-disk round-trip (which is exactly where F-7 originated). Two-store-reload
+    // pattern proves the invariants survive a process restart.
+
+    private static async Task SeedConversationFixtureAsync(FileSessionStore store, DateTimeOffset baseTime)
+    {
+        var convA = ConversationId.From("conv-a");
+        var convB = ConversationId.From("conv-b");
+
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-active"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(10),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convA }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-sealed"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            Status = SessionStatus.Sealed,
+            Session = { ConversationId = convA }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-other-agent"),
+            AgentId = AgentId.From("agent-y"),
+            CreatedAt = baseTime.AddMinutes(5),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convA }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-b"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(20),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convB }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-orphan"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(15),
+            Status = SessionStatus.Active
+        });
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_AcrossReload_ReturnsActiveAndSealedSessions_InCreatedAtAscOrder()
+    {
+        // Invariants 1+3 combined, on disk: includes Active+Sealed AND chronological order
+        // survives a full second-store reload (the F-7 originating scenario).
+        using var fixture = new StoreFixture();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedConversationFixtureAsync(fixture.CreateStore(), baseTime);
+
+        var reloadedStore = fixture.CreateStore();
+        var sessions = await reloadedStore.ListByConversationAsync(ConversationId.From("conv-a"));
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-other-agent", "s-a-active" }, ignoreOrder: false,
+                customMessage: "FileSessionStore ListByConversationAsync did not return chronological Active+Sealed slice after reload");
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_AcrossReload_ExcludesOtherConversations_AndOrphans()
+    {
+        using var fixture = new StoreFixture();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedConversationFixtureAsync(fixture.CreateStore(), baseTime);
+
+        var sessions = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"));
+
+        sessions.Select(s => s.SessionId.Value).ShouldNotContain("s-b");
+        sessions.Select(s => s.SessionId.Value).ShouldNotContain("s-orphan");
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ReturnsEmptyList_ForUnknownConversation()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var sessions = await store.ListByConversationAsync(ConversationId.From("nope"));
+
+        sessions.ShouldNotBeNull();
+        sessions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_AcrossReload_WithAgentFilter_NarrowsToOwner()
+    {
+        using var fixture = new StoreFixture();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedConversationFixtureAsync(fixture.CreateStore(), baseTime);
+
+        var sessions = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"), agentId: AgentId.From("agent-x"));
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-active" }, ignoreOrder: false);
+    }
+
     [Fact]
     public async Task GetExistenceAsync_ReturnsOwnedAndParticipantSessions_WithFiltersApplied()
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -11,6 +11,48 @@ namespace BotNexus.Gateway.Tests;
 public sealed class FileSessionStoreTests
 {
     [Fact]
+    public async Task SaveAsync_PreservesConversationId_AcrossReload()
+    {
+        // Regression pin (F-7): FileSessionStore historically dropped Session.ConversationId
+        // on round-trip because the SessionMeta sidecar record didn't include the field.
+        // After a server restart with FileSessionStore, every session became orphaned
+        // (ConversationId == null), severing the conversation -> sessions linkage.
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversationId = ConversationId.Create();
+
+        var session = await store.GetOrCreateAsync(SessionId.From("s-with-conv"), AgentId.From("agent-a"));
+        session.Session.ConversationId = conversationId;
+        await store.SaveAsync(session);
+
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-with-conv"));
+
+        reloaded.ShouldNotBeNull();
+        reloaded.Session.ConversationId.ShouldNotBeNull(
+            "FileSessionStore lost ConversationId on round-trip — sessions go orphan on restart (F-7)");
+        reloaded.Session.ConversationId!.Value.ShouldBe(
+            conversationId,
+            "FileSessionStore corrupted ConversationId on round-trip");
+    }
+
+    [Fact]
+    public async Task SaveAsync_PreservesNullConversationId_AcrossReload()
+    {
+        // Companion to the above — a session saved with null ConversationId must
+        // round-trip as null (not as some sentinel string, not as an exception).
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var session = await store.GetOrCreateAsync(SessionId.From("s-no-conv"), AgentId.From("agent-a"));
+        await store.SaveAsync(session);
+
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-no-conv"));
+
+        reloaded.ShouldNotBeNull();
+        reloaded.Session.ConversationId.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task GetOrCreateAsync_WithUnknownSession_CreatesAndPersistsSession()
     {
         using var fixture = new StoreFixture();

--- a/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
@@ -181,6 +181,169 @@ public sealed class InMemorySessionStoreTests
 
         sessions.Select(session => session.SessionId.Value).ShouldHaveSingleItem().ShouldBe("participant");
     }
+
+    // --- ListByConversationAsync: F-7 contract pins ---
+    //
+    // The 5 invariants (rubber-duck review):
+    //   1. Returns ALL sessions (Active + Sealed) for the conversation — not just active.
+    //   2. Excludes sessions for other conversations AND sessions with null ConversationId.
+    //   3. Stable chronological order — CreatedAt ascending with SessionId as tie-breaker.
+    //   4. Returns empty list (NEVER null) for unknown conversation id.
+    //   5. Optional AgentId filter narrows by owner.
+    //
+    // These pins protect against the regression that issue F-7 documents: callers
+    // doing `ListAsync(...).Where(s => s.ConversationId == ...)` silently miss
+    // sessions on FileSessionStore-backed deployments (pre-this-PR) and load the
+    // entire session table on SQLite-backed ones.
+
+    private static async Task SeedConversationFixtureAsync(InMemorySessionStore store, DateTimeOffset baseTime)
+    {
+        var convA = ConversationId.From("conv-a");
+        var convB = ConversationId.From("conv-b");
+
+        // Active session in convA (newest)
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-active"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(10),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convA }
+        });
+        // Sealed session in convA (older)
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-sealed"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            Status = SessionStatus.Sealed,
+            Session = { ConversationId = convA }
+        });
+        // Session in convA owned by a DIFFERENT agent (for agent filter test)
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-other-agent"),
+            AgentId = AgentId.From("agent-y"),
+            CreatedAt = baseTime.AddMinutes(5),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convA }
+        });
+        // Session in DIFFERENT conversation (must not leak)
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-b"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(20),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convB }
+        });
+        // ORPHAN session with NULL ConversationId (must not leak into any query)
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-orphan"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(15),
+            Status = SessionStatus.Active
+        });
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ReturnsActiveAndSealedSessions_ForConversation()
+    {
+        // Invariant 1: includes both Active and Sealed (history needs full timeline).
+        var store = new InMemorySessionStore();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedConversationFixtureAsync(store, baseTime);
+
+        var sessions = await store.ListByConversationAsync(ConversationId.From("conv-a"));
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-other-agent", "s-a-active" }, ignoreOrder: false);
+        // Belt-and-braces: both statuses are present.
+        sessions.Select(s => s.Status).ShouldContain(SessionStatus.Sealed);
+        sessions.Select(s => s.Status).ShouldContain(SessionStatus.Active);
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ExcludesOtherConversations_AndOrphanSessions()
+    {
+        // Invariant 2: must not leak sessions belonging to other conversations,
+        // and must not leak orphan sessions (ConversationId == null).
+        var store = new InMemorySessionStore();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedConversationFixtureAsync(store, baseTime);
+
+        var sessions = await store.ListByConversationAsync(ConversationId.From("conv-a"));
+
+        sessions.Select(s => s.SessionId.Value).ShouldNotContain("s-b");
+        sessions.Select(s => s.SessionId.Value).ShouldNotContain("s-orphan");
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ReturnsCreatedAtAscending_WithSessionIdTieBreaker()
+    {
+        // Invariant 3: chronological order with deterministic tie-break.
+        var store = new InMemorySessionStore();
+        var same = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var convId = ConversationId.From("conv-tie");
+
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-z"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = same,
+            Session = { ConversationId = convId }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = same,
+            Session = { ConversationId = convId }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-later"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = same.AddMinutes(1),
+            Session = { ConversationId = convId }
+        });
+
+        var sessions = await store.ListByConversationAsync(convId);
+
+        // Same CreatedAt: ordinal SessionId ascending. Then later session at the end.
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a", "s-z", "s-later" }, ignoreOrder: false);
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ReturnsEmptyList_ForUnknownConversation()
+    {
+        // Invariant 4: empty list, never null, never throws.
+        var store = new InMemorySessionStore();
+
+        var sessions = await store.ListByConversationAsync(ConversationId.From("does-not-exist"));
+
+        sessions.ShouldNotBeNull();
+        sessions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_WithAgentFilter_NarrowsToOwner()
+    {
+        // Invariant 5: optional AgentId filter.
+        var store = new InMemorySessionStore();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedConversationFixtureAsync(store, baseTime);
+
+        var sessions = await store.ListByConversationAsync(
+            ConversationId.From("conv-a"),
+            agentId: AgentId.From("agent-x"));
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-active" }, ignoreOrder: false);
+        sessions.ShouldAllBe(s => s.AgentId == AgentId.From("agent-x"));
+    }
 }
 
 

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -640,6 +640,166 @@ public sealed class SqliteSessionStoreTests
         reloaded!.History[0].ToolArgs.ShouldBe("{}");
     }
 
+    // --- ListByConversationAsync: F-7 contract pins (SqliteSessionStore) ---
+    //
+    // Same 5 invariants as InMemory + File. ALSO verifies:
+    //   - the idx_sessions_conversation_agent index exists on the table after init
+    //   - the indexed query is actually used (loose smoke test: query runs without
+    //     a full-scan plan would require EXPLAIN QUERY PLAN; we settle for "returns
+    //     the right rows" + "index is present" which is what regression would catch).
+
+    private static async Task SeedSqliteConversationFixtureAsync(SqliteSessionStore store, DateTimeOffset baseTime)
+    {
+        var convA = ConversationId.From("conv-a");
+        var convB = ConversationId.From("conv-b");
+
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-active"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(10),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convA }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-sealed"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            Status = SessionStatus.Sealed,
+            Session = { ConversationId = convA }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a-other-agent"),
+            AgentId = AgentId.From("agent-y"),
+            CreatedAt = baseTime.AddMinutes(5),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convA }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-b"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(20),
+            Status = SessionStatus.Active,
+            Session = { ConversationId = convB }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-orphan"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime.AddMinutes(15),
+            Status = SessionStatus.Active
+        });
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_CreatesConversationAgentIndex_ForListByConversationLookups()
+    {
+        // Pin the index exists. If a future schema change removes it, this fails first.
+        using var fixture = new StoreFixture();
+        // Trigger schema creation by a no-op read.
+        _ = await fixture.CreateStore().GetAsync(SessionId.From("warm"));
+
+        await using var verifyConnection = new SqliteConnection(fixture.ConnectionString);
+        await verifyConnection.OpenAsync();
+        await using var cmd = verifyConnection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'sessions'";
+
+        var indexes = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            indexes.Add(reader.GetString(0));
+
+        indexes.ShouldContain(
+            "idx_sessions_conversation_agent",
+            "Missing index — ListByConversationAsync degrades to a full table scan");
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_AcrossReload_ReturnsActiveAndSealed_InCreatedAtAscOrder()
+    {
+        using var fixture = new StoreFixture();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedSqliteConversationFixtureAsync(fixture.CreateStore(), baseTime);
+
+        var sessions = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"));
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-other-agent", "s-a-active" }, ignoreOrder: false);
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_AcrossReload_ExcludesOtherConversations_AndOrphans()
+    {
+        using var fixture = new StoreFixture();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedSqliteConversationFixtureAsync(fixture.CreateStore(), baseTime);
+
+        var sessions = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"));
+
+        sessions.Select(s => s.SessionId.Value).ShouldNotContain("s-b");
+        sessions.Select(s => s.SessionId.Value).ShouldNotContain("s-orphan");
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ReturnsEmptyList_ForUnknownConversation()
+    {
+        using var fixture = new StoreFixture();
+
+        var sessions = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("ghost"));
+
+        sessions.ShouldNotBeNull();
+        sessions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_AcrossReload_WithAgentFilter_NarrowsToOwner()
+    {
+        using var fixture = new StoreFixture();
+        var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        await SeedSqliteConversationFixtureAsync(fixture.CreateStore(), baseTime);
+
+        var sessions = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"), agentId: AgentId.From("agent-x"));
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-active" }, ignoreOrder: false);
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_HandlesSameCreatedAt_WithSessionIdTieBreaker()
+    {
+        using var fixture = new StoreFixture();
+        var same = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var convId = ConversationId.From("conv-tie");
+        var store = fixture.CreateStore();
+
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-z"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = same,
+            Session = { ConversationId = convId }
+        });
+        await store.SaveAsync(new GatewaySession
+        {
+            SessionId = SessionId.From("s-a"),
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = same,
+            Session = { ConversationId = convId }
+        });
+
+        var sessions = await fixture.CreateStore().ListByConversationAsync(convId);
+
+        sessions.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a", "s-z" }, ignoreOrder: false);
+    }
+
     private sealed class StoreFixture : IDisposable
     {
         public StoreFixture()


### PR DESCRIPTION
# Phase 4.3 / F-7 — `ISessionStore.ListByConversationAsync` + FileSessionStore orphan-on-restart fix

Removes the F-7 "load-all-sessions-then-filter-by-ConversationId" anti-pattern
flagged by the §3 domain-model review, and fixes a real bug surfaced during the
TDD-first investigation: `FileSessionStore` was silently dropping
`ConversationId` on every round-trip, so any FileStore-backed deployment was
orphaning every session at every server restart.

Refs §4 Phase 4 item 3 of the domain-cleanup plan.

## What changed

### 1. `ISessionStore.ListByConversationAsync(ConversationId, AgentId? = null, CancellationToken)`

New first-class API on `ISessionStore` for "list every session bound to this
conversation, narrow by owning agent if given." Mirrors the existing
`ListByChannelAsync` pattern.

#### Why on `ISessionStore`, not `IConversationStore`

The plan originally proposed `IConversationStore.GetSessionsAsync(...)`.
**Rejected**: `SqliteSessionStore` already takes an `IConversationStore` ctor
dep for orphan-session migration on startup (`SqliteSessionStore.cs:41,55-59`).
Adding `ISessionStore` as a dep of `IConversationStore` would create a circular
dependency. The correct home is `ISessionStore`, mirroring the existing
`ListByChannelAsync` shape.

#### Five-invariant contract (pinned by per-store tests)

1. Returns ALL sessions for the conversation — both `Active` and `Sealed`.
   History views need the full timeline; filtering happens at the call site.
2. Excludes other conversations AND orphan sessions (`ConversationId == null`).
3. CreatedAt-ascending with `SessionId.Value` as ordinal tie-break for
   deterministic ordering.
4. Returns an empty list (never `null`) for unknown conversation ids.
5. Optional `AgentId` filter narrows by owner.

#### Default impl on `SessionStoreBase`

Enumerates all sessions, filters in-memory, and sorts. Works correctly for
`InMemorySessionStore` and `FileSessionStore`.

#### SQLite override

`SqliteSessionStore` overrides with an indexed query backed by a new
`idx_sessions_conversation_agent(conversation_id, agent_id, created_at)`
composite index. The index creation runs **after** `MigrateAsync(...)`, not in
the schema bootstrap block — legacy DBs need the `conversation_id` column
ALTER-ADDed by the migration before any index can reference it.

### 2. Callers migrated (load-all-then-filter → indexed lookup)

- `CronTrigger.NormalizeDuplicateCronConversationsAsync`: per-duplicate and
  canonical-pin lookups now use `ListByConversationAsync` instead of loading
  every session for the agent and filtering in-memory.
- `ConversationsController.GetHistory`: a single call replaces the
  full-table-scan + `.Where(s => s.Session.ConversationId.HasValue && ...)`
  pattern.

### 3. `FileSessionStore` ConversationId round-trip bug — FIXED

#### The bug

`FileSessionStore`'s `SessionMeta` sidecar record was missing a
`ConversationId` field. Result: every server restart on a FileStore-backed
deployment silently set `ConversationId = null` on every session — orphaning
the entire transcript history from its conversation. `SqliteSessionStore` has
a startup orphan-migration safety net that wraps these in fake
`legacy:<agentId>` conversations; `FileSessionStore` had none.

This was suspected by rubber-duck review of `FileSessionStore.cs`. Confirmed
TDD-first with two RED tests (write → reload via second store instance → assert
`ConversationId.HasValue`). Both failed with `should not be null but was`
before the fix.

#### The fix

Added `ConversationId? ConversationId = null` as the 12th positional record
parameter on `SessionMeta`. `WriteToFileAsync` propagates the live session's
ConversationId; `LoadFromFileAsync` restores it. Existing sidecar files
deserialise with `null` (matches their on-disk state); the next save populates
the field. No back-migration needed.

### 4. Architecture fence — `SessionConversationFilterArchitectureTests`

Source-scans every C# file under `src/` for the F-7 fingerprint:

- a `.ListAsync(...)` call
- in the same file as a `.Where(...)` lambda
- whose lambda directly accesses `.ConversationId` with no intervening parens.

Regex: `\.Where\([^()]*?\.ConversationId`

This precisely matches the historic shape
`.Where(s => s.Session.ConversationId.HasValue && s.Session.ConversationId.Value == x)`
and correctly does NOT match downstream `.Select(...)` blocks that expose
`ConversationId` as a response field (because the `(` of the next chain call
interrupts the match).

Verified against the pre-migration shape in commit `3c5dee16^` — the regex
matches the exact `_sessions.ListAsync(...) + .Where(s => s.Session.ConversationId...)`
block that was removed from `GetHistory`. The fence is not a no-op.

`AllowedFiles` covers legitimate cross-conversation walks:
- `SqliteSessionStore.cs` — orphan migration must see every conversation-less session
- `MemoryIndexer.cs` — memory backfill indexes every session by design
- `SessionTool.cs` — access-controlled listing tool, not conversation-scoped
- `SessionWarmupService.cs` — per-agent warmup, not conversation-scoped
- `SessionCleanupService.cs` — cross-conversation TTL scan
- `CronTrigger.cs` — file-grain false positive (calls `_conversations.ListAsync(agentId)` returning Conversations and dedupes by `Conversation.ConversationId`; session-by-conversation lookups in the same file already use `ListByConversationAsync`)

### 5. Test coverage added

Per-store invariant tests (5 invariants × 3 stores):

- `InMemorySessionStoreTests` — 5 new tests + `SeedConversationFixtureAsync` helper. **16/16 green.**
- `FileSessionStoreTests` — 4 new tests using the two-store-reload pattern (proves disk round-trip) + 2 regression pins for the ConversationId bug. **21/21 green.**
- `SqliteSessionStoreTests` — 6 new tests, including `EnsureCreatedAsync_CreatesConversationAgentIndex_ForListByConversationLookups` (pins the new index by querying `sqlite_master`). **32/32 green.**

Caller migration:

- `CronTriggerTests` — Moq setup updated to mock `ListByConversationAsync` with dynamic `ReturnsAsync` reflecting post-save state. **35/35 controller+cron tests green.**

Full solution: **0 failures, 0 warnings, 0 errors** under `TreatWarningsAsErrors=true`.

## What is NOT in scope for this PR

The following load-all callers were reviewed and intentionally left allowlisted
because they really do need a cross-conversation walk:

- `MemoryIndexer.cs` — memory backfill must index every session.
- `SessionTool.cs` — broader access-controlled listing.
- `SessionWarmupService.cs` — per-agent warmup, not conversation-scoped.
- `SessionCleanupService.cs` — TTL scan across conversations.

These are covered by the architecture fence's `AllowedFiles` list with
rationale.

## Risk

- Low. Three behaviour changes:
  1. `ConversationsController.GetHistory` and `CronTrigger.NormalizeDuplicateCronConversationsAsync` now go through the indexed path. Same semantics, less I/O.
  2. SQLite gets a new index (idempotent `CREATE INDEX IF NOT EXISTS`).
  3. `FileSessionStore` now persists ConversationId on save — old sidecar files load with `null` (current behaviour), next save populates the field.

## Commits

1. `e8228c49` — `fix(sessions): FileSessionStore loses ConversationId on round-trip (F-7)`
2. `dfa70d2f` — `feat(sessions): add ISessionStore.ListByConversationAsync (F-7)`
3. `3c5dee16` — `refactor(sessions): migrate F-7 callers to ListByConversationAsync`
4. `4feb1eb0` — `test(arch): add F-7 fence — load-all-sessions-then-filter-by-conversation`
