### PR TITLE
fix(gateway): heartbeat ack-prune must not clobber concurrent session activity (#573)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -183,11 +183,12 @@ public sealed class GatewaySession
     /// Thread-safe atomic append + snapshot. Equivalent to
     /// <see cref="AddEntry"/> followed by <see cref="SnapshotHistoryForCompaction"/>
     /// but performed under a single runtime lock so the appended entry is
-    /// guaranteed to be at <c>snapshot.Count - 1</c> regardless of concurrent
-    /// destructive mutations. Content is redacted before storage when a
-    /// redactor is configured.
+    /// guaranteed to be at <c>Snapshot.Count - 1</c> regardless of concurrent
+    /// destructive mutations, AND the pre-append
+    /// <see cref="UpdatedAt"/> value is captured atomically with the append.
+    /// Content is redacted before storage when a redactor is configured.
     /// </summary>
-    public HistorySnapshot AddEntryAndSnapshot(SessionEntry entry) => Runtime.AddEntryAndSnapshot(Redact(entry));
+    public SessionAppendResult AddEntryAndSnapshot(SessionEntry entry) => Runtime.AddEntryAndSnapshot(Redact(entry));
 
     /// <summary>Replaces the session history with a compacted version.</summary>
     public void ReplaceHistory(IReadOnlyList<SessionEntry> compactedEntries) => Runtime.ReplaceHistory(compactedEntries);

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -179,6 +179,16 @@ public sealed class GatewaySession
     /// <summary>Thread-safe append of multiple entries. Content is redacted before storage when a redactor is configured.</summary>
     public void AddEntries(IEnumerable<SessionEntry> entries) => Runtime.AddEntries(entries.Select(Redact));
 
+    /// <summary>
+    /// Thread-safe atomic append + snapshot. Equivalent to
+    /// <see cref="AddEntry"/> followed by <see cref="SnapshotHistoryForCompaction"/>
+    /// but performed under a single runtime lock so the appended entry is
+    /// guaranteed to be at <c>snapshot.Count - 1</c> regardless of concurrent
+    /// destructive mutations. Content is redacted before storage when a
+    /// redactor is configured.
+    /// </summary>
+    public HistorySnapshot AddEntryAndSnapshot(SessionEntry entry) => Runtime.AddEntryAndSnapshot(Redact(entry));
+
     /// <summary>Replaces the session history with a compacted version.</summary>
     public void ReplaceHistory(IReadOnlyList<SessionEntry> compactedEntries) => Runtime.ReplaceHistory(compactedEntries);
 
@@ -196,13 +206,15 @@ public sealed class GatewaySession
     /// Optimistically applies a replacement history derived from an earlier
     /// snapshot. See <see cref="HistoryReplaceOutcome"/> for outcomes; see
     /// <see cref="GatewaySessionRuntime.TryReplaceHistoryFromSnapshot"/> for
-    /// the full contract.
+    /// the full contract including the <paramref name="restoreUpdatedAtOnApplied"/>
+    /// in-lock UpdatedAt restoration semantics.
     /// </summary>
     public HistoryReplaceOutcome TryReplaceHistoryFromSnapshot(
         IReadOnlyList<SessionEntry> replacement,
         long expectedDestructiveVersion,
-        int expectedHistoryCount)
-        => Runtime.TryReplaceHistoryFromSnapshot(replacement, expectedDestructiveVersion, expectedHistoryCount);
+        int expectedHistoryCount,
+        DateTimeOffset? restoreUpdatedAtOnApplied = null)
+        => Runtime.TryReplaceHistoryFromSnapshot(replacement, expectedDestructiveVersion, expectedHistoryCount, restoreUpdatedAtOnApplied);
 
     /// <summary>Returns a snapshot of the history (safe to iterate).</summary>
     public IReadOnlyList<SessionEntry> GetHistorySnapshot() => Runtime.GetHistorySnapshot();

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
@@ -110,23 +110,43 @@ public sealed class GatewaySessionRuntime
     /// <see cref="AddEntry"/> followed by <see cref="SnapshotHistoryForCompaction"/>
     /// as separate locked operations leaves a window where a concurrent
     /// destructive mutation can shift the appended entry away from
-    /// <c>snapshot.Count - 1</c>.
+    /// <c>snapshot.Count - 1</c>. Also captures the
+    /// <see cref="Session.UpdatedAt"/> value observed immediately before the
+    /// append in <see cref="SessionAppendResult.PriorUpdatedAt"/>, so callers
+    /// that intend to restore UpdatedAt after a slow follow-on operation
+    /// don't have to do an unsafe pre-call read.
     /// </summary>
     /// <param name="entry">The entry to append.</param>
     /// <returns>
-    /// A snapshot taken under the same lock as the append. The appended
-    /// entry is always at index <c>snapshot.Count - 1</c>.
+    /// The result of the append. <see cref="SessionAppendResult.Snapshot"/>
+    /// is taken under the same lock as the append (the appended entry is
+    /// always at index <c>snapshot.Count - 1</c>);
+    /// <see cref="SessionAppendResult.PriorUpdatedAt"/> is the
+    /// <see cref="Session.UpdatedAt"/> value sampled immediately before the
+    /// append, also under the same lock.
     /// </returns>
