### PR TITLE
refactor(gateway): migrate router + host to typed InboundMessage routing hints (#582)

### DIFF
--- a/src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs
@@ -39,12 +39,11 @@ public sealed record InboundMessageContext(
     /// / <see cref="RequestedSessionId"/> properties on the context.
     /// </summary>
     /// <remarks>
-    /// This is the only legitimate site that reads <see cref="InboundMessage.TargetAgentId"/>,
-    /// <see cref="InboundMessage.SessionId"/>, and <see cref="InboundMessage.ConversationId"/>
-    /// — the architecture fence in <c>InboundMessageOverrideFenceTests</c> bans every other
-    /// consumer from re-parsing those raw fields. Null / empty / whitespace inputs are
-    /// gracefully normalised to a <c>null</c> override (the Vogen factories would otherwise
-    /// throw on whitespace and crash the inbound pipeline).
+    /// Delegates the legacy-field lift to <see cref="InboundMessageRoutingHints.FromMessage"/>
+    /// — that helper is the architecture-fence-sanctioned single reader of the legacy
+    /// override fields (see <c>InboundMessageOverrideFenceTests</c>). Null / empty /
+    /// whitespace inputs are gracefully normalised to a <c>null</c> override (the Vogen
+    /// factories would otherwise throw on whitespace and crash the inbound pipeline).
     /// </remarks>
     /// <param name="agentId">Agent selected for the message.</param>
     /// <param name="message">Inbound transport payload.</param>
@@ -57,21 +56,13 @@ public sealed record InboundMessageContext(
             message.ChannelAddress,
             message.SenderId,
             message.BindingId);
+        var hints = InboundMessageRoutingHints.FromMessage(message);
         return new InboundMessageContext(
             agentId,
             message,
             source,
-            RequestedConversationId: TryLiftConversationId(message.ConversationId),
-            RequestedAgentId: TryLiftAgentId(message.TargetAgentId),
-            RequestedSessionId: TryLiftSessionId(message.SessionId));
+            RequestedConversationId: hints.RequestedConversationId,
+            RequestedAgentId: hints.RequestedAgentId,
+            RequestedSessionId: hints.RequestedSessionId);
     }
-
-    private static ConversationId? TryLiftConversationId(string? raw)
-        => string.IsNullOrWhiteSpace(raw) ? null : ConversationId.From(raw);
-
-    private static AgentId? TryLiftAgentId(string? raw)
-        => string.IsNullOrWhiteSpace(raw) ? null : AgentId.From(raw);
-
-    private static SessionId? TryLiftSessionId(string? raw)
-        => string.IsNullOrWhiteSpace(raw) ? null : SessionId.From(raw);
 }

