### PR TITLE
feat(gateway): migrate GatewayHost.ResolveSessionType off SessionId.IsSubAgent substring (Phase 5 / F-6 step 2)

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -51,6 +51,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private readonly ISessionCompactor _compactor;
     private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
     private readonly ILogger<GatewayHost> _logger;
+    private readonly IAgentRegistry? _registry;
     private readonly IMediaPipeline? _mediaPipeline;
     private readonly IConversationDispatcher? _conversationDispatcher;
     private readonly IConversationRouter? _conversationRouter;
@@ -74,7 +75,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         IConversationDispatcher? conversationDispatcher = null,
         IConversationRouter? conversationRouter = null,
         PendingAskUserInterceptor? pendingAskUserInterceptor = null,
-        IPreCompactionMemoryFlusher? memoryFlusher = null)
+        IPreCompactionMemoryFlusher? memoryFlusher = null,
+        IAgentRegistry? registry = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -90,6 +92,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         _sessionLifecycleEvents = sessionLifecycleEvents;
         _pendingAskUserInterceptor = pendingAskUserInterceptor;
         _memoryFlusher = memoryFlusher;
+        _registry = registry;
         SessionQueueCapacity = Math.Max(sessionQueueCapacity, 1);
     }
 
@@ -1082,9 +1085,17 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         });
     }
 
-    private static SessionType ResolveSessionType(GatewaySession session, InboundMessage message)
+    private SessionType ResolveSessionType(GatewaySession session, InboundMessage message)
     {
-        if (session.SessionId.IsSubAgent)
+        // Phase 5 / F-6 step 2 (#554): sub-agent classification is driven by the
+        // typed AgentDescriptor.Kind signal sourced from IAgentRegistry rather than
+        // the legacy SessionId.IsSubAgent substring check. When the registry has no
+        // descriptor for this agent (test composition or transient deregister race)
+        // we default to UserAgent rather than parsing the SessionId — the substring
+        // path has been deleted from this method as a hard architecture invariant
+        // pinned by AgentKindArchitectureTests.
+        var descriptor = _registry?.Get(session.AgentId);
+        if (descriptor is { Kind: AgentKind.SubAgent })
             return SessionType.AgentSubAgent;
 
         if (session.SessionId.IsSoul)

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -43,6 +43,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private const string ControlSteer = "steer";
     private const string ControlCompact = "compact";
 
+    // Cached to avoid per-dispatch allocation in ResolveSessionType's hot path.
+    private static readonly ChannelKey CronChannelKey = ChannelKey.From("cron");
+
     private readonly IAgentSupervisor _supervisor;
     private readonly IMessageRouter _router;
     private readonly ISessionStore _sessions;
@@ -363,7 +366,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             if (resolution is not null && session.Session.ConversationId != resolution.ConversationId)
                 session.Session.ConversationId = resolution.ConversationId;
             session.CallerId ??= message.SenderId;
-            session.SessionType = ResolveSessionType(session, message);
+            session.SessionType = ResolveSessionType(session, message, isNewSession: createdSession);
             EnsureCallerParticipant(session, message.Sender);
             if (ShouldInitializeSystemPrompt(session))
             {
@@ -1085,23 +1088,33 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         });
     }
 
