### PR TITLE
fix(gateway): cancellation must not seal cross-world relay session (#553)

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -237,6 +237,22 @@ public sealed class CrossWorldFederationController(
                 FinishSummary = exchangeFinished ? finishSummary : null
             });
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // #553: caller-initiated cancellation must NOT seal the session. Sealing here would
+            // poison the session for any sender retry — the sender's next call would hit the
+            // sealed-session 409 guard in ResolveSessionAsync and the exchange would be
+            // permanently broken by a transient client-side timeout / abort. Rethrow without
+            // touching session.Status; the session remains Active and the sender can retry
+            // with the same RemoteSessionId. Note: ActiveSessionId is intentionally LEFT
+            // pinned so a fast retry sees the conversation as in-flight rather than briefly
+            // flipping to "idle" then back to "active" in the portal.
+            //
+            // Guard is `when (cancellationToken.IsCancellationRequested)` so OCEs raised by
+            // any OTHER token (e.g. an internal timeout linked downstream) still fall through
+            // to the catch-all and seal — those are genuine failures, not caller intent.
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex,

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -198,6 +198,13 @@ public sealed class AgentExchangeService : IAgentExchangeService
             await _sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
             await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // #553: caller-initiated cancellation must NOT seal the session. See the matching
+            // comment in CrossWorldFederationController.ExecuteRelayAsync for full rationale —
+            // sealing here would poison the session for any caller retry.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Agent conversation failed for session '{SessionId}'.", sessionId);
@@ -358,6 +365,12 @@ public sealed class AgentExchangeService : IAgentExchangeService
             session.Metadata["remoteSessionId"] = remoteSessionId;
             await _sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
             await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // #553: caller-initiated cancellation must NOT seal the session. See the matching
