### PR TITLE
refactor(dispatching): lift InboundMessage overrides into typed InboundMessageContext (#580)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -698,6 +698,9 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // Use agentId as the channel address so every connection from the same agent
         // routes to the same portal conversation, regardless of SignalR connection ID.
         var channelAddress = ChannelAddress.From(agentId.Value);
+        var typedConversationId = string.IsNullOrWhiteSpace(conversationId)
+            ? (ConversationId?)null
+            : ConversationId.From(conversationId);
         var context = new InboundMessageContext(
             agentId,
             new InboundMessage
@@ -714,7 +717,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 channelType,
                 channelAddress,
                 Context.ConnectionId),
-            conversationId);
+            RequestedConversationId: typedConversationId,
+            RequestedAgentId: agentId);
         var dispatchResult = await _conversationDispatcher.DispatchAsync(context, Context.ConnectionAborted);
 
         var session = await _sessions.GetOrCreateAsync(dispatchResult.Resolution.SessionId, agentId, Context.ConnectionAborted);

--- a/src/gateway/BotNexus.Gateway.Dispatching/DefaultConversationDispatcher.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/DefaultConversationDispatcher.cs
@@ -36,7 +36,7 @@ public sealed class DefaultConversationDispatcher : IConversationDispatcher
             context.AgentId,
             context.Source.ChannelType,
             context.Source.ChannelAddress,
-            context.RequestedConversationId,
+            context.RequestedConversationId?.Value,
             cancellationToken,
             initiator: context.Message.Sender);
 