-    private SessionType ResolveSessionType(GatewaySession session, InboundMessage message)
+    private SessionType ResolveSessionType(GatewaySession session, InboundMessage message, bool isNewSession)
     {
         // Phase 5 / F-6 step 2 (#554): sub-agent classification is driven by the
         // typed AgentDescriptor.Kind signal sourced from IAgentRegistry rather than
-        // the legacy SessionId.IsSubAgent substring check. When the registry has no
-        // descriptor for this agent (test composition or transient deregister race)
-        // we default to UserAgent rather than parsing the SessionId — the substring
-        // path has been deleted from this method as a hard architecture invariant
-        // pinned by AgentKindArchitectureTests.
+        // the legacy SessionId.IsSubAgent substring check. The substring path is
+        // deleted from this method — pinned by AgentKindArchitectureTests.
         var descriptor = _registry?.Get(session.AgentId);
         if (descriptor is { Kind: AgentKind.SubAgent })
+            return SessionType.AgentSubAgent;
+
+        // Fail-closed preservation: an EXISTING session previously stamped as
+        // AgentSubAgent stays AgentSubAgent when no typed signal contradicts it.
+        // This guards the gateway-restart and post-Unregister windows where the
+        // sub-agent descriptor is transiently absent from the in-memory registry
+        // (DefaultSubAgentManager.OnChildCompleteAsync calls _registry.Unregister
+        // when a sub-agent finishes). Silently downgrading to UserAgent would
+        // flip Session.IsInteractive and warmup/memory-flush gating downstream.
+        // Note: we explicitly require isNewSession=false so this does NOT re-open
+        // a substring back door for fresh dispatches — first-classification of a
+        // sub-agent-shaped SessionId still depends on the typed registry signal.
+        if (!isNewSession && descriptor is null && session.SessionType == SessionType.AgentSubAgent)
             return SessionType.AgentSubAgent;
 
         if (session.SessionId.IsSoul)
             return SessionType.Soul;
 
-        if (message.ChannelType.Equals(ChannelKey.From("cron")))
+        if (message.ChannelType.Equals(CronChannelKey))
             return SessionType.Cron;
 
         return SessionType.UserAgent;

--- a/tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs
@@ -28,12 +28,14 @@ namespace BotNexus.Architecture.Tests;
 /// (d) synthetic-clean self-test (proves the regex doesn't fire on legitimate code).
 /// </para>
 /// <para>
-/// Deferred to follow-up PRs (in <c>plan.md</c> Phase 5 follow-ups):
-/// migrating <c>GatewayHost.ResolveSessionType</c> and <c>SessionsController.GetHistory</c>
-/// off the substring predicate (those need broader session-creation / read-path changes)
-/// and removing the <c>"::subagent::"</c> literal depth calculation in
-/// <c>DefaultSubAgentManager</c> (needs a typed <c>ParentSessionId</c> chain on
-/// <c>Session</c>). All three callsites are explicitly allowlisted here with a comment.
+/// Migration history: <c>GatewayHost.ResolveSessionType</c> was migrated to the
+/// typed signal in PR #554 (sub-agent classification now reads
+/// <c>IAgentRegistry.Get(agentId)?.Kind</c>). Remaining DEFERRED entry —
+/// <c>SessionsController</c> read-side filter (#555) — requires a persisted
+/// <see cref="SessionType"/> discriminator on the session row before its substring
+/// check can be cut. The <c>"::subagent::"</c> literal depth calculation in
+/// <c>DefaultSubAgentManager</c> is tracked for a typed <c>ParentSessionId</c> chain
+/// on <c>Session</c>.
 /// </para>
 /// </remarks>
 public sealed class AgentKindArchitectureTests
@@ -57,11 +59,6 @@ public sealed class AgentKindArchitectureTests
             "Defense-in-depth OR-gate combined with descriptor.Kind == AgentKind.SubAgent. " +
             "Ensures the spawn-tool gate fails CLOSED if a future path registers a sub-agent " +
             "descriptor without going through DefaultSubAgentManager.SpawnAsync."),
