### PR TITLE
refactor(gateway): extract SessionStreamReplay from GatewaySession (#575)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewayActivity.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewayActivity.cs
@@ -4,7 +4,9 @@ namespace BotNexus.Gateway.Abstractions.Models;
 
 /// <summary>
 /// A real-time activity event broadcast by the Gateway for monitoring and UI updates.
-/// Subscribers (WebSocket clients, dashboards) receive these as they happen.
+/// Subscribers (channel adapters, dashboards, monitoring tools) receive these as
+/// they happen. The gateway is transport-agnostic — how each subscriber delivers
+/// the event to a user-facing surface is the subscriber's concern.
 /// </summary>
 public sealed record GatewayActivity
 {

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -149,10 +149,12 @@ public sealed class GatewaySession
     }
 
     /// <summary>
-    /// Dedicated WebSocket reconnect-replay peer for this session. The 8
+    /// Dedicated outbound-stream reconnect-replay peer for this session. The 8
     /// stream-replay members previously hosted on the facade (#575) collapsed
     /// here so the conversational session surface is no longer mixed with
-    /// transport-replay infrastructure.
+    /// outbound-stream replay infrastructure. The gateway is transport-agnostic
+    /// — channels (SignalR, Teams, ...) own how outbound payloads reach a user;
+    /// this peer only records the sequenced stream for replay on reconnect.
     /// </summary>
     public SessionStreamReplay StreamReplay => Runtime.StreamReplay;
 
@@ -299,7 +301,10 @@ public sealed record SessionEntry
 }
 
 /// <summary>
-/// A sequenced outbound WebSocket payload stored for reconnect replay.
+/// A sequenced outbound stream payload stored for reconnect replay. The
+/// payload is transport-agnostic — channel adapters own delivery; this record
+/// just timestamps and sequences the JSON body so a reconnecting channel can
+/// replay any gap from the last acknowledged sequence ID.
 /// </summary>
 /// <param name="SequenceId">Monotonically increasing sequence ID.</param>
 /// <param name="PayloadJson">Serialized outbound payload.</param>

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -149,23 +149,12 @@ public sealed class GatewaySession
     }
 
     /// <summary>
-    /// Next WebSocket outbound sequence ID for reconnect replay.
+    /// Dedicated WebSocket reconnect-replay peer for this session. The 8
+    /// stream-replay members previously hosted on the facade (#575) collapsed
+    /// here so the conversational session surface is no longer mixed with
+    /// transport-replay infrastructure.
     /// </summary>
-    public long NextSequenceId
-    {
-        get => Runtime.NextSequenceId;
-        set => Runtime.NextSequenceId = value;
-    }
-
-    /// <summary>
-    /// Bounded replay log of sequenced outbound WebSocket payloads.
-    /// </summary>
-    public List<GatewaySessionStreamEvent> StreamEventLog => Runtime.StreamEventLog;
-
-    /// <summary>
-    /// Replay buffer for outbound sequenced payloads.
-    /// </summary>
-    public SessionReplayBuffer ReplayBuffer => Runtime.ReplayBuffer;
+    public SessionStreamReplay StreamReplay => Runtime.StreamReplay;
 
     /// <summary>
     /// Removes any crash-sentinel entries from the session history.
@@ -226,34 +215,6 @@ public sealed class GatewaySession
     /// <param name="offset">Zero-based offset into history.</param>
     /// <param name="limit">Maximum number of items to return.</param>
     public IReadOnlyList<SessionEntry> GetHistorySnapshot(int offset, int limit) => Runtime.GetHistorySnapshot(offset, limit);
-
-    /// <summary>
-    /// Atomically allocates and returns the next outbound sequence ID.
-    /// </summary>
-    public long AllocateSequenceId() => Runtime.AllocateSequenceId();
-
-    /// <summary>
-    /// Records a sequenced outbound payload into the bounded replay log.
-    /// </summary>
-    public void AddStreamEvent(long sequenceId, string payloadJson, int replayWindowSize) => Runtime.AddStreamEvent(sequenceId, payloadJson, replayWindowSize);
-
-    /// <summary>
-    /// Returns replay entries after <paramref name="lastSequenceId"/>, bounded by <paramref name="maxReplayCount"/>.
-    /// </summary>
-    public IReadOnlyList<GatewaySessionStreamEvent> GetStreamEventsAfter(long lastSequenceId, int maxReplayCount)
-        => Runtime.GetStreamEventsAfter(lastSequenceId, maxReplayCount);
-
-    /// <summary>
-    /// Returns a safe snapshot of replay entries.
-    /// </summary>
-    public IReadOnlyList<GatewaySessionStreamEvent> GetStreamEventSnapshot()
-        => Runtime.GetStreamEventSnapshot();
-
-    /// <summary>
-    /// Replaces replay state from persisted storage.
-    /// </summary>
-    public void SetStreamReplayState(long nextSequenceId, IEnumerable<GatewaySessionStreamEvent>? streamEvents)
-        => Runtime.SetStreamReplayState(nextSequenceId, streamEvents);
 
     /// <summary>
     /// Wraps an existing domain <see cref="Session"/> record in a new

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
@@ -7,7 +7,6 @@ namespace BotNexus.Gateway.Abstractions.Models;
 public sealed class GatewaySessionRuntime
 {
     private readonly Lock _lock = new();
-    private readonly SessionReplayBuffer _replayBuffer = new();
 
     // Optimistic-concurrency counters for the compaction-rebase protocol (#532).
     // _additionVersion increments on append-only mutations (AddEntry/AddEntries).
@@ -24,6 +23,7 @@ public sealed class GatewaySessionRuntime
     public GatewaySessionRuntime(Session session)
     {
         Session = session ?? throw new ArgumentNullException(nameof(session));
+        StreamReplay = new SessionStreamReplay(new SessionReplayBuffer(), session);
     }
 
     /// <summary>
@@ -31,15 +31,13 @@ public sealed class GatewaySessionRuntime
     /// </summary>
     public Session Session { get; }
 
-    public long NextSequenceId
-    {
-        get => _replayBuffer.NextSequenceId;
-        set => _replayBuffer.NextSequenceId = value;
-    }
-
-    public List<GatewaySessionStreamEvent> StreamEventLog => [.. _replayBuffer.GetStreamEventSnapshot()];
-
-    public SessionReplayBuffer ReplayBuffer => _replayBuffer;
+    /// <summary>
+    /// Gets the dedicated WebSocket reconnect-replay peer for this session.
+    /// The 8 forwarding stream-replay methods previously hosted here moved to
+    /// <see cref="SessionStreamReplay"/> (#575); production and test callers
+    /// must funnel through <c>session.StreamReplay</c>.
+    /// </summary>
+    public SessionStreamReplay StreamReplay { get; }
 
     /// <summary>
     /// Executes add entry.
@@ -279,50 +277,4 @@ public sealed class GatewaySessionRuntime
         }
     }
 
-    /// <summary>
-    /// Executes allocate sequence id.
-    /// </summary>
-    /// <returns>The allocate sequence id result.</returns>
-    public long AllocateSequenceId()
-    {
-        var sequenceId = _replayBuffer.AllocateSequenceId();
-        Session.UpdatedAt = DateTimeOffset.UtcNow;
-        return sequenceId;
-    }
-
-    /// <summary>
-    /// Executes add stream event.
-    /// </summary>
-    /// <param name="sequenceId">The sequence id.</param>
-    /// <param name="payloadJson">The payload json.</param>
-    /// <param name="replayWindowSize">The replay window size.</param>
-    public void AddStreamEvent(long sequenceId, string payloadJson, int replayWindowSize)
-    {
-        _replayBuffer.AddStreamEvent(sequenceId, payloadJson, replayWindowSize);
-        Session.UpdatedAt = DateTimeOffset.UtcNow;
-    }
-
-    /// <summary>
-    /// Executes get stream events after.
-    /// </summary>
-    /// <param name="lastSequenceId">The last sequence id.</param>
-    /// <param name="maxReplayCount">The max replay count.</param>
-    /// <returns>The get stream events after result.</returns>
-    public IReadOnlyList<GatewaySessionStreamEvent> GetStreamEventsAfter(long lastSequenceId, int maxReplayCount)
-        => _replayBuffer.GetStreamEventsAfter(lastSequenceId, maxReplayCount);
-
-    /// <summary>
-    /// Executes get stream event snapshot.
-    /// </summary>
-    /// <returns>The get stream event snapshot result.</returns>
-    public IReadOnlyList<GatewaySessionStreamEvent> GetStreamEventSnapshot()
-        => _replayBuffer.GetStreamEventSnapshot();
-
-    /// <summary>
-    /// Executes set stream replay state.
-    /// </summary>
-    /// <param name="nextSequenceId">The next sequence id.</param>
-    /// <param name="streamEvents">The stream events.</param>
-    public void SetStreamReplayState(long nextSequenceId, IEnumerable<GatewaySessionStreamEvent>? streamEvents)
-        => _replayBuffer.SetState(nextSequenceId, streamEvents);
 }

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySessionRuntime.cs
@@ -32,10 +32,11 @@ public sealed class GatewaySessionRuntime
     public Session Session { get; }
 
     /// <summary>
-    /// Gets the dedicated WebSocket reconnect-replay peer for this session.
-    /// The 8 forwarding stream-replay methods previously hosted here moved to
-    /// <see cref="SessionStreamReplay"/> (#575); production and test callers
-    /// must funnel through <c>session.StreamReplay</c>.
+    /// Gets the dedicated outbound-stream reconnect-replay peer for this
+    /// session. The 8 forwarding stream-replay methods previously hosted here
+    /// moved to <see cref="SessionStreamReplay"/> (#575); production and test
+    /// callers must funnel through <c>session.StreamReplay</c>. Channels own
+    /// the actual transport; this peer is only the in-memory sequenced log.
     /// </summary>
     public SessionStreamReplay StreamReplay { get; }
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/SessionReplayBuffer.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SessionReplayBuffer.cs
@@ -1,7 +1,9 @@
 namespace BotNexus.Gateway.Abstractions.Models;
 
 /// <summary>
