### PR TITLE
feat(gateway): SubAgentSpawnMode = Embody | Mirror discriminated union

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/EmbodyCustomizations.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/EmbodyCustomizations.cs
@@ -1,0 +1,56 @@
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Optional per-spawn overrides applied on top of an <see cref="Embody"/> sub-agent's
+/// role defaults. Each field, when null, falls back to a sensible default derived
+/// from the role or the parent agent's descriptor. Use <see cref="Default"/> for
+/// "no overrides" rather than constructing an empty record by hand.
+///
+/// <para>By design this type is strictly pass-through — no field changes the
+/// child descriptor's effective configuration today; they are surfaced via
+/// <c>SubAgentInfo</c> (display name, metadata) or applied during background-turn
+/// dispatch. Role-derived defaults (per-role tool sets, role-specific system
+/// prompts) are scoped to GitHub issue #467 and intentionally out of scope here.</para>
+/// </summary>
+public sealed record EmbodyCustomizations
+{
+    /// <summary>
+    /// Shared "no overrides" instance. Use this instead of constructing a new
+    /// instance with all-null fields so equality checks and JSON round-trips
+    /// remain trivial.
+    /// </summary>
+    public static readonly EmbodyCustomizations Default = new();
+
+    /// <summary>
+    /// Optional friendly display name surfaced on <c>SubAgentInfo.Name</c>.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Optional system-prompt override. Currently captured but not applied to
+    /// the child descriptor (the parent descriptor's prompt is used). Reserved
+    /// for future role-prompt work tracked in #467.
+    /// </summary>
+    public string? SystemPromptOverride { get; init; }
+
+    /// <summary>
+    /// Optional model override surfaced on <c>SubAgentInfo.Model</c>. Today this
+    /// is metadata-only and does not change the model the child descriptor
+    /// invokes; that wiring is tracked separately.
+    /// </summary>
+    public string? ModelOverride { get; init; }
+
+    /// <summary>
+    /// Optional API-provider override. Currently captured but not applied to
+    /// the child descriptor.
+    /// </summary>
+    public string? ApiProviderOverride { get; init; }
+
+    /// <summary>
+    /// Optional explicit tool allowlist. When non-empty, each entry is validated
+    /// against the parent agent's effective deny-list before the spawn proceeds —
+    /// any tool denied to the parent is also denied to the child (privilege-
+    /// escalation prevention).
+    /// </summary>
+    public IReadOnlyList<string>? ToolIds { get; init; }
+}

--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnMode.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnMode.cs
@@ -1,0 +1,94 @@
+using System.Text.Json.Serialization;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Discriminated union of the two ways a sub-agent can be brought into existence:
+/// <see cref="Embody"/> — embodying a role (researcher / coder / planner / etc.)
+/// with optional per-spawn customisation; or <see cref="Mirror"/> — mirroring an
+/// already-registered named agent, using its descriptor as-is.
+///
+/// <para>This type was introduced as part of the Phase 5 / F-6 typed-discriminator
+/// refactor that replaced the bag of optional <c>TargetAgentId</c> /
+/// <c>SystemPromptOverride</c> / etc. fields on <see cref="SubAgentSpawnRequest"/>
+/// with an explicit one-of. See GitHub issue #562.</para>
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "mode")]
+[JsonDerivedType(typeof(Embody), "embody")]
+[JsonDerivedType(typeof(Mirror), "mirror")]
+public abstract record SubAgentSpawnMode;
+
+/// <summary>
+/// Spawn a sub-agent that embodies the supplied role. The role is required and
+/// must be one of the known <see cref="SubAgentArchetype"/> values
+/// (Researcher / Coder / Planner / Reviewer / Writer / General); unknown values
+/// throw <see cref="ArgumentException"/> at construction.
+/// </summary>
+public sealed record Embody : SubAgentSpawnMode
+{
+    private static readonly HashSet<string> s_knownRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        SubAgentArchetype.Researcher.Value,
+        SubAgentArchetype.Coder.Value,
+        SubAgentArchetype.Planner.Value,
+        SubAgentArchetype.Reviewer.Value,
+        SubAgentArchetype.Writer.Value,
+        SubAgentArchetype.General.Value
+    };
+
+    /// <summary>
+    /// Gets the role this sub-agent embodies. Required and validated against the
+    /// 6 known <see cref="SubAgentArchetype"/> static values at construction time
+    /// (closed-enum semantics — unknown smart-enum values produced by the open
+    /// <see cref="SubAgentArchetype.FromString"/> registry are rejected here so
+    /// the spawn contract cannot smuggle arbitrary role names through).
+    /// </summary>
+    public SubAgentArchetype Role { get; }
+
+    /// <summary>
+    /// Gets the optional per-spawn customisations applied on top of the role's
+    /// defaults. Use <see cref="EmbodyCustomizations.Default"/> when no overrides
+    /// are required.
+    /// </summary>
+    public EmbodyCustomizations Customizations { get; }
+
+    /// <summary>
+    /// Initialises a new <see cref="Embody"/> spawn mode.
+    /// </summary>
+    /// <param name="Role">Required role; must be a known <see cref="SubAgentArchetype"/> static value.</param>
+    /// <param name="Customizations">Optional per-spawn overrides. Defaults to <see cref="EmbodyCustomizations.Default"/>.</param>
+    /// <exception cref="ArgumentNullException">Either argument is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="Role"/> is not a known archetype.</exception>
+    [JsonConstructor]
+    public Embody(SubAgentArchetype Role, EmbodyCustomizations Customizations)
+    {
+        ArgumentNullException.ThrowIfNull(Role);
+        ArgumentNullException.ThrowIfNull(Customizations);
+        if (!s_knownRoles.Contains(Role.Value))
+            throw new ArgumentException(
+                $"Embody.Role must be one of the known SubAgentArchetype values " +
+                $"(researcher / coder / planner / reviewer / writer / general); got '{Role.Value}'.",
+                nameof(Role));
+
+        this.Role = Role;
+        this.Customizations = Customizations;
+    }
+
+    /// <summary>
+    /// Convenience constructor that defaults <see cref="Customizations"/> to
+    /// <see cref="EmbodyCustomizations.Default"/>.
+    /// </summary>
+    public Embody(SubAgentArchetype Role) : this(Role, EmbodyCustomizations.Default) { }
+}
+
+/// <summary>
+/// Spawn a sub-agent that mirrors a registered named agent. The named agent's
+/// descriptor (system prompt, model, tools, display name) is used as-is. Only
+/// the delegated <see cref="SubAgentSpawnRequest.Task"/> (top-level on the spawn
+/// request) differs from the named agent's normal operation. By design no
+/// per-spawn overrides are accepted; the agent-facing JSON tool returns a tool
+/// error when callers mix <c>targetAgentId</c> with override fields.
+/// </summary>
+/// <param name="TargetAgentId">Identifier of the registered agent to mirror. Must resolve in the agent registry at spawn time.</param>
+public sealed record Mirror(AgentId TargetAgentId) : SubAgentSpawnMode;

--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
@@ -89,4 +89,17 @@ public sealed record SubAgentSpawnRequest
     /// callers cannot forget to supply it.
     /// </summary>
     public required ConversationId InheritedConversationId { get; init; }
+
+    /// <summary>
+    /// The spawn mode: <see cref="Embody"/> a role with optional customisations, or
+    /// <see cref="Mirror"/> a registered named agent. Introduced in Phase 5 / F-6
+    /// step 3 (#562) to replace the bag of optional top-level fields
+    /// (<see cref="TargetAgentId"/> / <see cref="SystemPromptOverride"/> / etc.)
+    /// with an explicit discriminated union.
+    ///
+    /// <para>OPTIONAL during the migration window. When set, supersedes the
+    /// equivalent top-level fields. Will become <c>required</c> once all
+    /// callers are migrated (step 5 of the migration).</para>
+    /// </summary>
+    public SubAgentSpawnMode? Mode { get; init; }
 }

--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentSpawnRequest.cs
@@ -23,31 +23,6 @@ public sealed record SubAgentSpawnRequest
     public required string Task { get; init; }
 
     /// <summary>
-    /// Gets an optional friendly name for the sub-agent instance.
-    /// </summary>
-    public string? Name { get; init; }
-
-    /// <summary>
-    /// Gets an optional model override for the sub-agent run.
-    /// </summary>
-    public string? ModelOverride { get; init; }
-
-    /// <summary>
-    /// Gets an optional API provider override for the sub-agent run.
-    /// </summary>
-    public string? ApiProviderOverride { get; init; }
-
-    /// <summary>
-    /// Gets an optional tool allowlist for the sub-agent.
-    /// </summary>
-    public IReadOnlyList<string>? ToolIds { get; init; }
-
-    /// <summary>
-    /// Gets an optional system prompt override for the sub-agent.
-    /// </summary>
-    public string? SystemPromptOverride { get; init; }
-
-    /// <summary>
     /// Gets the maximum number of turns the sub-agent may execute.
     /// </summary>
     public int MaxTurns { get; init; } = 30;
@@ -58,22 +33,11 @@ public sealed record SubAgentSpawnRequest
     public int TimeoutSeconds { get; init; } = 600;
 
     /// <summary>
-    /// Gets the behavioral archetype to apply to the sub-agent.
-    /// </summary>
-    public SubAgentArchetype Archetype { get; init; } = SubAgentArchetype.General;
-
-    /// <summary>
     /// Gets the spawn depth of this request within the sub-agent tree.
     /// Zero means the parent is a top-level session; one means the parent is itself a sub-agent.
     /// Used to enforce <see cref="BotNexus.Gateway.Configuration.SubAgentOptions.MaxDepth"/>.
     /// </summary>
     public int SpawnDepth { get; init; }
-
-    /// <summary>
-    /// Optional registered agent ID to use as the sub-agent identity. When set, the sub-agent
-    /// runs as this agent's descriptor (system prompt, model, tools) rather than as a clone of the parent.
-    /// </summary>
-    public string? TargetAgentId { get; init; }
 
     /// <summary>
     /// Gets the union of tool names that the parent agent is denied, inherited from the
@@ -93,13 +57,9 @@ public sealed record SubAgentSpawnRequest
     /// <summary>
     /// The spawn mode: <see cref="Embody"/> a role with optional customisations, or
     /// <see cref="Mirror"/> a registered named agent. Introduced in Phase 5 / F-6