--- a/src/gateway/BotNexus.Gateway.Dispatching/InboundMessageRoutingHints.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/InboundMessageRoutingHints.cs
@@ -1,0 +1,90 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Dispatching;
+
+/// <summary>
+/// Strongly-typed projection of the routing-hint subset of an inbound transport
+/// payload — the three optional override fields a channel may carry to tell the
+/// gateway "the client wants to talk to this agent, in this session, in this
+/// conversation". Constructed once per inbound message via
+/// <see cref="FromMessage(InboundMessage)"/>; consumers downstream of routing read
+/// the Vogen-typed properties instead of re-parsing the legacy
+/// <c>string?</c> fields on <see cref="InboundMessage"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is the sanctioned single reader of the legacy
+/// <see cref="InboundMessage.TargetAgentId"/>,
+/// <see cref="InboundMessage.SessionId"/>, and
+/// <see cref="InboundMessage.ConversationId"/> fields. The architecture fence in
+/// <c>InboundMessageOverrideFenceTests</c> allowlists exactly this file (plus the
+/// three out-of-scope <c>OutboundMessage</c> adapter readers); every other
+/// production consumer routes through these typed hints. See umbrella
+/// <c>#579</c> / Phase 6 / F-10 — sub-PR 6.1 (<c>#580</c>) added typed properties
+/// to <see cref="InboundMessageContext"/>; sub-PR 6.2 (<c>#582</c>) introduced this
+/// helper so the remaining reader sites (<c>DefaultMessageRouter</c>,
+/// <c>GatewayHost</c>) could migrate without depending on a fully-constructed
+/// context (the router runs before <see cref="InboundMessageContext.AgentId"/> is
+/// known). Sub-PR 6.3 deletes the legacy <see cref="InboundMessage"/> fields and
+/// this type becomes the typed factory at the channel-adapter boundary.
+/// </para>
+/// <para>
+/// The lift is intentionally lenient: <c>null</c>, empty, and whitespace inputs
+/// normalise to a <c>null</c> hint. Channel adapters have historically populated
+/// the legacy fields with empty strings, and the Vogen <c>From()</c> factories
+/// reject whitespace — the lift must absorb that mismatch so the inbound pipeline
+/// does not crash on adapter-supplied empties.
+/// </para>
+/// </remarks>
+/// <param name="RequestedAgentId">
+/// Optional explicit target agent supplied by the transport. Equivalent to the
+/// pre-#580 <see cref="InboundMessage.TargetAgentId"/> string field.
+/// </param>
+/// <param name="RequestedSessionId">
+/// Optional explicit session resume target. Equivalent to the pre-#580
+/// <see cref="InboundMessage.SessionId"/> string field.
+/// </param>
+/// <param name="RequestedConversationId">
+/// Optional explicit conversation target supplied by the transport. Equivalent to
+/// the pre-#580 <see cref="InboundMessage.ConversationId"/> string field.
+/// </param>
+public sealed record InboundMessageRoutingHints(
+    AgentId? RequestedAgentId,
+    SessionId? RequestedSessionId,
+    ConversationId? RequestedConversationId)
+{
+    /// <summary>
+    /// An "all-empty" hint payload. Useful as a default for code paths where no
+    /// routing hint is meaningful (e.g. internal wake messages that already know
+    /// their target session).
+    /// </summary>
+    public static InboundMessageRoutingHints Empty { get; } = new(null, null, null);
+
+    /// <summary>
+    /// Lifts the three legacy routing-hint fields from an inbound transport
+    /// payload into their Vogen-typed equivalents. Empty and whitespace inputs
+    /// normalise to <c>null</c> rather than throwing, because adapters
+    /// historically populate the legacy fields with empty strings.
+    /// </summary>
+    /// <param name="message">Inbound transport payload.</param>
+    /// <returns>Typed routing hints; never <c>null</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+    public static InboundMessageRoutingHints FromMessage(InboundMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        return new InboundMessageRoutingHints(
+            TryLiftAgentId(message.TargetAgentId),
+            TryLiftSessionId(message.SessionId),
+            TryLiftConversationId(message.ConversationId));
+    }
+
+    private static ConversationId? TryLiftConversationId(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : ConversationId.From(raw);
+
+    private static AgentId? TryLiftAgentId(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : AgentId.From(raw);
+
+    private static SessionId? TryLiftSessionId(string? raw)
+        => string.IsNullOrWhiteSpace(raw) ? null : SessionId.From(raw);
+}

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -232,20 +232,28 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
 
     private async Task ProcessInboundMessageAsync(InboundMessage message, CancellationToken cancellationToken)
     {
+        // Sub-PR 6.2 (#582): lift the legacy string-typed routing overrides into Vogen-typed
+        // hints once at entry; every downstream telemetry tag / activity payload / fall-back
+        // reads from the typed hints. This matches the pattern established for the conversation
+        // dispatcher in 6.1 and is the structural prerequisite for sub-PR 6.3 deleting the
+        // legacy fields from InboundMessage.
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+        var requestedSessionIdValue = hints.RequestedSessionId?.Value;
+
         using var activity = GatewayDiagnostics.Source.StartActivity("gateway.dispatch", ActivityKind.Server);
         activity?.SetTag("botnexus.channel.type", message.ChannelType);
-        activity?.SetTag("botnexus.session.id", message.SessionId);
+        activity?.SetTag("botnexus.session.id", requestedSessionIdValue);
         activity?.SetTag("botnexus.correlation.id", System.Diagnostics.Activity.Current?.TraceId.ToString());
         GatewayTelemetry.MessagesProcessed.Add(1,
             new KeyValuePair<string, object?>("botnexus.channel.type", message.ChannelType),
-            new KeyValuePair<string, object?>("botnexus.session.id", message.SessionId));
+            new KeyValuePair<string, object?>("botnexus.session.id", requestedSessionIdValue));
 
         await _activity.PublishAsync(new GatewayActivity
         {
             Type = GatewayActivityType.MessageReceived,
             ChannelType = message.ChannelType,
             Message = message.Content,
-            SessionId = message.SessionId
+            SessionId = requestedSessionIdValue
         }, cancellationToken);
 
         var targetAgents = await _router.ResolveAsync(message, cancellationToken);
@@ -257,7 +265,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
 
         foreach (var agentId in targetAgents)
         {
-            var sessionId = message.SessionId ?? $"{message.ChannelType}:{message.ChannelAddress}:{agentId}";
+            var sessionId = requestedSessionIdValue ?? $"{message.ChannelType}:{message.ChannelAddress}:{agentId}";
             using var agentActivity = GatewayDiagnostics.Source.StartActivity("gateway.agent_process", ActivityKind.Internal);
             agentActivity?.SetTag("botnexus.agent.id", agentId);
             agentActivity?.SetTag("botnexus.session.id", sessionId);
@@ -297,9 +305,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 // Internal sub-agent wake-ups target an already-known parent session.
                 // Routing them through conversation resolution creates synthetic internal
                 // conversations and can misroute the user-visible response stream.
-                var internalTargetSessionId = !string.IsNullOrWhiteSpace(message.SessionId)
-                    ? message.SessionId
-                    : message.ChannelAddress.Value;
+                var internalTargetSessionId = requestedSessionIdValue
+                    ?? message.ChannelAddress.Value;
 
                 if (!string.IsNullOrWhiteSpace(internalTargetSessionId))
                     sessionId = internalTargetSessionId;
@@ -324,7 +331,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     AgentId.From(agentId),
                     message.ChannelType,
                     message.ChannelAddress,
-                    conversationId: message.ConversationId,
+                    conversationId: hints.RequestedConversationId?.Value,
                     cancellationToken,
                     initiator: message.Sender);
                 sessionId = routingResult.SessionId.Value;
@@ -918,9 +925,16 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     }
 
     private static string GetQueueKey(InboundMessage message)
