### PR TITLE
chore(gateway): rename single-shot CompletionReason "objectiveMet" to "singleShot" (#552)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentConversationResult.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentConversationResult.cs
@@ -34,10 +34,13 @@ public sealed record AgentExchangeResult
     /// Why the conversation loop ended.
     /// <list type="bullet">
     ///   <item><c>exchangeFinished</c> — the target agent invoked the <c>finish_agent_exchange</c>
-    ///   tool successfully (Phase 8 / F-11 — replaces the deprecated <c>objectiveMet</c> substring
-    ///   heuristic from issue #379).</item>
-    ///   <item><c>maxTurnsReached</c> — loop exhausted all turns without a completion signal</item>
-    ///   <item><c>error</c> — an exception was thrown during the exchange</item>
+    ///   tool successfully (Phase 8 / F-11; this replaced the old prose-substring objective
+    ///   detection from issue #379).</item>
+    ///   <item><c>singleShot</c> — the request did not set an <see cref="AgentExchangeRequest.Objective"/>,
+    ///   so the exchange ran for exactly one prompt and returned the target's first response.</item>
+    ///   <item><c>maxTurnsReached</c> — the multi-turn loop exhausted <see cref="AgentExchangeRequest.MaxTurns"/>
+    ///   without a completion signal.</item>
+    ///   <item><c>error</c> — an exception was thrown during the exchange.</item>
     /// </list>
     /// </summary>
     public string? CompletionReason { get; init; }

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -400,7 +400,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
     private static string ResolveCompletionReason(bool exchangeFinished, bool singleShot)
     {
         if (exchangeFinished) return "exchangeFinished";
-        if (singleShot) return "objectiveMet"; // preserve old back-compat name for the single-shot case
+        if (singleShot) return "singleShot";
         return "maxTurnsReached";
     }
 

--- a/tests/architecture/BotNexus.Architecture.Tests/SingleShotWireValueArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SingleShotWireValueArchitectureTests.cs
@@ -1,0 +1,326 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function enforcing the <c>#552</c> wire-value rename: the legacy
+/// <c>CompletionReason = "objectiveMet"</c> token MUST NOT appear in any production
+/// source file under <c>src/</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AgentExchangeResult.CompletionReason</c> reports <c>"singleShot"</c> when the
+/// caller did not set an <c>Objective</c> and the exchange ran for exactly one prompt.
+/// The old wire value <c>"objectiveMet"</c> was misleading because no objective was ever
+/// provided, and was renamed in PR <c>#552</c>. Since BotNexus has no external API consumers
+/// (only the in-process <c>AgentConverseTool</c> serialises the result back to its calling
+/// LLM), the rename is a strict break — there is no back-compat layer to preserve.
+/// </para>
+/// <para>
+/// This fence catches the regression shape where someone reverts <c>ResolveCompletionReason</c>
+/// or adds a new code path emitting the old wire value. The behavioural pin lives in
+/// <c>AgentExchangeServiceTests.ConverseAsync_NoObjectiveSet_SingleShotReasonReturned</c>.
+/// </para>
+/// </remarks>
+public sealed class SingleShotWireValueArchitectureTests
+{
+    [Fact]
+    public void NoProductionSourceFile_ContainsLegacyObjectiveMetWireValue()
+    {
+        var srcRoot = FindSourceRoot();
+
+        var violations = new List<string>();
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var stripped = StripComments(File.ReadAllText(path));
+            if (ContainsLegacyWireValue(stripped))
+            {
+                violations.Add(NormalizePath(path));
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "The wire value `\"objectiveMet\"` was renamed to `\"singleShot\"` in #552. " +
+            "Any remaining occurrence in production source (outside C# comments) is a regression — " +
+            "the legacy literal must not be re-introduced under any code path. If a deprecation " +
+            "shim is genuinely required, document it explicitly in a comment (which the fence " +
+            "ignores) and add an allowlist entry here.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticRegression()
+    {
+        // Synthetic post-revert shape: code emitting the legacy literal MUST trip the fence.
+        // If this test fails, the fence has been weakened so far that the original
+        // regression class is undetectable.
+        const string syntheticViolation = """
+            public static string ResolveCompletionReason(bool exchangeFinished, bool singleShot)
+            {
+                if (exchangeFinished) return "exchangeFinished";
+                if (singleShot) return "objectiveMet"; // back-compat
+                return "maxTurnsReached";
+            }
+            """;
+        ContainsLegacyWireValue(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Vacuity guard: the fence must flag any production code emitting the legacy " +
+            "`\"objectiveMet\"` literal — this is the pre-#552 bug shape and the entire point " +
+            "of this fitness function. If this assertion fails, the literal check has been " +
+            "neutered.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMention()
+    {
+        // Synthetic clean shape: a deprecation comment that MENTIONS the legacy literal for
+        // historical reference is fine — the comment stripper removes it before the fence
+        // applies. This avoids forcing future authors to delete explanatory comments about
+        // the rename when they document the wire-value history.
+        const string syntheticClean = """
+            public static string ResolveCompletionReason(bool exchangeFinished, bool singleShot)
+            {
+                // Renamed from "objectiveMet" in #552 because the wire value was misleading
+                // when no Objective was set.
+                if (exchangeFinished) return "exchangeFinished";
+                if (singleShot) return "singleShot";
+                return "maxTurnsReached";
+            }
+            """;
+        ContainsLegacyWireValue(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: the fence must not flag a comment-only mention of the " +
+            "legacy literal. If this fails, the comment stripper has regressed and the fence " +
+            "will block PRs that legitimately document the rename in comments.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnXmlDocMention()
+    {
+        // Synthetic clean shape: an XML doc comment (triple-slash) mentioning the legacy
+        // wire value as historical context must NOT trip the fence. The comment stripper
+        // handles `///` just like `//`.
+        const string syntheticClean = """
+            /// <summary>
+            /// The completion reason. Possible values include "singleShot" (renamed from
+            /// "objectiveMet" in #552), "exchangeFinished", "maxTurnsReached", "error".
+            /// </summary>
+            public string CompletionReason { get; init; } = "singleShot";
+            """;
+        ContainsLegacyWireValue(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: the fence must not flag an XML doc reference to the legacy " +
+            "literal. If this fails, the comment stripper is not handling triple-slash comments " +
+            "correctly and the fence will block authors from documenting the rename in DocFX/XML " +
+            "summaries.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedToken()
+    {
+        // Synthetic clean shape: tokens like `objectiveMet` as an identifier (variable name,
+        // property name) without the surrounding quotes are NOT the wire value and must be
+        // allowed. The fence specifically targets the quoted string literal.
+        const string syntheticClean = """
+            public bool objectiveMet { get; set; } = false;
+            var flagObjectiveMet = isCompleted;
+            """;
+        ContainsLegacyWireValue(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: the fence targets the quoted literal `\"objectiveMet\"`. " +
+            "Identifier-level uses (variable names, property names) are unrelated to the wire " +
+            "value and must not be flagged. If this fails, the fence has been broadened to " +
+            "ban a substring rather than a quoted literal.");
+    }
+
+    [Fact]
+    public void Fence_DetectsLegacyLiteral_OnLineWithUrlString()
+    {
+        // Critique-sweep fold-in (#552 bug-hunt MEDIUM / security LOW / plan-vs-impl LOW):
+        // before the string-aware stripper, the naive regex `//[^\r\n]*` would treat any `//`
+        // inside a regular string literal (e.g. a URL) as a line-comment start and strip
+        // everything to the next newline — including a real `"objectiveMet"` on the same line.
+        // The fence would then silently pass with zero candidates. This test pins the
+        // string-aware stripper: `//` inside a `"…"` literal must NOT be treated as a comment.
+        const string syntheticViolation = """
+            var url = "https://example.com/v1"; var reason = "objectiveMet";
+            """;
+        ContainsLegacyWireValue(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Realistic false-negative pin: the fence must still detect the legacy literal " +
+            "when the same line contains a URL string with `//`. If this fails, the " +
+            "string-aware comment stripper has regressed to the naive regex form and " +
+            "production code with URL literals near the wire value would silently bypass.");
+    }
+
+    [Fact]
+    public void Fence_DetectsLegacyLiteral_AfterVerbatimStringWithSlashes()
+    {
+        // Critique-sweep fold-in: verbatim strings (`@"…"`) can contain `//` directly with
+        // no escaping (e.g. Windows-style `\\server//share` or doc-string slashes). The
+        // string-aware stripper must recognize the `@"…"` form and not strip the `//` inside.
+        const string syntheticViolation = """"
+            var path = @"C:\foo//bar"; var reason = "objectiveMet";
+            """";
+        ContainsLegacyWireValue(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Verbatim-string false-negative pin: `//` inside `@\"…\"` must not be treated " +
+            "as a comment-start. If this fails, the stripper does not handle verbatim " +
+            "strings and the fence has a real coverage gap.");
+    }
+
+    private static bool ContainsLegacyWireValue(string source)
+    {
+        // The wire value is the quoted string literal "objectiveMet". Matching the quotes
+        // specifically avoids false-positives on unrelated identifiers that happen to
+        // contain the same letter sequence. Both regular and verbatim string literals end
+        // with a closing double-quote, so `"objectiveMet"` matches both `"objectiveMet"`
+        // and `@"objectiveMet"` (the `@` is the only meaningful prefix difference).
+        return Regex.IsMatch(source, "\"objectiveMet\"");
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving the contents of string and char literals. Required to avoid the
+    /// false-negative shape <c>var u = "https://x"; var r = "objectiveMet";</c> where a
+    /// regex-only stripper would treat the <c>//</c> inside the URL string as a comment
+    /// start and silently bypass the fence (see <c>Fence_DetectsLegacyLiteral_OnLineWithUrlString</c>).
+    /// Handles regular strings (with <c>\\</c>/<c>\"</c> escapes), verbatim strings
+    /// (<c>@"…"</c> with <c>""</c>-escaped quotes), and char literals.
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                if (i + 1 < n)
+                {
+                    i += 2;
+                }
+                else
+                {
+                    i = n;
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -669,13 +669,13 @@ public sealed class AgentExchangeServiceTests
     }
 
     [Fact]
-    public async Task ConverseAsync_NoObjectiveSet_ObjectiveMetReasonReturned()
+    public async Task ConverseAsync_NoObjectiveSet_SingleShotReasonReturned()
     {
-        // Wire-value back-compat pin (plan-vs-impl PR #553 suggestion S-2). When no objective is
-        // set, the loop runs exactly one turn (single-shot) and CompletionReason is "objectiveMet"
-        // — the LEGACY name preserved across the F-11 refactor so existing consumers that switch
-        // on this string continue to work. Renaming to "singleShot" would be a wire break and is
-        // explicitly tracked as a Phase 8 follow-up in plan.md (not in scope for this PR).
+        // Wire-value pin (closes #552). When no objective is set, the loop runs exactly one
+        // turn (single-shot) and CompletionReason is "singleShot" — renamed from the historical
+        // "objectiveMet" because no objective was ever provided in this code path. The rename
+        // is a deliberate wire change; the architecture fence in
+        // SingleShotWireValueArchitectureTests bans the legacy literal from production source.
         var initiator = AgentId.From("test-agent");
         var target = AgentId.From("agent-c");
         var registry = CreateRegistry(initiator, target, ["agent-c"]);
@@ -704,7 +704,10 @@ public sealed class AgentExchangeServiceTests
         });
 
         handle.Verify(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
-        result.CompletionReason.ShouldBe("objectiveMet");
+        result.CompletionReason.ShouldBe("singleShot",
+            "When no Objective is set, the exchange runs exactly one prompt and CompletionReason " +
+            "must report \"singleShot\" — not \"objectiveMet\" (renamed in #552). If this fails " +
+            "with the legacy value, the rename has been reverted.");
     }
 
     [Fact]


### PR DESCRIPTION

The wire value `CompletionReason = "objectiveMet"` was emitted by `ResolveCompletionReason`
when the caller provided NO `Objective` — i.e. single-shot exchanges that ran for exactly
one prompt and stopped because there was nothing to drive toward. The name was a holdover
from the pre-Phase 8 prose-substring objective detection (issue #379) that Phase 8 / F-11
replaced. Post-#379 the literal was misleading: it announced "objective met" when no
objective was ever set. This PR renames the wire value to `"singleShot"` — the same name
the corresponding local variable already uses (`singleShot = true` at
`AgentExchangeService.cs:185`) — and adds an architecture fitness function that bans the
legacy literal from production source under `src/**/*.cs`.

## Surface map (4 occurrences total)

1. `src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs:400-405` (producer; helper
   funnels both call sites at lines 228 + 394)
2. `src/domain/BotNexus.Domain/Gateway/Models/AgentConversationResult.cs:33-46` (XML doc
   rewritten to list all 4 current values: `exchangeFinished`, `singleShot`,
   `maxTurnsReached`, `error`)
3. `tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs:671-708` (test
   renamed in place + assertion + regression-pin message)
4. NEW `tests/architecture/BotNexus.Architecture.Tests/SingleShotWireValueArchitectureTests.cs`
   (7 tests: 1 fence + 1 vacuity guard + 3 false-positive guards + 2 critique-fold-in
   false-negative pins)

## No back-compat concerns

- BotNexus has no external API consumers (AGENTS.md). The wire value is consumed only by
  in-process callers (the LLM tool layer).
- `CompletionReason` is LOCAL-ONLY: it lives on `AgentExchangeResult` (the return type of
  `ConverseAsync`) and is JSON-serialised to camelCase by `AgentConverseTool.cs:77-80` for
  the LLM to read as tool-call response text.
- **`CrossWorldRelayResponse` has no `CompletionReason` field** (verified at
  `src/gateway/BotNexus.Gateway.Contracts/CrossWorld/CrossWorldRelayModels.cs:42-76`).
  The cross-world wire carries `ExchangeFinished`, `FinishReason`, `FinishSummary` — the
  computed `CompletionReason` never crosses the federation boundary.
- `CompletionReason` is NOT a persisted entity field — no store schema or replay log
  references the old literal.
- A repo-wide grep for `objectiveMet` confirms zero references in `*.json` / `*.md` /
  `*.yaml` / `*.razor` / `*.resx` — no fixtures or docs to migrate.

## Architecture fence (7 tests)

`NoProductionSourceFile_ContainsLegacyObjectiveMetWireValue` scans `src/**/*.cs` for the
quoted literal `"objectiveMet"` after comment-stripping. Matches the quoted literal
specifically (not bare identifier) to avoid false-positives on variable names. Excludes
`bin/` and `obj/`.

Supporting tests:
- `Fence_IsNotVacuous_AgainstSyntheticRegression` — synthetic post-revert shape must trip.
- `Fence_DoesNotFalsePositive_OnCommentMention` — `//` line-comment mention is allowed.
- `Fence_DoesNotFalsePositive_OnXmlDocMention` — `///` XML doc mention is allowed.
- `Fence_DoesNotFalsePositive_OnUnrelatedToken` — bare identifier `objectiveMet` is allowed.
- `Fence_DetectsLegacyLiteral_OnLineWithUrlString` (fold-in) — pins the URL-on-same-line
  false-negative the critique sweep found.
- `Fence_DetectsLegacyLiteral_AfterVerbatimStringWithSlashes` (fold-in) — pins the
  verbatim-string-with-slashes false-negative.

## Multi-model critique sweep summary

Three reviewers ran in parallel after impl (autopilot policy):

- **security/gpt-5.5** — 1 LOW (fence bypass-able by concatenation / interpolation / `//`
  inside string). Adopted the realistic part (`//` inside string) — see fold-in below.
  Adversarial bypasses (concatenation, interpolation) deferred: the fence is regression
  detection, not adversarial defense; a developer hand-crafting `"object" + "iveMet"` to
  evade detection is acting in bad faith. **Critically verified**: no authz/audit/persistence
  switch on `CompletionReason`; no cross-world wire exposure.
- **plan-vs-impl/claude-opus-4.7** — **PASS** on all ACs. All 4 current wire values
  documented in XML doc. Helper is the single funnel both call sites pass through.
  Test rename consistent (name + comment + assertion). 2 LOW cosmetic items deferred
  (close-issue comment + a stale doc in `docs/development/triggers-and-federation.md`
  describing a fictional `bool ObjectiveMet` field on a long-gone type — out of scope).
- **bug-hunt/gpt-5.3-codex** — 1 MEDIUM + 1 LOW. MEDIUM is the same `//`-inside-string
  false-negative (rated higher than the other two reviewers) — **adopted via fold-in**.
  LOW (`IsObjectiveMet` comment at `AgentExchangeService.cs:182` and test name
  `MaxTurnsReachedWithoutObjectiveMet` at `AgentExchangeServiceTests.cs:637`) deferred:
  the comment is a HISTORICAL reference to the pre-Phase 8 method that the new code
  fixed; the test asserts `"maxTurnsReached"` not the renamed literal and describes a
  domain concept (was the objective met) not the wire value. The architecture fence
  correctly does NOT ban these — it bans the quoted literal only.

## Critique fold-in: string-aware comment stripper

Replaced the naive regex `//[^\r\n]*` with a small state-machine lexer that:
- Recognises regular strings (`"…"` with `\\` / `\"` escapes).
- Recognises verbatim strings (`@"…"` with `""`-escaped quotes).
- Recognises char literals (`'…'`).
- Only strips `//` and `/* */` when NOT inside any of the above.

Two new tests pin the fix:
- `Fence_DetectsLegacyLiteral_OnLineWithUrlString` — input
  `var url = "https://x"; var reason = "objectiveMet";` would be stripped to
  `var url = "https:` by the old regex, hiding the literal. The new lexer preserves the
  string and the fence catches the literal.
- `Fence_DetectsLegacyLiteral_AfterVerbatimStringWithSlashes` — same shape for verbatim
  strings (`@"C:\foo//bar"`).

No new dependencies (no Roslyn). ~110 lines including XML doc.

## Verification

- Build: 0 warnings / 0 errors under `TreatWarningsAsErrors`.
- Targeted `SingleShot|NoObjectiveSet`: 1/0.
- Targeted `SingleShotWireValue`: 7/0 (5 original + 2 fold-in).
- Full `BotNexus.Architecture.Tests`: 76/0 (74 baseline + 2 new).
- Full `BotNexus.Gateway.Tests`: 1883/0/1 skipped (unchanged from post-#565 baseline).
- Full solution suite: green (pre-fold-in run before laptop reboot).

Closes #552.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