-    /// step 3 (#562) to replace the bag of optional top-level fields
-    /// (<see cref="TargetAgentId"/> / <see cref="SystemPromptOverride"/> / etc.)
-    /// with an explicit discriminated union.
-    ///
-    /// <para>OPTIONAL during the migration window. When set, supersedes the
-    /// equivalent top-level fields. Will become <c>required</c> once all
-    /// callers are migrated (step 5 of the migration).</para>
+    /// (#562) to replace the bag of optional top-level fields (TargetAgentId /
+    /// SystemPromptOverride / etc.) with an explicit discriminated union.
+    /// Required: every spawn must pick a mode at construction time.
     /// </summary>
-    public SubAgentSpawnMode? Mode { get; init; }
+    public required SubAgentSpawnMode Mode { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -104,21 +104,77 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         }
 
         var uniqueId = Guid.NewGuid().ToString("N");
-        var archetype = request.Archetype ?? SubAgentArchetype.General;
-        var childSessionId = SessionId.ForSubAgent(request.ParentSessionId, uniqueId);
         var subAgentId = uniqueId;
-        var childAgentId = AgentId.From($"{request.ParentAgentId}--subagent--{archetype.Value}--{uniqueId}");
+        var childSessionId = SessionId.ForSubAgent(request.ParentSessionId, uniqueId);
 
+        // Phase 5 / F-6 step 3 (#562): pattern-match on Mode when present (set by
+        // SubAgentSpawnTool as of step 2). Legacy callers (tests not yet migrated)
+        // still pass the old top-level fields and hit the `case null:` fallback;
+        // both shapes are removed in step 5.
+        SubAgentArchetype archetype;
         AgentDescriptor baseDescriptor;
-        if (!string.IsNullOrWhiteSpace(request.TargetAgentId))
+        AgentId childAgentId;
+        string? name;
+        string? modelOverride;
+        string? apiProviderOverride;
+        IReadOnlyList<string>? toolIds;
+        string? systemPromptOverride;
+
+        switch (request.Mode)
         {
-            var targetId = AgentId.From(request.TargetAgentId);
-            baseDescriptor = _registry.Get(targetId)
-                ?? throw new KeyNotFoundException($"Target agent '{request.TargetAgentId}' is not registered.");
-        }
-        else
-        {
-            baseDescriptor = parentDescriptor;
+            case Embody embody:
+                archetype = embody.Role;
+                baseDescriptor = parentDescriptor;
+                childAgentId = AgentId.From($"{request.ParentAgentId}--subagent--{archetype.Value}--{uniqueId}");
+                name = embody.Customizations.Name;
+                modelOverride = embody.Customizations.ModelOverride;
+                apiProviderOverride = embody.Customizations.ApiProviderOverride;
+                toolIds = embody.Customizations.ToolIds;
+                systemPromptOverride = embody.Customizations.SystemPromptOverride;
+                break;
+
+            case Mirror mirror:
+                // Mirror is strict pass-through of the target's descriptor. The
+                // archetype slot in the child agent id is filled with the target
+                // id (locked design #562) so the child surfaces the mirrored
+                // identity rather than a generic role label.
+                archetype = SubAgentArchetype.General;
+                baseDescriptor = _registry.Get(mirror.TargetAgentId)
+                    ?? throw new KeyNotFoundException($"Target agent '{mirror.TargetAgentId}' is not registered.");
+                childAgentId = AgentId.From($"{request.ParentAgentId}--subagent--{mirror.TargetAgentId.Value}--{uniqueId}");
+                name = null;
+                modelOverride = null;
+                apiProviderOverride = null;
+                toolIds = null;
+                systemPromptOverride = null;
+                break;
+
+            case null:
+                // Legacy path — read from the old top-level fields. Removed in
+                // #562 step 5 once all callsites are migrated to Mode.
+                archetype = request.Archetype ?? SubAgentArchetype.General;
+                if (!string.IsNullOrWhiteSpace(request.TargetAgentId))
+                {
+                    var targetId = AgentId.From(request.TargetAgentId);
+                    baseDescriptor = _registry.Get(targetId)
+                        ?? throw new KeyNotFoundException($"Target agent '{request.TargetAgentId}' is not registered.");
+                }
+                else
+                {
+                    baseDescriptor = parentDescriptor;
+                }
+                childAgentId = AgentId.From($"{request.ParentAgentId}--subagent--{archetype.Value}--{uniqueId}");
+                name = request.Name;
+                modelOverride = request.ModelOverride;
+                apiProviderOverride = request.ApiProviderOverride;
+                toolIds = request.ToolIds;
+                systemPromptOverride = request.SystemPromptOverride;
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown SubAgentSpawnMode subclass '{request.Mode.GetType().FullName}'. "
+                    + "Embody and Mirror are the only legal modes — see SubAgentSpawnMode.");
         }
 
         if (!_registry.Contains(childAgentId))
@@ -158,9 +214,9 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             SubAgentId = subAgentId,
             ParentSessionId = request.ParentSessionId,
             ChildSessionId = childSessionId,
-            Name = request.Name,
+            Name = name,
             Task = request.Task,
-            Model = request.ModelOverride ?? configuredDefaultModel ?? parentDescriptor.ModelId,
+            Model = modelOverride ?? configuredDefaultModel ?? parentDescriptor.ModelId,
             Archetype = archetype,
             Status = SubAgentStatus.Running,
             StartedAt = DateTimeOffset.UtcNow,

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -62,6 +62,11 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
     public async Task<SubAgentInfo> SpawnAsync(SubAgentSpawnRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        // Defence in depth: `required` is a compile-time guarantee only —
+        // callers using `null!` (or producing a null Mode via reflection / JSON
+        // deserialization quirks) would otherwise reach the default arm and
+        // hit a NullReferenceException dereferencing request.Mode.GetType().
+        ArgumentNullException.ThrowIfNull(request.Mode);
 
         var parentDescriptor = _registry.Get(request.ParentAgentId)
             ?? throw new KeyNotFoundException($"Parent agent '{request.ParentAgentId}' is not registered.");
@@ -197,7 +202,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             ChildSessionId = childSessionId,
             Name = name,
             Task = request.Task,
-            Model = modelOverride ?? configuredDefaultModel ?? parentDescriptor.ModelId,
+            Model = modelOverride ?? configuredDefaultModel ?? baseDescriptor.ModelId,
             Archetype = archetype,
             Status = SubAgentStatus.Running,
             StartedAt = DateTimeOffset.UtcNow,

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -76,21 +76,6 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
                     $"Cannot spawn sub-agent: parent session depth {depth} has reached the maximum depth of {maxDepth}.");
         }
 
-        // Validate tool grants against parent's deny-list (privilege escalation prevention)
-        if (_policyProvider is not null && request.ToolIds is { Count: > 0 })
-        {
-            var parentDenyList = _policyProvider.GetEffectiveDenyList(request.ParentAgentId.Value);
-            if (parentDenyList.Count > 0)
-            {
-                var denied = request.ToolIds
-                    .Where(t => parentDenyList.Contains(t, StringComparer.OrdinalIgnoreCase))
-                    .ToList();
-                if (denied.Count > 0)
-                    throw new InvalidOperationException(
-                        $"Sub-agent cannot be granted tools denied to the parent: {string.Join(", ", denied)}");
-            }
-        }
-
         var maxConcurrent = _options.CurrentValue.SubAgents.MaxConcurrentPerSession;
         if (maxConcurrent > 0)
         {
@@ -107,10 +92,11 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
         var subAgentId = uniqueId;
         var childSessionId = SessionId.ForSubAgent(request.ParentSessionId, uniqueId);
 
-        // Phase 5 / F-6 step 3 (#562): pattern-match on Mode when present (set by
-        // SubAgentSpawnTool as of step 2). Legacy callers (tests not yet migrated)
-        // still pass the old top-level fields and hit the `case null:` fallback;
-        // both shapes are removed in step 5.
+        // Phase 5 / F-6 (#562): pattern-match on the required Mode discriminated
+        // union. Mode is `required` on SubAgentSpawnRequest as of step 5, so the
+        // null case is structurally unreachable — the default arm exists only to
+        // catch a future third subclass of SubAgentSpawnMode being added without
+        // updating this switch.
         SubAgentArchetype archetype;
         AgentDescriptor baseDescriptor;
         AgentId childAgentId;
@@ -149,32 +135,27 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
                 systemPromptOverride = null;
                 break;
 
-            case null:
-                // Legacy path — read from the old top-level fields. Removed in
-                // #562 step 5 once all callsites are migrated to Mode.
-                archetype = request.Archetype ?? SubAgentArchetype.General;
-                if (!string.IsNullOrWhiteSpace(request.TargetAgentId))
-                {
-                    var targetId = AgentId.From(request.TargetAgentId);
-                    baseDescriptor = _registry.Get(targetId)
-                        ?? throw new KeyNotFoundException($"Target agent '{request.TargetAgentId}' is not registered.");
-                }
-                else
-                {
-                    baseDescriptor = parentDescriptor;
-                }
-                childAgentId = AgentId.From($"{request.ParentAgentId}--subagent--{archetype.Value}--{uniqueId}");
-                name = request.Name;
-                modelOverride = request.ModelOverride;
-                apiProviderOverride = request.ApiProviderOverride;
-                toolIds = request.ToolIds;
-                systemPromptOverride = request.SystemPromptOverride;
-                break;
-
             default:
                 throw new InvalidOperationException(
                     $"Unknown SubAgentSpawnMode subclass '{request.Mode.GetType().FullName}'. "
                     + "Embody and Mirror are the only legal modes — see SubAgentSpawnMode.");
+        }
+
+        // Validate tool grants against parent's deny-list (privilege escalation
+        // prevention). Runs AFTER the switch so it reads the typed `toolIds`
+        // local resolved from Mode, not a deleted top-level request field.
+        if (_policyProvider is not null && toolIds is { Count: > 0 })
+        {
+            var parentDenyList = _policyProvider.GetEffectiveDenyList(request.ParentAgentId.Value);
+            if (parentDenyList.Count > 0)
+            {
+                var denied = toolIds
+                    .Where(t => parentDenyList.Contains(t, StringComparer.OrdinalIgnoreCase))
+                    .ToList();
+                if (denied.Count > 0)
+                    throw new InvalidOperationException(
+                        $"Sub-agent cannot be granted tools denied to the parent: {string.Join(", ", denied)}");
+            }
         }
 
         if (!_registry.Contains(childAgentId))

