### PR TITLE
feat(agents): add integration-mock LLM provider with scripted responses

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -23,6 +23,7 @@
     <Project Path="src/agent/BotNexus.Agent.Providers.OpenAI/BotNexus.Agent.Providers.OpenAI.csproj" />
     <Project Path="src/agent/BotNexus.Agent.Providers.OpenAICompat/BotNexus.Agent.Providers.OpenAICompat.csproj" />
     <Project Path="src/agent/BotNexus.Agent.Providers.Copilot/BotNexus.Agent.Providers.Copilot.csproj" />
+    <Project Path="src/agent/BotNexus.Agent.Providers.IntegrationMock/BotNexus.Agent.Providers.IntegrationMock.csproj" />
   </Folder>
   <Folder Name="/src/gateway/">
     <Project Path="src/gateway/BotNexus.Cli/BotNexus.Cli.csproj" />
@@ -60,6 +61,7 @@
     <Project Path="tests/agent/BotNexus.Agent.Providers.Core.Tests/BotNexus.Agent.Providers.Core.Tests.csproj" />
     <Project Path="tests/agent/BotNexus.Agent.Providers.OpenAI.Tests/BotNexus.Agent.Providers.OpenAI.Tests.csproj" />
     <Project Path="tests/agent/BotNexus.Agent.Providers.OpenAICompat.Tests/BotNexus.Agent.Providers.OpenAICompat.Tests.csproj" />
