### PR TITLE
feat(domain): add AgentKind on AgentDescriptor + route sub-agent isolation gate via typed property (Phase 5 / F-6 step 1)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -17,6 +17,22 @@ public sealed record AgentDescriptor : ICitizen
     public required string DisplayName { get; init; }
 
     /// <summary>
+    /// Discriminates a named (configuration / REST-registered) agent from a runtime-spawned
+    /// sub-agent. Defaults to <see cref="AgentKind.Named"/> so existing JSON payloads round-trip
+    /// unchanged. <see cref="AgentKind.SubAgent"/> is set exclusively by
+    /// <c>DefaultSubAgentManager.SpawnAsync</c>; configuration sources that attempt to declare
+    /// <see cref="AgentKind.SubAgent"/> are rejected by
+    /// <c>AgentDescriptorValidator.ValidateForConfig</c>.
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>InProcessIsolationStrategy</c> as the primary signal for blocking recursive
+    /// spawn-tool registration. The SessionId-substring fallback (<c>SessionId.IsSubAgent</c>)
+    /// is retained as defense-in-depth for sessions created before this property existed or by
+    /// future paths that bypass <c>DefaultSubAgentManager</c>.
+    /// </remarks>
+    public AgentKind Kind { get; init; } = AgentKind.Named;
+
+    /// <summary>
     /// Discriminated citizen identity. Always <see cref="CitizenId.Of(AgentId)"/> for an agent —
     /// satisfies <see cref="ICitizen"/> so the descriptor can flow through cross-cutting code
     /// that addresses users and agents uniformly without losing the typed <see cref="AgentId"/>.

--- a/src/domain/BotNexus.Domain/World/AgentKind.cs
+++ b/src/domain/BotNexus.Domain/World/AgentKind.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Discriminates the species sub-kind of an <see cref="BotNexus.Gateway.Abstractions.Models.AgentDescriptor"/>.
+/// A named agent is a first-class World citizen registered by configuration or REST; a
+/// sub-agent is a runtime-spawned ephemeral helper created by another agent via
+/// <c>spawn_subagent</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This enum is the canonical typed signal for "is this descriptor a sub-agent?" — it
+/// replaces the prior pattern of inferring sub-agent status by substring-matching
+/// <c>::subagent::</c> inside <c>SessionId</c>. The <see cref="SubAgent"/> value is set
+/// exactly once, by <c>DefaultSubAgentManager.SpawnAsync</c>, on the child registration
+/// it creates; configuration-loaded descriptors must remain <see cref="Named"/>.
+/// </para>
+/// <para>
+/// <see cref="Named"/> is the default so existing JSON / config / REST payloads that
+/// omit <c>kind</c> round-trip with the correct intent. The
+/// <c>AgentDescriptorValidator.ValidateForConfig</c> overload rejects config-loaded
+/// descriptors that attempt to assert <see cref="SubAgent"/> directly — sub-agents are
+/// runtime-only by construction.
+/// </para>
+/// <para>
+/// Orthogonal to <see cref="BotNexus.Domain.Primitives.SubAgentArchetype"/>, which
+/// describes a sub-agent's <em>role</em> (researcher / coder / reviewer / …). A
+/// descriptor with <c>Kind == SubAgent</c> always carries an archetype on its
+/// originating <c>SubAgentSpawnRequest</c>; the archetype lives on the spawn info, not
+/// on the descriptor.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<AgentKind>))]
+public enum AgentKind
+{
+    /// <summary>
+    /// A first-class agent registered through configuration or the REST API. The default
+    /// for any descriptor that does not explicitly opt in to a different kind.
+    /// </summary>
+    Named = 0,
+
+    /// <summary>
+    /// A runtime-spawned ephemeral sub-agent created by another agent via
+    /// <c>spawn_subagent</c>. Sub-agents inherit the parent agent's deny-list, cannot
+    /// recursively spawn further sub-agents, and have no configuration persistence.
+    /// </summary>
+    SubAgent = 1,
+}

--- a/src/domain/BotNexus.Domain/World/AgentKind.cs
+++ b/src/domain/BotNexus.Domain/World/AgentKind.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace BotNexus.Domain.World;
@@ -30,8 +31,16 @@ namespace BotNexus.Domain.World;
 /// originating <c>SubAgentSpawnRequest</c>; the archetype lives on the spawn info, not
 /// on the descriptor.
 /// </para>
+/// <para>
+/// JSON serialization is locked to the STRING form only — the converter rejects
+/// integer payloads (e.g. <c>"kind": 1</c>) so future enum-value reordering cannot
+/// silently mutate persisted descriptors, and so a payload that supplies an
+/// out-of-range integer (e.g. <c>"kind": 99</c>) cannot smuggle past the
+/// <c>Kind == SubAgent</c> rejection guards in <c>AgentsController</c> /
+/// <c>AgentDescriptorValidator.ValidateForConfig</c>.
+/// </para>
 /// </remarks>
-[JsonConverter(typeof(JsonStringEnumConverter<AgentKind>))]
+[JsonConverter(typeof(AgentKindJsonConverter))]
 public enum AgentKind
 {
     /// <summary>
@@ -46,4 +55,54 @@ public enum AgentKind
     /// recursively spawn further sub-agents, and have no configuration persistence.
     /// </summary>
     SubAgent = 1,
+}
+
+/// <summary>
+/// Strict JSON converter for <see cref="AgentKind"/>. Accepts only the string form
+/// (<c>"Named"</c> / <c>"SubAgent"</c>, case-insensitive); rejects integer payloads,
+/// out-of-range strings, and out-of-range integers. This is the defence that makes
+/// the rejection of <c>Kind = SubAgent</c> in <c>AgentDescriptorValidator</c> /
+/// <c>AgentsController</c> actually work — without it, a payload of
+/// <c>"kind": 99</c> would deserialize to an undefined enum value and slip past the
+/// equality check.
+/// </summary>
+internal sealed class AgentKindJsonConverter : JsonConverter<AgentKind>
+{
+    public override AgentKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException(
+                $"AgentKind must be serialized as a JSON string ('Named' or 'SubAgent'); " +
+                $"got token type '{reader.TokenType}'. Integer values are intentionally rejected " +
+                $"to prevent enum-value reordering and out-of-range smuggling.");
+        }
+
+        var raw = reader.GetString();
+        if (raw is null)
+        {
+            throw new JsonException("AgentKind cannot be null.");
+        }
+
+        if (!Enum.TryParse<AgentKind>(raw, ignoreCase: true, out var parsed) || !Enum.IsDefined(parsed))
+        {
+            throw new JsonException(
+                $"AgentKind '{raw}' is not a recognised value. Allowed values: " +
+                $"{string.Join(", ", Enum.GetNames<AgentKind>())}.");
+        }
+
+        return parsed;
+    }
+
+    public override void Write(Utf8JsonWriter writer, AgentKind value, JsonSerializerOptions options)
+    {
+        if (!Enum.IsDefined(value))
+        {
+            throw new JsonException(
+                $"AgentKind value '{(int)value}' is not defined. Refusing to serialize an " +
+                $"out-of-range value to avoid producing a payload that would fail strict " +
+                $"deserialization on the other end.");
+        }
+        writer.WriteStringValue(value.ToString());
+    }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs
@@ -1,4 +1,5 @@
 using BotNexus.Cron;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
@@ -59,6 +60,14 @@ public sealed class AgentsController : ControllerBase
     [HttpPost]
     public async Task<ActionResult> Register([FromBody] AgentDescriptor descriptor, CancellationToken cancellationToken)
     {
+        if (descriptor.Kind == AgentKind.SubAgent)
+        {
+            return BadRequest(new
+            {
+                error = "Kind = SubAgent is reserved for runtime-spawned sub-agents and may not be registered via the REST API."
+            });
+        }
+
         try
         {
             _registry.Register(descriptor);
@@ -90,6 +99,14 @@ public sealed class AgentsController : ControllerBase
             return BadRequest(new
             {
                 error = $"Route agentId '{agentId}' does not match payload agentId '{descriptor.AgentId}'."
+            });
+        }
+
+        if (descriptor.Kind == AgentKind.SubAgent)
+        {
+            return BadRequest(new
+            {
+                error = "Kind = SubAgent is reserved for runtime-spawned sub-agents and may not be set via the REST API."
             });
         }
 

--- a/src/gateway/BotNexus.Gateway/Agents/AgentDescriptorValidator.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentDescriptorValidator.cs
@@ -1,3 +1,4 @@
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 
 namespace BotNexus.Gateway.Agents;
@@ -35,6 +36,33 @@ internal static class AgentDescriptorValidator
                     $"IsolationStrategy '{descriptor.IsolationStrategy}' is not registered. " +
                     $"Available: {string.Join(", ", strategyNames.Order(StringComparer.OrdinalIgnoreCase))}.");
             }