@@ -63,9 +63,9 @@ public sealed class DefaultConversationDispatcher : IConversationDispatcher
         InboundMessageContext context,
         CancellationToken cancellationToken)
     {
-        if (!string.IsNullOrWhiteSpace(context.RequestedConversationId))
+        if (context.RequestedConversationId is { } requested)
         {
-            return await _conversationStore.GetAsync(ConversationId.From(context.RequestedConversationId), cancellationToken);
+            return await _conversationStore.GetAsync(requested, cancellationToken);
         }
 
         return await _conversationStore.ResolveByBindingAsync(

--- a/src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs
@@ -11,18 +11,41 @@ namespace BotNexus.Gateway.Dispatching;
 /// <param name="Message">Inbound payload received from the transport.</param>
 /// <param name="Source">Normalized channel source identity for the inbound payload.</param>
 /// <param name="RequestedConversationId">
-/// Optional explicit conversation target from the transport when the client already knows its active conversation.
+/// Optional explicit conversation target from the transport when the client already knows
+/// its active conversation. Lifted from the legacy <see cref="InboundMessage.ConversationId"/>
+/// override by <see cref="FromInboundMessage"/>; consumers must read this typed property
+/// rather than re-parsing the raw string field.
+/// </param>
+/// <param name="RequestedAgentId">
+/// Optional explicit agent target supplied by the transport. Lifted from the legacy
+/// <see cref="InboundMessage.TargetAgentId"/> override by <see cref="FromInboundMessage"/>.
+/// </param>
+/// <param name="RequestedSessionId">
+/// Optional explicit session resume target supplied by the transport. Lifted from the legacy
+/// <see cref="InboundMessage.SessionId"/> override by <see cref="FromInboundMessage"/>.
 /// </param>
 public sealed record InboundMessageContext(
     AgentId AgentId,
     InboundMessage Message,
     ChannelSource Source,
-    string? RequestedConversationId = null)
+    ConversationId? RequestedConversationId = null,
+    AgentId? RequestedAgentId = null,
+    SessionId? RequestedSessionId = null)
 {
     /// <summary>
-    /// Creates a dispatch context directly from an inbound transport payload.
-    /// This is the default adapter path for existing gateway callers.
+    /// Creates a dispatch context directly from an inbound transport payload, lifting the
+    /// legacy stringly-typed routing overrides on <see cref="InboundMessage"/> into the
+    /// strongly-typed <see cref="RequestedConversationId"/> / <see cref="RequestedAgentId"/>
+    /// / <see cref="RequestedSessionId"/> properties on the context.
     /// </summary>
+    /// <remarks>
+    /// This is the only legitimate site that reads <see cref="InboundMessage.TargetAgentId"/>,
+    /// <see cref="InboundMessage.SessionId"/>, and <see cref="InboundMessage.ConversationId"/>
+    /// — the architecture fence in <c>InboundMessageOverrideFenceTests</c> bans every other
+    /// consumer from re-parsing those raw fields. Null / empty / whitespace inputs are
+    /// gracefully normalised to a <c>null</c> override (the Vogen factories would otherwise
+    /// throw on whitespace and crash the inbound pipeline).
+    /// </remarks>
     /// <param name="agentId">Agent selected for the message.</param>
     /// <param name="message">Inbound transport payload.</param>
     /// <returns>Normalized context ready for dispatching.</returns>
@@ -34,6 +57,21 @@ public sealed record InboundMessageContext(
             message.ChannelAddress,
             message.SenderId,
             message.BindingId);
-        return new InboundMessageContext(agentId, message, source, message.ConversationId);
+        return new InboundMessageContext(
+            agentId,
+            message,
+            source,
+            RequestedConversationId: TryLiftConversationId(message.ConversationId),
+            RequestedAgentId: TryLiftAgentId(message.TargetAgentId),
+            RequestedSessionId: TryLiftSessionId(message.SessionId));
     }
+
+    private static ConversationId? TryLiftConversationId(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : ConversationId.From(raw);
+
+    private static AgentId? TryLiftAgentId(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : AgentId.From(raw);
+
+    private static SessionId? TryLiftSessionId(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : SessionId.From(raw);
 }

--- a/tests/architecture/BotNexus.Architecture.Tests/InboundMessageOverrideFenceTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/InboundMessageOverrideFenceTests.cs
@@ -1,0 +1,483 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function enforcing the <c>#580</c> sub-PR 6.1 contract: production
+/// source code must not read the legacy weakly-typed <c>InboundMessage.{TargetAgentId, SessionId,
+/// ConversationId}</c> override fields. The typed equivalents on <see langword="InboundMessageContext"/>
+/// (<c>RequestedAgentId</c>, <c>RequestedSessionId</c>, <c>RequestedConversationId</c>) carry the
+/// same routing intent in Vogen-typed shape and are the only sanctioned readers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The legacy fields remain on <see langword="InboundMessage"/> for one umbrella-issue (#579)
+/// cycle so adapter writers (Telegram, SignalR, ServiceBus, internal channel adapter) can
+/// continue populating them while the migration is in flight. Sub-PR 6.2 (issue
+/// <c>#581</c>) migrates the deferred reader sites listed in the allowlist; sub-PR 6.3 deletes
+/// the legacy fields entirely and this fence becomes trivially vacuous.
+/// </para>
+/// <para>
+/// The fence bans the pattern <c>message.&lt;FieldName&gt;</c> outside an allowlist. The
+/// allowlist has two categories: (1) the shim itself
+/// (<c>InboundMessageContext.FromInboundMessage</c>) which exists precisely to lift the legacy
+/// fields into the typed context once at the channel boundary, and (2) the sites deferred to
+/// sub-PR 6.2 because they need broader refactoring (pre-routing reads that don't yet have a
+/// typed context, or scattered reads inside <see langword="GatewayHost"/>'s queue/cleanup
+/// pipeline). Each deferred allowlist entry must cite the follow-up issue so the migration
+/// is auditable.
+/// </para>
+/// </remarks>
+public sealed class InboundMessageOverrideFenceTests
+{
+    /// <summary>
+    /// Source files allowed to read the legacy <c>InboundMessage</c> override fields, with the
+    /// rationale recorded inline. The list must shrink monotonically across sub-PRs 6.2 / 6.3.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> s_allowlist = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        // The lift-shim itself: the WHOLE POINT of FromInboundMessage is to read these three
+        // fields ONCE at the channel boundary and project them into typed RequestedAgentId /
+        // RequestedSessionId / RequestedConversationId on InboundMessageContext.
+        ["src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs"] = "Lift-shim — the sanctioned single reader that projects legacy override fields into the typed context.",
+
+        // DEFERRED to sub-PR 6.2 (#581): pre-routing reader. DefaultMessageRouter.ResolveAsync
+        // receives a raw InboundMessage BEFORE the agent has been resolved, so it cannot yet
+        // construct an InboundMessageContext (which requires AgentId). Migrating this requires
+        // either changing IMessageRouter's shape or constructing the context partially earlier
+        // in the pipeline — both larger than 6.1.
+        ["src/gateway/BotNexus.Gateway/Routing/DefaultMessageRouter.cs"] = "DEFERRED to #581 (sub-PR 6.2): pre-routing reader; runs before AgentId is known.",
+
+        // DEFERRED to sub-PR 6.2 (#581): GatewayHost has ~12 sites of message.SessionId
+        // / message.ConversationId reads scattered across ProcessInboundMessageAsync,
+        // GetQueueKey, SendBusyAsync, and CleanupQueueIfClosedSessionAsync. Most call sites
+        // don't have an InboundMessageContext in scope; migration requires either threading
+        // context through 4+ private methods or constructing context once early. Either is a
+        // separate change.
+        ["src/gateway/BotNexus.Gateway/GatewayHost.cs"] = "DEFERRED to #581 (sub-PR 6.2): scattered legacy reads in queue/cleanup pipeline; needs broader refactor.",
+
+        // OUT OF SCOPE for Phase 6 / F-10 entirely: these three adapters read message.SessionId
+        // on OutboundMessage (NOT InboundMessage). The legacy override fields targeted by #580
+        // are an InboundMessage migration; OutboundMessage carries SessionId as a legitimate
+        // routing field at the outbound boundary (the gateway tells the adapter which session
+        // a streamed reply belongs to). The fence regex anchors on `message.` and cannot
+        // syntactically distinguish between an InboundMessage and an OutboundMessage receiver
+        // with the same parameter name. If an OutboundMessage routing-field cleanup happens
+        // in a future phase, these entries should be revisited; for now they are correct usage
+        // of a distinct routing axis.
+        ["src/extensions/BotNexus.Extensions.Channels.ServiceBus/ServiceBusChannelAdapter.cs"] = "OUT OF SCOPE: reads OutboundMessage.SessionId — not InboundMessage. Different type, same property name; fence cannot syntactically disambiguate.",
+        ["src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs"] = "OUT OF SCOPE: reads OutboundMessage.SessionId — not InboundMessage. Different type, same property name; fence cannot syntactically disambiguate.",
+        ["src/gateway/BotNexus.Gateway/Channels/InternalChannelAdapter.cs"] = "OUT OF SCOPE: reads OutboundMessage.SessionId — not InboundMessage. Different type, same property name; fence cannot syntactically disambiguate.",
+    };
+
+    [Fact]
+    public void NoProductionSourceFile_OutsideAllowlist_ReadsLegacyOverrideFields()
+    {
+        var srcRoot = FindSourceRoot();
+
+        var violations = new List<string>();
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var rel = NormalizeRelativePath(srcRoot, path);
+            if (s_allowlist.ContainsKey(rel))
+            {
+                continue;
+            }
+
+            var stripped = StripComments(File.ReadAllText(path));
+            if (ContainsLegacyOverrideRead(stripped))
+            {
+                violations.Add(rel);
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Reads of the legacy `InboundMessage.{TargetAgentId,SessionId,ConversationId}` " +
+            "fields were replaced with typed `InboundMessageContext.{RequestedAgentId," +
+            "RequestedSessionId,RequestedConversationId}` in #580 (Phase 6 / F-10 sub-PR 6.1). " +
+            "If you must add a new reader, either:\n" +
+            "  (a) consume the typed properties on `InboundMessageContext` instead (preferred), or\n" +
+            "  (b) add an explicit allowlist entry with an issue link explaining why the typed " +
+            "path is not yet workable.\n" +
+            "Adding without an allowlist entry will fail CI.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Allowlist_ReferencesOnlyExistingFiles()
+    {
+        // Vacuity guard #1: the allowlist must not accumulate stale entries that quietly grant
+        // permission to files that no longer exist. If a file is renamed or deleted, the entry
+        // here must move with it — otherwise a future file at the same path silently inherits
+        // the legacy-read allowance.
+        var srcRoot = FindSourceRoot();
+        var missing = new List<string>();
+        foreach (var rel in s_allowlist.Keys)
+        {
+            var full = Path.Combine(srcRoot, "..", rel.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(Path.GetFullPath(full)))
+            {
+                missing.Add(rel);
+            }
+        }
+
+        missing.ShouldBeEmpty(
+            "Allowlist hygiene: every entry must point to an existing source file. " +
+            "Stale entries silently grant the legacy-read allowance to whatever future file " +
+            "lands at that path. Update the allowlist when files move.\nMissing:\n  " +
+            string.Join("\n  ", missing));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticRegression()
+    {
+        // Vacuity guard #2: the fence must flag the canonical pre-#580 shapes — reading
+        // message.TargetAgentId / message.SessionId / message.ConversationId outside the
+        // shim. If this assertion fails, the fence regex has been weakened so far that the
+        // original regression class is undetectable.
+        const string syntheticTargetAgent = """
+            var agent = message.TargetAgentId;
+            """;
+        const string syntheticSession = """
+            var sid = message.SessionId;
+            """;
+        const string syntheticConv = """
+            if (message.ConversationId is { } id) { /* ... */ }
+            """;
+
+        ContainsLegacyOverrideRead(StripComments(syntheticTargetAgent)).ShouldBeTrue(
+            "Vacuity guard: the fence must flag `message.TargetAgentId` reads. If this fails, " +
+            "the regex no longer catches the canonical pre-#580 shape and the entire purpose " +
+            "of the fence is defeated.");
+        ContainsLegacyOverrideRead(StripComments(syntheticSession)).ShouldBeTrue(
+            "Vacuity guard: the fence must flag `message.SessionId` reads. If this fails, " +
+            "the regex no longer catches the canonical pre-#580 shape.");
+        ContainsLegacyOverrideRead(StripComments(syntheticConv)).ShouldBeTrue(
+            "Vacuity guard: the fence must flag `message.ConversationId` reads. If this fails, " +
+            "the regex no longer catches the canonical pre-#580 shape.");
+    }
+
+    [Fact]
+    public void Fence_DetectsLegacyRead_NullConditional()
+    {
+        // Critique-sweep fold-in (#580 bug-hunt HIGH): null-conditional reads
+        // (`message?.SessionId`) are a real-world C# idiom that the original
+        // strict `message.` regex missed. This shape MUST trip the fence;
+        // otherwise legacy reads can slip past unnoticed in any code path that
+        // treats `message` as nullable.
+        const string syntheticNullConditional = """
+            var sid = message?.SessionId;
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticNullConditional)).ShouldBeTrue(
+            "Null-conditional vacuity pin: `message?.SessionId` MUST be detected. Without " +
+            "this, any code reading the legacy field through a nullable reference silently " +
+            "bypasses the migration fence.");
+    }
+
+    [Fact]
+    public void Fence_DetectsLegacyRead_WhitespaceAroundDot()
+    {
+        // Critique-sweep fold-in (#580 bug-hunt HIGH): valid C# tolerates whitespace
+        // between the receiver and the member-access dot. The fence must too.
+        const string syntheticWhitespaced = """
+            var sid = message .SessionId;
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticWhitespaced)).ShouldBeTrue(
+            "Whitespace-tolerant vacuity pin: `message .SessionId` (with space before the " +
+            "dot) is legal C# and MUST trip the fence. Without this, a reformatter or a " +
+            "deliberate spacing convention silently bypasses the migration.");
+    }
+
+    [Fact]
+    public void Fence_DetectsLegacyRead_PropertyPattern()
+    {
+        // Critique-sweep fold-in (#580 bug-hunt HIGH): C# property patterns
+        // (`message is { SessionId: { } sid }`) are reads — there is no equivalent
+        // write form. The fence must detect them; without this, modern pattern-matching
+        // code can deconstruct the legacy fields without tripping the migration.
+        const string syntheticPropertyPattern = """
+            if (message is { SessionId: { } sid }) { /* ... */ }
+            """;
+        const string syntheticMultiFieldPattern = """
+            if (message is { Foo: var f, TargetAgentId: { } agent }) { /* ... */ }
+            """;
+        const string syntheticMultilinePattern = """
+            if (message is
+                {
+                    ConversationId: { } conv
+                }) { /* ... */ }
+            """;
+
+        ContainsLegacyOverrideRead(StripComments(syntheticPropertyPattern)).ShouldBeTrue(
+            "Property-pattern vacuity pin: `message is { SessionId: ... }` is a READ shape " +
+            "and MUST trip the fence. Pattern matching is increasingly idiomatic; missing " +
+            "this would leave a large class of legacy reads undetectable.");
+        ContainsLegacyOverrideRead(StripComments(syntheticMultiFieldPattern)).ShouldBeTrue(
+            "Multi-field property-pattern vacuity pin: `message is { Foo: …, TargetAgentId: …}` " +
+            "MUST trip even when the legacy field is not the first property in the pattern.");
+        ContainsLegacyOverrideRead(StripComments(syntheticMultilinePattern)).ShouldBeTrue(
+            "Multi-line property-pattern vacuity pin: pattern matches MUST work when the " +
+            "pattern spans multiple lines — real-world property patterns often do.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnAssignmentToLegacyField()
+    {
+        // False-positive guard #1: WRITING to the legacy fields is fine — adapters still
+        // populate them on the InboundMessage they construct, and the shim reads them once.
+        // The fence must only flag READS of the form `message.<Field>` not WRITES like
+        // `... = message; message.<Field> = ...;` or object-initialiser `{ TargetAgentId = X }`.
+        const string syntheticClean = """
+            var msg = new InboundMessage
+            {
+                TargetAgentId = "agent-a",
+                SessionId = "sess-1",
+                ConversationId = "conv-1",
+            };
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: object-initialiser writes to the legacy fields must not " +
+            "trip the fence. Adapter code still populates these fields; only reads are banned. " +
+            "If this fails, the fence has been broadened to ban all references.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedReceiver()
+    {
+        // False-positive guard #2: reads of identically-named properties on different
+        // receivers (e.g. `result.SessionId`, `context.ConversationId`, `request.TargetAgentId`)
+        // are unrelated to the InboundMessage shape and must not be flagged. The fence is
+        // anchored specifically on the `message.` receiver.
+        const string syntheticClean = """
+            var sessionId = result.SessionId;
+            var convId = context.ConversationId;
+            var agentId = request.TargetAgentId;
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: reads on receivers other than `message.` are unrelated " +
+            "to the InboundMessage override fields and must not be flagged. If this fails, " +
+            "the fence has been broadened to ban a substring rather than the anchored pattern.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMention()
+    {
+        // False-positive guard #3: a deprecation comment that MENTIONS `message.SessionId`
+        // or similar as historical context is fine — the comment stripper removes it before
+        // the fence applies. Authors must be able to document the migration in comments
+        // without tripping the rule.
+        const string syntheticClean = """
+            /// <summary>
+            /// Replaces the pre-#580 pattern `message.TargetAgentId` / `message.SessionId` /
+            /// `message.ConversationId` with the typed RequestedAgentId / RequestedSessionId /
+            /// RequestedConversationId on InboundMessageContext.
+            /// </summary>
+            public AgentId AgentId { get; }
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment-only mentions of the legacy shape must not trip " +
+            "the fence. If this fails, the comment stripper has regressed and the fence will " +
+            "block PRs that legitimately document the migration history.");
+    }
+
+    /// <summary>
+    /// Matches reads of the form <c>message.TargetAgentId</c>, <c>message?.SessionId</c>, or
+    /// <c>message is { ConversationId: …}</c> — but not writes (those have <c>=</c>
+    /// immediately after the field name in source). Anchored on the <c>message</c> receiver
+    /// (with optional null-conditional and whitespace) so unrelated properties on other
+    /// receivers (<c>result.SessionId</c>, <c>request.TargetAgentId</c>) are not flagged.
+    /// </summary>
+    /// <remarks>
+    /// Three syntactic shapes are covered:
+    /// <list type="bullet">
+    /// <item><description>Member access (dot or null-conditional): <c>message.X</c>, <c>message?.X</c>, <c>message .X</c></description></item>
+    /// <item><description>Property pattern: <c>message is { X: …</c> and <c>message is { …, X: …</c></description></item>
+    /// </list>
+    /// Bug-hunt critique fold-in (#580 critique sweep, HIGH): the prior regex only caught the
+    /// strict <c>message.X</c> form. Null-conditional reads (<c>message?.SessionId</c>) and
+    /// pattern-matched reads (<c>message is { SessionId: { } sid }</c>) silently slipped past.
+    /// The vacuity guards below pin all three shapes.
+    /// </remarks>
+    private static bool ContainsLegacyOverrideRead(string source)
+    {
+        // Shape 1: member access with optional null-conditional and whitespace.
+        //   message.X        — classic
+        //   message?.X       — null-conditional
+        //   message .X       — odd whitespace, still valid C#
+        //   message?  . X    — odd whitespace + null-conditional, still valid C#
+        // The trailing negative lookahead `(?!\s*=\s*[^=])` excludes assignments while still
+        // accepting `==` comparisons (the second `=` is captured by `[^=]` exclusion).
+        if (Regex.IsMatch(
+            source,
+            @"\bmessage\s*\??\s*\.\s*(TargetAgentId|SessionId|ConversationId)\b(?!\s*=\s*[^=])"))
+        {
+            return true;
+        }
+
+        // Shape 2: property pattern read.
+        //   message is { TargetAgentId: …}
+        //   message is { Foo: x, SessionId: { } sid }
+        // Pattern matching is a READ shape — there is no equivalent write form, so no
+        // exclusion lookahead is needed. We use Singleline mode so the pattern can span
+        // multiple lines (real property patterns often do).
+        return Regex.IsMatch(
+            source,
+            @"\bmessage\s+is\s*\{[^}]*\b(TargetAgentId|SessionId|ConversationId)\s*:",
+            RegexOptions.Singleline);
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving the contents of string and char literals. Handles regular strings
+    /// (with <c>\\</c>/<c>\"</c> escapes), verbatim strings (<c>@"…"</c> with <c>""</c>-escaped
+    /// quotes), and char literals. Required to avoid false-negatives where a <c>//</c> inside
+    /// a URL string literal would otherwise be treated as a comment-start and silently strip
+    /// real production code (see <c>SingleShotWireValueArchitectureTests</c> for the canonical
+    /// reproduction and the rationale).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                if (i + 1 < n)
+                {
+                    i += 2;
+                }
+                else
+                {
+                    i = n;
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeRelativePath(string srcRoot, string fullPath)
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(srcRoot, ".."));
+        var rel = Path.GetRelativePath(repoRoot, fullPath);
+        return rel.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/InboundMessageOverrideFenceTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/InboundMessageOverrideFenceTests.cs
@@ -16,7 +16,7 @@ namespace BotNexus.Architecture.Tests;
 /// The legacy fields remain on <see langword="InboundMessage"/> for one umbrella-issue (#579)
 /// cycle so adapter writers (Telegram, SignalR, ServiceBus, internal channel adapter) can
 /// continue populating them while the migration is in flight. Sub-PR 6.2 (issue
-/// <c>#581</c>) migrates the deferred reader sites listed in the allowlist; sub-PR 6.3 deletes
+/// <c>#582</c>) migrates the deferred reader sites listed in the allowlist; sub-PR 6.3 deletes
 /// the legacy fields entirely and this fence becomes trivially vacuous.
 /// </para>
 /// <para>
@@ -43,20 +43,20 @@ public sealed class InboundMessageOverrideFenceTests
         // RequestedSessionId / RequestedConversationId on InboundMessageContext.
         ["src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs"] = "Lift-shim — the sanctioned single reader that projects legacy override fields into the typed context.",
 
-        // DEFERRED to sub-PR 6.2 (#581): pre-routing reader. DefaultMessageRouter.ResolveAsync
+        // DEFERRED to sub-PR 6.2 (#582): pre-routing reader. DefaultMessageRouter.ResolveAsync
         // receives a raw InboundMessage BEFORE the agent has been resolved, so it cannot yet
         // construct an InboundMessageContext (which requires AgentId). Migrating this requires
         // either changing IMessageRouter's shape or constructing the context partially earlier
         // in the pipeline — both larger than 6.1.
-        ["src/gateway/BotNexus.Gateway/Routing/DefaultMessageRouter.cs"] = "DEFERRED to #581 (sub-PR 6.2): pre-routing reader; runs before AgentId is known.",
+        ["src/gateway/BotNexus.Gateway/Routing/DefaultMessageRouter.cs"] = "DEFERRED to #582 (sub-PR 6.2): pre-routing reader; runs before AgentId is known.",
 
-        // DEFERRED to sub-PR 6.2 (#581): GatewayHost has ~12 sites of message.SessionId
+        // DEFERRED to sub-PR 6.2 (#582): GatewayHost has ~12 sites of message.SessionId
         // / message.ConversationId reads scattered across ProcessInboundMessageAsync,
         // GetQueueKey, SendBusyAsync, and CleanupQueueIfClosedSessionAsync. Most call sites
         // don't have an InboundMessageContext in scope; migration requires either threading
         // context through 4+ private methods or constructing context once early. Either is a
         // separate change.
-        ["src/gateway/BotNexus.Gateway/GatewayHost.cs"] = "DEFERRED to #581 (sub-PR 6.2): scattered legacy reads in queue/cleanup pipeline; needs broader refactor.",
+        ["src/gateway/BotNexus.Gateway/GatewayHost.cs"] = "DEFERRED to #582 (sub-PR 6.2): scattered legacy reads in queue/cleanup pipeline; needs broader refactor.",
 
         // OUT OF SCOPE for Phase 6 / F-10 entirely: these three adapters read message.SessionId
         // on OutboundMessage (NOT InboundMessage). The legacy override fields targeted by #580

--- a/tests/gateway/BotNexus.Gateway.Tests/Dispatching/InboundMessageContextTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Dispatching/InboundMessageContextTests.cs
@@ -1,0 +1,177 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Dispatching;
+
+namespace BotNexus.Gateway.Tests.Dispatching;
+
+/// <summary>
+/// Pins the strongly-typed override contract on <see cref="InboundMessageContext"/>
+/// added in F-10 sub-PR 6.1. Pre-PR these overrides lived as <c>string?</c> directly
+/// on <see cref="InboundMessage"/>; <see cref="InboundMessageContext.FromInboundMessage"/>
+/// is the only legitimate site that may still read those legacy fields — every other
+/// consumer must read the typed properties on the context.
+/// </summary>
+public sealed class InboundMessageContextTests
+{
+    [Fact]
+    public void FromInboundMessage_WithAllOverridesSet_LiftsAllThreeToTypedProperties()
+    {
+        var message = CreateMessage(
+            targetAgentId: "agent-a",
+            sessionId: "session-42",
+            conversationId: "c_abc123");
+
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("agent-a"), message);
+
+        context.RequestedAgentId.ShouldBe(AgentId.From("agent-a"));
+        context.RequestedSessionId.ShouldBe(SessionId.From("session-42"));
+        context.RequestedConversationId.ShouldBe(ConversationId.From("c_abc123"));
+    }
+
+    [Fact]
+    public void FromInboundMessage_WithNullOverrides_LeavesAllTypedPropertiesNull()
+    {
+        var message = CreateMessage(
+            targetAgentId: null,
+            sessionId: null,
+            conversationId: null);
+
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("agent-a"), message);
+
+        context.RequestedAgentId.ShouldBeNull();
+        context.RequestedSessionId.ShouldBeNull();
+        context.RequestedConversationId.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void FromInboundMessage_WithEmptyOrWhitespaceOverrides_LeavesTypedPropertiesNull_GracefullyDoesNotThrow(string blank)
+    {
+        var message = CreateMessage(
+            targetAgentId: blank,
+            sessionId: blank,
+            conversationId: blank);
+
+        // The shim must NOT throw on whitespace inputs — channel adapters pass empty strings
+        // historically. The Vogen From(...) factories reject whitespace, so the shim must
+        // gracefully degrade to null rather than crash the inbound pipeline.
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("agent-a"), message);
+
+        context.RequestedAgentId.ShouldBeNull();
+        context.RequestedSessionId.ShouldBeNull();
+        context.RequestedConversationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromInboundMessage_NullMessage_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            InboundMessageContext.FromInboundMessage(AgentId.From("agent-a"), null!));
+    }
+
+    [Fact]
+    public void DirectConstructor_AcceptsTypedOverrides_AndPreservesThem()
+    {
+        var message = CreateMessage();
+        var source = new ChannelSource(message.ChannelType, message.ChannelAddress, message.SenderId, message.BindingId);
+
+        var context = new InboundMessageContext(
+            AgentId.From("agent-x"),
+            message,
+            source,
+            RequestedConversationId: ConversationId.From("c_explicit"),
+            RequestedAgentId: AgentId.From("agent-target"),
+            RequestedSessionId: SessionId.From("s_target"));
+
+        context.RequestedConversationId.ShouldBe(ConversationId.From("c_explicit"));
+        context.RequestedAgentId.ShouldBe(AgentId.From("agent-target"));
+        context.RequestedSessionId.ShouldBe(SessionId.From("s_target"));
+    }
+
+    [Fact]
+    public void DirectConstructor_AcceptsAllNullOverrides_AsDefault()
+    {
+        var message = CreateMessage();
+        var source = new ChannelSource(message.ChannelType, message.ChannelAddress, message.SenderId, message.BindingId);
+
+        var context = new InboundMessageContext(AgentId.From("agent-x"), message, source);
+
+        context.RequestedConversationId.ShouldBeNull();
+        context.RequestedAgentId.ShouldBeNull();
+        context.RequestedSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromInboundMessage_PreservesChannelSourceDetails()
+    {
+        var message = CreateMessage(targetAgentId: "agent-a");
+
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("agent-a"), message);
+
+        context.AgentId.ShouldBe(AgentId.From("agent-a"));
+        context.Message.ShouldBe(message);
+        context.Source.ChannelType.ShouldBe(message.ChannelType);
+        context.Source.ChannelAddress.ShouldBe(message.ChannelAddress);
+        context.Source.SenderId.ShouldBe(message.SenderId);
+        context.Source.BindingId.ShouldBe(message.BindingId);
+    }
+
+    [Fact]
+    public void FromInboundMessage_WithOnlyTargetAgentIdSet_LiftsOnlyAgentId_LeavesOthersNull()
+    {
+        // Pin-vs-impl critique fold-in: regression-shape coverage for "lift pulled from the
+        // wrong source field". If TryLiftAgentId were ever rewired to read message.SessionId
+        // (or vice-versa), the all-set / all-null facts wouldn't catch it; only an
+        // independence pin does.
+        var message = CreateMessage(targetAgentId: "only-agent");
+
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("router-agent"), message);
+
+        context.RequestedAgentId.ShouldBe(AgentId.From("only-agent"));
+        context.RequestedSessionId.ShouldBeNull("only TargetAgentId was set on the inbound message; SessionId must remain null");
+        context.RequestedConversationId.ShouldBeNull("only TargetAgentId was set on the inbound message; ConversationId must remain null");
+    }
+
+    [Fact]
+    public void FromInboundMessage_WithOnlySessionIdSet_LiftsOnlySessionId_LeavesOthersNull()
+    {
+        var message = CreateMessage(sessionId: "only-session");
+
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("router-agent"), message);
+
+        context.RequestedSessionId.ShouldBe(SessionId.From("only-session"));
+        context.RequestedAgentId.ShouldBeNull("only SessionId was set on the inbound message; TargetAgentId must remain null");
+        context.RequestedConversationId.ShouldBeNull("only SessionId was set on the inbound message; ConversationId must remain null");
+    }
+
+    [Fact]
+    public void FromInboundMessage_WithOnlyConversationIdSet_LiftsOnlyConversationId_LeavesOthersNull()
+    {
+        var message = CreateMessage(conversationId: "only-conv");
+
+        var context = InboundMessageContext.FromInboundMessage(AgentId.From("router-agent"), message);
+
+        context.RequestedConversationId.ShouldBe(ConversationId.From("only-conv"));
+        context.RequestedAgentId.ShouldBeNull("only ConversationId was set on the inbound message; TargetAgentId must remain null");
+        context.RequestedSessionId.ShouldBeNull("only ConversationId was set on the inbound message; SessionId must remain null");
+    }
+
+    private static InboundMessage CreateMessage(
+        string? targetAgentId = null,
+        string? sessionId = null,
+        string? conversationId = null)
+        => new()
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("addr-1"),
+            SenderId = "sender-1",
+            Sender = CitizenId.Of(UserId.From("sender-1")),
+            Content = "hello",
+            TargetAgentId = targetAgentId,
+            SessionId = sessionId,
+            ConversationId = conversationId
+        };
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -169,7 +169,7 @@ public sealed class SignalRHubTests
 
         var conversationDispatcher = new Mock<IConversationDispatcher>();
         conversationDispatcher.Setup(value => value.DispatchAsync(
-                It.Is<InboundMessageContext>(context => context.RequestedConversationId == targetConversationId),
+                It.Is<InboundMessageContext>(context => context.RequestedConversationId == BotNexus.Domain.Primitives.ConversationId.From(targetConversationId)),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((InboundMessageContext context, CancellationToken _) => new DispatchResult(
                 context,


### PR DESCRIPTION
## Summary

Sub-PR 6.1 of the **Phase 6 / F-10** channel-routing-combinatorics campaign (umbrella #579). Strongly-types the three weakly-typed routing overrides on `InboundMessage` and lifts them into typed properties on `InboundMessageContext`. Closes #580.

**Behaviour: zero change.** Adapters still populate the legacy `InboundMessage.{TargetAgentId, SessionId, ConversationId}` fields; the typed properties are derived from them via a single `FromInboundMessage` shim. Consumers migrate to read the typed channel; legacy fields are removed in sub-PR 6.3 (a future PR).

## What changed

### Production
- `InboundMessageContext` (the central change) gains typed `AgentId? RequestedAgentId`, `SessionId? RequestedSessionId`, and re-types `RequestedConversationId` from `string?` to `ConversationId?`. `FromInboundMessage` lifts via `TryLift{ConversationId,AgentId,SessionId}` helpers that normalise null/empty/whitespace to `null`.
- `DefaultConversationDispatcher` reads typed `RequestedConversationId` directly; drops the `string.IsNullOrWhiteSpace` guard and the `ConversationId.From(...)` conversion.
- `GatewayHub.ResolveOrCreateSessionAsync` uses named-arg ctor with typed `ConversationId?` and `AgentId?`. **Note**: this PR now passes `RequestedAgentId` from the hub (previously unset) — harmless population since the hub knows the agent at that point, but downstream consumers (sub-PR 6.2) will observe the new value.

### Tests (28 new facts across two files; 0 regressions)
- `InboundMessageContextTests` — **12 facts** pinning round-trip behaviour: all-set, all-null, `[Theory]` ×3 for null/empty/whitespace, direct-ctor ergonomics (with and without typed overrides), channel-source preservation, null-message guard, and **3 independence pins** (only one field set at a time) to catch the "lift pulled from the wrong source field" regression class.
- `InboundMessageOverrideFenceTests` — **9 architecture fence facts** banning legacy `message.X` reads outside an explicit allowlist.

### Architecture fence allowlist (3 categories, 6 entries total)
| Category | Files | Why |
| --- | --- | --- |
| **SANCTIONED** | `InboundMessageContext.cs` | The lift-shim itself — the single sanctioned reader. |
| **DEFERRED → #581 (sub-PR 6.2)** | `DefaultMessageRouter.cs`, `GatewayHost.cs` | Pre-routing reader (no `AgentId` yet) and scattered queue/cleanup reads needing broader refactor. |
| **OUT OF SCOPE for F-10** | `ServiceBusChannelAdapter.cs`, `SignalRChannelAdapter.cs`, `InternalChannelAdapter.cs` | All three read `OutboundMessage.SessionId`, not `InboundMessage.SessionId`. The fence regex anchors on `message.` and cannot syntactically distinguish the two types when the parameter names match. |

## Sub-PR plan refinement

The original Phase 6 / F-10 plan promised one large PR migrating all consumers. Scoping revealed two consumer sites need broader refactoring than 6.1 should bear. The migration now splits into three sub-PRs:

| Sub-PR | Issue | Status |
| --- | --- | --- |
| **6.1 (this PR)** | #580 | ✅ This PR — type re-shape + 2 consumer migrations + architecture fence |
| **6.2** | #582 (filed) | Migrate `DefaultMessageRouter` + `GatewayHost` |
| **6.3** | #583 (to be filed) | Delete the three legacy fields; remove fence allowlist entries; fence becomes vacuous and can be archived |

Both deferred sites carry explicit fence allowlist entries citing #581.

## Critique sweep

Three parallel critique passes were run pre-merge:

- **Security review** (gpt-5.5): **CLEAN** — no MEDIUM+ vulnerabilities. Confirmed `RequestedConversationId` remains lookup-only (not persisted as new id), Vogen `From()` validation preserved on the typed path, `TryLift*` helpers normalise whitespace correctly, allowlisted adapters do read `OutboundMessage` not `InboundMessage`.
- **Plan-vs-impl review** (claude-opus-4.7): **PASS** — all 7 ACs satisfied with evidence; fence verified non-vacuous against the real deferred files (`GatewayHost` has 13 reads, `DefaultMessageRouter` has 6); flagged one optional independence-of-lifts test row → adopted (3 new pins added).
- **Bug-hunt review** (gpt-5.3-codex): **1 HIGH** — original fence regex only caught the strict `message.X` form; `message?.X`, `message .X` (whitespace), and `message is { X: ... }` (property pattern) silently bypassed → **adopted**. Fence regex now covers all three syntactic shapes with explicit vacuity pins.

## Acceptance criteria
- [x] `InboundMessageContext` has typed `AgentId?`, `SessionId?`, `ConversationId?` overrides.
- [x] `FromInboundMessage` lifts via null-safe `TryLift*` helpers.
- [x] `DefaultConversationDispatcher` reads typed `RequestedConversationId` directly.
- [x] `GatewayHub.cs` ctor uses typed `ConversationId?` / `AgentId?`.
- [x] Architecture fence with vacuity, false-positive, and allowlist-hygiene guards.
- [x] Deferred sites (`DefaultMessageRouter`, `GatewayHost`) carry allowlist entries citing #581.
- [x] Full suite green: `dotnet test BotNexus.slnx --nologo --tl:off` — 0 failures (modulo known shell-tool flake unrelated to this change), 0 warnings under `TreatWarningsAsErrors`.

Refs #579.