-/// Thread-safe bounded replay buffer for sequenced WebSocket outbound payloads.
+/// Thread-safe bounded replay buffer for sequenced outbound stream payloads.
+/// The buffer is transport-agnostic — channel adapters (SignalR, Teams, etc.)
+/// own the actual wire delivery and decide whether to replay on reconnect.
 /// </summary>
 public sealed class SessionReplayBuffer
 {
@@ -12,7 +14,7 @@ public sealed class SessionReplayBuffer
     private long _nextSequenceId = 1;
 
     /// <summary>
-    /// Next WebSocket outbound sequence ID for reconnect replay.
+    /// Next outbound stream sequence ID for reconnect replay.
     /// </summary>
     public long NextSequenceId
     {

--- a/src/domain/BotNexus.Domain/Gateway/Models/SessionStreamReplay.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SessionStreamReplay.cs
@@ -1,0 +1,89 @@
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Dedicated facade over the WebSocket reconnect-replay infrastructure for a single
+/// <see cref="Session"/>. Owns the underlying <see cref="SessionReplayBuffer"/> and
+/// stamps <see cref="Session"/>.<c>UpdatedAt</c> on activity that the runtime
+/// previously stamped through forwarding methods on
+/// <see cref="GatewaySessionRuntime"/>.
+/// </summary>
+/// <remarks>
+/// Reached via <see cref="GatewaySession"/>.<c>StreamReplay</c>. The 8-member
+/// stream-replay surface previously exposed on the facade collapses to one peer
+/// accessor; the leak through <c>session.ReplayBuffer</c> is closed because the
+/// underlying buffer is no longer reachable from the facade. Construction is
+/// restricted to <see cref="GatewaySessionRuntime"/> via the <c>internal</c>
+/// constructor so the peer is always paired with its owning session.
+///
+/// Thread-safety: the underlying <see cref="SessionReplayBuffer"/> serialises its
+/// own state under an internal lock; the <see cref="Session"/>.<c>UpdatedAt</c>
+/// stamp is intentionally written outside any lock, preserving pre-extract
+/// behaviour. A pre-existing race with concurrent history-mutating callers under
+/// <c>GatewaySessionRuntime._lock</c> is out of scope for this extract — fixing
+/// it would expand the refactor into behavioural concurrency work.
+/// </remarks>
+public sealed class SessionStreamReplay
+{
+    private readonly SessionReplayBuffer _buffer;
+    private readonly Session _session;
+
+    internal SessionStreamReplay(SessionReplayBuffer buffer, Session session)
+    {
+        _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+    }
+
+    /// <summary>
+    /// Gets the next WebSocket outbound sequence ID for reconnect replay.
+    /// The value is rehydrated from persistence through <see cref="SetState"/>;
+    /// there is no public setter, so <see cref="SetState"/> is the single
+    /// mutation surface for state restore.
+    /// </summary>
+    public long NextSequenceId => _buffer.NextSequenceId;
+
+    /// <summary>
+    /// Atomically allocates and returns the next outbound sequence ID. Also
+    /// stamps <see cref="Session"/>.<c>UpdatedAt</c> so replay activity counts
+    /// as session activity for downstream warmup/eviction.
+    /// </summary>
+    public long AllocateSequenceId()
+    {
+        var sequenceId = _buffer.AllocateSequenceId();
+        _session.UpdatedAt = DateTimeOffset.UtcNow;
+        return sequenceId;
+    }
+
+    /// <summary>
+    /// Records a sequenced outbound payload into the bounded replay log. Also
+    /// stamps <see cref="Session"/>.<c>UpdatedAt</c>.
+    /// </summary>
+    /// <param name="sequenceId">The sequence id allocated for this payload.</param>
+    /// <param name="payloadJson">The serialised outbound payload.</param>
+    /// <param name="replayWindowSize">Maximum number of events retained in the buffer.</param>
+    public void AddEvent(long sequenceId, string payloadJson, int replayWindowSize)
+    {
+        _buffer.AddStreamEvent(sequenceId, payloadJson, replayWindowSize);
+        _session.UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Returns replay entries after <paramref name="lastSequenceId"/>, bounded
+    /// by <paramref name="maxReplayCount"/>.
+    /// </summary>
+    public IReadOnlyList<GatewaySessionStreamEvent> GetEventsAfter(long lastSequenceId, int maxReplayCount)
+        => _buffer.GetStreamEventsAfter(lastSequenceId, maxReplayCount);
+
+    /// <summary>
+    /// Returns a safe snapshot of the replay entries.
+    /// </summary>
+    public IReadOnlyList<GatewaySessionStreamEvent> GetEventSnapshot()
+        => _buffer.GetStreamEventSnapshot();
+
+    /// <summary>
+    /// Replaces replay state from persisted storage. The only mutation surface
+    /// for rehydration — there is no public <see cref="NextSequenceId"/>
+    /// setter so persistence loaders must funnel through this method.
+    /// </summary>
+    public void SetState(long nextSequenceId, IEnumerable<GatewaySessionStreamEvent>? streamEvents)
+        => _buffer.SetState(nextSequenceId, streamEvents);
+}

--- a/src/domain/BotNexus.Domain/Gateway/Models/SessionStreamReplay.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SessionStreamReplay.cs
@@ -1,10 +1,14 @@
 namespace BotNexus.Gateway.Abstractions.Models;
 
 /// <summary>
-/// Dedicated facade over the WebSocket reconnect-replay infrastructure for a single
-/// <see cref="Session"/>. Owns the underlying <see cref="SessionReplayBuffer"/> and
-/// stamps <see cref="Session"/>.<c>UpdatedAt</c> on activity that the runtime
-/// previously stamped through forwarding methods on
+/// Dedicated facade over the outbound-stream reconnect-replay infrastructure for a
+/// single <see cref="Session"/>. The gateway is transport-agnostic — channels
+/// (SignalR, Teams, TUI, ...) own the actual wire delivery. This peer only
+/// records the sequenced outbound stream so a channel that supports reconnect
+/// (e.g. a SignalR hub negotiating a new transport after a drop) can replay any
+/// gap from the last acknowledged sequence ID. Owns the underlying
+/// <see cref="SessionReplayBuffer"/> and stamps <see cref="Session"/>.<c>UpdatedAt</c>
+/// on activity that the runtime previously stamped through forwarding methods on
 /// <see cref="GatewaySessionRuntime"/>.
 /// </summary>
 /// <remarks>
@@ -34,7 +38,9 @@ public sealed class SessionStreamReplay
     }
 
     /// <summary>
-    /// Gets the next WebSocket outbound sequence ID for reconnect replay.
+    /// Gets the next outbound-stream sequence ID for reconnect replay. The
+    /// sequence is transport-agnostic and is consumed by whichever channel
+    /// adapter is currently delivering this session's outbound payloads.
     /// The value is rehydrated from persistence through <see cref="SetState"/>;
     /// there is no public setter, so <see cref="SetState"/> is the single
     /// mutation surface for state restore.

--- a/src/extensions/BotNexus.Extensions.Channels.Tui/README.md
+++ b/src/extensions/BotNexus.Extensions.Channels.Tui/README.md
@@ -53,10 +53,10 @@ builder.Services.AddBotNexusTuiChannel();
 
 ### Local Testing
 
-The TUI adapter is useful for verifying the outbound message pipeline without a WebSocket client or external channel:
+The TUI adapter is useful for verifying the outbound message pipeline without any streaming channel extension or external surface:
 
 1. Register the TUI channel in your Gateway host
-2. Send a message via the REST API or WebSocket targeting the `"tui"` channel
+2. Send a message via the REST API targeting the `"tui"` channel
 3. Observe the output on the console
 
 ## Configuration

--- a/src/gateway/BotNexus.Gateway.Abstractions/README.md
+++ b/src/gateway/BotNexus.Gateway.Abstractions/README.md
@@ -24,7 +24,7 @@ This is a leaf dependency — it references no other BotNexus packages.
 | `IChannelManager` | Channels | Read-only registry for looking up registered channel adapters. |
 | `IIsolationStrategy` | Isolation | Security boundary between agent and user — bounds what the agent can reach and leak (in-process, sandbox, container, remote). |
 | `IMessageRouter` | Routing | Routes inbound messages to the appropriate agent(s) based on targeting, session, and defaults. |
-| `IGatewayAuthHandler` | Security | Authenticates API and WebSocket requests; returns a caller identity. |
+| `IGatewayAuthHandler` | Security | Authenticates HTTP requests reaching the Gateway (REST API plus any extension endpoints such as the SignalR hub); returns a caller identity. |
 | `ISessionStore` | Sessions | Persistence interface for gateway sessions (get, create, save, delete, list). |
 
 ### Models (Records and Classes)

--- a/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/TypeForwards.cs
@@ -32,6 +32,7 @@
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.OutboundMessage))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SessionHistoryResponse))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SessionReplayBuffer))]
+[assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SessionStreamReplay))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SessionStatus))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.SoulAgentConfig))]
 [assembly: TypeForwardedTo(typeof(BotNexus.Gateway.Abstractions.Models.HeartbeatAgentConfig))]

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ChatController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ChatController.cs
@@ -9,7 +9,9 @@ namespace BotNexus.Gateway.Api.Controllers;
 
 /// <summary>
 /// REST endpoint for non-streaming chat. Routes through the gateway message queue