-        => !string.IsNullOrWhiteSpace(message.SessionId)
-            ? message.SessionId
+    {
+        // Sub-PR 6.2 (#582): typed routing-hint read replaces direct legacy field read.
+        // Whitespace SessionId values now collapse to channel-key fallback (was: kept the
+        // whitespace string as the queue key, which would have prevented two real sessions
+        // sharing whitespace ids — vanishingly unlikely but the new shape is more honest).
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+        return hints.RequestedSessionId is { } sid
+            ? sid.Value
             : $"{message.ChannelType}:{message.ChannelAddress}";
+    }
 
     private async Task HandleUserInputRequiredAsync(
         InboundMessage message,
@@ -1020,24 +1034,33 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         if (ResolveChannelAdapter(message.ChannelType) is not { } channel)
             return;
 
+        // Sub-PR 6.2 (#582): forward typed session-id hint into the OutboundMessage envelope
+        // (OutboundMessage.SessionId remains a string property — it is the wire shape and
+        // is out of scope for the InboundMessage fence).
+        var hints = InboundMessageRoutingHints.FromMessage(message);
         await channel.SendAsync(new OutboundMessage
         {
             ChannelType = message.ChannelType,
             ChannelAddress = message.ChannelAddress,
             Content = BusyMessage,
-            SessionId = message.SessionId
+            SessionId = hints.RequestedSessionId?.Value
         }, cancellationToken);
     }
 
     private async Task CleanupQueueIfClosedSessionAsync(string queueKey, InboundMessage message, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(message.SessionId))
+        // Sub-PR 6.2 (#582): lift hints inline; the typed RequestedSessionId carries the
+        // pre-normalised Vogen SessionId, so we can pass it straight into _sessions.GetAsync
+        // without re-parsing through SessionId.From (which the prior code did on the raw
+        // string). Whitespace inputs collapse to null hints and short-circuit the cleanup.
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+        if (hints.RequestedSessionId is not { } requestedSessionId)
             return;
 
         using var sessionActivity = GatewayDiagnostics.Source.StartActivity("session.get", ActivityKind.Internal);
-        sessionActivity?.SetTag("botnexus.session.id", message.SessionId);
+        sessionActivity?.SetTag("botnexus.session.id", requestedSessionId.Value);
 
-        var session = await _sessions.GetAsync(SessionId.From(message.SessionId), cancellationToken);
+        var session = await _sessions.GetAsync(requestedSessionId, cancellationToken);
         if (session?.Status is not SessionStatus.Sealed)
             return;
 

--- a/src/gateway/BotNexus.Gateway/Routing/DefaultMessageRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Routing/DefaultMessageRouter.cs
@@ -6,6 +6,7 @@ using BotNexus.Gateway.Abstractions.Routing;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Diagnostics;
+using BotNexus.Gateway.Dispatching;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -47,23 +48,28 @@ public sealed class DefaultMessageRouter : IMessageRouter
             return targets;
         }
 
+        // Sub-PR 6.2 (#582): consume Vogen-typed routing hints instead of reading the legacy
+        // string fields directly. InboundMessageRoutingHints.FromMessage is the sanctioned
+        // single reader (architecture fence allowlist); whitespace-or-empty inputs normalise
+        // to null hints, replacing the prior IsNullOrEmpty branches in this method.
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
         // Priority 1: Explicit target
-        if (!string.IsNullOrEmpty(message.TargetAgentId))
+        if (hints.RequestedAgentId is { } targetAgentId)
         {
-            var targetAgentId = AgentId.From(message.TargetAgentId);
             if (_registry.Contains(targetAgentId))
                 return Complete([targetAgentId.Value]);
 
-            _logger.LogWarning("Explicit target agent '{AgentId}' not found", message.TargetAgentId);
+            _logger.LogWarning("Explicit target agent '{AgentId}' not found", targetAgentId.Value);
             return Complete([]);
         }
 
         // Priority 2: Session-bound agent
-        if (!string.IsNullOrEmpty(message.SessionId))
+        if (hints.RequestedSessionId is { } requestedSessionId)
         {
             using var sessionActivity = GatewayDiagnostics.Source.StartActivity("session.get", ActivityKind.Internal);
-            sessionActivity?.SetTag("botnexus.session.id", message.SessionId);
-            var session = await _sessions.GetAsync(SessionId.From(message.SessionId), cancellationToken);
+            sessionActivity?.SetTag("botnexus.session.id", requestedSessionId.Value);
+            var session = await _sessions.GetAsync(requestedSessionId, cancellationToken);
             if (session is not null && _registry.Contains(session.AgentId))
                 return Complete([session.AgentId.Value]);
         }

--- a/tests/architecture/BotNexus.Architecture.Tests/InboundMessageOverrideFenceTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/InboundMessageOverrideFenceTests.cs
@@ -8,26 +8,29 @@ namespace BotNexus.Architecture.Tests;
 /// Architecture fitness function enforcing the <c>#580</c> sub-PR 6.1 contract: production
 /// source code must not read the legacy weakly-typed <c>InboundMessage.{TargetAgentId, SessionId,
 /// ConversationId}</c> override fields. The typed equivalents on <see langword="InboundMessageContext"/>