--- a/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
@@ -69,21 +69,44 @@ public sealed class SubAgentSpawnTool(
         var task = ReadString(arguments, "task")
             ?? throw new ArgumentException("Missing required argument: task.");
 
+        var name = ReadString(arguments, "name");
+        var modelOverride = ReadString(arguments, "model");
+        var apiProviderOverride = ReadString(arguments, "apiProvider");
+        var toolIds = ReadStringArray(arguments, "tools");
+        var systemPromptOverride = ReadString(arguments, "systemPrompt");
+        var archetypeRaw = ReadString(arguments, "archetype");
+        var targetAgentId = ReadString(arguments, "targetAgentId");
+
+        // Phase 5 / F-6 step 3 (#562): Mode rejects mode-mixing.
+        // When the caller asks to mirror an existing named agent, none of the
+        // embody-only customisation fields may be supplied — Mirror is strict
+        // pass-through of the target's full descriptor. Build the Mode union
+        // here so DefaultSubAgentManager can prefer it over the legacy bag.
+        var mode = BuildSpawnMode(
+            targetAgentId: targetAgentId,
+            name: name,
+            modelOverride: modelOverride,
+            apiProviderOverride: apiProviderOverride,
+            toolIds: toolIds,
+            systemPromptOverride: systemPromptOverride,
+            archetypeRaw: archetypeRaw);
+
         var request = new SubAgentSpawnRequest
         {
             ParentAgentId = agentId,
             ParentSessionId = sessionId,
             Task = task,
-            Name = ReadString(arguments, "name"),
-            ModelOverride = ReadString(arguments, "model"),
-            ApiProviderOverride = ReadString(arguments, "apiProvider"),
-            ToolIds = ReadStringArray(arguments, "tools"),
-            SystemPromptOverride = ReadString(arguments, "systemPrompt"),
+            Name = name,
+            ModelOverride = modelOverride,
+            ApiProviderOverride = apiProviderOverride,
+            ToolIds = toolIds,
+            SystemPromptOverride = systemPromptOverride,
             MaxTurns = ReadInt(arguments, "maxTurns", 30),
             TimeoutSeconds = ReadInt(arguments, "timeoutSeconds", 600),
-            Archetype = ReadArchetype(arguments),
-            TargetAgentId = ReadString(arguments, "targetAgentId"),
-            InheritedConversationId = conversationId
+            Archetype = ResolveArchetype(archetypeRaw),
+            TargetAgentId = targetAgentId,
+            InheritedConversationId = conversationId,
+            Mode = mode
         };
 
         var spawned = await subAgentManager.SpawnAsync(request, cancellationToken).ConfigureAwait(false);
@@ -97,6 +120,68 @@ public sealed class SubAgentSpawnTool(
 
         return TextResult(result);
     }
+
+    private static SubAgentSpawnMode BuildSpawnMode(
+        string? targetAgentId,
+        string? name,
+        string? modelOverride,
+        string? apiProviderOverride,
+        IReadOnlyList<string>? toolIds,
+        string? systemPromptOverride,
+        string? archetypeRaw)
+    {
+        if (!string.IsNullOrWhiteSpace(targetAgentId))
+        {
+            var conflicts = new List<string>(6);
+            if (!string.IsNullOrWhiteSpace(name)) conflicts.Add("name");
+            if (!string.IsNullOrWhiteSpace(modelOverride)) conflicts.Add("model");
+            if (!string.IsNullOrWhiteSpace(apiProviderOverride)) conflicts.Add("apiProvider");
+            if (toolIds is { Count: > 0 }) conflicts.Add("tools");
+            if (!string.IsNullOrWhiteSpace(systemPromptOverride)) conflicts.Add("systemPrompt");
+            if (!string.IsNullOrWhiteSpace(archetypeRaw)) conflicts.Add("archetype");
+
+            if (conflicts.Count > 0)
+            {
+                throw new ArgumentException(
+                    $"targetAgentId is incompatible with embody-only fields: {string.Join(", ", conflicts)}. "
+                    + "Mirror mode runs the target agent's full descriptor verbatim — supply targetAgentId alone, "
+                    + "or omit it and customise via embody fields.");
+            }
+
+            return new Mirror(AgentId.From(targetAgentId));
+        }
+
+        var archetype = ResolveArchetype(archetypeRaw);
+        var customizations = HasAnyEmbodyCustomization(name, modelOverride, apiProviderOverride, toolIds, systemPromptOverride)
+            ? new EmbodyCustomizations
+            {
+                Name = name,
+                ModelOverride = modelOverride,
+                ApiProviderOverride = apiProviderOverride,
+                ToolIds = toolIds,
+                SystemPromptOverride = systemPromptOverride
+            }
+            : EmbodyCustomizations.Default;
+
+        return new Embody(archetype, customizations);
+    }
+
+    private static bool HasAnyEmbodyCustomization(
+        string? name,
+        string? modelOverride,
+        string? apiProviderOverride,
+        IReadOnlyList<string>? toolIds,
+        string? systemPromptOverride)
+        => !string.IsNullOrWhiteSpace(name)
+        || !string.IsNullOrWhiteSpace(modelOverride)
+        || !string.IsNullOrWhiteSpace(apiProviderOverride)
+        || toolIds is { Count: > 0 }
+        || !string.IsNullOrWhiteSpace(systemPromptOverride);
+
+    private static SubAgentArchetype ResolveArchetype(string? archetypeRaw)
+        => string.IsNullOrWhiteSpace(archetypeRaw)
+            ? SubAgentArchetype.General
+            : SubAgentArchetype.FromString(archetypeRaw);
 
     private static string? ReadString(IReadOnlyDictionary<string, object?> args, string key)
     {
@@ -153,14 +238,6 @@ public sealed class SubAgentSpawnTool(
         }
 
         return null;
-    }
-
-    private static SubAgentArchetype ReadArchetype(IReadOnlyDictionary<string, object?> args)
-    {
-        var archetype = ReadString(args, "archetype");
-        return string.IsNullOrWhiteSpace(archetype)
-            ? SubAgentArchetype.General
-            : SubAgentArchetype.FromString(archetype);
     }
 
     private static AgentToolResult TextResult(string text)

--- a/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/SubAgentSpawnTool.cs
@@ -96,15 +96,8 @@ public sealed class SubAgentSpawnTool(
             ParentAgentId = agentId,
             ParentSessionId = sessionId,
             Task = task,
-            Name = name,
-            ModelOverride = modelOverride,
-            ApiProviderOverride = apiProviderOverride,
-            ToolIds = toolIds,
-            SystemPromptOverride = systemPromptOverride,
             MaxTurns = ReadInt(arguments, "maxTurns", 30),
             TimeoutSeconds = ReadInt(arguments, "timeoutSeconds", 600),
-            Archetype = ResolveArchetype(archetypeRaw),
-            TargetAgentId = targetAgentId,
             InheritedConversationId = conversationId,
             Mode = mode
         };

--- a/tests/architecture/BotNexus.Architecture.Tests/SubAgentSpawnRequestShapeTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SubAgentSpawnRequestShapeTests.cs
@@ -1,0 +1,191 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 5 / F-6 (#562 step 5)
+/// final shape of <see cref="SubAgentSpawnRequest"/>: the bag of optional
+/// top-level fields (<c>TargetAgentId</c>, <c>Name</c>, <c>ModelOverride</c>,
+/// <c>ApiProviderOverride</c>, <c>ToolIds</c>, <c>SystemPromptOverride</c>,
+/// <c>Archetype</c>) has been collapsed into a required <c>Mode</c> property of
+/// type <see cref="SubAgentSpawnMode"/> — a discriminated union of
+/// <see cref="Embody"/> and <see cref="Mirror"/>.
+/// </summary>
+/// <remarks>
+/// The old shape allowed callers to populate any subset of the legacy fields
+/// and the runtime path silently picked an interpretation. The new shape
+/// forces every spawn to pick exactly one of the two modes at construction
+/// time. These fences make the regression structurally impossible:
+/// 1. The seven deleted properties must not exist on the type.
+/// 2. <c>Mode</c> must exist, be <c>required</c>, typed as
+///    <see cref="SubAgentSpawnMode"/>, and non-nullable.
+/// 3. <c>DefaultSubAgentManager.SpawnAsync</c> must pattern-match on
+///    <c>request.Mode</c> rather than reading any legacy field.
+/// </remarks>
+public sealed class SubAgentSpawnRequestShapeTests
+{
+    private static readonly string[] s_deletedLegacyProperties =
+    {
+        "TargetAgentId",
+        "Name",
+        "ModelOverride",
+        "ApiProviderOverride",
+        "ToolIds",
+        "SystemPromptOverride",
+        "Archetype",
+    };
+
+    /// <summary>
+    /// Asserts each legacy property removed in #562 step 5 no longer exists
+    /// on <see cref="SubAgentSpawnRequest"/>. If any one reappears, the
+    /// mode-bag bug class is re-opened.
+    /// </summary>
+    [Fact]
+    public void SubAgentSpawnRequest_DoesNotExpose_LegacyFields()
+    {
+        var requestType = typeof(SubAgentSpawnRequest);
+        var resurrected = s_deletedLegacyProperties
+            .Where(name => requestType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance) is not null)
+            .ToArray();
+
+        resurrected.ShouldBeEmpty(
+            "SubAgentSpawnRequest has resurrected one or more legacy " +
+            "properties that were deleted in #562 step 5. The Mode discriminated " +
+            "union (Embody | Mirror) is now the single source of truth for spawn " +
+            "intent; reintroducing any of these fields reopens the mode-bag bug " +
+            "class (callers populating an inconsistent subset that the runtime " +
+            "silently interprets).\n" +
+            "Resurrected: " + string.Join(", ", resurrected));
+    }
+
+    /// <summary>
+    /// Asserts <c>Mode</c> is declared as a <c>required</c> non-nullable
+    /// <see cref="SubAgentSpawnMode"/>. The required modifier prevents pinless
+    /// construction at compile time; the non-nullable type makes the null
+    /// case structurally unreachable inside <c>DefaultSubAgentManager.SpawnAsync</c>.
+    /// </summary>
+    [Fact]
+    public void SubAgentSpawnRequest_Mode_IsRequired_AndTypedAsSubAgentSpawnMode()
+    {
+        var modeProperty = typeof(SubAgentSpawnRequest)
+            .GetProperty("Mode", BindingFlags.Public | BindingFlags.Instance);
+
+        modeProperty.ShouldNotBeNull(
+            "SubAgentSpawnRequest must expose a public instance property named " +
+            "'Mode'. It carries the Embody | Mirror discriminated union and is " +
+            "the single source of truth for spawn intent.");
+
+        modeProperty!.PropertyType.ShouldBe(typeof(SubAgentSpawnMode),
+            "SubAgentSpawnRequest.Mode must be typed as SubAgentSpawnMode (the " +
+            "discriminated-union root), not a concrete subclass or an interface. " +
+            "Pattern-matching on Mode in DefaultSubAgentManager.SpawnAsync " +
+            "depends on the root type being exposed.");
+
+        modeProperty.CustomAttributes
+            .Any(attr => attr.AttributeType == typeof(RequiredMemberAttribute))
+            .ShouldBeTrue(
+                "SubAgentSpawnRequest.Mode must be marked with the 'required' " +
+                "modifier (RequiredMemberAttribute). Without it, callers can " +
+                "construct a request with Mode = null and the manager's switch " +
+                "loses its compile-time guarantee.");
+
+        var nullabilityContext = new NullabilityInfoContext();
+        var nullability = nullabilityContext.Create(modeProperty);
+        nullability.WriteState.ShouldBe(NullabilityState.NotNull,
+            "SubAgentSpawnRequest.Mode must be a non-nullable reference. A " +
+            "nullable Mode forces the manager to keep a legacy fallback arm and " +
+            "defeats the discriminated-union contract.");
+    }
+
+    /// <summary>
+    /// Source-scan on <c>DefaultSubAgentManager.cs</c>: the spawn path must
+    /// pattern-match on <c>request.Mode</c> and must not read any of the
+    /// deleted legacy fields. Catches a regression where someone re-adds a
+    /// property to <see cref="SubAgentSpawnRequest"/> and starts reading it
+    /// in the manager.
+    /// </summary>
+    [Fact]
+    public void DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields()
+    {
+        var managerPath = LocateManagerFile();
+        var source = File.ReadAllText(managerPath);
+
+        var hasModeSwitch = source.Contains("switch (request.Mode)", StringComparison.Ordinal);
+        var hasEmbodyPattern = source.Contains("Embody embody", StringComparison.Ordinal);
+        var hasMirrorPattern = source.Contains("Mirror mirror", StringComparison.Ordinal);
+
+        (hasModeSwitch || (hasEmbodyPattern && hasMirrorPattern)).ShouldBeTrue(
+            "DefaultSubAgentManager.cs must drive spawn behaviour by " +
+            "pattern-matching on request.Mode (either `switch (request.Mode)` " +
+            "or `is Embody` plus `is Mirror`). The discriminated-union contract " +
+            "from #562 step 5 requires Mode to be the single source of truth.\n" +
+            "File: " + managerPath);
+
+        var leakedReads = s_deletedLegacyProperties
+            .Where(name => source.Contains("request." + name, StringComparison.Ordinal))
+            .ToArray();
+
+        leakedReads.ShouldBeEmpty(
+            "DefaultSubAgentManager.cs reads at least one legacy spawn-request " +
+            "field that was deleted in #562 step 5. These reads must go through " +
+            "the typed Mode arms (Embody / Mirror) — re-adding them resurrects " +
+            "the bag-of-optionals shape and silently widens the runtime contract.\n" +
+            "Leaked reads: " + string.Join(", ", leakedReads.Select(name => "request." + name)) + "\n" +
+            "File: " + managerPath);
+    }
+
+    /// <summary>
+    /// Vacuity guard: the legacy-property scan in
+    /// <see cref="DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields"/>
+    /// must actually catch a violation when one is present. This synthetic
+    /// shape would slip through silently if the fence regex were ever broken.
+    /// </summary>
+    [Fact]
+    public void Fence_DetectsSyntheticLegacyFieldRead()
+    {
+        var syntheticSource = """
+            namespace Synthetic;
+            public sealed class Probe
+            {
+                public void Spawn(object request)
+                {
+                    var x = request.TargetAgentId; // synthetic violation
+                }
+            }
+            """;
+
+        var leaks = s_deletedLegacyProperties
+            .Where(name => syntheticSource.Contains("request." + name, StringComparison.Ordinal))
+            .ToArray();
+
+        leaks.ShouldContain("TargetAgentId",
+            "The legacy-field scan failed to detect a synthetic `request.TargetAgentId` " +
+            "read. The fence in DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields " +
+            "would also silently miss real violations.");
+    }
+
+    private static string LocateManagerFile()
+    {
+        var srcRoot = FindSourceRoot();
+        var path = Path.Combine(srcRoot, "gateway", "BotNexus.Gateway", "Agents", "DefaultSubAgentManager.cs");
+        File.Exists(path).ShouldBeTrue("Expected DefaultSubAgentManager.cs at " + path);
+        return path;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current!.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SubAgentSpawnRequestShapeTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SubAgentSpawnRequestShapeTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using BotNexus.Gateway.Abstractions.Models;
 using Shouldly;
 
@@ -100,6 +101,18 @@ public sealed class SubAgentSpawnRequestShapeTests
             "defeats the discriminated-union contract.");
     }
 
+    private static readonly Regex s_modeSwitchPattern = new(
+        @"switch\s*\(\s*request\.Mode\s*\)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex s_embodyPattern = new(
+        @"\b(is|case)\s+Embody\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex s_mirrorPattern = new(
+        @"\b(is|case)\s+Mirror\b",
+        RegexOptions.Compiled);
+
     /// <summary>
     /// Source-scan on <c>DefaultSubAgentManager.cs</c>: the spawn path must
     /// pattern-match on <c>request.Mode</c> and must not read any of the
@@ -113,15 +126,16 @@ public sealed class SubAgentSpawnRequestShapeTests
         var managerPath = LocateManagerFile();
         var source = File.ReadAllText(managerPath);
 
-        var hasModeSwitch = source.Contains("switch (request.Mode)", StringComparison.Ordinal);
-        var hasEmbodyPattern = source.Contains("Embody embody", StringComparison.Ordinal);
-        var hasMirrorPattern = source.Contains("Mirror mirror", StringComparison.Ordinal);
+        var hasModeSwitch = s_modeSwitchPattern.IsMatch(source);
+        var hasEmbodyPattern = s_embodyPattern.IsMatch(source);
+        var hasMirrorPattern = s_mirrorPattern.IsMatch(source);
 
         (hasModeSwitch || (hasEmbodyPattern && hasMirrorPattern)).ShouldBeTrue(
             "DefaultSubAgentManager.cs must drive spawn behaviour by " +
             "pattern-matching on request.Mode (either `switch (request.Mode)` " +
-            "or `is Embody` plus `is Mirror`). The discriminated-union contract " +
-            "from #562 step 5 requires Mode to be the single source of truth.\n" +
+            "or `is Embody` / `case Embody` plus `is Mirror` / `case Mirror`). " +
+            "The discriminated-union contract from #562 step 5 requires Mode " +
+            "to be the single source of truth.\n" +
             "File: " + managerPath);
 
         var leakedReads = s_deletedLegacyProperties
@@ -138,10 +152,10 @@ public sealed class SubAgentSpawnRequestShapeTests
     }
 
     /// <summary>