+    <Project Path="tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/BotNexus.Agent.Providers.IntegrationMock.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/architecture/">
     <Project Path="tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj" />

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/BotNexus.Agent.Providers.IntegrationMock.csproj
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/BotNexus.Agent.Providers.IntegrationMock.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Agent.Providers.IntegrationMock</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/DefaultCatalog.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/DefaultCatalog.cs
@@ -1,0 +1,30 @@
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Built-in scripts that ship with the integration-mock provider. Always loaded as a fallback
+/// so well-known keys (currently <see cref="HelloWorldKey"/>) are available without any
+/// configuration or external catalog file.
+/// </summary>
+public static class DefaultCatalog
+{
+    /// <summary>The well-known smoke-test key — produces a small "Hello, world!" stream.</summary>
+    public const string HelloWorldKey = "HELLO_WORLD";
+
+    /// <summary>
+    /// The default catalog. Currently contains a single script for <see cref="HelloWorldKey"/>
+    /// that emits four text deltas with 20ms gaps followed by a normal stop.
+    /// </summary>
+    public static readonly MockCatalog Catalog = new(
+        new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>(StringComparer.Ordinal)
+        {
+            [HelloWorldKey] = new List<ScriptedResponseStep>
+            {
+                new("text_delta", Delta: "Hello", DelayMs: 20),
+                new("text_delta", Delta: ", ", DelayMs: 20),
+                new("text_delta", Delta: "world", DelayMs: 20),
+                new("text_delta", Delta: "!", DelayMs: 20),
+                new("text_end"),
+                new("done", StopReason: "stop")
+            }
+        });
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockModels.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockModels.cs
@@ -1,0 +1,37 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Built-in model definitions for the integration-mock provider. Models registered here use
+/// <c>Api = "integration-mock"</c> so the <see cref="ApiProviderRegistry"/> routes them to
+/// <see cref="IntegrationMockProvider"/>.
+/// </summary>
+public sealed class IntegrationMockModels
+{
+    /// <summary>The provider name used in registry lookups and config files.</summary>
+    public const string ProviderName = "integration-mock";
+
+    /// <summary>The API identifier shared with <see cref="IntegrationMockProvider.Api"/>.</summary>
+    public const string ApiName = "integration-mock";
+
+    /// <summary>Default echo model id — always present in the registry regardless of config.</summary>
+    public const string DefaultModelId = "integration-mock-echo";
+
+    /// <summary>Register the built-in mock model. Idempotent — safe to call repeatedly.</summary>
+    public void RegisterAll(ModelRegistry modelRegistry)
+    {
+        modelRegistry.Register(ProviderName, new LlmModel(
+            Id: DefaultModelId,
+            Name: "Integration Mock Echo",
+            Api: ApiName,
+            Provider: ProviderName,
+            BaseUrl: string.Empty,
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 128000,
+            MaxTokens: 32000));
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockProvider.cs
@@ -1,0 +1,306 @@
+using System.Diagnostics;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Diagnostics;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Deterministic LLM provider that returns scripted responses keyed by the trimmed text of
+/// the last <see cref="UserMessage"/> in the request. Designed for integration, UI, and
+/// concurrency tests where a real provider would be slow, costly, or non-deterministic.
+///
+/// <para>Scripts are sourced from a <see cref="MockCatalog"/> resolved by
+/// <see cref="MockCatalogLoader"/>; see that type for path precedence. When no script matches
+/// the key the provider emits a single text event <c>"NO_SCRIPT:&lt;key&gt;"</c> and stops —
+/// failing loud rather than silently behaving like a default LLM.</para>
+/// </summary>
+public sealed class IntegrationMockProvider : IApiProvider
+{
+    private readonly MockCatalogLoader _loader;
+
+    /// <summary>The API identifier this provider serves.</summary>
+    public string Api => IntegrationMockModels.ApiName;
+
+    /// <summary>
+    /// Create a provider. Pass <paramref name="loader"/> in tests to inject a fixed catalog;
+    /// production wiring uses the default loader which reads the path from <c>model.BaseUrl</c>,
+    /// the <c>BOTNEXUS_MOCK_CATALOG</c> env var, or the built-in default.
+    /// </summary>
+    public IntegrationMockProvider(MockCatalogLoader? loader = null)
+    {
+        _loader = loader ?? new MockCatalogLoader();
+    }
+
+    /// <inheritdoc />
+    public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+    {
+        var stream = new LlmStream();
+
+        _ = Task.Run(async () =>
+        {
+            using var activity = ProviderDiagnostics.Source.StartActivity(
+                "provider.integration-mock.stream", ActivityKind.Client);
+            activity?.SetTag("botnexus.provider.name", model.Provider);
+            activity?.SetTag("botnexus.model", model.Id);
+            activity?.SetTag("botnexus.model.api", model.Api);
+
+            try
+            {
+                await StreamCoreAsync(model, context, options, stream);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+            }
+            catch (Exception ex)
+            {
+                var errorMessage = CreateErrorMessage(model, ex.Message);
+                stream.Push(new ErrorEvent(StopReason.Error, errorMessage));
+                stream.End(errorMessage);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            }
+        });
+
+        return stream;
+    }
+
+    /// <inheritdoc />
+    public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+        => Stream(model, context, options);
+
+    private async Task StreamCoreAsync(LlmModel model, Context context, StreamOptions? options, LlmStream stream)
+    {
+        var ct = options?.CancellationToken ?? CancellationToken.None;
+        var catalog = _loader.Resolve(string.IsNullOrWhiteSpace(model.BaseUrl) ? null : model.BaseUrl);
+        var key = ExtractKey(context);
+
+        // Track running state for partial AssistantMessage snapshots emitted with each event.
+        var contentBlocks = new List<ContentBlock>();
+        var textBuffers = new Dictionary<int, System.Text.StringBuilder>();
+        var thinkingBuffers = new Dictionary<int, System.Text.StringBuilder>();
+        var currentIndex = -1;
+
+        AssistantMessage Snapshot(StopReason stopReason = StopReason.Stop, string? errorMessage = null)
+            => new(
+                Content: contentBlocks.ToArray(),
+                Api: Api,
+                Provider: model.Provider,
+                ModelId: model.Id,
+                Usage: Usage.Empty(),
+                StopReason: stopReason,
+                ErrorMessage: errorMessage,
+                ResponseId: null,
+                Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new StartEvent(Snapshot()));
+
+        var script = _loader.Lookup(catalog, key);
+        if (script is null)
+        {
+            await EmitNoScriptAsync(stream, model, key, contentBlocks, Snapshot, ct);
+            return;
+        }
+
+        foreach (var step in script)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (step.DelayMs is > 0)
+                await Task.Delay(step.DelayMs.Value, ct);
+
+            switch (step.Type)
+            {
+                case "text_delta":
+                    {
+                        var (index, builder) = EnsureTextBlock(contentBlocks, textBuffers, ref currentIndex);
+                        if (builder.Length == 0)
+                            stream.Push(new TextStartEvent(index, Snapshot()));
+                        var delta = step.Delta ?? string.Empty;
+                        builder.Append(delta);
+                        contentBlocks[index] = new TextContent(builder.ToString());
+                        stream.Push(new TextDeltaEvent(index, delta, Snapshot()));
+                        break;
+                    }
+                case "text_end":
+                    {
+                        if (currentIndex >= 0 && textBuffers.TryGetValue(currentIndex, out var builder))
+                        {
+                            var text = builder.ToString();
+                            contentBlocks[currentIndex] = new TextContent(text);
+                            stream.Push(new TextEndEvent(currentIndex, text, Snapshot()));
+                            currentIndex = -1;
+                        }
+                        break;
+                    }
+                case "thinking_delta":
+                    {
+                        var (index, builder) = EnsureThinkingBlock(contentBlocks, thinkingBuffers, ref currentIndex);
+                        if (builder.Length == 0)
+                            stream.Push(new ThinkingStartEvent(index, Snapshot()));
+                        var delta = step.Delta ?? string.Empty;
+                        builder.Append(delta);
+                        contentBlocks[index] = new ThinkingContent(builder.ToString());
+                        stream.Push(new ThinkingDeltaEvent(index, delta, Snapshot()));
+                        break;
+                    }
+                case "thinking_end":
+                    {
+                        if (currentIndex >= 0 && thinkingBuffers.TryGetValue(currentIndex, out var builder))
+                        {
+                            var content = builder.ToString();
+                            contentBlocks[currentIndex] = new ThinkingContent(content);
+                            stream.Push(new ThinkingEndEvent(currentIndex, content, Snapshot()));
+                            currentIndex = -1;
+                        }
+                        break;
+                    }
+                case "tool_call":
+                    {
+                        var toolName = step.ToolName
+                            ?? throw new InvalidOperationException("tool_call step requires toolName.");
+                        var toolCallId = step.ToolCallId ?? $"mock-{Guid.NewGuid():N}";
+                        var args = step.ToolArguments ?? new Dictionary<string, object?>();
+                        var toolCall = new ToolCallContent(toolCallId, toolName, args);
+                        contentBlocks.Add(toolCall);
+                        var index = contentBlocks.Count - 1;
+                        stream.Push(new ToolCallStartEvent(index, Snapshot(StopReason.ToolUse)));
+                        stream.Push(new ToolCallEndEvent(index, toolCall, Snapshot(StopReason.ToolUse)));
+                        currentIndex = -1;
+                        break;
+                    }
+                case "done":
+                    {
+                        var reason = ParseStopReason(step.StopReason) ?? StopReason.Stop;
+                        var message = Snapshot(reason);
+                        stream.Push(new DoneEvent(reason, message));
+                        return;
+                    }
+                case "error":
+                    {
+                        var reason = ParseStopReason(step.StopReason) ?? StopReason.Error;
+                        var errorText = step.ErrorMessage ?? "Mock error.";
+                        var message = Snapshot(reason, errorText);
+                        stream.Push(new ErrorEvent(reason, message));
+                        stream.End(message);
+                        return;
+                    }
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown scripted step type '{step.Type}' for key '{key}'.");
+            }
+        }
+
+        // Script ended without an explicit done/error — synthesize a normal stop.
+        var fallback = Snapshot();
+        stream.Push(new DoneEvent(StopReason.Stop, fallback));
+    }
+
+    private async Task EmitNoScriptAsync(
+        LlmStream stream,
+        LlmModel model,
+        string key,
+        List<ContentBlock> contentBlocks,
+        Func<StopReason, string?, AssistantMessage> snapshot,
+        CancellationToken ct)
+    {
+        // Allow callers to await the result.
+        await Task.Yield();
+
+        var text = $"NO_SCRIPT:{key}";
+        contentBlocks.Add(new TextContent(text));
+        var index = contentBlocks.Count - 1;
+        stream.Push(new TextStartEvent(index, snapshot(StopReason.Stop, null)));
+        stream.Push(new TextDeltaEvent(index, text, snapshot(StopReason.Stop, null)));
+        stream.Push(new TextEndEvent(index, text, snapshot(StopReason.Stop, null)));
+        stream.Push(new DoneEvent(StopReason.Stop, snapshot(StopReason.Stop, null)));
+    }
+
+    private static (int Index, System.Text.StringBuilder Builder) EnsureTextBlock(
+        List<ContentBlock> blocks,
+        Dictionary<int, System.Text.StringBuilder> buffers,
+        ref int currentIndex)
+    {
+        if (currentIndex >= 0 && blocks[currentIndex] is TextContent && buffers.ContainsKey(currentIndex))
+            return (currentIndex, buffers[currentIndex]);
+
+        blocks.Add(new TextContent(string.Empty));
+        var index = blocks.Count - 1;
+        var builder = new System.Text.StringBuilder();
+        buffers[index] = builder;
+        currentIndex = index;
+        return (index, builder);
+    }
+
+    private static (int Index, System.Text.StringBuilder Builder) EnsureThinkingBlock(
+        List<ContentBlock> blocks,
+        Dictionary<int, System.Text.StringBuilder> buffers,
+        ref int currentIndex)
+    {
+        if (currentIndex >= 0 && blocks[currentIndex] is ThinkingContent && buffers.ContainsKey(currentIndex))
+            return (currentIndex, buffers[currentIndex]);
+
+        blocks.Add(new ThinkingContent(string.Empty));
+        var index = blocks.Count - 1;
+        var builder = new System.Text.StringBuilder();
+        buffers[index] = builder;
+        currentIndex = index;
+        return (index, builder);
+    }
+
+    private static StopReason? ParseStopReason(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "stop" => StopReason.Stop,
+            "length" => StopReason.Length,
+            "tooluse" or "tool_use" or "tool-use" => StopReason.ToolUse,
+            "error" => StopReason.Error,
+            "aborted" => StopReason.Aborted,
+            "refusal" => StopReason.Refusal,
+            "sensitive" => StopReason.Sensitive,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Extract the lookup key from <paramref name="context"/>. The key is the trimmed text of
+    /// the final <see cref="UserMessage"/>; multi-block user messages concatenate their
+    /// <see cref="TextContent"/> blocks. Returns an empty string when no user message is found.
+    /// </summary>
+    public static string ExtractKey(Context context)
+    {
+        for (var i = context.Messages.Count - 1; i >= 0; i--)
+        {
+            if (context.Messages[i] is not UserMessage user)
+                continue;
+
+            if (user.Content.IsText)
+                return (user.Content.Text ?? string.Empty).Trim();
+
+            if (user.Content.Blocks is { Count: > 0 } blocks)
+            {
+                var combined = string.Concat(blocks.OfType<TextContent>().Select(t => t.Text));
+                return combined.Trim();
+            }
+
+            return string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private AssistantMessage CreateErrorMessage(LlmModel model, string error)
+        => new(
+            Content: [new TextContent(error)],
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Error,
+            ErrorMessage: error,
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/MockCatalogLoader.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/MockCatalogLoader.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Resolves and parses mock response catalogs. Catalog source precedence:
+/// <list type="number">
+///   <item><description>Catalog passed to the constructor (in-memory override, for tests).</description></item>
+///   <item><description>Per-request path from <c>model.BaseUrl</c> when it points at an existing file.</description></item>
+///   <item><description><c>BOTNEXUS_MOCK_CATALOG</c> environment variable.</description></item>
+///   <item><description>Built-in default catalog containing the <c>HELLO_WORLD</c> script.</description></item>
+/// </list>
+/// File catalogs are parsed once and cached by absolute path. The built-in default is always
+/// consulted as a fallback so well-known scripts like <c>HELLO_WORLD</c> are available even
+/// when a custom catalog omits them.
+/// </summary>
+public sealed class MockCatalogLoader
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, MockCatalog> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly MockCatalog? _override;
+
+    /// <summary>
+    /// Create a loader. When <paramref name="explicitCatalog"/> is supplied it is used in
+    /// preference to any file/environment source — primarily for unit testing.
+    /// </summary>
+    public MockCatalogLoader(MockCatalog? explicitCatalog = null)
+    {
+        _override = explicitCatalog;
+    }
+
+    /// <summary>
+    /// Resolve the catalog for a request. A <paramref name="catalogPath"/> sourced from
+    /// <c>model.BaseUrl</c> takes precedence over the environment variable when it points
+    /// at an existing file.
+    /// </summary>
+    public MockCatalog Resolve(string? catalogPath)
+    {
+        if (_override is not null)
+            return _override;
+
+        if (!string.IsNullOrWhiteSpace(catalogPath) && File.Exists(catalogPath))
+            return LoadCached(catalogPath);
+
+        var fromEnv = Environment.GetEnvironmentVariable("BOTNEXUS_MOCK_CATALOG");
+        if (!string.IsNullOrWhiteSpace(fromEnv) && File.Exists(fromEnv))
+            return LoadCached(fromEnv);
+
+        return DefaultCatalog.Catalog;
+    }
+
+    /// <summary>
+    /// Looks up a script in <paramref name="catalog"/>, falling back to the built-in default
+    /// catalog so well-known keys remain available when a custom catalog omits them.
+    /// </summary>
+    public IReadOnlyList<ScriptedResponseStep>? Lookup(MockCatalog catalog, string key)
+    {
+        if (catalog.Scripts is not null && catalog.Scripts.TryGetValue(key, out var script))
+            return script;
+
+        if (!ReferenceEquals(catalog, DefaultCatalog.Catalog)
+            && DefaultCatalog.Catalog.Scripts.TryGetValue(key, out var fallback))
+            return fallback;
+
+        return null;
+    }
+
+    private MockCatalog LoadCached(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+
+        lock (_gate)
+        {
+            if (_cache.TryGetValue(fullPath, out var cached))
+                return cached;
+
+            var json = File.ReadAllText(fullPath);
+            var parsed = JsonSerializer.Deserialize<MockCatalog>(json, JsonOptions)
+                ?? throw new InvalidOperationException(
+                    $"Mock catalog at '{fullPath}' deserialized to null.");
+
+            _cache[fullPath] = parsed;
+            return parsed;
+        }
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/ScriptedResponse.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/ScriptedResponse.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// A single step in a scripted response. One step maps to either a single streaming event
+/// (text/thinking delta, end) or a higher-level action such as a tool call, completion,
+/// or simulated error. Steps execute in order with an optional <see cref="DelayMs"/> applied
+/// before the step is pushed onto the stream.
+/// </summary>
+/// <param name="Type">
+/// Event kind. One of: <c>text_delta</c>, <c>text_end</c>, <c>thinking_delta</c>,
+/// <c>thinking_end</c>, <c>tool_call</c>, <c>done</c>, <c>error</c>.
+/// </param>
+/// <param name="Delta">Text or thinking delta to push (for <c>text_delta</c>/<c>thinking_delta</c>).</param>
+/// <param name="ToolName">Function name (for <c>tool_call</c>).</param>
+/// <param name="ToolArguments">Argument map (for <c>tool_call</c>).</param>
+/// <param name="ToolCallId">Optional stable identifier (for <c>tool_call</c>). Generated when omitted.</param>
+/// <param name="StopReason">
+/// Stop reason for <c>done</c> / <c>error</c>. Defaults to <c>stop</c> for <c>done</c> and
+/// <c>error</c> for <c>error</c>. Tool-call scripts should use <c>toolUse</c>.
+/// </param>
+/// <param name="ErrorMessage">Error text for <c>error</c>.</param>
+/// <param name="DelayMs">
+/// Milliseconds to wait BEFORE pushing this step. Lets scripts simulate token cadence and
+/// inter-event pauses for realistic streaming and concurrency testing.
+/// </param>
+public sealed record ScriptedResponseStep(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("delta")] string? Delta = null,
+    [property: JsonPropertyName("toolName")] string? ToolName = null,
+    [property: JsonPropertyName("toolArguments")] Dictionary<string, object?>? ToolArguments = null,
+    [property: JsonPropertyName("toolCallId")] string? ToolCallId = null,
+    [property: JsonPropertyName("stopReason")] string? StopReason = null,
+    [property: JsonPropertyName("errorMessage")] string? ErrorMessage = null,
+    [property: JsonPropertyName("delayMs")] int? DelayMs = null);
+
+/// <summary>
+/// The on-disk and in-memory catalog of mock responses. Keyed by the trimmed text of the
+/// final user message (case-sensitive).
+/// </summary>
+public sealed record MockCatalog(
+    [property: JsonPropertyName("scripts")] Dictionary<string, IReadOnlyList<ScriptedResponseStep>> Scripts);

--- a/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
+++ b/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Anthropic\BotNexus.Agent.Providers.Anthropic.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.OpenAI\BotNexus.Agent.Providers.OpenAI.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.OpenAICompat\BotNexus.Agent.Providers.OpenAICompat.csproj" />
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.IntegrationMock\BotNexus.Agent.Providers.IntegrationMock.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -13,6 +13,7 @@ using BotNexus.Agent.Providers.Core.Registry;
 using Microsoft.Extensions.Options;
 using BotNexus.Agent.Providers.OpenAI;
 using BotNexus.Agent.Providers.OpenAICompat;
+using BotNexus.Agent.Providers.IntegrationMock;
 using BotNexus.Cron;
 using BotNexus.Cron.Extensions;
 using BotNexus.Domain.World;
@@ -228,16 +229,28 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
     apiProviders.Register(new OpenAICompletionsProvider(httpClient, loggerFactory.CreateLogger<OpenAICompletionsProvider>()));
     apiProviders.Register(new OpenAIResponsesProvider(httpClient, loggerFactory.CreateLogger<OpenAIResponsesProvider>()));
     apiProviders.Register(new OpenAICompatProvider(httpClient));
+    apiProviders.Register(new IntegrationMockProvider());
 
     serviceProvider.GetRequiredService<BuiltInModels>().RegisterAll(models);
+    new IntegrationMockModels().RegisterAll(models);
 
-    // Register models from openai-compat providers in config (e.g. Ollama, LM Studio)
+    // Register models from openai-compat providers in config (e.g. Ollama, LM Studio),
+    // or any provider with an explicit Api override (e.g. integration-mock).
     var platformConfig = serviceProvider.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue;
     if (platformConfig.Providers is not null)
     {
         foreach (var (providerName, providerConfig) in platformConfig.Providers)
         {
-            if (!providerConfig.Enabled || string.IsNullOrWhiteSpace(providerConfig.BaseUrl))
+            if (!providerConfig.Enabled)
+                continue;
+
+            var apiName = string.IsNullOrWhiteSpace(providerConfig.Api)
+                ? "openai-completions"
+                : providerConfig.Api!;
+            // For openai-completions a BaseUrl is required (the HTTP endpoint). For other
+            // apis (e.g. integration-mock) BaseUrl is provider-specific (catalog file path,
+            // possibly empty) — skip the BaseUrl gate.
+            if (apiName == "openai-completions" && string.IsNullOrWhiteSpace(providerConfig.BaseUrl))
                 continue;
 
             if (providerConfig.Models is { Count: > 0 })
@@ -247,9 +260,9 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
                     models.Register(providerName, new LlmModel(
                         Id: modelId,
                         Name: modelId,
-                        Api: "openai-completions",
+                        Api: apiName,
                         Provider: providerName,
-                        BaseUrl: providerConfig.BaseUrl,
+                        BaseUrl: providerConfig.BaseUrl ?? string.Empty,
                         Reasoning: modelId.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
                         Input: ["text"],
                         Cost: new ModelCost(0, 0, 0, 0),
@@ -260,7 +273,7 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
         }
     }
 
-    // Register the model for any agent using an openai-compat provider not in BuiltInModels
+    // Register the model for any agent using a config-defined provider not in BuiltInModels.
     if (platformConfig.Agents is not null && platformConfig.Providers is not null)
     {
         foreach (KeyValuePair<string, AgentDefinitionConfig> agentEntry in platformConfig.Agents)
@@ -270,7 +283,10 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
                 continue;
             if (!platformConfig.Providers.TryGetValue(agentConfig.Provider, out var agentProvider))
                 continue;
-            if (string.IsNullOrWhiteSpace(agentProvider.BaseUrl))
+            var apiName = string.IsNullOrWhiteSpace(agentProvider.Api)
+                ? "openai-completions"
+                : agentProvider.Api!;
+            if (apiName == "openai-completions" && string.IsNullOrWhiteSpace(agentProvider.BaseUrl))
                 continue;
             if (models.GetModel(agentConfig.Provider, agentConfig.Model) is not null)
                 continue;
@@ -278,9 +294,9 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
             models.Register(agentConfig.Provider, new LlmModel(
                 Id: agentConfig.Model,
                 Name: agentConfig.Model,
-                Api: "openai-completions",
+                Api: apiName,
                 Provider: agentConfig.Provider,
-                BaseUrl: agentProvider.BaseUrl,
+                BaseUrl: agentProvider.BaseUrl ?? string.Empty,
                 Reasoning: agentConfig.Model.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
                 Input: ["text"],
                 Cost: new ModelCost(0, 0, 0, 0),

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -78,6 +78,15 @@ public sealed class ProviderConfig
 
     /// <summary>Allowed model IDs for this provider. Null means all models, empty means none.</summary>
     public List<string>? Models { get; set; }
+
+    /// <summary>
+    /// Optional API identifier used when registering models from this provider's <see cref="Models"/>
+    /// list. Defaults to <c>"openai-completions"</c> for backward compatibility with config-driven
+    /// OpenAI-compatible endpoints (Ollama, LM Studio, etc.). Set to <c>"integration-mock"</c> or
+    /// another registered provider's API name to register models against a different
+    /// <see cref="BotNexus.Agent.Providers.Core.Registry.IApiProvider"/>.
+    /// </summary>
+    public string? Api { get; set; }
 }
 
 /// <summary>Gateway runtime configuration.</summary>

--- a/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/BotNexus.Agent.Providers.IntegrationMock.Tests.csproj
+++ b/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/BotNexus.Agent.Providers.IntegrationMock.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.IntegrationMock\BotNexus.Agent.Providers.IntegrationMock.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/IntegrationMockProviderTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/IntegrationMockProviderTests.cs
@@ -1,0 +1,220 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Streaming;
+
+namespace BotNexus.Agent.Providers.IntegrationMock.Tests;
+
+public class IntegrationMockProviderTests
+{
+    private static Context UserContext(string text) => new(
+        SystemPrompt: null,
+        Messages: new[] { new UserMessage(new UserMessageContent(text), 0L) });
+
+    private static LlmModel Model(string baseUrl = "") => new(
+        Id: IntegrationMockModels.DefaultModelId,
+        Name: "Integration Mock Echo",
+        Api: IntegrationMockModels.ApiName,
+        Provider: IntegrationMockModels.ProviderName,
+        BaseUrl: baseUrl,
+        Reasoning: false,
+        Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 128000,
+        MaxTokens: 32000);
+
+    [Fact]
+    public async Task Stream_HelloWorld_ProducesExpectedEventsAndText()
+    {
+        var provider = new IntegrationMockProvider();
+
+        var stream = provider.Stream(Model(), UserContext(DefaultCatalog.HelloWorldKey));
+
+        var events = new List<AssistantMessageEvent>();
+        await foreach (var evt in stream)
+            events.Add(evt);
+
+        var result = await stream.GetResultAsync();
+
+        // First event is StartEvent, final is DoneEvent with Stop.
+        events.First().ShouldBeOfType<StartEvent>();
+        events.Last().ShouldBeOfType<DoneEvent>();
+        ((DoneEvent)events.Last()).Reason.ShouldBe(StopReason.Stop);
+
+        // Expect exactly one TextStartEvent and one TextEndEvent.
+        events.OfType<TextStartEvent>().Count().ShouldBe(1);
+        events.OfType<TextEndEvent>().Count().ShouldBe(1);
+
+        // Combined deltas reconstruct the canonical message.
+        var combined = string.Concat(events.OfType<TextDeltaEvent>().Select(d => d.Delta));
+        combined.ShouldBe("Hello, world!");
+
+        // Final result also exposes the text.
+        result.Content.OfType<TextContent>().Single().Text.ShouldBe("Hello, world!");
+        result.StopReason.ShouldBe(StopReason.Stop);
+        result.Api.ShouldBe(IntegrationMockModels.ApiName);
+        result.Provider.ShouldBe(IntegrationMockModels.ProviderName);
+    }
+
+    [Fact]
+    public async Task Stream_UnknownKey_EmitsLoudNoScriptResponse()
+    {
+        var provider = new IntegrationMockProvider();
+
+        var stream = provider.Stream(Model(), UserContext("UNKNOWN_KEY"));
+
+        await foreach (var _ in stream) { }
+        var result = await stream.GetResultAsync();
+
+        result.StopReason.ShouldBe(StopReason.Stop);
+        var text = result.Content.OfType<TextContent>().Single().Text;
+        text.ShouldBe("NO_SCRIPT:UNKNOWN_KEY");
+    }
+
+    [Fact]
+    public async Task Stream_HonoursDelaysBetweenSteps()
+    {
+        // Custom catalog with two ~80ms delays — total wall-clock must be at least ~150ms.
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["DELAY"] = new List<ScriptedResponseStep>
+            {
+                new("text_delta", Delta: "A", DelayMs: 80),
+                new("text_delta", Delta: "B", DelayMs: 80),
+                new("text_end"),
+                new("done")
+            }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var stream = provider.Stream(Model(), UserContext("DELAY"));
+        await foreach (var _ in stream) { }
+        await stream.GetResultAsync();
+        sw.Stop();
+
+        sw.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(140);
+    }
+
+    [Fact]
+    public async Task Stream_ToolCallScript_EmitsToolCallEventsWithToolUseStop()
+    {
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["CALL_TOOL"] = new List<ScriptedResponseStep>
+            {
+                new("tool_call",
+                    ToolName: "get_weather",
+                    ToolArguments: new Dictionary<string, object?> { ["city"] = "Sydney" },
+                    ToolCallId: "tc-1"),
+                new("done", StopReason: "toolUse")
+            }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var stream = provider.Stream(Model(), UserContext("CALL_TOOL"));
+        var events = new List<AssistantMessageEvent>();
+        await foreach (var evt in stream)
+            events.Add(evt);
+        var result = await stream.GetResultAsync();
+
+        events.OfType<ToolCallStartEvent>().Count().ShouldBe(1);
+        var endEvt = events.OfType<ToolCallEndEvent>().Single();
+        endEvt.ToolCall.Name.ShouldBe("get_weather");
+        endEvt.ToolCall.Id.ShouldBe("tc-1");
+        endEvt.ToolCall.Arguments["city"].ShouldBe("Sydney");
+
+        result.StopReason.ShouldBe(StopReason.ToolUse);
+        result.Content.OfType<ToolCallContent>().Single().Name.ShouldBe("get_weather");
+    }
+
+    [Fact]
+    public async Task Stream_ErrorStep_EmitsErrorEvent()
+    {
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["BOOM"] = new List<ScriptedResponseStep>
+            {
+                new("error", ErrorMessage: "simulated failure")
+            }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var stream = provider.Stream(Model(), UserContext("BOOM"));
+        var events = new List<AssistantMessageEvent>();
+        await foreach (var evt in stream)
+            events.Add(evt);
+        var result = await stream.GetResultAsync();
+
+        events.OfType<ErrorEvent>().Single().Error.ErrorMessage.ShouldBe("simulated failure");
+        result.StopReason.ShouldBe(StopReason.Error);
+        result.ErrorMessage.ShouldBe("simulated failure");
+    }
+
+    [Fact]
+    public async Task Stream_CustomCatalogViaBaseUrl_OverridesDefault()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"mock-catalog-{Guid.NewGuid():N}.json");
+        try
+        {
+            await File.WriteAllTextAsync(path,
+                """
+                {
+                  "scripts": {
+                    "CUSTOM": [
+                      { "type": "text_delta", "delta": "from-file" },
+                      { "type": "text_end" },
+                      { "type": "done" }
+                    ]
+                  }
+                }
+                """);
+
+            var provider = new IntegrationMockProvider();
+            var stream = provider.Stream(Model(baseUrl: path), UserContext("CUSTOM"));
+            await foreach (var _ in stream) { }
+            var result = await stream.GetResultAsync();
+
+            result.Content.OfType<TextContent>().Single().Text.ShouldBe("from-file");
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Stream_CustomCatalogMissingHelloWorld_StillServesBuiltInDefault()
+    {
+        // Custom catalog that does NOT define HELLO_WORLD — the default fallback must still apply.
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["OTHER"] = new List<ScriptedResponseStep> { new("done") }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var stream = provider.Stream(Model(), UserContext(DefaultCatalog.HelloWorldKey));
+        await foreach (var _ in stream) { }
+        var result = await stream.GetResultAsync();
+
+        result.Content.OfType<TextContent>().Single().Text.ShouldBe("Hello, world!");
+    }
+
+    [Fact]
+    public void ExtractKey_TrimmedLastUserMessageWins()
+    {
+        var context = new Context(
+            SystemPrompt: null,
+            Messages: new Message[]
+            {
+                new UserMessage(new UserMessageContent("FIRST"), 0L),
+                new AssistantMessage(
+                    Content: [new TextContent("noise")],
+                    Api: "x", Provider: "x", ModelId: "x",
+                    Usage: Usage.Empty(), StopReason: StopReason.Stop,
+                    ErrorMessage: null, ResponseId: null, Timestamp: 0L),
+                new UserMessage(new UserMessageContent("  HELLO_WORLD  "), 0L)
+            });
+
+        IntegrationMockProvider.ExtractKey(context).ShouldBe("HELLO_WORLD");
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/xunit.runner.json
+++ b/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0
+}


### PR DESCRIPTION
Adds `BotNexus.Agent.Providers.IntegrationMock` — a deterministic LLM provider for integration, UI, and concurrency testing.

## What

- New provider project: `src/agent/BotNexus.Agent.Providers.IntegrationMock`
- New test project: `tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests` (8 tests, all passing)
- Optional `Api` field on `ProviderConfig` so config can target non-OpenAI-compatible APIs (defaults to `openai-completions` — backward compatible)

## How it works

- The incoming user message text is the lookup **key** into a scripted catalog.
- Built-in `HELLO_WORLD` script returns 4 text deltas (20ms apart) + Done.
- Unknown keys return `NO_SCRIPT:<key>` — fail loud, not silent.
- Scripts can emit text/thinking deltas, tool calls, errors, and configurable delays between steps.
- Catalog resolution precedence: ctor override → model `BaseUrl` (file path) → `BOTNEXUS_MOCK_CATALOG` env → built-in default. Default catalog always merges in so `HELLO_WORLD` always works.

## Why

This is **PR A** in a three-PR series for integration testing:
- **PR A (this)**: deterministic provider for tests
- **PR B**: non-interactive `botnexus provider` CLI flags + comprehensive doc sweep
- **PR C**: local-pack-and-install harness wiring everything into `BotNexus.Integration.Cli.Tests` (#583/#584)

## Validation

- `dotnet build BotNexus.slnx` — 0 warnings, 0 errors
- `dotnet test BotNexus.slnx` — all 8 new tests green; only pre-existing flaky `ShellToolTests` (unrelated, passes in isolation)

Closes #587
