### PR TITLE
feat(cli+tests): non-interactive provider commands, integration-mock provider, and CLI integration test harness

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -83,6 +83,9 @@
     <Project Path="tests/extensions/BotNexus.Extensions.WebTools.Tests/BotNexus.Extensions.WebTools.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj" />
   </Folder>
+  <Folder Name="/tests/integration/">
+    <Project Path="tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj" />
+  </Folder>
   <Folder Name="/tests/gateway/">
     <Project Path="tests/gateway/BotNexus.Cli.Tests/BotNexus.Cli.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Cron.Tests/BotNexus.Cron.Tests.csproj" />

--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -23,6 +23,7 @@
     <Project Path="src/agent/BotNexus.Agent.Providers.OpenAI/BotNexus.Agent.Providers.OpenAI.csproj" />
     <Project Path="src/agent/BotNexus.Agent.Providers.OpenAICompat/BotNexus.Agent.Providers.OpenAICompat.csproj" />
     <Project Path="src/agent/BotNexus.Agent.Providers.Copilot/BotNexus.Agent.Providers.Copilot.csproj" />
+    <Project Path="src/agent/BotNexus.Agent.Providers.IntegrationMock/BotNexus.Agent.Providers.IntegrationMock.csproj" />
   </Folder>
   <Folder Name="/src/gateway/">
     <Project Path="src/gateway/BotNexus.Cli/BotNexus.Cli.csproj" />
@@ -60,6 +61,7 @@
     <Project Path="tests/agent/BotNexus.Agent.Providers.Core.Tests/BotNexus.Agent.Providers.Core.Tests.csproj" />
     <Project Path="tests/agent/BotNexus.Agent.Providers.OpenAI.Tests/BotNexus.Agent.Providers.OpenAI.Tests.csproj" />
     <Project Path="tests/agent/BotNexus.Agent.Providers.OpenAICompat.Tests/BotNexus.Agent.Providers.OpenAICompat.Tests.csproj" />