-/// (<c>RequestedAgentId</c>, <c>RequestedSessionId</c>, <c>RequestedConversationId</c>) carry the
-/// same routing intent in Vogen-typed shape and are the only sanctioned readers.
+/// (<c>RequestedAgentId</c>, <c>RequestedSessionId</c>, <c>RequestedConversationId</c>) and on the
+/// new <see langword="InboundMessageRoutingHints"/> projection carry the same routing intent in
+/// Vogen-typed shape and are the only sanctioned readers.
 /// </summary>
 /// <remarks>
 /// <para>
 /// The legacy fields remain on <see langword="InboundMessage"/> for one umbrella-issue (#579)
 /// cycle so adapter writers (Telegram, SignalR, ServiceBus, internal channel adapter) can
 /// continue populating them while the migration is in flight. Sub-PR 6.2 (issue
-/// <c>#582</c>) migrates the deferred reader sites listed in the allowlist; sub-PR 6.3 deletes
-/// the legacy fields entirely and this fence becomes trivially vacuous.
+/// <c>#582</c>) introduced <c>InboundMessageRoutingHints</c> as the sanctioned single reader and
+/// migrated <see langword="DefaultMessageRouter"/> and <see langword="GatewayHost"/> through it;
+/// at that point <see langword="InboundMessageContext.FromInboundMessage"/> stopped reading the
+/// legacy fields directly (it delegates to the hints helper) and dropped off the allowlist.
+/// Sub-PR 6.3 deletes the legacy fields entirely and this fence becomes trivially vacuous.
 /// </para>
 /// <para>
 /// The fence bans the pattern <c>message.&lt;FieldName&gt;</c> outside an allowlist. The
-/// allowlist has two categories: (1) the shim itself
-/// (<c>InboundMessageContext.FromInboundMessage</c>) which exists precisely to lift the legacy
-/// fields into the typed context once at the channel boundary, and (2) the sites deferred to
-/// sub-PR 6.2 because they need broader refactoring (pre-routing reads that don't yet have a
-/// typed context, or scattered reads inside <see langword="GatewayHost"/>'s queue/cleanup
-/// pipeline). Each deferred allowlist entry must cite the follow-up issue so the migration
-/// is auditable.
+/// allowlist has two categories: (1) the single sanctioned reader
+/// (<c>InboundMessageRoutingHints.FromMessage</c>) which exists precisely to lift the legacy
+/// fields into typed routing hints once at the routing boundary, and (2) the
+/// <c>OutboundMessage</c> adapter readers that share property names with <c>InboundMessage</c>
+/// but operate on a distinct type and a different routing axis. After sub-PR 6.2 the allowlist
+/// shrunk from 6 entries to 4.
 /// </para>
 /// </remarks>
 public sealed class InboundMessageOverrideFenceTests
@@ -38,25 +41,13 @@ public sealed class InboundMessageOverrideFenceTests
     /// </summary>
     private static readonly IReadOnlyDictionary<string, string> s_allowlist = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
-        // The lift-shim itself: the WHOLE POINT of FromInboundMessage is to read these three
-        // fields ONCE at the channel boundary and project them into typed RequestedAgentId /
-        // RequestedSessionId / RequestedConversationId on InboundMessageContext.
-        ["src/gateway/BotNexus.Gateway.Dispatching/InboundMessageContext.cs"] = "Lift-shim — the sanctioned single reader that projects legacy override fields into the typed context.",
-
-        // DEFERRED to sub-PR 6.2 (#582): pre-routing reader. DefaultMessageRouter.ResolveAsync
-        // receives a raw InboundMessage BEFORE the agent has been resolved, so it cannot yet
-        // construct an InboundMessageContext (which requires AgentId). Migrating this requires
-        // either changing IMessageRouter's shape or constructing the context partially earlier
-        // in the pipeline — both larger than 6.1.
-        ["src/gateway/BotNexus.Gateway/Routing/DefaultMessageRouter.cs"] = "DEFERRED to #582 (sub-PR 6.2): pre-routing reader; runs before AgentId is known.",
-
-        // DEFERRED to sub-PR 6.2 (#582): GatewayHost has ~12 sites of message.SessionId
-        // / message.ConversationId reads scattered across ProcessInboundMessageAsync,
-        // GetQueueKey, SendBusyAsync, and CleanupQueueIfClosedSessionAsync. Most call sites
-        // don't have an InboundMessageContext in scope; migration requires either threading
-        // context through 4+ private methods or constructing context once early. Either is a
-        // separate change.
-        ["src/gateway/BotNexus.Gateway/GatewayHost.cs"] = "DEFERRED to #582 (sub-PR 6.2): scattered legacy reads in queue/cleanup pipeline; needs broader refactor.",
+        // The sanctioned single reader (#582 sub-PR 6.2): InboundMessageRoutingHints.FromMessage
+        // is the WHOLE POINT — it reads these three fields ONCE and projects them into typed
+        // Vogen-shaped RequestedAgentId / RequestedSessionId / RequestedConversationId. Every
+        // production consumer (DefaultMessageRouter, GatewayHost, InboundMessageContext) routes
+        // through this helper instead of touching the legacy fields directly. Sub-PR 6.3 deletes
+        // the legacy fields and this entry becomes vacuous (no fields to read).
+        ["src/gateway/BotNexus.Gateway.Dispatching/InboundMessageRoutingHints.cs"] = "Sanctioned single reader — projects legacy override fields into typed routing hints at the routing boundary.",
 
         // OUT OF SCOPE for Phase 6 / F-10 entirely: these three adapters read message.SessionId
         // on OutboundMessage (NOT InboundMessage). The legacy override fields targeted by #580