-    public HistorySnapshot AddEntryAndSnapshot(SessionEntry entry)
+    public SessionAppendResult AddEntryAndSnapshot(SessionEntry entry)
     {
         ArgumentNullException.ThrowIfNull(entry);
         lock (_lock)
         {
+            // Capture the pre-append UpdatedAt under the same lock as the
+            // append (rubber-duck bug-hunt BLOCKING for #573). A callsite
+            // that reads session.UpdatedAt OUTSIDE the lock before calling
+            // AddEntryAndSnapshot can be raced by a concurrent destructive
+            // mutation that lands between the read and the lock, leaving
+            // the caller with a stale anchor that — if later passed to
+            // TryReplaceHistoryFromSnapshot(restoreUpdatedAtOnApplied: ...)
+            // on the Applied path — would roll the timestamp backwards
+            // past the concurrent mutation.
+            var priorUpdatedAt = Session.UpdatedAt;
             Session.History.Add(entry);
             _additionVersion++;
             Session.UpdatedAt = DateTimeOffset.UtcNow;
             var snapshot = Session.History.ToArray();
-            return new HistorySnapshot(snapshot, _destructiveVersion, snapshot.Length);
+            return new SessionAppendResult(
+                new HistorySnapshot(snapshot, _destructiveVersion, snapshot.Length),
+                priorUpdatedAt);
         }
     }
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
@@ -102,6 +102,35 @@ public sealed class GatewaySessionRuntime
     }
 
     /// <summary>
+    /// Atomically appends <paramref name="entry"/> to the history AND returns
+    /// an immutable snapshot of the resulting history together with the
+    /// destructive-mutation version observed at snapshot time. Use this when
+    /// a subsequent locked operation (such as heartbeat ack-prune) must
+    /// identify the just-appended entry by its position — calling
+    /// <see cref="AddEntry"/> followed by <see cref="SnapshotHistoryForCompaction"/>
+    /// as separate locked operations leaves a window where a concurrent
+    /// destructive mutation can shift the appended entry away from
+    /// <c>snapshot.Count - 1</c>.
+    /// </summary>
+    /// <param name="entry">The entry to append.</param>
+    /// <returns>
+    /// A snapshot taken under the same lock as the append. The appended
+    /// entry is always at index <c>snapshot.Count - 1</c>.
+    /// </returns>
+    public HistorySnapshot AddEntryAndSnapshot(SessionEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        lock (_lock)
+        {
+            Session.History.Add(entry);
+            _additionVersion++;
+            Session.UpdatedAt = DateTimeOffset.UtcNow;
+            var snapshot = Session.History.ToArray();
+            return new HistorySnapshot(snapshot, _destructiveVersion, snapshot.Length);
+        }
+    }
+
+    /// <summary>
     /// Atomically captures (a) an immutable snapshot of the current history,
     /// (b) the destructive-mutation version observed at snapshot time, and
     /// (c) the snapshot length. Compactors operate on the returned snapshot —
@@ -129,10 +158,24 @@ public sealed class GatewaySessionRuntime
     /// aborted (concurrent destructive mutation detected — live history
     /// unchanged).
     /// </summary>
+    /// <param name="replacement">The replacement history derived from the snapshot.</param>
+    /// <param name="expectedDestructiveVersion">Destructive-mutation version observed when the snapshot was taken.</param>
+    /// <param name="expectedHistoryCount">Snapshot count.</param>
+    /// <param name="restoreUpdatedAtOnApplied">
+    /// When non-null AND the apply takes the fast Applied path (no concurrent
+    /// activity), the session's <c>UpdatedAt</c> is restored to this value
+    /// INSIDE the same runtime lock as the apply. The lock is the critical
+    /// invariant: a separate post-apply write to <c>UpdatedAt</c> would race
+    /// with concurrent <see cref="AddEntry"/> calls and clobber legitimate
+    /// fresh activity timestamps. On Rebased the parameter is ignored (the
+    /// concurrent activity legitimately bumped <c>UpdatedAt</c>); on Aborted
+    /// no write occurs.
+    /// </param>
     public HistoryReplaceOutcome TryReplaceHistoryFromSnapshot(
         IReadOnlyList<SessionEntry> replacement,
         long expectedDestructiveVersion,
-        int expectedHistoryCount)
+        int expectedHistoryCount,
+        DateTimeOffset? restoreUpdatedAtOnApplied = null)
     {
         ArgumentNullException.ThrowIfNull(replacement);
         if (expectedHistoryCount < 0)
@@ -149,7 +192,10 @@ public sealed class GatewaySessionRuntime
                 Session.History.Clear();
                 Session.History.AddRange(replacement);
                 _destructiveVersion++;
-                Session.UpdatedAt = DateTimeOffset.UtcNow;
+                // Restore caller-supplied UpdatedAt under the lock when supplied;
+                // otherwise stamp the apply time. The lock is the invariant —
+                // a separate post-apply write would race with concurrent AddEntry.
+                Session.UpdatedAt = restoreUpdatedAtOnApplied ?? DateTimeOffset.UtcNow;
                 return HistoryReplaceOutcome.Applied;
             }
 
@@ -164,6 +210,9 @@ public sealed class GatewaySessionRuntime
                 Session.History.AddRange(replacement);
                 Session.History.AddRange(concurrentTail);
                 _destructiveVersion++;
+                // Rebased: concurrent activity is real; do NOT honor
+                // restoreUpdatedAtOnApplied — restoring to a stale pre-apply
+                // value would lie about activity timing.
                 Session.UpdatedAt = DateTimeOffset.UtcNow;
                 return HistoryReplaceOutcome.Rebased;
             }

