### PR TITLE
feat(cli): add non-interactive provider add/remove and fix outdated docs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -65,6 +65,8 @@ You should see the root command help listing all available subcommands.
 13. [provider](#provider) — Show or set up providers
 14. [provider setup](#provider-setup) — Interactive provider setup wizard
 15. [provider list](#provider-list) — List configured providers
+16. [provider add](#provider-add) — Add or update a provider non-interactively (scripts and CI)
+17. [provider remove](#provider-remove) — Remove a provider non-interactively
 16. [prompt](#prompt) — Manage prompt templates
 17. [prompt list](#prompt-list) — List available prompt templates
 18. [prompt render](#prompt-render) — Render a prompt template
@@ -824,6 +826,85 @@ Example output:
 │ github-copilot  │ Yes     │ OAuth │ gpt-4.1       │ default │
 │ openai          │ Yes     │ sk-…  │ gpt-4o        │ default │
 └─────────────────┴─────────┴───────┴───────────────┴─────────┘
+```
+
+---
+
+## provider add
+
+Add or update a provider entry in `config.json` non-interactively. Designed for scripts, CI, and integration tests that need to configure providers without the interactive wizard.
+
+When a provider with the given `--name` already exists, only the flags you pass are updated; unspecified fields preserve their previous values. To clear a previously-set value, pass an empty string explicitly.
+
+### Usage
+
+```powershell
+botnexus provider add --name <NAME> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--name <NAME>` | **Required.** Provider name (e.g. `openai`, `integration-mock`). |
+| `--api <API>` | API contract this provider handles. One of `openai-completions` (default), `openai-responses`, `anthropic-messages`, `integration-mock`. |
+| `--api-key <KEY>` | API key value, or `auth:<name>` to reference an OAuth entry in `auth.json`. |
+| `--base-url <URL>` | Base URL for OpenAI-compatible endpoints, or catalog file path for `integration-mock`. |
+| `--default-model <ID>` | Default model id for this provider. |
+| `--model <ID>` | Allowed model id. Repeatable. Omit to allow all models registered for this provider. |
+| `--disabled` | Add the provider in disabled state. Disabled providers are hidden from the API. |
+| `--target <PATH>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+| `--verbose` | Print the serialized provider entry after save. |
+
+### Examples
+
+**Add an OpenAI provider:**
+
+```powershell
+botnexus provider add --name openai --api-key sk-... --default-model gpt-4o
+```
+
+**Add the integration-mock provider for tests (uses built-in `HELLO_WORLD` catalog):**
+
+```powershell
+botnexus provider add --name integration-mock --api integration-mock --default-model integration-mock-echo
+```
+
+**Add an OpenAI-compatible local endpoint with a restricted model list:**
+
+```powershell
+botnexus provider add --name local-vllm `
+    --api openai-completions `
+    --base-url http://localhost:8000/v1 `
+    --api-key not-needed `
+    --model llama-3-8b --model llama-3-70b `
+    --default-model llama-3-8b
+```
+
+---
+
+## provider remove
+
+Remove a provider entry from `config.json` non-interactively. Returns exit code 0 even if the named provider does not exist (idempotent).
+
+### Usage
+
+```powershell
+botnexus provider remove --name <NAME> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--name <NAME>` | **Required.** Provider name to remove. |
+| `--target <PATH>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+| `--verbose` | Print remaining provider count after removal. |
+
+### Examples
+
+```powershell
+botnexus provider remove --name integration-mock
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,17 +55,11 @@ On first run, BotNexus creates a minimal default config:
 
 ```json
 {
-  "BotNexus": {
-    "ExtensionsPath": "~/.botnexus/extensions",
-    "Providers": {},
-    "Channels": {
-      "Instances": {}
-    },
-    "Tools": {
-      "Extensions": {},
-      "McpServers": {}
-    }
-  }
+  "$schema": "https://raw.githubusercontent.com/sytone/botnexus/main/docs/botnexus-config.schema.json",
+  "version": 1,
+  "providers": {},
+  "agents": {},
+  "channels": {}
 }
 ```
 
@@ -75,22 +69,36 @@ To add your first provider, run the interactive setup wizard:
 botnexus provider setup
 ```
 
-Or add it manually to the `Providers` section:
+Or add it manually to the `providers` section. `config.json` is a flat top-level document — there is **no** `BotNexus` wrapper. All keys use `camelCase`:
 
 ```json
 {
-  "BotNexus": {
-    "ExtensionsPath": "~/.botnexus/extensions",
-    "Providers": {
-      "copilot": {
-        "Auth": "oauth",
-        "DefaultModel": "gpt-4o",
-        "ApiBase": "https://api.githubcopilot.com"
-      }
+  "version": 1,
+  "providers": {
+    "github-copilot": {
+      "enabled": true,
+      "apiKey": "auth:github-copilot",
+      "defaultModel": "gpt-4o"
+    },
+    "openai": {
+      "enabled": true,
+      "apiKey": "sk-...",
+      "defaultModel": "gpt-4o-mini"
     }
   }
 }
 ```
+
+**`ProviderConfig` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | `bool` | Whether this provider is active. Disabled providers are hidden from the API. Defaults to `true`. |
+| `apiKey` | `string?` | API key value, or `auth:<name>` to reference an OAuth entry in `auth.json`. |
+| `baseUrl` | `string?` | Base URL override for OpenAI-compatible endpoints, or catalog file path for `integration-mock`. |
+| `defaultModel` | `string?` | Default model id used when an agent does not specify one. |
+| `models` | `string[]?` | Allowed model ids. `null` means all registered models; `[]` means none. |
+| `api` | `string?` | Wire-contract identifier. One of `openai-completions` (default), `openai-responses`, `anthropic-messages`, `integration-mock`. Required when the provider speaks a non-OpenAI-completions contract. |
 
 ---
 
@@ -1003,14 +1011,15 @@ extensions/
 
 ### Extension Registration
 
-Each extension assembly can implement `IExtensionRegistrar` to register types in the DI container:
+Each extension assembly can implement `IExtensionRegistrar` to register types in the DI container. (LLM providers are not currently extension-loaded — they ship as `src/agent/BotNexus.Agent.Providers.*/` projects and are wired in `Program.cs`. The snippet below illustrates the historical extension shape only.)
 
 ```csharp
 public class CopilotExtensionRegistrar : IExtensionRegistrar
 {
     public void Register(IServiceCollection services, IConfiguration configuration)
     {
-        services.AddSingleton<ILlmProvider>(sp =>
+        // Historical example only — providers are not currently extension-loaded.
+        services.AddSingleton<IApiProvider>(sp =>
         {
             var tokenStore = new FileOAuthTokenStore();
             // ... create and return CopilotProvider

--- a/docs/extension-development.md
+++ b/docs/extension-development.md
@@ -311,11 +311,17 @@ Enable the extension in `~/.botnexus/config.json` (or `appsettings.json`):
 
 ## Creating a Provider Extension
 
+> **Note:** LLM providers are currently **not** loaded through the extension pipeline. They live in `src/agent/BotNexus.Agent.Providers.*/` projects and implement
+> `IApiProvider` (from `BotNexus.Agent.Providers.Core.Registry`). Registration is wired directly in
+> `src/gateway/BotNexus.Gateway.Api/Program.cs` rather than discovered from the `extensions/providers/` folder. The historical pattern below is kept for reference and as a target for a future provider-extension host; until that lands, ship new providers as agent projects following the convention in `src/agent/AGENTS.md`.
+
 **Providers** are LLM backends that agents use for intelligence. Examples: OpenAI, Anthropic, GitHub Copilot, local models.
 
 ### Step 1: Create a Provider Class
 
-Inherit from `LlmProviderBase` (or implement `ILlmProvider` directly for advanced use cases).
+Implement `IApiProvider` from `BotNexus.Agent.Providers.Core.Registry`. The interface exposes an `Api` string (the wire-contract identifier, e.g. `"openai-completions"`) and a `Stream`/`StreamSimple` pair that returns an `LlmStream`. See `src/agent/BotNexus.Agent.Providers.OpenAICompat/` for a working reference implementation, and `src/agent/BotNexus.Agent.Providers.IntegrationMock/` for a deterministic test-only provider.
+
+The (legacy, non-functional) `LlmProviderBase` example below is preserved only to illustrate the historical extension shape — do **not** copy it verbatim.
 
 ```csharp
 using System.Runtime.CompilerServices;
@@ -878,7 +884,7 @@ public sealed class GitHubExtensionRegistrar : IExtensionRegistrar
 
 ### Convention-Based Registration (Automatic)
 
-If your extension assembly contains **exactly one** type implementing `IChannel`, `ILlmProvider`, or `ITool`, the loader will automatically register it without requiring an `IExtensionRegistrar`.
+If your extension assembly contains **exactly one** type implementing `IChannel` or `ITool`, the loader will automatically register it without requiring an `IExtensionRegistrar`. (LLM providers are not currently extension-loaded — see the [Creating a Provider Extension](#creating-a-provider-extension) note.)
 
 ```csharp
 // Extension loader discovers this automatically
@@ -1570,7 +1576,7 @@ dotnet publish src/BotNexus.Gateway -o ./publish
 
 ### "IExtensionRegistrar not found"
 
-**Cause:** Extension assembly doesn't have an `IExtensionRegistrar` implementation and convention-based registration failed (multiple or no implementations of `IChannel`/`ILlmProvider`/`ITool`).
+**Cause:** Extension assembly doesn't have an `IExtensionRegistrar` implementation and convention-based registration failed (multiple or no implementations of `IChannel`/`ITool`).
 
 **Fix:**
 1. Create a class implementing `IExtensionRegistrar`
@@ -1639,7 +1645,7 @@ To create a BotNexus extension:
 1. **Create a class library** targeting `net10.0`
 2. **Add `ExtensionType` and `ExtensionName`** to `.csproj`
 3. **Import `Extension.targets`** to auto-copy binaries
-4. **Implement the interface** (`IChannel`, `ILlmProvider`, or `ITool`)
+4. **Implement the interface** (`IChannel` or `ITool`; LLM providers ship as `src/agent/` projects implementing `IApiProvider`)
 5. **Optionally implement `IExtensionRegistrar`** for advanced DI
 6. **Add configuration** to `~/.botnexus/config.json` (or `appsettings.json`)
 7. **Build** and binaries appear in `extensions/{type}/{name}/`

--- a/src/agent/AGENTS.md
+++ b/src/agent/AGENTS.md
@@ -24,10 +24,12 @@ Projects in `src/agent/` must **never** depend on projects outside this folder. 
 | `BotNexus.Agent.Providers.Anthropic` | Anthropic Messages API provider |
 | `BotNexus.Agent.Providers.Copilot` | GitHub Copilot provider |
 | `BotNexus.Agent.Providers.OpenAICompat` | OpenAI-compatible endpoint provider (vLLM, SGLang, etc.) |
+| `BotNexus.Agent.Providers.IntegrationMock` | Deterministic provider for integration, UI, and concurrency tests — returns scripted, key-based responses |
 
 ## Adding a new provider
 
 1. Create `src/agent/BotNexus.Agent.Providers.{Name}/`
 2. Reference only `BotNexus.Agent.Providers.Core` (sibling project)
-3. Implement `ILlmProvider` or extend `LlmClient`
-4. Do not reference gateway, extension, or domain projects
+3. Implement `IApiProvider` (from `BotNexus.Agent.Providers.Core.Registry`) — declare an `Api` string that uniquely identifies the wire contract (e.g. `"openai-completions"`, `"anthropic-messages"`, `"integration-mock"`)
+4. Register the provider and its models in `src/gateway/BotNexus.Gateway.Api/Program.cs`
+5. Do not reference gateway, extension, or domain projects

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -57,6 +57,8 @@ internal sealed class ProviderCommand
 
         command.AddCommand(setupCommand);
         command.AddCommand(listCommand);
+        command.AddCommand(BuildAddCommand(verboseOption));
+        command.AddCommand(BuildRemoveCommand(verboseOption));
 
         // Default to setup when no subcommand given
         var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
@@ -71,6 +73,149 @@ internal sealed class ProviderCommand
         });
 
         return command;
+    }
+
+    private static Command BuildAddCommand(Option<bool> verboseOption)
+    {
+        var cmd = new Command("add", "Add or update a provider non-interactively. Useful for scripts and CI.");
+        var nameOpt = new Option<string>("--name", "Provider name (e.g. 'openai', 'integration-mock').") { IsRequired = true };
+        var apiOpt = new Option<string?>("--api", () => null, "API contract handled by this provider (e.g. 'openai-completions', 'openai-responses', 'anthropic-messages', 'integration-mock'). Defaults to 'openai-completions'.");
+        var apiKeyOpt = new Option<string?>("--api-key", () => null, "API key value, or 'auth:<name>' to reference an auth.json OAuth entry.");
+        var baseUrlOpt = new Option<string?>("--base-url", () => null, "Base URL for OpenAI-compatible endpoints, or catalog path for 'integration-mock'.");
+        var defaultModelOpt = new Option<string?>("--default-model", () => null, "Default model id for this provider.");
+        var modelsOpt = new Option<string[]>("--model", () => Array.Empty<string>(), "Allowed model id (repeatable). Omit to allow all models registered for this provider.")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
+        var disabledOpt = new Option<bool>("--disabled", () => false, "Mark the provider as disabled. Disabled providers are hidden from the API.");
+        var targetOpt = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+
+        cmd.AddOption(nameOpt);
+        cmd.AddOption(apiOpt);
+        cmd.AddOption(apiKeyOpt);
+        cmd.AddOption(baseUrlOpt);
+        cmd.AddOption(defaultModelOpt);
+        cmd.AddOption(modelsOpt);
+        cmd.AddOption(disabledOpt);
+        cmd.AddOption(targetOpt);
+
+        cmd.SetHandler(async context =>
+        {
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var target = context.ParseResult.GetValueForOption(targetOpt);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            var name = context.ParseResult.GetValueForOption(nameOpt)!;
+            var api = context.ParseResult.GetValueForOption(apiOpt);
+            var apiKey = context.ParseResult.GetValueForOption(apiKeyOpt);
+            var baseUrl = context.ParseResult.GetValueForOption(baseUrlOpt);
+            var defaultModel = context.ParseResult.GetValueForOption(defaultModelOpt);
+            var models = context.ParseResult.GetValueForOption(modelsOpt) ?? Array.Empty<string>();
+            var disabled = context.ParseResult.GetValueForOption(disabledOpt);
+
+            context.ExitCode = await new ProviderCommand().ExecuteAddAsync(
+                configPath, name, api, apiKey, baseUrl, defaultModel, models, enabled: !disabled, verbose, CancellationToken.None);
+        });
+
+        return cmd;
+    }
+
+    private static Command BuildRemoveCommand(Option<bool> verboseOption)
+    {
+        var cmd = new Command("remove", "Remove a provider non-interactively.");
+        var nameOpt = new Option<string>("--name", "Provider name to remove.") { IsRequired = true };
+        var targetOpt = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+
+        cmd.AddOption(nameOpt);
+        cmd.AddOption(targetOpt);
+
+        cmd.SetHandler(async context =>
+        {
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var target = context.ParseResult.GetValueForOption(targetOpt);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            var name = context.ParseResult.GetValueForOption(nameOpt)!;
+
+            context.ExitCode = await new ProviderCommand().ExecuteRemoveAsync(configPath, name, verbose, CancellationToken.None);
+        });
+
+        return cmd;
+    }
+
+    internal async Task<int> ExecuteAddAsync(
+        string configPath,
+        string name,
+        string? api,
+        string? apiKey,
+        string? baseUrl,
+        string? defaultModel,
+        IReadOnlyCollection<string> models,
+        bool enabled,
+        bool verbose,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            AnsiConsole.MarkupLine("[red]--name is required.[/]");
+            return 1;
+        }
+
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
+        config.Providers ??= new Dictionary<string, ProviderConfig>(StringComparer.OrdinalIgnoreCase);
+
+        var existed = config.Providers.TryGetValue(name, out var existing);
+        var updated = new ProviderConfig
+        {
+            Enabled = enabled,
+            ApiKey = apiKey ?? (existed ? existing!.ApiKey : null),
+            BaseUrl = baseUrl ?? (existed ? existing!.BaseUrl : null),
+            DefaultModel = defaultModel ?? (existed ? existing!.DefaultModel : null),
+            Api = api ?? (existed ? existing!.Api : null),
+            Models = models.Count > 0 ? models.ToList() : (existed ? existing!.Models : null)
+        };
+
+        config.Providers[name] = updated;
+        await SaveConfigAsync(config, configPath, cancellationToken);
+
+        AnsiConsole.MarkupLine(existed
+            ? $"[green]✓[/] Provider [green]{name}[/] updated."
+            : $"[green]✓[/] Provider [green]{name}[/] added.");
+        AnsiConsole.MarkupLine($"  Config saved to: {configPath}");
+
+        if (verbose)
+        {
+            var json = JsonSerializer.Serialize(updated, WriteJsonOptions);
+            AnsiConsole.MarkupLine($"\n[dim]{Markup.Escape(json)}[/]");
+        }
+
+        return 0;
+    }
+
+    internal async Task<int> ExecuteRemoveAsync(string configPath, string name, bool verbose, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            AnsiConsole.MarkupLine("[red]--name is required.[/]");
+            return 1;
+        }
+
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
+        if (config.Providers is null || !config.Providers.ContainsKey(name))
+        {
+            AnsiConsole.MarkupLine($"[yellow]No provider named '{Markup.Escape(name)}' to remove.[/]");
+            return 0;
+        }
+
+        config.Providers.Remove(name);
+        await SaveConfigAsync(config, configPath, cancellationToken);
+
+        AnsiConsole.MarkupLine($"[green]✓[/] Provider [green]{Markup.Escape(name)}[/] removed.");
+        AnsiConsole.MarkupLine($"  Config saved to: {configPath}");
+        if (verbose)
+            AnsiConsole.MarkupLine($"[dim]Remaining providers: {config.Providers.Count}[/]");
+
+        return 0;
     }
 
     internal async Task<int> ExecuteDefaultAsync(bool verbose, CancellationToken cancellationToken)

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
@@ -100,4 +100,148 @@ public class ProviderCommandTests
 
         entry.Expires.ShouldBe(1700000000000);
     }
+
+    [Fact]
+    public async Task ExecuteAddAsync_creates_new_provider_with_all_fields()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+
+            var exit = await cmd.ExecuteAddAsync(
+                configPath,
+                name: "integration-mock",
+                api: "integration-mock",
+                apiKey: "n/a",
+                baseUrl: null,
+                defaultModel: "integration-mock-echo",
+                models: new[] { "integration-mock-echo" },
+                enabled: true,
+                verbose: false,
+                CancellationToken.None);
+
+            exit.ShouldBe(0);
+            File.Exists(configPath).ShouldBeTrue();
+
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var providers = doc.RootElement.GetProperty("providers");
+            var prov = providers.GetProperty("integration-mock");
+            prov.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+            prov.GetProperty("api").GetString().ShouldBe("integration-mock");
+            prov.GetProperty("apiKey").GetString().ShouldBe("n/a");
+            prov.GetProperty("defaultModel").GetString().ShouldBe("integration-mock-echo");
+            prov.GetProperty("models").EnumerateArray().Select(e => e.GetString()).ShouldContain("integration-mock-echo");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAddAsync_updates_existing_provider_preserving_unspecified_fields()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+
+            await cmd.ExecuteAddAsync(
+                configPath, "openai", api: "openai-completions", apiKey: "sk-original",
+                baseUrl: "https://example.test", defaultModel: "gpt-x", models: Array.Empty<string>(),
+                enabled: true, verbose: false, CancellationToken.None);
+
+            // Update only the default model — other fields should remain.
+            var exit = await cmd.ExecuteAddAsync(
+                configPath, "openai", api: null, apiKey: null,
+                baseUrl: null, defaultModel: "gpt-y", models: Array.Empty<string>(),
+                enabled: true, verbose: false, CancellationToken.None);
+
+            exit.ShouldBe(0);
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var prov = doc.RootElement.GetProperty("providers").GetProperty("openai");
+            prov.GetProperty("apiKey").GetString().ShouldBe("sk-original");
+            prov.GetProperty("baseUrl").GetString().ShouldBe("https://example.test");
+            prov.GetProperty("defaultModel").GetString().ShouldBe("gpt-y");
+            prov.GetProperty("api").GetString().ShouldBe("openai-completions");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAddAsync_disabled_flag_persists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+
+            await cmd.ExecuteAddAsync(
+                configPath, "foo", api: null, apiKey: "k",
+                baseUrl: null, defaultModel: null, models: Array.Empty<string>(),
+                enabled: false, verbose: false, CancellationToken.None);
+
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.GetProperty("providers").GetProperty("foo").GetProperty("enabled").GetBoolean().ShouldBeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteRemoveAsync_removes_provider_when_present()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+            await cmd.ExecuteAddAsync(configPath, "to-remove", null, "k", null, null, Array.Empty<string>(), true, false, CancellationToken.None);
+
+            var exit = await cmd.ExecuteRemoveAsync(configPath, "to-remove", verbose: false, CancellationToken.None);
+
+            exit.ShouldBe(0);
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.GetProperty("providers").TryGetProperty("to-remove", out _).ShouldBeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteRemoveAsync_returns_zero_when_provider_missing()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+            var exit = await cmd.ExecuteRemoveAsync(configPath, "never-existed", verbose: false, CancellationToken.None);
+            exit.ShouldBe(0);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
 }


### PR DESCRIPTION
Adds non-interactive `botnexus provider add` / `botnexus provider remove` and corrects outdated provider documentation surfaced during the integration-mock work in #588.

> Stacked on #588 (`feat/587-integration-mock-provider`). Once #588 merges, GitHub will narrow this PR's diff to just the changes below.

## CLI changes

### `provider add`
Required `--name`; optional `--api`, `--api-key`, `--base-url`, `--default-model`, `--model` (repeatable), `--disabled`, `--target`, `--verbose`.

Update semantics: when the provider already exists, only the flags you pass are updated; unspecified fields preserve their previous values — least-surprise for scripted updates.

### `provider remove`
Required `--name`; idempotent (returns 0 when missing).

### Example (integration-test setup, fully scripted):
```powershell
botnexus init --target 
botnexus provider add --name integration-mock --api integration-mock `
    --default-model integration-mock-echo --target 
```

## Documentation sweep

These were broken on `main` — users following these guides today would fail to build:

- `src/agent/AGENTS.md` — fixed `ILlmProvider`/`LlmClient` → `IApiProvider`; added Agent.Providers.IntegrationMock entry; added step about wiring providers in `Program.cs`.
- `docs/extension-development.md` — clarified that LLM providers are **not** currently extension-loaded (they ship in `src/agent/` and implement `IApiProvider`); dropped `ILlmProvider` from convention-based registration and troubleshooting sections.
- `docs/configuration.md` — replaced the wrong `BotNexus.Providers` (PascalCase, nested) example with the actual flat camelCase schema; added a table documenting every `ProviderConfig` field including the new `api` field.
- `docs/cli-reference.md` — full reference entries for the two new subcommands with examples.

## Validation

- `dotnet build BotNexus.slnx` — 0 warnings, 0 errors
- `dotnet test tests\gateway\BotNexus.Cli.Tests` — **91 passed** (5 new `ProviderCommandTests`)
- Smoke-tested the real CLI end-to-end (`provider add → provider remove` round-trip writes/clears `config.json` correctly)

Closes #589