-
-        ("gateway/BotNexus.Gateway/GatewayHost.cs",
-            "DEFERRED (sytone/botnexus#554): ResolveSessionType still infers SessionType from the " +
-            "SessionId substring during session creation. Tracked for migration to descriptor.Kind + " +
-            "explicit SessionType on the InboundMessage handler path."),
 
         ("gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs",
             "DEFERRED (sytone/botnexus#555): Read-side filter switches to session.SessionType == AgentSubAgent " +

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs
@@ -31,9 +31,12 @@ namespace BotNexus.Gateway.Tests;
 /// session is bucketed as <see cref="SessionType.UserAgent"/>, not
 /// <see cref="SessionType.AgentSubAgent"/>;
 /// (3) when the descriptor is missing from the registry the host defaults to
-/// <see cref="SessionType.UserAgent"/> and does NOT fall back to the substring
-/// — proving the legacy code path has been cut;
-/// (4) <see cref="SessionType.Soul"/> and <see cref="SessionType.Cron"/>
+/// <see cref="SessionType.UserAgent"/> for FRESH sessions and does NOT fall
+/// back to the substring — proving the legacy code path has been cut;
+/// (4) a PERSISTED <see cref="SessionType.AgentSubAgent"/> session survives a
+/// transient registry-deregister / gateway restart and is not silently
+/// downgraded (defense against the bug-hunt HIGH finding);
+/// (5) <see cref="SessionType.Soul"/> and <see cref="SessionType.Cron"/>
 /// classifications remain intact (regression-pin for the other branches).
 /// </para>
 /// </remarks>
@@ -45,7 +48,10 @@ public sealed class GatewayHostResolveSessionTypeTests
     public async Task DispatchAsync_WhenRegistryReturnsSubAgentDescriptor_StampsSessionTypeAsAgentSubAgent()
     {
         // Registry-backed typed signal: descriptor.Kind = SubAgent -> SessionType.AgentSubAgent.
-        const string sessionIdValue = "session-with-subagent-descriptor";
+        // SessionId literal deliberately avoids the word "subagent" so the SubAgent
+        // classification can only come from the typed descriptor, not from any
+        // accidental substring match.
+        const string sessionIdValue = "plain-session-id-1";
         var registry = new Mock<IAgentRegistry>();
         registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
             .Returns(CreateDescriptor(AgentKind.SubAgent));
@@ -174,6 +180,59 @@ public sealed class GatewayHostResolveSessionTypeTests
         var reloaded = await sessions.GetAsync(SessionId.From(sessionIdValue));
         reloaded.ShouldNotBeNull();
         reloaded!.SessionType.ShouldBe(SessionType.AgentSubAgent);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenSessionAlreadyPersistedAsAgentSubAgent_AndRegistryHasNoDescriptor_PreservesAgentSubAgent()
+    {
+        // REGRESSION PIN (bug-hunt finding HIGH): a sub-agent session previously
+        // classified AgentSubAgent (via SessionStoreBase.InferSessionType at
+        // creation time, while the descriptor was still in the registry) must NOT
+        // be silently downgraded to UserAgent on a later dispatch when the
+        // descriptor has since been Unregister()'d (sub-agent completed) or is
+        // transiently absent (gateway restart before re-registration).
+        //
+        // Without this preservation: Session.IsInteractive would flip,
+        // SessionWarmupService visibility and PreCompactionMemoryFlusher gating
+        // would change behaviour mid-session — a real production regression.
+        var subAgentShapedId = SessionId.ForSubAgent("parent-session", "child-persisted");
+        var sessions = new InMemorySessionStore();
+
+        // Seed an existing session in the store — mimics a sub-agent session
+        // that was created earlier (descriptor was present then) and is now
+        // being re-dispatched after the descriptor has been unregistered.
+        var seeded = await sessions.GetOrCreateAsync(subAgentShapedId, AgentId.From(AgentIdValue));
+        seeded.SessionType.ShouldBe(SessionType.AgentSubAgent, "InferSessionType should have stamped the sub-agent-shaped id at creation");
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+        await using var host = CreateHost(sessions, registry.Object, subAgentShapedId.Value);
+
+        await host.DispatchAsync(CreateMessage(subAgentShapedId.Value, "follow-up message"));
+
+        var reloaded = await sessions.GetAsync(subAgentShapedId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.AgentSubAgent, "persisted AgentSubAgent must survive registry deregistration / restart");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenRegistryReturnsNamedDescriptor_AndSessionIdIsPlain_StampsAsUserAgent()
+    {
+        // Baseline truth-table row (plan-vs-impl finding): Named descriptor +
+        // plain SessionId + web channel -> UserAgent. This is the default
+        // human-conversation case and must always classify as UserAgent.
+        const string sessionIdValue = "plain-session-id-2";
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
+            .Returns(CreateDescriptor(AgentKind.Named));
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, sessionIdValue);
+
+        await host.DispatchAsync(CreateMessage(sessionIdValue, "hello"));
+
+        var reloaded = await sessions.GetAsync(SessionId.From(sessionIdValue));
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.UserAgent);
     }
 
     private static AgentDescriptor CreateDescriptor(AgentKind kind)

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs
@@ -1,0 +1,241 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Routing;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Behavioural tests for Phase 5 / F-6 step 2 (#554): <c>GatewayHost.ResolveSessionType</c>
+/// must derive the sub-agent species discriminator from the typed
+/// <see cref="AgentDescriptor.Kind"/> via <see cref="IAgentRegistry"/>, not from
+/// the legacy <c>SessionId.IsSubAgent</c> substring check.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each test pins one row of the migration truth table. Together they prove:
+/// (1) typed signal works when registry holds a SubAgent descriptor;
+/// (2) typed signal trumps the legacy substring even when the SessionId has
+/// the canonical <c>::subagent::</c> infix and the descriptor is Named — the
+/// session is bucketed as <see cref="SessionType.UserAgent"/>, not
+/// <see cref="SessionType.AgentSubAgent"/>;
+/// (3) when the descriptor is missing from the registry the host defaults to
+/// <see cref="SessionType.UserAgent"/> and does NOT fall back to the substring
+/// — proving the legacy code path has been cut;
+/// (4) <see cref="SessionType.Soul"/> and <see cref="SessionType.Cron"/>
+/// classifications remain intact (regression-pin for the other branches).
+/// </para>
+/// </remarks>
+public sealed class GatewayHostResolveSessionTypeTests
+{
+    private const string AgentIdValue = "agent-resolve";
+
+    [Fact]
+    public async Task DispatchAsync_WhenRegistryReturnsSubAgentDescriptor_StampsSessionTypeAsAgentSubAgent()
+    {
+        // Registry-backed typed signal: descriptor.Kind = SubAgent -> SessionType.AgentSubAgent.
+        const string sessionIdValue = "session-with-subagent-descriptor";
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
+            .Returns(CreateDescriptor(AgentKind.SubAgent));
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, sessionIdValue);
+
+        await host.DispatchAsync(CreateMessage(sessionIdValue, "hello"));
+
+        var reloaded = await sessions.GetAsync(SessionId.From(sessionIdValue));
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.AgentSubAgent);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenRegistryReturnsNamedDescriptor_AndSessionIdHasSubAgentInfix_StampsAsUserAgent()
+    {
+        // CRITICAL regression pin: typed signal trumps substring. Even with the
+        // legacy "::subagent::" infix on the SessionId, a Named descriptor
+        // means SessionType.UserAgent. This is the row that proves the migration
+        // off SessionId.IsSubAgent is complete in this code path.
+        var subAgentShapedId = SessionId.ForSubAgent("parent-session", "child-1");
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
+            .Returns(CreateDescriptor(AgentKind.Named));
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, subAgentShapedId.Value);
+
+        await host.DispatchAsync(CreateMessage(subAgentShapedId.Value, "hello"));
+
+        var reloaded = await sessions.GetAsync(subAgentShapedId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.UserAgent);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenRegistryHasNoDescriptor_AndSessionIdHasSubAgentInfix_StampsAsUserAgent()
+    {
+        // Cuts the legacy substring fallback: if the registry doesn't know the
+        // agent (transient race, deregister, or test misconfiguration), we MUST
+        // default to UserAgent rather than parsing the SessionId. This is the
+        // exact path that #554 deletes.
+        var subAgentShapedId = SessionId.ForSubAgent("parent-session", "child-2");
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, subAgentShapedId.Value);
+
+        await host.DispatchAsync(CreateMessage(subAgentShapedId.Value, "hello"));
+
+        var reloaded = await sessions.GetAsync(subAgentShapedId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.UserAgent);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenRegistryNotProvided_AndSessionIdHasSubAgentInfix_StampsAsUserAgent()
+    {
+        // Belt-and-braces variant of the above: no registry passed at all
+        // (test composition root). Still must NOT fall back to substring detection.
+        var subAgentShapedId = SessionId.ForSubAgent("parent-session", "child-3");
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry: null, sessionIdValue: subAgentShapedId.Value);
+
+        await host.DispatchAsync(CreateMessage(subAgentShapedId.Value, "hello"));
+
+        var reloaded = await sessions.GetAsync(subAgentShapedId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.UserAgent);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenSessionIdIsSoul_StampsAsSoul()
+    {
+        // Regression pin: Soul bucketing is preserved. The Soul predicate
+        // (SessionId.IsSoul) is unrelated to the AgentKind migration and
+        // remains in place.
+        var soulId = SessionId.ForSoul(AgentId.From(AgentIdValue), DateOnly.FromDateTime(DateTime.UtcNow));
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
+            .Returns(CreateDescriptor(AgentKind.Named));
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, soulId.Value);
+
+        await host.DispatchAsync(CreateMessage(soulId.Value, "hello"));
+
+        var reloaded = await sessions.GetAsync(soulId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.Soul);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenChannelTypeIsCron_StampsAsCron()
+    {
+        // Regression pin: Cron bucketing is preserved (driven by channel type,
+        // not by the descriptor or the SessionId).
+        const string sessionIdValue = "cron-session-1";
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
+            .Returns(CreateDescriptor(AgentKind.Named));
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, sessionIdValue);
+
+        await host.DispatchAsync(CreateMessage(sessionIdValue, "fire", channelType: "cron"));
+
+        var reloaded = await sessions.GetAsync(SessionId.From(sessionIdValue));
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.Cron);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenChannelTypeIsCron_AndDescriptorKindIsSubAgent_PrefersSubAgentBucketing()
+    {
+        // Edge case truth-table row: the SubAgent kind takes precedence over
+        // Cron channel-type because the original method's branch order
+        // checked sub-agent first. Pinned so the precedence doesn't flip
+        // silently under refactor.
+        const string sessionIdValue = "cron-by-subagent";
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
+            .Returns(CreateDescriptor(AgentKind.SubAgent));
+        var sessions = new InMemorySessionStore();
+        await using var host = CreateHost(sessions, registry.Object, sessionIdValue);
+
+        await host.DispatchAsync(CreateMessage(sessionIdValue, "fire", channelType: "cron"));
+
+        var reloaded = await sessions.GetAsync(SessionId.From(sessionIdValue));
+        reloaded.ShouldNotBeNull();
+        reloaded!.SessionType.ShouldBe(SessionType.AgentSubAgent);
+    }
+
+    private static AgentDescriptor CreateDescriptor(AgentKind kind)
+        => new()
+        {
+            AgentId = AgentId.From(AgentIdValue),
+            DisplayName = AgentIdValue,
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            Kind = kind
+        };
+
+    private static GatewayHost CreateHost(
+        InMemorySessionStore sessions,
+        IAgentRegistry? registry,
+        string sessionIdValue)
+    {
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AgentIdValue]);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentId.From(AgentIdValue));
+        handle.SetupGet(h => h.SessionId).Returns(SessionId.From(sessionIdValue));
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.PromptAsync(It.IsAny<AgentUserMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "ack" });
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "ack" });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                It.IsAny<AgentId>(),
+                It.IsAny<SessionId>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var channelManager = new Mock<IChannelManager>();
+        channelManager.SetupGet(m => m.Adapters).Returns([]);
+        channelManager.Setup(m => m.Get(It.IsAny<ChannelKey>())).Returns((IChannelAdapter?)null);
+        channelManager.Setup(m => m.Get(It.IsAny<ChannelKey>(), It.IsAny<string?>())).Returns((IChannelAdapter?)null);
+
+        return new GatewayHost(
+            supervisor.Object,
+            router.Object,
+            sessions,
+            Mock.Of<IActivityBroadcaster>(),
+            channelManager.Object,
+            Mock.Of<ISessionCompactor>(),
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            NullLogger<GatewayHost>.Instance,
+            registry: registry);
+    }
+
+    private static InboundMessage CreateMessage(string sessionId, string content, string channelType = "web")
+        => new()
+        {
+            ChannelType = ChannelKey.From(channelType),
+            SenderId = "sender-1",
+            Sender = CitizenId.Of(UserId.From("sender-1")),
+            ChannelAddress = ChannelAddress.From("conv-1"),
+            Content = content,
+            SessionId = sessionId
+        };
+}