-/// to ensure proper session serialization. For real-time streaming, use the WebSocket endpoint.
+/// to ensure proper session serialization. For real-time streaming, use a
+/// streaming channel extension (e.g. the SignalR channel) — the gateway itself
+/// only exposes a REST surface; streaming transports live in channel extensions.
 /// </summary>
 /// <summary>
 /// Represents chat controller.

--- a/src/gateway/BotNexus.Gateway.Api/README.md
+++ b/src/gateway/BotNexus.Gateway.Api/README.md
@@ -1,10 +1,10 @@
 # BotNexus.Gateway.Api
 
-> ASP.NET Core API surface — REST controllers and WebSocket middleware for the BotNexus Gateway.
+> ASP.NET Core API surface — REST controllers and middleware for the BotNexus Gateway.
 
 ## Overview
 
-This package provides the public HTTP and WebSocket API for the BotNexus Gateway. All REST endpoints (`/api/*`) and WebSocket connections (`/ws`) are served here. The Blazor WebUI (`BotNexus.WebUI`) is hosted as a separate project. This package contains no orchestration logic — that is in `BotNexus.Gateway` — it only translates between HTTP/WebSocket and the gateway's internal interfaces.
+This package provides the public HTTP API for the BotNexus Gateway. All REST endpoints (`/api/*`) and supporting middleware (auth, rate-limiting, correlation-id) are served here. The Blazor portal (hosted by the `BotNexus.Extensions.Channels.SignalR.BlazorClient` extension) and any other channel that needs to push streaming data to a user mount their own endpoints (e.g. a SignalR hub) via `MapExtensionEndpoints` — this package contains no transport-specific delivery code. It also contains no orchestration logic — that is in `BotNexus.Gateway` — it only translates between HTTP and the gateway's internal interfaces.
 
 ## API Endpoints
 
@@ -58,31 +58,9 @@ All REST endpoints are in the `/api/` path and require authentication (if config
 | `PATCH` | `/api/sessions/{sessionId}/suspend` | Suspend a session |
 | `PATCH` | `/api/sessions/{sessionId}/resume` | Resume a suspended session |
 
-### WebSocket
+### Real-time Streaming
 
-**Endpoint:** `ws://localhost:5005/ws?agent=<agentId>&session=<sessionId>`
-
-The WebSocket connection provides streaming chat access to an agent session. Messages are JSON:
-
-```json
-{
-  "type": "message",
-  "content": "Hello!"
-}
-```
-
-Responses stream as `GatewayStreamEvent` JSON events:
-
-```json
-{
-  "type": "content_delta",
-  "content": "Hello! I'm"
-}
-```
-
-**Activity Stream:** `ws://localhost:5005/ws/activity?agent=<agentId>`
-
-Subscribes to real-time activity events (agent started, tool called, streaming ended, etc.).
+This package does not expose a streaming endpoint. Streaming events (`message_start`, `content_delta`, `thinking_delta`, `tool_start`, `tool_end`, `message_end`, …) are published in-process on `IActivityBroadcaster`; channel extensions subscribe to that broadcaster and re-encode events for whatever transport they own. The bundled Blazor portal is served by the SignalR channel extension at `src/extensions/BotNexus.Extensions.Channels.SignalR/` — that extension mounts a SignalR hub via `MapExtensionEndpoints` for browser delivery.
 
 ### Health & Documentation
 
@@ -161,7 +139,6 @@ Adds an `X-Correlation-Id` header to every request/response for end-to-end traci
 | `GatewayAuthMiddleware` | - | ASP.NET Core middleware for authentication and authorization |
 | `RateLimitingMiddleware` | - | Per-client HTTP request rate limiting (429 + Retry-After) |
 | `CorrelationIdMiddleware` | - | Adds X-Correlation-Id header for end-to-end request tracing |
-| `ActivityWebSocketHandler` | WebSocket | Handles WebSocket connections for activity stream and chat |
 
 ## Development
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Activity/IActivityBroadcaster.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Activity/IActivityBroadcaster.cs
@@ -3,9 +3,12 @@ using BotNexus.Gateway.Abstractions.Models;
 namespace BotNexus.Gateway.Abstractions.Activity;
 
 /// <summary>
-/// Broadcasts real-time activity events to subscribers (WebSocket clients, monitoring tools).
-/// Uses a fan-out pattern: each subscriber gets their own bounded channel with drop-oldest
-/// semantics to prevent slow consumers from blocking the Gateway.
+/// Broadcasts real-time activity events to subscribers. The gateway is
+/// transport-agnostic — subscribers are typically channel adapters that
+/// re-encode and deliver events to user-facing surfaces, or in-process
+/// monitoring tools (dashboards, audit pipelines). Uses a fan-out pattern:
+/// each subscriber gets their own bounded channel with drop-oldest semantics
+/// to prevent slow consumers from blocking the Gateway.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/gateway/BotNexus.Gateway.Contracts/Security/IGatewayAuthHandler.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/IGatewayAuthHandler.cs
@@ -1,12 +1,16 @@
 namespace BotNexus.Gateway.Abstractions.Security;
 
 /// <summary>
-/// Authenticates API and WebSocket requests to the Gateway.
+/// Authenticates HTTP requests reaching the Gateway. The Gateway only hosts a
+/// REST API; channel extensions own their own user-facing transports and may
+/// mount additional endpoints (e.g. a SignalR hub) through the same HTTP host,
+/// in which case those endpoints also pass through this handler.
 /// Implementations validate credentials and return a caller identity.
 /// </summary>
 /// <remarks>
-/// <para>Built into the Gateway API middleware pipeline. Each request passes through
-/// authentication before reaching controllers or WebSocket handlers.</para>
+/// <para>Built into the Gateway API middleware pipeline. Every request passes
+/// through authentication before reaching REST controllers or extension-hosted
+/// endpoints.</para>
 /// <para>Built-in implementations (planned):</para>
 /// <list type="bullet">
 ///   <item><b>ApiKeyAuthHandler</b> — Static API key validation. Suitable for development
@@ -45,7 +49,10 @@ public sealed record GatewayAuthContext
     /// <summary>The request path.</summary>
     public required string Path { get; init; }
 
-    /// <summary>The HTTP method (GET, POST, etc.) or "WS" for WebSocket.</summary>
+    /// <summary>The HTTP method (GET, POST, etc.) or "WS" for an HTTP-upgrade
+    /// request (e.g. a SignalR negotiation transitioning to a WebSocket-backed
+    /// transport — the upgrade still arrives as an HTTP request but is
+    /// classified here for audit-friendly logging).</summary>
     public required string Method { get; init; }
 }
 

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -205,7 +205,7 @@ public sealed class FileSessionStore : SessionStoreBase
             foreach (var pair in meta.Metadata)
                 session.Metadata[pair.Key] = pair.Value;
         }
-        session.SetStreamReplayState(meta.NextSequenceId, meta.StreamEvents);
+        session.StreamReplay.SetState(meta.NextSequenceId, meta.StreamEvents);
 
         var historyPath = GetHistoryPath(sessionId);
         var entries = await SessionJsonl.ReadAllAsync<SessionEntry>(
@@ -248,8 +248,8 @@ public sealed class FileSessionStore : SessionStoreBase
             session.UpdatedAt,
             session.Status,
             session.ExpiresAt,
-            session.NextSequenceId,
-            [.. session.GetStreamEventSnapshot()],
+            session.StreamReplay.NextSequenceId,
+            [.. session.StreamReplay.GetEventSnapshot()],
             session.ConversationId,
             session.Metadata.Count == 0 ? null : new Dictionary<string, object?>(session.Metadata));
         await SessionMetadataSidecar.WriteAsync(

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Diagnostics;
 using System.IO.Abstractions;
 using AgentId = BotNexus.Domain.Primitives.AgentId;
@@ -205,7 +206,7 @@ public sealed class FileSessionStore : SessionStoreBase
             foreach (var pair in meta.Metadata)
                 session.Metadata[pair.Key] = pair.Value;
         }