-    /// Vacuity guard: the legacy-property scan in
-    /// <see cref="DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields"/>
-    /// must actually catch a violation when one is present. This synthetic
-    /// shape would slip through silently if the fence regex were ever broken.
+    /// Vacuity guard for the legacy-field scan in
+    /// <see cref="DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields"/>:
+    /// the synthetic shape must be caught. Without this test, a broken regex
+    /// would silently pass on real violations.
     /// </summary>
     [Fact]
     public void Fence_DetectsSyntheticLegacyFieldRead()
@@ -165,6 +179,53 @@ public sealed class SubAgentSpawnRequestShapeTests
             "The legacy-field scan failed to detect a synthetic `request.TargetAgentId` " +
             "read. The fence in DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields " +
             "would also silently miss real violations.");
+    }
+
+    /// <summary>
+    /// Vacuity guard for the switch / pattern detection clause in
+    /// <see cref="DefaultSubAgentManager_PatternMatchesOnMode_NotLegacyFields"/>.
+    /// Three synthetic shapes must be matched by their respective regexes
+    /// (`switch (request.Mode)`, `is Embody`, `case Mirror`); a clean shape
+    /// that contains none of them must be rejected. Without this guard a
+    /// regex regression could silently downgrade the fence to a no-op while
+    /// the legacy-field scan continues to pass on its own.
+    /// </summary>
+    [Fact]
+    public void Fence_DetectsSyntheticModeSwitchShapes()
+    {
+        // Realistic mutations: missing space after `switch`, padded parens —
+        // shapes an IDE or human might produce. `request . Mode` with spaces
+        // inside the dotted access is not a realistic mutation (no formatter
+        // emits it) and is deliberately not pinned.
+        const string syntheticSwitchNoSpace = "var x = switch(request.Mode) { _ => 0 };";
+        s_modeSwitchPattern.IsMatch(syntheticSwitchNoSpace).ShouldBeTrue(
+            "The mode-switch regex failed to match `switch(request.Mode)` " +
+            "(missing space after switch). Real code in this shape would " +
+            "slip past the fence.");
+
+        const string syntheticSwitchPadded = "var x = switch ( request.Mode ) { _ => 0 };";
+        s_modeSwitchPattern.IsMatch(syntheticSwitchPadded).ShouldBeTrue(
+            "The mode-switch regex failed to match `switch ( request.Mode )` " +
+            "(padded parens). Real code in this shape would slip past the fence.");
+
+        const string syntheticIsEmbody = "if (request.Mode is Embody e) { return; }";
+        s_embodyPattern.IsMatch(syntheticIsEmbody).ShouldBeTrue(
+            "The Embody-pattern regex failed to match `is Embody e`. " +
+            "Pattern-match regressions would slip past the fence.");
+
+        const string syntheticCaseMirror = "switch (m) { case Mirror x: break; }";
+        s_mirrorPattern.IsMatch(syntheticCaseMirror).ShouldBeTrue(
+            "The Mirror-pattern regex failed to match `case Mirror x`. " +
+            "Pattern-match regressions would slip past the fence.");
+
+        const string cleanShape = "var p = parentDescriptor.ModelId;";
+        s_modeSwitchPattern.IsMatch(cleanShape).ShouldBeFalse(
+            "The mode-switch regex falsely matched clean source. The fence " +
+            "would emit spurious failures on unrelated edits.");
+        s_embodyPattern.IsMatch(cleanShape).ShouldBeFalse(
+            "The Embody-pattern regex falsely matched clean source.");
+        s_mirrorPattern.IsMatch(cleanShape).ShouldBeFalse(
+            "The Mirror-pattern regex falsely matched clean source.");
     }
 
     private static string LocateManagerFile()

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/DefaultSubAgentManagerActivityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/DefaultSubAgentManagerActivityTests.cs
@@ -117,6 +117,7 @@ public sealed class DefaultSubAgentManagerActivityTests
             ParentAgentId = BotNexus.Domain.Primitives.AgentId.From("parent-agent"),
             ParentSessionId = BotNexus.Domain.Primitives.SessionId.From("parent-session"),
             Task = "Do background work",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/DefaultSubAgentManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/DefaultSubAgentManagerTests.cs
