### PR TITLE
refactor(gateway): close GatewaySession proxy gap; ban reach-through (#570)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -77,6 +77,19 @@ public sealed class GatewaySession
         set => Session.SessionType = value;
     }
 
+    /// <summary>
+    /// Conversation this session belongs to, or <c>null</c> for orphan / legacy
+    /// ungrouped sessions. Always mutate through this proxy — the
+    /// <see cref="GatewaySessionFacadeArchitectureTests"/> fence bans reach-through
+    /// access via <c>session.Session.ConversationId</c> so the proxy stays the
+    /// single source of truth (F-9 / Phase 7).
+    /// </summary>
+    public ConversationId? ConversationId
+    {
+        get => Session.ConversationId;
+        set => Session.ConversationId = value;
+    }
+
     /// <summary>Computed interactivity marker.</summary>
     public bool IsInteractive => Session.IsInteractive;
 
@@ -230,16 +243,10 @@ public sealed class GatewaySession
         => Runtime.SetStreamReplayState(nextSequenceId, streamEvents);
 
     /// <summary>
-    /// Executes to session.
+    /// Wraps an existing domain <see cref="Session"/> record in a new
+    /// <see cref="GatewaySession"/>. Used by tests and serialization paths that
+    /// already hold a domain record and need the gateway-level lock + replay buffer.
     /// </summary>
-    /// <returns>The to session result.</returns>
-    public Session ToSession() => Session;
-
-    /// <summary>
-    /// Executes from session.
-    /// </summary>
-    /// <param name="session">The session.</param>
-    /// <returns>The from session result.</returns>
     public static GatewaySession FromSession(Session session) => new(session);
 
     // Applies the injected redactor to sensitive fields before the entry is stored.

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -493,7 +493,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
         var gatewaySession = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
 