-        session.StreamReplay.SetState(meta.NextSequenceId, meta.StreamEvents);
+        session.StreamReplay.SetState(meta.PersistedNextSequenceId, meta.StreamEvents);
 
         var historyPath = GetHistoryPath(sessionId);
         var entries = await SessionJsonl.ReadAllAsync<SessionEntry>(
@@ -273,7 +274,10 @@ public sealed class FileSessionStore : SessionStoreBase
         DateTimeOffset UpdatedAt,
         SessionStatus Status = SessionStatus.Active,
         DateTimeOffset? ExpiresAt = null,
-        long NextSequenceId = 1,
+        // Renamed from NextSequenceId to keep the #575 SessionStreamReplay architecture fence
+        // (`SessionStreamReplayArchitectureTests`) maximally tight. The JSON wire shape stays
+        // `nextSequenceId` (CamelCase) so existing on-disk sidecars round-trip unchanged.
+        [property: JsonPropertyName("nextSequenceId")] long PersistedNextSequenceId = 1,
         List<GatewaySessionStreamEvent>? StreamEvents = null,
         ConversationId? ConversationId = null,
         // PR #549: cross-world federation receiver requires Session.Metadata to round-trip on disk

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -205,7 +205,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 {
                     // Use a detached token for agent processing so client disconnect
                     // doesn't kill in-progress agent work. The agent continues in the
-                    // background even if the WebSocket closes.
+                    // background even if the originating channel disconnects.
                     await ProcessInboundMessageAsync(item.Message, CancellationToken.None);
                     item.Completion.TrySetResult();
                 }

--- a/src/gateway/BotNexus.Gateway/Security/ApiKeyGatewayAuthHandler.cs
+++ b/src/gateway/BotNexus.Gateway/Security/ApiKeyGatewayAuthHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 namespace BotNexus.Gateway.Security;
 
 /// <summary>
-/// API key authentication handler for Gateway HTTP and WebSocket requests.
+/// API key authentication handler for Gateway HTTP requests.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -1,6 +1,6 @@
 # BotNexus Gateway
 
-The **Gateway** is the central orchestrator of the BotNexus platform. It manages multi-agent execution, session persistence, real-time WebSocket streaming, and extensibility via pluggable strategies and channel adapters.
+The **Gateway** is the central orchestrator of the BotNexus platform. It manages multi-agent execution, session persistence, outbound-stream broadcasting, and extensibility via pluggable strategies and channel adapters. The gateway itself only hosts a REST API — real-time delivery to end-user surfaces (browser, Teams, TUI, …) is owned by channel extensions that subscribe to gateway events and bring their own transport (e.g. the bundled SignalR channel extension mounts a SignalR hub).
 
 ## Architecture
 
@@ -10,7 +10,7 @@ The Gateway is composed of **6 core projects**:
 |---------|---------|
 | **BotNexus.Gateway.Abstractions** | Interface contracts (IAgentConfigurationSource, IIsolationStrategy, IChannelAdapter, ISessionStore) |
 | **BotNexus.Gateway** | Main host — message routing, agent supervision, hot reload, channel management |
-| **BotNexus.Gateway.Api** | REST API (agents, sessions, chat, config) + WebSocket handler + SignalR hub |
+| **BotNexus.Gateway.Api** | REST API (agents, sessions, chat, config) and middleware (auth, rate-limit, correlation-id). Channel extensions mount their own additional endpoints (e.g. the SignalR channel mounts a hub) via `MapExtensionEndpoints`. |
 | **BotNexus.Gateway.Sessions** | Session persistence implementations (InMemory, FileSessionStore) |
 | **BotNexus.Gateway.Conversations** | Conversation persistence (InMemory, File, Sqlite) and routing |
 | **BotNexus.Cli** | Command-line interface for Gateway management and interaction |
@@ -104,7 +104,7 @@ Channels declare which interaction features they support. The Gateway uses these
 
 | Flag | Purpose | Example |
 |------|---------|---------|
-| `SupportsStreaming` | Real-time token streaming | WebSocket: ✅, REST: ❌ |
+| `SupportsStreaming` | Real-time token streaming | SignalR: ✅, REST: ❌ |
 | `SupportsSteering` | Mid-run steering injection | WebUI: ✅, Telegram: ❌ |
 | `SupportsFollowUp` | Queued follow-up messages | WebUI: ✅, Slack: ✅ |
 | `SupportsThinkingDisplay` | Display agent reasoning | WebUI: ✅, Discord: ❌ |
@@ -298,7 +298,7 @@ The `GatewayAuthManager` auto-refreshes expired OAuth tokens when needed.
 
 ### Gateway Endpoint Protection (Auth Middleware)
 
-The `GatewayAuthMiddleware` protects the Gateway's HTTP and WebSocket endpoints. It delegates validation to `ApiKeyGatewayAuthHandler`.
+The `GatewayAuthMiddleware` protects the Gateway's HTTP endpoints (REST API plus any endpoints mounted by channel extensions, such as the SignalR hub). It delegates validation to `ApiKeyGatewayAuthHandler`. Requests that upgrade from HTTP (for example, a SignalR negotiation that selects the WebSocket transport) pass through the same middleware — these are classified as `"WS"` in audit logs to distinguish them from plain HTTP requests, but they share one auth pipeline.
 
 #### How It Works
 
@@ -395,15 +395,9 @@ Configure via the `gateway` section in `config.json`:
 }
 ```
 
-### Session Locking (WebSocket)
+### Session Concurrency
 
-Each session allows **one active WebSocket connection** at a time. When a second WebSocket attempts to connect to the same session:
-
-1. The duplicate connection is accepted briefly
-2. Immediately closed with status code **4409** and message `"Session already has an active connection"`
-3. The original connection continues unaffected
-
-This prevents race conditions from multiple browser tabs or clients writing to the same session simultaneously.
+The gateway does not bind a session to any single transport connection. Multiple subscribers (e.g. multiple browser tabs of the same user, the Blazor portal plus a TUI debugger) can observe the same session simultaneously; outbound payloads fan out to every live binding the conversation has, and the channel extension owning each binding is responsible for delivering them. When a channel extension detects that one of its connections is no longer reachable, it raises `StaleChannelConnectionException` so the gateway can demote that binding to `Muted` without sealing the session.
 
 ### MaxConcurrentSessions
 
@@ -594,116 +588,9 @@ The script builds the Gateway, starts it on a temporary port, fetches `/swagger/
 - **PATCH `/api/sessions/{sessionId}/resume`** — Resume a suspended session
 - **DELETE `/api/sessions/{sessionId}`** — Delete a session
 
-### WebSocket (Real-time Streaming)
-- **GET/WebSocket `/ws`**
-  - Query params: `?agent={agentId}&session={sessionId}`
-  - See [WebSocket Protocol](#websocket-protocol) section in root README
+### Realtime Streaming
 
-## WebSocket Protocol
-
-### Connection
-```
-ws://localhost:5005/ws?agent=assistant&session={sessionId}
-```
-
-If `session` is omitted, a new session ID is auto-generated.
-
-### Client → Server Messages
-
-**Send a message:**
-```json
-{ "type": "message", "content": "What is 2+2?" }
-```
-
-**Abort active execution:**
-```json
-{ "type": "abort" }
-```
-
-**Inject steering message into active run:**
-```json
-{ "type": "steer", "content": "Focus on the main point." }
-```
-
-**Queue a follow-up for the next run:**
-```json
-{ "type": "follow_up", "content": "And what about 3+3?" }
-```
-
-**Keepalive ping:**
-```json
-{ "type": "ping" }
-```
-
-### Server → Client Messages
-
-**Connection established:**
-```json
-{ "type": "connected", "connectionId": "...", "sessionId": "...", "sequenceId": 1 }
-```
-
-**Agent started processing:**
-```json
-{ "type": "message_start", "messageId": "uuid-..." }
-```
-
-**Thinking delta (streaming agent reasoning):**
-```json
-{ "type": "thinking_delta", "delta": "Let me think about...", "messageId": "uuid-..." }
-```
-
-**Content delta (streaming response text):**
-```json
-{ "type": "content_delta", "delta": "2+2 is", "messageId": "uuid-..." }
-```
-
-**Tool execution started:**
-```json
-{
-  "type": "tool_start",
-  "toolCallId": "call_...",
-  "toolName": "calculate",
-  "messageId": "uuid-..."
-}
-```
-
-**Tool result received:**
-```json
-{
-  "type": "tool_end",
-  "toolCallId": "call_...",
-  "toolName": "calculate",
-  "toolResult": "4",
-  "toolIsError": false,
-  "messageId": "uuid-..."
-}
-```
-
-**Agent completed:**
-```json
-{
-  "type": "message_end",
-  "messageId": "uuid-...",
-  "usage": {
-    "inputTokens": 50,
-    "outputTokens": 100
-  }
-}
-```
-
-**Error occurred:**
-```json
-{
-  "type": "error",
-  "message": "Agent not found",
-  "code": "NOT_FOUND"
-}
-```
-
-**Keepalive pong:**
-```json
-{ "type": "pong" }
-```
+The gateway exposes streaming events (`message_start`, `content_delta`, `thinking_delta`, `tool_start`, `tool_end`, `message_end`, …) as in-process events on `IActivityBroadcaster`. Subscribers — typically channel extensions — re-encode those events for their own transport and deliver them to end-user surfaces. The bundled SignalR channel extension mounts a SignalR hub for the Blazor portal; see `src/extensions/BotNexus.Extensions.Channels.SignalR/` for that hub's wire shape and the Blazor client. To consume streaming events from your own channel, implement `IChannelAdapter` and subscribe to `IActivityBroadcaster` (see `src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs` for a reference implementation).
 
 ## Gateway Lifecycle Management
 
@@ -873,12 +760,9 @@ curl -X POST http://localhost:5005/api/chat \
   }'
 ```
 
-### Test via WebSocket
-```bash
-# Use websocat, wscat, or any WebSocket client
-wscat -c "ws://localhost:5005/ws?agent=test-agent&session=test-session-1"
-# Type: { "type": "message", "content": "Hello!" }
-```
+### Test Real-time Streaming
+
+Use the Blazor portal (`http://localhost:5005`) — it connects through the bundled SignalR channel extension. To exercise streaming from a custom channel, register your own `IChannelAdapter` and observe `IActivityBroadcaster` events.
 
 ### Explore the API
 
@@ -943,8 +827,7 @@ src/gateway/
 │   │   ├── AgentsController.cs
 │   │   ├── SessionsController.cs
 │   │   └── ConfigController.cs
-│   └── WebSocket/
-│       └── GatewayHub.cs              # SignalR hub + session groups
+│   └── (channel hubs — e.g. the SignalR hub — live in their own extension projects under src/extensions/)
 ├── BotNexus.Gateway.Sessions/
 │   ├── InMemorySessionStore.cs
 │   ├── FileSessionStore.cs
@@ -980,21 +863,16 @@ src/gateway/
 2. Wait for existing sessions to complete, or increase the limit in agent config
 3. Set `maxConcurrentSessions: 0` for unlimited
 
-### WebSocket 4409 (Session Already Connected)
-1. Another WebSocket client is already connected to this session
-2. Close the existing connection first, or use a different session ID
-3. Each session allows exactly one active WebSocket connection
-
 ### Session history lost
 1. Verify `sessionsDirectory` is writable
 2. Check disk space availability
 3. Confirm `ISessionStore` is not in-memory for production
 4. Check if `SessionCleanupService` TTL is too aggressive — default is 24 hours
 