--- a/src/domain/BotNexus.Domain/Gateway/Models/SessionAppendResult.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SessionAppendResult.cs
@@ -1,0 +1,19 @@
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Result of <see cref="GatewaySessionRuntime.AddEntryAndSnapshot"/>. Bundles
+/// the post-append <see cref="HistorySnapshot"/> with the
+/// <see cref="Session.UpdatedAt"/> value sampled <em>immediately before</em>
+/// the append — both captured under the same runtime lock as the append.
+/// Callers that need to restore the prior UpdatedAt after a slow follow-on
+/// operation (e.g. heartbeat ack-prune) must use
+/// <see cref="PriorUpdatedAt"/> rather than reading
+/// <see cref="GatewaySession.UpdatedAt"/> before the call — the latter is
+/// race-prone if a concurrent destructive mutation lands between the read and
+/// the lock.
+/// </summary>
+/// <param name="Snapshot">Post-append snapshot. The appended entry is at <c>Snapshot.Count - 1</c>.</param>
+/// <param name="PriorUpdatedAt">Pre-append <see cref="Session.UpdatedAt"/>, captured under the runtime lock.</param>
+public sealed record SessionAppendResult(
+    HistorySnapshot Snapshot,
+    DateTimeOffset PriorUpdatedAt);

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
@@ -136,7 +136,7 @@ public sealed class HeartbeatTrigger(
 
         // --- Phase 2 (race-safe ack-prune, #573) ---------------------------
         // The soul path shares its session with concurrent flows (interactive
-        // turns, compaction). Two race windows must be closed:
+        // turns, compaction). Three race windows must be closed:
         //  (1) AddEntry + SnapshotHistoryForCompaction as separate locked
         //      calls leaves a window where a concurrent destructive mutation
         //      shifts the heartbeat user away from snapshot.Count - 1.
@@ -146,12 +146,19 @@ public sealed class HeartbeatTrigger(
         //      timestamps. => pass restoreUpdatedAtOnApplied so the
         //      restoration happens INSIDE the runtime lock on the Applied
         //      path only.
+        //  (3) An UNLOCKED pre-append read of session.UpdatedAt would race
+        //      a concurrent ReplaceHistory landing between the read and the
+        //      AddEntryAndSnapshot lock — Applied would then restore to a
+        //      stale anchor predating that ReplaceHistory. => the prior
+        //      UpdatedAt is captured atomically inside AddEntryAndSnapshot
+        //      and returned in SessionAppendResult.PriorUpdatedAt.
         // The heartbeat path (RunInHeartbeatSessionAsync) mints a unique
         // sessionId per run so concurrent activity is impossible; the same
         // shared helper applies harmlessly stricter semantics there.
-        var preHeartbeatUpdatedAt = session.UpdatedAt;
-        var snapshotWithHeartbeat = session.AddEntryAndSnapshot(
+        var appendResult = session.AddEntryAndSnapshot(
             new SessionEntry { Role = MessageRole.User, Content = prompt });
+        var snapshotWithHeartbeat = appendResult.Snapshot;
+        var preHeartbeatUpdatedAt = appendResult.PriorUpdatedAt;
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);
 
         var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
@@ -120,7 +120,7 @@ public sealed class HeartbeatTrigger(
     }
 
     // -----------------------------------------------------------------
-    // Shared execution — with Phase 2 transcript pruning
+    // Shared execution — with Phase 2 race-safe transcript pruning (#573)
     // -----------------------------------------------------------------
     private async Task<SessionId> ExecuteInSessionAsync(
         AgentId agentId,
@@ -134,11 +134,24 @@ public sealed class HeartbeatTrigger(
         var session = preloadedSession
             ?? await sessions.GetOrCreateAsync(sessionId, agentId, ct).ConfigureAwait(false);
 
-        // --- Phase 2: snapshot pre-turn state ---
-        var preHeartbeatHistory = session.GetHistorySnapshot();
+        // --- Phase 2 (race-safe ack-prune, #573) ---------------------------
+        // The soul path shares its session with concurrent flows (interactive
+        // turns, compaction). Two race windows must be closed:
+        //  (1) AddEntry + SnapshotHistoryForCompaction as separate locked
+        //      calls leaves a window where a concurrent destructive mutation
+        //      shifts the heartbeat user away from snapshot.Count - 1.
+        //      => use atomic AddEntryAndSnapshot.
+        //  (2) A post-apply assignment to session.UpdatedAt would race with
+        //      concurrent AddEntry and clobber legitimate fresh activity
+        //      timestamps. => pass restoreUpdatedAtOnApplied so the
+        //      restoration happens INSIDE the runtime lock on the Applied
+        //      path only.
+        // The heartbeat path (RunInHeartbeatSessionAsync) mints a unique
+        // sessionId per run so concurrent activity is impossible; the same
+        // shared helper applies harmlessly stricter semantics there.
         var preHeartbeatUpdatedAt = session.UpdatedAt;
-
-        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = prompt });
+        var snapshotWithHeartbeat = session.AddEntryAndSnapshot(
+            new SessionEntry { Role = MessageRole.User, Content = prompt });
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);
 
         var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);