+        }
+
+        return errors;
+    }
+
+    /// <summary>
+    /// Configuration-source variant of <see cref="Validate(AgentDescriptor, IEnumerable{string}?)"/>
+    /// that additionally rejects any descriptor declaring <see cref="AgentKind.SubAgent"/>.
+    /// Sub-agents are runtime-only — they are created exclusively by
+    /// <c>DefaultSubAgentManager.SpawnAsync</c> on the spawn path and never persisted as
+    /// configuration. A config file or REST payload that asserts <c>Kind = SubAgent</c> is
+    /// either a misconfiguration (a named agent the operator wanted to register would be
+    /// silently denied <c>spawn_subagent</c>) or a privilege-confusion attempt; either way
+    /// the safer response is to reject at load time.
+    /// </summary>
+    public static IReadOnlyList<string> ValidateForConfig(
+        AgentDescriptor descriptor,
+        IEnumerable<string>? availableIsolationStrategies = null)
+    {
+        var errors = new List<string>(Validate(descriptor, availableIsolationStrategies));
+
+        if (descriptor.Kind == AgentKind.SubAgent)
+        {
+            errors.Add(
+                "Kind = SubAgent is reserved for runtime-spawned sub-agents and may not be " +
+                "declared in configuration or REST payloads. Remove the 'kind' property or set " +
+                "it to 'Named'.");
         }
 
         return errors;

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -126,7 +126,8 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             _registry.Register(baseDescriptor with
             {
                 AgentId = childAgentId,
-                DisplayName = $"{baseDescriptor.DisplayName} ({archetype.Value})"
+                DisplayName = $"{baseDescriptor.DisplayName} ({archetype.Value})",
+                Kind = AgentKind.SubAgent
             });
         }
 

--- a/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
@@ -67,7 +67,7 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             }
 
             var descriptor = BuildDescriptor(jsonConfig);
-            var validationErrors = AgentDescriptorValidator.Validate(descriptor);
+            var validationErrors = AgentDescriptorValidator.ValidateForConfig(descriptor);
             if (validationErrors.Count > 0)
             {
                 _logger.LogWarning(

--- a/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.IO.Abstractions;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -160,7 +161,8 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             IsolationOptions = ConvertObject(config.IsolationOptions),
             Soul = CloneSoulConfig(config.Soul),
             Heartbeat = CloneHeartbeatConfig(config.Heartbeat),
-            FileAccess = MapFileAccessPolicy(config.FileAccess)
+            FileAccess = MapFileAccessPolicy(config.FileAccess),
+            Kind = config.Kind ?? AgentKind.Named
         };
     }
 
@@ -383,5 +385,14 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
         public IReadOnlyList<string>? SubAgentRoles { get; init; }
 
         public FileAccessPolicyConfig? FileAccess { get; init; }
+
+        /// <summary>
+        /// Optional. Kind of agent — currently only <c>"Named"</c> is accepted from config.
+        /// <c>"SubAgent"</c> is rejected by <see cref="AgentDescriptorValidator.ValidateForConfig"/>;
+        /// sub-agents are runtime-only and produced exclusively by
+        /// <c>DefaultSubAgentManager.SpawnAsync</c>. Omit the field entirely on existing
+        /// configs; the default is <c>Named</c>.
+        /// </summary>
+        public AgentKind? Kind { get; init; }
     }
 }

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Domain;
+using BotNexus.Domain.World;
 
 namespace BotNexus.Gateway.Configuration;
 
@@ -455,6 +456,15 @@ public sealed class AgentDefinitionConfig
 
     /// <summary>Tool policy overrides for this agent.</summary>
     public ToolPolicyConfig? ToolPolicy { get; set; }
+
+    /// <summary>
+    /// Optional. Kind of agent — currently only <c>Named</c> is accepted from config.
+    /// <c>SubAgent</c> is rejected by <c>AgentDescriptorValidator.ValidateForConfig</c>;
+    /// sub-agents are runtime-only and produced exclusively by
+    /// <c>DefaultSubAgentManager.SpawnAsync</c>. Omit the field entirely on existing
+    /// configs; the default is <c>Named</c>.
+    /// </summary>
+    public AgentKind? Kind { get; set; }
 }
 
 /// <summary>Per-agent file access policy configuration.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -4,6 +4,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Agents;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
@@ -114,7 +115,8 @@ public sealed class PlatformConfigAgentSource(
                 FileAccess = MapFileAccessPolicy(effectiveConfig.FileAccess, platformConfig.Gateway?.FileAccess),
                 ExtensionConfig = ExtensionConfigMerger.Merge(
                     platformConfig.Gateway?.Extensions?.Defaults,
-                    effectiveConfig.Extensions)
+                    effectiveConfig.Extensions),
+                Kind = effectiveConfig.Kind ?? AgentKind.Named
             };
 
             var validationErrors = AgentDescriptorValidator.ValidateForConfig(descriptor);

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -117,7 +117,7 @@ public sealed class PlatformConfigAgentSource(
                     effectiveConfig.Extensions)
             };
 