@@ -223,6 +223,7 @@ public sealed class DefaultSubAgentManagerTests
             ParentSessionId = parentSessionId ?? BotNexus.Domain.Primitives.SessionId.From("parent-session"),
             Task = "Investigate timeout",
             TimeoutSeconds = timeoutSeconds,
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 
@@ -304,14 +305,15 @@ public sealed class DefaultSubAgentManagerTests
             var startedAt = DateTimeOffset.UtcNow;
             var timeoutSeconds = request.TimeoutSeconds > 0 ? request.TimeoutSeconds : options.DefaultTimeoutSeconds;
 
+            var customizations = (request.Mode as Embody)?.Customizations ?? EmbodyCustomizations.Default;
             var info = new SubAgentInfo
             {
                 SubAgentId = subAgentId,
                 ParentSessionId = request.ParentSessionId,
                 ChildSessionId = childSessionId,
-                Name = request.Name,
+                Name = customizations.Name,
                 Task = request.Task,
-                Model = request.ModelOverride ?? options.DefaultModel,
+                Model = customizations.ModelOverride ?? options.DefaultModel,
                 Status = SubAgentStatus.Running,
                 StartedAt = startedAt
             };

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentArchetypeIdentityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentArchetypeIdentityTests.cs
@@ -65,7 +65,7 @@ public sealed class SubAgentArchetypeIdentityTests
             ParentAgentId = parentAgentId,
             ParentSessionId = parentSessionId,
             Task = "Investigate issue",
-            Archetype = SubAgentArchetype.Reviewer,
+            Mode = new Embody(SubAgentArchetype.Reviewer),
             InheritedConversationId = ConversationId.From("inherited-conv")
         });
 
@@ -125,6 +125,7 @@ public sealed class SubAgentArchetypeIdentityTests
             ParentAgentId = parentAgentId,
             ParentSessionId = parentSessionId,
             Task = "Investigate issue",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         });
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentCompletionWakeDeliveryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentCompletionWakeDeliveryTests.cs
@@ -199,6 +199,7 @@ public sealed class SubAgentCompletionWakeDeliveryTests
             ParentAgentId = AgentId.From("parent-agent"),
             ParentSessionId = SessionId.From("parent-session"),
             Task = "Do background work",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentCompletionWakeUpTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentCompletionWakeUpTests.cs
@@ -144,6 +144,7 @@ public sealed class SubAgentCompletionWakeUpTests
             ParentAgentId = AgentId.From("parent-agent"),
             ParentSessionId = SessionId.From("parent-session"),
             Task = "Do background work",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentEagerConversationPinTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentEagerConversationPinTests.cs
@@ -57,6 +57,7 @@ public sealed class SubAgentEagerConversationPinTests
             ParentAgentId = AgentId.From("parent"),
             ParentSessionId = SessionId.From("parent-session"),
             Task = "x",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("conv-1")
         };
 
@@ -117,6 +118,7 @@ public sealed class SubAgentEagerConversationPinTests
             ParentAgentId = AgentId.From("parent"),
             ParentSessionId = SessionId.From("parent-session"),
             Task = "x",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("conv-99")
         };
 
@@ -167,6 +169,7 @@ public sealed class SubAgentEagerConversationPinTests
             ParentAgentId = AgentId.From("parent"),
             ParentSessionId = SessionId.From("parent-session"),
             Task = "go",
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("conv-order")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -276,6 +276,7 @@ public sealed class SubAgentIntegrationTests
             ParentSessionId = BotNexus.Domain.Primitives.SessionId.From("parent-session"),
             Task = "Investigate flaky test",
             TimeoutSeconds = timeoutSeconds,
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
@@ -101,7 +101,7 @@ public sealed class SubAgentKindTests
             ParentSessionId = SessionId.From("parent-session"),
             Task = "Investigate via mirror of researcher-prime",
             TimeoutSeconds = 600,
-            TargetAgentId = "researcher-prime",
+            Mode = new Mirror(AgentId.From("researcher-prime")),
             InheritedConversationId = ConversationId.From("inherited-conv")
         });
 
@@ -330,6 +330,7 @@ public sealed class SubAgentKindTests
             ParentSessionId = SessionId.From("parent-session"),
             Task = "Investigate flaky test",
             TimeoutSeconds = 600,
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentModelsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentModelsTests.cs
@@ -16,7 +16,7 @@ public sealed class SubAgentModelsTests
             .Select(property => property.Name)
             .ToArray();
 
-        requiredProperties.ShouldBe(new[] { "ParentAgentId", "ParentSessionId", "Task", "InheritedConversationId" }, ignoreOrder: true);
+        requiredProperties.ShouldBe(new[] { "ParentAgentId", "ParentSessionId", "Task", "InheritedConversationId", "Mode" }, ignoreOrder: true);
     }
 
     [Fact]
@@ -27,17 +27,15 @@ public sealed class SubAgentModelsTests
             ParentAgentId = BotNexus.Domain.Primitives.AgentId.From("parent-agent"),
             ParentSessionId = BotNexus.Domain.Primitives.SessionId.From("parent-session"),
             Task = "Analyze issue",
-            InheritedConversationId = ConversationId.From("inherited-conv")
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = new Embody(SubAgentArchetype.General)
         };
 
         request.MaxTurns.ShouldBe(30);
         request.TimeoutSeconds.ShouldBe(600);
-        request.Name.ShouldBeNull();
-        request.ModelOverride.ShouldBeNull();
-        request.ApiProviderOverride.ShouldBeNull();
-        request.ToolIds.ShouldBeNull();
-        request.SystemPromptOverride.ShouldBeNull();
-        request.Archetype.ShouldBe(SubAgentArchetype.General);
+        request.SpawnDepth.ShouldBe(0);
+        request.ParentToolDenyList.ShouldBeNull();
+        request.Mode.ShouldBeOfType<Embody>();
     }
 
     [Fact]
@@ -48,8 +46,8 @@ public sealed class SubAgentModelsTests
             ParentAgentId = BotNexus.Domain.Primitives.AgentId.From("parent-agent"),
             ParentSessionId = BotNexus.Domain.Primitives.SessionId.From("parent-session"),
             Task = "Analyze issue",
-            Name = "researcher",
-            InheritedConversationId = ConversationId.From("inherited-conv")
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = new Embody(SubAgentArchetype.Researcher)
         };
 
         var equalCopy = baseline with { };

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnDepthTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnDepthTests.cs
@@ -127,6 +127,7 @@ public sealed class SubAgentSpawnDepthTests
             ParentSessionId = parentSessionId ?? SessionId.From("root-session"),
             Task = "Do something",
             TimeoutSeconds = 600,
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeRoutingTests.cs
@@ -125,6 +125,13 @@ public sealed class SubAgentSpawnModeRoutingTests
 
         result.ShouldNotBeNull();
         result.Status.ShouldBe(SubAgentStatus.Running);
+        // Bug-hunt MEDIUM (#562): Mirror's model fallback must derive from the
+        // mirrored target's descriptor, not the parent's. A regression to
+        // `parentDescriptor.ModelId` would report "gpt-4o" here instead of
+        // the target's "claude-sonnet-4" — silent metadata corruption that
+        // downstream telemetry / cost accounting would compute against the
+        // wrong model.
+        result.Model.ShouldBe("claude-sonnet-4");
         registeredDescriptor.Value.ShouldNotBeNull();
         registeredDescriptor.Value!.ModelId.ShouldBe("claude-sonnet-4");
         registeredDescriptor.Value.SystemPrompt.ShouldBe("You are Farnsworth, a coding assistant.");
@@ -161,6 +168,40 @@ public sealed class SubAgentSpawnModeRoutingTests
         var ex = await Should.ThrowAsync<KeyNotFoundException>(
             () => manager.SpawnAsync(request));
         ex.Message.ShouldContain("ghost-agent");
