### PR TITLE
fix(gateway): per-session lock on cross-world relay write→prompt→reload window

### DIFF
--- a/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
@@ -100,6 +100,7 @@
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.ISessionLifecycleEvents))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.ISessionStore))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.ISessionWarmupService))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.ISessionWriteLock))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.SessionLifecycleEventType))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.SessionLifecycleEvent))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Sessions.SessionSummary))]

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -48,6 +48,7 @@ public sealed class CrossWorldFederationController(
     IAgentSupervisor supervisor,
     ISessionStore sessionStore,
     IConversationStore conversationStore,
+    ISessionWriteLock sessionWriteLock,
     CrossWorldInboundAuthService inboundAuthService,
     IOptionsMonitor<PlatformConfig> platformConfig,
     ILogger<CrossWorldFederationController> logger) : ControllerBase
@@ -91,13 +92,59 @@ public sealed class CrossWorldFederationController(
         if (!registry.Contains(targetAgentId))
             return NotFound(new { error = $"Target agent '{request.TargetAgentId}' is not registered." });
 
-        // Phase 4 / F-3 (receiver branch): resolve or create the local conversation+session pair.
-        var resolveResult = await ResolveSessionAsync(request, targetAgentId, cancellationToken).ConfigureAwait(false);
-        if (resolveResult.Error is { } error)
-            return error;
+        // Per-session lock holds across resolve → write → prompt → reload → save → (seal-on-error).
+        // The single critical race that motivated #551 is two concurrent senders supplying the
+        // SAME RemoteSessionId: without the lock they can interleave their per-turn
+        // active-exchange-id writes and satisfy each other's freshness gate with the wrong
+        // payload. For supplied RemoteSessionId we acquire the lock BEFORE ResolveSessionAsync
+        // so a concurrent caller can never observe the session as Active in resolve and then
+        // sneak past after the first caller seals it (rubber-duck critique #3). For fresh
+        // sessions we resolve first to mint the new sessionId, then acquire for uniformity —
+        // the lock is functionally a no-op in that branch because no other caller can possibly
+        // hold the same just-minted id. The whole try/catch including the error-seal SaveAsync
+        // is INSIDE the lock scope so a second caller cannot sneak in between the failure and
+        // the seal persist (rubber-duck critique #4).
+        if (!string.IsNullOrWhiteSpace(request.RemoteSessionId))
+        {
+            var suppliedSessionId = SessionId.From(request.RemoteSessionId);
+            await using var lease = await sessionWriteLock
+                .AcquireAsync(suppliedSessionId, cancellationToken)
+                .ConfigureAwait(false);
 
-        var session = resolveResult.Session!;
-        var conversation = resolveResult.Conversation!;
+            var resolved = await ResolveSessionAsync(request, targetAgentId, cancellationToken).ConfigureAwait(false);
+            if (resolved.Error is { } resolveError)
+                return resolveError;
+
+            return await ExecuteRelayAsync(request, resolved.Session!, resolved.Conversation!, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var resolved = await ResolveSessionAsync(request, targetAgentId, cancellationToken).ConfigureAwait(false);
+            if (resolved.Error is { } resolveError)
+                return resolveError;
+
+            await using var lease = await sessionWriteLock
+                .AcquireAsync(resolved.Session!.SessionId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return await ExecuteRelayAsync(request, resolved.Session!, resolved.Conversation!, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Runs the actual relay turn — append user entry, persist, prompt the target, reload,
+    /// consume the completion gate, persist the outcome. Invoked under the per-session lock
+    /// acquired by <see cref="RelayAsync"/>. The lock holds across <c>PromptAsync</c> by
+    /// design — the freshness gate in <see cref="AgentExchangeCompletionGate"/> requires that
+    /// the tool's persisted finish payload be readable in the same logical turn that wrote
+    /// the active id, and any concurrent caller would race the freshness invariant.
+    /// </summary>
+    private async Task<ActionResult<CrossWorldRelayResponse>> ExecuteRelayAsync(
+        CrossWorldRelayRequest request,
+        GatewaySession session,
+        Conversation conversation,
+        CancellationToken cancellationToken)
+    {
         var sessionId = session.SessionId;
 
         session.AddEntry(new SessionEntry
@@ -125,7 +172,7 @@ public sealed class CrossWorldFederationController(
             AgentExchangeCompletionGate.PrepareTurn(session.Metadata, exchangeId);
             await sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
 
-            var handle = await supervisor.GetOrCreateAsync(targetAgentId, sessionId, cancellationToken).ConfigureAwait(false);
+            var handle = await supervisor.GetOrCreateAsync(session.AgentId, sessionId, cancellationToken).ConfigureAwait(false);
             var response = await handle.PromptAsync(request.Message, cancellationToken).ConfigureAwait(false);
             session.AddEntry(new SessionEntry
             {
@@ -194,7 +241,7 @@ public sealed class CrossWorldFederationController(
         {
             logger.LogWarning(ex,
                 "Cross-world relay failed for session '{SessionId}' on agent '{TargetAgentId}'.",
-                sessionId, targetAgentId);
+                sessionId, session.AgentId);
             session.Metadata.Remove(FinishAgentExchangeTool.ActiveExchangeIdKey);
             session.Status = GatewaySessionStatus.Sealed;
             session.Metadata["error"] = ex.Message;

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionWriteLock.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionWriteLock.cs
@@ -1,0 +1,57 @@
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Sessions;
+
+/// <summary>
+/// Per-session mutex that serializes the entire write→prompt→reload→save
+/// window of an agent exchange. Required because the freshness gate in
+/// <c>AgentExchangeCompletionGate</c> reads metadata written by a tool that
+/// executes during the prompt — without this lock, two concurrent callers
+/// holding the same <see cref="SessionId"/> can interleave their per-turn
+/// active-exchange-id writes and satisfy each other's gate with the wrong
+/// payload (issue #551, surfaced by PR #550 bug-hunt critique HIGH-1 and
+/// MEDIUM-2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Scope:</b> Single-process only. The lock is an in-memory primitive
+/// keyed by <see cref="SessionId"/>; multiple gateway instances against
+/// the same persistent session store are not serialized by this contract.
+/// That topology is not supported by the current store implementations
+/// (no row versioning, no transactional write spanning prompts), so the
+/// single-process scope matches the platform's overall consistency model.
+/// </para>
+/// <para>
+/// <b>Non-reentrant.</b> Tools invoked inside <c>PromptAsync</c> while the
+/// lock is held MUST NOT try to acquire the same session's lock — doing so
+/// will deadlock. Tools operate on session metadata through
+/// <see cref="ISessionStore"/> directly; the lock guards the orchestration
+/// layer (relay receiver, exchange service) where the active-exchange-id
+/// write→prompt→reload→consume sequence runs as a single logical unit.
+/// </para>
+/// <para>
+/// <b>Lifetime:</b> Slots are refcounted; the dictionary entry is removed
+/// as soon as the last in-flight acquire completes its release. There is
+/// no per-session leak even for sessions that are sealed mid-flight.
+/// </para>
+/// </remarks>
+public interface ISessionWriteLock
+{
+    /// <summary>
+    /// Acquires the per-session lock for <paramref name="sessionId"/>.
+    /// Blocks asynchronously if another caller holds the lock for the same
+    /// session id; returns immediately if uncontested. Dispose the returned
+    /// lease to release the lock (<c>await using</c> is recommended).
+    /// </summary>
+    /// <param name="sessionId">The session id to serialize on.</param>
+    /// <param name="cancellationToken">
+    /// Cancellation token that aborts the wait. The slot refcount is
+    /// correctly decremented on cancellation, so a cancelled acquire does
+    /// not leak a permanent dictionary entry.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IAsyncDisposable"/> lease that releases the lock when
+    /// disposed.
+    /// </returns>
+    Task<IAsyncDisposable> AcquireAsync(SessionId sessionId, CancellationToken cancellationToken = default);
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/BotNexus.Gateway.Sessions.csproj
+++ b/src/gateway/BotNexus.Gateway.Sessions/BotNexus.Gateway.Sessions.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Gateway.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionWriteLock.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionWriteLock.cs
@@ -1,0 +1,137 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Sessions;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// In-memory <see cref="ISessionWriteLock"/> implementation backed by
+/// per-session <see cref="SemaphoreSlim"/> instances stored in a
+/// refcounted dictionary. Dictionary bookkeeping is serialized through a
+/// single gate object — concurrent acquires across different session ids
+/// run fully in parallel because the gate is released before
+/// <see cref="SemaphoreSlim.WaitAsync(CancellationToken)"/> is awaited.
+/// </summary>
+/// <remarks>
+/// The refcounted design ensures the slot is removed from the dictionary
+/// as soon as the last in-flight acquire completes its release. Cancelling
+/// a pending <c>WaitAsync</c> still decrements the refcount, so a cancelled
+/// caller never leaks a permanent dictionary entry. See <see cref="ISessionWriteLock"/>
+/// for the scope/reentrancy contract.
+/// </remarks>
+public sealed class SessionWriteLock : ISessionWriteLock, IDisposable
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<SessionId, LockSlot> _locks = new();
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable> AcquireAsync(
+        SessionId sessionId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        LockSlot slot;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (!_locks.TryGetValue(sessionId, out var existing))
+            {
+                existing = new LockSlot();
+                _locks[sessionId] = existing;
+            }
+            existing.RefCount++;
+            slot = existing;
+        }
+
+        try
+        {
+            await slot.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The wait was cancelled or faulted before we got the semaphore.
+            // We already took a refcount in the gate above and must give it
+            // back, otherwise the slot is permanently pinned in the dictionary.
+            DecrementRefCount(sessionId, slot);
+            throw;
+        }
+
+        return new Releaser(this, sessionId, slot);
+    }
+
+    private void Release(SessionId sessionId, LockSlot slot)
+    {
+        // Order matters: release the semaphore BEFORE manipulating the
+        // dictionary so a waiter parked on this slot's WaitAsync can resume
+        // promptly. The refcount it holds keeps the slot alive across the
+        // window between our refcount decrement and the waiter's eventual
+        // release — there is no race that frees a slot under a live waiter.
+        slot.Semaphore.Release();
+        DecrementRefCount(sessionId, slot);
+    }
+
+    private void DecrementRefCount(SessionId sessionId, LockSlot slot)
+    {
+        lock (_gate)
+        {
+            slot.RefCount--;
+            if (slot.RefCount == 0 && _locks.TryGetValue(sessionId, out var stored) && ReferenceEquals(stored, slot))
+            {
+                _locks.Remove(sessionId);
+                slot.Semaphore.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Disposes every outstanding semaphore. Callers must not be holding any
+    /// leases at this point; in practice the lock is registered as a
+    /// singleton and disposed only on host shutdown.
+    /// </summary>
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            foreach (var slot in _locks.Values)
+                slot.Semaphore.Dispose();
+            _locks.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Exposed for tests: returns the current number of dictionary entries.
+    /// In production this is observable only via the singleton's internal
+    /// state and is not part of the public contract.
+    /// </summary>
+    internal int OutstandingSlotCount
+    {
+        get
+        {
+            lock (_gate)
+                return _locks.Count;
+        }
+    }
+
+    private sealed class LockSlot
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+        public int RefCount;
+    }
+
+    private sealed class Releaser(SessionWriteLock owner, SessionId sessionId, LockSlot slot) : IAsyncDisposable
+    {
+        private int _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+                owner.Release(sessionId, slot);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionWriteLock.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionWriteLock.cs
@@ -117,6 +117,20 @@ public sealed class SessionWriteLock : ISessionWriteLock, IDisposable
         }
     }
 
+    /// <summary>
+    /// Exposed for tests: returns the current refcount of the slot for
+    /// <paramref name="sessionId"/>, or 0 if no slot exists. This is the
+    /// "how many callers currently hold OR are waiting for this session's
+    /// lock" probe — used by concurrency tests to deterministically detect
+    /// that a waiter has entered <c>WaitAsync</c> (refcount == 2) without
+    /// relying on a timing-based <c>Task.Delay</c>.
+    /// </summary>
+    internal int RefCountFor(SessionId sessionId)
+    {
+        lock (_gate)
+            return _locks.TryGetValue(sessionId, out var slot) ? slot.RefCount : 0;
+    }
+
     private sealed class LockSlot
     {
         public SemaphoreSlim Semaphore { get; } = new(1, 1);

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -134,6 +134,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IConfigPathResolver, ConfigPathResolver>();
         services.TryAddSingleton<IChannelManager, ChannelManager>();
         services.TryAddSingleton<ISessionStore, InMemorySessionStore>();
+        services.TryAddSingleton<ISessionWriteLock, SessionWriteLock>();
         services.TryAddSingleton<IConversationStore, InMemoryConversationStore>();
         services.AddSingleton<IAgentCanvasNotifier, ConversationCanvasNotifier>();
         services.TryAddSingleton<IConversationRouter, DefaultConversationRouter>();

--- a/tests/architecture/BotNexus.Architecture.Tests/CrossWorldReceiverArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/CrossWorldReceiverArchitectureTests.cs
@@ -110,25 +110,55 @@ public sealed class CrossWorldReceiverArchitectureTests
             "Method splitter could not find RelayAsync — fence is vacuous. Method splitter found: " +
             string.Join(", ", methods.Select(m => m.Name)));
 
-        var inlineFailures = FindInlineLateAssignments(relay.Body);
-        var firstPromptInRelay = FindFirstPromptIndex(relay.Body);
-        firstPromptInRelay.ShouldBeGreaterThanOrEqualTo(0,
-            "RelayAsync has no .PromptAsync( call — fence is vacuous. Either the controller " +
-            "stopped invoking the supervisor or the API was renamed.");
+        // #551 refactor: RelayAsync now delegates the actual write→prompt→reload pipeline to an
+        // extracted helper (ExecuteRelayAsync) that runs inside the per-session write lock. The
+        // helper holds the .PromptAsync( call. Without the inlining step below, the vacuity
+        // guard would (incorrectly) declare the fence dead the moment anyone extracts a method.
+        // We treat any helper called from RelayAsync whose body contains .PromptAsync( as a
+        // logical continuation of RelayAsync and concatenate its body in.
+        var inlinedHelperNames = new HashSet<string>(StringComparer.Ordinal);
+        var logicalRelayBody = relay.Body;
+        foreach (var helper in methods.Where(m => m.Name != "RelayAsync"))
+        {
+            if (!System.Text.RegularExpressions.Regex.IsMatch(helper.Body, @"\.PromptAsync\s*\("))
+                continue;
+            // The helper must actually be called from RelayAsync — don't inline unrelated
+            // methods just because they happen to call PromptAsync (e.g. a sibling endpoint).
+            var calledFromRelay = System.Text.RegularExpressions.Regex.IsMatch(
+                relay.Body,
+                $@"\b{System.Text.RegularExpressions.Regex.Escape(helper.Name)}\s*\(");
+            if (!calledFromRelay)
+                continue;
+            inlinedHelperNames.Add(helper.Name);
+            logicalRelayBody += "\n" + helper.Body;
+        }
 
+        var firstPromptInRelay = FindFirstPromptIndex(logicalRelayBody);
+        firstPromptInRelay.ShouldBeGreaterThanOrEqualTo(0,
+            "Neither RelayAsync nor any helper it invokes has a .PromptAsync( call — fence is " +
+            "vacuous. Either the controller stopped invoking the supervisor or the API was " +
+            "renamed. (Searched RelayAsync + inlined helpers: " +
+            string.Join(", ", inlinedHelperNames) + ")");
+
+        var inlineFailures = FindInlineLateAssignments(logicalRelayBody);
+
+        // Helpers that mutate .ConversationId AND are NOT already inlined into the logical
+        // relay flow. The inlined helpers are scanned directly by the inline check above —
+        // double-counting them would produce duplicate failures.
         var helpersWithAssignments = methods
             .Where(m => m.Name != "RelayAsync")
+            .Where(m => !inlinedHelperNames.Contains(m.Name))
             .Where(m => System.Text.RegularExpressions.Regex.IsMatch(m.Body, @"\.ConversationId\s*="))
             .Select(m => m.Name)
             .ToHashSet(StringComparer.Ordinal);
 
-        var postPromptHelperCalls = FindHelperInvocationsAfter(relay.Body, firstPromptInRelay, helpersWithAssignments);
+        var postPromptHelperCalls = FindHelperInvocationsAfter(logicalRelayBody, firstPromptInRelay, helpersWithAssignments);
 
         var failureMessage = new List<string>();
         foreach (var (line, name) in inlineFailures)
-            failureMessage.Add($"  inline assignment at line {LineNumberAt(source, relay.StartIndex + line)} (first PromptAsync at line {LineNumberAt(source, relay.StartIndex + firstPromptInRelay)})");
+            failureMessage.Add($"  inline assignment at logical-body offset {line} (first PromptAsync at logical-body offset {firstPromptInRelay})");
         foreach (var (line, name) in postPromptHelperCalls)
-            failureMessage.Add($"  RelayAsync calls helper '{name}()' at line {LineNumberAt(source, relay.StartIndex + line)} AFTER first .PromptAsync — and {name}() mutates .ConversationId");
+            failureMessage.Add($"  logical RelayAsync flow calls helper '{name}()' at offset {line} AFTER first .PromptAsync — and {name}() mutates .ConversationId");
 
         failureMessage.ShouldBeEmpty(
             "CrossWorldFederationController.RelayAsync has a .ConversationId mutation path that " +
@@ -138,6 +168,7 @@ public sealed class CrossWorldReceiverArchitectureTests
             "visible in the store with ConversationId == null and is invisible to " +
             "ISessionStore.ListByConversationAsync, the portal, and any fan-out that filters by " +
             "conversation.\n" +
+            "Inlined prompt-host helpers: " + string.Join(", ", inlinedHelperNames) + "\n" +
             string.Join("\n", failureMessage));
     }
 

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionWriteLockArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionWriteLockArchitectureTests.cs
@@ -45,6 +45,42 @@ public sealed class SessionWriteLockArchitectureTests
             "File: " + path);
     }
 
+    /// <summary>
+    /// The lock MUST be registered as a singleton — a transient or scoped registration would
+    /// make every request acquire its own private lock with no contention, silently re-opening
+    /// the #551 race window. The behavioural tests in <c>CrossWorldFederationControllerTests</c>
+    /// wire a single shared lock by hand so they cannot catch this regression. Per plan-vs-impl
+    /// critique MEDIUM-4 on the PR sweep, scan the DI composition root explicitly.
+    /// </summary>
+    [Fact]
+    public void GatewayDi_RegistersISessionWriteLock_AsSingleton()
+    {
+        var path = LocateGatewayServiceCollectionExtensionsFile();
+        var source = File.ReadAllText(path);
+
+        // The registration must be a singleton variant. Accept either AddSingleton or
+        // TryAddSingleton — both produce the same lifetime semantics.
+        var singletonPattern = new System.Text.RegularExpressions.Regex(
+            @"\b(?:AddSingleton|TryAddSingleton)\s*<\s*ISessionWriteLock\s*,\s*SessionWriteLock\s*>",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+        singletonPattern.IsMatch(source).ShouldBeTrue(
+            "GatewayServiceCollectionExtensions.cs must register ISessionWriteLock as a singleton " +
+            "(AddSingleton or TryAddSingleton). A transient or scoped registration silently " +
+            "re-opens the #551 race window because every request would get its own private lock " +
+            "instance and never contend on the shared per-session slots.\n" +
+            "File: " + path);
+
+        // Sanity: there must NOT be a competing non-singleton registration anywhere in the file.
+        var transientPattern = new System.Text.RegularExpressions.Regex(
+            @"\b(?:AddTransient|TryAddTransient|AddScoped|TryAddScoped)\s*<\s*ISessionWriteLock\s*,",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+        transientPattern.IsMatch(source).ShouldBeFalse(
+            "GatewayServiceCollectionExtensions.cs contains a transient or scoped registration of " +
+            "ISessionWriteLock alongside the singleton one. The DI container would pick whichever " +
+            "ran last, silently downgrading the lock lifetime and re-opening the #551 race.\n" +
+            "File: " + path);
+    }
+
     [Fact]
     public void Fence_IsNotVacuous_AgainstSyntheticViolation_NoAcquireAtAll()
     {
@@ -194,6 +230,14 @@ public sealed class SessionWriteLockArchitectureTests
         var srcRoot = FindSourceRoot();
         var path = Path.Combine(srcRoot, "gateway", "BotNexus.Gateway.Api", "Controllers", "CrossWorldFederationController.cs");
         File.Exists(path).ShouldBeTrue("Expected CrossWorldFederationController.cs at " + path);
+        return path;
+    }
+
+    private static string LocateGatewayServiceCollectionExtensionsFile()
+    {
+        var srcRoot = FindSourceRoot();
+        var path = Path.Combine(srcRoot, "gateway", "BotNexus.Gateway", "Extensions", "GatewayServiceCollectionExtensions.cs");
+        File.Exists(path).ShouldBeTrue("Expected GatewayServiceCollectionExtensions.cs at " + path);
         return path;
     }
 

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionWriteLockArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionWriteLockArchitectureTests.cs
@@ -1,0 +1,212 @@
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the <c>#551</c> contract: the cross-world
+/// relay <c>RelayAsync</c> entry point must acquire an <c>ISessionWriteLock</c> before
+/// touching the per-turn write→prompt→reload window. Two concurrent senders supplying
+/// the same <c>RemoteSessionId</c> would otherwise interleave their per-turn
+/// active-exchange-id writes and satisfy each other's freshness gate with the wrong
+/// finish payload (cross-attribution + concurrent-writer reason/summary tampering — see
+/// bug-hunt HIGH-1 and MEDIUM-2 against PR #550).
+/// </summary>
+/// <remarks>
+/// This is a <strong>smoke test</strong>, not a correctness proof. The fence shows that
+/// the lock-acquire call appears textually before any <c>PromptAsync</c> or
+/// <c>PrepareTurn</c> call in the receiver file — that's the structural shape a regression
+/// would have to defeat. The behavioural pins are in
+/// <c>CrossWorldFederationControllerTests</c> (the two concurrent RelayAsync tests with
+/// the deterministic-barrier handle) and in <c>SessionWriteLockTests</c>. A clever
+/// regression that retained the textual ordering but broke semantics (e.g. wrapped
+/// <c>AcquireAsync</c> in a no-op <c>IAsyncDisposable</c>) would pass this fence and
+/// fail the behavioural tests — by design. The two layers complement; neither alone
+/// is sufficient.
+/// </remarks>
+public sealed class SessionWriteLockArchitectureTests
+{
+    [Fact]
+    public void CrossWorldFederationController_AcquiresSessionWriteLock_BeforePromptAndFinishGate()
+    {
+        var path = LocateCrossWorldFederationControllerFile();
+        var source = File.ReadAllText(path);
+
+        var violations = FindOrderingViolations(source);
+
+        violations.ShouldBeEmpty(
+            $"{Path.GetFileName(path)} has a call to PromptAsync(...) or " +
+            "AgentExchangeCompletionGate.PrepareTurn(...) that is NOT preceded by an " +
+            "ISessionWriteLock.AcquireAsync(...) call in the same file. This is the #551 " +
+            "structural invariant: two concurrent senders supplying the same RemoteSessionId " +
+            "must serialise on the per-session lock for the entire write→prompt→reload window, " +
+            "otherwise their per-turn active-exchange-id writes interleave and satisfy each " +
+            "other's freshness gate with the wrong finish payload.\n" +
+            "Ordering violations:\n" + string.Join("\n", violations) + "\n" +
+            "File: " + path);
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticViolation_NoAcquireAtAll()
+    {
+        // If a regression deletes the lock entirely (most likely accidental form), the
+        // fence must fire because PromptAsync still appears in the file with no
+        // AcquireAsync to precede it.
+        const string syntheticViolation = """
+            public async Task<ActionResult> RelayAsync(CrossWorldRelayRequest request, CancellationToken ct)
+            {
+                var session = await sessionStore.GetAsync(SessionId.From(request.RemoteSessionId), ct);
+                AgentExchangeCompletionGate.PrepareTurn(session.Metadata, Guid.NewGuid().ToString("N"));
+                var handle = await supervisor.GetOrCreateAsync(session.AgentId, session.SessionId, ct);
+                var response = await handle.PromptAsync(request.Message, ct);
+                return Ok();
+            }
+            """;
+        var violations = FindOrderingViolations(syntheticViolation);
+        violations.ShouldNotBeEmpty(
+            "Vacuity guard: the fence must catch the most obvious regression shape — " +
+            "PromptAsync and PrepareTurn calls with no AcquireAsync anywhere in the file. " +
+            "If this assertion fails, the fence has been weakened so far that it cannot " +
+            "catch the original #551 bug class.");
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticViolation_AcquireAfterPrompt()
+    {
+        // Subtler regression: a future refactor that moves AcquireAsync into a "post-prompt
+        // hardening" block. The lock exists but is acquired too late, missing the entire
+        // write→prompt window. The fence must catch this too.
+        const string syntheticViolation = """
+            public async Task<ActionResult> RelayAsync(CrossWorldRelayRequest request, CancellationToken ct)
+            {
+                var session = await sessionStore.GetAsync(SessionId.From(request.RemoteSessionId), ct);
+                AgentExchangeCompletionGate.PrepareTurn(session.Metadata, Guid.NewGuid().ToString("N"));
+                var handle = await supervisor.GetOrCreateAsync(session.AgentId, session.SessionId, ct);
+                var response = await handle.PromptAsync(request.Message, ct);
+                await using var lease = await sessionWriteLock.AcquireAsync(session.SessionId, ct);
+                await sessionStore.SaveAsync(session, ct);
+                return Ok();
+            }
+            """;
+        var violations = FindOrderingViolations(syntheticViolation);
+        violations.ShouldNotBeEmpty(
+            "Vacuity guard: the fence must catch AcquireAsync that appears textually AFTER " +
+            "the first PromptAsync/PrepareTurn — a lock acquired post-prompt cannot serialise " +
+            "the write→prompt window the #551 race occurs in.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnLegitimateOrdering()
+    {
+        // Legitimate two-branch acquisition: lock first on supplied RemoteSessionId, resolve
+        // first then lock on fresh-mint, ExecuteRelayAsync extracted as helper. The fence
+        // must not flag this shape (otherwise authors will disable it instead of fixing real
+        // regressions).
+        const string syntheticClean = """
+            public async Task<ActionResult> RelayAsync(CrossWorldRelayRequest request, CancellationToken ct)
+            {
+                if (!string.IsNullOrWhiteSpace(request.RemoteSessionId))
+                {
+                    var supplied = SessionId.From(request.RemoteSessionId);
+                    await using var lease = await sessionWriteLock.AcquireAsync(supplied, ct);
+                    var resolved = await ResolveSessionAsync(request, targetAgentId, ct);
+                    return await ExecuteRelayAsync(request, resolved.Session!, resolved.Conversation!, ct);
+                }
+                else
+                {
+                    var resolved = await ResolveSessionAsync(request, targetAgentId, ct);
+                    await using var lease = await sessionWriteLock.AcquireAsync(resolved.Session!.SessionId, ct);
+                    return await ExecuteRelayAsync(request, resolved.Session!, resolved.Conversation!, ct);
+                }
+            }
+
+            private async Task<ActionResult> ExecuteRelayAsync(CrossWorldRelayRequest request, GatewaySession session, Conversation conversation, CancellationToken ct)
+            {
+                await sessionStore.SaveAsync(session, ct);
+                AgentExchangeCompletionGate.PrepareTurn(session.Metadata, Guid.NewGuid().ToString("N"));
+                var handle = await supervisor.GetOrCreateAsync(session.AgentId, session.SessionId, ct);
+                var response = await handle.PromptAsync(request.Message, ct);
+                return Ok();
+            }
+            """;
+        var violations = FindOrderingViolations(syntheticClean);
+        violations.ShouldBeEmpty(
+            "False-positive guard: the fence must not flag the canonical two-branch " +
+            "lock-acquisition shape used in production. If this assertion fails, the fence " +
+            "is over-broad and authors will disable it instead of using it.\n" +
+            "Violations: " + string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Finds every <c>PromptAsync(</c> or <c>AgentExchangeCompletionGate.PrepareTurn(</c>
+    /// call that is not preceded by at least one <c>AcquireAsync(</c> call somewhere
+    /// earlier in the source.
+    /// </summary>
+    /// <remarks>
+    /// Textual ordering is a structural smoke check — it confirms the lock-acquire token
+    /// appears before the prompt/prepare tokens in the file, which is the shape any
+    /// regression that deletes or relocates the lock would have to defeat. It does not
+    /// prove the lock has the right scope, the right key, or holds across the right
+    /// statements (those are behavioural concerns covered by the unit + concurrency tests).
+    /// </remarks>
+    private static List<string> FindOrderingViolations(string source)
+    {
+        var violations = new List<string>();
+
+        var firstAcquireIdx = source.IndexOf("AcquireAsync(", StringComparison.Ordinal);
+
+        var promptRegex = new System.Text.RegularExpressions.Regex(
+            @"\.PromptAsync\s*\(",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+        var prepareRegex = new System.Text.RegularExpressions.Regex(
+            @"AgentExchangeCompletionGate\s*\.\s*PrepareTurn\s*\(",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        foreach (System.Text.RegularExpressions.Match m in promptRegex.Matches(source))
+        {
+            if (firstAcquireIdx < 0 || m.Index < firstAcquireIdx)
+            {
+                violations.Add($"  PromptAsync at offset {m.Index} with no preceding AcquireAsync: " +
+                    $"'{Snippet(source, m.Index)}'");
+            }
+        }
+
+        foreach (System.Text.RegularExpressions.Match m in prepareRegex.Matches(source))
+        {
+            if (firstAcquireIdx < 0 || m.Index < firstAcquireIdx)
+            {
+                violations.Add($"  PrepareTurn at offset {m.Index} with no preceding AcquireAsync: " +
+                    $"'{Snippet(source, m.Index)}'");
+            }
+        }
+
+        return violations;
+    }
+
+    private static string Snippet(string source, int idx)
+    {
+        var start = Math.Max(0, idx - 10);
+        var end = Math.Min(source.Length, idx + 60);
+        return source[start..end].Replace("\n", "\\n").Replace("\r", "");
+    }
+
+    private static string LocateCrossWorldFederationControllerFile()
+    {
+        var srcRoot = FindSourceRoot();
+        var path = Path.Combine(srcRoot, "gateway", "BotNexus.Gateway.Api", "Controllers", "CrossWorldFederationController.cs");
+        File.Exists(path).ShouldBeTrue("Expected CrossWorldFederationController.cs at " + path);
+        return path;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current!.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -977,26 +977,27 @@ public sealed class AgentExchangeServiceTests
         sessionA.ShouldNotBeNull();
         sessionB.ShouldNotBeNull();
 
-        sessionA!.History
-            .Where(e => e.Role == MessageRole.User)
-            .Select(e => e.Content)
-            .ShouldContain("msg-A");
-        sessionA.History
-            .Where(e => e.Role == MessageRole.User)
-            .Select(e => e.Content)
-            .ShouldNotContain("msg-B",
-                "Caller B's message leaked into caller A's session — concurrent ConverseAsync " +
-                "calls cross-contaminated state. Either ConverseAsync regressed to shared-session " +
-                "shape, or its sessions aren't actually isolated.");
-        sessionB!.History
-            .Where(e => e.Role == MessageRole.User)
-            .Select(e => e.Content)
-            .ShouldContain("msg-B");
-        sessionB.History
-            .Where(e => e.Role == MessageRole.User)
-            .Select(e => e.Content)
-            .ShouldNotContain("msg-A",
-                "Caller A's message leaked into caller B's session — same regression class as above.");
+        // Full-shape assertion (bug-hunt LOW #4 on PR #551 critique sweep): a regression that
+        // leaks assistant-side content (e.g. shared response buffer, swapped reply queues) would
+        // not surface in a user-only filter. Assert each session's entire history shape — counts,
+        // ordering, and both user + assistant content — to catch corruption on either side.
+        sessionA!.History.Count.ShouldBe(2,
+            "Session A must contain exactly its own user + assistant pair (no leaked entries).");
+        sessionA.History[0].Role.ShouldBe(MessageRole.User);
+        sessionA.History[0].Content.ShouldBe("msg-A");
+        sessionA.History[1].Role.ShouldBe(MessageRole.Assistant);
+        sessionA.History[1].Content.ShouldBe("reply:msg-A",
+            "Caller A's assistant turn is the response keyed to A's user message. A leaked " +
+            "'reply:msg-B' here would prove cross-session response cross-attribution.");
+
+        sessionB!.History.Count.ShouldBe(2,
+            "Session B must contain exactly its own user + assistant pair (no leaked entries).");
+        sessionB.History[0].Role.ShouldBe(MessageRole.User);
+        sessionB.History[0].Content.ShouldBe("msg-B");
+        sessionB.History[1].Role.ShouldBe(MessageRole.Assistant);
+        sessionB.History[1].Content.ShouldBe("reply:msg-B",
+            "Caller B's assistant turn is the response keyed to B's user message. A leaked " +
+            "'reply:msg-A' here would prove cross-session response cross-attribution.");
     }
 
         private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target, IReadOnlyList<string> allowedTargets)

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -890,6 +890,115 @@ public sealed class AgentExchangeServiceTests
         result.Status.ShouldBe("sealed");
     }
 
+    [Fact]
+    public async Task ConcurrentConverseAsync_OnSameSourceTarget_ProducesDistinctSessionIds_AndIsolatedTranscripts()
+    {
+        // #551 AC #2: AgentExchangeService.ConverseAsync mints a fresh SessionId.Create() per call
+        // (see AgentExchangeService.cs:96), so two concurrent calls on the same initiator/target
+        // pair produce DIFFERENT session ids by construction and cannot interleave. This makes
+        // the per-session write lock that protects CrossWorldFederationController.RelayAsync
+        // intentionally absent here — the per-call sessionId freshness IS the isolation guarantee.
+        //
+        // This test pins that invariant. A regression that introduced a shared session for
+        // concurrent calls (e.g. "reuse the active session for this pair") would cause:
+        //   (1) overlapping session ids — caught by the distinct-ids assertion below, OR
+        //   (2) interleaved transcripts — caught by the per-session content assertions.
+        //
+        // Either symptom would invalidate the "no lock needed" reasoning and require either
+        // adding the lock here OR reverting the regression. The barrier in the handle ensures
+        // both calls are genuinely in flight simultaneously rather than serialised by chance.
+
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
+        var sessionStore = new InMemorySessionStore();
+
+        var bothEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBoth = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = 0;
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string msg, CancellationToken ct) =>
+            {
+                if (Interlocked.Increment(ref entered) == 2)
+                    bothEntered.SetResult();
+                // Both callers must reach this point before either proceeds, proving they
+                // were ACTUALLY concurrent (not sequenced by Task.Run scheduling order).
+                await releaseBoth.Task.WaitAsync(ct);
+                return new AgentResponse { Content = $"reply:{msg}" };
+            });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            new InMemoryConversationStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var taskA = Task.Run(() => service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "msg-A",
+            MaxTurns = 1
+        }));
+        var taskB = Task.Run(() => service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "msg-B",
+            MaxTurns = 1
+        }));
+
+        // Wait until both are genuinely parked inside PromptAsync — proves they're concurrent.
+        await bothEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        releaseBoth.SetResult();
+        var resultA = await taskA.WaitAsync(TimeSpan.FromSeconds(5));
+        var resultB = await taskB.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Primary invariant: per-call sessionId freshness. If this fails, ConverseAsync has
+        // started reusing sessions across concurrent calls and the no-lock assumption breaks.
+        resultA.SessionId.ShouldNotBe(resultB.SessionId,
+            "Concurrent ConverseAsync calls must produce distinct SessionIds — that's the " +
+            "per-call freshness guarantee that justifies skipping the per-session write lock in " +
+            "this service. A regression here would re-open the #551 race class in AgentExchangeService.");
+
+        // Secondary invariant: each session's transcript contains ONLY its own turns. Interleaving
+        // would manifest as msg-A appearing in session B's transcript or vice versa.
+        var sessionA = await sessionStore.GetAsync(resultA.SessionId);
+        var sessionB = await sessionStore.GetAsync(resultB.SessionId);
+        sessionA.ShouldNotBeNull();
+        sessionB.ShouldNotBeNull();
+
+        sessionA!.History
+            .Where(e => e.Role == MessageRole.User)
+            .Select(e => e.Content)
+            .ShouldContain("msg-A");
+        sessionA.History
+            .Where(e => e.Role == MessageRole.User)
+            .Select(e => e.Content)
+            .ShouldNotContain("msg-B",
+                "Caller B's message leaked into caller A's session — concurrent ConverseAsync " +
+                "calls cross-contaminated state. Either ConverseAsync regressed to shared-session " +
+                "shape, or its sessions aren't actually isolated.");
+        sessionB!.History
+            .Where(e => e.Role == MessageRole.User)
+            .Select(e => e.Content)
+            .ShouldContain("msg-B");
+        sessionB.History
+            .Where(e => e.Role == MessageRole.User)
+            .Select(e => e.Content)
+            .ShouldNotContain("msg-A",
+                "Caller A's message leaked into caller B's session — same regression class as above.");
+    }
+
         private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target, IReadOnlyList<string> allowedTargets)
     {
         var registry = new Mock<IAgentRegistry>();

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -898,6 +898,164 @@ public sealed class CrossWorldFederationControllerTests
         conflict.StatusCode.ShouldBe(StatusCodes.Status409Conflict);
     }
 
+    [Fact]
+    public async Task RelayAsync_WhenSecondCallerUsesSameRemoteSessionId_BlocksOnLock_AndRunsSequentially()
+    {
+        // #551 regression pin: the lock acquired in RelayAsync for the supplied RemoteSessionId
+        // MUST serialize concurrent relays that target the same session. Without the lock, both
+        // callers race through the write → prompt → reload → consume-gate sequence, their per-turn
+        // active-exchange-id writes interleave, and the freshness gate can credit caller B's
+        // finish payload to caller A or vice versa (the original PR #550 bug-hunt HIGH-1 / MEDIUM-2
+        // findings that motivated this PR). We pin the lock's existence end-to-end by:
+        //  (1) issuing two concurrent relays for the same seeded RemoteSessionId,
+        //  (2) parking caller A inside PromptAsync via a barrier in the supervisor mock,
+        //  (3) asserting caller B has NOT entered PromptAsync while A is parked
+        //      (the lock prevents B from even reaching PromptAsync — without the lock, B's
+        //       PromptAsync would also be invoked and the barrier would catch it),
+        //  (4) releasing A and verifying B then runs to completion with the history showing
+        //      both turns in strict order (no interleaving).
+        //
+        // A no-op lock regression (returning a Releaser that never blocked) would let both
+        // callers progress to PromptAsync simultaneously — step (3) would observe a second
+        // PromptCallCount tick before A is released.
+
+        var (controller, sessions, conversations, _, barrier) = BuildControllerWithBarrier();
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        // Seed a reusable cross-world session so the RemoteSessionId branch (which acquires the
+        // lock BEFORE ResolveSessionAsync) is exercised. This mirrors lines 296-311 of the
+        // existing ownership-validation tests.
+        var seededId = SessionId.Create();
+        var target = AgentId.From(TargetAgentId);
+        var conv = await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = target,
+            Kind = ConversationKind.AgentAgent,
+            Title = "Cross-world agent exchange"
+        });
+        var seeded = await sessions.GetOrCreateAsync(seededId, target);
+        seeded.Session.ConversationId = conv.ConversationId;
+        seeded.SessionType = SessionType.AgentAgent;
+        seeded.ChannelType = ChannelKey.From("cross-world");
+        seeded.Metadata["sourceWorldId"] = SourceWorldId;
+        seeded.Metadata["sourceAgentId"] = SourceAgentId;
+        await sessions.SaveAsync(seeded);
+
+        var callerATask = Task.Run(() => controller.RelayAsync(
+            BuildRequest(message: "turn-A", remoteSessionId: seededId.Value),
+            CancellationToken.None));
+
+        // Wait until caller A is parked inside PromptAsync — this proves A has the lock.
+        await barrier.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Volatile.Read(ref barrier.PromptCallCount).ShouldBe(1,
+            "Pre-condition: caller A's PromptAsync must have been invoked and parked.");
+
+        var callerBTask = Task.Run(() => controller.RelayAsync(
+            BuildRequest(message: "turn-B", remoteSessionId: seededId.Value),
+            CancellationToken.None));
+
+        // Give caller B plenty of time to reach AcquireAsync. With the lock in place B parks in
+        // SemaphoreSlim.WaitAsync. Without the lock B would proceed to PromptAsync and the
+        // barrier would tick the counter to 2.
+        await Task.Delay(150);
+        callerBTask.IsCompleted.ShouldBeFalse(
+            "Caller B must be blocked on SessionWriteLock.AcquireAsync while caller A holds the " +
+            "lease. A no-op lock would let B race A through PromptAsync and complete here.");
+        Volatile.Read(ref barrier.PromptCallCount).ShouldBe(1,
+            "Lock regression: caller B's PromptAsync was invoked while caller A's lease was still " +
+            "held — SessionWriteLock failed to serialize concurrent relays on the same session id, " +
+            "re-opening the #551 race window.");
+
+        // Release caller A — caller B should now acquire the lock, run, and complete.
+        barrier.Release.SetResult();
+        var aResponse = await callerATask.WaitAsync(TimeSpan.FromSeconds(5));
+        var bResponse = await callerBTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        aResponse.Result.ShouldBeOfType<OkObjectResult>();
+        bResponse.Result.ShouldBeOfType<OkObjectResult>();
+        Volatile.Read(ref barrier.PromptCallCount).ShouldBe(2,
+            "Both callers' PromptAsync must have run exactly once.");
+
+        // History should reflect strict serialization: A's user + assistant entries appear
+        // before B's. Interleaving would manifest as [user-A, user-B, assistant-A, assistant-B]
+        // or similar; sequential execution yields the deterministic [A.user, A.asst, B.user, B.asst].
+        var finalSession = (await sessions.GetAsync(seededId, CancellationToken.None))!;
+        finalSession.History.Count.ShouldBe(4,
+            "Two relays × two entries each (user + assistant) = 4 entries in the persisted session.");
+        finalSession.History[0].Role.ShouldBe(MessageRole.User);
+        finalSession.History[0].Content.ShouldBe("turn-A");
+        finalSession.History[1].Role.ShouldBe(MessageRole.Assistant);
+        finalSession.History[1].Content.ShouldBe("reply-A");
+        finalSession.History[2].Role.ShouldBe(MessageRole.User);
+        finalSession.History[2].Content.ShouldBe("turn-B");
+        finalSession.History[3].Role.ShouldBe(MessageRole.Assistant);
+        finalSession.History[3].Content.ShouldBe("reply-B");
+    }
+
+    [Fact]
+    public async Task RelayAsync_WhenSecondCallerUsesDifferentRemoteSessionId_DoesNotBlock()
+    {
+        // Per-session keying: a relay against session X must NOT block a relay against session Y.
+        // Defends against a regression that uses a single global mutex instead of per-session
+        // keying — that would silently serialize unrelated cross-world traffic and make the
+        // gateway a global bottleneck.
+
+        var (controller, sessions, conversations, _, barrier) = BuildControllerWithBarrier();
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        // Two independently seeded cross-world sessions belonging to the same target agent.
+        var sessionXId = SessionId.Create();
+        var sessionYId = SessionId.Create();
+        var target = AgentId.From(TargetAgentId);
+        foreach (var sid in new[] { sessionXId, sessionYId })
+        {
+            var conv = await conversations.CreateAsync(new Conversation
+            {
+                ConversationId = ConversationId.Create(),
+                AgentId = target,
+                Kind = ConversationKind.AgentAgent,
+                Title = "Cross-world agent exchange"
+            });
+            var seeded = await sessions.GetOrCreateAsync(sid, target);
+            seeded.Session.ConversationId = conv.ConversationId;
+            seeded.SessionType = SessionType.AgentAgent;
+            seeded.ChannelType = ChannelKey.From("cross-world");
+            seeded.Metadata["sourceWorldId"] = SourceWorldId;
+            seeded.Metadata["sourceAgentId"] = SourceAgentId;
+            await sessions.SaveAsync(seeded);
+        }
+
+        var taskX = Task.Run(() => controller.RelayAsync(
+            BuildRequest(message: "X", remoteSessionId: sessionXId.Value), CancellationToken.None));
+
+        // Wait for X's PromptAsync to park.
+        await barrier.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var taskY = Task.Run(() => controller.RelayAsync(
+            BuildRequest(message: "Y", remoteSessionId: sessionYId.Value), CancellationToken.None));
+
+        // Y targets a DIFFERENT session id — its PromptAsync should be invoked despite X being
+        // parked. Because the barrier counter only blocks the FIRST call, Y's call returns
+        // immediately on entry (no barrier wait). We assert PromptCallCount reaches 2 BEFORE
+        // releasing X. A global lock regression would keep PromptCallCount at 1 here.
+        var pollDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (DateTime.UtcNow < pollDeadline && Volatile.Read(ref barrier.PromptCallCount) < 2)
+            await Task.Delay(25);
+
+        Volatile.Read(ref barrier.PromptCallCount).ShouldBe(2,
+            "Caller Y's PromptAsync must have run while caller X is parked — per-session keying " +
+            "requires unrelated sessions to NOT block each other. A regression to a global lock " +
+            "would prevent Y from progressing until X is released.");
+        taskY.IsCompleted.ShouldBeTrue(
+            "Y should have completed independently of X because the lock is keyed per session id.");
+
+        // Release X and verify it completes cleanly.
+        barrier.Release.SetResult();
+        var xResponse = await taskX.WaitAsync(TimeSpan.FromSeconds(5));
+        xResponse.Result.ShouldBeOfType<OkObjectResult>();
+    }
+
     // ---- helpers ----
 
     private static (CrossWorldFederationController Controller, InMemorySessionStore Sessions,
@@ -1047,6 +1205,15 @@ public sealed class CrossWorldFederationControllerTests
         IConversationStore conversations,
         IAgentSupervisor supervisor)
     {
+        return BuildControllerCore(sessions, conversations, supervisor, new SessionWriteLock());
+    }
+
+    private static CrossWorldFederationController BuildControllerCore(
+        ISessionStore sessions,
+        IConversationStore conversations,
+        IAgentSupervisor supervisor,
+        ISessionWriteLock sessionWriteLock)
+    {
         var platformConfig = new PlatformConfig
         {
             Gateway = new GatewaySettingsConfig
@@ -1082,6 +1249,7 @@ public sealed class CrossWorldFederationControllerTests
             supervisor,
             sessions,
             conversations,
+            sessionWriteLock,
             new CrossWorldInboundAuthService(monitor),
             monitor,
             NullLogger<CrossWorldFederationController>.Instance)
@@ -1091,6 +1259,56 @@ public sealed class CrossWorldFederationControllerTests
                 HttpContext = new DefaultHttpContext()
             }
         };
+    }
+
+    /// <summary>
+    /// Builds a controller whose agent handle parks the FIRST <c>PromptAsync</c> invocation on a
+    /// barrier (signals <see cref="BarrierState.Entered"/>; awaits <see cref="BarrierState.Release"/>)
+    /// and returns immediately for subsequent invocations. Used by the #551 concurrency pin to
+    /// prove the per-session lock serialises concurrent relays on the same RemoteSessionId.
+    /// </summary>
+    private static (CrossWorldFederationController Controller, InMemorySessionStore Sessions,
+        InMemoryConversationStore Conversations, Mock<IAgentSupervisor> Supervisor, BarrierState Barrier)
+        BuildControllerWithBarrier()
+    {
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+        var barrier = new BarrierState();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string msg, CancellationToken ct) =>
+            {
+                var callNumber = Interlocked.Increment(ref barrier.PromptCallCount);
+                if (callNumber == 1)
+                {
+                    barrier.Entered.SetResult();
+                    await barrier.Release.Task.WaitAsync(ct);
+                    return new AgentResponse { Content = "reply-A" };
+                }
+                return new AgentResponse { Content = $"reply-{msg.Substring(msg.Length - 1)}" };
+            });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From(TargetAgentId), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        // Share one SessionWriteLock across both concurrent callers — the production singleton
+        // shape. A fresh-per-controller lock would make the test vacuous (each caller would have
+        // its own lock and never serialise).
+        var controller = BuildControllerCore(sessions, conversations, supervisor.Object, new SessionWriteLock());
+        return (controller, sessions, conversations, supervisor, barrier);
+    }
+
+    /// <summary>
+    /// Shared barrier state for the #551 concurrency pin. Public mutable field for
+    /// <see cref="Interlocked.Increment(ref int)"/>; tasks signal via the <see cref="TaskCompletionSource"/>s.
+    /// </summary>
+    private sealed class BarrierState
+    {
+        public readonly TaskCompletionSource Entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int PromptCallCount;
     }
 
     private static void SetApiKeyHeader(CrossWorldFederationController controller, string key)

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -919,7 +919,7 @@ public sealed class CrossWorldFederationControllerTests
         // callers progress to PromptAsync simultaneously — step (3) would observe a second
         // PromptCallCount tick before A is released.
 
-        var (controller, sessions, conversations, _, barrier) = BuildControllerWithBarrier();
+        var (controller, sessions, conversations, _, barrier, sessionWriteLock) = BuildControllerWithBarrier();
         SetApiKeyHeader(controller, SharedApiKey);
 
         // Seed a reusable cross-world session so the RemoteSessionId branch (which acquires the
@@ -955,13 +955,22 @@ public sealed class CrossWorldFederationControllerTests
             BuildRequest(message: "turn-B", remoteSessionId: seededId.Value),
             CancellationToken.None));
 
-        // Give caller B plenty of time to reach AcquireAsync. With the lock in place B parks in
-        // SemaphoreSlim.WaitAsync. Without the lock B would proceed to PromptAsync and the
-        // barrier would tick the counter to 2.
-        await Task.Delay(150);
+        // Deterministically wait until caller B has reached AcquireAsync and is parked behind
+        // caller A (refcount == 2). Without this probe a Task.Delay heuristic could fire BEFORE
+        // B reached the lock, masking a lock regression that lets B race through PromptAsync
+        // on a slow CI runner. The lock instance was constructed in BuildControllerWithBarrier
+        // and is the same singleton both callers were wired against.
+        var lockInstance = sessionWriteLock;
+        var spinDeadline = DateTime.UtcNow.AddSeconds(5);
+        while (lockInstance.RefCountFor(seededId) < 2 && DateTime.UtcNow < spinDeadline && !callerBTask.IsCompleted)
+            await Task.Yield();
+
         callerBTask.IsCompleted.ShouldBeFalse(
-            "Caller B must be blocked on SessionWriteLock.AcquireAsync while caller A holds the " +
-            "lease. A no-op lock would let B race A through PromptAsync and complete here.");
+            "Caller B completed BEFORE caller A released — SessionWriteLock failed to serialize " +
+            "concurrent relays on the same session id, re-opening the #551 race window.");
+        lockInstance.RefCountFor(seededId).ShouldBe(2,
+            "Lock regression: caller B is not parked on the same slot as caller A. Either the " +
+            "lock is not being acquired or the per-session keying is wrong.");
         Volatile.Read(ref barrier.PromptCallCount).ShouldBe(1,
             "Lock regression: caller B's PromptAsync was invoked while caller A's lease was still " +
             "held — SessionWriteLock failed to serialize concurrent relays on the same session id, " +
@@ -1001,7 +1010,7 @@ public sealed class CrossWorldFederationControllerTests
         // keying — that would silently serialize unrelated cross-world traffic and make the
         // gateway a global bottleneck.
 
-        var (controller, sessions, conversations, _, barrier) = BuildControllerWithBarrier();
+        var (controller, sessions, conversations, _, barrier, _) = BuildControllerWithBarrier();
         SetApiKeyHeader(controller, SharedApiKey);
 
         // Two independently seeded cross-world sessions belonging to the same target agent.
@@ -1268,7 +1277,8 @@ public sealed class CrossWorldFederationControllerTests
     /// prove the per-session lock serialises concurrent relays on the same RemoteSessionId.
     /// </summary>
     private static (CrossWorldFederationController Controller, InMemorySessionStore Sessions,
-        InMemoryConversationStore Conversations, Mock<IAgentSupervisor> Supervisor, BarrierState Barrier)
+        InMemoryConversationStore Conversations, Mock<IAgentSupervisor> Supervisor, BarrierState Barrier,
+        SessionWriteLock Lock)
         BuildControllerWithBarrier()
     {
         var sessions = new InMemorySessionStore();
@@ -1295,9 +1305,12 @@ public sealed class CrossWorldFederationControllerTests
 
         // Share one SessionWriteLock across both concurrent callers — the production singleton
         // shape. A fresh-per-controller lock would make the test vacuous (each caller would have
-        // its own lock and never serialise).
-        var controller = BuildControllerCore(sessions, conversations, supervisor.Object, new SessionWriteLock());
-        return (controller, sessions, conversations, supervisor, barrier);
+        // its own lock and never serialise). The lock is returned so callers can probe its
+        // refcount deterministically (see #551 critique-sweep MEDIUM-2/3 — replaces a
+        // Task.Delay(150) timing heuristic with a refcount spin-wait).
+        var sessionWriteLock = new SessionWriteLock();
+        var controller = BuildControllerCore(sessions, conversations, supervisor.Object, sessionWriteLock);
+        return (controller, sessions, conversations, supervisor, barrier, sessionWriteLock);
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWriteLockTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWriteLockTests.cs
@@ -1,0 +1,186 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+/// <summary>
+/// Unit tests for <see cref="SessionWriteLock"/> — the per-session mutex that closes
+/// the cross-world relay race window pinned by issue #551 (PR #550 bug-hunt critique
+/// HIGH-1 and MEDIUM-2). Each test pins a property of the locking primitive that the
+/// concurrency-bug fix at the call sites depends on.
+/// </summary>
+public sealed class SessionWriteLockTests
+{
+    [Fact]
+    public async Task AcquireAsync_SameSessionId_SerializesConcurrentCallers()
+    {
+        // The whole point: two callers on the same session id must NOT run their
+        // critical sections at the same time. A regression to a no-op lock would
+        // let both progress past the WaitAsync and observe interleaved state.
+        var sut = new SessionWriteLock();
+        var sessionId = SessionId.Create();
+        var enteredOrder = new List<int>();
+        var releaseA = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Acquire A synchronously FIRST so the ordering is deterministic — without
+        // this, the first scheduled Task.Run could be either A or B and the test
+        // would be racy on who acquires the lock first.
+        var leaseA = await sut.AcquireAsync(sessionId);
+        lock (enteredOrder) enteredOrder.Add(1);
+
+        // Start B; it must block in WaitAsync until A releases.
+        var b = Task.Run(async () =>
+        {
+            await using var lease = await sut.AcquireAsync(sessionId);
+            lock (enteredOrder) enteredOrder.Add(2);
+            releaseA.Task.IsCompleted.ShouldBeTrue(
+                "Caller B entered the critical section while caller A's lease was still held; " +
+                "SessionWriteLock did not serialize concurrent acquires on the same SessionId.");
+        });
+
+        // Give B time to attempt and block in WaitAsync.
+        await Task.Delay(75);
+        b.IsCompleted.ShouldBeFalse(
+            "Caller B completed before A released its lease — SessionWriteLock did not block B.");
+
+        releaseA.SetResult();
+        await leaseA.DisposeAsync();
+        await b.WaitAsync(TimeSpan.FromSeconds(2));
+
+        enteredOrder.ShouldBe(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task AcquireAsync_DifferentSessionIds_RunInParallel()
+    {
+        // Locks keyed by different SessionIds must not serialize each other —
+        // otherwise the lock becomes a global gateway-wide bottleneck and any
+        // long-running cross-world prompt blocks unrelated sessions.
+        var sut = new SessionWriteLock();
+        var sessionA = SessionId.Create();
+        var sessionB = SessionId.Create();
+        var bothEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entries = 0;
+
+        async Task AcquireAndWait(SessionId id)
+        {
+            await using var lease = await sut.AcquireAsync(id);
+            if (Interlocked.Increment(ref entries) == 2)
+                bothEntered.SetResult();
+            // Park until both callers are inside their critical sections.
+            await bothEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+
+        var taskA = AcquireAndWait(sessionA);
+        var taskB = AcquireAndWait(sessionB);
+
+        await Task.WhenAll(taskA, taskB).WaitAsync(TimeSpan.FromSeconds(5));
+        // Reaching here without a TimeoutException is the proof; both callers
+        // necessarily held their locks simultaneously.
+        entries.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_Cancelled_DoesNotLeakRefCount()
+    {
+        // A cancelled WaitAsync must still decrement the refcount we took in the
+        // dictionary gate, otherwise a slot is permanently pinned and never
+        // evicted — a slow leak that only manifests after long uptime.
+        var sut = new SessionWriteLock();
+        var sessionId = SessionId.Create();
+
+        // Hold the lock so the second caller blocks in WaitAsync.
+        var holder = await sut.AcquireAsync(sessionId);
+
+        using var cts = new CancellationTokenSource();
+        var waiterTask = sut.AcquireAsync(sessionId, cts.Token);
+
+        // Yield to give the waiter a chance to actually enter WaitAsync before we cancel.
+        await Task.Delay(50);
+        cts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () => await waiterTask);
+
+        // Release the original holder — slot should now be removed because the
+        // cancelled waiter correctly decremented its refcount.
+        await holder.DisposeAsync();
+
+        sut.OutstandingSlotCount.ShouldBe(0,
+            "Cancelling a pending acquire must decrement the refcount the gate took. " +
+            "A leaked refcount keeps the slot in the dictionary forever even though no " +
+            "caller holds the lock.");
+    }
+
+    [Fact]
+    public async Task AcquireAsync_AfterFullRelease_RemovesSlotFromDictionary()
+    {
+        // Refcount cleanup is the only mechanism preventing per-session-id memory
+        // growth. If a regression switched to a never-evict ConcurrentDictionary
+        // (the duck's "simpler but leaky" alternative), this test would catch it.
+        var sut = new SessionWriteLock();
+        var sessionId = SessionId.Create();
+
+        var lease = await sut.AcquireAsync(sessionId);
+        sut.OutstandingSlotCount.ShouldBe(1);
+
+        await lease.DisposeAsync();
+        sut.OutstandingSlotCount.ShouldBe(0,
+            "After the last lease for a session id is released, the dictionary entry " +
+            "must be removed so the lock primitive does not accumulate per-session " +
+            "memory over the lifetime of the gateway.");
+    }
+
+    [Fact]
+    public async Task AcquireAsync_RepeatedCycles_DoNotLeak()
+    {
+        // 100 sequential acquire/release cycles on the same session id must
+        // leave the dictionary empty. Catches a class of bugs where slot
+        // disposal is asymmetric with slot creation (e.g. semaphore reused
+        // across cycles instead of recreated, or a release that doesn't
+        // remove on RefCount==0).
+        var sut = new SessionWriteLock();
+        var sessionId = SessionId.Create();
+
+        for (var i = 0; i < 100; i++)
+        {
+            await using var lease = await sut.AcquireAsync(sessionId);
+        }
+
+        sut.OutstandingSlotCount.ShouldBe(0,
+            "Repeated acquire/release cycles on the same session id leaked dictionary entries.");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_MultipleTimes_OnlyReleasesOnce()
+    {
+        // Releaser is reentrancy-safe via Interlocked.Exchange — a stray double
+        // dispose must not over-release the semaphore (which would corrupt the
+        // semaphore count and let two future callers into the critical section).
+        var sut = new SessionWriteLock();
+        var sessionId = SessionId.Create();
+
+        var lease = await sut.AcquireAsync(sessionId);
+        await lease.DisposeAsync();
+        await lease.DisposeAsync();
+
+        // Acquire+release one more time — must succeed without a SemaphoreFullException
+        // or any other corruption symptom.
+        await using var probe = await sut.AcquireAsync(sessionId);
+        sut.OutstandingSlotCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_AfterDispose_Throws()
+    {
+        // Defensive: once the lock primitive is disposed, future acquires must
+        // throw rather than silently no-op (which would be a correctness bomb
+        // for any code that depends on the serialization guarantee).
+        var sut = new SessionWriteLock();
+        sut.Dispose();
+
+        await Should.ThrowAsync<ObjectDisposedException>(
+            () => sut.AcquireAsync(SessionId.Create()));
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWriteLockTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWriteLockTests.cs
@@ -97,8 +97,17 @@ public sealed class SessionWriteLockTests
         using var cts = new CancellationTokenSource();
         var waiterTask = sut.AcquireAsync(sessionId, cts.Token);
 
-        // Yield to give the waiter a chance to actually enter WaitAsync before we cancel.
-        await Task.Delay(50);
+        // Spin-wait deterministically until the waiter has actually incremented the slot's
+        // refcount (proving it entered the gate and is parked in WaitAsync). Without this,
+        // a Task.Delay(50) heuristic could fire BEFORE the waiter parked, in which case
+        // cancelling would short-circuit before the catch/decrement path runs — and the
+        // refcount-leak regression we're trying to catch would survive.
+        var spinDeadline = DateTime.UtcNow.AddSeconds(5);
+        while (sut.RefCountFor(sessionId) < 2 && DateTime.UtcNow < spinDeadline)
+            await Task.Yield();
+        sut.RefCountFor(sessionId).ShouldBe(2,
+            "Waiter never entered WaitAsync — cancellation would not exercise the catch path.");
+
         cts.Cancel();
 
         await Should.ThrowAsync<OperationCanceledException>(async () => await waiterTask);


### PR DESCRIPTION
# Closes #551 — Per-session lock on cross-world relay write→prompt→reload window

## Why

Two concurrent `CrossWorldFederationController.RelayAsync` calls supplying the
same `RemoteSessionId` interleave through the session
write → `PromptAsync` → reload window and satisfy each other's freshness gate
with the wrong finish payload. That is bug-hunt **HIGH-1** + **MEDIUM-2** from
PR #550's critique sweep — cross-attribution of finish payloads and
concurrent-writer reason/summary tampering.

## What

* **New abstraction** `ISessionWriteLock` (BotNexus.Gateway.Contracts.Sessions)
  exposing `Task<IAsyncDisposable> AcquireAsync(SessionId, CancellationToken)`.
  XML doc covers single-process scope, non-reentrancy, refcounted slot
  lifecycle.
* **New implementation** `SessionWriteLock` — gated refcount design. A single
  `lock(_gate)` guards `Dictionary<SessionId, LockSlot>` mutation + refcount
  transitions; the SemaphoreSlim itself is awaited outside the gate so
  per-session waiters do not block siblings. `try/catch` around `WaitAsync`
  decrements the refcount on cancellation. The `Releaser` uses
  `Interlocked.Exchange` for double-dispose safety. Registered as a
  **singleton** in the DI extensions.
* **`RelayAsync` two-branch lock acquisition**:
  * Supplied `RemoteSessionId` → acquire lock **FIRST**, then resolve. A
    concurrent caller can never observe the session as Active and sneak past
    after the first caller seals it.
  * Fresh mint → resolve first (so the new sessionId exists), then acquire.
    Functionally a no-op in this branch but uniform.
  * Extracted `ExecuteRelayAsync` private helper holds the entire
    write → prompt → reload → save pipeline under the lock. **The `try/catch`
    including the error-seal `SaveAsync` is INSIDE the lock scope** so a
    second caller cannot sneak in between the failure and the seal persist.
* **`AgentExchangeService.ConverseAsync` is intentionally not locked** — both
  `ConverseAsync` and `ConverseCrossWorldAsync` mint
  `sessionId = SessionId.Create()` per call, so two concurrent calls produce
  different sessionIds by construction. AC #2 is satisfied via a new
  isolation test that **pins** this invariant rather than by adding dead code.

## Rubber-duck findings adopted (BLOCKING — applied before any code)

1. **Lock-free CAS refcount has split-brain race** → replaced with single
   `lock(_gate)`.
2. **Cancellation during `WaitAsync` would leak refcount** → wrapped in
   `try/catch` that decrements + evicts.
3. **Supplied `RemoteSessionId` MUST acquire BEFORE `ResolveSessionAsync`** —
   otherwise concurrent callers can both observe Active state past the first
   sealing.
4. **`try/catch` MUST be INSIDE lock scope** — error-seal `SaveAsync` runs
   under the lock.
5. **Single-process scope MUST be documented** — XML doc on `ISessionWriteLock`
   calls this out explicitly.

## Tests

| Suite | Tests added | Coverage |
|---|---|---|
| `SessionWriteLockTests` | 7 unit | Serialise-same-session, parallel-different-ids, cancel-no-leak, evict-on-release, 100-cycle no-leak, double-dispose safety, dispose-then-acquire-throws |
| `CrossWorldFederationControllerTests` | 2 concurrency | Same-RemoteSessionId blocks on lock with strict transcript ordering; different-RemoteSessionId does not block (proves per-session keying) |
| `AgentExchangeServiceTests` | 1 isolation | Concurrent `ConverseAsync` on same initiator/target produces distinct SessionIds AND isolated transcripts (proves no-lock claim) |
| `SessionWriteLockArchitectureTests` | 5 fence | Order-of-calls smoke fence + 3 vacuity/false-positive self-tests + DI singleton registration assertion |
| `CrossWorldReceiverArchitectureTests` | 1 updated | Existing fence updated to follow `RelayAsync` → `ExecuteRelayAsync` delegation chain |

**Vacuity-verified**: I temporarily swapped the real lock for a
`NoOpSessionWriteLock` harness — the same-session test failed as expected,
proving the assertions are non-vacuous. Reverted before commit.

## Multi-model critique sweep (3 agents in parallel)

| Agent | Model | Verdict |
|---|---|---|
| security-review | gpt-5.5 | **No security vulnerabilities** |
| plan-vs-impl | claude-opus-4.7 | No HIGH; 1 MEDIUM (fence completeness); 2 LOW |
| bug-hunt | gpt-5.3-codex | No BLOCKING/HIGH; 3 MEDIUM (timing-jitter in 2 tests + fence bypass); 1 LOW (isolation assertions) |

### Folded in (commit d9920630)

* **Deterministic refcount probe** replacing `Task.Delay(150)` and
  `Task.Delay(50)` in two concurrency tests — exposes
  `SessionWriteLock.RefCountFor(SessionId)` as an `internal` test probe,
  spin-waits until `refcount == 2` to confirm the waiter parked, then
  asserts blockage. Catches the bug-hunt MEDIUM-2/3 timing-jitter false-positive
  scenarios.
* **Full transcript-shape assertion** in the isolation test — asserts count,
  ordering, AND assistant content (not just user). Catches assistant-side
  cross-attribution.
* **DI singleton fence** scanning `GatewayServiceCollectionExtensions.cs` for
  `(Try)AddSingleton<ISessionWriteLock, SessionWriteLock>` AND no competing
  transient/scoped registration. A scoped registration would silently
  re-open the race (each request gets its own private lock).

### Deferred with rationale (in PR body, not code)

* **MEDIUM (bug-hunt / plan-vs-impl)**: Roslyn-based syntactic fence instead
  of text scan. Both reviewers agreed behavioural tests cover the gaps
  (acquire-then-immediately-dispose, wrong key, branch asymmetry) — same-
  session concurrency test catches all three. Adopting Roslyn would add a
  Microsoft.CodeAnalysis dependency for marginal incremental coverage.
* **LOW (plan-vs-impl)**: "Different-session" test polls for 3 seconds. Slow
  CI would slow the test, not false-pass or false-fail.

## Out of scope / deferred

* **Authorization**. Per the user's standing instruction, no authz model is
  in place — the platform user is responsible. The only auth currently in
  scope is the `X-Cross-World-Key` check that already exists. The lock is
  unrelated to authz — it serialises legitimate concurrent callers, not
  unauthenticated ones.
* **Distributed deployments**. The lock is single-process. Multi-instance
  gateway deployments would need a distributed lock (e.g. Redis) — out of
  scope for the receiver bug class this PR fixes.

## Validation

```
dotnet build BotNexus.slnx --nologo --tl:off
  → 0 Warning(s) / 0 Error(s) under TreatWarningsAsErrors

dotnet test tests/gateway/BotNexus.Gateway.Tests/...
  → 1877 passed, 1 skipped (browser integration; +10 over baseline 1867)

dotnet test tests/architecture/BotNexus.Architecture.Tests/...
  → 59 passed (+5 over baseline 54: 4 smoke fences + 1 DI singleton)

Same-session concurrency + isolation + SessionWriteLock unit tests:
  → 10/10 stable across 5 consecutive reruns
```

Closes #551.