-            var validationErrors = AgentDescriptorValidator.Validate(descriptor);
+            var validationErrors = AgentDescriptorValidator.ValidateForConfig(descriptor);
             if (validationErrors.Count > 0)
             {
                 _logger.LogWarning(

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -20,6 +20,7 @@ using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Services;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Agents;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Security;
@@ -205,7 +206,17 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
 
         var subAgentOptions = _serviceProvider.GetService<IOptions<GatewayOptions>>()?.Value.SubAgents;
         var subAgentManager = _serviceProvider.GetService<ISubAgentManager>();
-        var isSubAgentSession = context.SessionId.IsSubAgent;
+        // Phase 5 / F-6 part 1: primary signal is the typed descriptor.Kind (AgentKind.SubAgent
+        // is set exactly once by DefaultSubAgentManager.SpawnAsync). The SessionId.IsSubAgent
+        // substring check is retained as defense-in-depth so the gate fails CLOSED if a future
+        // path registers a sub-agent descriptor without going through SpawnAsync (or if a
+        // legacy ::subagent:: session is replayed against a Kind-defaulted descriptor). The
+        // architecture fence in AgentKindArchitectureTests deliberately allowlists this file
+        // as the one production callsite of SessionId.IsSubAgent outside the legacy
+        // SessionStoreBase read-path bucketing.
+        var isSubAgentSession =
+            descriptor.Kind == AgentKind.SubAgent
+            || context.SessionId.IsSubAgent;
         if (subAgentManager is not null &&
             subAgentOptions is { MaxDepth: > 0 } &&
             !isSubAgentSession)

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -217,6 +217,32 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         var isSubAgentSession =
             descriptor.Kind == AgentKind.SubAgent
             || context.SessionId.IsSubAgent;
+
+        // Defense-in-depth observability: if the typed and substring signals disagree,
+        // an invariant has drifted (a sub-agent descriptor was registered without
+        // Kind = SubAgent, or a sub-agent SessionId was attached to a Named descriptor).
+        // Either case means a future migration removed the OR fallback would break this
+        // call. Log at Warning so operators can alert on it.
+        if (descriptor.Kind == AgentKind.SubAgent && !context.SessionId.IsSubAgent)
+        {
+            _logger.LogWarning(
+                "Isolation gate: descriptor.Kind=SubAgent but SessionId '{SessionId}' is not a sub-agent shape " +
+                "for agent '{AgentId}'. Spawn tools will be blocked (correct), but this indicates an invariant " +
+                "drift — typed and substring signals must agree.",
+                context.SessionId,
+                descriptor.AgentId);
+        }
+        else if (descriptor.Kind != AgentKind.SubAgent && context.SessionId.IsSubAgent)
+        {
+            _logger.LogWarning(
+                "Isolation gate: SessionId '{SessionId}' is a sub-agent shape but descriptor.Kind={Kind} for " +
+                "agent '{AgentId}'. The substring fallback is correctly blocking spawn tools, but the typed " +
+                "signal should also be SubAgent — this indicates the descriptor was registered outside of " +
+                "DefaultSubAgentManager.SpawnAsync.",
+                context.SessionId,
+                descriptor.Kind,
+                descriptor.AgentId);
+        }
         if (subAgentManager is not null &&
             subAgentOptions is { MaxDepth: > 0 } &&
             !isSubAgentSession)

--- a/tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs
@@ -1,0 +1,234 @@
+using System.Text.RegularExpressions;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 5 / F-6 (part 1) contract:
+/// sub-agent detection is the responsibility of the typed
+/// <see cref="AgentKind"/> property on <see cref="AgentDescriptor"/>, NOT of
+/// substring-matching <c>::subagent::</c> inside a <see cref="BotNexus.Domain.Primitives.SessionId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The substring-based predicate <c>SessionId.IsSubAgent</c> is preserved for
+/// back-compat (legacy persisted sessions and a deliberate defense-in-depth
+/// callsite in the isolation strategy), but no NEW production code may rely on
+/// it. The allowlist below pins exactly which files are permitted to reference
+/// <c>SessionId.IsSubAgent</c>; every other use must route through
+/// <c>descriptor.Kind == AgentKind.SubAgent</c> instead.
+/// </para>
+/// <para>
+/// Pattern follows the multi-model-critique-approved fence shape from PR #549 / PR #550:
+/// (a) compound check (the allowlist is explicit and small),
+/// (b) vacuity self-test (proves the regex catches the canonical violation shape),
+/// (c) synthetic-violation self-test (proves the regex fires when violated),
+/// (d) synthetic-clean self-test (proves the regex doesn't fire on legitimate code).
+/// </para>
+/// <para>
+/// Deferred to follow-up PRs (in <c>plan.md</c> Phase 5 follow-ups):
+/// migrating <c>GatewayHost.ResolveSessionType</c> and <c>SessionsController.GetHistory</c>
+/// off the substring predicate (those need broader session-creation / read-path changes)
+/// and removing the <c>"::subagent::"</c> literal depth calculation in
+/// <c>DefaultSubAgentManager</c> (needs a typed <c>ParentSessionId</c> chain on
+/// <c>Session</c>). All three callsites are explicitly allowlisted here with a comment.
+/// </para>
+/// </remarks>
+public sealed class AgentKindArchitectureTests
+{
+    /// <summary>
+    /// Files allowed to reference <c>SessionId.IsSubAgent</c>. Every entry here must
+    /// have a justification — adding a new allowlist entry without one is the same
+    /// shape of bug the fence exists to prevent. Paths are repo-relative under <c>src/</c>.
+    /// </summary>
+    private static readonly (string RepoRelativePath, string Reason)[] s_substringAllowlist =
+    {
+        ("domain/BotNexus.Domain/Primitives/SessionId.cs",
+            "Declaration site of IsSubAgent. The predicate itself is allowed to mention its own name."),
+
+        ("gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs",
+            "Legacy read-path bucketing in InferSessionType: required to assign SessionType correctly " +
+            "when loading sessions persisted before SessionType was reliably saved on every store. " +
+            "Removing this would orphan legacy session rows."),
+
+        ("gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs",
+            "Defense-in-depth OR-gate combined with descriptor.Kind == AgentKind.SubAgent. " +
+            "Ensures the spawn-tool gate fails CLOSED if a future path registers a sub-agent " +
+            "descriptor without going through DefaultSubAgentManager.SpawnAsync."),
+
+        ("gateway/BotNexus.Gateway/GatewayHost.cs",
+            "DEFERRED: ResolveSessionType still infers SessionType from the SessionId substring " +
+            "during session creation. Follow-up issue tracks migration to descriptor.Kind + " +
+            "explicit SessionType on the InboundMessage handler path."),
+
+        ("gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs",
+            "DEFERRED: Read-side filter switches to session.SessionType == AgentSubAgent in a " +
+            "follow-up PR — this PR scopes the production write-side gate only."),
+    };
+
+    [Fact]
+    public void AgentDescriptor_HasKindPropertyOfTypeAgentKind()
+    {
+        // Reflection pin: prevents a regression that renames or retypes the property without updating
+        // the rest of the fence. AgentKind is the single source of truth for the sub-agent species
+        // discriminator; if it ever stops being a property of AgentDescriptor of type AgentKind,
+        // the production callsites in InProcessIsolationStrategy and DefaultSubAgentManager
+        // become silently broken.
+        var descriptorType = typeof(AgentDescriptor);
+        var kindProperty = descriptorType.GetProperty("Kind");
+
+        kindProperty.ShouldNotBeNull(
+            "AgentDescriptor.Kind property is missing. Phase 5 / F-6 (PR introducing AgentKind) " +
+            "requires this property to exist as the typed sub-agent discriminator.");
+        kindProperty.PropertyType.ShouldBe(typeof(AgentKind),
+            $"AgentDescriptor.Kind must be of type AgentKind (was {kindProperty.PropertyType.Name}).");
+    }
+
+    [Fact]
+    public void NoNewProductionCodeUsesSessionIdSubstringForSubAgentDetection()
+    {
+        var srcRoot = FindSourceRoot();
+        var allowlistFullPaths = s_substringAllowlist
+            .Select(entry => NormalizePath(Path.Combine(srcRoot, entry.RepoRelativePath)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var violations = new List<string>();
+        foreach (var file in EnumerateProductionCsFiles(srcRoot))
+        {
+            if (allowlistFullPaths.Contains(NormalizePath(file)))
+                continue;
+
+            var source = File.ReadAllText(file);
+            if (ContainsBannedShape(source))
+            {
+                violations.Add($"  {Path.GetRelativePath(srcRoot, file)}");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Production code is using SessionId.IsSubAgent for sub-agent detection. " +
+            "Phase 5 / F-6 (part 1) replaces this substring-based heuristic with the typed " +
+            "AgentDescriptor.Kind property. New callsites must route through " +
+            "descriptor.Kind == AgentKind.SubAgent. If you genuinely need the substring " +
+            "check (e.g., a new legacy-data read-path), add the file to s_substringAllowlist " +
+            "with a justification.\n" +
+            "Violations:\n" + string.Join("\n", violations) + "\n" +
+            $"Current allowlist:\n{string.Join("\n", s_substringAllowlist.Select(e => $"  - {e.RepoRelativePath}: {e.Reason}"))}");
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticViolation()
+    {
+        const string syntheticViolation = """
+            public void DoSomething(AgentExecutionContext context)
+            {
+                if (context.SessionId.IsSubAgent)
+                {
+                    skipSpawnTools = true;
+                }
+            }
+            """;
+        ContainsBannedShape(syntheticViolation).ShouldBeTrue(
+            "Vacuity guard: the fence regex must match the canonical violation shape " +
+            "(SessionId.IsSubAgent on a SessionId-typed expression). If this assertion fails, " +
+            "the fence has been weakened so far that it cannot catch the F-6 regression.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnLegitimateCode()
+    {
+        // Legitimate sub-agent detection uses descriptor.Kind — no SessionId substring ops.
+        const string syntheticClean = """
+            public void DoSomething(AgentDescriptor descriptor, AgentExecutionContext context)
+            {
+                var isSubAgent = descriptor.Kind == AgentKind.SubAgent;
+                if (isSubAgent)
+                {
+                    skipSpawnTools = true;
+                }
+            }
+            """;
+        ContainsBannedShape(syntheticClean).ShouldBeFalse(
+            "False-positive guard: the fence must not flag the canonical Kind-based detection. " +
+            "If this assertion fails, the fence is over-broad and will force authors to disable " +
+            "it instead of fixing real bugs.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedSubAgentReferences()
+    {
+        // The fence targets SessionId.IsSubAgent specifically — not every property named IsSubAgent.
+        // E.g. Blazor's CurrentAgent?.SessionType == "agent-subagent" pattern in AgentPanel.razor
+        // is unrelated to the SessionId substring concern.
+        const string syntheticClean = """
+            private bool IsSubAgent => CurrentAgent?.SessionType == "agent-subagent";
+            private bool IsSubAgentActive(SubAgentInfo sub) => sub.SubAgentId == _activeId;
+            """;
+        ContainsBannedShape(syntheticClean).ShouldBeFalse(
+            "False-positive guard: the fence must not flag unrelated IsSubAgent identifiers " +
+            "(properties on view models, parameter names, etc.). It must specifically target " +
+            "the SessionId.IsSubAgent property access on a SessionId-typed expression.");
+    }
+
+    private static bool ContainsBannedShape(string source)
+    {
+        // Strip C# comments first so docstrings and inline comments that legitimately
+        // MENTION the predicate by name (e.g., "see also SessionId.IsSubAgent") don't
+        // false-positive the fence. The signal we care about is actual code that
+        // depends on the predicate at runtime, not prose explaining the design.
+        var stripped = StripComments(source);
+
+        // Banned: any access to .IsSubAgent on something that looks like a SessionId expression.
+        // We approximate "SessionId expression" via common variable/property names that hold one,
+        // and the explicit type-name prefix for static-style or full-qualifier accesses.
+        // This intentionally OVER-INCLUDES on variable-name heuristics so an unguarded check
+        // is more likely to trip the fence than to slip past it.
+        var patterns = new[]
+        {
+            // someThing.SessionId.IsSubAgent / context.SessionId.IsSubAgent / session.SessionId.IsSubAgent
+            @"\bSessionId\s*\.\s*IsSubAgent\b",
+            // sessionId.IsSubAgent — a local of type SessionId named sessionId / sid / childSessionId
+            @"\b(sessionId|sid|childSessionId|parentSessionId)\s*\.\s*IsSubAgent\b",
+        };
+        return patterns.Any(p => Regex.IsMatch(stripped, p, RegexOptions.IgnoreCase));
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments.
+    /// Naive but sufficient for fence-scan purposes (does not need to handle every
+    /// pathological string-literal edge case — false positives in fence checks are
+    /// acceptable, false negatives are not).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var noBlockComments = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+        var noLineComments = Regex.Replace(noBlockComments, @"//[^\r\n]*", string.Empty);
+        return noLineComments;
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs
@@ -59,13 +59,13 @@ public sealed class AgentKindArchitectureTests
             "descriptor without going through DefaultSubAgentManager.SpawnAsync."),
 
         ("gateway/BotNexus.Gateway/GatewayHost.cs",
-            "DEFERRED: ResolveSessionType still infers SessionType from the SessionId substring " +
-            "during session creation. Follow-up issue tracks migration to descriptor.Kind + " +
+            "DEFERRED (sytone/botnexus#554): ResolveSessionType still infers SessionType from the " +
+            "SessionId substring during session creation. Tracked for migration to descriptor.Kind + " +
             "explicit SessionType on the InboundMessage handler path."),
 
         ("gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs",
-            "DEFERRED: Read-side filter switches to session.SessionType == AgentSubAgent in a " +
-            "follow-up PR — this PR scopes the production write-side gate only."),
+            "DEFERRED (sytone/botnexus#555): Read-side filter switches to session.SessionType == AgentSubAgent " +
+            "in a follow-up PR — this PR scopes the production write-side gate only."),
     };
 
     [Fact]

--- a/tests/domain/BotNexus.Domain.Tests/AgentKindTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/AgentKindTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Domain.Tests;
+
+/// <summary>
+/// Round-trip and contract tests for <see cref="AgentKind"/>. The enum carries
+/// <c>[JsonConverter(typeof(JsonStringEnumConverter&lt;AgentKind&gt;))]</c> so it
+/// serializes as a string (e.g. <c>"Named"</c> / <c>"SubAgent"</c>) — never as a number.
+/// String form is mandatory because numeric values can be silently shifted by a future
+/// enum reorder (e.g. adding a value between Named and SubAgent), which would break
+/// persisted JSON and stored config. String form is also more readable in REST traffic
+/// and config files.
+/// </summary>
+public sealed class AgentKindTests
+{
+    [Fact]
+    public void AgentDescriptor_KindDefault_IsNamed()
+    {
+        // Back-compat: any descriptor created without setting Kind must default to Named.
+        // Pre-existing JSON payloads and config files omit "kind"; they must continue to
+        // round-trip as Named so we do not silently regress the spawn-tool gate for
+        // legitimate named agents.
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("alpha"),
+            DisplayName = "Alpha",
+            ModelId = "m",
+            ApiProvider = "p"
+        };
+
+        descriptor.Kind.ShouldBe(AgentKind.Named,
+            "AgentDescriptor.Kind must default to AgentKind.Named so that descriptors " +
+            "constructed without an explicit Kind are treated as first-class named agents.");
+    }
+
+    [Fact]
+    public void AgentDescriptor_SerializesKind_AsStringForm()
+    {
+        // Wire-contract pin: Kind serializes as a STRING, not a number. If a future change
+        // strips the [JsonConverter(JsonStringEnumConverter<AgentKind>)] attribute or
+        // changes the global JsonSerializerOptions to drop string-enum conversion, this
+        // assertion catches it before persisted documents break.
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("alpha"),
+            DisplayName = "Alpha",
+            ModelId = "m",
+            ApiProvider = "p",
+            Kind = AgentKind.SubAgent
+        };
+
+        var json = JsonSerializer.Serialize(descriptor);
+
+        json.ShouldContain("\"SubAgent\"");
+        json.ShouldNotContain("\"kind\":1");
+        json.ShouldNotContain("\"Kind\":1");
+    }
+
+    [Fact]
+    public void AgentDescriptor_DeserializesMissingKind_AsNamed()
+    {
+        // Critical back-compat pin: a JSON payload that does NOT include a "kind" field
+        // (every pre-Phase-5 payload, every legacy config file) must deserialize with
+        // Kind = Named. Any regression here would silently down-grade every existing named
+        // agent to lose spawn_subagent capability on next load.
+        const string json = """
+            {
+              "agentId": "alpha",
+              "displayName": "Alpha",
+              "modelId": "m",
+              "apiProvider": "p"
+            }
+            """;
+
+        var descriptor = JsonSerializer.Deserialize<AgentDescriptor>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        descriptor.ShouldNotBeNull();
+        descriptor!.Kind.ShouldBe(AgentKind.Named,
+            "Descriptors deserialized from JSON without an explicit 'kind' field must default " +
+            "to AgentKind.Named. Any regression silently breaks back-compat for every legacy " +
+            "config file and persisted REST payload.");
+    }
+
+    [Fact]
+    public void AgentDescriptor_DeserializesKindSubAgent_FromStringForm()
+    {
+        // Round-trip pin: the symmetric read of the SerializesKind_AsStringForm test.
+        // String-form deserialization must succeed (case-insensitive — STJ enum converters
+        // accept the camelCase / PascalCase variant by default).
+        const string json = """
+            {
+              "agentId": "beta",
+              "displayName": "Beta",
+              "modelId": "m",
+              "apiProvider": "p",
+              "kind": "SubAgent"
+            }
+            """;
+
+        var descriptor = JsonSerializer.Deserialize<AgentDescriptor>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        descriptor.ShouldNotBeNull();
+        descriptor!.Kind.ShouldBe(AgentKind.SubAgent);
+    }
+
+    [Theory]
+    [InlineData(AgentKind.Named)]
+    [InlineData(AgentKind.SubAgent)]
+    public void AgentDescriptor_KindRoundTrips_ThroughJson(AgentKind kind)
+    {
+        var original = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("gamma"),
+            DisplayName = "Gamma",
+            ModelId = "m",
+            ApiProvider = "p",
+            Kind = kind
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<AgentDescriptor>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        restored.ShouldNotBeNull();
+        restored!.Kind.ShouldBe(kind);
+    }
+
+    [Fact]
+    public void AgentDescriptor_WithExpression_PreservesKind()
+    {
+        // AgentDescriptor is a sealed record with init-only properties. The DefaultSubAgentManager
+        // spawn path uses `baseDescriptor with { ..., Kind = AgentKind.SubAgent }` to derive the
+        // child registration. If `Kind` ever drops the init setter or is removed from the record
+        // copy-constructor, the `with` clone would not preserve Kind correctly. Pin the semantic
+        // explicitly so a future refactor cannot silently regress it.
+        var baseDescriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("delta"),
+            DisplayName = "Delta",
+            ModelId = "m",
+            ApiProvider = "p"
+        };
+
+        var spawned = baseDescriptor with { Kind = AgentKind.SubAgent };
+
+        spawned.Kind.ShouldBe(AgentKind.SubAgent,
+            "`with` clone must propagate Kind = SubAgent to the new instance — this is the " +
+            "exact shape DefaultSubAgentManager.SpawnAsync uses to register child sub-agents.");
+        baseDescriptor.Kind.ShouldBe(AgentKind.Named,
+            "`with` clone must NOT mutate the source descriptor. Records are immutable; the " +
+            "source must remain Named.");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentDescriptorValidatorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentDescriptorValidatorTests.cs
@@ -97,6 +97,55 @@ public sealed class AgentDescriptorValidatorTests
         errors.ShouldBeEmpty();
     }
 
+    // ---- ValidateForConfig (Phase 5 / F-6 — config & REST guard for AgentKind.SubAgent) ----
+
+    [Fact]
+    public void ValidateForConfig_WithKindNamed_DefaultKind_ReturnsNoKindError()
+    {
+        // Baseline: default Kind (Named) on a valid descriptor must produce no Kind-related error.
+        var descriptor = CreateValidDescriptor();
+
+        var errors = AgentDescriptorValidator.ValidateForConfig(descriptor);
+
+        errors.ShouldNotContain(error => error.Contains("Kind", StringComparison.Ordinal),
+            "ValidateForConfig must allow Kind = Named (the default). Errors received: " +
+            string.Join("; ", errors));
+    }
+
+    [Fact]
+    public void ValidateForConfig_WithKindSubAgent_ReturnsKindError()
+    {
+        // Security guard: a sub-agent must NEVER be declared from config / REST. Only
+        // DefaultSubAgentManager.SpawnAsync is allowed to stamp Kind = SubAgent on a descriptor.
+        // If we allowed this from config, an attacker who could write to the agent config could
+        // either (a) bypass the spawn-tool deny gate (Named privilege under the guise of a
+        // SubAgent registration) or (b) silently deprive a legitimate named agent of
+        // spawn_subagent on every session.
+        var descriptor = CreateValidDescriptor() with { Kind = BotNexus.Domain.World.AgentKind.SubAgent };
+
+        var errors = AgentDescriptorValidator.ValidateForConfig(descriptor);
+
+        errors.ShouldContain(error => error.Contains("Kind = SubAgent is reserved", StringComparison.Ordinal),
+            "ValidateForConfig must reject Kind = SubAgent. Errors received: " +
+            string.Join("; ", errors));
+    }
+
+    [Fact]
+    public void Validate_WithKindSubAgent_DoesNotReturnKindError()
+    {
+        // Runtime path contract: the spawn-time supervisor lookup uses Validate (not
+        // ValidateForConfig), so Validate MUST accept Kind = SubAgent. If this assertion
+        // regresses, every sub-agent spawn would fail at supervisor.GetOrCreateAsync time,
+        // breaking all sub-agent functionality across the platform.
+        var descriptor = CreateValidDescriptor() with { Kind = BotNexus.Domain.World.AgentKind.SubAgent };
+
+        var errors = AgentDescriptorValidator.Validate(descriptor);
+
+        errors.ShouldNotContain(error => error.Contains("Kind", StringComparison.Ordinal),
+            "Validate (runtime path) must allow Kind = SubAgent — used by DefaultSubAgentManager " +
+            "via DefaultAgentSupervisor.GetOrCreateAsync. Errors received: " + string.Join("; ", errors));
+    }
+
     private static AgentDescriptor CreateValidDescriptor()
         => new()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
@@ -236,6 +236,51 @@ public sealed class SubAgentKindTests
         toolNames.ShouldContain("manage_subagent");
     }
 
+    [Fact]
+    public async Task IsolationStrategy_DescriptorKindSubAgent_SubAgentSubstringSessionId_BlocksSpawnTools()
+    {
+        // 4TH ROW OF THE OR-GATE TRUTH TABLE: both signals are TRUE (Kind = SubAgent AND
+        // the SessionId carries the ::subagent:: substring). This is the normal-operation
+        // shape — DefaultSubAgentManager.SpawnAsync sets BOTH signals together. Logically
+        // redundant for an OR-gate, but the row exists as a regression-pin: if a future
+        // refactor changes the gate to AND (which would fail OPEN under the previous three
+        // rows for various single-signal cases), this row plus the prior two would still
+        // block — but the prior two would START PASSING (i.e. NOT blocking). The full
+        // 4-row matrix is the only configuration that lets a polarity-flip regression
+        // surface in CI.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        await SeedBoundSessionAsync(conversationStore, sessionStore,
+            AgentId.From("sub-agent"),
+            SessionId.From("parent::subagent::child"),
+            ConversationId.From("inherited-conv"));
+
+        var strategy = CreateStrategy(conversationStore, sessionStore);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("sub-agent"),
+            DisplayName = "Sub Agent (normal operation — both signals agree)",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ToolIds = ["spawn_subagent", "list_subagents", "manage_subagent"],
+            Kind = AgentKind.SubAgent
+        };
+
+        var handle = await strategy.CreateAsync(descriptor, new AgentExecutionContext
+        {
+            SessionId = SessionId.From("parent::subagent::child")
+        });
+        var toolNames = GetToolNames(handle);
+
+        toolNames.ShouldNotContain("spawn_subagent",
+            "NORMAL OPERATION: both Kind and SessionId signals say SubAgent — gate must block. " +
+            "This row plus the three single-signal rows form the complete 4-row OR-gate truth " +
+            "table; a polarity flip from OR to AND would invert the three single-signal rows " +
+            "but leave this row unchanged.");
+        toolNames.ShouldNotContain("list_subagents");
+        toolNames.ShouldNotContain("manage_subagent");
+    }
+
     // ---------------------------------------------------------------------------
     // Test infrastructure (kept local to this file to avoid cross-test coupling).
     // ---------------------------------------------------------------------------

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
@@ -1,0 +1,444 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Isolation;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Gateway.Tools;
+using BotNexus.Memory;
+using BotNexus.Memory.Models;
+using BotNexus.Agent.Core;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Behavioural tests for the Phase 5 / F-6 (part 1) contract:
+/// <list type="bullet">
+///   <item><c>DefaultSubAgentManager.SpawnAsync</c> registers child descriptors with
+///         <c>Kind = AgentKind.SubAgent</c>.</item>
+///   <item>Parent / mirror-target descriptors are NEVER mutated to SubAgent —
+///         they remain <c>AgentKind.Named</c>.</item>
+///   <item><c>InProcessIsolationStrategy</c> blocks <c>spawn_subagent</c> tools when
+///         <c>descriptor.Kind == AgentKind.SubAgent</c> (the new primary signal).</item>
+///   <item>Defense-in-depth: <c>InProcessIsolationStrategy</c> also still honours the
+///         legacy <c>SessionId.IsSubAgent</c> substring as a SECONDARY signal so the
+///         gate fails CLOSED if a future path skips <c>DefaultSubAgentManager</c>.</item>
+/// </list>
+/// </summary>
+public sealed class SubAgentKindTests
+{
+    [Fact]
+    public async Task SpawnAsync_RegistersChildDescriptor_WithKindSubAgent()
+    {
+        var (registry, manager) = CreateRegistryAndManager();
+
+        var spawned = await manager.SpawnAsync(CreateSpawnRequest());
+
+        var childAgentId = ResolveChildAgentId(registry, spawned.SubAgentId);
+        var childDescriptor = registry.Get(childAgentId);
+        childDescriptor.ShouldNotBeNull();
+        childDescriptor!.Kind.ShouldBe(AgentKind.SubAgent,
+            "DefaultSubAgentManager.SpawnAsync must register the child with Kind = SubAgent " +
+            "so InProcessIsolationStrategy can deny recursive spawn tools using the typed " +
+            "descriptor.Kind signal instead of substring-matching the SessionId.");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_DoesNotMutateParentDescriptor_KindRemainsNamed()
+    {
+        var (registry, manager) = CreateRegistryAndManager();
+        var parentBefore = registry.Get(AgentId.From("parent-agent"));
+        parentBefore.ShouldNotBeNull();
+        parentBefore!.Kind.ShouldBe(AgentKind.Named, "Sanity: seeded parent must default to Named.");
+
+        await manager.SpawnAsync(CreateSpawnRequest());
+
+        var parentAfter = registry.Get(AgentId.From("parent-agent"));
+        parentAfter.ShouldNotBeNull();
+        parentAfter!.Kind.ShouldBe(AgentKind.Named,
+            "SpawnAsync must NEVER mutate the parent descriptor's Kind. A named agent must " +
+            "remain Named after spawning a sub-agent or it would lose access to spawn_subagent " +
+            "on subsequent turns.");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_MirrorOfNamedAgent_ChildIsKindSubAgent_BaseRemainsNamed()
+    {
+        var (registry, manager) = CreateRegistryAndManager();
+
+        // Register a named "researcher-prime" agent that the spawn will MIRROR.
+        // The child should be Kind = SubAgent; the base researcher-prime must remain Named.
+        var researcherPrime = new AgentDescriptor
+        {
+            AgentId = AgentId.From("researcher-prime"),
+            DisplayName = "Researcher Prime",
+            ModelId = "test-model",
+            ApiProvider = "test-provider"
+        };
+        registry.Register(researcherPrime);
+
+        var spawned = await manager.SpawnAsync(new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("parent-agent"),
+            ParentSessionId = SessionId.From("parent-session"),
+            Task = "Investigate via mirror of researcher-prime",
+            TimeoutSeconds = 600,
+            TargetAgentId = "researcher-prime",
+            InheritedConversationId = ConversationId.From("inherited-conv")
+        });
+
+        var childAgentId = ResolveChildAgentId(registry, spawned.SubAgentId);
+        var childDescriptor = registry.Get(childAgentId);
+        childDescriptor.ShouldNotBeNull();
+        childDescriptor!.Kind.ShouldBe(AgentKind.SubAgent,
+            "Mirror-of-named child must still be Kind = SubAgent. The spawned child is a " +
+            "runtime ephemeral agent regardless of which descriptor it mirrors.");
+
+        var basePrime = registry.Get(AgentId.From("researcher-prime"));
+        basePrime.ShouldNotBeNull();
+        basePrime!.Kind.ShouldBe(AgentKind.Named,
+            "The mirrored TARGET descriptor must remain Named — it's a first-class registered " +
+            "agent, not a sub-agent. Confusing the two would cause the named researcher-prime " +
+            "to lose spawn_subagent on subsequent independent invocations.");
+    }
+
+    [Fact]
+    public async Task IsolationStrategy_DescriptorKindSubAgent_PlainSessionId_BlocksSpawnTools()
+    {
+        // Primary signal under test: descriptor.Kind == SubAgent (no ::subagent:: in SessionId).
+        // Pre-Phase-5 logic was substring-only and would have INCORRECTLY granted spawn tools
+        // because the SessionId is plain. This test pins the new typed-routing primary signal.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        await SeedBoundSessionAsync(conversationStore, sessionStore,
+            AgentId.From("sub-agent"),
+            SessionId.From("plain-session-no-substring"),
+            ConversationId.From("inherited-conv"));
+
+        var strategy = CreateStrategy(conversationStore, sessionStore);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("sub-agent"),
+            DisplayName = "Sub Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ToolIds = ["spawn_subagent", "list_subagents", "manage_subagent"],
+            Kind = AgentKind.SubAgent
+        };
+
+        var handle = await strategy.CreateAsync(descriptor, new AgentExecutionContext
+        {
+            SessionId = SessionId.From("plain-session-no-substring")
+        });
+        var toolNames = GetToolNames(handle);
+
+        toolNames.ShouldNotContain("spawn_subagent",
+            "PRIMARY SIGNAL: descriptor.Kind == SubAgent must block spawn_subagent registration " +
+            "regardless of SessionId shape. If this fails, the typed-routing primary signal is " +
+            "not wired into InProcessIsolationStrategy and we still have the F-11-shaped substring " +
+            "dependency.");
+        toolNames.ShouldNotContain("list_subagents");
+        toolNames.ShouldNotContain("manage_subagent");
+    }
+
+    [Fact]
+    public async Task IsolationStrategy_DescriptorKindNamed_SubAgentSubstringSessionId_StillBlocksSpawnTools()
+    {
+        // DEFENSE-IN-DEPTH signal under test: even if descriptor.Kind defaults to Named (e.g.,
+        // a legacy path registered the sub-agent descriptor without Kind), the SessionId
+        // ::subagent:: substring still triggers the block. The OR-gate fails CLOSED.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        await SeedBoundSessionAsync(conversationStore, sessionStore,
+            AgentId.From("legacy-agent"),
+            SessionId.From("parent-session::subagent::legacy-child"),
+            ConversationId.From("inherited-conv"));
+
+        var strategy = CreateStrategy(conversationStore, sessionStore);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("legacy-agent"),
+            DisplayName = "Legacy Agent (Kind defaulted to Named — simulating bypass of SpawnAsync)",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ToolIds = ["spawn_subagent", "list_subagents", "manage_subagent"]
+            // Kind deliberately NOT set — defaults to Named
+        };
+
+        var handle = await strategy.CreateAsync(descriptor, new AgentExecutionContext
+        {
+            SessionId = SessionId.From("parent-session::subagent::legacy-child")
+        });
+        var toolNames = GetToolNames(handle);
+
+        toolNames.ShouldNotContain("spawn_subagent",
+            "DEFENSE-IN-DEPTH: even with descriptor.Kind = Named (e.g., a future path that " +
+            "registers a sub-agent descriptor without going through DefaultSubAgentManager), " +
+            "the SessionId ::subagent:: substring must still cause the gate to fail CLOSED. " +
+            "If this fails, we have regressed the security property to an OPEN-by-default gate.");
+        toolNames.ShouldNotContain("list_subagents");
+        toolNames.ShouldNotContain("manage_subagent");
+    }
+
+    [Fact]
+    public async Task IsolationStrategy_DescriptorKindNamed_PlainSessionId_GrantsSpawnTools()
+    {
+        // Sanity baseline: a normal named agent with a normal session GETS the spawn tools.
+        // This is the existing pre-Phase-5 behaviour; the test pins that the new Kind-based
+        // gate did not regress the happy path.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        await SeedBoundSessionAsync(conversationStore, sessionStore,
+            AgentId.From("named-agent"),
+            SessionId.From("ordinary-session"),
+            ConversationId.From("inherited-conv"));
+
+        var strategy = CreateStrategy(conversationStore, sessionStore);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("named-agent"),
+            DisplayName = "Named Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ToolIds = ["spawn_subagent", "list_subagents", "manage_subagent"]
+            // Kind defaults to Named.
+        };
+
+        var handle = await strategy.CreateAsync(descriptor, new AgentExecutionContext
+        {
+            SessionId = SessionId.From("ordinary-session")
+        });
+        var toolNames = GetToolNames(handle);
+
+        toolNames.ShouldContain("spawn_subagent",
+            "Sanity: named agent + ordinary session must STILL register spawn_subagent. " +
+            "If this fails, the new Kind-based gate is over-broad and would block legitimate " +
+            "named-agent spawning.");
+        toolNames.ShouldContain("list_subagents");
+        toolNames.ShouldContain("manage_subagent");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test infrastructure (kept local to this file to avoid cross-test coupling).
+    // ---------------------------------------------------------------------------
+
+    private static (DefaultAgentRegistry Registry, DefaultSubAgentManager Manager) CreateRegistryAndManager()
+    {
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        var parent = new AgentDescriptor
+        {
+            AgentId = AgentId.From("parent-agent"),
+            DisplayName = "Parent Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ToolIds = ["spawn_subagent", "list_subagents", "manage_subagent"]
+        };
+        registry.Register(parent);
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateHangingHandle().Object);
+
+        var manager = new DefaultSubAgentManager(
+            supervisor.Object,
+            registry,
+            new Mock<IActivityBroadcaster>().Object,
+            new Mock<IChannelDispatcher>().Object,
+            new TestOptionsMonitor<GatewayOptions>(new GatewayOptions()),
+            NullLogger<DefaultSubAgentManager>.Instance);
+
+        return (registry, manager);
+    }
+
+    private static AgentId ResolveChildAgentId(IAgentRegistry registry, string subAgentId)
+    {
+        var all = registry.GetAll().ToList();
+        var match = all.FirstOrDefault(d => d.AgentId.Value.Contains(subAgentId, StringComparison.OrdinalIgnoreCase));
+        match.ShouldNotBeNull(
+            $"Expected a child descriptor whose AgentId contains the sub-agent id '{subAgentId}'. " +
+            $"Registered: {string.Join(", ", all.Select(d => d.AgentId.Value))}");
+        return match!.AgentId;
+    }
+
+    private static SubAgentSpawnRequest CreateSpawnRequest()
+        => new()
+        {
+            ParentAgentId = AgentId.From("parent-agent"),
+            ParentSessionId = SessionId.From("parent-session"),
+            Task = "Investigate flaky test",
+            TimeoutSeconds = 600,
+            InheritedConversationId = ConversationId.From("inherited-conv")
+        };
+
+    private static Mock<IAgentHandle> CreateHangingHandle()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentId.From("parent-agent"));
+        handle.SetupGet(h => h.SessionId).Returns(SessionId.From("child-session"));
+        handle.SetupGet(h => h.IsRunning).Returns(true);
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>(async (_, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return new AgentResponse { Content = "never" };
+            });
+        return handle;
+    }
+
+    private static InProcessIsolationStrategy CreateStrategy(
+        IConversationStore conversationStore,
+        ISessionStore sessionStore)
+    {
+        var modelRegistry = new ModelRegistry();
+        modelRegistry.Register("test-provider", new LlmModel(
+            Id: "test-model",
+            Name: "test-model",
+            Api: "test-api",
+            Provider: "test-provider",
+            BaseUrl: "http://localhost",
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 8192,
+            MaxTokens: 1024));
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ISubAgentManager>(new Mock<ISubAgentManager>().Object);
+        services.AddSingleton<IOptions<GatewayOptions>>(Options.Create(new GatewayOptions
+        {
+            SubAgents = new SubAgentOptions { MaxDepth = 1 }
+        }));
+        services.AddSingleton(conversationStore);
+        services.AddSingleton(sessionStore);
+
+        return new InProcessIsolationStrategy(
+            new LlmClient(new ApiProviderRegistry(), modelRegistry),
+            new GatewayAuthManager(
+                new StaticOptionsMonitor<PlatformConfig>(new PlatformConfig()),
+                NullLogger<GatewayAuthManager>.Instance,
+                new FileSystem()),
+            new PassthroughContextBuilder(),
+            new EmptyToolFactory(),
+            new TestWorkspaceManager(),
+            new DefaultToolRegistry([]),
+            Array.Empty<IAgentToolContributor>(),
+            new StubMemoryStoreFactory(),
+            services.BuildServiceProvider(),
+            NullLogger<InProcessIsolationStrategy>.Instance);
+    }
+
+    private static async Task SeedBoundSessionAsync(
+        IConversationStore conversationStore,
+        ISessionStore sessionStore,
+        AgentId agentId,
+        SessionId sessionId,
+        ConversationId conversationId)
+    {
+        await conversationStore.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = agentId,
+            ActiveSessionId = sessionId
+        });
+        var session = await sessionStore.GetOrCreateAsync(sessionId, agentId);
+        session.Session.ConversationId = conversationId;
+        await sessionStore.SaveAsync(session);
+    }
+
+    private static IReadOnlyList<string> GetToolNames(IAgentHandle handle)
+    {
+        var agentField = handle.GetType().GetField("_agent",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        agentField.ShouldNotBeNull();
+        var agent = agentField!.GetValue(handle) as BotNexus.Agent.Core.Agent;
+        agent.ShouldNotBeNull();
+        return [.. agent!.State.Tools.Select(tool => tool.Name)];
+    }
+}
+
+// File-scoped helpers (mirrors of the same private types inside SubAgentIntegrationTests).
+// Local copies kept here so this test file is self-contained and does not depend on
+// the private nested types of another test class. File-scoped means they don't leak
+// into the rest of the assembly.
+
+file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
+}
+
+file sealed class PassthroughContextBuilder : IContextBuilder
+{
+    public Task<string> BuildSystemPromptAsync(
+        AgentDescriptor descriptor,
+        AgentExecutionContext? executionContext,
+        CancellationToken ct = default)
+        => Task.FromResult(descriptor.SystemPrompt ?? string.Empty);
+}
+
+file sealed class EmptyToolFactory : IAgentToolFactory
+{
+    public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null) => [];
+}
+
+file sealed class TestWorkspaceManager : IAgentWorkspaceManager
+{
+    public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken cancellationToken = default)
+        => Task.FromResult(new AgentWorkspace(agentName, string.Empty, string.Empty, string.Empty, string.Empty));
+
+    public Task SaveMemoryAsync(string agentName, string content, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task SaveMemoryAsync(
+        string agentName,
+        string? filePath,
+        string content,
+        string? memoryPathOverride,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public string GetWorkspacePath(string agentName) => AppContext.BaseDirectory;
+}
+
+file sealed class StubMemoryStoreFactory : IMemoryStoreFactory
+{
+    private readonly IMemoryStore _store = new StubMemoryStore();
+    public IMemoryStore Create(string agentId) => _store;
+}
+
+file sealed class StubMemoryStore : IMemoryStore
+{
+    public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public Task<MemoryEntry> InsertAsync(MemoryEntry entry, CancellationToken ct = default) => Task.FromResult(entry);
+    public Task<MemoryEntry?> GetByIdAsync(string id, CancellationToken ct = default) => Task.FromResult<MemoryEntry?>(null);
+    public Task<IReadOnlyList<MemoryEntry>> GetBySessionAsync(string sessionId, int limit = 20, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+    public Task<IReadOnlyList<MemoryEntry>> SearchAsync(string query, int topK = 10, MemorySearchFilter? filter = null, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+    public Task DeleteAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+    public Task ClearAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs
@@ -574,4 +574,62 @@ public sealed class AgentsControllerTests
             ApiProvider = "test-provider",
             Heartbeat = new HeartbeatAgentConfig { Enabled = true, IntervalMinutes = 30 }
         };
+
+    // ── AgentKind REST guard tests (Phase 5 / F-6 part 1) ──────────────────────
+
+    [Fact]
+    public async Task Register_WithKindSubAgent_ReturnsBadRequest()
+    {
+        // SECURITY GUARD: a REST POST that attempts to register an agent with Kind = SubAgent
+        // must be rejected at the controller. Sub-agents are runtime-only — only
+        // DefaultSubAgentManager.SpawnAsync may stamp Kind = SubAgent on a descriptor.
+        // If we accepted this, an attacker with REST access could either bypass the
+        // spawn-tool deny gate or silently deprive a named agent of spawn_subagent.
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        var writer = new Mock<IAgentConfigurationWriter>();
+        var controller = new AgentsController(
+            registry,
+            Mock.Of<IAgentSupervisor>(),
+            writer.Object,
+            [CreateNotifier().Object]);
+        var descriptor = CreateDescriptor("attacker") with { Kind = BotNexus.Domain.World.AgentKind.SubAgent };
+
+        var result = await controller.Register(descriptor, CancellationToken.None);
+
+        result.ShouldBeOfType<BadRequestObjectResult>(
+            "Register must reject Kind = SubAgent with 400 BadRequest. If this fails, the " +
+            "REST-side sub-agent privilege guard is missing.");
+        registry.Get(BotNexus.Domain.Primitives.AgentId.From("attacker")).ShouldBeNull(
+            "Rejected descriptor must NOT have been written to the registry.");
+        writer.Verify(w => w.SaveAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>()), Times.Never,
+            "Rejected descriptor must NOT have been persisted to config.");
+    }
+
+    [Fact]
+    public async Task Update_WithKindSubAgent_ReturnsBadRequest()
+    {
+        // Symmetric guard on the PUT path: a previously-Named agent must not be silently
+        // converted to Kind = SubAgent through an Update payload. Same threat model as Register.
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor("agent-a"));
+        var writer = new Mock<IAgentConfigurationWriter>();
+        var controller = new AgentsController(
+            registry,
+            Mock.Of<IAgentSupervisor>(),
+            writer.Object,
+            [CreateNotifier().Object]);
+        var updated = CreateDescriptor("agent-a") with { Kind = BotNexus.Domain.World.AgentKind.SubAgent };
+
+        var result = await controller.Update("agent-a", updated, CancellationToken.None);
+
+        result.Result.ShouldBeOfType<BadRequestObjectResult>(
+            "Update must reject Kind = SubAgent with 400 BadRequest. If this fails, an " +
+            "attacker could convert a Named agent to SubAgent through PUT and deprive it " +
+            "of spawn_subagent permanently.");
+        registry.Get(BotNexus.Domain.Primitives.AgentId.From("agent-a"))!
+            .Kind.ShouldBe(BotNexus.Domain.World.AgentKind.Named,
+                "Rejected update must NOT have mutated the registered descriptor.");
+        writer.Verify(w => w.SaveAsync(It.IsAny<AgentDescriptor>(), It.IsAny<CancellationToken>()), Times.Never,
+            "Rejected descriptor must NOT have been persisted to config.");
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/FileAgentConfigurationSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileAgentConfigurationSourceTests.cs
@@ -308,6 +308,124 @@ public sealed class FileAgentConfigurationSourceTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadAsync_WithoutKindField_DefaultsToNamed_BackCompat()
+    {
+        // Critical back-compat pin: every config file written before Phase 5 omits the
+        // 'kind' field. Loading those configs must result in Kind = Named so the
+        // pre-existing fleet doesn't lose spawn_subagent permissions on the next reload.
+        _fileSystem.File.WriteAllText(
+            Path.Combine(_directoryPath, "agent.json"),
+            """
+            {
+              "agentId": "legacy-agent",
+              "displayName": "Legacy Agent",
+              "modelId": "model",
+              "apiProvider": "provider"
+            }
+            """);
+
+        var source = new FileAgentConfigurationSource(_directoryPath, new ListLogger<FileAgentConfigurationSource>(), _fileSystem);
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.Kind.ShouldBe(BotNexus.Domain.World.AgentKind.Named,
+            "Missing 'kind' field MUST default to Named. Pre-Phase-5 configs that don't " +
+            "specify kind silently being treated as SubAgent would break every existing " +
+            "agent's tool surface on the next gateway restart.");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithExplicitKindNamed_AcceptsDescriptor()
+    {
+        _fileSystem.File.WriteAllText(
+            Path.Combine(_directoryPath, "agent.json"),
+            """
+            {
+              "agentId": "named-agent",
+              "displayName": "Named Agent",
+              "modelId": "model",
+              "apiProvider": "provider",
+              "kind": "Named"
+            }
+            """);
+
+        var source = new FileAgentConfigurationSource(_directoryPath, new ListLogger<FileAgentConfigurationSource>(), _fileSystem);
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.Kind.ShouldBe(BotNexus.Domain.World.AgentKind.Named);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithExplicitKindSubAgent_RejectsDescriptorAndLogsWarning()
+    {
+        // The PRIMARY rejection invariant for the config path: Kind = SubAgent must NEVER
+        // come from a config file. Sub-agents are runtime-only — produced exclusively by
+        // DefaultSubAgentManager.SpawnAsync. If an operator (or attacker who can edit
+        // config) writes "kind": "SubAgent" to escalate a normal agent's tool surface (or
+        // restrict it — the privilege boundary cuts both ways), the gateway MUST refuse
+        // to load that descriptor and log a warning so the misconfiguration is visible.
+        var logger = new ListLogger<FileAgentConfigurationSource>();
+        _fileSystem.File.WriteAllText(
+            Path.Combine(_directoryPath, "agent.json"),
+            """
+            {
+              "agentId": "smuggled-subagent",
+              "displayName": "Smuggled Sub-Agent",
+              "modelId": "model",
+              "apiProvider": "provider",
+              "kind": "SubAgent"
+            }
+            """);
+
+        var source = new FileAgentConfigurationSource(_directoryPath, logger, _fileSystem);
+
+        var descriptors = await source.LoadAsync();
+
+        descriptors.ShouldBeEmpty(
+            "A config file declaring 'kind': 'SubAgent' MUST be rejected. If this fails, " +
+            "the configuration path is now a vector to bypass the runtime-only sub-agent " +
+            "invariant — an attacker with edit access to agents.json could attach the " +
+            "sub-agent-internal tool surface to a Named agent.");
+        logger.Entries.ShouldContain(e =>
+            e.Level == LogLevel.Warning &&
+            e.Message.Contains("validation", StringComparison.OrdinalIgnoreCase),
+            "The rejection must be logged at Warning so operators see misconfiguration " +
+            "alerts — a silent drop would hide the problem.");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithKindAsIntegerOne_RejectsDescriptor()
+    {
+        // The strict JSON converter for AgentKind refuses integer payloads outright, so
+        // a try at "kind": 1 (which would resolve to SubAgent if integer values were
+        // allowed) must fail to deserialize — and the file should be skipped as malformed
+        // rather than silently loaded with a default Kind. This pins the converter's
+        // string-only contract end-to-end through the config loader.
+        var logger = new ListLogger<FileAgentConfigurationSource>();
+        _fileSystem.File.WriteAllText(
+            Path.Combine(_directoryPath, "integer-kind.json"),
+            """
+            {
+              "agentId": "integer-attempt",
+              "displayName": "Integer Kind",
+              "modelId": "model",
+              "apiProvider": "provider",
+              "kind": 1
+            }
+            """);
+
+        var source = new FileAgentConfigurationSource(_directoryPath, logger, _fileSystem);
+
+        var descriptors = await source.LoadAsync();
+
+        descriptors.ShouldBeEmpty(
+            "Integer 'kind' value must NOT round-trip to SubAgent. The strict converter " +
+            "rejects integers so future enum reordering and out-of-range smuggling " +
+            "(e.g. 'kind': 99) cannot bypass the equality-based rejection guards.");
+    }
+
+    [Fact]
     public void Watch_WithExistingDirectory_ReturnsDisposableWatcher()
     {
         var watchDirectory = Path.Combine(Path.GetTempPath(), "botnexus-file-config-watch-tests", Guid.NewGuid().ToString("N"));

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -141,6 +141,121 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadAsync_WithoutKindField_DefaultsToNamed_BackCompat()
+    {
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["legacy"] = new() { Provider = "copilot", Model = "gpt-4.1" }
+            }
+        };
+
+        var source = new PlatformConfigAgentSource(new TestOptionsMonitor<PlatformConfig>(config), _configDirectory, new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.Kind.ShouldBe(AgentKind.Named,
+            "Platform-config entries omitting 'kind' must default to Named so existing fleet " +
+            "configurations don't shift semantics on upgrade.");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithExplicitKindSubAgent_RejectsDescriptorAndLogsWarning()
+    {
+        // PRIMARY rejection invariant for the platform-config path: Kind = SubAgent must
+        // never come from configuration. If an operator (or attacker who can edit
+        // botnexus.json) supplies "kind": "SubAgent" the descriptor MUST be dropped at
+        // load time so it never reaches the registry — otherwise the sub-agent-internal
+        // tool surface would attach to what is, semantically, a named agent.
+        var logger = new ListLogger<PlatformConfigAgentSource>();
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["smuggled"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    Kind = AgentKind.SubAgent
+                }
+            }
+        };
+
+        var source = new PlatformConfigAgentSource(new TestOptionsMonitor<PlatformConfig>(config), _configDirectory, logger);
+
+        var descriptors = await source.LoadAsync();
+
+        descriptors.ShouldBeEmpty(
+            "Platform-config 'kind: SubAgent' MUST be rejected. If this fails, the platform " +
+            "config path is now a vector to bypass the runtime-only sub-agent invariant.");
+        logger.Entries.ShouldContain(e =>
+            e.Level == LogLevel.Warning &&
+            e.Message.Contains("validation", StringComparison.OrdinalIgnoreCase),
+            "Rejection must surface as a Warning log so operators can detect misconfiguration.");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithExplicitKindNamed_AcceptsDescriptor()
+    {
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["named"] = new()
+                {
+                    Provider = "copilot",
+                    Model = "gpt-4.1",
+                    Kind = AgentKind.Named
+                }
+            }
+        };
+
+        var source = new PlatformConfigAgentSource(new TestOptionsMonitor<PlatformConfig>(config), _configDirectory, new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.Kind.ShouldBe(AgentKind.Named);
+    }
+
+    [Fact]
+    public void LoadAsync_WithKindAsIntegerOneInJson_RejectsDescriptor()
+    {
+        // End-to-end strict-converter check through JSON deserialization into PlatformConfig.
+        // A JSON config supplying "kind": 1 (which would resolve to SubAgent under the
+        // default System.Text.Json behaviour) must fail to bind to the strict
+        // AgentKindJsonConverter — otherwise integer smuggling could bypass the
+        // string-form rejection guard.
+        var configDirectory = Path.Combine(Path.GetTempPath(), "botnexus-platform-int-kind", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(configDirectory);
+        try
+        {
+            const string rawJson = """
+                {
+                  "agents": {
+                    "smuggle": {
+                      "provider": "copilot",
+                      "model": "gpt-4.1",
+                      "kind": 1
+                    }
+                  }
+                }
+                """;
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var bind = () => JsonSerializer.Deserialize<PlatformConfig>(rawJson, options);
+
+            var ex = Should.Throw<JsonException>(bind);
+            ex.Message.ShouldContain("AgentKind");
+        }
+        finally
+        {
+            if (Directory.Exists(configDirectory))
+                Directory.Delete(configDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task LoadAsync_WithWorldDefaults_MergesIntoAgentExtensionConfig()
     {
         var config = JsonSerializer.Deserialize<PlatformConfig>(


### PR DESCRIPTION
## Summary

Introduces `AgentKind { Named, SubAgent }` as a first-class typed discriminator on `AgentDescriptor`, replacing substring-based sub-agent detection via `SessionId.IsSubAgent`. This is **Phase 5 / F-6 step 1** of the BotNexus domain-model refactor, the same pattern proven by PR #550 (Phase 8 / F-11 `finish_agent_exchange`).

The PR delivers three layered guarantees so `Kind = AgentKind.SubAgent` can only land on a descriptor that came out of `DefaultSubAgentManager.SpawnAsync`:

1. **Runtime path** — `DefaultSubAgentManager.SpawnAsync` stamps `Kind = SubAgent` on the child descriptor it registers; this is the only legitimate writer.
2. **Configuration path** — `ValidateForConfig` rejects `Kind = SubAgent` from both `FileAgentConfigurationSource` and `PlatformConfigAgentSource`. To make this actually fire (the bug-hunt critique caught that it was previously dead code), this PR also plumbs `AgentKind? Kind` through both config DTOs and verifies rejection end to end.
3. **REST API** — `AgentsController.Register` / `Update` return `400 BadRequest` for `Kind = SubAgent` payloads.

The isolation gate in `InProcessIsolationStrategy` uses `descriptor.Kind == AgentKind.SubAgent || context.SessionId.IsSubAgent` — typed `Kind` is the primary signal, `SessionId.IsSubAgent` is a fail-CLOSED defence-in-depth fallback. When the two signals disagree it now logs a Warning so invariant drift is observable in production.

The JSON converter for `AgentKind` is strict: refuses integer tokens (so `""kind"": 1` cannot smuggle past the equality guards), refuses unknown strings, refuses out-of-range integers on write.

## Multi-model critique sweep

| Reviewer | Model | Verdict |
|---|---|---|
| `security-review` | gpt-5.5 | CLEAN — full evidence trail provided in PR session log (all registry write sinks, all REST endpoints accepting `AgentDescriptor`, JSON typo/case/integer behaviour, supervisor `Validate` chain traced). |
| `code-review` (plan-vs-impl) | claude-opus-4.6 | PASS on all 6 criteria. Two non-blocking items addressed: 4th OR-gate truth-table row added; deferred allowlist entries now cite issues #554 / #555. |
| `rubber-duck` (bug-hunt) | gpt-5.3-codex | 1 HIGH + 2 MEDIUM + 1 LOW — **all fixed in this PR**: <br>① HIGH: config DTOs didn't carry `Kind`, making `ValidateForConfig`'s rejection dead code → DTOs now include `Kind` and end-to-end JSON → DTO → validator path is covered by 7 new tests. <br>② MEDIUM: `JsonStringEnumConverter` accepted integer + undefined enum values → replaced with strict `AgentKindJsonConverter`. <br>③ MEDIUM: OR-gate disagreement not observable → Warning log added for both directions. <br>④ LOW: missing 4th truth-table row → pinned with regression-rationale comment. |

## Files changed

**Production (10 files):**
- `src/domain/BotNexus.Domain/World/AgentKind.cs` — NEW (enum + strict `AgentKindJsonConverter`)
- `src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs` — `Kind` property
- `src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs` — stamps `Kind = SubAgent` on spawn
- `src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs` — OR-gate primary signal + signal-disagreement Warning logs
- `src/gateway/BotNexus.Gateway/Agents/AgentDescriptorValidator.cs` — `ValidateForConfig` overload
- `src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs` — `Kind` on DTO + mapping
- `src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs` — `Kind` on `AgentDefinitionConfig`
- `src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs` — `Kind` mapping
- `src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs` — Register/Update 400 guards

**Tests (6 files):**
- `tests/domain/BotNexus.Domain.Tests/AgentKindTests.cs` — NEW (JSON shape, default, `with`-clone semantics)
- `tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs` — NEW (spawn-time invariant + full 4-row OR-gate truth table)
- `tests/gateway/BotNexus.Gateway.Tests/AgentDescriptorValidatorTests.cs` — runtime vs config-path validator tests
- `tests/gateway/BotNexus.Gateway.Tests/AgentsControllerTests.cs` — REST 400-guard tests
- `tests/gateway/BotNexus.Gateway.Tests/FileAgentConfigurationSourceTests.cs` — end-to-end JSON → DTO → validator rejection tests
- `tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs` — end-to-end platform-config tests including strict-converter integer rejection
- `tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs` — NEW fence: bans new `SessionId.IsSubAgent` runtime use outside the allowlist

## Validation

Full suite: `dotnet test BotNexus.slnx --no-build --nologo --tl:off` — **4,571 passed, 41 skipped, 1 known-flaky CLI timing test** (`HttpHealthCheckerTests.WaitForHealthyAsync_WhenTimeoutReached_StopsRetrying` — unrelated to this PR; passes in isolation).

Build: 0 warnings, 0 errors under `TreatWarningsAsErrors=true`.

## Deferred to follow-up

- **#554** — `GatewayHost.ResolveSessionType` migration off `SessionId.IsSubAgent`.
- **#555** — `SessionsController` read-side filter migration to a typed `SessionType`.

Both sites are explicitly allowlisted in `AgentKindArchitectureTests` with the issue numbers cited inline so any drift trips CI with a discoverable owner.

## Refs

- Plan: Phase 5 / F-6 step 1 (`Embody | Mirror` discriminated union is step 2 — separate PR)
- Pattern model: PR #550 (Phase 8 / F-11 `finish_agent_exchange`)
- Follow-up issues: #554, #555