+    }
+
+    /// <summary>
+    /// Bug-hunt HIGH (#562): <c>required</c> is a compile-time guarantee
+    /// only. Callers using <c>null!</c> or JSON deserialization quirks can
+    /// surface a runtime null Mode. The manager must reject this with a
+    /// clean <see cref="ArgumentNullException"/> rather than hitting the
+    /// default switch arm and dereferencing <c>request.Mode.GetType()</c>
+    /// (NullReferenceException would propagate as an HTTP 500 to callers).
+    /// </summary>
+    [Fact]
+    public async Task SpawnAsync_WithNullMode_ThrowsArgumentNullException()
+    {
+        var (manager, _, _, _) = BuildHarness(
+            parentDescriptor: new AgentDescriptor
+            {
+                AgentId = AgentId.From("nova"),
+                DisplayName = "Nova",
+                ModelId = "gpt-4o",
+                ApiProvider = "openai"
+            });
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("nova"),
+            ParentSessionId = SessionId.From("nova-session"),
+            Task = "Do something",
+            TimeoutSeconds = 600,
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = null!
+        };
+
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => manager.SpawnAsync(request));
     }
 
     private static (

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeRoutingTests.cs
@@ -1,0 +1,222 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Security;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Tests for <see cref="DefaultSubAgentManager"/> Mode-driven spawn path
+/// introduced in Phase 5 / F-6 step 3 (#562). These pin the new
+/// SubAgentSpawnMode = Embody | Mirror discriminated union behaviour
+/// independently from the legacy top-level field path, which is covered
+/// by <see cref="SubAgentTargetAgentIdTests"/>.
+/// </summary>
+public sealed class SubAgentSpawnModeRoutingTests
+{
+    [Fact]
+    public async Task SpawnAsync_WithModeEmbody_ClonesParentDescriptor_AndChildIdUsesArchetypeSlot()
+    {
+        var (manager, registry, registeredDescriptor, registeredAgentId) = BuildHarness(
+            parentDescriptor: new AgentDescriptor
+            {
+                AgentId = AgentId.From("nova"),
+                DisplayName = "Nova",
+                ModelId = "gpt-4o",
+                ApiProvider = "openai",
+                SystemPrompt = "You are Nova."
+            });
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("nova"),
+            ParentSessionId = SessionId.From("nova-session"),
+            Task = "Write some code",
+            TimeoutSeconds = 600,
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = new Embody(SubAgentArchetype.Coder)
+        };
+
+        var result = await manager.SpawnAsync(request);
+
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe(SubAgentStatus.Running);
+        result.Archetype.ShouldBe(SubAgentArchetype.Coder);
+        registeredDescriptor.Value.ShouldNotBeNull();
+        registeredDescriptor.Value!.ModelId.ShouldBe("gpt-4o");
+        registeredDescriptor.Value.SystemPrompt.ShouldBe("You are Nova.");
+        registeredDescriptor.Value.Kind.ShouldBe(AgentKind.SubAgent);
+        registeredDescriptor.Value.DisplayName.ShouldContain("(coder)");
+        registeredAgentId.Value.ShouldNotBeNull();
+        registeredAgentId.Value!.Value.Value.ShouldStartWith("nova--subagent--coder--");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_WithModeEmbody_CustomisationsPropagateTo_SubAgentInfo()
+    {
+        var (manager, _, _, _) = BuildHarness(
+            parentDescriptor: new AgentDescriptor
+            {
+                AgentId = AgentId.From("nova"),
+                DisplayName = "Nova",
+                ModelId = "gpt-4o",
+                ApiProvider = "openai"
+            });
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("nova"),
+            ParentSessionId = SessionId.From("nova-session"),
+            Task = "T",
+            TimeoutSeconds = 600,
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = new Embody(
+                SubAgentArchetype.Reviewer,
+                new EmbodyCustomizations
+                {
+                    Name = "code-checker",
+                    ModelOverride = "gpt-5-mini"
+                })
+        };
+
+        var info = await manager.SpawnAsync(request);
+
+        info.Name.ShouldBe("code-checker");
+        info.Model.ShouldBe("gpt-5-mini");
+        info.Archetype.ShouldBe(SubAgentArchetype.Reviewer);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_WithModeMirror_UsesTargetDescriptor_AndChildIdUsesTargetSlot()
+    {
+        var (manager, registry, registeredDescriptor, registeredAgentId) = BuildHarness(
+            parentDescriptor: new AgentDescriptor
+            {
+                AgentId = AgentId.From("nova"),
+                DisplayName = "Nova",
+                ModelId = "gpt-4o",
+                ApiProvider = "openai",
+                SystemPrompt = "You are Nova."
+            },
+            extra: new AgentDescriptor
+            {
+                AgentId = AgentId.From("farnsworth"),
+                DisplayName = "Farnsworth",
+                ModelId = "claude-sonnet-4",
+                ApiProvider = "anthropic",
+                SystemPrompt = "You are Farnsworth, a coding assistant."
+            });
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("nova"),
+            ParentSessionId = SessionId.From("nova-session"),
+            Task = "Write some code",
+            TimeoutSeconds = 600,
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = new Mirror(AgentId.From("farnsworth"))
+        };
+
+        var result = await manager.SpawnAsync(request);
+
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe(SubAgentStatus.Running);
+        registeredDescriptor.Value.ShouldNotBeNull();
+        registeredDescriptor.Value!.ModelId.ShouldBe("claude-sonnet-4");
+        registeredDescriptor.Value.SystemPrompt.ShouldBe("You are Farnsworth, a coding assistant.");
+        registeredDescriptor.Value.Kind.ShouldBe(AgentKind.SubAgent);
+        registeredAgentId.Value.ShouldNotBeNull();
+        // Mirror child id encodes the target agent id in the role slot
+        // (#562 locked design), distinguishing the mirror from any role-based
+        // Embody spawn against the same parent.
+        registeredAgentId.Value!.Value.Value.ShouldStartWith("nova--subagent--farnsworth--");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_WithModeMirror_UnknownTarget_ThrowsKeyNotFound()
+    {
+        var (manager, _, _, _) = BuildHarness(
+            parentDescriptor: new AgentDescriptor
+            {
+                AgentId = AgentId.From("nova"),
+                DisplayName = "Nova",
+                ModelId = "gpt-4o",
+                ApiProvider = "openai"
+            });
+
+        var request = new SubAgentSpawnRequest
+        {
+            ParentAgentId = AgentId.From("nova"),
+            ParentSessionId = SessionId.From("nova-session"),
+            Task = "Do something",
+            TimeoutSeconds = 600,
+            InheritedConversationId = ConversationId.From("inherited-conv"),
+            Mode = new Mirror(AgentId.From("ghost-agent"))
+        };
+
+        var ex = await Should.ThrowAsync<KeyNotFoundException>(
+            () => manager.SpawnAsync(request));
+        ex.Message.ShouldContain("ghost-agent");
+    }
+
+    private static (
+        DefaultSubAgentManager Manager,
+        Mock<IAgentRegistry> Registry,
+        Box<AgentDescriptor?> RegisteredDescriptor,
+        Box<AgentId?> RegisteredAgentId) BuildHarness(
+        AgentDescriptor parentDescriptor,
+        AgentDescriptor? extra = null)
+    {
+        var childHandle = CreateHandle();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(childHandle.Object);
+
+        var registeredDescriptor = new Box<AgentDescriptor?>();
+        var registeredAgentId = new Box<AgentId?>();
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(parentDescriptor.AgentId)).Returns(parentDescriptor);
+        if (extra is not null)
+            registry.Setup(r => r.Get(extra.AgentId)).Returns(extra);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+        registry
+            .Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback<AgentDescriptor>(d =>
+            {
+                registeredDescriptor.Value = d;
+                registeredAgentId.Value = d.AgentId;
+            });
+
+        var options = new TestOptionsMonitor<GatewayOptions>(new GatewayOptions());
+        var manager = new DefaultSubAgentManager(
+            supervisor.Object,
+            registry.Object,
+            new Mock<BotNexus.Gateway.Abstractions.Activity.IActivityBroadcaster>().Object,
+            new Mock<BotNexus.Gateway.Abstractions.Channels.IChannelDispatcher>().Object,
+            options,
+            new Mock<Microsoft.Extensions.Logging.ILogger<DefaultSubAgentManager>>().Object);
+
+        return (manager, registry, registeredDescriptor, registeredAgentId);
+    }
+
+    private static Mock<IAgentHandle> CreateHandle()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.SetupGet(h => h.AgentId).Returns(AgentId.From("nova"));
+        handle.SetupGet(h => h.SessionId).Returns(SessionId.From("session"));
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "done" });
+        handle.Setup(h => h.FollowUpAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return handle;
+    }
+
+    // Mutable wrapper so the Moq callback can publish back into the test scope.
+    private sealed class Box<T> { public T? Value { get; set; } }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Pins the contract for <see cref="SubAgentSpawnMode"/> and its two cases
+/// (<see cref="Embody"/>, <see cref="Mirror"/>) introduced by Phase 5 / F-6
+/// step 3 (#562). These tests target the new types in isolation; the broader
+/// <see cref="SubAgentSpawnRequest"/> migration is exercised separately.
+/// </summary>
+public sealed class SubAgentSpawnModeTests
+{
+    // ---- EmbodyCustomizations.Default --------------------------------------
+
+    [Fact]
+    public void EmbodyCustomizations_Default_HasAllFieldsNull()
+    {
+        var d = EmbodyCustomizations.Default;
+
+        d.Name.ShouldBeNull();
+        d.SystemPromptOverride.ShouldBeNull();
+        d.ModelOverride.ShouldBeNull();
+        d.ApiProviderOverride.ShouldBeNull();
+        d.ToolIds.ShouldBeNull();
+    }
+
+    [Fact]
+    public void EmbodyCustomizations_Default_IsSingleton()
+    {
+        EmbodyCustomizations.Default.ShouldBeSameAs(EmbodyCustomizations.Default);
+    }
+
+    [Fact]
+    public void EmbodyCustomizations_DefaultEqualsExplicitlyEmpty_ByRecordEquality()
+    {
+        // Pin record equality so callers can compare without juggling reference
+        // identity. If someone changes Default to non-empty, this breaks.
+        EmbodyCustomizations.Default.ShouldBe(new EmbodyCustomizations());
+    }
+
+    // ---- Embody construction & validation ----------------------------------
+
+    [Theory]
+    [InlineData("researcher")]
+    [InlineData("coder")]
+    [InlineData("planner")]
+    [InlineData("reviewer")]
+    [InlineData("writer")]
+    [InlineData("general")]
+    public void Embody_WithKnownRole_ConstructsCleanly(string role)
+    {
+        var archetype = SubAgentArchetype.FromString(role);
+
+        var embody = new Embody(archetype);
+
+        embody.Role.ShouldBe(archetype);
+        embody.Customizations.ShouldBe(EmbodyCustomizations.Default);
+    }
+
+    [Fact]
+    public void Embody_WithCustomizations_PreservesThem()
+    {
+        var customizations = new EmbodyCustomizations
+        {
+            Name = "my-researcher",
+            ModelOverride = "gpt-5-mini",
+            ToolIds = new[] { "web_search", "memory_search" }
+        };
+
+        var embody = new Embody(SubAgentArchetype.Researcher, customizations);
+
+        embody.Customizations.ShouldBeSameAs(customizations);
+        embody.Customizations.Name.ShouldBe("my-researcher");
+    }
+
+    [Fact]
+    public void Embody_WithUnknownRole_ThrowsArgumentException()
+    {
+        // SubAgentArchetype is an open smart-enum (FromString accepts anything);
+        // this guard pins that Embody.Role is constrained to the 6 known statics
+        // so the spawn contract cannot smuggle arbitrary role names.
+        var unknownRole = SubAgentArchetype.FromString("admin");
+
+        Should.Throw<ArgumentException>(() => new Embody(unknownRole))
+            .ParamName.ShouldBe("Role");
+    }
+
+    [Fact]
+    public void Embody_WithNullRole_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() => new Embody(null!));
+    }
+
+    [Fact]
+    public void Embody_WithNullCustomizations_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(
+            () => new Embody(SubAgentArchetype.Coder, null!));
+    }
+
+    // ---- Mirror construction -----------------------------------------------
+
+    [Fact]
+    public void Mirror_WithTargetAgentId_ConstructsCleanly()
+    {
+        var targetId = AgentId.From("named-agent-a");
+
+        var mirror = new Mirror(targetId);
+
+        mirror.TargetAgentId.ShouldBe(targetId);
+    }
+
+    // ---- Polymorphic JSON round-trip ---------------------------------------
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    [Fact]
+    public void Mode_JsonRoundTrip_Embody_PreservesShape()
+    {
+        SubAgentSpawnMode original = new Embody(SubAgentArchetype.Researcher);
+
+        var json = JsonSerializer.Serialize(original, s_jsonOptions);
+        var roundTripped = JsonSerializer.Deserialize<SubAgentSpawnMode>(json, s_jsonOptions);
+
+        roundTripped.ShouldBeOfType<Embody>()
+            .Role.Value.ShouldBe("researcher");
+        json.ShouldContain("\"mode\":\"embody\"");
+    }
+
+    [Fact]
+    public void Mode_JsonRoundTrip_Mirror_PreservesShape()
+    {
+        SubAgentSpawnMode original = new Mirror(AgentId.From("target-x"));
+
+        var json = JsonSerializer.Serialize(original, s_jsonOptions);
+        var roundTripped = JsonSerializer.Deserialize<SubAgentSpawnMode>(json, s_jsonOptions);
+
+        roundTripped.ShouldBeOfType<Mirror>()
+            .TargetAgentId.ShouldBe(AgentId.From("target-x"));
+        json.ShouldContain("\"mode\":\"mirror\"");
+    }
+
+    [Fact]
+    public void Mode_JsonDeserialize_UnknownDiscriminator_Throws()
+    {
+        var bogus = "{\"mode\":\"telekinesis\",\"TargetAgentId\":\"x\"}";
+
+        Should.Throw<JsonException>(() =>
+            JsonSerializer.Deserialize<SubAgentSpawnMode>(bogus, s_jsonOptions));
+    }
+
+    [Fact]
+    public void Mode_JsonDeserialize_MissingDiscriminator_Throws()
+    {
+        var noDiscriminator = "{\"TargetAgentId\":\"x\"}";
+
+        // STJ raises NotSupportedException (wrapping the underlying invariant) when a payload
+        // for a polymorphic abstract base type omits the discriminator property.
+        Should.Throw<NotSupportedException>(() =>
+            JsonSerializer.Deserialize<SubAgentSpawnMode>(noDiscriminator, s_jsonOptions));
+    }
+
+    [Fact]
+    public void Mode_JsonRoundTrip_EmbodyWithCustomizations_PreservesAllFields()
+    {
+        SubAgentSpawnMode original = new Embody(
+            SubAgentArchetype.Coder,
+            new EmbodyCustomizations
+            {
+                Name = "my-coder",
+                ModelOverride = "claude-opus-4.7",
+                ApiProviderOverride = "anthropic",
+                ToolIds = new[] { "read", "write", "shell" }
+            });
+
+        var json = JsonSerializer.Serialize(original, s_jsonOptions);
+        var roundTripped = JsonSerializer.Deserialize<SubAgentSpawnMode>(json, s_jsonOptions);
+
+        var embody = roundTripped.ShouldBeOfType<Embody>();
+        embody.Role.Value.ShouldBe("coder");
+        embody.Customizations.Name.ShouldBe("my-coder");
+        embody.Customizations.ModelOverride.ShouldBe("claude-opus-4.7");
+        embody.Customizations.ApiProviderOverride.ShouldBe("anthropic");
+        embody.Customizations.ToolIds.ShouldBe(new[] { "read", "write", "shell" });
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentSpawnModeTests.cs
@@ -165,6 +165,22 @@ public sealed class SubAgentSpawnModeTests
             JsonSerializer.Deserialize<SubAgentSpawnMode>(noDiscriminator, s_jsonOptions));
     }
 
