### PR TITLE
test(integration): add BotNexus.Integration.Cli.Tests project

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -81,6 +81,9 @@
     <Project Path="tests/extensions/BotNexus.Extensions.WebTools.Tests/BotNexus.Extensions.WebTools.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj" />
   </Folder>
+  <Folder Name="/tests/integration/">
+    <Project Path="tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj" />
+  </Folder>
   <Folder Name="/tests/gateway/">
     <Project Path="tests/gateway/BotNexus.Cli.Tests/BotNexus.Cli.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Cron.Tests/BotNexus.Cron.Tests.csproj" />

--- a/tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!--
+      Integration tests that exercise the published BotNexus.Cli .NET global tool from nuget.org.
+      No ProjectReference to BotNexus.Cli — we intentionally validate the shipped package, not the local build.
+    -->
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliHelpTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliHelpTests.cs
@@ -1,0 +1,43 @@
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Test 2: verify the installed CLI emits sensible help output that advertises the core commands.
+/// </summary>
+[Collection(CliCollection.Name)]
+public sealed class CliHelpTests
+{
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly CliInstallFixture _fixture;
+
+    public CliHelpTests(CliInstallFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Cli_Help_ListsCoreCommands()
+    {
+        _fixture.InstallSucceeded.ShouldBeTrue(
+            "CLI install fixture did not complete successfully — see CliInstallationTests for the install failure.");
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            "--help",
+            timeout: CommandTimeout);
+
+        result.ExitCode.ShouldBe(
+            0,
+            $"botnexus --help exited with {result.ExitCode}.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+
+        var output = result.Combined;
+        output.ShouldNotBeNullOrWhiteSpace();
+        output.ShouldContain("BotNexus");
+
+        // Sanity-check that the published CLI exposes the commands this test project relies on.
+        foreach (var expected in new[] { "init", "install", "validate", "agent" })
+        {
+            output.ShouldContain(
+                expected,
+                Case.Insensitive,
+                customMessage: $"Help output did not advertise expected command '{expected}'. Full output:\n{output}");
+        }
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallAndInitWorkflowTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallAndInitWorkflowTests.cs
@@ -93,9 +93,71 @@ public sealed class CliInstallAndInitWorkflowTests : IAsyncLifetime
             0,
             $"botnexus init failed.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
 
+        // ── Directory layout ──────────────────────────────────────────────
+        // With an explicit --target (non-default home), the CLI seeds only the
+        // config file. The richer layout (auth.json, agents/, sessions/, logs/)
+        // is reserved for BotNexusHome.Initialize() on the default home path,
+        // so we assert that nothing extra leaks into the sandbox.
         Directory.Exists(configHome).ShouldBeTrue(
             $"Expected init to create config home at {configHome}.");
-        File.Exists(Path.Combine(configHome, "config.json")).ShouldBeTrue(
-            "Expected init to create config.json in the target home.");
+
+        var configPath = Path.Combine(configHome, "config.json");
+        File.Exists(configPath).ShouldBeTrue(
+            $"Expected init to create config.json at {configPath}.");
+
+        var actualEntries = Directory.GetFileSystemEntries(configHome)
+            .Select(p => Path.GetFileName(p)!)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        actualEntries.ShouldBe(
+            new[] { "config.json" },
+            $"Unexpected entries in {configHome}. Got: {string.Join(", ", actualEntries)}");
+
+        // ── config.json content ───────────────────────────────────────────
+        await using var stream = File.OpenRead(configPath);
+        using var doc = await System.Text.Json.JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Object);
+
+        // version
+        root.TryGetProperty("version", out var version).ShouldBeTrue("config.json missing 'version'.");
+        version.GetInt32().ShouldBe(1);
+
+        // gateway block
+        root.TryGetProperty("gateway", out var gateway).ShouldBeTrue("config.json missing 'gateway'.");
+        gateway.GetProperty("listenUrl").GetString().ShouldBe("http://0.0.0.0:5005");
+        gateway.GetProperty("defaultAgentId").GetString().ShouldBe("assistant");
+        gateway.GetProperty("enableProviderRequestLogging").GetBoolean().ShouldBeFalse();
+
+        var sessionStore = gateway.GetProperty("sessionStore");
+        sessionStore.GetProperty("type").GetString().ShouldBe("Sqlite");
+        var connectionString = sessionStore.GetProperty("connectionString").GetString();
+        connectionString.ShouldNotBeNullOrWhiteSpace();
+        connectionString!.ShouldStartWith("Data Source=");
+        // Connection string must point inside the sandboxed home (not the user's real ~/.botnexus).
+        connectionString.ShouldContain("sessions.sqlite");
+        var expectedSqlitePath = Path.Combine(configHome, "sessions.sqlite");
+        connectionString.ShouldContain(
+            expectedSqlitePath,
+            customMessage: $"sessionStore.connectionString must point at the sandboxed home. Got: {connectionString}");
+
+        // cron block
+        root.TryGetProperty("cron", out var cron).ShouldBeTrue("config.json missing 'cron'.");
+        cron.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+        cron.GetProperty("tickIntervalSeconds").GetInt32().ShouldBe(60);
+
+        // agents block + defaults + seeded assistant
+        root.TryGetProperty("agents", out var agents).ShouldBeTrue("config.json missing 'agents'.");
+
+        agents.TryGetProperty("defaults", out var defaults).ShouldBeTrue("agents.defaults missing.");
+        var memory = defaults.GetProperty("memory");
+        memory.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+        memory.GetProperty("indexing").GetString().ShouldBe("auto");
+
+        agents.TryGetProperty("assistant", out var assistant).ShouldBeTrue("agents.assistant missing.");
+        assistant.GetProperty("provider").GetString().ShouldBe("github-copilot");
+        assistant.GetProperty("model").GetString().ShouldBe("gpt-4.1");
+        assistant.GetProperty("enabled").GetBoolean().ShouldBeTrue();
     }
 }

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallAndInitWorkflowTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallAndInitWorkflowTests.cs
@@ -1,0 +1,101 @@
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Test 3: drive the installed CLI through the <c>install</c> and <c>init</c> flow.
+///
+/// Uses a fresh temp directory as a self-contained sandbox:
+///   - <c>&lt;tmp&gt;/source</c>     → target for <c>botnexus install --source</c> (git clones the current repo here)
+///   - <c>&lt;tmp&gt;/.botnexus</c>  → target for <c>botnexus init --target</c>     (config home)
+///
+/// The <c>--repo</c> argument points at the current repository on disk so the test
+/// does not require external network for the git clone step (the CLI itself was
+/// installed from nuget.org by the fixture).
+/// </summary>
+[Collection(CliCollection.Name)]
+public sealed class CliInstallAndInitWorkflowTests : IAsyncLifetime
+{
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromMinutes(5);
+
+    private readonly CliInstallFixture _fixture;
+    private string _sandbox = string.Empty;
+
+    public CliInstallAndInitWorkflowTests(CliInstallFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync()
+    {
+        _sandbox = Path.Combine(Path.GetTempPath(), "botnexus-cli-flow", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_sandbox);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_sandbox))
+                Directory.Delete(_sandbox, recursive: true);
+        }
+        catch
+        {
+            // Cloned .git directories can have read-only files on Windows; best-effort cleanup.
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Cli_Install_ClonesCurrentRepoIntoSandbox()
+    {
+        _fixture.InstallSucceeded.ShouldBeTrue(
+            "CLI install fixture did not complete successfully — see CliInstallationTests for the install failure.");
+
+        var repoRoot = RepoLocator.FindRepoRoot();
+        var sourceDir = Path.Combine(_sandbox, "source");
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"install --source \"{sourceDir}\" --repo \"{repoRoot}\"",
+            timeout: CommandTimeout);
+
+        result.ExitCode.ShouldBe(
+            0,
+            $"botnexus install failed.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+
+        Directory.Exists(sourceDir).ShouldBeTrue(
+            $"Expected source directory at {sourceDir} after install.");
+        Directory.Exists(Path.Combine(sourceDir, ".git")).ShouldBeTrue(
+            "Cloned source should contain a .git directory.");
+        File.Exists(Path.Combine(sourceDir, "BotNexus.slnx")).ShouldBeTrue(
+            "Cloned source should contain BotNexus.slnx (proves the clone is of the current repo).");
+    }
+
+    [Fact]
+    public async Task Cli_Init_CreatesConfigInIsolatedHome()
+    {
+        _fixture.InstallSucceeded.ShouldBeTrue(
+            "CLI install fixture did not complete successfully — see CliInstallationTests for the install failure.");
+
+        var configHome = Path.Combine(_sandbox, ".botnexus");
+
+        // Explicit --target is the contract this test pins; BOTNEXUS_HOME is also cleared
+        // to make sure nothing leaks from the test host into the CLI invocation.
+        var env = new Dictionary<string, string?>
+        {
+            ["BOTNEXUS_HOME"] = null
+        };
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"init --target \"{configHome}\"",
+            environment: env,
+            timeout: CommandTimeout);
+
+        result.ExitCode.ShouldBe(
+            0,
+            $"botnexus init failed.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+
+        Directory.Exists(configHome).ShouldBeTrue(
+            $"Expected init to create config home at {configHome}.");
+        File.Exists(Path.Combine(configHome, "config.json")).ShouldBeTrue(
+            "Expected init to create config.json in the target home.");
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallFixture.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallFixture.cs
@@ -1,0 +1,72 @@
+using System.Runtime.InteropServices;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// xUnit collection fixture that installs the BotNexus.Cli .NET global tool from nuget.org
+/// into an isolated --tool-path so tests can exercise the published binary without
+/// polluting the host's global tool catalogue.
+///
+/// The install runs once per test run. Failures are captured (not thrown) so that
+/// <see cref="CliInstallationTests"/> can assert against them explicitly while still
+/// allowing dependent tests to skip gracefully.
+/// </summary>
+public sealed class CliInstallFixture : IAsyncLifetime
+{
+    private const string PackageId = "BotNexus.Cli";
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(3);
+
+    public string ToolPath { get; private set; } = string.Empty;
+    public string CliExecutablePath { get; private set; } = string.Empty;
+    public bool InstallSucceeded { get; private set; }
+    public int InstallExitCode { get; private set; } = -1;
+    public string InstallOutput { get; private set; } = string.Empty;
+    public string? InstallError { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        // Each test run gets a fresh tool-path so re-installs don't see "already installed" errors.
+        ToolPath = Path.Combine(Path.GetTempPath(), "botnexus-integration-cli", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(ToolPath);
+
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "botnexus.exe" : "botnexus";
+        CliExecutablePath = Path.Combine(ToolPath, exeName);
+
+        try
+        {
+            var result = await ProcessRunner.RunAsync(
+                "dotnet",
+                $"tool install --tool-path \"{ToolPath}\" {PackageId}",
+                timeout: InstallTimeout);
+
+            InstallExitCode = result.ExitCode;
+            InstallOutput = result.Combined;
+            InstallSucceeded = result.ExitCode == 0 && File.Exists(CliExecutablePath);
+        }
+        catch (Exception ex)
+        {
+            InstallError = ex.ToString();
+            InstallSucceeded = false;
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(ToolPath))
+                Directory.Delete(ToolPath, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; locked files on Windows are not worth failing the suite over.
+        }
+        return Task.CompletedTask;
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class CliCollection : ICollectionFixture<CliInstallFixture>
+{
+    public const string Name = "CLI install collection";
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallationTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallationTests.cs
@@ -1,0 +1,32 @@
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Test 1 (also the setup test for the project): verify that <c>BotNexus.Cli</c> is
+/// available on nuget.org and can be installed as a .NET global tool. The actual
+/// install is performed once by <see cref="CliInstallFixture"/>; this class asserts
+/// the result so failures surface as a normal test failure rather than a fixture crash.
+/// </summary>
+[Collection(CliCollection.Name)]
+public sealed class CliInstallationTests
+{
+    private readonly CliInstallFixture _fixture;
+
+    public CliInstallationTests(CliInstallFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void CliPackage_IsInstallableFromNuget()
+    {
+        _fixture.InstallError.ShouldBeNull(
+            $"dotnet tool install threw before exiting:\n{_fixture.InstallError}");
+
+        _fixture.InstallExitCode.ShouldBe(
+            0,
+            $"dotnet tool install BotNexus.Cli failed.\nExit: {_fixture.InstallExitCode}\nOutput:\n{_fixture.InstallOutput}");
+
+        File.Exists(_fixture.CliExecutablePath).ShouldBeTrue(
+            $"Expected CLI executable at {_fixture.CliExecutablePath} after install. " +
+            $"Install output:\n{_fixture.InstallOutput}");
+
+        _fixture.InstallSucceeded.ShouldBeTrue();
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/ProcessRunner.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/ProcessRunner.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+internal sealed record ProcessResult(int ExitCode, string StdOut, string StdErr)
+{
+    public string Combined => StdOut + StdErr;
+}
+
+internal static class ProcessRunner
+{
+    public static async Task<ProcessResult> RunAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string?>? environment = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        if (workingDirectory is not null)
+            psi.WorkingDirectory = workingDirectory;
+        if (environment is not null)
+        {
+            foreach (var kvp in environment)
+                psi.Environment[kvp.Key] = kvp.Value;
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+
+        var stdOut = new StringBuilder();
+        var stdErr = new StringBuilder();
+
+        var outTask = ReadAllAsync(process.StandardOutput, stdOut, cancellationToken);
+        var errTask = ReadAllAsync(process.StandardError, stdErr, cancellationToken);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (timeout is { } t)
+            cts.CancelAfter(t);
+
+        try
+        {
+            await process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new TimeoutException(
+                $"Process '{fileName} {arguments}' did not exit within {timeout}. " +
+                $"Partial stdout: {stdOut}\nPartial stderr: {stdErr}");
+        }
+
+        await Task.WhenAll(outTask, errTask);
+        return new ProcessResult(process.ExitCode, stdOut.ToString(), stdErr.ToString());
+    }
+
+    private static async Task ReadAllAsync(StreamReader reader, StringBuilder sink, CancellationToken cancellationToken)
+    {
+        var buffer = new char[4096];
+        int read;
+        while ((read = await reader.ReadAsync(buffer, cancellationToken)) > 0)
+            sink.Append(buffer, 0, read);
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/RepoLocator.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/RepoLocator.cs
@@ -1,0 +1,28 @@
+using System.IO;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Locates the repository root by walking up from the test assembly's base directory
+/// until a marker file (.git or BotNexus.slnx) is found. Used by integration tests
+/// that need to clone or build from the in-tree repo.
+/// </summary>
+internal static class RepoLocator
+{
+    public static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git")) ||
+                File.Exists(Path.Combine(dir.FullName, "BotNexus.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (no .git or BotNexus.slnx marker) walking up from {AppContext.BaseDirectory}.");
+    }
+}


### PR DESCRIPTION
Closes #583

Adds `tests/integration/BotNexus.Integration.Cli.Tests` — a new integration test project that exercises the published `BotNexus.Cli` .NET global tool end-to-end.

## Tests

1. **`CliInstallationTests` (setup test):** Verifies `BotNexus.Cli` is published on nuget.org and installable. A shared `CliInstallFixture` (xUnit `ICollectionFixture`) runs `dotnet tool install --tool-path <tmp> BotNexus.Cli` once per test run; the test asserts the install succeeded.
2. **`CliHelpTests`:** Runs `botnexus --help` and asserts the output advertises `init`, `install`, `validate`, `agent`.
3. **`CliInstallAndInitWorkflowTests`:** Creates a per-test temp sandbox, runs `botnexus install --source <tmp>/source --repo <current repo>` to clone the in-tree repo, then `botnexus init --target <tmp>/.botnexus` to seed an isolated config home — verifying the on-disk artefacts in each case.

## Notes

- No `ProjectReference` to `BotNexus.Cli` — the project intentionally validates the shipped NuGet package, not the local build.
- All temp paths use `Path.GetTempPath()` + `Path.Combine` for cross-platform portability.
- `BOTNEXUS_HOME` is explicitly cleared in the init test so the host environment cannot leak in.

## Validation

- `dotnet build BotNexus.slnx` → 0 warnings, 0 errors
- `dotnet test tests/integration/BotNexus.Integration.Cli.Tests` → 4/4 passed (~11s)