@@ -148,14 +161,40 @@ public sealed class HeartbeatTrigger(
 
         if (IsHeartbeatAck(response.Content, ackMaxChars))
         {
-            // --- Phase 2: prune the heartbeat turn and restore UpdatedAt ---
-            session.ReplaceHistory(preHeartbeatHistory);
-            session.UpdatedAt = preHeartbeatUpdatedAt;
-            await sessions.SaveAsync(session, ct).ConfigureAwait(false);
+            // Replacement = snapshot minus its last entry (the heartbeat user
+            // we just appended). The atomic AddEntryAndSnapshot guaranteed
+            // that the heartbeat user is at index snapshot.Count - 1.
+            var replacement = snapshotWithHeartbeat.Entries
+                .Take(snapshotWithHeartbeat.Count - 1)
+                .ToArray();
+            var outcome = session.TryReplaceHistoryFromSnapshot(
+                replacement,
+                snapshotWithHeartbeat.DestructiveVersion,
+                snapshotWithHeartbeat.Count,
+                restoreUpdatedAtOnApplied: preHeartbeatUpdatedAt);
 
-            logger.LogDebug(
-                "HeartbeatTrigger: ack from agent '{AgentId}' session '{SessionId}' — turn pruned.",
-                agentId, sessionId);
+            switch (outcome)
+            {
+                case HistoryReplaceOutcome.Applied:
+                    logger.LogDebug(
+                        "HeartbeatTrigger: ack from agent '{AgentId}' session '{SessionId}' — turn pruned, UpdatedAt restored.",
+                        agentId, sessionId);
+                    break;
+
+                case HistoryReplaceOutcome.Rebased:
+                    logger.LogDebug(
+                        "HeartbeatTrigger: ack from agent '{AgentId}' session '{SessionId}' — turn pruned; concurrent activity preserved, UpdatedAt left at concurrent time.",
+                        agentId, sessionId);
+                    break;
+
+                case HistoryReplaceOutcome.Aborted:
+                    logger.LogWarning(
+                        "HeartbeatTrigger: ack from agent '{AgentId}' session '{SessionId}' — concurrent destructive mutation detected; ack-prune aborted to preserve compactor work. The heartbeat user turn was already replaced by the concurrent mutation.",
+                        agentId, sessionId);
+                    break;
+            }
+
+            await sessions.SaveAsync(session, ct).ConfigureAwait(false);
         }
         else
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
@@ -237,8 +237,10 @@ public sealed class HeartbeatTriggerTests
         var entries = soulSession.GetHistorySnapshot();
         entries.Select(e => e.Content).ToList().ShouldBe(["u1", "raced-in"]);
         // Concurrent activity is real — UpdatedAt must NOT be restored to the
-        // pre-heartbeat anchor (would lie about activity timing).
-        soulSession.UpdatedAt.ShouldBeGreaterThan(preHeartbeatTime);
+        // pre-heartbeat anchor (would lie about activity timing). The Rebased
+        // path stamps UtcNow, which is the legitimate concurrent activity time
+        // — explicitly assert NOT the stale restore anchor.
+        soulSession.UpdatedAt.ShouldNotBe(preHeartbeatTime);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
@@ -7,6 +7,7 @@ using BotNexus.Gateway.Api.Triggers;
 using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
 namespace BotNexus.Gateway.Tests.Api;
 
@@ -122,6 +123,182 @@ public sealed class HeartbeatTriggerTests
         savedSession.Metadata["cronJobId"].ShouldBe("heartbeat:agent-a");
         savedSession.Metadata.ShouldContainKey("modelOverride");
         savedSession.Metadata["modelOverride"].ShouldBe("openai/gpt-4.1");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 2 race-safety regression suite (#573)
+    //
+    // The shared `ExecuteInSessionAsync` runs both the soul path (which
+    // reuses today's active soul session — concurrent activity is real)
+    // and the heartbeat path (which mints a unique per-run sessionId, so
+    // no concurrent activity is possible). All three tests below drive
+    // the soul path to exercise the race window.
+    //
+    // Before #573 the trigger snapshotted history, appended the heartbeat
+    // user, awaited the (slow) LLM call, then on ack unconditionally
+    // called `session.ReplaceHistory(preSnapshot)` followed by
+    // `session.UpdatedAt = preTime`. Both writes were race-unsafe:
+    //  - HIGH-1: any AddEntry between snapshot and ReplaceHistory was
+    //    silently dropped by the apply.
+    //  - HIGH-2: any AddEntry between TryReplace and the UpdatedAt
+    //    assignment was overwritten with the stale pre-heartbeat time.
+    //
+    // Post-fix the trigger uses `AddEntryAndSnapshot` (atomic) and
+    // `TryReplaceHistoryFromSnapshot(..., restoreUpdatedAtOnApplied: ...)`
+    // (UpdatedAt restoration inside the runtime lock on Applied only).
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task ExecuteInSessionAsync_AckPath_NoConcurrentActivity_PrunesHeartbeatAndRestoresUpdatedAt()
+    {
+        var agentId = AgentId.From("agent-a");
+        var sessionId = SessionId.From("agent-a::soul::2026-05-31");
+        var preHeartbeatTime = new DateTimeOffset(2026, 5, 31, 12, 0, 0, TimeSpan.Zero);
+
+        var (trigger, mocks) = BuildTriggerWithMocks(soul: true);
+        var soulSession = new GatewaySession
+        {
+            SessionId = sessionId,
+            AgentId = agentId,
+            Status = GatewaySessionStatus.Active,
+            UpdatedAt = preHeartbeatTime,
+            SessionType = SessionType.Soul,
+        };
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a1" });
+        // AddEntry bumps UpdatedAt — re-anchor so the test can prove the
+        // restoration happened (vs simply not changing it).
+        soulSession.UpdatedAt = preHeartbeatTime;
+
+        mocks.Sessions.Setup(s => s.ListAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([soulSession]);
+        mocks.Sessions.Setup(s => s.GetOrCreateAsync(sessionId, agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(soulSession);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "HEARTBEAT_OK" });
+        mocks.Supervisor.Setup(s => s.GetOrCreateAsync(agentId, sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        await trigger.CreateSessionAsync(agentId, "ping");
+
+        var entries = soulSession.GetHistorySnapshot();
+        entries.Select(e => e.Content).ToList().ShouldBe(["u1", "a1"]);
+        soulSession.UpdatedAt.ShouldBe(preHeartbeatTime);
+    }
+
+    [Fact]
+    public async Task ExecuteInSessionAsync_AckPath_ConcurrentAddEntry_PrunesHeartbeatButPreservesConcurrentTail()
+    {
+        var agentId = AgentId.From("agent-a");
+        var sessionId = SessionId.From("agent-a::soul::2026-05-31");
+        var preHeartbeatTime = new DateTimeOffset(2026, 5, 31, 12, 0, 0, TimeSpan.Zero);
+
+        var (trigger, mocks) = BuildTriggerWithMocks(soul: true);
+        var soulSession = new GatewaySession
+        {
+            SessionId = sessionId,
+            AgentId = agentId,
+            Status = GatewaySessionStatus.Active,
+            UpdatedAt = preHeartbeatTime,
+            SessionType = SessionType.Soul,
+        };
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+        soulSession.UpdatedAt = preHeartbeatTime;
+
+        mocks.Sessions.Setup(s => s.ListAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([soulSession]);
+        mocks.Sessions.Setup(s => s.GetOrCreateAsync(sessionId, agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(soulSession);
+
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>(async (_, ct) =>
+            {
+                entered.TrySetResult();
+                var content = await release.Task.WaitAsync(ct).ConfigureAwait(false);
+                return new AgentResponse { Content = content };
+            });
+        mocks.Supervisor.Setup(s => s.GetOrCreateAsync(agentId, sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var triggerTask = trigger.CreateSessionAsync(agentId, "ping");
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Concurrent activity on the shared soul session during the LLM window.
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "raced-in" });
+
+        release.TrySetResult("HEARTBEAT_OK");
+        await triggerTask;
+
+        var entries = soulSession.GetHistorySnapshot();
+        entries.Select(e => e.Content).ToList().ShouldBe(["u1", "raced-in"]);
+        // Concurrent activity is real — UpdatedAt must NOT be restored to the
+        // pre-heartbeat anchor (would lie about activity timing).
+        soulSession.UpdatedAt.ShouldBeGreaterThan(preHeartbeatTime);
+    }
+
+    [Fact]
+    public async Task ExecuteInSessionAsync_AckPath_ConcurrentDestructiveMutation_AbortsAndDoesNotClobberCompactor()
+    {
+        var agentId = AgentId.From("agent-a");
+        var sessionId = SessionId.From("agent-a::soul::2026-05-31");
+
+        var (trigger, mocks) = BuildTriggerWithMocks(soul: true);
+        var soulSession = new GatewaySession
+        {
+            SessionId = sessionId,
+            AgentId = agentId,
+            Status = GatewaySessionStatus.Active,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            SessionType = SessionType.Soul,
+        };
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a1" });
+        soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u2" });
+
+        mocks.Sessions.Setup(s => s.ListAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([soulSession]);
+        mocks.Sessions.Setup(s => s.GetOrCreateAsync(sessionId, agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(soulSession);
+
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>(async (_, ct) =>
+            {
+                entered.TrySetResult();
+                var content = await release.Task.WaitAsync(ct).ConfigureAwait(false);
+                return new AgentResponse { Content = content };
+            });
+        mocks.Supervisor.Setup(s => s.GetOrCreateAsync(agentId, sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var triggerTask = trigger.CreateSessionAsync(agentId, "ping");
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Concurrent destructive mutation — simulates a compactor applying a
+        // summary while the heartbeat LLM call is in flight. The compactor's
+        // output below intentionally does NOT preserve the heartbeat user (a
+        // real compactor would not know it was a heartbeat).
+        soulSession.ReplaceHistory([
+            new SessionEntry { Role = MessageRole.System, Content = "compaction-summary", IsCompactionSummary = true },
+            new SessionEntry { Role = MessageRole.User, Content = "u2" },
+        ]);
+
+        release.TrySetResult("HEARTBEAT_OK");
+        await triggerTask;
+
+        // Aborted: the heartbeat prune did NOT run, so the compactor's output
+        // survives untouched. The pre-fix code would have called
+        // `ReplaceHistory(preSnapshot)` and clobbered the compactor's work to
+        // `[u1, a1, u2]`.
+        var entries = soulSession.GetHistorySnapshot();
+        entries.Select(e => e.Content).ToList().ShouldBe(["compaction-summary", "u2"]);
     }
 
     // -----------------------------------------------------------------

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionThreadSafetyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionThreadSafetyTests.cs
@@ -177,6 +177,129 @@ public sealed class GatewaySessionThreadSafetyTests
             .ShouldBe(3);
     }
 
+    [Fact]
+    public void AddEntryAndSnapshot_AppendsEntry_AndReturnsSnapshotWithEntryAsLast()
+    {
+        var session = CreateSession();
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+
+        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+
+        snapshot.Count.ShouldBe(2);
+        snapshot.Entries[^1].Content.ShouldBe("hb");
+        session.History.Count.ShouldBe(2);
+        session.History[^1].Content.ShouldBe("hb");
+    }
+
+    [Fact]
+    public async Task AddEntryAndSnapshot_UnderConcurrentReplaceHistory_AppendIsAtomicWithSnapshot()
+    {
+        // The atomicity invariant the heartbeat path depends on: across
+        // many interleavings of AddEntryAndSnapshot vs ReplaceHistory, the
+        // returned snapshot must ALWAYS identify the appended entry as the
+        // last one — never have the destructive mutation shift it out.
+        // (A naive AddEntry-then-Snapshot pair would fail this contract
+        // because the destructive mutation can land between the two calls.)
+        var session = CreateSession();
+        const int iterations = 200;
+        var mismatches = 0;
+        var iterationCounter = 0;
+
+        var appender = Task.Run(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                var snapshot = session.AddEntryAndSnapshot(new SessionEntry
+                {
+                    Role = MessageRole.User,
+                    Content = $"hb-{i}"
+                });
+                if (snapshot.Entries[^1].Content != $"hb-{i}")
+                    Interlocked.Increment(ref mismatches);
+                Interlocked.Increment(ref iterationCounter);
+            }
+        });
+
+        var destroyer = Task.Run(() =>
+        {
+            while (Volatile.Read(ref iterationCounter) < iterations)
+            {
+                session.ReplaceHistory([new SessionEntry { Role = MessageRole.System, Content = "wipe" }]);
+            }
+        });
+
+        await Task.WhenAll(appender, destroyer);
+        mismatches.ShouldBe(0);
+    }
+
+    [Fact]
+    public void TryReplaceHistoryFromSnapshot_AppliedPath_RestoresUpdatedAtFromCaller()
+    {
+        var session = CreateSession();
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+        var restoreTo = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var outcome = session.TryReplaceHistoryFromSnapshot(
+            [new SessionEntry { Role = MessageRole.User, Content = "u1" }],
+            snapshot.DestructiveVersion,
+            snapshot.Count,
+            restoreUpdatedAtOnApplied: restoreTo);
+
+        outcome.ShouldBe(HistoryReplaceOutcome.Applied);
+        session.UpdatedAt.ShouldBe(restoreTo);
+        session.History.Select(e => e.Content).ToList().ShouldBe(["u1"]);
+    }
+
+    [Fact]
+    public void TryReplaceHistoryFromSnapshot_RebasedPath_IgnoresRestoreUpdatedAt()
+    {
+        var session = CreateSession();
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+        var staleAnchor = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Concurrent AddEntry between snapshot and apply -> Rebased.
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "raced-in" });
+        var preApply = session.UpdatedAt;
+
+        var outcome = session.TryReplaceHistoryFromSnapshot(
+            [new SessionEntry { Role = MessageRole.User, Content = "u1" }],
+            snapshot.DestructiveVersion,
+            snapshot.Count,
+            restoreUpdatedAtOnApplied: staleAnchor);
+
+        outcome.ShouldBe(HistoryReplaceOutcome.Rebased);
+        session.UpdatedAt.ShouldBeGreaterThanOrEqualTo(preApply);
+        session.UpdatedAt.ShouldNotBe(staleAnchor);
+        session.History.Select(e => e.Content).ToList().ShouldBe(["u1", "raced-in"]);
+    }
+
+    [Fact]
+    public void TryReplaceHistoryFromSnapshot_AbortedPath_DoesNotTouchUpdatedAt()
+    {
+        var session = CreateSession();
+        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+
+        // Concurrent destructive mutation -> Aborted.
+        session.ReplaceHistory([new SessionEntry { Role = MessageRole.System, Content = "wipe" }]);
+        var postWipeUpdatedAt = session.UpdatedAt;
+        var anyRestoreAnchor = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var outcome = session.TryReplaceHistoryFromSnapshot(
+            [],
+            snapshot.DestructiveVersion,
+            snapshot.Count,
+            restoreUpdatedAtOnApplied: anyRestoreAnchor);
+
+        outcome.ShouldBe(HistoryReplaceOutcome.Aborted);
+        // Aborted MUST NOT touch UpdatedAt — the concurrent destructive
+        // mutation already stamped it; we must not overwrite with the
+        // caller's restore anchor (or anything else).
+        session.UpdatedAt.ShouldBe(postWipeUpdatedAt);
+        session.History.Select(e => e.Content).ToList().ShouldBe(["wipe"]);
+    }
+
     private static GatewaySession CreateSession()
         => new() { SessionId = SessionId.From($"session-{Guid.NewGuid():N}"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a") };
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionThreadSafetyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionThreadSafetyTests.cs
@@ -183,12 +183,82 @@ public sealed class GatewaySessionThreadSafetyTests
         var session = CreateSession();
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
 
-        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+        var appendResult = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
 
-        snapshot.Count.ShouldBe(2);
-        snapshot.Entries[^1].Content.ShouldBe("hb");
+        appendResult.Snapshot.Count.ShouldBe(2);
+        appendResult.Snapshot.Entries[^1].Content.ShouldBe("hb");
         session.History.Count.ShouldBe(2);
         session.History[^1].Content.ShouldBe("hb");
+    }
+
+    [Fact]
+    public void AddEntryAndSnapshot_CapturesPriorUpdatedAt_AtomicallyWithAppend()
+    {
+        // The atomicity contract: PriorUpdatedAt reflects what UpdatedAt
+        // was IMMEDIATELY BEFORE the append (under the same lock), not
+        // what a caller's unlocked pre-call read might have observed.
+        // Without this contract, a caller pattern like
+        //     pre = session.UpdatedAt;          // UNLOCKED read
+        //     snap = session.AddEntryAndSnapshot(...);
+        // is race-prone — a concurrent ReplaceHistory can land between the
+        // read and the lock, leaving `pre` stale. This pin makes the
+        // atomic-prior-UpdatedAt the contract.
+        var session = CreateSession();
+        var oldAnchor = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
+        session.UpdatedAt = oldAnchor;
+
+        var appendResult = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+
+        appendResult.PriorUpdatedAt.ShouldBe(oldAnchor);
+        // The append itself stamped UpdatedAt forward; the returned
+        // PriorUpdatedAt is the pre-append observation, not the post.
+        session.UpdatedAt.ShouldNotBe(oldAnchor);
+    }
+
+    [Fact]
+    public async Task AddEntryAndSnapshot_UnderConcurrentReplaceHistory_PriorUpdatedAtNeverPredatesObservedDestructiveStamp()
+    {
+        // Rubber-duck bug-hunt BLOCKING regression (#573): without atomic
+        // capture, a caller that reads UpdatedAt before AddEntryAndSnapshot
+        // could observe a stale pre-ReplaceHistory time and then restore
+        // backwards on Applied. Atomic capture closes that window: every
+        // AddEntryAndSnapshot's PriorUpdatedAt is consistent with the
+        // history state that ReplaceHistory left behind.
+        var session = CreateSession();
+        const int iterations = 200;
+        var iterationCounter = 0;
+        var violations = 0;
+
+        var appender = Task.Run(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                var observedBefore = session.UpdatedAt;
+                var appendResult = session.AddEntryAndSnapshot(new SessionEntry
+                {
+                    Role = MessageRole.User,
+                    Content = $"hb-{i}"
+                });
+                // PriorUpdatedAt cannot predate any prior mutation that
+                // the appender's own pre-call read observed (because the
+                // atomic lock pairs prior-UpdatedAt with the append).
+                if (appendResult.PriorUpdatedAt < observedBefore)
+                    Interlocked.Increment(ref violations);
+                Interlocked.Increment(ref iterationCounter);
+            }
+        });
+
+        var destroyer = Task.Run(() =>
+        {
+            while (Volatile.Read(ref iterationCounter) < iterations)
+            {
+                session.ReplaceHistory([new SessionEntry { Role = MessageRole.System, Content = "wipe" }]);
+            }
+        });
+
+        await Task.WhenAll(appender, destroyer);
+        violations.ShouldBe(0);
     }
 
     [Fact]
@@ -209,12 +279,12 @@ public sealed class GatewaySessionThreadSafetyTests
         {
             for (var i = 0; i < iterations; i++)
             {
-                var snapshot = session.AddEntryAndSnapshot(new SessionEntry
+                var appendResult = session.AddEntryAndSnapshot(new SessionEntry
                 {
                     Role = MessageRole.User,
                     Content = $"hb-{i}"
                 });
-                if (snapshot.Entries[^1].Content != $"hb-{i}")
+                if (appendResult.Snapshot.Entries[^1].Content != $"hb-{i}")
                     Interlocked.Increment(ref mismatches);
                 Interlocked.Increment(ref iterationCounter);
             }
@@ -237,13 +307,13 @@ public sealed class GatewaySessionThreadSafetyTests
     {
         var session = CreateSession();
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
-        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+        var appendResult = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
         var restoreTo = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         var outcome = session.TryReplaceHistoryFromSnapshot(
             [new SessionEntry { Role = MessageRole.User, Content = "u1" }],
-            snapshot.DestructiveVersion,
-            snapshot.Count,
+            appendResult.Snapshot.DestructiveVersion,
+            appendResult.Snapshot.Count,
             restoreUpdatedAtOnApplied: restoreTo);
 
         outcome.ShouldBe(HistoryReplaceOutcome.Applied);
@@ -256,7 +326,7 @@ public sealed class GatewaySessionThreadSafetyTests
     {
         var session = CreateSession();
         session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
-        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+        var appendResult = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
         var staleAnchor = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         // Concurrent AddEntry between snapshot and apply -> Rebased.
@@ -265,8 +335,8 @@ public sealed class GatewaySessionThreadSafetyTests
 
         var outcome = session.TryReplaceHistoryFromSnapshot(
             [new SessionEntry { Role = MessageRole.User, Content = "u1" }],
-            snapshot.DestructiveVersion,
-            snapshot.Count,
+            appendResult.Snapshot.DestructiveVersion,
+            appendResult.Snapshot.Count,
             restoreUpdatedAtOnApplied: staleAnchor);
 
         outcome.ShouldBe(HistoryReplaceOutcome.Rebased);
@@ -279,7 +349,7 @@ public sealed class GatewaySessionThreadSafetyTests
     public void TryReplaceHistoryFromSnapshot_AbortedPath_DoesNotTouchUpdatedAt()
     {
         var session = CreateSession();
-        var snapshot = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
+        var appendResult = session.AddEntryAndSnapshot(new SessionEntry { Role = MessageRole.User, Content = "hb" });
 
         // Concurrent destructive mutation -> Aborted.
         session.ReplaceHistory([new SessionEntry { Role = MessageRole.System, Content = "wipe" }]);
@@ -288,8 +358,8 @@ public sealed class GatewaySessionThreadSafetyTests
 
         var outcome = session.TryReplaceHistoryFromSnapshot(
             [],
-            snapshot.DestructiveVersion,
-            snapshot.Count,
+            appendResult.Snapshot.DestructiveVersion,
+            appendResult.Snapshot.Count,
             restoreUpdatedAtOnApplied: anyRestoreAnchor);
 
         outcome.ShouldBe(HistoryReplaceOutcome.Aborted);


### PR DESCRIPTION
Closes #573.

## What & Why

The HeartbeatTrigger soul path was racing on the shared soul session during the ack-prune step. Four race windows have been closed:

1. **HIGH-1 (rubber-duck initial critique)** — `AddEntry` + `SnapshotHistoryForCompaction` as two separate locked calls left a window where a concurrent destructive mutation shifted the heartbeat user away from `snapshot.Count - 1` → wrong entry pruned.
2. **HIGH-2 (rubber-duck initial critique)** — Post-apply unlocked `session.UpdatedAt = preTime` raced concurrent `AddEntry` and clobbered legitimate fresh activity timestamps.
3. **BLOCKING (bug-hunt sweep, gpt-5.3-codex)** — Pre-append unlocked read of `session.UpdatedAt` raced a concurrent `ReplaceHistory` landing between the read and the lock, leaving the trigger with a stale anchor that on Applied would roll the timestamp backwards past the concurrent mutation.
4. **User-visible original** — Aborted path used to `ReplaceHistory(preSnapshot)` and wipe the compactor's work.

## Approach

Introduce a small race-safe runtime API + migrate the trigger off the two-phase unlocked pattern.

- **New** `GatewaySessionRuntime.AddEntryAndSnapshot(entry) -> SessionAppendResult` — under a single lock: capture pre-append `UpdatedAt`, append, bump `_additionVersion`, stamp `UpdatedAt = UtcNow`, snapshot. Returns `SessionAppendResult(Snapshot, PriorUpdatedAt)`.
- **Augmented** `TryReplaceHistoryFromSnapshot(..., DateTimeOffset? restoreUpdatedAtOnApplied = null)`:
  - Applied: restores `UpdatedAt` from the caller value INSIDE the runtime lock (or `UtcNow` if `null`).
  - Rebased: ignores the parameter (concurrent activity is real — restoring would lie about timing).
  - Aborted: leaves `UpdatedAt` alone (concurrent destructive mutation already stamped it).
- **Migrated** `HeartbeatTrigger.ExecuteInSessionAsync` to consume the new API:
  - `appendResult = session.AddEntryAndSnapshot(heartbeatEntry)`
  - `preHeartbeatUpdatedAt = appendResult.PriorUpdatedAt`
  - on ack: `TryReplaceHistoryFromSnapshot(replacement, appendResult.Snapshot.DV, appendResult.Snapshot.Count, restoreUpdatedAtOnApplied: preHeartbeatUpdatedAt)`
  - outcome switch: Applied/Rebased → Debug log, Aborted → **Warning** log + no second-guessing of compactor.

## Tests

10 net-new tests, all green on full suite:

- **3 behavioural pins** on `HeartbeatTrigger` (Applied / Rebased / Aborted paths, `TaskCompletionSource` barrier for deterministic race injection):
  - `ExecuteInSessionAsync_AckPath_NoConcurrentActivity_PrunesHeartbeatAndRestoresUpdatedAt`
  - `ExecuteInSessionAsync_AckPath_ConcurrentAddEntry_PrunesHeartbeatButPreservesConcurrentTail`
  - `ExecuteInSessionAsync_AckPath_ConcurrentDestructiveMutation_AbortsAndDoesNotClobberCompactor`
- **7 runtime pins** on `GatewaySessionThreadSafetyTests`:
  - `AddEntryAndSnapshot_AppendsEntry_AndReturnsSnapshotWithEntryAsLast`
  - `AddEntryAndSnapshot_CapturesPriorUpdatedAt_AtomicallyWithAppend`
  - `AddEntryAndSnapshot_UnderConcurrentReplaceHistory_PriorUpdatedAtNeverPredatesObservedDestructiveStamp` (200-iter)
  - `AddEntryAndSnapshot_UnderConcurrentReplaceHistory_AppendIsAtomicWithSnapshot` (200-iter)
  - `TryReplaceHistoryFromSnapshot_AppliedPath_RestoresUpdatedAtFromCaller`
  - `TryReplaceHistoryFromSnapshot_RebasedPath_IgnoresRestoreUpdatedAt`
  - `TryReplaceHistoryFromSnapshot_AbortedPath_DoesNotTouchUpdatedAt`

## Multi-Model Critique Sweep

Ran 3 critique agents in parallel after the first impl pass:
- **security-review (gpt-5.5):** CLEAN.
- **plan-vs-impl (claude-opus-4.7):** PASS, no findings.
- **bug-hunt (gpt-5.3-codex):** 1 BLOCKING (folded in as commit `ba7b0283`), 1 MEDIUM + 2 LOW deferred (see below).

## Deferred

- **MEDIUM — concurrent overlapping heartbeats on same soul session.** If the scheduler fires two heartbeat jobs for the same agent before the first completes, only one can prune; the second aborts with the heartbeat user stuck in the transcript. Mitigation requires scheduler-level dedup/serialization — out of scope for #573. Stuck-heartbeat-user is strictly better than the prior behavior of clobbering compactor work.
- **LOW — `restoreUpdatedAtOnApplied: default(DateTimeOffset)` would stamp UpdatedAt to year 0001.** Footgun for future callers. Defer; no current caller does this. Could be hardened later with a runtime guard.
- **LOW — telemetry consistency.** Applied/Rebased are Debug-only and omit JobId. Could be lifted to Information with structured `{AgentId,SessionId,JobId,Outcome}` fields. Defer; current Warning on Aborted already covers the operator-visible case.

## Architecture Fences

- `ThreadSafeHistoryArchitectureTests` allowlist already permits mutation in `GatewaySessionRuntime.cs` — no fence change needed.
- All 83 architecture tests pass.

## Commits

1. `bcb8b7e5` — failing TDD tests (Commit 1, pre-impl).
2. `92ed5bda` — runtime API + migration + 5 runtime pins (Commit 2, makes Commit 1 green).
3. `ba7b0283` — bug-hunt BLOCKING fold-in: `SessionAppendResult` + atomic prior-UpdatedAt capture + 2 additional runtime pins.

## Build & Test Status

`dotnet build BotNexus.slnx`: 0 warnings, 0 errors.
`dotnet test BotNexus.slnx`: 26 projects pass, 0 fail (after one Shell/FileWatcher environmental-flake retry, unrelated to this change).
