### PR TITLE
test(integration): add Copilot device-code probe + mock provider list verification

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -94,7 +94,7 @@ Shared vocabulary (referenced by everything above):
 | | **Independent Libraries (no BotNexus dependency)** | |
 | **BotNexus.Agent.Core** | Agent execution library | Agent loop runner, tool execution engine, hooks. Generic — usable outside BotNexus. |
 | **BotNexus.Agent.Providers.Core** | LLM client library | LLM client abstraction, streaming, model registry. Generic — usable outside BotNexus. |
-| **BotNexus.Providers.{Anthropic,OpenAI,Copilot}** | LLM provider implementations | Provider-specific LLM implementations. Depend only on Providers.Core. |
+| **BotNexus.Agent.Providers.{Anthropic,OpenAI,Copilot,IntegrationMock}** | LLM provider implementations | Provider-specific LLM implementations. Depend only on Agent.Providers.Core. |
 | **BotNexus.Tools** | File tool library | read, write, edit, grep, glob, ls. Generic — usable outside BotNexus. |
 | | **BotNexus Platform** | |
 | **BotNexus.Domain** | Platform vocabulary | Primitives, value objects, smart enums, domain models. Zero dependencies. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -744,6 +744,8 @@ botnexus provider setup [OPTIONS]
 
 | Option | Description |
 |---|---|
+| `--target <DIR>` | BotNexus home directory (config, workspace, extensions). Defaults to `~/.botnexus`. |
+| `--provider <NAME>` | Pre-select the provider (`github-copilot`, `openai`, or `anthropic`) and skip the interactive provider-selection prompt. Useful for scripting and integration tests where the rest of the flow (API-key prompt, OAuth device-code flow) is still exercised but the first prompt is suppressed. |
 | `--verbose` | Show the saved provider configuration in JSON. |
 
 ### Examples

--- a/docs/development/cli-wizard.md
+++ b/docs/development/cli-wizard.md
@@ -274,6 +274,7 @@ The flow demonstrates several wizard patterns:
 3. **Branching** — `Check` step routes to OAuth flow or API key prompt based on provider type
 4. **Custom steps** — `OAuthFlowStep` runs the GitHub device code flow, `PickModelStep` queries the model registry and prompts for selection
 5. **Action step** — final `save` step writes the config and auth files
+6. **Bypassable first prompt** — `provider setup --provider <name>` pre-seeds the wizard context with the chosen provider key and substitutes the `AskSelection` step with a no-op `Action`, letting scripts and integration tests skip the interactive selection prompt while still exercising the remainder of the flow (API-key prompt or OAuth device-code handoff).
 
 See `Commands/ProviderCommand.cs` for the full implementation.
 

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -33,14 +33,18 @@ internal sealed class ProviderCommand
 
         var setupCommand = new Command("setup", "Interactively add and authenticate a new provider.");
         var setupTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        var setupProviderOption = new Option<string?>("--provider", () => null,
+            $"Pre-select the provider to configure ({string.Join(" | ", KnownProviders)}). Skips the interactive provider-selection prompt and runs the rest of the setup flow (API-key prompt or OAuth device-code flow). Useful for scripting and integration tests.");
         setupCommand.Add(setupTargetOption);
+        setupCommand.Add(setupProviderOption);
         setupCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var target = context.ParseResult.GetValueForOption(setupTargetOption);
+            var preselected = context.ParseResult.GetValueForOption(setupProviderOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
-            context.ExitCode = await ExecuteSetupAsync(configPath, home, verbose, CancellationToken.None);
+            context.ExitCode = await ExecuteSetupAsync(configPath, home, verbose, preselected, CancellationToken.None);
         });
 
         var listCommand = new Command("list", "List configured providers.");
@@ -62,14 +66,20 @@ internal sealed class ProviderCommand
 
         // Default to setup when no subcommand given
         var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
+        var defaultProviderOption = new Option<string?>("--provider", () => null,
+            $"Pre-select the provider to configure ({string.Join(" | ", KnownProviders)}). Skips the interactive provider-selection prompt.");
         command.Add(defaultTargetOption);
+        command.Add(defaultProviderOption);
         command.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var target = context.ParseResult.GetValueForOption(defaultTargetOption);
+            var preselected = context.ParseResult.GetValueForOption(defaultProviderOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
-            context.ExitCode = await ExecuteDefaultAsync(configPath, home, verbose, CancellationToken.None);
+            context.ExitCode = preselected is null
+                ? await ExecuteDefaultAsync(configPath, home, verbose, CancellationToken.None)
+                : await ExecuteSetupAsync(configPath, home, verbose, preselected, CancellationToken.None);
         });
 
         return command;