-        if (gatewaySession?.Session.ConversationId is { } conversationId && _resetService is not null)
+        if (gatewaySession?.ConversationId is { } conversationId && _resetService is not null)
         {
             await _resetService.ResetActiveSessionAsync(
                 conversationId,
@@ -516,8 +516,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 _logger.LogWarning(ex, "Supervisor stop failed for orphan session {SessionId}; reset will proceed.", typedSessionId);
             }
 
-            gatewaySession.Session.Status = GatewaySessionStatus.Sealed;
-            gatewaySession.Session.UpdatedAt = DateTimeOffset.UtcNow;
+            gatewaySession.Status = GatewaySessionStatus.Sealed;
+            gatewaySession.UpdatedAt = DateTimeOffset.UtcNow;
             await _sessions.SaveAsync(gatewaySession, CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -548,7 +548,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             var outcome = session.TryApplyCompactionResult(result);
             if (outcome != HistoryReplaceOutcome.Aborted)
             {
-                session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+                session.UpdatedAt = DateTimeOffset.UtcNow;
             }
         }
         await _sessions.SaveAsync(session, CancellationToken.None);

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ChannelHistoryController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ChannelHistoryController.cs
@@ -104,16 +104,16 @@ public sealed class ChannelHistoryController : ControllerBase
             {
                 boundaries.Add(new ChannelHistorySessionBoundary(
                     messages.Count,
-                    slice.Session.SessionId.Value,
-                    slice.Session.CreatedAt));
+                    slice.GatewaySession.SessionId.Value,
+                    slice.GatewaySession.CreatedAt));
             }
 
             var messageIndex = slice.StartIndex;
             foreach (var entry in slice.Entries)
             {
                 messages.Add(new ChannelHistoryMessage(
-                    $"{slice.Session.SessionId}:{messageIndex}",
-                    slice.Session.SessionId.Value,
+                    $"{slice.GatewaySession.SessionId}:{messageIndex}",
+                    slice.GatewaySession.SessionId.Value,
                     entry.Role,
                     StripControlTags(entry.Content),
                     entry.Timestamp,
@@ -128,7 +128,7 @@ public sealed class ChannelHistoryController : ControllerBase
 
         var oldestSlice = slices[^1];
         var hasMore = oldestSlice.StartIndex > 0 || oldestSlice.SessionIndex < sessions.Count - 1;
-        var nextCursor = hasMore ? $"{oldestSlice.Session.SessionId}:{oldestSlice.StartIndex}" : null;
+        var nextCursor = hasMore ? $"{oldestSlice.GatewaySession.SessionId}:{oldestSlice.StartIndex}" : null;
 
         return Ok(new ChannelHistoryResponse(messages, nextCursor, hasMore, boundaries));
     }
@@ -191,7 +191,7 @@ public sealed class ChannelHistoryController : ControllerBase
 
     private sealed record HistorySlice(
         int SessionIndex,
-        GatewaySession Session,
+        GatewaySession GatewaySession,
         int StartIndex,
         IReadOnlyList<SessionEntry> Entries);
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -361,7 +361,7 @@ public sealed class ConversationsController : ControllerBase
             if (virtualSession is null)
                 return NoContent();
 
-            if (virtualSession.Session.ConversationId is { } linkedConversationId)
+            if (virtualSession.ConversationId is { } linkedConversationId)
                 conversation = await _conversations.GetAsync(linkedConversationId, cancellationToken);
 
             if (conversation is null)

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -115,7 +115,7 @@ public sealed class CrossWorldFederationController(
             if (resolved.Error is { } resolveError)
                 return resolveError;
 
-            return await ExecuteRelayAsync(request, resolved.Session!, resolved.Conversation!, cancellationToken).ConfigureAwait(false);
+            return await ExecuteRelayAsync(request, resolved.GatewaySession!, resolved.Conversation!, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -124,10 +124,10 @@ public sealed class CrossWorldFederationController(
                 return resolveError;
 
             await using var lease = await sessionWriteLock
-                .AcquireAsync(resolved.Session!.SessionId, cancellationToken)
+                .AcquireAsync(resolved.GatewaySession!.SessionId, cancellationToken)
                 .ConfigureAwait(false);
 
-            return await ExecuteRelayAsync(request, resolved.Session!, resolved.Conversation!, cancellationToken).ConfigureAwait(false);
+            return await ExecuteRelayAsync(request, resolved.GatewaySession!, resolved.Conversation!, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -293,7 +293,7 @@ public sealed class CrossWorldFederationController(
             if (existing.Status == GatewaySessionStatus.Sealed)
                 return ResolveResult.Fail(Conflict(new { error = $"RemoteSessionId '{request.RemoteSessionId}' is sealed and cannot be reused — start a new cross-world exchange." }));
 
-            if (existing.Session.ConversationId is not { } existingConversationId)
+            if (existing.ConversationId is not { } existingConversationId)
                 return ResolveResult.Fail(Conflict(new { error = $"RemoteSessionId '{request.RemoteSessionId}' has no bound conversation — refuse to reuse." }));
 
             var existingConv = await conversationStore.GetAsync(existingConversationId, cancellationToken).ConfigureAwait(false);
@@ -331,7 +331,7 @@ public sealed class CrossWorldFederationController(
 
         var sessionId = SessionId.Create();
         var session = await sessionStore.GetOrCreateAsync(sessionId, targetAgentId, cancellationToken).ConfigureAwait(false);
-        session.Session.ConversationId = conversation.ConversationId;
+        session.ConversationId = conversation.ConversationId;
         session.SessionType = SessionType.AgentAgent;
         session.ChannelType = CrossWorldChannel;
         session.CallerId = null;
@@ -463,7 +463,7 @@ public sealed class CrossWorldFederationController(
         }
     }
 
-    private readonly record struct ResolveResult(GatewaySession? Session, Conversation? Conversation, ActionResult<CrossWorldRelayResponse>? Error)
+    private readonly record struct ResolveResult(GatewaySession? GatewaySession, Conversation? Conversation, ActionResult<CrossWorldRelayResponse>? Error)
     {
         public static ResolveResult Ok(GatewaySession session, Conversation conversation)
             => new(session, conversation, null);

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs
@@ -69,7 +69,7 @@ public sealed class SessionsController : ControllerBase
             sessionId = s.SessionId.Value,
             agentId = s.AgentId.Value,
             channelType = s.ChannelType?.Value,
-            conversationId = s.Session.ConversationId?.Value,
+            conversationId = s.ConversationId?.Value,
             status = s.Status.ToString(),
             sessionType = s.SessionType.Value,
             isInteractive = s.IsInteractive,

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -82,8 +82,8 @@ public sealed class CronTrigger(
         if (request is not null && request.ResolvedConversationId is null)
             request.ResolvedConversationId = conversation.ConversationId;
 
-        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
-            session.Session.ConversationId = conversation.ConversationId;
+        if (session.ConversationId is null || session.ConversationId != conversation.ConversationId)
+            session.ConversationId = conversation.ConversationId;
 
         // Update the conversation's active session to this run so history loads the latest.
         if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
@@ -231,7 +231,7 @@ public sealed class CronTrigger(
                 .ConfigureAwait(false);
             foreach (var session in duplicateSessions)
             {
-                session.Session.ConversationId = canonical.ConversationId;
+                session.ConversationId = canonical.ConversationId;
                 await sessions.SaveAsync(session, ct).ConfigureAwait(false);
             }
 

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
@@ -96,7 +96,7 @@ public sealed class HeartbeatTrigger(
         session.ChannelType = null;
         session.CallerId ??= $"heartbeat:{agentId.Value}";
         session.SessionType = SessionType.Heartbeat;
-        session.Session.ConversationId = conversation.ConversationId;
+        session.ConversationId = conversation.ConversationId;
         session.Metadata["triggerType"] = Type.Value;
 
         if (string.IsNullOrWhiteSpace(request?.ModelOverride))

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -174,7 +174,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
             return [];
         }
 
-        var conversationId = session.Session.ConversationId;
+        var conversationId = session.ConversationId;
         if (conversationId is null)
         {
             _logger.LogDebug("GetOutboundBindings: session {SessionId} has no ConversationId -- returning empty", sessionId);
@@ -334,9 +334,9 @@ public sealed class DefaultConversationRouter : IConversationRouter
             isNewSession = true;
         }
 
-        if (session.Session.ConversationId is null || session.Session.ConversationId != conversation.ConversationId)
+        if (session.ConversationId is null || session.ConversationId != conversation.ConversationId)
         {
-            session.Session.ConversationId = conversation.ConversationId;
+            session.ConversationId = conversation.ConversationId;
             await _sessionStore.SaveAsync(session, ct);
         }
 

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -250,7 +250,7 @@ public sealed class FileSessionStore : SessionStoreBase
             session.ExpiresAt,
             session.NextSequenceId,
             [.. session.GetStreamEventSnapshot()],
-            session.Session.ConversationId,
+            session.ConversationId,
             session.Metadata.Count == 0 ? null : new Dictionary<string, object?>(session.Metadata));
         await SessionMetadataSidecar.WriteAsync(
             _fileSystem,

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -59,8 +59,8 @@ public abstract class SessionStoreBase : ISessionStore
     {
         var sessions = await EnumerateSessionsAsync(cancellationToken).ConfigureAwait(false);
         IEnumerable<GatewaySession> result = sessions
-            .Where(session => session.Session.ConversationId is not null
-                && session.Session.ConversationId.Value == conversationId);
+            .Where(session => session.ConversationId is not null
+                && session.ConversationId.Value == conversationId);
         if (agentId is not null)
         {
             result = result.Where(session => session.AgentId == agentId);

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -607,7 +607,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
         command.Parameters.AddWithValue("$metadata", JsonSerializer.Serialize(session.Metadata, JsonOptions));
         command.Parameters.AddWithValue("$createdAt", session.CreatedAt.ToString("O"));
         command.Parameters.AddWithValue("$updatedAt", session.UpdatedAt.ToString("O"));
-        command.Parameters.AddWithValue("$conversationId", (object?)session.Session.ConversationId?.Value ?? DBNull.Value);
+        command.Parameters.AddWithValue("$conversationId", (object?)session.ConversationId?.Value ?? DBNull.Value);
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -98,7 +98,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
         // F-6 eager-pin pattern (PR #547): set ConversationId and save BEFORE any path that could
         // observe the child session, so it is never visible to ListByConversationAsync as an orphan.
-        session.Session.ConversationId = conversation.ConversationId;
+        session.ConversationId = conversation.ConversationId;
         session.SessionType = SessionType.AgentAgent;
         session.ChannelType = null;
         session.CallerId = null;
@@ -262,7 +262,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
         var sessionId = SessionId.Create();
         var session = await _sessionStore.GetOrCreateAsync(sessionId, request.InitiatorId, cancellationToken).ConfigureAwait(false);
-        session.Session.ConversationId = conversation.ConversationId;
+        session.ConversationId = conversation.ConversationId;
         session.SessionType = SessionType.AgentAgent;
         session.ChannelType = ChannelKey.From("cross-world");
         session.CallerId = null;

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -186,7 +186,7 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             var childSession = await _sessionStore.GetAsync(childSessionId, ct).ConfigureAwait(false);
             if (childSession is not null)
             {
-                childSession.Session.ConversationId = request.InheritedConversationId;
+                childSession.ConversationId = request.InheritedConversationId;
                 await _sessionStore.SaveAsync(childSession, ct).ConfigureAwait(false);
             }
         }

--- a/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
@@ -169,7 +169,7 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
         if (_sessionStore is not null)
         {
             var session = await _sessionStore.GetAsync(executionContext.SessionId, cancellationToken).ConfigureAwait(false);
-            if (session?.Session.ConversationId is { } conversationId)
+            if (session?.ConversationId is { } conversationId)
                 conversation = await _conversationStore.GetAsync(conversationId, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationResetService.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/DefaultConversationResetService.cs
@@ -162,8 +162,8 @@ internal sealed class DefaultConversationResetService : IConversationResetServic
         }
 
         // Step 4: seal the session (Status = Sealed; SaveAsync). Not ArchiveAsync — see class docs.
-        gatewaySession.Session.Status = SessionStatus.Sealed;
-        gatewaySession.Session.UpdatedAt = _timeProvider.GetUtcNow();
+        gatewaySession.Status = SessionStatus.Sealed;
+        gatewaySession.UpdatedAt = _timeProvider.GetUtcNow();
         await _sessions.SaveAsync(gatewaySession, cancellationToken).ConfigureAwait(false);
 
         // Step 5: clear ActiveSessionId. The router creates a fresh session on next inbound.

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -363,8 +363,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             // Update session ConversationId from dispatch resolution.
             // Always update (not just when null) so that switching conversations on the same
             // session correctly routes messages to the new conversation (#314).
-            if (resolution is not null && session.Session.ConversationId != resolution.ConversationId)
-                session.Session.ConversationId = resolution.ConversationId;
+            if (resolution is not null && session.ConversationId != resolution.ConversationId)
+                session.ConversationId = resolution.ConversationId;
             session.CallerId ??= message.SenderId;
             session.SessionType = ResolveSessionType(session, message, isNewSession: createdSession);
             EnsureCallerParticipant(session, message.Sender);
@@ -407,7 +407,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             }
 
             if (_pendingAskUserInterceptor is not null &&
-                session.Session.ConversationId is { } activeConversationId &&
+                session.ConversationId is { } activeConversationId &&
                 _pendingAskUserInterceptor.TryIntercept(message, activeConversationId))
             {
                 _logger.LogInformation(
@@ -451,7 +451,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     {
                         try
                         {
-                            await _memoryFlusher.FlushAsync(session.Session.AgentId, session.Session, _compactionOptions.CurrentValue, cancellationToken).ConfigureAwait(false);
+                            await _memoryFlusher.FlushAsync(session.AgentId, session.Session, _compactionOptions.CurrentValue, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception flushEx)
                         {
@@ -465,10 +465,10 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         switch (outcome)
                         {
                             case HistoryReplaceOutcome.Applied:
-                                session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+                                session.UpdatedAt = DateTimeOffset.UtcNow;
                                 break;
                             case HistoryReplaceOutcome.Rebased:
-                                session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+                                session.UpdatedAt = DateTimeOffset.UtcNow;
                                 _logger.LogInformation(
                                     "Session {SessionId} auto-compaction rebased over concurrent additions; " +
                                     "TokensAfter is approximate.", sessionId);
@@ -849,7 +849,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             outcome = session.TryApplyCompactionResult(result);
             if (outcome != HistoryReplaceOutcome.Aborted)
             {
-                session.Session.UpdatedAt = DateTimeOffset.UtcNow;
+                session.UpdatedAt = DateTimeOffset.UtcNow;
             }
         }
         await _sessions.SaveAsync(session, cancellationToken);
@@ -1188,7 +1188,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         "Fan-out: stale connection for binding {BindingId} in conversation {ConversationId}. Demoting to Muted.",
                         ex.BindingId, ex.ConversationId);
 
-                    if (session?.Session.ConversationId is { } convId)
+                    if (session?.ConversationId is { } convId)
                         await _conversationRouter.MuteBindingAsync(convId, ex.BindingId, cancellationToken);
                 }
                 catch (Exception ex)

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -577,7 +577,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         if (sessionStore is not null)
         {
             var session = await sessionStore.GetAsync(sessionId, cancellationToken).ConfigureAwait(false);
-            if (session?.Session.ConversationId is { } conversationId)
+            if (session?.ConversationId is { } conversationId)
                 return conversationId;
         }
 

--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -139,7 +139,7 @@ public sealed class ConversationTool(
             else
             {
                 session = await sessionStore.GetOrCreateAsync(SessionId.Create(), conversation.AgentId, ct).ConfigureAwait(false);
-                session.Session.ConversationId = conversation.ConversationId;
+                session.ConversationId = conversation.ConversationId;
                 conversation.ActiveSessionId = session.SessionId;
                 conversation.UpdatedAt = DateTimeOffset.UtcNow;
                 await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
@@ -148,7 +148,7 @@ public sealed class ConversationTool(
         else
         {
             session = await sessionStore.GetOrCreateAsync(SessionId.Create(), conversation.AgentId, ct).ConfigureAwait(false);
-            session.Session.ConversationId = conversation.ConversationId;
+            session.ConversationId = conversation.ConversationId;
             conversation.ActiveSessionId = session.SessionId;
             conversation.UpdatedAt = DateTimeOffset.UtcNow;
             await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
@@ -261,7 +261,7 @@ public sealed class ConversationTool(
             var session = await sessionStore
                 .GetOrCreateAsync(SessionId.Create(), targetAgentId, ct)
                 .ConfigureAwait(false);
-            session.Session.ConversationId = created.ConversationId;
+            session.ConversationId = created.ConversationId;
             session.AddEntry(new SessionEntry
             {
                 Role = MessageRole.User,

--- a/tests/architecture/BotNexus.Architecture.Tests/GatewaySessionFacadeArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/GatewaySessionFacadeArchitectureTests.cs
@@ -1,0 +1,357 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function enforcing the F-9 / Phase 7 contract: production code
+/// must mutate session state through the <c>GatewaySession</c> proxy, never by reaching
+/// through to the inner <c>Session</c> record via <c>gatewaySession.Session.Field</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before Phase 7 the codebase had ~25 reach-through call sites of the shape
+/// <c>session.Session.ConversationId = ...</c>, <c>session.Session.UpdatedAt = ...</c>,
+/// and <c>session.Session.AgentId</c>. The reach-throughs existed because the proxy was
+/// missing a <c>ConversationId</c> facade — every caller that needed to read/write the
+/// conversation id had to dive through the inner record. Once a few call sites had done
+/// it for <c>ConversationId</c>, the same shape spread to fields that already had proxies
+/// (laziness pattern).
+/// </para>
+/// <para>
+/// The damage: thread-safety guarantees from <c>GatewaySessionRuntime</c> (the lock, the
+/// stream replay buffer, the secret redactor) only fire if mutation happens through the
+/// proxy. Reach-through writes bypass <em>all</em> of that quietly. PR #540 already had
+/// to add a <c>ThreadSafeHistoryArchitectureTests</c> fence for the History case; this
+/// fence generalises the same defence to every other proxied field.
+/// </para>
+/// <para>
+/// The fence is intentionally narrow: only <c>GatewaySession.cs</c> and
+/// <c>GatewaySessionRuntime.cs</c> (the proxy and its runtime) are allowed to use
+/// <c>this.Session.X</c> internally — every other production file under <c>src/</c> must
+/// route through the proxy properties. Tests are out of scope so behavioural pins like
+/// <c>GatewaySessionBehaviorSnapshotTests</c> can still inspect the inner record.
+/// </para>
+/// <para>
+/// The fence uses the same comment-stripping state-machine lexer from
+/// <c>SingleShotWireValueArchitectureTests</c> (PR #569) so XML doc references to the
+/// banned shape (e.g. inside <c>&lt;see cref="..."/&gt;</c> or prose comments) do not
+/// false-positive. The matching regex <c>\.Session\b\s*!?\s*\.\s*\w+</c> permits the
+/// null-forgiving operator (<c>session.Session!.X</c>) and inter-token whitespace, both
+/// of which appear in real reach-through shapes. The word-boundary after <c>Session</c>
+/// avoids matching <c>Sessions.X</c> (e.g. <c>ServiceCollection.Sessions.Foo</c>) and
+/// <c>SessionStore.X</c>.
+/// </para>
+/// </remarks>
+public sealed class GatewaySessionFacadeArchitectureTests
+{
+    private static readonly string[] s_allowlist =
+    {
+        // The proxy itself — its whole job is to talk to the inner Session.
+        Path.Combine("domain", "BotNexus.Domain", "Gateway", "Models", "GatewaySession.cs"),
+        // The runtime that owns the lock + history mutation; also a legitimate insider.
+        Path.Combine("domain", "BotNexus.Domain", "Gateway", "Models", "GatewaySessionRuntime.cs"),
+    };
+
+    [Fact]
+    public void NoProductionSourceFile_ReachesThroughGatewaySession_ToInnerRecord()
+    {
+        var srcRoot = FindSourceRoot();
+
+        var violations = new List<string>();
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            if (IsAllowlisted(path, srcRoot))
+                continue;
+
+            var stripped = StripComments(File.ReadAllText(path));
+            if (ContainsReachThrough(stripped))
+            {
+                violations.Add(NormalizePath(path));
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "F-9 / Phase 7: production code must mutate session state through the " +
+            "GatewaySession proxy properties — never by reaching through to the inner " +
+            "record via `gatewaySession.Session.Field`. Reach-through writes bypass " +
+            "the GatewaySessionRuntime lock, the stream replay buffer, and the secret " +
+            "redactor. If a needed proxy is missing, add it to GatewaySession.cs (this " +
+            "is how the ConversationId proxy was added in Phase 7) rather than reaching " +
+            "through.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReachThrough()
+    {
+        // Synthetic post-revert shape: a typical reach-through write MUST trip the fence.
+        // If this test fails, the fence has been weakened so far that the original
+        // bug class is undetectable.
+        const string syntheticViolation = """
+            public void Pin(GatewaySession session, ConversationId? conversationId)
+            {
+                session.Session.ConversationId = conversationId;
+            }
+            """;
+        ContainsReachThrough(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Vacuity guard: the fence must flag the canonical reach-through shape " +
+            "`gatewaySession.Session.Field = ...`. If this assertion fails, the fence " +
+            "is no longer detecting the very bug it was created to prevent.");
+    }
+
+    [Fact]
+    public void Fence_DetectsReachThrough_ThroughNullForgivingOperator()
+    {
+        // Real call sites sometimes use the null-forgiving operator (e.g. after a null
+        // check that the compiler cannot prove). The fence must catch this shape too.
+        const string syntheticViolation = """
+            var ts = session!.Session!.UpdatedAt;
+            """;
+        ContainsReachThrough(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Null-forgiving operator pin: `session!.Session!.UpdatedAt` is still a " +
+            "reach-through. If this fails, the fence regex is missing the `!` allowance " +
+            "and a realistic regression shape would bypass.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnArgumentPassing()
+    {
+        // Passing the whole `session.Session` record as an argument to a method that
+        // accepts `Session` is legitimate — the receiver gets the value record, not
+        // the proxy, by design (e.g. persistence layer signatures). The fence matches
+        // `.Session.<identifier>`, so `.Session)` (followed by close-paren or comma)
+        // must not trip it.
+        const string syntheticClean = """
+            await _memoryFlusher.FlushAsync(session.AgentId, session.Session, options, ct);
+            await store.SaveAsync(session.Session);
+            DoStuff(session.Session, more, args);
+            """;
+        ContainsReachThrough(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: passing `session.Session` as a bare argument " +
+            "(without `.Field` after it) is legitimate — the fence specifically " +
+            "targets reach-through reads/writes of the form `.Session.<identifier>`. " +
+            "If this fails, the fence would block legitimate persistence-layer calls.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnObjectInitializer()
+    {
+        // Constructing a GatewaySession via record initializer uses
+        // `{ Session = ... }` which is a property assignment on the proxy, not a
+        // reach-through. The fence regex requires `\.Session` (a member access on
+        // some receiver), so initializer assignments without a receiver dot don't match.
+        const string syntheticClean = """
+            var gs = new GatewaySession { Session = inner };
+            return gs with { Session = updated };
+            """;
+        ContainsReachThrough(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: object/record initializer `{ Session = ... }` is " +
+            "not a reach-through (no `.Session.Field` access chain). If this fails, " +
+            "the fence would block legitimate construction.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnSimilarNamedMembers()
+    {
+        // `Sessions.X`, `SessionStore.X`, `SessionId.X` etc. must NOT trip the fence —
+        // the `\b` word boundary after `Session` is the discriminator. Without it,
+        // `services.Sessions.X` would false-positive.
+        const string syntheticClean = """
+            var first = services.Sessions.First();
+            var store = ctx.SessionStore.SaveAsync(x);
+            var id = session.SessionId.Value;
+            """;
+        ContainsReachThrough(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: `Sessions.X`, `SessionStore.X`, and `SessionId.X` " +
+            "are NOT the inner-record reach-through. If this fails, the word-boundary " +
+            "after `Session` has been lost and the fence would over-fire on unrelated " +
+            "members.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMention()
+    {
+        // XML doc and prose comments that mention `.Session.X` for historical reference
+        // (e.g. documenting the F-9 ban) must NOT trip the fence — the comment stripper
+        // removes them before regex matching.
+        const string syntheticClean = """
+            /// <summary>
+            /// Banned shape under Phase 7: session.Session.ConversationId = id.
+            /// Use the GatewaySession.ConversationId proxy instead.
+            /// </summary>
+            public void SafeSetter(GatewaySession s, ConversationId? id) => s.ConversationId = id;
+            // Note: do not write session.Session.UpdatedAt directly — use the proxy.
+            """;
+        ContainsReachThrough(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: XML doc and `//` comments referencing the banned " +
+            "shape for historical context must not trip the fence. If this fails, the " +
+            "comment-stripping lexer has regressed.");
+    }
+
+    private static bool ContainsReachThrough(string source)
+    {
+        // The reach-through shape: a member access ending in `.Session` (with optional
+        // null-forgiving `!`) followed by another `.identifier` access. The `\b` after
+        // `Session` prevents matching `Sessions.X` / `SessionStore.X` / `SessionId.X`.
+        return Regex.IsMatch(source, @"\.Session\b\s*!?\s*\.\s*\w+");
+    }
+
+    private static bool IsAllowlisted(string path, string srcRoot)
+    {
+        var relative = Path.GetRelativePath(srcRoot, path);
+        foreach (var allowed in s_allowlist)
+        {
+            if (string.Equals(relative, allowed, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Required so XML docs and prose comments
+    /// that legitimately mention the banned shape do not false-positive the fence.
+    /// Identical lexer to <c>SingleShotWireValueArchitectureTests.StripComments</c> (PR #569).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                if (i + 1 < n)
+                {
+                    i += 2;
+                }
+                else
+                {
+                    i = n;
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
@@ -84,6 +84,47 @@ public sealed class GatewaySessionBehaviorSnapshotTests
         gatewaySession.MessageCount.ShouldBe(1);
     }
 
+    [Fact]
+    public void ConversationId_RoundTripsThroughProxy_ReadingInnerRecord()
+    {
+        var session = CreateSession();
+        var conversationId = ConversationId.From("conv-abc");
+
+        session.ConversationId = conversationId;
+
+        session.ConversationId.ShouldBe(conversationId);
+        session.Session.ConversationId.ShouldBe(conversationId,
+            "F-9 / Phase 7: the ConversationId proxy setter must mutate the inner " +
+            "Session record so persistence sees the value. If this fails, the proxy " +
+            "is storing the value in a private field instead of delegating.");
+    }
+
+    [Fact]
+    public void ConversationId_ProxyGetter_ReflectsInnerRecordChanges()
+    {
+        var session = CreateSession();
+        session.Session.ConversationId = ConversationId.From("conv-direct");
+
+        session.ConversationId.ShouldBe(ConversationId.From("conv-direct"),
+            "F-9 / Phase 7: the ConversationId proxy getter must read directly from " +
+            "the inner Session record. If this fails, the proxy is caching a stale " +
+            "value and reads after persistence-layer writes would be wrong.");
+    }
+
+    [Fact]
+    public void ConversationId_ProxyAcceptsNull_ForOrphanSessions()
+    {
+        var session = CreateSession();
+        session.ConversationId = ConversationId.From("conv-set");
+        session.ConversationId = null;
+
+        session.ConversationId.ShouldBeNull(
+            "F-9 / Phase 7: the ConversationId proxy must accept null assignment for " +
+            "orphan / legacy ungrouped sessions. If this fails, the proxy lost null-" +
+            "tolerance and callers cannot clear the binding.");
+        session.Session.ConversationId.ShouldBeNull();
+    }
+
     private static GatewaySession CreateSession()
         => new()
         {


### PR DESCRIPTION
## Summary

Closes #570. Refs #523.

Adds the missing `ConversationId` proxy to `GatewaySession`, migrates every production reach-through (`session.Session.X`) to the proxy (25 sites across 18 files), and adds an architecture fence preventing regression.

## Root cause

`GatewaySession` proxied 14 fields of the inner `Session` record but **`ConversationId` was missing**. Every caller that needed conversation-id read/write had to dive through `session.Session.ConversationId`. Once a few sites did that, the same shape spread to fields that DID have proxies (laziness pattern).

**The damage**: reach-through writes bypass `GatewaySessionRuntime` — its lock, the stream replay buffer, the secret redactor. PR #540 added a `ThreadSafeHistoryArchitectureTests` fence for the `History` case; this PR generalises the defence to every other proxied field.

## Changes

### Domain — proxy facade

- `GatewaySession.cs`: added `ConversationId` get/set proxy (the missing facade). Deleted dead `ToSession()` (zero callers). Rewrote `FromSession()` XML doc to be meaningful.

### Production — reach-through migration (18 files, 25 sites)

All `session.Session.X` → `session.X`:

| Area | Files | Sites |
|---|---|---|
| GatewayHost (auto-compaction, fan-out, ask-user, dispatch) | `GatewayHost.cs` | 8 |
| Channels | `GatewayHub.cs` | 4 |
| API controllers | `ChannelHistoryController.cs`, `ConversationsController.cs`, `CrossWorldFederationController.cs`, `SessionsController.cs` | 9 |
| Triggers | `CronTrigger.cs`, `HeartbeatTrigger.cs` | 4 |
| Routing / reset | `DefaultConversationRouter.cs`, `DefaultConversationResetService.cs` | 5 |
| Stores | `FileSessionStore.cs`, `SessionStoreBase.cs`, `SqliteSessionStore.cs` | 3 |
| Agent layer | `AgentExchangeService.cs`, `DefaultSubAgentManager.cs`, `WorkspaceContextBuilder.cs` | 4 |
| Isolation / tools | `InProcessIsolationStrategy.cs`, `ConversationTool.cs` | 4 |

### False-positive renames (caught pre/at-impl)

- **Rubber-duck pre-impl review caught**: `ChannelHistoryController.HistorySlice.Session` (type `GatewaySession`) — the record property name collided with the banned shape. Renamed to `HistorySlice.GatewaySession` (5 callsites migrated).
- **Verification grep caught (post-edits)**: `CrossWorldFederationController.ResolveResult.Session` had the same shape. Renamed to `ResolveResult.GatewaySession` (3 callsites migrated). Filed in commit; mention this here because it surfaced after the rubber-duck pass.

### Architecture fence — `GatewaySessionFacadeArchitectureTests` (7 tests)

- **Main fence (1)**: source-scans `src/**/*.cs` for `\.Session\b\s*!?\s*\.\s*\w+` outside a 2-entry allowlist (`GatewaySession.cs`, `GatewaySessionRuntime.cs` — the proxy and its runtime).
- **Vacuity guard (1)**: synthetic `session.Session.ConversationId = ...` MUST trip the fence.
- **Null-forgiving operator pin (1)**: `session!.Session!.UpdatedAt` MUST also trip — realistic shape, regex permits `[!]?`.
- **False-positive guards (4)**:
  - `.Session` as bare argument (`FlushAsync(..., session.Session, ...)`) — not banned (receiver takes value record by design).
  - Object/record initializer (`new GatewaySession { Session = inner }`, `gs with { Session = updated }`) — not banned.
  - `Sessions.X` / `SessionStore.X` / `SessionId.X` — `\b` word boundary discriminates.
  - Comment mention (XML doc / `//`) — comment stripper removes before regex.

- **Comment-stripping lexer**: identical state-machine from `SingleShotWireValueArchitectureTests` (PR #569) — handles regular strings, verbatim strings (`@"…"`), char literals.

### Behavior pins — `GatewaySessionBehaviorSnapshotTests` (3 tests)

- `ConversationId_RoundTripsThroughProxy_ReadingInnerRecord` — set via proxy, assert visible on inner record (persistence sees it).
- `ConversationId_ProxyGetter_ReflectsInnerRecordChanges` — set on inner, assert proxy reads through (defends against cached-field regression).
- `ConversationId_ProxyAcceptsNull_ForOrphanSessions` — null tolerance for orphan / legacy sessions.

## Intentional non-bans

Passing `session.Session` as a **bare argument** to a method that takes `Session` is **not** banned — the receiver gets the value record by design (e.g. `_memoryFlusher.FlushAsync(..., session.Session, options, ct)` at `GatewayHost.cs:454`, persistence-layer signatures). The fence regex requires `.Session.<identifier>` (an access chain after the dot), so bare-argument shapes don't match.

## Out of scope (separate PRs)

- **Thinning the 8 stream-replay proxies** (`NextSequenceId`, `StreamEventLog`, `ReplayBuffer`, `AllocateSequenceId`, `AddStreamEvent`, `GetStreamEventsAfter`, `GetStreamEventSnapshot`, `SetStreamReplayState`). Only `FileSessionStore` (3 sites) and tests use them — separate cleanup PR.
- **`HeartbeatTrigger.ReplaceHistory` → `TryReplaceHistoryFromSnapshot` migration**. Behavior change (race-safety), separate PR.

> **Plan deviation note** (plan-vs-impl critique LOW, accepted with rationale):
> Original `plan.md` §4 Phase 7 proposed *splitting* `GatewaySession` into a thin core + a separate `SessionStreamReplay` type. This PR does NOT split — it adds the missing `ConversationId` proxy and enforces facade-only access via the fence. The split is the LARGER refactor; you cannot safely extract `SessionStreamReplay` until every caller already routes through the proxy. This PR is the **structural prerequisite** for that split — once the fence is in place, the 8 stream-replay proxies can be carved out into a new type with confidence that no production code reaches into the inner record. Filed as follow-up scope (above bullet) for a separate issue.

## Known fence gaps (documented, not supported v1)

- Parenthesized: `(session.Session).ConversationId` — won't match. Realistic but unusual; future PR can extend if needed.
- Local-var aliasing: `var inner = session.Session; inner.X = …` — won't match.

Neither pattern appears anywhere in current `src/`. Adding regex variants for them is scope creep until a real call site emerges.

## Validation

- Build clean (`dotnet build BotNexus.slnx --nologo --tl:off`): **0 warnings, 0 errors** under `TreatWarningsAsErrors`.
- Full test suite (`dotnet test BotNexus.slnx --nologo --tl:off --no-build`):
  - Gateway.Tests: **1886 passed / 0 failed / 1 skipped** (+3 ConversationId proxy pins).
  - Architecture.Tests: **83 passed** (76 baseline + 7 new = main fence + vacuity + null-forgiving + 4 false-positive guards).
  - All other projects green; only pre-existing E2E/conversation `[Skip]` flags unchanged.

## Multi-model critique sweep (autopilot policy)

Per user directive, 3 critique agents reviewed this PR before merge:

| Agent | Model | Verdict |
|---|---|---|
| security-review | `gpt-5.5` | **CLEAN** — verified authz, federation invariants, XPIA, secret redaction, fence completeness, behavioural pins; no HIGH/MEDIUM/LOW findings |
| plan-vs-impl review | `claude-opus-4.7` | **PASS** — migration verified complete, fence correct, renames wire-safe (both record types are file-local privates), `ToSession()` deletion verified, 1 LOW (plan-deviation note, folded into "Out of scope" above) |
| bug-hunt review | `gpt-5.3-codex` | **NO_BUGS_FOUND** — verified all 8 areas (proxy substitution correctness, behavioural pin coverage, thread-safety not widened, fence runtime/CI validity, no reflective bypass helper exists, build clean, F-6 fence still matches) |

No HIGH/MEDIUM findings to fold in.

## Verification grep

After all edits, `grep -nE '\.Session\b\s*!?\s*\.\s*\w+' src/**/*.cs` returns exactly one hit:

- `GatewaySession.cs:84` — inside the XML doc on the new `ConversationId` proxy, documenting the banned shape. Stripped by the lexer; file is allowlisted anyway.