-### WebSocket connection drops
-1. Check browser WebSocket support (console for errors)
-2. Verify firewall allows WebSocket connections
-3. Check Gateway logs for timeout or protocol errors
+### Streaming events don't reach the browser
+1. Check the channel extension that owns the connection (e.g. the SignalR hub at `/hubs/gateway` for the Blazor portal) — its logs should show negotiation + transport selection
+2. Verify the relevant binding hasn't been demoted to `Muted` after a stale-connection event (see Session Concurrency above)
+3. Check Gateway logs for any `StaleChannelConnectionException` from the channel adapter
 
 ### Config changes not taking effect
 1. Verify the file was saved (some editors use write-rename which the watcher detects)

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionStreamReplayArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionStreamReplayArchitectureTests.cs
@@ -1,0 +1,361 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function enforcing PR <c>#575</c>: the 8 stream-replay
+/// members previously hosted on <c>GatewaySession</c> / <c>GatewaySessionRuntime</c>
+/// (<c>NextSequenceId</c>, <c>StreamEventLog</c>, <c>ReplayBuffer</c>,
+/// <c>AllocateSequenceId</c>, <c>AddStreamEvent</c>, <c>GetStreamEventsAfter</c>,
+/// <c>GetStreamEventSnapshot</c>, <c>SetStreamReplayState</c>) collapse to a single
+/// <c>StreamReplay</c> peer accessor; the renamed surface is
+/// <c>StreamReplay.AddEvent</c>, <c>StreamReplay.GetEventsAfter</c>,
+/// <c>StreamReplay.GetEventSnapshot</c>, <c>StreamReplay.SetState</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Production source under <c>src/</c> must not contain a member-access shape
+/// referencing any of the 8 legacy names. The only allowlisted file is the new
+/// <c>SessionStreamReplay.cs</c>, which legitimately calls
+/// <c>_buffer.AllocateSequenceId</c> / <c>_buffer.AddStreamEvent</c> / etc. as the
+/// composition target of the extract. <c>SessionReplayBuffer.cs</c> only contains
+/// declarations (no <c>.X</c> access shapes) so it does not need an allowlist
+/// entry. <c>GatewaySessionRuntime.cs</c> post-extract owns the type by
+/// construction only and does not call any legacy member access shape.
+/// </para>
+/// <para>
+/// The <c>.ReplayBuffer</c> ban (inherent in the 8-name list) closes the
+/// reach-through leak that <c>GatewaySessionThreadSafetyTests</c> previously
+/// exploited at <c>session.ReplayBuffer.AddStreamEvent(...)</c>, bypassing the
+/// <c>UpdatedAt</c>-stamping facade.
+/// </para>
+/// <para>
+/// The fence scans <c>src/</c> only so <c>SessionReplayBufferTests</c> (which
+/// legitimately uses the underlying <c>SessionReplayBuffer</c> type via
+/// <c>new SessionReplayBuffer()</c>) is not false-positively flagged.
+/// </para>
+/// <para>
+/// Comment stripping reuses the string-aware state-machine lexer from
+/// <see cref="SingleShotWireValueArchitectureTests"/> to defend against the
+/// realistic regression shape <c>var u = "https://x"; session.AddStreamEvent(...)</c>
+/// where a naive line-comment regex would strip from the first <c>//</c> inside
+/// the URL string to end-of-line, hiding the violation.
+/// </para>
+/// </remarks>
+public sealed class SessionStreamReplayArchitectureTests
+{
+    // Negative lookbehind on `\.StreamReplay` distinguishes new facade access
+    // (`session.StreamReplay.NextSequenceId` — allowed) from legacy direct access
+    // (`session.NextSequenceId` — banned). .NET regex supports fixed-width lookbehind,
+    // and `.StreamReplay` is 13 characters fixed-width. The `\b` after the member name
+    // prevents prefix-collision matches like `.AddStreamEventBatch`.
+    private static readonly Regex s_legacyMemberAccess = new(
+        @"(?<!\.StreamReplay)\.(NextSequenceId|StreamEventLog|ReplayBuffer|AllocateSequenceId|AddStreamEvent|GetStreamEventsAfter|GetStreamEventSnapshot|SetStreamReplayState)\b",
+        RegexOptions.Compiled);
+
+    private static readonly HashSet<string> s_allowlistFilenames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // The new extracted facade is the single composition root that legitimately
+        // calls the underlying SessionReplayBuffer members (`_buffer.AddStreamEvent`,
+        // `_buffer.AllocateSequenceId`, etc.) via field-access (`_buffer.X`) — which
+        // is NOT covered by the `(?<!\.StreamReplay)` guard. No other file under src/
+        // should reach into the buffer or the legacy access shapes post-#575.
+        "SessionStreamReplay.cs",
+    };
+
+    [Fact]
+    public void NoProductionSourceFile_ReferencesLegacyStreamReplayMembersByAccess()
+    {
+        var srcRoot = FindSourceRoot();
+
+        var violations = new List<string>();
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var filename = Path.GetFileName(path);
+            if (s_allowlistFilenames.Contains(filename))
+                continue;
+
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_legacyMemberAccess.IsMatch(stripped))
+            {
+                violations.Add(NormalizePath(path));
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "The 8 legacy stream-replay members on GatewaySession / GatewaySessionRuntime " +
+            "(NextSequenceId, StreamEventLog, ReplayBuffer, AllocateSequenceId, AddStreamEvent, " +
+            "GetStreamEventsAfter, GetStreamEventSnapshot, SetStreamReplayState) were extracted " +
+            "to `session.StreamReplay.*` in #575. Production code must funnel through the new " +
+            "facade — `session.StreamReplay.AddEvent`, `.GetEventsAfter`, `.GetEventSnapshot`, " +
+            "`.SetState`. The `.ReplayBuffer` reach-through is structurally closed; any " +
+            "regression is a real bypass of the UpdatedAt-stamping layer.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticRegression()
+    {
+        // Synthetic post-revert shape: code calling any of the 8 legacy members MUST trip
+        // the fence. If this test fails, the fence has been weakened enough that the
+        // original regression class is undetectable.
+        const string syntheticViolation = """
+            public void Persist(GatewaySession session)
+            {
+                var nextId = session.NextSequenceId;
+                var snapshot = session.GetStreamEventSnapshot();
+                session.SetStreamReplayState(nextId, snapshot);
+            }
+            """;
+        s_legacyMemberAccess.IsMatch(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Vacuity guard: the fence must flag any production code accessing the legacy " +
+            "stream-replay members on GatewaySession. If this assertion fails, the regex " +
+            "has been neutered and a #575 regression would be undetectable.");
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstReachThroughLeak()
+    {
+        // The reach-through shape `session.ReplayBuffer.AddStreamEvent(...)` was the
+        // specific leak GatewaySessionThreadSafetyTests previously exploited at L169-171
+        // pre-#575 — it bypassed the UpdatedAt-stamping facade. The fence must catch
+        // BOTH `.ReplayBuffer` access AND the chained `.AddStreamEvent` call.
+        const string syntheticViolation = """
+            session.ReplayBuffer.AddStreamEvent(1, "{}", 10);
+            """;
+        s_legacyMemberAccess.IsMatch(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Reach-through guard: the fence must flag `session.ReplayBuffer.X` access. " +
+            "If this fails, the leak that motivated the entire extract has been re-opened " +
+            "without detection.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnNewFacadeUsage()
+    {
+        // Canonical post-#575 shape: code routing through the new facade
+        // `session.StreamReplay.X` must NOT trip the fence. The `(?<!\.StreamReplay)`
+        // negative lookbehind in the regex blocks matches preceded by `.StreamReplay`,
+        // so the facade-access surface (the only valid post-#575 shape) cleanly passes.
+        const string syntheticClean = """
+            public void Persist(GatewaySession session)
+            {
+                var nextId = session.StreamReplay.NextSequenceId;
+                var snapshot = session.StreamReplay.GetEventSnapshot();
+                session.StreamReplay.SetState(nextId, snapshot);
+                session.StreamReplay.AddEvent(nextId, "{}", 10);
+                var after = session.StreamReplay.GetEventsAfter(0, 10);
+            }
+            """;
+        s_legacyMemberAccess.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "Facade-access guard: routing through `session.StreamReplay.X` must not be " +
+            "flagged. If this fails, the negative-lookbehind on `.StreamReplay` has " +
+            "regressed and every FileSessionStore / GatewaySession call into the facade " +
+            "would be a false positive.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnFileSessionStoreShape()
+    {
+        // FileSessionStore is the only production persistence caller of the facade. Its
+        // exact post-migration shape must not trip the fence — if it does, the only
+        // legitimate caller cannot exist outside the allowlist, which would force the
+        // entire `src/gateway/BotNexus.Gateway.Sessions/` to be allowlisted (defeating
+        // the fence). This is the round-trip pin for the negative-lookbehind guard.
+        const string fileStoreShape = """
+            var meta = new SessionMeta(
+                session.AgentId,
+                session.ConversationId,
+                session.StreamReplay.NextSequenceId,
+                [.. session.StreamReplay.GetEventSnapshot()],
+                session.Metadata);
+            """;
+        s_legacyMemberAccess.IsMatch(StripComments(fileStoreShape)).ShouldBeFalse(
+            "FileSessionStore round-trip pin: the canonical `session.StreamReplay.X` " +
+            "shape used by the only persistence caller must not be flagged. If this " +
+            "fails, the lookbehind guard is broken and the fence would block every " +
+            "legitimate facade caller.");
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReplayBufferAccess_OutsideAllowlist()
+    {
+        // Synthetic violation: any file outside the allowlist that returns the raw
+        // SessionReplayBuffer (re-introducing the leak) must trip the `.ReplayBuffer`
+        // rule. This guards against a regression where someone re-adds the proxy on
+        // GatewaySession or exposes it via a different type.
+        const string syntheticViolation = """
+            public SessionReplayBuffer ReplayBuffer => _runtime.ReplayBuffer;
+            """;
+        s_legacyMemberAccess.IsMatch(StripComments(syntheticViolation)).ShouldBeTrue(
+            "Reach-through fence: any expression matching `.ReplayBuffer` must trip the " +
+            "fence outside the allowlist. If this fails, the raw buffer can be re-leaked " +
+            "via a new property and the structural protection of #575 is gone.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMention()
+    {
+        // Synthetic clean shape: a comment mentioning a legacy member name for historical
+        // reference must NOT trip the fence — the string-aware stripper removes comments
+        // before the regex applies. This is what allows the rename to be documented in
+        // place without forcing future authors to remove explanatory text.
+        const string syntheticClean = """
+            // Legacy `session.AddStreamEvent` and `session.GetStreamEventSnapshot` were
+            // extracted to `session.StreamReplay.AddEvent` / `.GetEventSnapshot` in #575.
+            public void Noop() { }
+            """;
+        s_legacyMemberAccess.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: the fence must not flag comment-only mentions of the " +
+            "legacy member names. If this fails, the comment stripper has regressed and " +
+            "the fence will block PRs that legitimately document the rename.");
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving the contents of string and char literals. Reused (verbatim shape)
+    /// from <see cref="SingleShotWireValueArchitectureTests"/>; see that file for the full
+    /// rationale on why a naive regex would miss the `var u = "https://x"; session.X(...)`
+    /// realistic regression shape.
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                if (i + 1 < n)
+                {
+                    i += 2;
+                }
+                else
+                {
+                    i = n;
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionStreamReplayArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionStreamReplayArchitectureTests.cs
@@ -212,12 +212,61 @@ public sealed class SessionStreamReplayArchitectureTests
             "the fence will block PRs that legitimately document the rename.");
     }
 
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstRawStringBypassShape()
+    {
+        // C# 11+ raw string literals (3+ consecutive `"`) could otherwise create a
+        // bypass: without raw-string-aware lexing, the contrived shape
+        //
+        //   var s = """a"//x"""; session.AddStreamEvent(...);
+        //
+        // is misparsed by a 1/2-quote-only lexer as `""` + `"a"` + `/` + `/x"""...`
+        // — the `//` after the inner `"` is treated as a real line comment that
+        // strips the trailing legacy-member call through to end-of-line, hiding the
+        // violation. Surfaced by the #575 bug-hunt critique. After raw-string-aware
+        // stripping the full call survives in the residue and the fence catches it.
+        const string bypassShape =
+            "var s = \"\"\"a\"//x\"\"\"; session.AddStreamEvent(1, \"{}\", 10);";
+        s_legacyMemberAccess.IsMatch(StripComments(bypassShape)).ShouldBeTrue(
+            "Raw-string-bypass guard: a trailing legacy-member call after a raw " +
+            "string literal containing `\"//` must remain visible to the fence " +
+            "regex after comment stripping. If this fails, the raw-string branch " +
+            "of `StripComments` has regressed and contrived strings could mask " +
+            "real legacy-member calls on the same line.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnRawStringContent()
+    {
+        // Canonical clean shape: a raw string literal whose content happens to
+        // contain a `//` or `/* */` sequence must not have that sequence
+        // mis-stripped as a comment, AND the literal itself (which has no
+        // banned-member call after it) must not trip the fence. This pins the
+        // realistic production case — tool-description JSON schemas in
+        // `BotNexus.Tools/*Tool.cs` use multi-line raw strings with embedded
+        // URLs (`https://`) and comment-like fragments.
+        const string cleanShape = "var schema = \"\"\"\nhello // world\n/* block */\n\"\"\";\n";
+        s_legacyMemberAccess.IsMatch(StripComments(cleanShape)).ShouldBeFalse(
+            "Raw-string false-positive guard: content inside a raw string literal " +
+            "must not be parsed as code, and embedded `//` / `/* */` sequences must " +
+            "not be stripped. If this fails, raw-string JSON schemas in tool " +
+            "implementations would either false-positive or mask real violations.");
+    }
+
     /// <summary>
     /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
-    /// while preserving the contents of string and char literals. Reused (verbatim shape)
-    /// from <see cref="SingleShotWireValueArchitectureTests"/>; see that file for the full
-    /// rationale on why a naive regex would miss the `var u = "https://x"; session.X(...)`
-    /// realistic regression shape.
+    /// while preserving the contents of string and char literals — including C# 11+
+    /// raw string literals (<c>"""…"""</c>). Reused (verbatim shape) from
+    /// <see cref="SingleShotWireValueArchitectureTests"/> with one additional branch:
+    /// see that file for the rationale on why a naive regex would miss the realistic
+    /// regression shape <c>var u = "https://x"; session.X(...)</c>. The raw-string
+    /// branch closes a further bypass surfaced in the #575 bug-hunt critique sweep:
+    /// without raw-string-aware lexing, the contrived shape
+    /// <c>var s = """a"//x"""; session.X(...)</c> is misparsed as two regular
+    /// strings followed by a line comment that strips the trailing call. Other
+    /// architecture fences in this folder share this lexer pattern and have the
+    /// same pre-#575 limitation; lifting the raw-string branch to them is tracked
+    /// as a separate follow-up.
     /// </summary>
     private static string StripComments(string source)
     {
@@ -254,6 +303,33 @@ public sealed class SessionStreamReplayArchitectureTests
 
             if (c == '"')
             {
+                // Detect raw string literal: 3+ consecutive double quotes open a raw
+                // string whose closer is any run of >= openCount consecutive `"`
+                // characters. Content of any length (including embedded `"`, `//`,
+                // and `/* */` sequences) is preserved verbatim into the residue so
+                // the regex sees the same shape as the original source.
+                var openCount = 1;
+                while (i + openCount < n && source[i + openCount] == '"') openCount++;
+                if (openCount >= 3)
+                {
+                    sb.Append(source, i, openCount);
+                    i += openCount;
+                    while (i < n)
+                    {
+                        if (source[i] == '"')
+                        {
+                            var closeCount = 0;
+                            while (i + closeCount < n && source[i + closeCount] == '"') closeCount++;
+                            sb.Append(source, i, closeCount);
+                            i += closeCount;
+                            if (closeCount >= openCount) break;
+                            continue;
+                        }
+                        sb.Append(source[i++]);
+                    }
+                    continue;
+                }
+
                 sb.Append('"');
                 i++;
                 while (i < n)

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
@@ -42,31 +42,34 @@ public sealed class GatewaySessionBehaviorSnapshotTests
     {
         var session = CreateSession();
 
-        session.SetStreamReplayState(10,
+        session.StreamReplay.SetState(10,
         [
             new GatewaySessionStreamEvent(5, """{"type":"delta","sequenceId":5}""", DateTimeOffset.UtcNow.AddSeconds(-2)),
             new GatewaySessionStreamEvent(3, """{"type":"delta","sequenceId":3}""", DateTimeOffset.UtcNow.AddSeconds(-3)),
             new GatewaySessionStreamEvent(4, """{"type":"delta","sequenceId":4}""", DateTimeOffset.UtcNow.AddSeconds(-1))
         ]);
 
-        session.NextSequenceId.ShouldBe(10);
-        session.GetStreamEventSnapshot().Select(e => e.SequenceId).ToList().ShouldBe(new long[] { 3, 4, 5 });
-        session.GetStreamEventsAfter(lastSequenceId: 3, maxReplayCount: 10)
+        session.StreamReplay.NextSequenceId.ShouldBe(10);
+        session.StreamReplay.GetEventSnapshot().Select(e => e.SequenceId).ToList().ShouldBe(new long[] { 3, 4, 5 });
+        session.StreamReplay.GetEventsAfter(lastSequenceId: 3, maxReplayCount: 10)
             .Select(e => e.SequenceId)
             .ShouldBe(new long[] { 4, 5 }, ignoreOrder: false);
     }
 
     [Fact]
-    public void StreamEventLog_ReturnsCopyOfReplaySnapshot()
+    public void GetEventSnapshot_ReturnsDefensiveCopy_NotAliasOfInternalState()
     {
         var session = CreateSession();
-        session.AddStreamEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 10);
-        session.AddStreamEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 10);
+        session.StreamReplay.AddEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 10);
+        session.StreamReplay.AddEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 10);
 
-        var snapshot = session.StreamEventLog;
-        snapshot.RemoveAt(0);
+        var snapshotBeforeAdd = session.StreamReplay.GetEventSnapshot();
+        session.StreamReplay.AddEvent(3, """{"type":"pong","sequenceId":3}""", replayWindowSize: 10);
 
-        session.GetStreamEventSnapshot().Select(evt => evt.SequenceId).ToList().ShouldBe(new long[] { 1, 2 });
+        // The previously-returned snapshot is a defensive copy and does NOT
+        // observe the post-snapshot addition; a freshly fetched snapshot does.
+        snapshotBeforeAdd.Select(evt => evt.SequenceId).ToList().ShouldBe(new long[] { 1, 2 });
+        session.StreamReplay.GetEventSnapshot().Select(evt => evt.SequenceId).ToList().ShouldBe(new long[] { 1, 2, 3 });
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
@@ -73,6 +73,54 @@ public sealed class GatewaySessionBehaviorSnapshotTests
     }
 
     [Fact]
+    public async Task AllocateSequenceId_StampsSessionUpdatedAt()
+    {
+        // Parity pin (#575 — rubber-duck HIGH): pre-extract, the runtime forwarding
+        // method `AllocateSequenceId` stamped `Session.UpdatedAt = DateTimeOffset.UtcNow`
+        // after delegating to the buffer. After extracting to `SessionStreamReplay`,
+        // the new facade must preserve this behaviour exactly — anything less would
+        // silently change the UpdatedAt cadence on the soul/heartbeat replay path.
+        var session = CreateSession();
+        var initialUpdatedAt = session.UpdatedAt;
+
+        // Use a real sleep rather than re-reading the wall clock because UpdatedAt is
+        // stamped via DateTimeOffset.UtcNow inside SessionStreamReplay — without a real
+        // gap the assertion is timing-sensitive on fast CI machines.
+        await Task.Delay(5);
+
+        var allocated = session.StreamReplay.AllocateSequenceId();
+
+        allocated.ShouldBe(1);
+        session.UpdatedAt.ShouldBeGreaterThan(initialUpdatedAt,
+            "F-9 / Phase 7 (#575) parity pin: AllocateSequenceId must stamp " +
+            "Session.UpdatedAt. If this fails, the extract dropped the UpdatedAt-stamping " +
+            "side-effect from the runtime's forwarding method and the soul-write " +
+            "freshness gate would observe stale timestamps on heartbeat sequencing.");
+    }
+
+    [Fact]
+    public async Task AddEvent_StampsSessionUpdatedAt()
+    {
+        // Parity pin (#575 — rubber-duck HIGH): pre-extract, the runtime forwarding
+        // method `AddStreamEvent` stamped `Session.UpdatedAt = DateTimeOffset.UtcNow`
+        // after delegating to the buffer. The new facade must preserve this exactly —
+        // otherwise streaming-only activity (no AddEntry, no AllocateSequenceId) would
+        // not bump the timestamp and idle-session detection would seal active streams.
+        var session = CreateSession();
+        var initialUpdatedAt = session.UpdatedAt;
+
+        await Task.Delay(5);
+
+        session.StreamReplay.AddEvent(1, """{"type":"delta","sequenceId":1}""", replayWindowSize: 10);
+
+        session.UpdatedAt.ShouldBeGreaterThan(initialUpdatedAt,
+            "F-9 / Phase 7 (#575) parity pin: AddEvent must stamp Session.UpdatedAt. " +
+            "If this fails, the extract dropped the UpdatedAt-stamping side-effect; " +
+            "streaming-only sessions would never refresh their freshness gate and the " +
+            "session-cleanup service would seal active streams as idle.");
+    }
+
+    [Fact]
     public void GatewaySession_Composition_UsesSharedDomainSessionState()
     {
         var domainSession = new Session

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionThreadSafetyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionThreadSafetyTests.cs
@@ -126,9 +126,9 @@ public sealed class GatewaySessionThreadSafetyTests
     {
         var session = CreateSession();
 
-        var first = session.AllocateSequenceId();
-        var second = session.AllocateSequenceId();
-        var third = session.AllocateSequenceId();
+        var first = session.StreamReplay.AllocateSequenceId();
+        var second = session.StreamReplay.AllocateSequenceId();
+        var third = session.StreamReplay.AllocateSequenceId();
 
         first.ShouldBe(1);
         second.ShouldBe(2);
@@ -136,42 +136,47 @@ public sealed class GatewaySessionThreadSafetyTests
     }
 
     [Fact]
-    public void AddStreamEvent_WithReplayWindow_KeepsLatestBoundedEvents()
+    public void AddEvent_WithReplayWindow_KeepsLatestBoundedEvents()
     {
         var session = CreateSession();
 
-        session.AddStreamEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 2);
-        session.AddStreamEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 2);
-        session.AddStreamEvent(3, """{"type":"pong","sequenceId":3}""", replayWindowSize: 2);
+        session.StreamReplay.AddEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 2);
+        session.StreamReplay.AddEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 2);
+        session.StreamReplay.AddEvent(3, """{"type":"pong","sequenceId":3}""", replayWindowSize: 2);
 
-        var replay = session.GetStreamEventSnapshot();
+        var replay = session.StreamReplay.GetEventSnapshot();
         replay.Count().ShouldBe(2);
         replay.Select(evt => evt.SequenceId).ToList().ShouldBe(new long[] { 2, 3 });
     }
 
     [Fact]
-    public void GetStreamEventsAfter_WithNoMissedMessages_ReturnsEmpty()
+    public void GetEventsAfter_WithNoMissedMessages_ReturnsEmpty()
     {
         var session = CreateSession();
-        session.AddStreamEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 10);
-        session.AddStreamEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 10);
+        session.StreamReplay.AddEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 10);
+        session.StreamReplay.AddEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 10);
 
-        var replay = session.GetStreamEventsAfter(lastSequenceId: 2, maxReplayCount: 10);
+        var replay = session.StreamReplay.GetEventsAfter(lastSequenceId: 2, maxReplayCount: 10);
 
         replay.ShouldBeEmpty();
     }
 
     [Fact]
-    public void ReplayBuffer_WhenUsedDirectly_RemainsCompatibleWithSessionReplayApis()
+    public void StreamReplay_AccessedViaFacade_DeliversSameSnapshotAndAfterQuery()
     {
+        // Pre-#575 this test reached through `session.ReplayBuffer.AddStreamEvent(...)`,
+        // bypassing the UpdatedAt-stamping facade. The `session.ReplayBuffer`
+        // accessor no longer exists and the `SessionStreamReplayArchitectureTests`
+        // fence prevents the reach-through shape from returning; this test now
+        // exercises the new facade and pins the snapshot/after-query round-trip.
         var session = CreateSession();
 
-        session.ReplayBuffer.AddStreamEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 2);
-        session.ReplayBuffer.AddStreamEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 2);
-        session.ReplayBuffer.AddStreamEvent(3, """{"type":"pong","sequenceId":3}""", replayWindowSize: 2);
+        session.StreamReplay.AddEvent(1, """{"type":"connected","sequenceId":1}""", replayWindowSize: 2);
+        session.StreamReplay.AddEvent(2, """{"type":"pong","sequenceId":2}""", replayWindowSize: 2);
+        session.StreamReplay.AddEvent(3, """{"type":"pong","sequenceId":3}""", replayWindowSize: 2);
 