@@ -95,13 +86,16 @@ public sealed class InboundMessageOverrideFenceTests
 
         violations.ShouldBeEmpty(
             "Reads of the legacy `InboundMessage.{TargetAgentId,SessionId,ConversationId}` " +
-            "fields were replaced with typed `InboundMessageContext.{RequestedAgentId," +
-            "RequestedSessionId,RequestedConversationId}` in #580 (Phase 6 / F-10 sub-PR 6.1). " +
-            "If you must add a new reader, either:\n" +
-            "  (a) consume the typed properties on `InboundMessageContext` instead (preferred), or\n" +
+            "fields were replaced with the typed `InboundMessageRoutingHints` projection " +
+            "(introduced in #580 sub-PR 6.1; expanded in #582 sub-PR 6.2 to cover the router " +
+            "and gateway-host call sites). If you must add a new reader, either:\n" +
+            "  (a) consume the typed properties via " +
+            "`InboundMessageRoutingHints.FromMessage(message).Requested{Agent,Session,Conversation}Id` " +
+            "(or `InboundMessageContext.FromInboundMessage(...)` if you already have an AgentId), or\n" +
             "  (b) add an explicit allowlist entry with an issue link explaining why the typed " +
             "path is not yet workable.\n" +
-            "Adding without an allowlist entry will fail CI.\n" +
+            "Adding without an allowlist entry will fail CI. Sub-PR 6.3 will delete the legacy " +
+            "fields entirely, at which point this fence becomes vacuous.\n" +
             "Violations:\n  " + string.Join("\n  ", violations));
     }
 
@@ -280,6 +274,46 @@ public sealed class InboundMessageOverrideFenceTests
             "False-positive guard: comment-only mentions of the legacy shape must not trip " +
             "the fence. If this fails, the comment stripper has regressed and the fence will " +
             "block PRs that legitimately document the migration history.");