+    /// <summary>
+    /// Plan-vs-impl MEDIUM (#562 critique sweep): pin the behaviour for an
+    /// explicit-null discriminator. STJ surfaces this as JsonException
+    /// (different from the missing-discriminator NotSupportedException pin
+    /// above). A test gap here would let a future STJ behaviour change
+    /// silently widen the contract for malformed payloads.
+    /// </summary>
+    [Fact]
+    public void Mode_JsonDeserialize_NullDiscriminator_Throws()
+    {
+        var nullDiscriminator = "{\"mode\":null,\"TargetAgentId\":\"x\"}";
+
+        Should.Throw<JsonException>(() =>
+            JsonSerializer.Deserialize<SubAgentSpawnMode>(nullDiscriminator, s_jsonOptions));
+    }
+
     [Fact]
     public void Mode_JsonRoundTrip_EmbodyWithCustomizations_PreservesAllFields()
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentTargetAgentIdTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentTargetAgentIdTests.cs
@@ -58,7 +58,7 @@ public sealed class SubAgentTargetAgentIdTests
             ParentSessionId = SessionId.From("nova-session"),
             Task = "Write some code",
             TimeoutSeconds = 600,
-            TargetAgentId = "farnsworth",
+            Mode = new Mirror(AgentId.From("farnsworth")),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 
@@ -99,7 +99,7 @@ public sealed class SubAgentTargetAgentIdTests
             ParentSessionId = SessionId.From("nova-session"),
             Task = "Do something",
             TimeoutSeconds = 600,
-            TargetAgentId = "ghost-agent",
+            Mode = new Mirror(AgentId.From("ghost-agent")),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 
@@ -144,7 +144,7 @@ public sealed class SubAgentTargetAgentIdTests
             ParentSessionId = SessionId.From("nova-session"),
             Task = "Do work",
             TimeoutSeconds = 600,
-            // no TargetAgentId
+            Mode = new Embody(SubAgentArchetype.General),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 
@@ -215,7 +215,7 @@ public sealed class SubAgentTargetAgentIdTests
             ParentSessionId = SessionId.From("nova-session"),
             Task = "Do work",
             TimeoutSeconds = 600,
-            TargetAgentId = "farnsworth",
+            Mode = new Mirror(AgentId.From("farnsworth")),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentToolInheritanceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentToolInheritanceTests.cs
@@ -160,7 +160,7 @@ public sealed class SubAgentToolInheritanceTests
             ParentSessionId = SessionId.From("root-session"),
             Task = "Do something",
             TimeoutSeconds = 600,
-            ToolIds = toolIds,
+            Mode = new Embody(SubAgentArchetype.General, EmbodyCustomizations.Default with { ToolIds = toolIds }),
             InheritedConversationId = ConversationId.From("inherited-conv")
         };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/SubAgentToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/SubAgentToolTests.cs
@@ -47,13 +47,14 @@ public sealed class SubAgentToolTests
         captured!.ParentAgentId.Value.ShouldBe("parent-agent");
         captured.ParentSessionId.Value.ShouldBe("parent-session");
         captured.Task.ShouldBe("Investigate issue");
-        captured.ModelOverride.ShouldBeNull();
-        captured.ToolIds.ShouldBeNull();
-        captured.SystemPromptOverride.ShouldBeNull();
         captured.MaxTurns.ShouldBe(30);
         captured.TimeoutSeconds.ShouldBe(600);
-        captured.Archetype.ShouldBe(SubAgentArchetype.General);
         captured.InheritedConversationId.Value.ShouldBe("conv-parent");
+        var embody = captured.Mode.ShouldBeOfType<Embody>();
+        embody.Role.ShouldBe(SubAgentArchetype.General);
+        embody.Customizations.ModelOverride.ShouldBeNull();
+        embody.Customizations.ToolIds.ShouldBeNull();
+        embody.Customizations.SystemPromptOverride.ShouldBeNull();
     }
 
     [Fact]
@@ -78,12 +79,13 @@ public sealed class SubAgentToolTests
         });
 
         captured.ShouldNotBeNull();
-        captured!.ModelOverride.ShouldBe("gpt-5-mini");
-        captured.ToolIds.ShouldBe(new[] { "read", "write" });
-        captured.SystemPromptOverride.ShouldBe("Focus on failures");
-        captured.MaxTurns.ShouldBe(12);
+        captured!.MaxTurns.ShouldBe(12);
         captured.TimeoutSeconds.ShouldBe(45);
-        captured.Archetype.ShouldBe(SubAgentArchetype.Reviewer);
+        var embody = captured.Mode.ShouldBeOfType<Embody>();
+        embody.Role.ShouldBe(SubAgentArchetype.Reviewer);
+        embody.Customizations.ModelOverride.ShouldBe("gpt-5-mini");
+        embody.Customizations.ToolIds.ShouldBe(new[] { "read", "write" });
+        embody.Customizations.SystemPromptOverride.ShouldBe("Focus on failures");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/SubAgentToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/SubAgentToolTests.cs
@@ -106,6 +106,165 @@ public sealed class SubAgentToolTests
         document.RootElement.GetProperty("name").GetString().ShouldBe("Research Task");
     }
 