-        session.GetStreamEventSnapshot().Select(evt => evt.SequenceId).ToList().ShouldBe(new long[] { 2, 3 });
-        session.GetStreamEventsAfter(lastSequenceId: 2, maxReplayCount: 10)
+        session.StreamReplay.GetEventSnapshot().Select(evt => evt.SequenceId).ToList().ShouldBe(new long[] { 2, 3 });
+        session.StreamReplay.GetEventsAfter(lastSequenceId: 2, maxReplayCount: 10)
             .Select(evt => evt.SequenceId)
             .ShouldHaveSingleItem()
             .ShouldBe(3);


### PR DESCRIPTION
## Summary

Extracts `SessionStreamReplay` as a dedicated peer type owned by `GatewaySessionRuntime`,
collapsing the 8 stream-replay members previously hosted on `GatewaySession` /
`GatewaySessionRuntime` (`NextSequenceId`, `StreamEventLog`, `ReplayBuffer`,
`AllocateSequenceId`, `AddStreamEvent`, `GetStreamEventsAfter`,
`GetStreamEventSnapshot`, `SetStreamReplayState`) into a single `session.StreamReplay`
peer accessor. The renamed surface drops the redundant `Stream` prefix:
`AddEvent`, `GetEventsAfter`, `GetEventSnapshot`, `SetState`.