### PR DESCRIPTION
## Summary

Phase 5 / F-6 step 2: migrate `GatewayHost.ResolveSessionType` off the legacy `SessionId.IsSubAgent` substring check. The sub-agent session-type discriminator is now driven by the typed `AgentDescriptor.Kind` signal sourced from `IAgentRegistry`. Closes #554.

This is the second migration step after PR #556 (which introduced `AgentKind`). The substring path stays alive only in the architecturally-allowlisted call sites: `SessionStoreBase.InferSessionType` (legacy read path), `InProcessIsolationStrategy` (defense-in-depth OR gate), and `SessionsController` (deferred to #555).

## Changes

| File | Change |
|---|---|
| `src/gateway/BotNexus.Gateway/GatewayHost.cs` | `ResolveSessionType` is now an instance method that reads `_registry?.Get(session.AgentId)?.Kind` instead of `session.SessionId.IsSubAgent`. New optional `IAgentRegistry? registry = null` ctor parameter (preserves back-compat with the 7 test composition roots). Cached `CronChannelKey` static field to remove per-dispatch allocation. New `isNewSession` parameter to enable the persisted-AgentSubAgent preservation rule (see Critique below). |
| `tests/architecture/BotNexus.Architecture.Tests/AgentKindArchitectureTests.cs` | Removed `GatewayHost.cs` allowlist entry. Rewrote XML doc remarks to record migration history and call out `SessionsController` (#555) as the remaining deferred site. |
| `tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs` | NEW behavioural test file. 9 tests pin every row of the migration truth table including the persisted-AgentSubAgent preservation regression. |

## Critique sweep — 3 background agents

Following the standing multi-model critique policy. All three completed before commit-amendment.

| Reviewer | Model | Verdict | Adopted |
|---|---|---|---|
| `security-review` | `gpt-5.5` | ✅ **PASS** — no vulnerabilities (7 focus areas: privilege escalation, registry poisoning, TOCTOU, info disclosure, optional DI failure mode, behaviour drift vs #556, test surface) | n/a |
| `code-review` plan-vs-impl | `claude-opus-4.7` (after `4.6` returned 401) | ✅ DoD #1 & #2 PASS · ⚠️ 3 SHOULD-CONSIDERs | 2 of 3 adopted: added missing baseline truth-table row, renamed fragile literal. Skipped: dropping the "no registry injected" test (subtly different DI scenario from "null returned from registry") |
| `rubber-duck` bug-hunt | `gpt-5.3-codex` | 🔴 1 HIGH · 🟡 1 MEDIUM · 🟢 1 LOW | All 3 adopted |

### HIGH adopted (production-bug-prevention)

> **Persisted `AgentSubAgent` sessions could be silently downgraded to `UserAgent` on next dispatch** when the sub-agent descriptor had been `Unregister()`'d (sub-agent completion via `DefaultSubAgentManager.cs:557`) or was transiently absent after a gateway restart. Downstream effects include flipping `Session.IsInteractive` (`Session.cs:35`), `SessionWarmupService.cs:183-190` visibility, and `PreCompactionMemoryFlusher.cs:33-36` / `SessionEndMemoryFlusher.cs:34-36` gating.

**Fix:** threaded `isNewSession` into `ResolveSessionType` and added a fail-closed branch that preserves `AgentSubAgent` on EXISTING sessions when no typed signal contradicts. The branch deliberately requires `isNewSession=false` so fresh dispatches do NOT re-open a substring back door — the #554 architecture-fence invariant stays intact.

**Regression test:** `DispatchAsync_WhenSessionAlreadyPersistedAsAgentSubAgent_AndRegistryHasNoDescriptor_PreservesAgentSubAgent` seeds an existing `AgentSubAgent` session via `GetOrCreateAsync`, then re-dispatches with a null registry and asserts the type is preserved.

### LOW adopted

`ChannelKey.From("cron")` allocated per dispatch → cached as `private static readonly CronChannelKey`.

### Plan-vs-impl adopted

- Added baseline truth-table row: `DispatchAsync_WhenRegistryReturnsNamedDescriptor_AndSessionIdIsPlain_StampsAsUserAgent`.
- Renamed fragile literal `"session-with-subagent-descriptor"` → `"plain-session-id-1"` so the SubAgent classification can only come from the typed descriptor, not from any accidental substring match.

## Truth table (pinned by tests)

| Descriptor.Kind | SessionId shape | Channel | isNewSession | Expected SessionType | Test |
|---|---|---|---|---|---|
| SubAgent | plain | web | true | `AgentSubAgent` | `…ReturnsSubAgentDescriptor_StampsSessionTypeAsAgentSubAgent` |
| Named | `::subagent::` infix | web | true | `UserAgent` (typed signal trumps substring) | `…ReturnsNamedDescriptor_AndSessionIdHasSubAgentInfix_StampsAsUserAgent` ⭐ critical pin |
| null (registry returns null) | `::subagent::` infix | web | true | `UserAgent` (no substring fallback) | `…RegistryHasNoDescriptor_AndSessionIdHasSubAgentInfix_StampsAsUserAgent` |
| null (no registry injected) | `::subagent::` infix | web | true | `UserAgent` (no substring fallback) | `…RegistryNotProvided_AndSessionIdHasSubAgentInfix_StampsAsUserAgent` |
| null (deregister race) | any | any | **false** + persisted=AgentSubAgent | `AgentSubAgent` (preserved) | `…SessionAlreadyPersistedAsAgentSubAgent_…_PreservesAgentSubAgent` ⭐ regression pin |
| Named | plain | web | true | `UserAgent` (baseline) | `…ReturnsNamedDescriptor_AndSessionIdIsPlain_StampsAsUserAgent` |
| Named | Soul shape | web | true | `Soul` | `…WhenSessionIdIsSoul_StampsAsSoul` |
| Named | plain | cron | true | `Cron` | `…WhenChannelTypeIsCron_StampsAsCron` |
| SubAgent | plain | cron | true | `AgentSubAgent` (precedence) | `…WhenChannelTypeIsCron_AndDescriptorKindIsSubAgent_PrefersSubAgentBucketing` |

## Validation

- Build: **0 warnings, 0 errors** under `TreatWarningsAsErrors`.
- `GatewayHostResolveSessionTypeTests`: **9/9 passed** (7 original + 2 added during critique fold-in).
- `BotNexus.Gateway.Tests`: **1815/1816 passed** (1 skipped, 0 failed).
- Architecture fence (`AgentKindArchitectureTests`): **49/49 passed**.
- Full solution suite: **~4,600 passed / 41 skipped / 0 failed**.

## Follow-up

- #555 — `SessionsController` substring filter migration. Bigger scope (~200–400 LoC; requires persisting a `SessionType` discriminator on the session list query). Will be the next PR in the Phase 5 / F-6 sequence.

Closes #554