+    // ---------------------------------------------------------------------
+    // Phase 5 / F-6 step 3 (#562): Mode = Embody | Mirror.
+    // The tool translates the flat JSON shape (preserved for the agent-facing
+    // contract) into the closed Mode union, and rejects mode-mixing.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task SpawnTool_BuildsMode_AsEmbodyGeneral_WhenNoCustomisations()
+    {
+        var captured = await CaptureSpawnRequest(new Dictionary<string, object?> { ["task"] = "T" });
+
+        var embody = captured.Mode.ShouldBeOfType<Embody>();
+        embody.Role.ShouldBe(SubAgentArchetype.General);
+        embody.Customizations.ShouldBeSameAs(EmbodyCustomizations.Default);
+    }
+
+    [Fact]
+    public async Task SpawnTool_BuildsMode_AsEmbodyWithArchetype_WhenArchetypeOnlySupplied()
+    {
+        var captured = await CaptureSpawnRequest(new Dictionary<string, object?>
+        {
+            ["task"] = "T",
+            ["archetype"] = "reviewer"
+        });
+
+        var embody = captured.Mode.ShouldBeOfType<Embody>();
+        embody.Role.ShouldBe(SubAgentArchetype.Reviewer);
+        embody.Customizations.ShouldBeSameAs(EmbodyCustomizations.Default);
+    }
+
+    [Fact]
+    public async Task SpawnTool_BuildsMode_AsEmbodyWithCustomisations_WhenAnyOverrideSupplied()
+    {
+        var captured = await CaptureSpawnRequest(new Dictionary<string, object?>
+        {
+            ["task"] = "T",
+            ["archetype"] = "coder",
+            ["name"] = "my-coder",
+            ["model"] = "gpt-5-mini",
+            ["apiProvider"] = "openai",
+            ["tools"] = new[] { "read", "write" },
+            ["systemPrompt"] = "Focus on tests"
+        });
+
+        var embody = captured.Mode.ShouldBeOfType<Embody>();
+        embody.Role.ShouldBe(SubAgentArchetype.Coder);
+        embody.Customizations.Name.ShouldBe("my-coder");
+        embody.Customizations.ModelOverride.ShouldBe("gpt-5-mini");
+        embody.Customizations.ApiProviderOverride.ShouldBe("openai");
+        embody.Customizations.ToolIds.ShouldBe(new[] { "read", "write" });
+        embody.Customizations.SystemPromptOverride.ShouldBe("Focus on tests");
+    }
+
+    [Fact]
+    public async Task SpawnTool_BuildsMode_AsMirror_WhenTargetAgentIdOnlySupplied()
+    {
+        var captured = await CaptureSpawnRequest(new Dictionary<string, object?>
+        {
+            ["task"] = "T",
+            ["targetAgentId"] = "alex"
+        });
+
+        var mirror = captured.Mode.ShouldBeOfType<Mirror>();
+        mirror.TargetAgentId.Value.ShouldBe("alex");
+    }
+
+    [Theory]
+    [InlineData("name", "my-mirror")]
+    [InlineData("model", "gpt-5-mini")]
+    [InlineData("apiProvider", "openai")]
+    [InlineData("systemPrompt", "Custom")]
+    [InlineData("archetype", "coder")]
+    public async Task SpawnTool_RejectsMixing_TargetAgentId_WithSingleEmbodyField(string conflictKey, object conflictValue)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["task"] = "T",
+            ["targetAgentId"] = "alex",
+            [conflictKey] = conflictValue
+        };
+        var tool = CreateSpawnTool(out _);
+
+        var ex = await Should.ThrowAsync<ArgumentException>(
+            () => tool.ExecuteAsync("call-1", args));
+
+        ex.Message.ShouldContain("targetAgentId");
+        ex.Message.ShouldContain(conflictKey);
+    }
+
+    [Fact]
+    public async Task SpawnTool_RejectsMixing_TargetAgentId_WithToolsArray()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["task"] = "T",
+            ["targetAgentId"] = "alex",
+            ["tools"] = new[] { "read" }
+        };
+        var tool = CreateSpawnTool(out _);
+
+        var ex = await Should.ThrowAsync<ArgumentException>(
+            () => tool.ExecuteAsync("call-1", args));
+
+        ex.Message.ShouldContain("tools");
+    }
+
+    [Fact]
+    public async Task SpawnTool_RejectsMixing_ReportsAllConflictingFields_InOneMessage()
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["task"] = "T",
+            ["targetAgentId"] = "alex",
+            ["name"] = "x",
+            ["model"] = "y",
+            ["systemPrompt"] = "z"
+        };
+        var tool = CreateSpawnTool(out _);
+
+        var ex = await Should.ThrowAsync<ArgumentException>(
+            () => tool.ExecuteAsync("call-1", args));
+
+        ex.Message.ShouldContain("name");
+        ex.Message.ShouldContain("model");
+        ex.Message.ShouldContain("systemPrompt");
+    }
+
+    private static SubAgentSpawnTool CreateSpawnTool(out Mock<ISubAgentManager> manager)
+    {
+        manager = new Mock<ISubAgentManager>();
+        manager.Setup(m => m.SpawnAsync(It.IsAny<SubAgentSpawnRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSubAgentInfo());
+        return new SubAgentSpawnTool(
+            manager.Object,
+            AgentId.From("parent-agent"),
+            SessionId.From("parent-session"),
+            ConversationId.From("conv-1"));
+    }
+
+    private static async Task<SubAgentSpawnRequest> CaptureSpawnRequest(IReadOnlyDictionary<string, object?> args)
+    {
+        SubAgentSpawnRequest? captured = null;
+        var manager = new Mock<ISubAgentManager>();
+        manager.Setup(m => m.SpawnAsync(It.IsAny<SubAgentSpawnRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SubAgentSpawnRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(CreateSubAgentInfo());
+        var tool = new SubAgentSpawnTool(
+            manager.Object,
+            AgentId.From("parent-agent"),
+            SessionId.From("parent-session"),
+            ConversationId.From("conv-1"));
+
+        await tool.ExecuteAsync("call-1", args);
+
+        captured.ShouldNotBeNull();
+        captured!.Mode.ShouldNotBeNull();
+        return captured;
+    }
+
     [Fact]
     public void ListTool_HasCorrectNameAndLabel()
     {


### PR DESCRIPTION
# Phase 5 / F-6 #562 — `SubAgentSpawnMode = Embody | Mirror` discriminated union

Replaces the bag-of-optionals shape on `SubAgentSpawnRequest` (top-level
`Archetype` / `TargetAgentId` / `Name` / `ModelOverride` etc., with mode
ambiguity resolved by null-checks scattered across the manager) with a
typed discriminated union — `SubAgentSpawnMode` = `Embody(Role,
EmbodyCustomizations)` | `Mirror(TargetAgentId)`. The manager pattern-
matches on `request.Mode` and the spawn contract is unambiguous at
compile time. Closes #562.

## What changed

### Domain (`SubAgentSpawnRequest`, `SubAgentSpawnMode`)

- New `SubAgentSpawnMode` abstract record with `[JsonPolymorphic]` +
  `[JsonDerivedType]` strict serialization.
- `Embody` carries a `SubAgentArchetype` allowlist-validated role and
  optional `EmbodyCustomizations` (Name, ModelOverride, SystemPrompt,
  ToolIds, ConfigurationOverrides — replaces 5 nullable top-level fields).
- `Mirror` carries an `AgentId` target only.
- `SubAgentSpawnRequest` legacy fields **deleted**; `Mode` is `required`.

### Gateway

- `SubAgentSpawnTool` builds `Mode` directly from the tool payload;
  request-level mode-mixing is rejected at the tool boundary.
- `DefaultSubAgentManager.SpawnAsync` pattern-matches on `request.Mode`:
  Embody → clones parent descriptor + applies customisations;
  Mirror → resolves target descriptor + uses verbatim. Deny-list check
  moved after the switch to read the typed `toolIds` local (Embody
  customisations only — Mirror is strict pass-through per the locked
  design).

### Tests

- 8 test files migrated to set `Mode = new Embody(...)` /
  `new Mirror(...)` instead of the legacy top-level fields.
- New architecture fence (`SubAgentSpawnRequestShapeTests`) with 5
  pins — see "Critique sweep" below.

## Commit story (6 commits)

1. `feat(domain): introduce SubAgentSpawnMode = Embody | Mirror DU (#562 step 1/5)`
2. `feat(gateway): SubAgentSpawnTool builds Mode from payload (#562 step 2/5)`
3. `feat(gateway): DefaultSubAgentManager pattern-matches on Mode (#562 step 3/5)`
4. `test(gateway): migrate test callsites to typed Mode (#562 step 4/5)`
5. `feat(gateway): delete legacy SubAgentSpawnRequest fields; Mode is required (#562 step 5/5)`
6. `fix(gateway): fold critique-sweep findings into SubAgentSpawnMode DU (#562)`

## Multi-model critique sweep

Per the autopilot policy (user mandate), 3 agents reviewed step 5
in parallel before opening this PR:

* **security/gpt-5.5** — 1 HIGH **deferred** (see Deferred section).
* **plan-vs-impl/claude-opus-4.7** — 2 HIGH + 1 MEDIUM **adopted**,
  1 HIGH + 2 LOW **deferred** with rationale.
* **bug-hunt/gpt-5.3-codex** — 1 HIGH + 1 MEDIUM **adopted**.

Findings folded in by commit 6:

1. **Null-Mode runtime guard** (bug-hunt HIGH) — `required` is
   compile-time only. A caller using `null!` or a JSON quirk could hit
   the default switch arm and raise NullReferenceException
   (HTTP 500 with unhelpful stack). Added
   `ArgumentNullException.ThrowIfNull(request.Mode)` after the
   request null-check.
2. **Mirror model fallback bug** (bug-hunt MEDIUM) — Mirror was
   reporting `parentDescriptor.ModelId` in `SubAgentInfo.Model`
   instead of the mirrored target's. Silent metadata corruption for
   downstream telemetry / cost accounting. Changed to
   `baseDescriptor.ModelId` (covers both Embody and Mirror arms).
3. **Architecture fence regex tightening** (plan-vs-impl HIGH) —
   step-5 fence used literal `source.Contains(...)`; mutations like
   `switch(request.Mode)` (no space) would silently bypass.
   Replaced with regex (whitespace-tolerant + supports both `is`
   and `case` patterns).
4. **Vacuity guard for the switch-detection clause** (plan-vs-impl
   HIGH) — step-5 only had a vacuity guard for the legacy-field-read
   clause. Added `Fence_DetectsSyntheticModeSwitchShapes` covering
   four synthetic mutations and a clean-shape negative pin.
5. **JSON null-discriminator test pin** (plan-vs-impl MEDIUM) —
   added `Mode_JsonDeserialize_NullDiscriminator_Throws` for the
   `{"mode": null}` shape (raises JsonException).
6. **Mirror-model assertion fold-in** to
   `SpawnAsync_WithModeMirror_UsesTargetDescriptor_AndChildIdUsesTargetSlot`
   — pins `info.Model` so a regression to the bug fixed in #2 fails
   immediately rather than slipping through.
7. **Null-Mode test pin** — `SpawnAsync_WithNullMode_ThrowsArgumentNullException`
   pins the new runtime guard.

## Deferred items (documented, not blockers)

* **Security HIGH — Mirror authz boundary (operator-owned).**
  A caller with the `spawn_subagent` tool can name any registered
  `targetAgentId` via `Mirror` and inherit that agent's tools / model
  / system-prompt without an authorization check. Authorization is
  explicitly **out of scope for this plan** (operator owns auth;
  only agent-provider auth is in scope per user's standing
  instruction). Operators control Mirror target registration; the
  registry is the trust boundary. Issue #560 (already closed
  not-planned) tracks the broader read-endpoint authz gap.
* **Plan-vs-impl HIGH #1 — archetype context-table mismatch.**
  My internal notes mentioned "Tester"; code uses "Writer" (the
  canonical 6-archetype allowlist: Researcher, Coder, Planner,
  Reviewer, Writer, General). Documentation typo only — no
  behavioural defect.
* **Plan-vs-impl LOW #6 / #7 — out-of-scope SubAgentInfo contract
  changes** for Mirror's `Archetype = General` label and Embody
  JSON-missing-customizations ArgumentNullException shape.
* **Plan-vs-impl MEDIUM #4 — Mirror inherits target's tools that
  may be on parent's deny-list.** Intentional: Mirror is strict
  pass-through; targets are admin-registered. Deny-list applies
  to Embody (mode-agnostic by design; reads the typed `toolIds`
  local from EmbodyCustomizations).

## Validation

* `dotnet build BotNexus.slnx` — clean (0 warnings / 0 errors under
  `TreatWarningsAsErrors`).
* `BotNexus.Gateway.Tests` — 1867 passed / 1 skipped (#383 canvas
  persistence, unrelated) / 0 failed (+2 from step-5 baseline of
  1865 — the two new fold-in pins).
* `BotNexus.Architecture.Tests` — 54 passed / 0 failed (+1 from
  step-5 baseline of 53 — the new vacuity guard).

## Behaviour-change call-out

`SubAgentSpawnRequest`'s spawn contract is now strict at compile
time. Pre-PR, any combination of legacy fields was accepted at the
type level and disambiguated at runtime by null-checks; certain
combinations (e.g. both `TargetAgentId` and `Archetype` populated)
were silently treated as Mirror, masking Embody intent. Post-PR,
callers must construct `new Embody(...)` or `new Mirror(...)`
explicitly. There are no production callers outside the gateway
that need to migrate — the spawn surface is internal.

Closes #562.