The reach-through leak that `GatewaySessionThreadSafetyTests` previously exploited at
`session.ReplayBuffer.AddStreamEvent(...)` — bypassing the `UpdatedAt`-stamping facade
— is now **structurally closed**: there is no longer any `.ReplayBuffer` accessor on
either `GatewaySession` or `GatewaySessionRuntime`. The buffer itself remains
constructible (`new SessionReplayBuffer()`) for the unit tests in
`SessionReplayBufferTests`, but it cannot be reached **through a session**.

Closes #575.
Refs #523.

## Surface reduction

```
Before (8 members proxied through GatewaySession → GatewaySessionRuntime):
  session.NextSequenceId
  session.StreamEventLog
  session.ReplayBuffer
  session.AllocateSequenceId()
  session.AddStreamEvent(...)
  session.GetStreamEventsAfter(...)
  session.GetStreamEventSnapshot()
  session.SetStreamReplayState(...)

After (1 accessor + 5 peer-type members):
  session.StreamReplay.NextSequenceId
  session.StreamReplay.AllocateSequenceId()
  session.StreamReplay.AddEvent(...)
  session.StreamReplay.GetEventsAfter(...)
  session.StreamReplay.GetEventSnapshot()
  session.StreamReplay.SetState(...)
```

`StreamEventLog` and `ReplayBuffer` (raw-buffer reach-through) are removed entirely
— they were redundant with `GetEventSnapshot()` and the underlying buffer respectively.

## Architecture fence

`SessionStreamReplayArchitectureTests` (9 tests) pins the surface reduction with:

* **Main fence**: regex with negative lookbehind `(?<!\.StreamReplay)\.(member|alt|...)\b`
  syntactically distinguishes the new facade (`session.StreamReplay.NextSequenceId` —
  allowed) from legacy direct access (`session.NextSequenceId` — banned). Allowlist is
  `{SessionStreamReplay.cs}` only — the single composition root that legitimately calls
  `_buffer.X` via field access (not covered by the `.StreamReplay` lookbehind).