+    <Project Path="tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/BotNexus.Agent.Providers.IntegrationMock.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/architecture/">
     <Project Path="tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj" />

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -65,6 +65,8 @@ You should see the root command help listing all available subcommands.
 13. [provider](#provider) — Show or set up providers
 14. [provider setup](#provider-setup) — Interactive provider setup wizard
 15. [provider list](#provider-list) — List configured providers
+16. [provider add](#provider-add) — Add or update a provider non-interactively (scripts and CI)
+17. [provider remove](#provider-remove) — Remove a provider non-interactively
 16. [prompt](#prompt) — Manage prompt templates
 17. [prompt list](#prompt-list) — List available prompt templates
 18. [prompt render](#prompt-render) — Render a prompt template
@@ -824,6 +826,85 @@ Example output:
 │ github-copilot  │ Yes     │ OAuth │ gpt-4.1       │ default │
 │ openai          │ Yes     │ sk-…  │ gpt-4o        │ default │
 └─────────────────┴─────────┴───────┴───────────────┴─────────┘
+```
+
+---
+
+## provider add
+
+Add or update a provider entry in `config.json` non-interactively. Designed for scripts, CI, and integration tests that need to configure providers without the interactive wizard.
+
+When a provider with the given `--name` already exists, only the flags you pass are updated; unspecified fields preserve their previous values. To clear a previously-set value, pass an empty string explicitly.
+
+### Usage
+
+```powershell
+botnexus provider add --name <NAME> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--name <NAME>` | **Required.** Provider name (e.g. `openai`, `integration-mock`). |
+| `--api <API>` | API contract this provider handles. One of `openai-completions` (default), `openai-responses`, `anthropic-messages`, `integration-mock`. |
+| `--api-key <KEY>` | API key value, or `auth:<name>` to reference an OAuth entry in `auth.json`. |
+| `--base-url <URL>` | Base URL for OpenAI-compatible endpoints, or catalog file path for `integration-mock`. |
+| `--default-model <ID>` | Default model id for this provider. |
+| `--model <ID>` | Allowed model id. Repeatable. Omit to allow all models registered for this provider. |
+| `--disabled` | Add the provider in disabled state. Disabled providers are hidden from the API. |
+| `--target <PATH>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+| `--verbose` | Print the serialized provider entry after save. |
+
+### Examples
+
+**Add an OpenAI provider:**
+
+```powershell
+botnexus provider add --name openai --api-key sk-... --default-model gpt-4o
+```
+
+**Add the integration-mock provider for tests (uses built-in `HELLO_WORLD` catalog):**
+
+```powershell
+botnexus provider add --name integration-mock --api integration-mock --default-model integration-mock-echo
+```
+
+**Add an OpenAI-compatible local endpoint with a restricted model list:**
+
+```powershell
+botnexus provider add --name local-vllm `
+    --api openai-completions `
+    --base-url http://localhost:8000/v1 `
+    --api-key not-needed `
+    --model llama-3-8b --model llama-3-70b `
+    --default-model llama-3-8b
+```
+
+---
+
+## provider remove
+
+Remove a provider entry from `config.json` non-interactively. Returns exit code 0 even if the named provider does not exist (idempotent).
+
+### Usage
+
+```powershell
+botnexus provider remove --name <NAME> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--name <NAME>` | **Required.** Provider name to remove. |
+| `--target <PATH>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+| `--verbose` | Print remaining provider count after removal. |
+
+### Examples
+
+```powershell
+botnexus provider remove --name integration-mock
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,17 +55,11 @@ On first run, BotNexus creates a minimal default config:
 
 ```json
 {
-  "BotNexus": {
-    "ExtensionsPath": "~/.botnexus/extensions",
-    "Providers": {},
-    "Channels": {
-      "Instances": {}
-    },
-    "Tools": {
-      "Extensions": {},
-      "McpServers": {}
-    }
-  }
+  "$schema": "https://raw.githubusercontent.com/sytone/botnexus/main/docs/botnexus-config.schema.json",
+  "version": 1,
+  "providers": {},
+  "agents": {},
+  "channels": {}
 }
 ```
 
@@ -75,22 +69,36 @@ To add your first provider, run the interactive setup wizard:
 botnexus provider setup
 ```
 
-Or add it manually to the `Providers` section:
+Or add it manually to the `providers` section. `config.json` is a flat top-level document — there is **no** `BotNexus` wrapper. All keys use `camelCase`:
 
 ```json
 {
-  "BotNexus": {
-    "ExtensionsPath": "~/.botnexus/extensions",
-    "Providers": {
-      "copilot": {
-        "Auth": "oauth",
-        "DefaultModel": "gpt-4o",
-        "ApiBase": "https://api.githubcopilot.com"
-      }
+  "version": 1,
+  "providers": {
+    "github-copilot": {
+      "enabled": true,
+      "apiKey": "auth:github-copilot",
+      "defaultModel": "gpt-4o"
+    },
+    "openai": {
+      "enabled": true,
+      "apiKey": "sk-...",
+      "defaultModel": "gpt-4o-mini"
     }
   }
 }
 ```
+
+**`ProviderConfig` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | `bool` | Whether this provider is active. Disabled providers are hidden from the API. Defaults to `true`. |
+| `apiKey` | `string?` | API key value, or `auth:<name>` to reference an OAuth entry in `auth.json`. |
+| `baseUrl` | `string?` | Base URL override for OpenAI-compatible endpoints, or catalog file path for `integration-mock`. |
+| `defaultModel` | `string?` | Default model id used when an agent does not specify one. |
+| `models` | `string[]?` | Allowed model ids. `null` means all registered models; `[]` means none. |
+| `api` | `string?` | Wire-contract identifier. One of `openai-completions` (default), `openai-responses`, `anthropic-messages`, `integration-mock`. Required when the provider speaks a non-OpenAI-completions contract. |
 
 ---
 
@@ -1003,14 +1011,15 @@ extensions/
 
 ### Extension Registration
 
-Each extension assembly can implement `IExtensionRegistrar` to register types in the DI container:
+Each extension assembly can implement `IExtensionRegistrar` to register types in the DI container. (LLM providers are not currently extension-loaded — they ship as `src/agent/BotNexus.Agent.Providers.*/` projects and are wired in `Program.cs`. The snippet below illustrates the historical extension shape only.)
 
 ```csharp
 public class CopilotExtensionRegistrar : IExtensionRegistrar
 {
     public void Register(IServiceCollection services, IConfiguration configuration)
     {
-        services.AddSingleton<ILlmProvider>(sp =>
+        // Historical example only — providers are not currently extension-loaded.
+        services.AddSingleton<IApiProvider>(sp =>
         {
             var tokenStore = new FileOAuthTokenStore();
             // ... create and return CopilotProvider

--- a/docs/extension-development.md
+++ b/docs/extension-development.md
@@ -311,11 +311,17 @@ Enable the extension in `~/.botnexus/config.json` (or `appsettings.json`):
 
 ## Creating a Provider Extension
 
+> **Note:** LLM providers are currently **not** loaded through the extension pipeline. They live in `src/agent/BotNexus.Agent.Providers.*/` projects and implement
+> `IApiProvider` (from `BotNexus.Agent.Providers.Core.Registry`). Registration is wired directly in
+> `src/gateway/BotNexus.Gateway.Api/Program.cs` rather than discovered from the `extensions/providers/` folder. The historical pattern below is kept for reference and as a target for a future provider-extension host; until that lands, ship new providers as agent projects following the convention in `src/agent/AGENTS.md`.
+
 **Providers** are LLM backends that agents use for intelligence. Examples: OpenAI, Anthropic, GitHub Copilot, local models.
 
 ### Step 1: Create a Provider Class
 
-Inherit from `LlmProviderBase` (or implement `ILlmProvider` directly for advanced use cases).
+Implement `IApiProvider` from `BotNexus.Agent.Providers.Core.Registry`. The interface exposes an `Api` string (the wire-contract identifier, e.g. `"openai-completions"`) and a `Stream`/`StreamSimple` pair that returns an `LlmStream`. See `src/agent/BotNexus.Agent.Providers.OpenAICompat/` for a working reference implementation, and `src/agent/BotNexus.Agent.Providers.IntegrationMock/` for a deterministic test-only provider.
+
+The (legacy, non-functional) `LlmProviderBase` example below is preserved only to illustrate the historical extension shape — do **not** copy it verbatim.
 
 ```csharp
 using System.Runtime.CompilerServices;
@@ -878,7 +884,7 @@ public sealed class GitHubExtensionRegistrar : IExtensionRegistrar
 
 ### Convention-Based Registration (Automatic)
 
-If your extension assembly contains **exactly one** type implementing `IChannel`, `ILlmProvider`, or `ITool`, the loader will automatically register it without requiring an `IExtensionRegistrar`.
+If your extension assembly contains **exactly one** type implementing `IChannel` or `ITool`, the loader will automatically register it without requiring an `IExtensionRegistrar`. (LLM providers are not currently extension-loaded — see the [Creating a Provider Extension](#creating-a-provider-extension) note.)
 
 ```csharp
 // Extension loader discovers this automatically
@@ -1570,7 +1576,7 @@ dotnet publish src/BotNexus.Gateway -o ./publish
 
 ### "IExtensionRegistrar not found"
 
-**Cause:** Extension assembly doesn't have an `IExtensionRegistrar` implementation and convention-based registration failed (multiple or no implementations of `IChannel`/`ILlmProvider`/`ITool`).
+**Cause:** Extension assembly doesn't have an `IExtensionRegistrar` implementation and convention-based registration failed (multiple or no implementations of `IChannel`/`ITool`).
 
 **Fix:**
 1. Create a class implementing `IExtensionRegistrar`
@@ -1639,7 +1645,7 @@ To create a BotNexus extension:
 1. **Create a class library** targeting `net10.0`
 2. **Add `ExtensionType` and `ExtensionName`** to `.csproj`
 3. **Import `Extension.targets`** to auto-copy binaries
-4. **Implement the interface** (`IChannel`, `ILlmProvider`, or `ITool`)
+4. **Implement the interface** (`IChannel` or `ITool`; LLM providers ship as `src/agent/` projects implementing `IApiProvider`)
 5. **Optionally implement `IExtensionRegistrar`** for advanced DI
 6. **Add configuration** to `~/.botnexus/config.json` (or `appsettings.json`)
 7. **Build** and binaries appear in `extensions/{type}/{name}/`

--- a/src/agent/AGENTS.md
+++ b/src/agent/AGENTS.md
@@ -24,10 +24,12 @@ Projects in `src/agent/` must **never** depend on projects outside this folder. 
 | `BotNexus.Agent.Providers.Anthropic` | Anthropic Messages API provider |
 | `BotNexus.Agent.Providers.Copilot` | GitHub Copilot provider |
 | `BotNexus.Agent.Providers.OpenAICompat` | OpenAI-compatible endpoint provider (vLLM, SGLang, etc.) |
+| `BotNexus.Agent.Providers.IntegrationMock` | Deterministic provider for integration, UI, and concurrency tests — returns scripted, key-based responses |
 
 ## Adding a new provider
 
 1. Create `src/agent/BotNexus.Agent.Providers.{Name}/`
 2. Reference only `BotNexus.Agent.Providers.Core` (sibling project)
-3. Implement `ILlmProvider` or extend `LlmClient`
-4. Do not reference gateway, extension, or domain projects
+3. Implement `IApiProvider` (from `BotNexus.Agent.Providers.Core.Registry`) — declare an `Api` string that uniquely identifies the wire contract (e.g. `"openai-completions"`, `"anthropic-messages"`, `"integration-mock"`)
+4. Register the provider and its models in `src/gateway/BotNexus.Gateway.Api/Program.cs`
+5. Do not reference gateway, extension, or domain projects

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/BotNexus.Agent.Providers.IntegrationMock.csproj
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/BotNexus.Agent.Providers.IntegrationMock.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Agent.Providers.IntegrationMock</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/DefaultCatalog.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/DefaultCatalog.cs
@@ -1,0 +1,30 @@
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Built-in scripts that ship with the integration-mock provider. Always loaded as a fallback
+/// so well-known keys (currently <see cref="HelloWorldKey"/>) are available without any
+/// configuration or external catalog file.
+/// </summary>
+public static class DefaultCatalog
+{
+    /// <summary>The well-known smoke-test key — produces a small "Hello, world!" stream.</summary>
+    public const string HelloWorldKey = "HELLO_WORLD";
+
+    /// <summary>
+    /// The default catalog. Currently contains a single script for <see cref="HelloWorldKey"/>
+    /// that emits four text deltas with 20ms gaps followed by a normal stop.
+    /// </summary>
+    public static readonly MockCatalog Catalog = new(
+        new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>(StringComparer.Ordinal)
+        {
+            [HelloWorldKey] = new List<ScriptedResponseStep>
+            {
+                new("text_delta", Delta: "Hello", DelayMs: 20),
+                new("text_delta", Delta: ", ", DelayMs: 20),
+                new("text_delta", Delta: "world", DelayMs: 20),
+                new("text_delta", Delta: "!", DelayMs: 20),
+                new("text_end"),
+                new("done", StopReason: "stop")
+            }
+        });
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockModels.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockModels.cs
@@ -1,0 +1,37 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Built-in model definitions for the integration-mock provider. Models registered here use
+/// <c>Api = "integration-mock"</c> so the <see cref="ApiProviderRegistry"/> routes them to
+/// <see cref="IntegrationMockProvider"/>.
+/// </summary>
+public sealed class IntegrationMockModels
+{
+    /// <summary>The provider name used in registry lookups and config files.</summary>
+    public const string ProviderName = "integration-mock";
+
+    /// <summary>The API identifier shared with <see cref="IntegrationMockProvider.Api"/>.</summary>
+    public const string ApiName = "integration-mock";
+
+    /// <summary>Default echo model id — always present in the registry regardless of config.</summary>
+    public const string DefaultModelId = "integration-mock-echo";
+
+    /// <summary>Register the built-in mock model. Idempotent — safe to call repeatedly.</summary>
+    public void RegisterAll(ModelRegistry modelRegistry)
+    {
+        modelRegistry.Register(ProviderName, new LlmModel(
+            Id: DefaultModelId,
+            Name: "Integration Mock Echo",
+            Api: ApiName,
+            Provider: ProviderName,
+            BaseUrl: string.Empty,
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 128000,
+            MaxTokens: 32000));
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/IntegrationMockProvider.cs
@@ -1,0 +1,306 @@
+using System.Diagnostics;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Diagnostics;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Deterministic LLM provider that returns scripted responses keyed by the trimmed text of
+/// the last <see cref="UserMessage"/> in the request. Designed for integration, UI, and
+/// concurrency tests where a real provider would be slow, costly, or non-deterministic.
+///
+/// <para>Scripts are sourced from a <see cref="MockCatalog"/> resolved by
+/// <see cref="MockCatalogLoader"/>; see that type for path precedence. When no script matches
+/// the key the provider emits a single text event <c>"NO_SCRIPT:&lt;key&gt;"</c> and stops —
+/// failing loud rather than silently behaving like a default LLM.</para>
+/// </summary>
+public sealed class IntegrationMockProvider : IApiProvider
+{
+    private readonly MockCatalogLoader _loader;
+
+    /// <summary>The API identifier this provider serves.</summary>
+    public string Api => IntegrationMockModels.ApiName;
+
+    /// <summary>
+    /// Create a provider. Pass <paramref name="loader"/> in tests to inject a fixed catalog;
+    /// production wiring uses the default loader which reads the path from <c>model.BaseUrl</c>,
+    /// the <c>BOTNEXUS_MOCK_CATALOG</c> env var, or the built-in default.
+    /// </summary>
+    public IntegrationMockProvider(MockCatalogLoader? loader = null)
+    {
+        _loader = loader ?? new MockCatalogLoader();
+    }
+
+    /// <inheritdoc />
+    public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+    {
+        var stream = new LlmStream();
+
+        _ = Task.Run(async () =>
+        {
+            using var activity = ProviderDiagnostics.Source.StartActivity(
+                "provider.integration-mock.stream", ActivityKind.Client);
+            activity?.SetTag("botnexus.provider.name", model.Provider);
+            activity?.SetTag("botnexus.model", model.Id);
+            activity?.SetTag("botnexus.model.api", model.Api);
+
+            try
+            {
+                await StreamCoreAsync(model, context, options, stream);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+            }
+            catch (Exception ex)
+            {
+                var errorMessage = CreateErrorMessage(model, ex.Message);
+                stream.Push(new ErrorEvent(StopReason.Error, errorMessage));
+                stream.End(errorMessage);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            }
+        });
+
+        return stream;
+    }
+
+    /// <inheritdoc />
+    public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+        => Stream(model, context, options);
+
+    private async Task StreamCoreAsync(LlmModel model, Context context, StreamOptions? options, LlmStream stream)
+    {
+        var ct = options?.CancellationToken ?? CancellationToken.None;
+        var catalog = _loader.Resolve(string.IsNullOrWhiteSpace(model.BaseUrl) ? null : model.BaseUrl);
+        var key = ExtractKey(context);
+
+        // Track running state for partial AssistantMessage snapshots emitted with each event.
+        var contentBlocks = new List<ContentBlock>();
+        var textBuffers = new Dictionary<int, System.Text.StringBuilder>();
+        var thinkingBuffers = new Dictionary<int, System.Text.StringBuilder>();
+        var currentIndex = -1;
+
+        AssistantMessage Snapshot(StopReason stopReason = StopReason.Stop, string? errorMessage = null)
+            => new(
+                Content: contentBlocks.ToArray(),
+                Api: Api,
+                Provider: model.Provider,
+                ModelId: model.Id,
+                Usage: Usage.Empty(),
+                StopReason: stopReason,
+                ErrorMessage: errorMessage,
+                ResponseId: null,
+                Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new StartEvent(Snapshot()));
+
+        var script = _loader.Lookup(catalog, key);
+        if (script is null)
+        {
+            await EmitNoScriptAsync(stream, model, key, contentBlocks, Snapshot, ct);
+            return;
+        }
+
+        foreach (var step in script)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (step.DelayMs is > 0)
+                await Task.Delay(step.DelayMs.Value, ct);
+
+            switch (step.Type)
+            {
+                case "text_delta":
+                    {
+                        var (index, builder) = EnsureTextBlock(contentBlocks, textBuffers, ref currentIndex);
+                        if (builder.Length == 0)
+                            stream.Push(new TextStartEvent(index, Snapshot()));
+                        var delta = step.Delta ?? string.Empty;
+                        builder.Append(delta);
+                        contentBlocks[index] = new TextContent(builder.ToString());
+                        stream.Push(new TextDeltaEvent(index, delta, Snapshot()));
+                        break;
+                    }
+                case "text_end":
+                    {
+                        if (currentIndex >= 0 && textBuffers.TryGetValue(currentIndex, out var builder))
+                        {
+                            var text = builder.ToString();
+                            contentBlocks[currentIndex] = new TextContent(text);
+                            stream.Push(new TextEndEvent(currentIndex, text, Snapshot()));
+                            currentIndex = -1;
+                        }
+                        break;
+                    }
+                case "thinking_delta":
+                    {
+                        var (index, builder) = EnsureThinkingBlock(contentBlocks, thinkingBuffers, ref currentIndex);
+                        if (builder.Length == 0)
+                            stream.Push(new ThinkingStartEvent(index, Snapshot()));
+                        var delta = step.Delta ?? string.Empty;
+                        builder.Append(delta);
+                        contentBlocks[index] = new ThinkingContent(builder.ToString());
+                        stream.Push(new ThinkingDeltaEvent(index, delta, Snapshot()));
+                        break;
+                    }
+                case "thinking_end":
+                    {
+                        if (currentIndex >= 0 && thinkingBuffers.TryGetValue(currentIndex, out var builder))
+                        {
+                            var content = builder.ToString();
+                            contentBlocks[currentIndex] = new ThinkingContent(content);
+                            stream.Push(new ThinkingEndEvent(currentIndex, content, Snapshot()));
+                            currentIndex = -1;
+                        }
+                        break;
+                    }
+                case "tool_call":
+                    {
+                        var toolName = step.ToolName
+                            ?? throw new InvalidOperationException("tool_call step requires toolName.");
+                        var toolCallId = step.ToolCallId ?? $"mock-{Guid.NewGuid():N}";
+                        var args = step.ToolArguments ?? new Dictionary<string, object?>();
+                        var toolCall = new ToolCallContent(toolCallId, toolName, args);
+                        contentBlocks.Add(toolCall);
+                        var index = contentBlocks.Count - 1;
+                        stream.Push(new ToolCallStartEvent(index, Snapshot(StopReason.ToolUse)));
+                        stream.Push(new ToolCallEndEvent(index, toolCall, Snapshot(StopReason.ToolUse)));
+                        currentIndex = -1;
+                        break;
+                    }
+                case "done":
+                    {
+                        var reason = ParseStopReason(step.StopReason) ?? StopReason.Stop;
+                        var message = Snapshot(reason);
+                        stream.Push(new DoneEvent(reason, message));
+                        return;
+                    }
+                case "error":
+                    {
+                        var reason = ParseStopReason(step.StopReason) ?? StopReason.Error;
+                        var errorText = step.ErrorMessage ?? "Mock error.";
+                        var message = Snapshot(reason, errorText);
+                        stream.Push(new ErrorEvent(reason, message));
+                        stream.End(message);
+                        return;
+                    }
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown scripted step type '{step.Type}' for key '{key}'.");
+            }
+        }
+
+        // Script ended without an explicit done/error — synthesize a normal stop.
+        var fallback = Snapshot();
+        stream.Push(new DoneEvent(StopReason.Stop, fallback));
+    }
+
+    private async Task EmitNoScriptAsync(
+        LlmStream stream,
+        LlmModel model,
+        string key,
+        List<ContentBlock> contentBlocks,
+        Func<StopReason, string?, AssistantMessage> snapshot,
+        CancellationToken ct)
+    {
+        // Allow callers to await the result.
+        await Task.Yield();
+
+        var text = $"NO_SCRIPT:{key}";
+        contentBlocks.Add(new TextContent(text));
+        var index = contentBlocks.Count - 1;
+        stream.Push(new TextStartEvent(index, snapshot(StopReason.Stop, null)));
+        stream.Push(new TextDeltaEvent(index, text, snapshot(StopReason.Stop, null)));
+        stream.Push(new TextEndEvent(index, text, snapshot(StopReason.Stop, null)));
+        stream.Push(new DoneEvent(StopReason.Stop, snapshot(StopReason.Stop, null)));
+    }
+
+    private static (int Index, System.Text.StringBuilder Builder) EnsureTextBlock(
+        List<ContentBlock> blocks,
+        Dictionary<int, System.Text.StringBuilder> buffers,
+        ref int currentIndex)
+    {
+        if (currentIndex >= 0 && blocks[currentIndex] is TextContent && buffers.ContainsKey(currentIndex))
+            return (currentIndex, buffers[currentIndex]);
+
+        blocks.Add(new TextContent(string.Empty));
+        var index = blocks.Count - 1;
+        var builder = new System.Text.StringBuilder();
+        buffers[index] = builder;
+        currentIndex = index;
+        return (index, builder);
+    }
+
+    private static (int Index, System.Text.StringBuilder Builder) EnsureThinkingBlock(
+        List<ContentBlock> blocks,
+        Dictionary<int, System.Text.StringBuilder> buffers,
+        ref int currentIndex)
+    {
+        if (currentIndex >= 0 && blocks[currentIndex] is ThinkingContent && buffers.ContainsKey(currentIndex))
+            return (currentIndex, buffers[currentIndex]);
+
+        blocks.Add(new ThinkingContent(string.Empty));
+        var index = blocks.Count - 1;
+        var builder = new System.Text.StringBuilder();
+        buffers[index] = builder;
+        currentIndex = index;
+        return (index, builder);
+    }
+
+    private static StopReason? ParseStopReason(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "stop" => StopReason.Stop,
+            "length" => StopReason.Length,
+            "tooluse" or "tool_use" or "tool-use" => StopReason.ToolUse,
+            "error" => StopReason.Error,
+            "aborted" => StopReason.Aborted,
+            "refusal" => StopReason.Refusal,
+            "sensitive" => StopReason.Sensitive,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Extract the lookup key from <paramref name="context"/>. The key is the trimmed text of
+    /// the final <see cref="UserMessage"/>; multi-block user messages concatenate their
+    /// <see cref="TextContent"/> blocks. Returns an empty string when no user message is found.
+    /// </summary>
+    public static string ExtractKey(Context context)
+    {
+        for (var i = context.Messages.Count - 1; i >= 0; i--)
+        {
+            if (context.Messages[i] is not UserMessage user)
+                continue;
+
+            if (user.Content.IsText)
+                return (user.Content.Text ?? string.Empty).Trim();
+
+            if (user.Content.Blocks is { Count: > 0 } blocks)
+            {
+                var combined = string.Concat(blocks.OfType<TextContent>().Select(t => t.Text));
+                return combined.Trim();
+            }
+
+            return string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private AssistantMessage CreateErrorMessage(LlmModel model, string error)
+        => new(
+            Content: [new TextContent(error)],
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Error,
+            ErrorMessage: error,
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/MockCatalogLoader.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/MockCatalogLoader.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// Resolves and parses mock response catalogs. Catalog source precedence:
+/// <list type="number">
+///   <item><description>Catalog passed to the constructor (in-memory override, for tests).</description></item>
+///   <item><description>Per-request path from <c>model.BaseUrl</c> when it points at an existing file.</description></item>
+///   <item><description><c>BOTNEXUS_MOCK_CATALOG</c> environment variable.</description></item>
+///   <item><description>Built-in default catalog containing the <c>HELLO_WORLD</c> script.</description></item>
+/// </list>
+/// File catalogs are parsed once and cached by absolute path. The built-in default is always
+/// consulted as a fallback so well-known scripts like <c>HELLO_WORLD</c> are available even
+/// when a custom catalog omits them.
+/// </summary>
+public sealed class MockCatalogLoader
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, MockCatalog> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly MockCatalog? _override;
+
+    /// <summary>
+    /// Create a loader. When <paramref name="explicitCatalog"/> is supplied it is used in
+    /// preference to any file/environment source — primarily for unit testing.
+    /// </summary>
+    public MockCatalogLoader(MockCatalog? explicitCatalog = null)
+    {
+        _override = explicitCatalog;
+    }
+
+    /// <summary>
+    /// Resolve the catalog for a request. A <paramref name="catalogPath"/> sourced from
+    /// <c>model.BaseUrl</c> takes precedence over the environment variable when it points
+    /// at an existing file.
+    /// </summary>
+    public MockCatalog Resolve(string? catalogPath)
+    {
+        if (_override is not null)
+            return _override;
+
+        if (!string.IsNullOrWhiteSpace(catalogPath) && File.Exists(catalogPath))
+            return LoadCached(catalogPath);
+
+        var fromEnv = Environment.GetEnvironmentVariable("BOTNEXUS_MOCK_CATALOG");
+        if (!string.IsNullOrWhiteSpace(fromEnv) && File.Exists(fromEnv))
+            return LoadCached(fromEnv);
+
+        return DefaultCatalog.Catalog;
+    }
+
+    /// <summary>
+    /// Looks up a script in <paramref name="catalog"/>, falling back to the built-in default
+    /// catalog so well-known keys remain available when a custom catalog omits them.
+    /// </summary>
+    public IReadOnlyList<ScriptedResponseStep>? Lookup(MockCatalog catalog, string key)
+    {
+        if (catalog.Scripts is not null && catalog.Scripts.TryGetValue(key, out var script))
+            return script;
+
+        if (!ReferenceEquals(catalog, DefaultCatalog.Catalog)
+            && DefaultCatalog.Catalog.Scripts.TryGetValue(key, out var fallback))
+            return fallback;
+
+        return null;
+    }
+
+    private MockCatalog LoadCached(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+
+        lock (_gate)
+        {
+            if (_cache.TryGetValue(fullPath, out var cached))
+                return cached;
+
+            var json = File.ReadAllText(fullPath);
+            var parsed = JsonSerializer.Deserialize<MockCatalog>(json, JsonOptions)
+                ?? throw new InvalidOperationException(
+                    $"Mock catalog at '{fullPath}' deserialized to null.");
+
+            _cache[fullPath] = parsed;
+            return parsed;
+        }
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.IntegrationMock/ScriptedResponse.cs
+++ b/src/agent/BotNexus.Agent.Providers.IntegrationMock/ScriptedResponse.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Agent.Providers.IntegrationMock;
+
+/// <summary>
+/// A single step in a scripted response. One step maps to either a single streaming event
+/// (text/thinking delta, end) or a higher-level action such as a tool call, completion,
+/// or simulated error. Steps execute in order with an optional <see cref="DelayMs"/> applied
+/// before the step is pushed onto the stream.
+/// </summary>
+/// <param name="Type">
+/// Event kind. One of: <c>text_delta</c>, <c>text_end</c>, <c>thinking_delta</c>,
+/// <c>thinking_end</c>, <c>tool_call</c>, <c>done</c>, <c>error</c>.
+/// </param>
+/// <param name="Delta">Text or thinking delta to push (for <c>text_delta</c>/<c>thinking_delta</c>).</param>
+/// <param name="ToolName">Function name (for <c>tool_call</c>).</param>
+/// <param name="ToolArguments">Argument map (for <c>tool_call</c>).</param>
+/// <param name="ToolCallId">Optional stable identifier (for <c>tool_call</c>). Generated when omitted.</param>
+/// <param name="StopReason">
+/// Stop reason for <c>done</c> / <c>error</c>. Defaults to <c>stop</c> for <c>done</c> and
+/// <c>error</c> for <c>error</c>. Tool-call scripts should use <c>toolUse</c>.
+/// </param>
+/// <param name="ErrorMessage">Error text for <c>error</c>.</param>
+/// <param name="DelayMs">
+/// Milliseconds to wait BEFORE pushing this step. Lets scripts simulate token cadence and
+/// inter-event pauses for realistic streaming and concurrency testing.
+/// </param>
+public sealed record ScriptedResponseStep(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("delta")] string? Delta = null,
+    [property: JsonPropertyName("toolName")] string? ToolName = null,
+    [property: JsonPropertyName("toolArguments")] Dictionary<string, object?>? ToolArguments = null,
+    [property: JsonPropertyName("toolCallId")] string? ToolCallId = null,
+    [property: JsonPropertyName("stopReason")] string? StopReason = null,
+    [property: JsonPropertyName("errorMessage")] string? ErrorMessage = null,
+    [property: JsonPropertyName("delayMs")] int? DelayMs = null);
+
+/// <summary>
+/// The on-disk and in-memory catalog of mock responses. Keyed by the trimmed text of the
+/// final user message (case-sensitive).
+/// </summary>
+public sealed record MockCatalog(
+    [property: JsonPropertyName("scripts")] Dictionary<string, IReadOnlyList<ScriptedResponseStep>> Scripts);

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -57,6 +57,8 @@ internal sealed class ProviderCommand
 
         command.AddCommand(setupCommand);
         command.AddCommand(listCommand);
+        command.AddCommand(BuildAddCommand(verboseOption));
+        command.AddCommand(BuildRemoveCommand(verboseOption));
 
         // Default to setup when no subcommand given
         var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
@@ -71,6 +73,149 @@ internal sealed class ProviderCommand
         });
 
         return command;
+    }
+
+    private static Command BuildAddCommand(Option<bool> verboseOption)
+    {
+        var cmd = new Command("add", "Add or update a provider non-interactively. Useful for scripts and CI.");
+        var nameOpt = new Option<string>("--name", "Provider name (e.g. 'openai', 'integration-mock').") { IsRequired = true };
+        var apiOpt = new Option<string?>("--api", () => null, "API contract handled by this provider (e.g. 'openai-completions', 'openai-responses', 'anthropic-messages', 'integration-mock'). Defaults to 'openai-completions'.");
+        var apiKeyOpt = new Option<string?>("--api-key", () => null, "API key value, or 'auth:<name>' to reference an auth.json OAuth entry.");
+        var baseUrlOpt = new Option<string?>("--base-url", () => null, "Base URL for OpenAI-compatible endpoints, or catalog path for 'integration-mock'.");
+        var defaultModelOpt = new Option<string?>("--default-model", () => null, "Default model id for this provider.");
+        var modelsOpt = new Option<string[]>("--model", () => Array.Empty<string>(), "Allowed model id (repeatable). Omit to allow all models registered for this provider.")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
+        var disabledOpt = new Option<bool>("--disabled", () => false, "Mark the provider as disabled. Disabled providers are hidden from the API.");
+        var targetOpt = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+
+        cmd.AddOption(nameOpt);
+        cmd.AddOption(apiOpt);
+        cmd.AddOption(apiKeyOpt);
+        cmd.AddOption(baseUrlOpt);
+        cmd.AddOption(defaultModelOpt);
+        cmd.AddOption(modelsOpt);
+        cmd.AddOption(disabledOpt);
+        cmd.AddOption(targetOpt);
+
+        cmd.SetHandler(async context =>
+        {
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var target = context.ParseResult.GetValueForOption(targetOpt);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            var name = context.ParseResult.GetValueForOption(nameOpt)!;
+            var api = context.ParseResult.GetValueForOption(apiOpt);
+            var apiKey = context.ParseResult.GetValueForOption(apiKeyOpt);
+            var baseUrl = context.ParseResult.GetValueForOption(baseUrlOpt);
+            var defaultModel = context.ParseResult.GetValueForOption(defaultModelOpt);
+            var models = context.ParseResult.GetValueForOption(modelsOpt) ?? Array.Empty<string>();
+            var disabled = context.ParseResult.GetValueForOption(disabledOpt);
+
+            context.ExitCode = await new ProviderCommand().ExecuteAddAsync(
+                configPath, name, api, apiKey, baseUrl, defaultModel, models, enabled: !disabled, verbose, CancellationToken.None);
+        });
+
+        return cmd;
+    }
+
+    private static Command BuildRemoveCommand(Option<bool> verboseOption)
+    {
+        var cmd = new Command("remove", "Remove a provider non-interactively.");
+        var nameOpt = new Option<string>("--name", "Provider name to remove.") { IsRequired = true };
+        var targetOpt = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+
+        cmd.AddOption(nameOpt);
+        cmd.AddOption(targetOpt);
+
+        cmd.SetHandler(async context =>
+        {
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var target = context.ParseResult.GetValueForOption(targetOpt);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            var name = context.ParseResult.GetValueForOption(nameOpt)!;
+
+            context.ExitCode = await new ProviderCommand().ExecuteRemoveAsync(configPath, name, verbose, CancellationToken.None);
+        });
+
+        return cmd;
+    }
+
+    internal async Task<int> ExecuteAddAsync(
+        string configPath,
+        string name,
+        string? api,
+        string? apiKey,
+        string? baseUrl,
+        string? defaultModel,
+        IReadOnlyCollection<string> models,
+        bool enabled,
+        bool verbose,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            AnsiConsole.MarkupLine("[red]--name is required.[/]");
+            return 1;
+        }
+
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
+        config.Providers ??= new Dictionary<string, ProviderConfig>(StringComparer.OrdinalIgnoreCase);
+
+        var existed = config.Providers.TryGetValue(name, out var existing);
+        var updated = new ProviderConfig
+        {
+            Enabled = enabled,
+            ApiKey = apiKey ?? (existed ? existing!.ApiKey : null),
+            BaseUrl = baseUrl ?? (existed ? existing!.BaseUrl : null),
+            DefaultModel = defaultModel ?? (existed ? existing!.DefaultModel : null),
+            Api = api ?? (existed ? existing!.Api : null),
+            Models = models.Count > 0 ? models.ToList() : (existed ? existing!.Models : null)
+        };
+
+        config.Providers[name] = updated;
+        await SaveConfigAsync(config, configPath, cancellationToken);
+
+        AnsiConsole.MarkupLine(existed
+            ? $"[green]✓[/] Provider [green]{name}[/] updated."
+            : $"[green]✓[/] Provider [green]{name}[/] added.");
+        AnsiConsole.MarkupLine($"  Config saved to: {configPath}");
+
+        if (verbose)
+        {
+            var json = JsonSerializer.Serialize(updated, WriteJsonOptions);
+            AnsiConsole.MarkupLine($"\n[dim]{Markup.Escape(json)}[/]");
+        }
+
+        return 0;
+    }
+
+    internal async Task<int> ExecuteRemoveAsync(string configPath, string name, bool verbose, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            AnsiConsole.MarkupLine("[red]--name is required.[/]");
+            return 1;
+        }
+
+        var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
+        if (config.Providers is null || !config.Providers.ContainsKey(name))
+        {
+            AnsiConsole.MarkupLine($"[yellow]No provider named '{Markup.Escape(name)}' to remove.[/]");
+            return 0;
+        }
+
+        config.Providers.Remove(name);
+        await SaveConfigAsync(config, configPath, cancellationToken);
+
+        AnsiConsole.MarkupLine($"[green]✓[/] Provider [green]{Markup.Escape(name)}[/] removed.");
+        AnsiConsole.MarkupLine($"  Config saved to: {configPath}");
+        if (verbose)
+            AnsiConsole.MarkupLine($"[dim]Remaining providers: {config.Providers.Count}[/]");
+
+        return 0;
     }
 
     internal async Task<int> ExecuteDefaultAsync(bool verbose, CancellationToken cancellationToken)

--- a/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
+++ b/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Anthropic\BotNexus.Agent.Providers.Anthropic.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.OpenAI\BotNexus.Agent.Providers.OpenAI.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.OpenAICompat\BotNexus.Agent.Providers.OpenAICompat.csproj" />
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.IntegrationMock\BotNexus.Agent.Providers.IntegrationMock.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -13,6 +13,7 @@ using BotNexus.Agent.Providers.Core.Registry;
 using Microsoft.Extensions.Options;
 using BotNexus.Agent.Providers.OpenAI;
 using BotNexus.Agent.Providers.OpenAICompat;
+using BotNexus.Agent.Providers.IntegrationMock;
 using BotNexus.Cron;
 using BotNexus.Cron.Extensions;
 using BotNexus.Domain.World;
@@ -228,16 +229,28 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
     apiProviders.Register(new OpenAICompletionsProvider(httpClient, loggerFactory.CreateLogger<OpenAICompletionsProvider>()));
     apiProviders.Register(new OpenAIResponsesProvider(httpClient, loggerFactory.CreateLogger<OpenAIResponsesProvider>()));
     apiProviders.Register(new OpenAICompatProvider(httpClient));
+    apiProviders.Register(new IntegrationMockProvider());
 
     serviceProvider.GetRequiredService<BuiltInModels>().RegisterAll(models);
+    new IntegrationMockModels().RegisterAll(models);
 
-    // Register models from openai-compat providers in config (e.g. Ollama, LM Studio)
+    // Register models from openai-compat providers in config (e.g. Ollama, LM Studio),
+    // or any provider with an explicit Api override (e.g. integration-mock).
     var platformConfig = serviceProvider.GetRequiredService<IOptionsMonitor<PlatformConfig>>().CurrentValue;
     if (platformConfig.Providers is not null)
     {
         foreach (var (providerName, providerConfig) in platformConfig.Providers)
         {
-            if (!providerConfig.Enabled || string.IsNullOrWhiteSpace(providerConfig.BaseUrl))
+            if (!providerConfig.Enabled)
+                continue;
+
+            var apiName = string.IsNullOrWhiteSpace(providerConfig.Api)
+                ? "openai-completions"
+                : providerConfig.Api!;
+            // For openai-completions a BaseUrl is required (the HTTP endpoint). For other
+            // apis (e.g. integration-mock) BaseUrl is provider-specific (catalog file path,
+            // possibly empty) — skip the BaseUrl gate.
+            if (apiName == "openai-completions" && string.IsNullOrWhiteSpace(providerConfig.BaseUrl))
                 continue;
 
             if (providerConfig.Models is { Count: > 0 })
@@ -247,9 +260,9 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
                     models.Register(providerName, new LlmModel(
                         Id: modelId,
                         Name: modelId,
-                        Api: "openai-completions",
+                        Api: apiName,
                         Provider: providerName,
-                        BaseUrl: providerConfig.BaseUrl,
+                        BaseUrl: providerConfig.BaseUrl ?? string.Empty,
                         Reasoning: modelId.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
                         Input: ["text"],
                         Cost: new ModelCost(0, 0, 0, 0),
@@ -260,7 +273,7 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
         }
     }
 
-    // Register the model for any agent using an openai-compat provider not in BuiltInModels
+    // Register the model for any agent using a config-defined provider not in BuiltInModels.
     if (platformConfig.Agents is not null && platformConfig.Providers is not null)
     {
         foreach (KeyValuePair<string, AgentDefinitionConfig> agentEntry in platformConfig.Agents)
@@ -270,7 +283,10 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
                 continue;
             if (!platformConfig.Providers.TryGetValue(agentConfig.Provider, out var agentProvider))
                 continue;
-            if (string.IsNullOrWhiteSpace(agentProvider.BaseUrl))
+            var apiName = string.IsNullOrWhiteSpace(agentProvider.Api)
+                ? "openai-completions"
+                : agentProvider.Api!;
+            if (apiName == "openai-completions" && string.IsNullOrWhiteSpace(agentProvider.BaseUrl))
                 continue;
             if (models.GetModel(agentConfig.Provider, agentConfig.Model) is not null)
                 continue;
@@ -278,9 +294,9 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
             models.Register(agentConfig.Provider, new LlmModel(
                 Id: agentConfig.Model,
                 Name: agentConfig.Model,
-                Api: "openai-completions",
+                Api: apiName,
                 Provider: agentConfig.Provider,
-                BaseUrl: agentProvider.BaseUrl,
+                BaseUrl: agentProvider.BaseUrl ?? string.Empty,
                 Reasoning: agentConfig.Model.Contains("reasoning", StringComparison.OrdinalIgnoreCase),
                 Input: ["text"],
                 Cost: new ModelCost(0, 0, 0, 0),

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -78,6 +78,15 @@ public sealed class ProviderConfig
 
     /// <summary>Allowed model IDs for this provider. Null means all models, empty means none.</summary>
     public List<string>? Models { get; set; }
+
+    /// <summary>
+    /// Optional API identifier used when registering models from this provider's <see cref="Models"/>
+    /// list. Defaults to <c>"openai-completions"</c> for backward compatibility with config-driven
+    /// OpenAI-compatible endpoints (Ollama, LM Studio, etc.). Set to <c>"integration-mock"</c> or
+    /// another registered provider's API name to register models against a different
+    /// <see cref="BotNexus.Agent.Providers.Core.Registry.IApiProvider"/>.
+    /// </summary>
+    public string? Api { get; set; }
 }
 
 /// <summary>Gateway runtime configuration.</summary>

--- a/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/BotNexus.Agent.Providers.IntegrationMock.Tests.csproj
+++ b/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/BotNexus.Agent.Providers.IntegrationMock.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.IntegrationMock\BotNexus.Agent.Providers.IntegrationMock.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/IntegrationMockProviderTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/IntegrationMockProviderTests.cs
@@ -1,0 +1,220 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Streaming;
+
+namespace BotNexus.Agent.Providers.IntegrationMock.Tests;
+
+public class IntegrationMockProviderTests
+{
+    private static Context UserContext(string text) => new(
+        SystemPrompt: null,
+        Messages: new[] { new UserMessage(new UserMessageContent(text), 0L) });
+
+    private static LlmModel Model(string baseUrl = "") => new(
+        Id: IntegrationMockModels.DefaultModelId,
+        Name: "Integration Mock Echo",
+        Api: IntegrationMockModels.ApiName,
+        Provider: IntegrationMockModels.ProviderName,
+        BaseUrl: baseUrl,
+        Reasoning: false,
+        Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 128000,
+        MaxTokens: 32000);
+
+    [Fact]
+    public async Task Stream_HelloWorld_ProducesExpectedEventsAndText()
+    {
+        var provider = new IntegrationMockProvider();
+
+        var stream = provider.Stream(Model(), UserContext(DefaultCatalog.HelloWorldKey));
+
+        var events = new List<AssistantMessageEvent>();
+        await foreach (var evt in stream)
+            events.Add(evt);
+
+        var result = await stream.GetResultAsync();
+
+        // First event is StartEvent, final is DoneEvent with Stop.
+        events.First().ShouldBeOfType<StartEvent>();
+        events.Last().ShouldBeOfType<DoneEvent>();
+        ((DoneEvent)events.Last()).Reason.ShouldBe(StopReason.Stop);
+
+        // Expect exactly one TextStartEvent and one TextEndEvent.
+        events.OfType<TextStartEvent>().Count().ShouldBe(1);
+        events.OfType<TextEndEvent>().Count().ShouldBe(1);
+
+        // Combined deltas reconstruct the canonical message.
+        var combined = string.Concat(events.OfType<TextDeltaEvent>().Select(d => d.Delta));
+        combined.ShouldBe("Hello, world!");
+
+        // Final result also exposes the text.
+        result.Content.OfType<TextContent>().Single().Text.ShouldBe("Hello, world!");
+        result.StopReason.ShouldBe(StopReason.Stop);
+        result.Api.ShouldBe(IntegrationMockModels.ApiName);
+        result.Provider.ShouldBe(IntegrationMockModels.ProviderName);
+    }
+
+    [Fact]
+    public async Task Stream_UnknownKey_EmitsLoudNoScriptResponse()
+    {
+        var provider = new IntegrationMockProvider();
+
+        var stream = provider.Stream(Model(), UserContext("UNKNOWN_KEY"));
+
+        await foreach (var _ in stream) { }
+        var result = await stream.GetResultAsync();
+
+        result.StopReason.ShouldBe(StopReason.Stop);
+        var text = result.Content.OfType<TextContent>().Single().Text;
+        text.ShouldBe("NO_SCRIPT:UNKNOWN_KEY");
+    }
+
+    [Fact]
+    public async Task Stream_HonoursDelaysBetweenSteps()
+    {
+        // Custom catalog with two ~80ms delays — total wall-clock must be at least ~150ms.
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["DELAY"] = new List<ScriptedResponseStep>
+            {
+                new("text_delta", Delta: "A", DelayMs: 80),
+                new("text_delta", Delta: "B", DelayMs: 80),
+                new("text_end"),
+                new("done")
+            }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var stream = provider.Stream(Model(), UserContext("DELAY"));
+        await foreach (var _ in stream) { }
+        await stream.GetResultAsync();
+        sw.Stop();
+
+        sw.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(140);
+    }
+
+    [Fact]
+    public async Task Stream_ToolCallScript_EmitsToolCallEventsWithToolUseStop()
+    {
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["CALL_TOOL"] = new List<ScriptedResponseStep>
+            {
+                new("tool_call",
+                    ToolName: "get_weather",
+                    ToolArguments: new Dictionary<string, object?> { ["city"] = "Sydney" },
+                    ToolCallId: "tc-1"),
+                new("done", StopReason: "toolUse")
+            }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var stream = provider.Stream(Model(), UserContext("CALL_TOOL"));
+        var events = new List<AssistantMessageEvent>();
+        await foreach (var evt in stream)
+            events.Add(evt);
+        var result = await stream.GetResultAsync();
+
+        events.OfType<ToolCallStartEvent>().Count().ShouldBe(1);
+        var endEvt = events.OfType<ToolCallEndEvent>().Single();
+        endEvt.ToolCall.Name.ShouldBe("get_weather");
+        endEvt.ToolCall.Id.ShouldBe("tc-1");
+        endEvt.ToolCall.Arguments["city"].ShouldBe("Sydney");
+
+        result.StopReason.ShouldBe(StopReason.ToolUse);
+        result.Content.OfType<ToolCallContent>().Single().Name.ShouldBe("get_weather");
+    }
+
+    [Fact]
+    public async Task Stream_ErrorStep_EmitsErrorEvent()
+    {
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["BOOM"] = new List<ScriptedResponseStep>
+            {
+                new("error", ErrorMessage: "simulated failure")
+            }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var stream = provider.Stream(Model(), UserContext("BOOM"));
+        var events = new List<AssistantMessageEvent>();
+        await foreach (var evt in stream)
+            events.Add(evt);
+        var result = await stream.GetResultAsync();
+
+        events.OfType<ErrorEvent>().Single().Error.ErrorMessage.ShouldBe("simulated failure");
+        result.StopReason.ShouldBe(StopReason.Error);
+        result.ErrorMessage.ShouldBe("simulated failure");
+    }
+
+    [Fact]
+    public async Task Stream_CustomCatalogViaBaseUrl_OverridesDefault()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"mock-catalog-{Guid.NewGuid():N}.json");
+        try
+        {
+            await File.WriteAllTextAsync(path,
+                """
+                {
+                  "scripts": {
+                    "CUSTOM": [
+                      { "type": "text_delta", "delta": "from-file" },
+                      { "type": "text_end" },
+                      { "type": "done" }
+                    ]
+                  }
+                }
+                """);
+
+            var provider = new IntegrationMockProvider();
+            var stream = provider.Stream(Model(baseUrl: path), UserContext("CUSTOM"));
+            await foreach (var _ in stream) { }
+            var result = await stream.GetResultAsync();
+
+            result.Content.OfType<TextContent>().Single().Text.ShouldBe("from-file");
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Stream_CustomCatalogMissingHelloWorld_StillServesBuiltInDefault()
+    {
+        // Custom catalog that does NOT define HELLO_WORLD — the default fallback must still apply.
+        var catalog = new MockCatalog(new Dictionary<string, IReadOnlyList<ScriptedResponseStep>>
+        {
+            ["OTHER"] = new List<ScriptedResponseStep> { new("done") }
+        });
+        var provider = new IntegrationMockProvider(new MockCatalogLoader(catalog));
+
+        var stream = provider.Stream(Model(), UserContext(DefaultCatalog.HelloWorldKey));
+        await foreach (var _ in stream) { }
+        var result = await stream.GetResultAsync();
+
+        result.Content.OfType<TextContent>().Single().Text.ShouldBe("Hello, world!");
+    }
+
+    [Fact]
+    public void ExtractKey_TrimmedLastUserMessageWins()
+    {
+        var context = new Context(
+            SystemPrompt: null,
+            Messages: new Message[]
+            {
+                new UserMessage(new UserMessageContent("FIRST"), 0L),
+                new AssistantMessage(
+                    Content: [new TextContent("noise")],
+                    Api: "x", Provider: "x", ModelId: "x",
+                    Usage: Usage.Empty(), StopReason: StopReason.Stop,
+                    ErrorMessage: null, ResponseId: null, Timestamp: 0L),
+                new UserMessage(new UserMessageContent("  HELLO_WORLD  "), 0L)
+            });
+
+        IntegrationMockProvider.ExtractKey(context).ShouldBe("HELLO_WORLD");
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/xunit.runner.json
+++ b/tests/agent/BotNexus.Agent.Providers.IntegrationMock.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0
+}

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
@@ -100,4 +100,148 @@ public class ProviderCommandTests
 
         entry.Expires.ShouldBe(1700000000000);
     }
+
+    [Fact]
+    public async Task ExecuteAddAsync_creates_new_provider_with_all_fields()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+
+            var exit = await cmd.ExecuteAddAsync(
+                configPath,
+                name: "integration-mock",
+                api: "integration-mock",
+                apiKey: "n/a",
+                baseUrl: null,
+                defaultModel: "integration-mock-echo",
+                models: new[] { "integration-mock-echo" },
+                enabled: true,
+                verbose: false,
+                CancellationToken.None);
+
+            exit.ShouldBe(0);
+            File.Exists(configPath).ShouldBeTrue();
+
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var providers = doc.RootElement.GetProperty("providers");
+            var prov = providers.GetProperty("integration-mock");
+            prov.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+            prov.GetProperty("api").GetString().ShouldBe("integration-mock");
+            prov.GetProperty("apiKey").GetString().ShouldBe("n/a");
+            prov.GetProperty("defaultModel").GetString().ShouldBe("integration-mock-echo");
+            prov.GetProperty("models").EnumerateArray().Select(e => e.GetString()).ShouldContain("integration-mock-echo");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAddAsync_updates_existing_provider_preserving_unspecified_fields()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+
+            await cmd.ExecuteAddAsync(
+                configPath, "openai", api: "openai-completions", apiKey: "sk-original",
+                baseUrl: "https://example.test", defaultModel: "gpt-x", models: Array.Empty<string>(),
+                enabled: true, verbose: false, CancellationToken.None);
+
+            // Update only the default model — other fields should remain.
+            var exit = await cmd.ExecuteAddAsync(
+                configPath, "openai", api: null, apiKey: null,
+                baseUrl: null, defaultModel: "gpt-y", models: Array.Empty<string>(),
+                enabled: true, verbose: false, CancellationToken.None);
+
+            exit.ShouldBe(0);
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var prov = doc.RootElement.GetProperty("providers").GetProperty("openai");
+            prov.GetProperty("apiKey").GetString().ShouldBe("sk-original");
+            prov.GetProperty("baseUrl").GetString().ShouldBe("https://example.test");
+            prov.GetProperty("defaultModel").GetString().ShouldBe("gpt-y");
+            prov.GetProperty("api").GetString().ShouldBe("openai-completions");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAddAsync_disabled_flag_persists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+
+            await cmd.ExecuteAddAsync(
+                configPath, "foo", api: null, apiKey: "k",
+                baseUrl: null, defaultModel: null, models: Array.Empty<string>(),
+                enabled: false, verbose: false, CancellationToken.None);
+
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.GetProperty("providers").GetProperty("foo").GetProperty("enabled").GetBoolean().ShouldBeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteRemoveAsync_removes_provider_when_present()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+            await cmd.ExecuteAddAsync(configPath, "to-remove", null, "k", null, null, Array.Empty<string>(), true, false, CancellationToken.None);
+
+            var exit = await cmd.ExecuteRemoveAsync(configPath, "to-remove", verbose: false, CancellationToken.None);
+
+            exit.ShouldBe(0);
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.GetProperty("providers").TryGetProperty("to-remove", out _).ShouldBeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteRemoveAsync_returns_zero_when_provider_missing()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "botnexus-cli-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "config.json");
+            var cmd = new ProviderCommand();
+            var exit = await cmd.ExecuteRemoveAsync(configPath, "never-existed", verbose: false, CancellationToken.None);
+            exit.ShouldBe(0);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
 }

--- a/tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!--
+      Integration tests that exercise the published BotNexus.Cli .NET global tool from nuget.org.
+      No ProjectReference to BotNexus.Cli — we intentionally validate the shipped package, not the local build.
+    -->
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliHelpTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliHelpTests.cs
@@ -1,0 +1,43 @@
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Test 2: verify the installed CLI emits sensible help output that advertises the core commands.
+/// </summary>
+[Collection(CliCollection.Name)]
+public sealed class CliHelpTests
+{
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly CliInstallFixture _fixture;
+
+    public CliHelpTests(CliInstallFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Cli_Help_ListsCoreCommands()
+    {
+        _fixture.InstallSucceeded.ShouldBeTrue(
+            "CLI install fixture did not complete successfully — see CliInstallationTests for the install failure.");
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            "--help",
+            timeout: CommandTimeout);
+
+        result.ExitCode.ShouldBe(
+            0,
+            $"botnexus --help exited with {result.ExitCode}.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+
+        var output = result.Combined;
+        output.ShouldNotBeNullOrWhiteSpace();
+        output.ShouldContain("BotNexus");
+
+        // Sanity-check that the published CLI exposes the commands this test project relies on.
+        foreach (var expected in new[] { "init", "install", "validate", "agent" })
+        {
+            output.ShouldContain(
+                expected,
+                Case.Insensitive,
+                customMessage: $"Help output did not advertise expected command '{expected}'. Full output:\n{output}");
+        }
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallAndInitWorkflowTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallAndInitWorkflowTests.cs
@@ -1,0 +1,163 @@
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Test 3: drive the installed CLI through the <c>install</c> and <c>init</c> flow.
+///
+/// Uses a fresh temp directory as a self-contained sandbox:
+///   - <c>&lt;tmp&gt;/source</c>     → target for <c>botnexus install --source</c> (git clones the current repo here)
+///   - <c>&lt;tmp&gt;/.botnexus</c>  → target for <c>botnexus init --target</c>     (config home)
+///
+/// The <c>--repo</c> argument points at the current repository on disk so the test
+/// does not require external network for the git clone step (the CLI itself was
+/// installed from nuget.org by the fixture).
+/// </summary>
+[Collection(CliCollection.Name)]
+public sealed class CliInstallAndInitWorkflowTests : IAsyncLifetime
+{
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromMinutes(5);
+
+    private readonly CliInstallFixture _fixture;
+    private string _sandbox = string.Empty;
+
+    public CliInstallAndInitWorkflowTests(CliInstallFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync()
+    {
+        _sandbox = Path.Combine(Path.GetTempPath(), "botnexus-cli-flow", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_sandbox);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_sandbox))
+                Directory.Delete(_sandbox, recursive: true);
+        }
+        catch
+        {
+            // Cloned .git directories can have read-only files on Windows; best-effort cleanup.
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Cli_Install_ClonesCurrentRepoIntoSandbox()
+    {
+        _fixture.InstallSucceeded.ShouldBeTrue(
+            "CLI install fixture did not complete successfully — see CliInstallationTests for the install failure.");
+
+        var repoRoot = RepoLocator.FindRepoRoot();
+        var sourceDir = Path.Combine(_sandbox, "source");
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"install --source \"{sourceDir}\" --repo \"{repoRoot}\"",
+            timeout: CommandTimeout);
+
+        result.ExitCode.ShouldBe(
+            0,
+            $"botnexus install failed.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+
+        Directory.Exists(sourceDir).ShouldBeTrue(
+            $"Expected source directory at {sourceDir} after install.");
+        Directory.Exists(Path.Combine(sourceDir, ".git")).ShouldBeTrue(
+            "Cloned source should contain a .git directory.");
+        File.Exists(Path.Combine(sourceDir, "BotNexus.slnx")).ShouldBeTrue(
+            "Cloned source should contain BotNexus.slnx (proves the clone is of the current repo).");
+    }
+
+    [Fact]
+    public async Task Cli_Init_CreatesConfigInIsolatedHome()
+    {
+        _fixture.InstallSucceeded.ShouldBeTrue(
+            "CLI install fixture did not complete successfully — see CliInstallationTests for the install failure.");
+
+        var configHome = Path.Combine(_sandbox, ".botnexus");
+
+        // Explicit --target is the contract this test pins; BOTNEXUS_HOME is also cleared
+        // to make sure nothing leaks from the test host into the CLI invocation.
+        var env = new Dictionary<string, string?>
+        {
+            ["BOTNEXUS_HOME"] = null
+        };
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"init --target \"{configHome}\"",
+            environment: env,
+            timeout: CommandTimeout);
+
+        result.ExitCode.ShouldBe(
+            0,
+            $"botnexus init failed.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+
+        // ── Directory layout ──────────────────────────────────────────────
+        // With an explicit --target (non-default home), the CLI seeds only the
+        // config file. The richer layout (auth.json, agents/, sessions/, logs/)
+        // is reserved for BotNexusHome.Initialize() on the default home path,
+        // so we assert that nothing extra leaks into the sandbox.
+        Directory.Exists(configHome).ShouldBeTrue(
+            $"Expected init to create config home at {configHome}.");
+
+        var configPath = Path.Combine(configHome, "config.json");
+        File.Exists(configPath).ShouldBeTrue(
+            $"Expected init to create config.json at {configPath}.");
+
+        var actualEntries = Directory.GetFileSystemEntries(configHome)
+            .Select(p => Path.GetFileName(p)!)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        actualEntries.ShouldBe(
+            new[] { "config.json" },
+            $"Unexpected entries in {configHome}. Got: {string.Join(", ", actualEntries)}");
+
+        // ── config.json content ───────────────────────────────────────────
+        await using var stream = File.OpenRead(configPath);
+        using var doc = await System.Text.Json.JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Object);
+
+        // version
+        root.TryGetProperty("version", out var version).ShouldBeTrue("config.json missing 'version'.");
+        version.GetInt32().ShouldBe(1);
+
+        // gateway block
+        root.TryGetProperty("gateway", out var gateway).ShouldBeTrue("config.json missing 'gateway'.");
+        gateway.GetProperty("listenUrl").GetString().ShouldBe("http://0.0.0.0:5005");
+        gateway.GetProperty("defaultAgentId").GetString().ShouldBe("assistant");
+        gateway.GetProperty("enableProviderRequestLogging").GetBoolean().ShouldBeFalse();
+
+        var sessionStore = gateway.GetProperty("sessionStore");
+        sessionStore.GetProperty("type").GetString().ShouldBe("Sqlite");
+        var connectionString = sessionStore.GetProperty("connectionString").GetString();
+        connectionString.ShouldNotBeNullOrWhiteSpace();
+        connectionString!.ShouldStartWith("Data Source=");
+        // Connection string must point inside the sandboxed home (not the user's real ~/.botnexus).
+        connectionString.ShouldContain("sessions.sqlite");
+        var expectedSqlitePath = Path.Combine(configHome, "sessions.sqlite");
+        connectionString.ShouldContain(
+            expectedSqlitePath,
+            customMessage: $"sessionStore.connectionString must point at the sandboxed home. Got: {connectionString}");
+
+        // cron block
+        root.TryGetProperty("cron", out var cron).ShouldBeTrue("config.json missing 'cron'.");
+        cron.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+        cron.GetProperty("tickIntervalSeconds").GetInt32().ShouldBe(60);
+
+        // agents block + defaults + seeded assistant
+        root.TryGetProperty("agents", out var agents).ShouldBeTrue("config.json missing 'agents'.");
+
+        agents.TryGetProperty("defaults", out var defaults).ShouldBeTrue("agents.defaults missing.");
+        var memory = defaults.GetProperty("memory");
+        memory.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+        memory.GetProperty("indexing").GetString().ShouldBe("auto");
+
+        agents.TryGetProperty("assistant", out var assistant).ShouldBeTrue("agents.assistant missing.");
+        assistant.GetProperty("provider").GetString().ShouldBe("github-copilot");
+        assistant.GetProperty("model").GetString().ShouldBe("gpt-4.1");
+        assistant.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallFixture.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallFixture.cs
@@ -1,0 +1,72 @@
+using System.Runtime.InteropServices;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// xUnit collection fixture that installs the BotNexus.Cli .NET global tool from nuget.org
+/// into an isolated --tool-path so tests can exercise the published binary without
+/// polluting the host's global tool catalogue.
+///
+/// The install runs once per test run. Failures are captured (not thrown) so that
+/// <see cref="CliInstallationTests"/> can assert against them explicitly while still
+/// allowing dependent tests to skip gracefully.
+/// </summary>
+public sealed class CliInstallFixture : IAsyncLifetime
+{
+    private const string PackageId = "BotNexus.Cli";
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(3);
+
+    public string ToolPath { get; private set; } = string.Empty;
+    public string CliExecutablePath { get; private set; } = string.Empty;
+    public bool InstallSucceeded { get; private set; }
+    public int InstallExitCode { get; private set; } = -1;
+    public string InstallOutput { get; private set; } = string.Empty;
+    public string? InstallError { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        // Each test run gets a fresh tool-path so re-installs don't see "already installed" errors.
+        ToolPath = Path.Combine(Path.GetTempPath(), "botnexus-integration-cli", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(ToolPath);
+
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "botnexus.exe" : "botnexus";
+        CliExecutablePath = Path.Combine(ToolPath, exeName);
+
+        try
+        {
+            var result = await ProcessRunner.RunAsync(
+                "dotnet",
+                $"tool install --tool-path \"{ToolPath}\" {PackageId}",
+                timeout: InstallTimeout);
+
+            InstallExitCode = result.ExitCode;
+            InstallOutput = result.Combined;
+            InstallSucceeded = result.ExitCode == 0 && File.Exists(CliExecutablePath);
+        }
+        catch (Exception ex)
+        {
+            InstallError = ex.ToString();
+            InstallSucceeded = false;
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(ToolPath))
+                Directory.Delete(ToolPath, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; locked files on Windows are not worth failing the suite over.
+        }
+        return Task.CompletedTask;
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class CliCollection : ICollectionFixture<CliInstallFixture>
+{
+    public const string Name = "CLI install collection";
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallationTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/CliInstallationTests.cs
@@ -1,0 +1,32 @@
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Test 1 (also the setup test for the project): verify that <c>BotNexus.Cli</c> is
+/// available on nuget.org and can be installed as a .NET global tool. The actual
+/// install is performed once by <see cref="CliInstallFixture"/>; this class asserts
+/// the result so failures surface as a normal test failure rather than a fixture crash.
+/// </summary>
+[Collection(CliCollection.Name)]
+public sealed class CliInstallationTests
+{
+    private readonly CliInstallFixture _fixture;
+
+    public CliInstallationTests(CliInstallFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void CliPackage_IsInstallableFromNuget()
+    {
+        _fixture.InstallError.ShouldBeNull(
+            $"dotnet tool install threw before exiting:\n{_fixture.InstallError}");
+
+        _fixture.InstallExitCode.ShouldBe(
+            0,
+            $"dotnet tool install BotNexus.Cli failed.\nExit: {_fixture.InstallExitCode}\nOutput:\n{_fixture.InstallOutput}");
+
+        File.Exists(_fixture.CliExecutablePath).ShouldBeTrue(
+            $"Expected CLI executable at {_fixture.CliExecutablePath} after install. " +
+            $"Install output:\n{_fixture.InstallOutput}");
+
+        _fixture.InstallSucceeded.ShouldBeTrue();
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliInstallFixture.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliInstallFixture.cs
@@ -1,0 +1,105 @@
+using System.Runtime.InteropServices;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// xUnit collection fixture that packs the in-tree BotNexus.Cli source as a NuGet
+/// global tool with a unique pre-release version and installs it into an isolated
+/// --tool-path. Lets integration tests exercise pre-release CLI features (e.g. the
+/// integration-mock provider, non-interactive `provider add`) before they ship to
+/// nuget.org.
+///
+/// Contrast with <see cref="CliInstallFixture"/>, which validates the
+/// already-published package on nuget.org. This fixture is the harness for
+/// PR-time validation of CLI changes.
+///
+/// The pack-and-install runs once per test run. Failures are captured (not thrown)
+/// so dependent tests can skip gracefully and the install diagnostics are visible
+/// in test output.
+/// </summary>
+public sealed class LocalCliInstallFixture : IAsyncLifetime
+{
+    private const string PackageId = "BotNexus.Cli";
+    private static readonly TimeSpan PackTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(3);
+
+    public string PackVersion { get; private set; } = string.Empty;
+    public string PackOutputDir { get; private set; } = string.Empty;
+    public string ToolPath { get; private set; } = string.Empty;
+    public string CliExecutablePath { get; private set; } = string.Empty;
+
+    public bool Succeeded { get; private set; }
+    public int PackExitCode { get; private set; } = -1;
+    public int InstallExitCode { get; private set; } = -1;
+    public string PackOutput { get; private set; } = string.Empty;
+    public string InstallOutput { get; private set; } = string.Empty;
+    public string? Error { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            var runId = Guid.NewGuid().ToString("N");
+            PackVersion = $"99.99.99-local-{runId[..8]}";
+            var sandboxRoot = Path.Combine(Path.GetTempPath(), "botnexus-local-cli", runId);
+            PackOutputDir = Path.Combine(sandboxRoot, "pack");
+            ToolPath = Path.Combine(sandboxRoot, "tool");
+            Directory.CreateDirectory(PackOutputDir);
+            Directory.CreateDirectory(ToolPath);
+
+            var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "botnexus.exe" : "botnexus";
+            CliExecutablePath = Path.Combine(ToolPath, exeName);
+
+            var repoRoot = RepoLocator.FindRepoRoot();
+            var cliProject = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Cli", "BotNexus.Cli.csproj");
+
+            // --- pack -------------------------------------------------------
+            var packResult = await ProcessRunner.RunAsync(
+                "dotnet",
+                $"pack \"{cliProject}\" --configuration Release --output \"{PackOutputDir}\" /p:Version={PackVersion} /p:PackageVersion={PackVersion} --nologo",
+                timeout: PackTimeout);
+
+            PackExitCode = packResult.ExitCode;
+            PackOutput = packResult.Combined;
+            if (PackExitCode != 0)
+                return;
+
+            // --- install ----------------------------------------------------
+            var installResult = await ProcessRunner.RunAsync(
+                "dotnet",
+                $"tool install --tool-path \"{ToolPath}\" --add-source \"{PackOutputDir}\" --version {PackVersion} {PackageId}",
+                timeout: InstallTimeout);
+
+            InstallExitCode = installResult.ExitCode;
+            InstallOutput = installResult.Combined;
+            Succeeded = installResult.ExitCode == 0 && File.Exists(CliExecutablePath);
+        }
+        catch (Exception ex)
+        {
+            Error = ex.ToString();
+            Succeeded = false;
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        // Walk back to the per-run sandbox root and remove the whole tree.
+        try
+        {
+            var sandboxRoot = Path.GetDirectoryName(ToolPath);
+            if (!string.IsNullOrEmpty(sandboxRoot) && Directory.Exists(sandboxRoot))
+                Directory.Delete(sandboxRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; locked .nupkg or tool files on Windows are not worth failing the suite over.
+        }
+        return Task.CompletedTask;
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class LocalCliCollection : ICollectionFixture<LocalCliInstallFixture>
+{
+    public const string Name = "Local CLI install collection";
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliMockProviderTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliMockProviderTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// End-to-end harness validation: packs and installs the in-tree CLI, then drives
+/// it through the integration-mock provider bootstrap flow via the new
+/// non-interactive <c>provider add</c> command.
+///
+/// This is the primary regression net for PR-time CLI changes that touch
+/// install/init/provider plumbing or the integration-mock provider.
+/// </summary>
+[Collection(LocalCliCollection.Name)]
+public sealed class LocalCliMockProviderTests : IAsyncLifetime
+{
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromMinutes(2);
+
+    private readonly LocalCliInstallFixture _fixture;
+    private string _home = string.Empty;
+
+    public LocalCliMockProviderTests(LocalCliInstallFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync()
+    {
+        _home = Path.Combine(Path.GetTempPath(), "botnexus-local-cli-home", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_home);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_home))
+                Directory.Delete(_home, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public void LocalPackAndInstall_ProducesUsableBinary()
+    {
+        AssertFixture();
+        File.Exists(_fixture.CliExecutablePath).ShouldBeTrue(
+            $"Expected CLI binary at {_fixture.CliExecutablePath}.");
+    }
+
+    [Fact]
+    public async Task Init_ThenProviderAdd_MockProvider_WritesExpectedConfig()
+    {
+        AssertFixture();
+
+        // 1. init the sandboxed home
+        var initResult = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"init --target \"{_home}\"",
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null },
+            timeout: CommandTimeout);
+        initResult.ExitCode.ShouldBe(0,
+            $"init failed.\nStdOut:\n{initResult.StdOut}\nStdErr:\n{initResult.StdErr}");
+
+        // 2. non-interactive provider add for the integration-mock provider
+        var addResult = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"provider add --name integration-mock --api integration-mock --default-model integration-mock-echo --target \"{_home}\"",
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null },
+            timeout: CommandTimeout);
+        addResult.ExitCode.ShouldBe(0,
+            $"provider add failed.\nStdOut:\n{addResult.StdOut}\nStdErr:\n{addResult.StdErr}");
+
+        // 3. assert the persisted config matches the contract
+        var configPath = Path.Combine(_home, "config.json");
+        File.Exists(configPath).ShouldBeTrue($"Expected config.json at {configPath}.");
+
+        await using var stream = File.OpenRead(configPath);
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var providers = doc.RootElement.GetProperty("providers");
+        providers.TryGetProperty("integration-mock", out var prov).ShouldBeTrue(
+            "providers.integration-mock missing from config.json.");
+
+        prov.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+        prov.GetProperty("api").GetString().ShouldBe("integration-mock");
+        prov.GetProperty("defaultModel").GetString().ShouldBe("integration-mock-echo");
+    }
+
+    [Fact]
+    public async Task ProviderRemove_IsIdempotent()
+    {
+        AssertFixture();
+
+        // Init first so we have a config to operate on.
+        var initResult = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"init --target \"{_home}\"",
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null },
+            timeout: CommandTimeout);
+        initResult.ExitCode.ShouldBe(0);
+
+        // Removing a never-added provider must still return 0.
+        var removeResult = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"provider remove --name never-existed --target \"{_home}\"",
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null },
+            timeout: CommandTimeout);
+        removeResult.ExitCode.ShouldBe(0,
+            $"provider remove must be idempotent.\nStdOut:\n{removeResult.StdOut}\nStdErr:\n{removeResult.StdErr}");
+    }
+
+    private void AssertFixture()
+    {
+        _fixture.Succeeded.ShouldBeTrue(
+            $"Local pack/install fixture did not succeed.\n" +
+            $"PackExitCode={_fixture.PackExitCode}\nInstallExitCode={_fixture.InstallExitCode}\n" +
+            $"PackOutput:\n{_fixture.PackOutput}\n\nInstallOutput:\n{_fixture.InstallOutput}\n\nError:\n{_fixture.Error}");
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/ProcessRunner.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/ProcessRunner.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+internal sealed record ProcessResult(int ExitCode, string StdOut, string StdErr)
+{
+    public string Combined => StdOut + StdErr;
+}
+
+internal static class ProcessRunner
+{
+    public static async Task<ProcessResult> RunAsync(
+        string fileName,
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string?>? environment = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        if (workingDirectory is not null)
+            psi.WorkingDirectory = workingDirectory;
+        if (environment is not null)
+        {
+            foreach (var kvp in environment)
+                psi.Environment[kvp.Key] = kvp.Value;
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+
+        var stdOut = new StringBuilder();
+        var stdErr = new StringBuilder();
+
+        var outTask = ReadAllAsync(process.StandardOutput, stdOut, cancellationToken);
+        var errTask = ReadAllAsync(process.StandardError, stdErr, cancellationToken);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (timeout is { } t)
+            cts.CancelAfter(t);
+
+        try
+        {
+            await process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new TimeoutException(
+                $"Process '{fileName} {arguments}' did not exit within {timeout}. " +
+                $"Partial stdout: {stdOut}\nPartial stderr: {stdErr}");
+        }
+
+        await Task.WhenAll(outTask, errTask);
+        return new ProcessResult(process.ExitCode, stdOut.ToString(), stdErr.ToString());
+    }
+
+    private static async Task ReadAllAsync(StreamReader reader, StringBuilder sink, CancellationToken cancellationToken)
+    {
+        var buffer = new char[4096];
+        int read;
+        while ((read = await reader.ReadAsync(buffer, cancellationToken)) > 0)
+            sink.Append(buffer, 0, read);
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/RepoLocator.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/RepoLocator.cs
@@ -1,0 +1,28 @@
+using System.IO;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Locates the repository root by walking up from the test assembly's base directory
+/// until a marker file (.git or BotNexus.slnx) is found. Used by integration tests
+/// that need to clone or build from the in-tree repo.
+/// </summary>
+internal static class RepoLocator
+{
+    public static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git")) ||
+                File.Exists(Path.Combine(dir.FullName, "BotNexus.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (no .git or BotNexus.slnx marker) walking up from {AppContext.BaseDirectory}.");
+    }
+}


### PR DESCRIPTION
Consolidates the reviewed-and-merged stack of #588, #590, #592 (and supersedes #584) onto main.

## Includes

- **#588** - integration-mock LLM provider with scripted responses (HELLO_WORLD + deltas/tool-calls/delays). Already on main but included here as part of the squash chain.
- **#590** - non-interactive `provider add` / `provider remove` CLI subcommands with full flag set; documentation sweep (`ILlmProvider` -> `IApiProvider`, real flat camelCase `config.json` schema, deprecation note in `extension-development.md`, full reference entries in `cli-reference.md`).
- **#592** - local-pack-and-install harness that packs the in-tree CLI, installs it as a `dotnet tool` to an isolated tool-path, and drives `init` -> `provider add --api integration-mock` -> `provider remove` end-to-end against an isolated `--target` directory.
- **#584 content** - `BotNexus.Integration.Cli.Tests` project scaffold (nuget-based install fixture, CLI help / install / init workflow tests). Folded in via #592; #584 should be closed as superseded.

## Tests

- 5 new `ProviderCommand` unit tests (PR #590)
- 8 unit tests for the mock provider (PR #588)
- 3 end-to-end local-pack-and-install tests (PR #592)
- Original integration tests from #584

All green locally. Build: 0 warn / 0 err.

## Notes

- #584 should be closed (not merged) as its content is included here.
- Future work (out of scope): hosting the gateway in-process to drive a real HELLO_WORLD HTTP round-trip through the installed CLI.