+            // comment in CrossWorldFederationController.ExecuteRelayAsync for full rationale.
+            throw;
         }
         catch (Exception ex)
         {

--- a/tests/architecture/BotNexus.Architecture.Tests/CancelNoSealArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/CancelNoSealArchitectureTests.cs
@@ -1,0 +1,391 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the <c>#553</c> contract: in
+/// <see cref="System.Threading.CancellationToken"/>-aware code paths that seal the
+/// session on any exception, the catch-all <c>catch (Exception)</c> block MUST be
+/// preceded by a
+/// <c>catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }</c>
+/// clause so caller-initiated cancellation does not flip the session to
+/// <c>SessionStatus.Sealed</c> and permanently break sender retries via the sealed-session
+/// 409 guard in <c>ResolveSessionAsync</c>.
+///
+/// The fence covers the three pre-existing seal-on-error catch sites identified in #553:
+/// <list type="bullet">
+///   <item><c>CrossWorldFederationController.ExecuteRelayAsync</c></item>
+///   <item><c>AgentExchangeService.ConverseAsync</c> (local agent-agent path)</item>
+///   <item><c>AgentExchangeService.ConverseAsync</c> (cross-world relay-out path)</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// This is a <strong>smoke test</strong>, not a correctness proof. The fence shows that
+/// a textual <c>catch (OperationCanceledException) when (...IsCancellationRequested) { throw; }</c>
+/// clause appears before every <c>catch (Exception ...) { ... GatewaySessionStatus.Sealed ... }</c>
+/// in the two target files. A clever regression that retained the textual ordering but
+/// broke semantics (e.g. inverted the <c>when</c> condition) would pass this fence and
+/// fail the behavioural tests in
+/// <c>CrossWorldFederationControllerTests.RelayAsync_When*</c> and
+/// <c>AgentExchangeServiceCancelNoSealTests</c>. The two layers complement; neither
+/// alone is sufficient.
+/// </remarks>
+public sealed class CancelNoSealArchitectureTests
+{
+    [Fact]
+    public void CrossWorldFederationController_SealOnErrorCatch_PrecededByCallerCancellationRethrow()
+    {
+        var path = LocateFile("gateway", "BotNexus.Gateway.Api", "Controllers", "CrossWorldFederationController.cs");
+        var source = File.ReadAllText(path);
+
+        var violations = FindMissingCancellationRethrow(source);
+
+        violations.ShouldBeEmpty(BuildViolationMessage(path, violations));
+    }
+
+    [Fact]
+    public void AgentExchangeService_SealOnErrorCatches_PrecededByCallerCancellationRethrow()
+    {
+        var path = LocateFile("gateway", "BotNexus.Gateway", "Agents", "AgentExchangeService.cs");
+        var source = File.ReadAllText(path);
+
+        var violations = FindMissingCancellationRethrow(source);
+
+        violations.ShouldBeEmpty(BuildViolationMessage(path, violations));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticRegression_NoCancellationGuard()
+    {
+        // Synthetic shape: catch-all that seals with no preceding OCE rethrow. This is the
+        // pre-#553 bug shape. The fence must flag it.
+        const string syntheticViolation = """
+            public async Task RelayAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await sessionStore.SaveAsync(session, cancellationToken);
+                    var response = await handle.PromptAsync(message, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    throw;
+                }
+            }
+            """;
+        var violations = FindMissingCancellationRethrow(syntheticViolation);
+        violations.ShouldNotBeEmpty(
+            "Vacuity guard: the fence must flag a seal-on-error catch-all with no preceding " +
+            "OperationCanceledException rethrow — this is exactly the pre-#553 bug shape. If " +
+            "this assertion fails, the fence has been weakened so far that it cannot catch " +
+            "the original bug class.");
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticRegression_BareOceWithoutWhen()
+    {
+        // Subtler regression: a bare `catch (OperationCanceledException)` without the
+        // `when (cancellationToken.IsCancellationRequested)` filter. This would catch ALL
+        // OCEs including downstream-timeout-token cancellations and silently mask them as
+        // "caller cancellation" — leaving the session Active when it should be sealed.
+        const string syntheticViolation = """
+            public async Task RelayAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await handle.PromptAsync(message, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    session.Status = GatewaySessionStatus.Sealed;
+                    throw;
+                }
+            }
+            """;
+        var violations = FindMissingCancellationRethrow(syntheticViolation);
+        violations.ShouldNotBeEmpty(
+            "Vacuity guard: the fence must flag a bare `catch (OperationCanceledException)` " +
+            "without the `when (cancellationToken.IsCancellationRequested)` filter. A bare " +
+            "catch swallows inner-token cancellations too, silently masking genuine failures " +
+            "as caller cancellation. The discriminator is the whole point of the #553 fix.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnLegitimateShape()
+    {
+        // Canonical shape from the #553 fix. The fence must NOT flag this — otherwise
+        // authors will disable it instead of fixing real regressions.
+        const string syntheticClean = """
+            public async Task RelayAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await sessionStore.SaveAsync(session, cancellationToken);
+                    var response = await handle.PromptAsync(message, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Caller-initiated cancellation: rethrow without sealing so the session
+                    // stays Active and the sender can retry.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    throw;
+                }
+            }
+            """;
+        var violations = FindMissingCancellationRethrow(syntheticClean);
+        violations.ShouldBeEmpty(
+            "False-positive guard: the fence must not flag the canonical post-#553 shape. " +
+            "If this assertion fails, the fence is over-broad and authors will disable it " +
+            "instead of using it.\n" +
+            "Violations: " + string.Join("\n", violations));
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnRethrowWithBraceInComment()
+    {
+        // The rethrow body intentionally includes a brace-bearing comment to pin the
+        // regex loosening that permits one level of nested braces. Before the loosening
+        // this shape would have been rejected, forcing a future author to either
+        // delete the explanatory comment or disable the fence — exactly the friction
+        // we want to avoid.
+        const string syntheticClean = """
+            public async Task RelayAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await handle.PromptAsync(message, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Caller-initiated cancellation: rethrow without sealing. See
+                    // ClearActiveSessionAsync { ... } for the diagnostic-only catches
+                    // that are deliberately outside this fence's scope.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    throw;
+                }
+            }
+            """;
+        var violations = FindMissingCancellationRethrow(syntheticClean);
+        violations.ShouldBeEmpty(
+            "False-positive guard: the fence must accept a rethrow body containing a comment " +
+            "with literal braces. If this fails, the body regex has been tightened back to " +
+            "`[^{}]*` and the next author who keeps the comment will have their PR blocked " +
+            "by an architecture test instead of by a real defect.\n" +
+            "Violations: " + string.Join("\n", violations));
+    }
+
+    [Fact]
+    public void CrossWorldFederationController_HasAtLeastOneSealWritingCatchAll()
+    {
+        // Counter-fence: if a future refactor moves the seal to a helper like
+        // `SealSessionAsync(session)` (no literal `GatewaySessionStatus.Sealed` in the
+        // catch body), the per-catch fence would silently pass with zero candidates.
+        // This test asserts at least one Sealed-writing catch-all is structurally present.
+        // If it fails, the author MUST either keep the literal token in the catch body
+        // OR update the fence regex to track whatever the new seal-shape is.
+        var path = LocateFile("gateway", "BotNexus.Gateway.Api", "Controllers", "CrossWorldFederationController.cs");
+        var source = File.ReadAllText(path);
+
+        var count = CountSealWritingCatchAlls(source);
+
+        count.ShouldBeGreaterThanOrEqualTo(1,
+            $"Counter-fence: {Path.GetFileName(path)} must contain at least one " +
+            "`catch (Exception ...) {{ ... GatewaySessionStatus.Sealed ... }}` block. If the " +
+            "seal-on-error logic has been extracted to a helper, the per-catch fence " +
+            "(`*_SealOnErrorCatch_PrecededByCallerCancellationRethrow`) is no longer protecting " +
+            "anything because it has zero candidates to check. Either inline the literal " +
+            "`GatewaySessionStatus.Sealed` back into the catch body OR update the regex in " +
+            "`CountSealWritingCatchAlls` / `FindMissingCancellationRethrow` to match the new shape.");
+    }
+
+    [Fact]
+    public void AgentExchangeService_HasAtLeastTwoSealWritingCatchAlls()
+    {
+        // Counter-fence: AgentExchangeService has two seal-on-error catch sites — the
+        // local agent-agent path in ConverseAsync and the cross-world relay-out path.
+        // If a refactor collapses both behind a helper (no literal `Sealed` in either
+        // catch body), the per-catch fence silently passes; this test forces the author
+        // to either restore the literal or update the fence.
+        var path = LocateFile("gateway", "BotNexus.Gateway", "Agents", "AgentExchangeService.cs");
+        var source = File.ReadAllText(path);
+
+        var count = CountSealWritingCatchAlls(source);
+
+        count.ShouldBeGreaterThanOrEqualTo(2,
+            $"Counter-fence: {Path.GetFileName(path)} must contain at least two " +
+            "`catch (Exception ...) {{ ... GatewaySessionStatus.Sealed ... }}` blocks (local " +
+            "agent-agent path + cross-world relay-out path). See the comment in " +
+            "CrossWorldFederationController_HasAtLeastOneSealWritingCatchAll for the rationale.");
+    }
+
+    [Fact]
+    public void SealCatchDetector_IdentifiesPositiveShape()
+    {
+        // Synthetic positive case. Pins the detector against accidental over-tightening
+        // (e.g. requiring `Sealed` to be on the same line as the assignment).
+        const string syntheticSeal = """
+            catch (Exception ex)
+            {
+                session.Status = GatewaySessionStatus.Sealed;
+                await sessionStore.SaveAsync(session, CancellationToken.None);
+                throw;
+            }
+            """;
+        CountSealWritingCatchAlls(syntheticSeal).ShouldBe(1,
+            "Detector vacuity guard: a synthetic catch-all that writes Sealed must be counted. " +
+            "If this fails, the detector heuristic is broken and the counter-fence is vacuous.");
+    }
+
+    [Fact]
+    public void SealCatchDetector_IgnoresNonSealingCatch()
+    {
+        // Synthetic negative case. The diagnostic-only catches in ClearActiveSessionAsync
+        // (which swallow without sealing) MUST be ignored — otherwise the per-catch fence
+        // would demand an OCE rethrow guard on every catch-all in the file, including
+        // unrelated diagnostic ones.
+        const string syntheticNoSeal = """
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to clear ActiveSessionId; swallowed.");
+            }
+            """;
+        CountSealWritingCatchAlls(syntheticNoSeal).ShouldBe(0,
+            "Detector specificity guard: a catch-all that does NOT write `GatewaySessionStatus.Sealed` " +
+            "must not be counted. If this fails, the detector is over-broad and the fence will " +
+            "force OCE guards onto unrelated diagnostic catches.");
+    }
+
+    /// <summary>
+    /// Finds every <c>catch (Exception ...)</c> block whose body sets
+    /// <c>GatewaySessionStatus.Sealed</c> (i.e. the bug-relevant seal-on-error catch-all)
+    /// and verifies the preceding text (within ~500 chars upstream) contains a
+    /// <c>catch (OperationCanceledException) when (...IsCancellationRequested...) { throw; }</c>
+    /// clause.
+    /// </summary>
+    /// <remarks>
+    /// The fence is textual and scoped to the file. It doesn't prove the <c>when</c> filter
+    /// references the same token the catch's enclosing method threads down to PromptAsync —
+    /// that's a behavioural concern covered by the unit tests. What it DOES prove is the
+    /// structural shape that any regression would have to defeat (delete the OCE clause,
+    /// invert the filter, change the body to something other than <c>throw</c>).
+    /// </remarks>
+    private static List<string> FindMissingCancellationRethrow(string source)
+    {
+        var violations = new List<string>();
+
+        foreach (Match m in SealCatchRegex.Matches(source))
+        {
+            // Look at the next ~600 chars of the catch body to confirm it sets Sealed.
+            // Skip non-relevant catch-all blocks (e.g. swallow-only diagnostic catches in
+            // ClearActiveSessionAsync).
+            var bodyEnd = Math.Min(source.Length, m.Index + 600);
+            var body = source[m.Index..bodyEnd];
+            if (!body.Contains("GatewaySessionStatus.Sealed", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Look back ~1500 chars for the cancellation-rethrow clause. A larger window
+            // is required because the rethrow catch carries a substantial doc comment
+            // explaining the #553 rationale; a tighter window would false-positive there.
+            var lookbackStart = Math.Max(0, m.Index - 1500);
+            var preceding = source[lookbackStart..m.Index];
+
+            if (!RethrowClauseRegex.IsMatch(preceding))
+            {
+                violations.Add(
+                    $"  catch-all at offset {m.Index} that seals the session has no preceding " +
+                    $"`catch (OperationCanceledException) when (...IsCancellationRequested) {{ throw; }}` clause " +
+                    $"within the prior 1500 chars. Snippet: '{Snippet(source, m.Index)}'");
+            }
+        }
+
+        return violations;
+    }
+
+    /// <summary>
+    /// Counts the number of <c>catch (Exception ...)</c> blocks in <paramref name="source"/>
+    /// whose body (next ~600 chars) contains <c>GatewaySessionStatus.Sealed</c>. Used by the
+    /// counter-fence to assert that the per-catch fence has candidates to check.
+    /// </summary>
+    private static int CountSealWritingCatchAlls(string source)
+    {
+        var count = 0;
+        foreach (Match m in SealCatchRegex.Matches(source))
+        {
+            var bodyEnd = Math.Min(source.Length, m.Index + 600);
+            var body = source[m.Index..bodyEnd];
+            if (body.Contains("GatewaySessionStatus.Sealed", StringComparison.Ordinal))
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static readonly Regex SealCatchRegex = new(
+        @"catch\s*\(\s*Exception\s+\w+\s*\)",
+        RegexOptions.Compiled);
+
+    // Loosened body alternation permits one level of nested braces so brace-bearing
+    // comments inside the rethrow body don't false-positive the fence. See
+    // Fence_DoesNotFalsePositive_OnRethrowWithBraceInComment.
+    private static readonly Regex RethrowClauseRegex = new(
+        @"catch\s*\(\s*OperationCanceledException\s*\)\s*when\s*\(\s*[\w\.]*\bIsCancellationRequested\b\s*\)\s*\{(?:[^{}]|\{[^{}]*\})*\bthrow\s*;(?:[^{}]|\{[^{}]*\})*\}",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private static string Snippet(string source, int idx)
+    {
+        var start = Math.Max(0, idx - 10);
+        var end = Math.Min(source.Length, idx + 80);
+        return source[start..end].Replace("\n", "\\n").Replace("\r", "");
+    }
+
+    private static string BuildViolationMessage(string path, List<string> violations) =>
+        $"{Path.GetFileName(path)} has a `catch (Exception)` block that seals the session " +
+        "(GatewaySessionStatus.Sealed) but is NOT preceded by a " +
+        "`catch (OperationCanceledException) when (...IsCancellationRequested) {{ throw; }}` clause. " +
+        "This is the #553 structural invariant: caller-initiated cancellation must NOT seal the " +
+        "session, otherwise the sender's retry policy hits the sealed-session 409 guard and the " +
+        "exchange is permanently broken by a transient client-side timeout.\n" +
+        "Violations:\n" + string.Join("\n", violations) + "\n" +
+        "File: " + path;
+
+    private static string LocateFile(params string[] relativeParts)
+    {
+        var srcRoot = FindSourceRoot();
+        var path = Path.Combine(new[] { srcRoot }.Concat(relativeParts).ToArray());
+        File.Exists(path).ShouldBeTrue("Expected " + Path.GetFileName(path) + " at " + path);
+        return path;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current!.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceCancelNoSealTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceCancelNoSealTests.cs
@@ -1,0 +1,279 @@
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Channels;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net;
+using System.Net.Http.Json;
+using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Pins issue <c>#553</c>: caller-initiated cancellation must NOT seal the session.
+/// Before the fix, an <see cref="OperationCanceledException"/> raised inside the
+/// per-turn write→prompt→reload window was caught by the catch-all that sealed the
+/// session, set <c>conversationStatus = "error"</c>, recorded the OCE message in
+/// <c>session.Metadata["error"]</c>, then rethrew. That made caller retries impossible
+/// because <c>ResolveSessionAsync</c>'s sealed-session guard returns 409.
+///
+/// The fix inserts a preceding
+/// <c>catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }</c>
+/// at both <see cref="AgentExchangeService.ConverseAsync"/> call sites — the local
+/// agent-agent path (around line 200) and the cross-world relay-out path (around line 360).
+/// The <c>when</c> filter is essential: an OCE raised from an unrelated inner token
+/// (e.g. a downstream HTTP-client timeout linked into the supervisor) MUST still fall
+/// through to the catch-all and seal — those are genuine failures, not caller intent.
+/// </summary>
+public sealed class AgentExchangeServiceCancelNoSealTests
+{
+    [Fact]
+    public async Task ConverseAsync_LocalPath_WhenCallerCancelsDuringPromptAsync_RethrowsOce_AndDoesNotSealSession()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+
+        using var cts = new CancellationTokenSource();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, CancellationToken ct) =>
+            {
+                // Caller-initiated cancellation: the same token the controller threaded all the
+                // way down to PromptAsync is the one that fires. The new catch's `when` filter
+                // checks `cancellationToken.IsCancellationRequested` (same token), so it MUST
+                // rethrow without sealing.
+                cts.Cancel();
+                ct.ThrowIfCancellationRequested();
+                throw new InvalidOperationException("unreachable");
+            });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var act = async () => await service.ConverseAsync(
+            new AgentExchangeRequest
+            {
+                InitiatorId = initiator,
+                TargetId = target,
+                Message = "hello",
+                MaxTurns = 3
+            },
+            cts.Token);
+
+        await act.ShouldThrowAsync<OperationCanceledException>();
+
+        // Find the session created by the failed call — there should be exactly one.
+        var sessions = await sessionStore.GetExistenceAsync(initiator, new ExistenceQuery());
+        sessions.Count.ShouldBe(1, "ConverseAsync should have created exactly one session before the cancellation");
+        var session = await sessionStore.GetAsync(sessions[0].SessionId);
+        session.ShouldNotBeNull();
+
+        // The core acceptance criterion of #553: cancellation does NOT seal.
+        session!.Status.ShouldBe(GatewaySessionStatus.Active,
+            "Caller-initiated cancellation must leave the session Active so the sender can retry. " +
+            "Sealing here was the bug: the sealed-session 409 guard in ResolveSessionAsync would " +
+            "permanently reject any retry attempt with the same SessionId.");
+        session.Metadata.ContainsKey("error").ShouldBeFalse(
+            "The error-metadata key is only written by the seal-on-error catch-all. If it's present, " +
+            "the OCE rethrow path took the wrong branch.");
+        session.Metadata.TryGetValue("conversationStatus", out var convStatus);
+        (convStatus as string).ShouldNotBe("error",
+            "conversationStatus='error' is set exclusively by the seal-on-error catch-all.");
+    }
+
+    /// <summary>
+    /// Vacuity guard for the <c>when (cancellationToken.IsCancellationRequested)</c> filter.
+    /// An OCE thrown by an UNRELATED token (e.g. a downstream timeout linked into the
+    /// supervisor) must still fall through to the catch-all and seal — otherwise a real
+    /// inner timeout would mask itself as caller cancellation and leak as a "session is
+    /// Active" lie. If this test fails, the filter has been weakened to a bare
+    /// <c>catch (OperationCanceledException)</c> and the discriminator is gone.
+    /// </summary>
+    [Fact]
+    public async Task ConverseAsync_LocalPath_WhenInnerTokenCancels_NotCallerToken_StillSealsSession()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("agent-c");
+        var registry = CreateRegistry(initiator, target, ["agent-c"]);
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+
+        // Inner CTS unrelated to the caller's token; the handle will cancel + throw using it.
+        using var innerCts = new CancellationTokenSource();
+        using var callerCts = new CancellationTokenSource();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, CancellationToken _) =>
+            {
+                innerCts.Cancel();
+                throw new OperationCanceledException(innerCts.Token);
+            });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var act = async () => await service.ConverseAsync(
+            new AgentExchangeRequest
+            {
+                InitiatorId = initiator,
+                TargetId = target,
+                Message = "hello",
+                MaxTurns = 3
+            },
+            callerCts.Token);
+
+        await act.ShouldThrowAsync<OperationCanceledException>();
+
+        var sessions = await sessionStore.GetExistenceAsync(initiator, new ExistenceQuery());
+        sessions.Count.ShouldBe(1);
+        var session = await sessionStore.GetAsync(sessions[0].SessionId);
+        session.ShouldNotBeNull();
+
+        // Filter must discriminate: callerCts was NEVER cancelled, so the OCE goes to the
+        // catch-all and seals. This pins the `when` filter against accidental weakening.
+        session!.Status.ShouldBe(GatewaySessionStatus.Sealed,
+            "An OCE from a token unrelated to the caller's must still seal — that's a genuine " +
+            "failure. The `when (cancellationToken.IsCancellationRequested)` filter is what " +
+            "discriminates between the two. If this assertion fails, the filter has been " +
+            "weakened to a bare `catch (OperationCanceledException)` and the discrimination is gone.");
+        session.Metadata.ShouldContainKey("error");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_CrossWorldPath_WhenCallerCancelsDuringRelay_RethrowsOce_AndDoesNotSealSession()
+    {
+        var initiator = AgentId.From("test-agent");
+        var target = AgentId.From("world-b:agent-c");
+        var registry = CreateRegistry(initiator, AgentId.From("agent-c"), ["world-b:agent-c"]);
+        registry.Setup(r => r.Contains(target)).Returns(false);
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+
+        using var cts = new CancellationTokenSource();
+
+        // Stub HTTP handler that on first request cancels the caller's token then throws OCE,
+        // emulating a slow remote relay that the caller abandons mid-flight (sender HTTP
+        // timeout, retry-policy abort, client disconnect).
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            cts.Cancel();
+            throw new OperationCanceledException(cts.Token);
+        });
+        var adapter = new CrossWorldChannelAdapter(
+            NullLogger<CrossWorldChannelAdapter>.Instance,
+            new HttpClient(handler));
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            Mock.Of<IAgentSupervisor>(),
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance,
+            Options.Create(BuildCrossWorldPlatformConfig()),
+            adapter);
+
+        var act = async () => await service.ConverseAsync(
+            new AgentExchangeRequest
+            {
+                InitiatorId = initiator,
+                TargetId = target,
+                Message = "hello",
+                MaxTurns = 1
+            },
+            cts.Token);
+
+        await act.ShouldThrowAsync<OperationCanceledException>();
+
+        var sessions = await sessionStore.GetExistenceAsync(initiator, new ExistenceQuery());
+        sessions.Count.ShouldBe(1);
+        var session = await sessionStore.GetAsync(sessions[0].SessionId);
+        session.ShouldNotBeNull();
+
+        session!.Status.ShouldBe(GatewaySessionStatus.Active,
+            "Cross-world caller cancellation must leave the session Active so the sender can " +
+            "retry the relay. Sealing here would poison the session for the sender's retry policy.");
+        session.Metadata.ContainsKey("error").ShouldBeFalse();
+    }
+
+    private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target, IReadOnlyList<string> allowedTargets)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Initiator",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentIds = allowedTargets
+        });
+        registry.Setup(r => r.Contains(target)).Returns(true);
+        return registry;
+    }
+
+    private static PlatformConfig BuildCrossWorldPlatformConfig() => new()
+    {
+        Gateway = new GatewaySettingsConfig
+        {
+            World = new BotNexus.Domain.WorldIdentity { Id = "world-a", Name = "World A" },
+            CrossWorldPermissions =
+            [
+                new CrossWorldPermissionConfig
+                {
+                    TargetWorldId = "world-b",
+                    AllowOutbound = true,
+                    AllowedAgents = ["test-agent"]
+                }
+            ],
+            CrossWorld = new CrossWorldFederationConfig
+            {
+                Peers = new Dictionary<string, CrossWorldPeerConfig>
+                {
+                    ["world-b"] = new()
+                    {
+                        Endpoint = "https://gateway-b.internal",
+                        ApiKey = "peer-key",
+                        Enabled = true
+                    }
+                }
+            }
+        }
+    };
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => responder(request, cancellationToken);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1209,6 +1209,172 @@ public sealed class CrossWorldFederationControllerTests
         return (controller, sessions, conversations, supervisor);
     }
 
+    // ─── #553 cancellation-no-seal pins ─────────────────────────────────────────────────
+    //
+    // Issue #553: caller-initiated cancellation must NOT seal the session. Before the fix
+    // the catch-all in ExecuteRelayAsync sealed the session on ANY exception (including
+    // OperationCanceledException raised by the caller's cancellation token), and the
+    // sealed-session 409 guard in ResolveSessionAsync then permanently rejected the
+    // sender's retry attempts. The fix inserts a
+    //     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+    // before the catch-all so caller cancellation rethrows without touching session.Status.
+    // The `when` filter is essential — OCEs from unrelated tokens still seal.
+
+    [Fact]
+    public async Task RelayAsync_WhenCallerCancelsDuringPromptAsync_RethrowsOce_AndDoesNotSealSession()
+    {
+        using var cts = new CancellationTokenSource();
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, CancellationToken ct) =>
+            {
+                // Cancel the caller's token then throw OCE bound to that same token, simulating
+                // a caller HTTP timeout / abort that propagates into PromptAsync.
+                cts.Cancel();
+                ct.ThrowIfCancellationRequested();
+                throw new InvalidOperationException("unreachable");
+            });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From(TargetAgentId), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var controller = BuildControllerCore(sessions, conversations, supervisor.Object);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var act = async () => await controller.RelayAsync(BuildRequest(message: "hello"), cts.Token);
+
+        await act.ShouldThrowAsync<OperationCanceledException>();
+
+        // Exactly one session was created by the relay before cancellation hit. Find it and
+        // assert it's still Active — the core acceptance criterion of #553.
+        var existence = await sessions.GetExistenceAsync(AgentId.From(TargetAgentId), new ExistenceQuery());
+        existence.Count.ShouldBe(1, "RelayAsync should have created exactly one session before the OCE fired");
+
+        var session = await sessions.GetAsync(existence[0].SessionId);
+        session.ShouldNotBeNull();
+        session!.Status.ShouldBe(GatewaySessionStatus.Active,
+            "#553: caller-initiated cancellation must NOT seal the session. Sealing here would " +
+            "poison the session for any sender retry — the sender's next call would hit the " +
+            "sealed-session 409 guard in ResolveSessionAsync and the exchange would be " +
+            "permanently broken by a transient client-side timeout.");
+        session.Metadata.ContainsKey("error").ShouldBeFalse(
+            "The 'error' metadata key is written exclusively by the seal-on-error catch-all. " +
+            "If it's present after caller cancellation, the OCE rethrow path took the wrong branch.");
+    }
+
+    [Fact]
+    public async Task RelayAsync_AfterCallerCancellation_SessionIsReusableByRetryWithSameRemoteSessionId()
+    {
+        // AC #3 from #553: a subsequent reuse of the same SessionId must succeed after a
+        // cancelled relay. The current sealed-session 409 guard in ResolveSessionAsync would
+        // reject the retry; this test only passes if the session was left Active.
+        using var cts = new CancellationTokenSource();
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+
+        var promptCallCount = 0;
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, CancellationToken ct) =>
+            {
+                var n = Interlocked.Increment(ref promptCallCount);
+                if (n == 1)
+                {
+                    cts.Cancel();
+                    ct.ThrowIfCancellationRequested();
+                    throw new InvalidOperationException("unreachable");
+                }
+                return Task.FromResult(new AgentResponse { Content = "retry-success" });
+            });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From(TargetAgentId), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var controller = BuildControllerCore(sessions, conversations, supervisor.Object);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        // Call 1: cancelled mid-flight, OCE rethrows, session must stay Active.
+        var act1 = async () => await controller.RelayAsync(BuildRequest(message: "first"), cts.Token);
+        await act1.ShouldThrowAsync<OperationCanceledException>();
+
+        var existence = await sessions.GetExistenceAsync(AgentId.From(TargetAgentId), new ExistenceQuery());
+        existence.Count.ShouldBe(1);
+        var sessionId = existence[0].SessionId;
+
+        var sessionAfterCancel = await sessions.GetAsync(sessionId);
+        sessionAfterCancel.ShouldNotBeNull();
+        sessionAfterCancel!.Status.ShouldBe(GatewaySessionStatus.Active);
+
+        // Call 2: retry with same RemoteSessionId, fresh token. Must succeed because the
+        // sealed-session 409 guard in ResolveSessionAsync only fires on Sealed sessions.
+        var retryRequest = BuildRequest(message: "retry", remoteSessionId: sessionId.Value);
+        var retryResponse = await controller.RelayAsync(retryRequest, CancellationToken.None);
+
+        var ok = retryResponse.Result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<CrossWorldRelayResponse>();
+        payload.Response.ShouldBe("retry-success",
+            "Retry with the same RemoteSessionId after a cancelled call must succeed (AC #3). " +
+            "If this fails with a 409 (sealed-session conflict), the OCE rethrow path is sealing " +
+            "the session contrary to #553.");
+        payload.SessionId.ShouldBe(sessionId.Value,
+            "Retry must reuse the same session — the sender's idempotent-retry semantic depends on it.");
+    }
+
+    /// <summary>
+    /// Vacuity guard for the <c>when (cancellationToken.IsCancellationRequested)</c> filter.
+    /// An OCE thrown by an UNRELATED token (e.g. a downstream timeout linked into the
+    /// supervisor) must still fall through to the catch-all and seal — otherwise a genuine
+    /// inner timeout would silently leak as "session is Active" and corrupt the retry contract.
+    /// If this test fails, the filter has been weakened to a bare
+    /// <c>catch (OperationCanceledException)</c> and the discriminator is gone.
+    /// </summary>
+    [Fact]
+    public async Task RelayAsync_WhenInnerTokenCancels_NotCallerToken_StillSealsSession()
+    {
+        using var innerCts = new CancellationTokenSource();
+        using var callerCts = new CancellationTokenSource();
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, CancellationToken _) =>
+            {
+                innerCts.Cancel();
+                throw new OperationCanceledException(innerCts.Token);
+            });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From(TargetAgentId), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var controller = BuildControllerCore(sessions, conversations, supervisor.Object);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var act = async () => await controller.RelayAsync(BuildRequest(message: "hello"), callerCts.Token);
+
+        await act.ShouldThrowAsync<OperationCanceledException>();
+
+        var existence = await sessions.GetExistenceAsync(AgentId.From(TargetAgentId), new ExistenceQuery());
+        existence.Count.ShouldBe(1);
+        var session = await sessions.GetAsync(existence[0].SessionId);
+        session.ShouldNotBeNull();
+
+        // callerCts was NEVER cancelled, so the `when` filter does not match and the OCE
+        // falls through to the catch-all that seals. This pins the filter against being
+        // weakened to a bare `catch (OperationCanceledException)`.
+        session!.Status.ShouldBe(GatewaySessionStatus.Sealed,
+            "An OCE from a token unrelated to the caller's must still seal — that's a genuine " +
+            "failure (e.g. downstream HTTP timeout). The `when (cancellationToken.IsCancellationRequested)` " +
+            "filter is what discriminates between caller intent and inner failure. If this assertion " +
+            "fails, the filter has been weakened and the discrimination is gone — every OCE " +
+            "anywhere downstream would now leak as 'session still Active' regardless of cause.");
+        session.Metadata.ShouldContainKey("error");
+    }
+
     private static CrossWorldFederationController BuildControllerCore(
         ISessionStore sessions,
         IConversationStore conversations,


### PR DESCRIPTION
# #553 — Cancellation must not seal the cross-world relay session

## What was wrong

Caller-initiated cancellation of a cross-world relay used to permanently seal the session via the catch-all `catch (Exception)` that fired on every OCE — including the caller's own. The sealed-session 409 guard in `ResolveSessionAsync` then turned a transient client timeout, browser tab close, or user-driven cancellation into a permanently broken sender-retry contract documented in PR #549.

## What changed

Insert a guarded re-throw BEFORE each existing catch-all so caller-initiated cancellation rethrows without sealing:

```csharp
catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
{
    // #553: caller-initiated cancellation must NOT seal the session.
    throw;
}
catch (Exception ex)
{
    // existing seal-on-error logic, now only sees inner-token cancels
    // and genuine failures.
}
```

The `when` filter is the discriminator: inner-token cancellations (downstream HTTP-client timeouts linked into the supervisor token) MUST still fall through to the catch-all and seal, because they are genuine downstream failures — not callers pulling out.

### Per-site coverage map

| Production site | Behavioural test |
|---|---|
| `CrossWorldFederationController.ExecuteRelayAsync` | `RelayAsync_WhenCallerCancelsDuringPromptAsync_RethrowsOce_AndDoesNotSealSession` |
| `AgentExchangeService.ConverseAsync` (local) | `ConverseAsync_LocalPath_WhenCallerCancelsDuringPromptAsync_RethrowsOce_AndDoesNotSealSession` |
| `AgentExchangeService.ConverseAsync` (cross-world relay-out) | `ConverseAsync_CrossWorldPath_WhenCallerCancelsDuringPromptAsync_RethrowsOce_AndDoesNotSealSession` |

## Acceptance criteria (from #553)

| AC | Pinned by | Verdict |
|---|---|---|
| AC #1 — cancelled relay throws OCE, session stays Active | `RelayAsync_WhenCallerCancels...` + local-path twin | ✅ |
| AC #2 — no error metadata recorded on cancellation | same tests assert `Metadata.ContainsKey("error").ShouldBeFalse()` | ✅ |
| AC #3 — retry with same `RemoteSessionId` succeeds | `RelayAsync_AfterCallerCancellation_SessionIsReusableByRetryWithSameRemoteSessionId` — exercises the real `RelayAsync` → `ResolveSessionAsync` reuse path including the 5-invariant `OwnedByRequester` check from PR #549 | ✅ |

## `when` filter vacuity guard

Removing the `when (cancellationToken.IsCancellationRequested)` filter would catch ALL OCEs — including inner-token cancellations that should still seal. The vacuity guard cancels an INNER `CancellationTokenSource` unrelated to the caller, throws OCE bound to the inner token, and asserts the session ends up `Sealed`. If the filter is weakened to a bare `catch (OperationCanceledException)`, the test fails.

- `RelayAsync_WhenInnerTokenCancels_NotCallerToken_StillSealsSession`
- `ConverseAsync_LocalPath_WhenInnerTokenCancels_NotCallerToken_StillSealsSession`

## Architecture fitness fence

`tests/architecture/BotNexus.Architecture.Tests/CancelNoSealArchitectureTests.cs` (10 tests):

- **Per-catch fence** on both production files: every `catch (Exception)` body containing `GatewaySessionStatus.Sealed` must be preceded by the required OCE-rethrow clause within the prior 1500 chars. The 500 → 1500 lookback window covers the substantial rationale comment carried by the controller's catch.
- **Counter-fence** on both production files: each must contain ≥N Sealed-writing catch-alls (controller ≥1, service ≥2), so a future refactor to a helper like `SealSessionAsync(session)` is forced to either keep the literal token OR update the fence regex — otherwise the per-catch fence would silently pass with zero candidates.
- **Vacuity guards**: synthetic catch-all without OCE guard + synthetic bare-OCE catch without `when` filter both correctly violate.
- **False-positive guards**: canonical post-#553 shape (with and without brace-bearing comments inside the rethrow body) correctly does NOT violate. Body regex permits ONE level of nested braces so explanatory comments like `// see Foo {...}` don't push future authors to delete them.
- **Detector specificity**: `ClearActiveSessionAsync` diagnostic catches (which swallow without sealing) are correctly ignored.

## Trade-offs (read these before requesting changes)

- **`Conversation.ActiveSessionId` is intentionally NOT cleared on caller cancellation.** A fast retry sees the conversation as still in-flight rather than briefly flipping idle → active in the portal. Staleness is bounded by `SessionCleanupService` TTL (default 24h, 5m sweep) and `ActiveSessionId` is documented as a diagnostic, not a correctness contract.
- **Catch-all `SaveAsync` calls pass `CancellationToken.None`** on all three sites — caller-token OCE cannot fire during the seal write, so the race that would leave `Status` mutated in-memory but unflushed is structurally avoided.
- **Cancelled turn's user-input is persisted before `PromptAsync`** — on retry the user message would be appended again. This is a real but bounded duplicate-message UX/transcript concern (NOT a security issue per the security review) and is filed as a deferred follow-up. Solving it requires per-turn idempotency keys, which is out of scope for the cancel-no-seal fix.
- **`ClearActiveSessionAsync` diagnostic catches** in both files are deliberately outside the fence's scope — they swallow without sealing and the fence's `Sealed`-keyed detection correctly skips them.

## Multi-model critique sweep

Run before opening the PR:

- **`security-review` (gpt-5.5)** — no vulnerabilities. DoS bounded by `SessionCleanupService` TTL; authz boundary (5-invariant `OwnedByRequester`) preserved.
- **`code-review` plan-vs-impl (claude-opus-4.7)** — all 3 ACs + `when` filter + rethrow + 3-site coverage + fence non-vacuity pinned. Adopted two SHOULD-CONSIDER findings:
  - Regex loosening to permit brace-bearing comments inside rethrow body.
  - Counter-fence on Sealed-writing catch count, so helper-refactor forces fence update.
- **`rubber-duck` bug-hunt (gpt-5.3-codex)** — no blocking issues. Confirmed lock scope is released by `await using`, token identity is the method parameter (not a wrapped/linked variant), vacuity guard truly pins the discriminator.

## Validation

- `dotnet test BotNexus.slnx --nologo --tl:off --no-build` → all green except the known `BotNexus.Cron.Tests.CronSchedulerTests.Scheduler_MultipleDueJobs_RunConcurrently_NotSerially` timing flake (passes on rerun, unrelated).
- `Gateway.Tests`: 1883 passed / 0 failed / 1 skip — +6 new behavioural tests.
- `Architecture.Tests`: 69 passed / 0 failed — +10 new fence tests (5 from initial draft + 5 from critique adoption).

Closes #553.