* **3 vacuity guards**: synthetic regression / reach-through / `.ReplayBuffer` re-leak
  shapes — each MUST trip the fence to prove the regex still polices its target.
* **3 false-positive guards**: new facade usage / `FileSessionStore` shape /
  comment-only mentions — each MUST NOT trip the fence to prove the lookbehind
  and comment-stripper don't over-flag.
* **C# 11+ raw-string lexer branch** in `StripComments` (commit 3) closes a
  bypass surfaced in the bug-hunt critique sweep: the contrived shape
  `var s = """a"//x"""; session.AddStreamEvent(...);` is misparsed by a
  1/2-quote-only lexer as two regular strings + a line comment that strips
  the trailing call. With raw-string-aware lexing, the full call survives.

The fence scans `src/` only — `SessionReplayBufferTests` (which legitimately uses
`new SessionReplayBuffer()`) is not false-positively flagged.

## Behavioural pins

Two new tests in `GatewaySessionBehaviorSnapshotTests` lock in the
`UpdatedAt`-stamping semantics that the pre-extract proxies preserved
implicitly through `GatewaySessionRuntime`:

* `AllocateSequenceId_StampsSessionUpdatedAt`
* `AddEvent_StampsSessionUpdatedAt`

These were the highest-risk regression vector identified in the rubber-duck
design pass: the new peer-type extract holds a reference to `Session` and
must stamp `_session.UpdatedAt = DateTimeOffset.UtcNow` on every mutating
operation (`AllocateSequenceId`, `AddEvent`). The stamps are OUTSIDE any
lock, preserving the pre-extract runtime behaviour exactly. (A pre-existing
race between `UpdatedAt` and concurrent history-mutating callers under
`GatewaySessionRuntime._lock` is documented as out of scope in the
`SessionStreamReplay` XML doc — fixing it would expand this refactor into
behavioural concurrency work.)

## DTO rename

`SessionMeta.NextSequenceId` → `PersistedNextSequenceId` (private record in
`FileSessionStore.cs`). The fence regex flagged `meta.NextSequenceId` reads
as ambiguous with the banned-member shape; three options were considered:

1. Allowlist `FileSessionStore.cs` — loses fence protection in that file.
2. Contextual local-variable name exclusion in the regex — brittle.
3. **Rename the DTO field with `[property: JsonPropertyName("nextSequenceId")]`** to
   preserve the JSON wire shape on disk. Chosen.

`JsonOptions` in `FileSessionStore.cs` uses `JsonNamingPolicy.CamelCase`, so the
`JsonPropertyName` attribute keeps on-disk sidecar files round-tripping. The DTO
rename is invisible to anyone outside the file.

## Commits (each green for `git bisect`)

| Commit | Title | Stats |
| --- | --- | --- |
| `7db68047` | `refactor(gateway): extract SessionStreamReplay from GatewaySession (#575)` | 7 files, +142/-131 |
| `94e22b70` | `test(gateway): pin SessionStreamReplay facade fence + UpdatedAt parity (#575)` | 3 files, +415/-2 |
| `6b195856` | `test(architecture): harden SessionStreamReplay fence lexer for C# raw strings (#575)` | 1 file, +80/-4 |
| `b947740a` | `docs(gateway): remove transport-coupled "WebSocket" terminology from domain + contracts + gateway core docs (#575)` | 10 files, +53/-25 |
| `2f0e8dc9` | `docs: align gateway/api/abstractions/tui READMEs with current REST-only gateway architecture (#575)` | 4 files, +23/-168 |

Commit 1 includes ALL caller migrations (production + tests) so every commit
in the bisect range builds and the test suite is green at every point.

## Transport-neutral doc cleanup (folded in 2026-05-31)

Surfaced when reviewing this PR: the new `SessionStreamReplay.cs` inherited
"WebSocket" framing from the pre-existing `SessionReplayBuffer` it wraps.
The user pointed out that the gateway is supposed to be transport-agnostic —
"The gateway only hosts the API for REST based calls, extensions and channels
handle any communications to a surface a user interacts with via the gateway
events they hook into" — but doc comments and READMEs leaked the assumption
that the gateway IS a WebSocket host.

**Code reality (verified):** `Program.cs` does not call `app.UseWebSockets()`;
no `/ws` route is mapped; `app.AddSignalR()` is registered in DI but the
SignalR hub is mounted by the SignalR channel extension via
`MapExtensionEndpoints(app)`. The `"WS"` literal in `GatewayAuthMiddleware.cs`
is live behaviour — SignalR negotiations upgrade through this path — and stays
in place (the doc on `IGatewayAuthHandler.Method` clarifies what it means).

**Three scopes addressed (doc-only, zero behaviour change):**

* **Scope A — domain layer (commit 4):** `SessionStreamReplay`,
  `SessionReplayBuffer`, `GatewaySession`, `GatewaySessionRuntime`,
  `GatewayActivity` — class summaries + property docs reframed:
  "WebSocket reconnect-replay" → "outbound-stream reconnect-replay";
  "WebSocket clients" → "channel adapters"; consistent
  "transport-agnostic — channels own delivery" framing.
* **Scope B — contracts + gateway core (commit 4):**
  `IActivityBroadcaster`, `IGatewayAuthHandler`, `ApiKeyGatewayAuthHandler`,
  `ChatController`, `GatewayHost` — interface contracts and implementation
  docs aligned. `IGatewayAuthHandler` summary now explicitly clarifies
  HTTP-only with HTTP-upgrade classification.
* **Scope C — READMEs (commit 5):** `src/gateway/README.md`,
  `BotNexus.Gateway.Api/README.md`, `BotNexus.Gateway.Abstractions/README.md`,
  `BotNexus.Extensions.Channels.Tui/README.md`. Largest cleanup is in
  `src/gateway/README.md` — deleted the entire `## WebSocket Protocol`
  section (~110 lines describing a removed `/ws` raw-WS endpoint with a
  JSON message protocol that does not exist anywhere in the code);
  deleted "Session Locking (WebSocket)" (described a one-connection-per-
  session model with status code 4409 that has been replaced by the
  current fan-out + stale-connection demotion model — confirmed `4409`
  literal is not in any source file; SignalR tests pin multi-tab support);
  removed the non-existent `WebSocket/` subfolder line from the file
  structure listing. `Api/README.md` deleted the `### WebSocket` +
  `### Activity Stream` subsections (the documented `/ws` +
  `/ws/activity` endpoints don't exist) and dropped the
  `ActivityWebSocketHandler` row from the middleware table (that type
  exists only in the README — no source file).

**Architecture-fence audit (in response to user's "any other arch based
calls" question):** All 20 architecture tests in
`tests/architecture/BotNexus.Architecture.Tests/` use transport-neutral
fence rules. Doc-only mentions of REST/SignalR in 3 tests are accurate
boundary-layer references (`ConversationResetServiceArchitectureTests`,
`JobIdRunIdArchitectureTests`, `ThreadIdRemovedArchitectureTests`) —
they don't bake in the assumption that the gateway IS a particular
transport. No code-level fences need changing.

**Known follow-up (out of scope for this PR, surfaced during scope C
audit):** The `docs/` top-level documentation set has wider stale
WebSocket content (`docs/api-reference.md` still has a "WebSocket Protocol"
section similar to the one deleted from `src/gateway/README.md`;
`docs/.vitepress/config.mts` nav still lists "WebSocket Protocol";
`docs/configuration.md` documents `WebSocketEnabled` / `WebSocketPath`
config fields that may no longer exist; `docs/observability.md` shows
`botnexus.channel.type = websocket` span attributes throughout). This is
a separate, larger cleanup — file renames + VitePress nav restructuring +
config-field accuracy verification — tracked as #578.

## Verification

* `dotnet build BotNexus.slnx --tl:off` — **0 warnings, 0 errors** under
  `TreatWarningsAsErrors=true`.
* `dotnet test BotNexus.slnx --tl:off` — full solution green (verified
  after each of the 5 commits):
  * Architecture: **92/92** (was 83 pre-#575, +9 for new fence)
  * Gateway: **1898/1898** + 1 `[Skip]` for known-issue #383
    (was 1886 pre-#575, +12 incl. 2 parity pins and migrations)
  * BlazorClient 338/338, CodingAgent 206/206, Cli 86/86,
    Gateway.Conversations 101/101, all other suites green.
* No new warnings, no new flakes.

## Multi-model critique sweep

Three agents reviewed both pre-fold-in commits in parallel:

* **Security (gpt-5.5)**: clean — no vulnerabilities found.
* **Plan-vs-impl (claude-opus-4.7)**: all 10 acceptance criteria PASS; 3 LOWs
  deferred with no-fix rationale (`Task.Delay(5)` margin OK on Windows
  ~15.6ms tick + Linux µs clock; `SessionReplayBuffer` type still
  constructible by design for unit tests; raw-string lexer limitation
  shared with `SingleShotWireValueArchitectureTests` and tracked separately).
* **Bug-hunt (gpt-5.3-codex)**: 1 MEDIUM — raw-string fence bypass. **Folded in as commit 3.**

## Out of scope (follow-up)

* Lift the raw-string lexer branch in `StripComments` to the other 4
  architecture fences in `tests/architecture/BotNexus.Architecture.Tests/`
  (`AgentKindArchitectureTests`, `GatewaySessionFacadeArchitectureTests`,
  `SessionConversationFilterArchitectureTests`,
  `SingleShotWireValueArchitectureTests`) that share the same lexer pattern.
* Fix the pre-existing `UpdatedAt` race between `GatewaySessionRuntime._lock`
  history mutations and out-of-lock replay activity — documented in the new
  `SessionStreamReplay.cs` XML doc as a behavioural concurrency task.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