@@ -274,10 +284,23 @@ internal sealed class ProviderCommand
     }
 
     internal async Task<int> ExecuteSetupAsync(bool verbose, CancellationToken cancellationToken)
-        => await ExecuteSetupAsync(PlatformConfigLoader.DefaultConfigPath, PlatformConfigLoader.DefaultHomePath, verbose, cancellationToken);
+        => await ExecuteSetupAsync(PlatformConfigLoader.DefaultConfigPath, PlatformConfigLoader.DefaultHomePath, verbose, null, cancellationToken);
 
     internal async Task<int> ExecuteSetupAsync(string configPath, string home, bool verbose, CancellationToken cancellationToken)
+        => await ExecuteSetupAsync(configPath, home, verbose, null, cancellationToken);
+
+    internal async Task<int> ExecuteSetupAsync(string configPath, string home, bool verbose, string? preselectedProvider, CancellationToken cancellationToken)
     {
+        if (preselectedProvider is not null)
+        {
+            if (!KnownProviders.Contains(preselectedProvider, StringComparer.OrdinalIgnoreCase))
+            {
+                AnsiConsole.MarkupLine($"[red]Unknown provider '{Markup.Escape(preselectedProvider)}'. Known providers: {string.Join(", ", KnownProviders)}.[/]");
+                AnsiConsole.MarkupLine("[dim]For other providers (e.g. local OpenAI-compatible servers or 'integration-mock'), use [green]botnexus provider add[/].[/]");
+                return 1;
+            }
+        }
+
         var config = await LoadOrCreateConfigAsync(configPath, cancellationToken);
 
         // Seed the wizard context with the loaded config
@@ -286,10 +309,23 @@ internal sealed class ProviderCommand
         ctx.Set("verbose", verbose);
         ctx.Set("home", home);
 
-        var wizard = new WizardBuilder()
-            .AskSelection("pick-provider", "Which provider do you want to configure?", "provider",
+        var wizardBuilder = new WizardBuilder();
+
+        if (preselectedProvider is null)
+        {
+            wizardBuilder.AskSelection("pick-provider", "Which provider do you want to configure?", "provider",
                 KnownProviders,
-                p => ProviderDisplayNames.TryGetValue(p, out var display) ? display : p)
+                p => ProviderDisplayNames.TryGetValue(p, out var display) ? display : p);
+        }
+        else
+        {
+            // Pre-seed the provider key and use a no-op action so the wizard stays linear.
+            var resolved = KnownProviders.First(p => string.Equals(p, preselectedProvider, StringComparison.OrdinalIgnoreCase));
+            ctx.Set("provider", resolved);
+            wizardBuilder.Action("pick-provider", (_, _) => Task.CompletedTask);
+        }
+
+        var wizard = wizardBuilder
             .Action("show-provider", (c, _) =>
             {
                 var name = c.Get<string>("provider");

--- a/tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliCopilotSetupTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliCopilotSetupTests.cs
@@ -1,0 +1,126 @@
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace BotNexus.Integration.Cli.Tests;
+
+/// <summary>
+/// Drives the installed CLI through the GitHub Copilot provider setup flow far enough
+/// to verify the device-code prompt is emitted, then aborts the process. We do not
+/// complete OAuth — the test only validates that running
+/// <c>botnexus provider setup --provider github-copilot --target &lt;tmp&gt;</c>
+/// reaches the auth handoff and surfaces the verification URL + user code to stdout.
+///
+/// Hits the real <c>https://github.com/login/device/code</c> endpoint (no auth required;
+/// codes expire on their own). Skipped automatically when the test host has no network
+/// access to github.com.
+///
+/// The non-interactive <c>--provider</c> flag is the seam that makes this test possible
+/// — it lets us bypass the interactive provider-selection Spectre.Console prompt that
+/// would otherwise require a TTY.
+/// </summary>
+[Collection(LocalCliCollection.Name)]
+public sealed class LocalCliCopilotSetupTests : IAsyncLifetime
+{
+    private static readonly TimeSpan SetupTimeout = TimeSpan.FromSeconds(45);
+    private static readonly Regex UserCodePattern = new("[A-Z0-9]{4}-[A-Z0-9]{4}", RegexOptions.Compiled);
+
+    private readonly LocalCliInstallFixture _fixture;
+    private string _home = string.Empty;
+
+    public LocalCliCopilotSetupTests(LocalCliInstallFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync()
+    {
+        _home = Path.Combine(Path.GetTempPath(), "botnexus-local-cli-home", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_home);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(_home))
+                Directory.Delete(_home, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+        return Task.CompletedTask;
+    }
+
+    [SkippableFact]
+    public async Task ProviderSetup_GithubCopilot_EmitsDeviceCodePrompt_ThenAborts()
+    {
+        AssertFixture();
+        Skip.IfNot(await CanReachGitHubAsync(), "GitHub device-code endpoint unreachable from this host.");
+
+        var watch = await ProcessRunner.RunUntilOutputMatchAsync(
+            _fixture.CliExecutablePath,
+            $"provider setup --provider github-copilot --target \"{_home}\"",
+            matchPredicate: output =>
+                output.Contains("github.com/login/device", StringComparison.OrdinalIgnoreCase)
+                && UserCodePattern.IsMatch(output),
+            timeout: SetupTimeout,
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null });
+
+        watch.Matched.ShouldBeTrue(
+            $"Did not see GitHub device-code prompt within {SetupTimeout}.\n" +
+            $"Output:\n{watch.Output}");
+
+        // Sanity: extract the code and verify the verification URI is well-formed.
+        var match = UserCodePattern.Match(watch.Output);
+        match.Success.ShouldBeTrue();
+        watch.Output.ShouldContain("github.com/login/device");
+
+        // We aborted before OAuth could complete, so no auth.json should have been written.
+        var authPath = Path.Combine(_home, "auth.json");
+        File.Exists(authPath).ShouldBeFalse(
+            "auth.json must not be written when the user has not completed device authorization.");
+    }
+
+    [Fact]
+    public async Task ProviderSetup_UnknownProvider_FailsWithGuidance()
+    {
+        AssertFixture();
+
+        var result = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"provider setup --provider does-not-exist --target \"{_home}\"",
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null },
+            timeout: TimeSpan.FromSeconds(30));
+
+        result.ExitCode.ShouldNotBe(0,
+            $"Expected non-zero exit code for unknown provider.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+        result.Combined.ShouldContain("Unknown provider",
+            customMessage: $"Expected guidance message.\nStdOut:\n{result.StdOut}\nStdErr:\n{result.StdErr}");
+        result.Combined.ShouldContain("provider add",
+            customMessage: "Error message should point the user at `provider add` for non-known providers.");
+    }
+
+    private static async Task<bool> CanReachGitHubAsync()
+    {
+        try
+        {
+            using var client = new TcpClient();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            await client.ConnectAsync("github.com", 443, cts.Token);
+            return client.Connected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void AssertFixture()
+    {
+        _fixture.Succeeded.ShouldBeTrue(
+            $"Local pack/install fixture did not succeed.\n" +
+            $"PackExitCode={_fixture.PackExitCode}\nInstallExitCode={_fixture.InstallExitCode}\n" +
+            $"PackOutput:\n{_fixture.PackOutput}\n\nInstallOutput:\n{_fixture.InstallOutput}\n\nError:\n{_fixture.Error}");
+    }
+}

--- a/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliMockProviderTests.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/LocalCliMockProviderTests.cs
@@ -85,6 +85,19 @@ public sealed class LocalCliMockProviderTests : IAsyncLifetime
         prov.GetProperty("enabled").GetBoolean().ShouldBeTrue();
         prov.GetProperty("api").GetString().ShouldBe("integration-mock");
         prov.GetProperty("defaultModel").GetString().ShouldBe("integration-mock-echo");
+
+        // 4. the CLI itself must see the provider via `provider list`
+        var listResult = await ProcessRunner.RunAsync(
+            _fixture.CliExecutablePath,
+            $"provider list --target \"{_home}\"",
+            environment: new Dictionary<string, string?> { ["BOTNEXUS_HOME"] = null },
+            timeout: CommandTimeout);
+        listResult.ExitCode.ShouldBe(0,
+            $"provider list failed.\nStdOut:\n{listResult.StdOut}\nStdErr:\n{listResult.StdErr}");
+        listResult.Combined.ShouldContain("integration-mock",
+            customMessage: $"provider list did not surface the just-added provider.\nStdOut:\n{listResult.StdOut}");
+        listResult.Combined.ShouldContain("integration-mock-echo",
+            customMessage: $"provider list did not surface the default model.\nStdOut:\n{listResult.StdOut}");
     }
 
     [Fact]

--- a/tests/integration/BotNexus.Integration.Cli.Tests/ProcessRunner.cs
+++ b/tests/integration/BotNexus.Integration.Cli.Tests/ProcessRunner.cs
@@ -71,4 +71,86 @@ internal static class ProcessRunner
         while ((read = await reader.ReadAsync(buffer, cancellationToken)) > 0)
             sink.Append(buffer, 0, read);
     }
+
+    /// <summary>
+    /// Starts a process and returns when either the combined stdout/stderr matches <paramref name="matchPredicate"/>
+    /// (the process is then killed) or the timeout expires. Useful for verifying that an interactive command
+    /// reaches a specific prompt (e.g. an OAuth device-code line) without driving it to completion.
+    /// </summary>
+    public static async Task<WatchResult> RunUntilOutputMatchAsync(
+        string fileName,
+        string arguments,
+        Func<string, bool> matchPredicate,
+        TimeSpan timeout,
+        IDictionary<string, string?>? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        if (environment is not null)
+        {
+            foreach (var kvp in environment)
+                psi.Environment[kvp.Key] = kvp.Value;
+        }
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+
+        var combined = new StringBuilder();
+        var matched = false;
+        var matchedAt = TimeSpan.Zero;
+        var started = DateTime.UtcNow;
+
+        using var matchCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        matchCts.CancelAfter(timeout);
+
+        var lockObj = new object();
+        void OnChunk(string chunk)
+        {
+            lock (lockObj)
+            {
+                combined.Append(chunk);
+                if (!matched && matchPredicate(combined.ToString()))
+                {
+                    matched = true;
+                    matchedAt = DateTime.UtcNow - started;
+                    matchCts.Cancel();
+                }
+            }
+        }
+
+        var outTask = StreamChunksAsync(process.StandardOutput, OnChunk, cancellationToken);
+        var errTask = StreamChunksAsync(process.StandardError, OnChunk, cancellationToken);
+
+        try
+        {
+            await process.WaitForExitAsync(matchCts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        }
+
+        try { await Task.WhenAll(outTask, errTask); }
+        catch { /* readers fail once the process is killed; that's fine */ }
+
+        return new WatchResult(matched, matchedAt, combined.ToString(), process.HasExited ? process.ExitCode : null);
+    }
+
+    private static async Task StreamChunksAsync(StreamReader reader, Action<string> onChunk, CancellationToken cancellationToken)
+    {
+        var buffer = new char[1024];
+        int read;
+        while (!cancellationToken.IsCancellationRequested && (read = await reader.ReadAsync(buffer, cancellationToken)) > 0)
+            onChunk(new string(buffer, 0, read));
+    }
 }
+
+internal sealed record WatchResult(bool Matched, TimeSpan MatchedAt, string Output, int? ExitCode);


### PR DESCRIPTION
## Summary

Extends the CLI integration test suite (#594) with two new scenarios:

1. **GitHub Copilot device-code prompt probe** — drives `provider setup` for `github-copilot`, watches stdout for the verification URL + `XXXX-XXXX` user code, then kills the process before OAuth completes. We test the *setup wiring*, not the OAuth round-trip.
2. **Mock provider end-to-end** — extends the existing mock-provider test with a `provider list` step that asserts the freshly-added provider shows up in the rendered table.

## How it works

The wizard normally calls `AnsiConsole.Prompt(SelectionPrompt<T>)` which throws under redirected stdio. Rather than wire the integration test through a TTY emulator, this PR adds a `--provider <name>` flag to `provider setup` that:

- Validates the name against `KnownProviders`.
- Pre-seeds the wizard context with the resolved provider.
- Substitutes the `AskSelection` step with a no-op so the rest of the flow (auth route -> OAuth/api-key prompts) runs unchanged.
- On unknown provider: exits non-zero with a hint pointing at `provider add`.

A new `ProcessRunner.RunUntilOutputMatchAsync` streams combined stdout/stderr and kills the process on first match — reusable for any future prompt-driven test.

## Files

- `src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs` — `--provider` flag + preselection branching.
- `tests/integration/.../LocalCliCopilotSetupTests.cs` (new) — 2 tests.
- `tests/integration/.../ProcessRunner.cs` — streaming watch helper.
- `tests/integration/.../LocalCliMockProviderTests.cs` — `provider list` step added.
- `docs/cli-reference.md`, `docs/development/cli-wizard.md` — document `--provider`.
- `docs/architecture/overview.md` — fix stale `BotNexus.Providers.*` namespace.

## Verification

- `dotnet build BotNexus.slnx` -> 0 warn / 0 err
- `dotnet test tests/integration/BotNexus.Integration.Cli.Tests` -> **9/9 pass in ~83s** (Copilot test matched the device-code prompt in ~1s).

## Doc cleanup followup

Filed #596 for remaining stale `BotNexus.Providers.*` / `ILlmProvider` references in `docs/training/` — out of scope for this PR.

Closes #595