+    }
+
+    [Fact]
+    public void Fence_KnownLimitation_AliasedReceiverEscapes()
+    {
+        // Bug-hunt critique fold-in (#582 sub-PR 6.2): the regex-based fence is anchored on
+        // the literal `message` identifier so it CANNOT detect a deliberate alias such as
+        // `var m = message; var sid = m.SessionId;`. Detecting alias chains requires symbol
+        // tracking (Roslyn-semantic analysis), which is out of scope for the transitional
+        // fence. The mitigation is sub-PR 6.3 (next PR): once the legacy fields are deleted
+        // from InboundMessage, the C# compiler enforces the contract directly and any alias
+        // bypass becomes a hard compile error. This pin documents the known limitation so a
+        // future contributor who tries to "fix" the regex understands the trade-off.
+        const string syntheticAlias = """
+            var m = message;
+            var sid = m.SessionId;
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticAlias)).ShouldBeFalse(
+            "Known-limitation pin: the regex fence does NOT detect aliased reads. This is " +
+            "deliberate — symbol tracking is out of scope for a transitional fence whose " +
+            "mitigation is sub-PR 6.3's field deletion. If this assertion starts FAILING " +
+            "because the regex was extended to catch aliases, that's an improvement: update " +
+            "this test to ShouldBeTrue and add a vacuity guard for the new shape.");
+    }
+
+    [Fact]
+    public void Fence_KnownLimitation_CastReceiverEscapes()
+    {
+        // Bug-hunt critique fold-in (#582 sub-PR 6.2): companion to the aliased-receiver
+        // pin above. A cast-then-read shape `((InboundMessage)obj).SessionId` slips past
+        // the receiver-anchored regex. Same mitigation: sub-PR 6.3's field deletion makes
+        // any such read a compile error. Pinned as a known limitation, not a defect.
+        const string syntheticCast = """
+            var sid = ((InboundMessage)obj).SessionId;
+            """;
+        ContainsLegacyOverrideRead(StripComments(syntheticCast)).ShouldBeFalse(
+            "Known-limitation pin: the regex fence does NOT detect cast-then-read shapes. " +
+            "Same trade-off as the aliased-receiver limitation; sub-PR 6.3's field deletion " +
+            "is the structural mitigation. If this starts FAILING because the regex was " +
+            "extended, update this test to ShouldBeTrue.");
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/DefaultMessageRouterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DefaultMessageRouterTests.cs
@@ -69,6 +69,44 @@ public sealed class DefaultMessageRouterTests
         route.ShouldBeEmpty();
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public async Task ResolveAsync_WithEmptyOrWhitespaceTargetAgentId_FallsThroughToDefault_DoesNotThrow(string blank)
+    {
+        // Sub-PR 6.2 normalisation pin: the typed routing-hint lift treats null / empty /
+        // whitespace as "no hint" rather than constructing a Vogen AgentId (which would
+        // throw on whitespace). Pre-PR the router used IsNullOrEmpty + AgentId.From, so a
+        // whitespace-only TargetAgentId would crash the route. Channel adapters historically
+        // pass empty strings on "no override"; this fall-through is the intended shape.
+        var registry = CreateRegistryWithAgents("agent-default");
+        var router = CreateRouter(registry, new InMemorySessionStore(), "agent-default");
+
+        var route = await router.ResolveAsync(CreateMessage(targetAgentId: blank));
+
+        route.ShouldHaveSingleItem().ShouldBe("agent-default");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public async Task ResolveAsync_WithEmptyOrWhitespaceSessionId_FallsThroughToDefault_DoesNotThrow(string blank)
+    {
+        // Sub-PR 6.2 normalisation pin: same shape as the TargetAgentId pin above, applied
+        // to the session-binding priority level. Whitespace-only SessionId must not throw
+        // and must not be looked up as a real session id; it falls through to the default
+        // agent. Defends against a regression that reverts the lift to IsNullOrEmpty +
+        // SessionId.From (which would throw on whitespace).
+        var registry = CreateRegistryWithAgents("agent-default");
+        var router = CreateRouter(registry, new InMemorySessionStore(), "agent-default");
+
+        var route = await router.ResolveAsync(CreateMessage(sessionId: blank));
+
+        route.ShouldHaveSingleItem().ShouldBe("agent-default");
+    }
+
     private static DefaultAgentRegistry CreateRegistryWithAgents(params string[] agentIds)
     {
         var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);

--- a/tests/gateway/BotNexus.Gateway.Tests/Dispatching/InboundMessageRoutingHintsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Dispatching/InboundMessageRoutingHintsTests.cs
@@ -1,0 +1,155 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Dispatching;
+
+namespace BotNexus.Gateway.Tests.Dispatching;
+
+/// <summary>
+/// Pins the strongly-typed routing-hint contract on
+/// <see cref="InboundMessageRoutingHints"/> introduced by F-10 sub-PR 6.2 (#582).
+/// This helper is the architecture-fence-sanctioned single reader of the legacy
+/// <see cref="InboundMessage.TargetAgentId"/>,
+/// <see cref="InboundMessage.SessionId"/>, and
+/// <see cref="InboundMessage.ConversationId"/> fields — every other production
+/// consumer (router, gateway host, conversation dispatcher) reads the typed
+/// projections produced here. These pins lock the lift behaviour at the new
+/// reader site so the sub-PR 6.3 legacy-field deletion lands on a stable shape.
+/// </summary>
+public sealed class InboundMessageRoutingHintsTests
+{
+    [Fact]
+    public void FromMessage_WithAllThreeFieldsSet_LiftsAllToTypedHints()
+    {
+        var message = CreateMessage(
+            targetAgentId: "agent-a",
+            sessionId: "session-42",
+            conversationId: "c_abc123");
+
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
+        hints.RequestedAgentId.ShouldBe(AgentId.From("agent-a"));
+        hints.RequestedSessionId.ShouldBe(SessionId.From("session-42"));
+        hints.RequestedConversationId.ShouldBe(ConversationId.From("c_abc123"));
+    }
+
+    [Fact]
+    public void FromMessage_WithAllFieldsNull_ReturnsAllNullHints()
+    {
+        var message = CreateMessage(targetAgentId: null, sessionId: null, conversationId: null);
+
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
+        hints.RequestedAgentId.ShouldBeNull();
+        hints.RequestedSessionId.ShouldBeNull();
+        hints.RequestedConversationId.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\r\n")]
+    public void FromMessage_WithEmptyOrWhitespaceFields_LiftsToNull_DoesNotThrow(string blank)
+    {
+        // Adapter contract: channel adapters have historically populated the legacy
+        // string fields with empty strings on "no override" instead of null. The
+        // Vogen From() factories reject whitespace — this helper MUST absorb the
+        // mismatch silently to keep the inbound pipeline from crashing.
+        var message = CreateMessage(targetAgentId: blank, sessionId: blank, conversationId: blank);
+
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
+        hints.RequestedAgentId.ShouldBeNull();
+        hints.RequestedSessionId.ShouldBeNull();
+        hints.RequestedConversationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromMessage_NullMessage_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() => InboundMessageRoutingHints.FromMessage(null!));
+    }
+
+    [Fact]
+    public void FromMessage_WithOnlyTargetAgentIdSet_LiftsOnlyAgentId_LeavesOthersNull()
+    {
+        // Independence pin: catches a regression where TryLift* is rewired to read
+        // the wrong source field. The all-set / all-null pins above wouldn't catch
+        // it; only an "only-X-set" assertion does.
+        var message = CreateMessage(targetAgentId: "only-agent");
+
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
+        hints.RequestedAgentId.ShouldBe(AgentId.From("only-agent"));
+        hints.RequestedSessionId.ShouldBeNull();
+        hints.RequestedConversationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromMessage_WithOnlySessionIdSet_LiftsOnlySessionId_LeavesOthersNull()
+    {
+        var message = CreateMessage(sessionId: "only-session");
+
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
+        hints.RequestedSessionId.ShouldBe(SessionId.From("only-session"));
+        hints.RequestedAgentId.ShouldBeNull();
+        hints.RequestedConversationId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromMessage_WithOnlyConversationIdSet_LiftsOnlyConversationId_LeavesOthersNull()
+    {
+        var message = CreateMessage(conversationId: "only-conv");
+
+        var hints = InboundMessageRoutingHints.FromMessage(message);
+
+        hints.RequestedConversationId.ShouldBe(ConversationId.From("only-conv"));
+        hints.RequestedAgentId.ShouldBeNull();
+        hints.RequestedSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Empty_ReturnsSingletonAllNullInstance()
+    {
+        var first = InboundMessageRoutingHints.Empty;
+        var second = InboundMessageRoutingHints.Empty;
+
+        first.RequestedAgentId.ShouldBeNull();
+        first.RequestedSessionId.ShouldBeNull();
+        first.RequestedConversationId.ShouldBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue(
+            "Empty must be a cached singleton — code paths that fall back to it should not " +
+            "allocate per inbound message.");
+    }
+
+    [Fact]
+    public void DirectConstructor_AcceptsTypedFields_AndPreservesThem()
+    {
+        var hints = new InboundMessageRoutingHints(
+            RequestedAgentId: AgentId.From("agent-x"),
+            RequestedSessionId: SessionId.From("s_x"),
+            RequestedConversationId: ConversationId.From("c_x"));
+
+        hints.RequestedAgentId.ShouldBe(AgentId.From("agent-x"));
+        hints.RequestedSessionId.ShouldBe(SessionId.From("s_x"));
+        hints.RequestedConversationId.ShouldBe(ConversationId.From("c_x"));
+    }
+
+    private static InboundMessage CreateMessage(
+        string? targetAgentId = null,
+        string? sessionId = null,
+        string? conversationId = null)
+        => new()
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("addr-1"),
+            SenderId = "sender-1",
+            Sender = CitizenId.Of(UserId.From("sender-1")),
+            Content = "hello",
+            TargetAgentId = targetAgentId,
+            SessionId = sessionId,
+            ConversationId = conversationId
+        };
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostQueueRoutingPinTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostQueueRoutingPinTests.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// AC #5 pin for sub-PR 6.2 (#582): <see cref="GatewayHost"/>.<c>GetQueueKey</c> must route
+/// by the typed <c>RequestedSessionId</c> when one is present, and fall back to the
+/// <c>&lt;channelType&gt;:&lt;channelAddress&gt;</c> composite when not. This is the
+/// behavioural safety net for sub-PR 6.3, which deletes the legacy
+/// <c>InboundMessage.SessionId</c> string field: after deletion the only path that can
+/// supply a session-id hint is the typed Vogen <see cref="SessionId"/>; if any future
+/// change reverts <c>GetQueueKey</c> to read a string field that no longer exists, the
+/// build will break — but if some intermediate change silently routes everything to the
+/// channel-key fallback (e.g. by reading the wrong field), that's a silent regression
+/// these tests catch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>GetQueueKey</c> is <c>private static</c> on <see cref="GatewayHost"/> so we invoke it
+/// via reflection. That is a deliberate trade-off: the alternative (making the method
+/// internal + <c>InternalsVisibleTo</c>) would expand the public surface of a security-
+/// sensitive type for the sake of a one-off migration pin. The migration is small (sub-PR
+/// 6.3 will likely fold this method into the hint helper anyway) and reflection failure
+/// here surfaces a contract change long before downstream queueing breaks in production.
+/// </para>
+/// </remarks>
+public sealed class GatewayHostQueueRoutingPinTests
+{
+    [Fact]
+    public void GetQueueKey_WithTypedSessionIdHint_UsesSessionIdValue()
+    {
+        var message = CreateMessage(sessionId: "sess-typed-1");
+
+        var key = InvokeGetQueueKey(message);
+
+        key.ShouldBe("sess-typed-1");
+    }
+
+    [Fact]
+    public void GetQueueKey_WithNoSessionIdHint_FallsBackToChannelComposite()
+    {
+        var message = CreateMessage(sessionId: null);
+
+        var key = InvokeGetQueueKey(message);
+
+        key.ShouldBe("web:conv-1");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void GetQueueKey_WithEmptyOrWhitespaceSessionId_FallsBackToChannelComposite(string blank)
+    {
+        // Whitespace SessionId values collapse to "no hint" through the typed routing-hint
+        // projection (InboundMessageRoutingHints normalises empty/whitespace to null) so
+        // they route to the channel-key fallback rather than producing a whitespace-only
+        // queue key (which would have collided unhelpfully with any other whitespace input).
+        var message = CreateMessage(sessionId: blank);
+
+        var key = InvokeGetQueueKey(message);
+
+        key.ShouldBe("web:conv-1");
+    }
+
+    private static string InvokeGetQueueKey(InboundMessage message)
+    {
+        var method = typeof(GatewayHost).GetMethod(
+            "GetQueueKey",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: [typeof(InboundMessage)],
+            modifiers: null);
+        method.ShouldNotBeNull("GatewayHost.GetQueueKey(InboundMessage) must exist as a private static method — if you renamed or moved it, update this pin.");
+        var result = method.Invoke(null, [message]);
+        return result.ShouldBeOfType<string>();
+    }
+
+    private static InboundMessage CreateMessage(string? sessionId)
+        => new()
+        {
+            ChannelType = ChannelKey.From("web"),
+            ChannelAddress = ChannelAddress.From("conv-1"),
+            SenderId = "sender-1",
+            Sender = CitizenId.Of(UserId.From("sender-1")),
+            Content = "hi",
+            SessionId = sessionId
+        };
+}


### PR DESCRIPTION
## Summary

Sub-PR 6.2 of the Phase 6 / F-10 InboundMessage override migration (umbrella #579, following #581 sub-PR 6.1).

Routes `DefaultMessageRouter` and `GatewayHost` through a single sanctioned reader — `InboundMessageRoutingHints` — that projects the legacy weakly-typed `InboundMessage.{TargetAgentId, SessionId, ConversationId}` string fields into Vogen-typed nullable hints, and shrinks the architecture-fence allowlist from 6 → 4 entries.

## Why now

The fence introduced in #580 (sub-PR 6.1) documented two deferred reader sites — `DefaultMessageRouter` (runs BEFORE agent resolution, so it can't yet construct an AgentId-bearing `InboundMessageContext`) and `GatewayHost` (~12 scattered reads across 4 methods whose call sites don't have a context in scope). Both needed broader refactoring than sub-PR 6.1's scope.

Introducing `InboundMessageRoutingHints` (a context-shape-independent projection of the same three fields) closes both reader sites in this PR. Sub-PR 6.3 will delete the legacy fields entirely.

## What changed

**New type:** `InboundMessageRoutingHints` (sealed record in `BotNexus.Gateway.Dispatching`)
- `RequestedAgentId? / RequestedSessionId? / RequestedConversationId?` Vogen-typed nullable hints
- `FromMessage(InboundMessage)` static factory normalises null / empty / whitespace inputs to `null` (instead of letting them through to `Vogen.From()` which would throw on whitespace)
- `Empty` singleton for the no-hints case

**Migrated consumers:**
- `InboundMessageContext.FromInboundMessage` now delegates to the new helper (private `TryLift*` moved into the helper file)
- `DefaultMessageRouter.ResolveAsync` lifts hints once at entry; passes `RequestedSessionId.Value` (typed `SessionId`) directly to `_sessions.GetAsync` — no `SessionId.From` re-parse
- `GatewayHost.ProcessInboundMessageAsync` lifts hints ONCE at entry; reuses across 7+ downstream consumers (telemetry tags, activity publish, sessionId fallback, internal-wake fallback, conversation-router back-compat). `GetQueueKey`, `SendBusyAsync`, `CleanupQueueIfClosedSessionAsync` each lift inline (each receives its own raw `InboundMessage`).

**Fence allowlist (6 → 4):**
- REMOVED: `DefaultMessageRouter.cs`, `GatewayHost.cs`, `InboundMessageContext.cs` (now delegates)
- ADDED: `InboundMessageRoutingHints.cs` as the sanctioned reader
- UNCHANGED: 3 out-of-scope `OutboundMessage` adapter entries

## Tests

| Project | Before | After | Delta |
|---|---|---|---|
| Gateway.Tests | 1910 | 1933 | +23 |
| Architecture.Tests | 99 fence-relevant | 101 fence-relevant | +2 |

**New test files:**
- `InboundMessageRoutingHintsTests` (12 pins) — all-set / all-null lifts, whitespace-normalisation Theory (×3), null-message guard, 3 independence pins, `Empty` singleton, direct ctor
- `GatewayHostQueueRoutingPinTests` (5 pins) — AC #5 behavioural pin for `GetQueueKey`. Typed `RequestedSessionId.Value` when set; `<channelType>:<channelAddress>` fallback when null/whitespace (Theory ×3). Reflection on the private static method; rationale documented inline.

**Extended:**
- `DefaultMessageRouterTests` — 2 Theory pins (×3 InlineData): whitespace `targetAgentId` / `sessionId` fall through to default agent (was: would throw in `Vogen.From()`). Pins the new whitespace-normalisation contract as intentional.
- `InboundMessageOverrideFenceTests` — 2 known-limitation pins (aliased receiver, cast-then-read) document regex bypass shapes the fence does NOT catch. Sub-PR 6.3's field deletion is the structural mitigation.

## Verification

```
dotnet test BotNexus.slnx --nologo --tl:off
```

- Gateway.Tests: **1933 passed**
- Architecture.Tests: **101 passed**
- Full suite: **0 failed, 1 [Skip] (pre-existing #383), 0 warnings, 0 errors** under `TreatWarningsAsErrors`

## Critique sweep (multi-model)

| Agent | Model | Finding |
|---|---|---|
| security-review | gpt-5.5 | No vulnerabilities |
| plan-vs-impl rubber-duck | claude-opus-4.7 | All ACs verified. 3 non-blocking observations. NH-3 (fence violation-message guidance referencing #582 + `InboundMessageRoutingHints.FromMessage`) folded in. |
| bug-hunt | gpt-5.3-codex | One HIGH on regex fence bypass via alias / cast. Folded as 2 documented known-limitation pins (rationale: sub-PR 6.3's field deletion structurally mitigates). |

## What's next

Sub-PR 6.3 deletes the legacy `InboundMessage.{TargetAgentId, SessionId, ConversationId}` fields entirely, migrates writers (adapters) to populate typed hints directly, and removes the fence allowlist + helper entries that this PR introduces. After 6.3, the C# compiler enforces the contract directly.

Closes #582
Refs #579 (umbrella), #580 / #581 (sub-PR 6.1)
