### PR TITLE
fix(compaction): fix rogue cron conversation, add user notification, and evict stale handle

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentSupervisor.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentSupervisor.cs
@@ -43,6 +43,11 @@ public interface IAgentSupervisor
     AgentInstance? GetInstance(AgentId agentId, SessionId sessionId);
 
     /// <summary>
+    /// Gets the live agent handle for the given session, or <c>null</c> if no instance is running.
+    /// </summary>
+    IAgentHandle? GetHandle(AgentId agentId, SessionId sessionId);
+
+    /// <summary>
     /// Gets all active agent instances.
     /// </summary>
     IReadOnlyList<AgentInstance> GetAllInstances();

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -466,6 +466,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         }
                     }
                     var result = await _compactor.CompactAsync(session, _compactionOptions.CurrentValue, cancellationToken);
+                    var compactionApplied = false;
                     if (result.Succeeded && result.CompactedHistory is not null)
                     {
                         var outcome = session.TryApplyCompactionResult(result);
@@ -473,9 +474,11 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         {
                             case HistoryReplaceOutcome.Applied:
                                 session.UpdatedAt = DateTimeOffset.UtcNow;
+                                compactionApplied = true;
                                 break;
                             case HistoryReplaceOutcome.Rebased:
                                 session.UpdatedAt = DateTimeOffset.UtcNow;
+                                compactionApplied = true;
                                 _logger.LogInformation(
                                     "Session {SessionId} auto-compaction rebased over concurrent additions; " +
                                     "TokensAfter is approximate.", sessionId);
@@ -491,6 +494,37 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     _logger.LogInformation(
                         "Session {SessionId} compacted: {Summarized} entries summarized, {Preserved} preserved",
                         sessionId, result.EntriesSummarized, result.EntriesPreserved);
+
+                    if (compactionApplied)
+                    {
+                        // Evict the cached agent handle so the next GetOrCreateAsync (below) builds
+                        // a fresh context that includes the compaction summary. Without this, a live
+                        // handle would continue with its pre-compaction in-memory message list and
+                        // have no knowledge of the summary that was just written to the session.
+                        await _supervisor.StopAsync(Domain.Primitives.AgentId.From(agentId), Domain.Primitives.SessionId.From(sessionId), cancellationToken).ConfigureAwait(false);
+
+                        // Notify the user in the conversation that compaction occurred. This is a
+                        // system-level status message — not an agent reply — so it is sent directly
+                        // to the channel without going through the LLM.
+                        var compactionNote = $"_[Session context compacted: {result.EntriesSummarized} older messages summarised, {result.EntriesPreserved} recent messages preserved. Continuing…]_";
+                        if (ResolveChannelAdapter(message.ChannelType) is { } notifyChannel)
+                        {
+                            try
+                            {
+                                await notifyChannel.SendAsync(new OutboundMessage
+                                {
+                                    ChannelType = message.ChannelType,
+                                    ChannelAddress = message.ChannelAddress,
+                                    Content = compactionNote,
+                                    SessionId = sessionId
+                                }, cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception notifyEx)
+                            {
+                                _logger.LogWarning(notifyEx, "Failed to send compaction notification for session {SessionId}", sessionId);
+                            }
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/gateway/BotNexus.Gateway/Sessions/PreCompactionMemoryFlusher.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/PreCompactionMemoryFlusher.cs
@@ -1,26 +1,31 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
-using BotNexus.Gateway.Abstractions.Triggers;
 using Microsoft.Extensions.Logging;
 
 namespace BotNexus.Gateway.Sessions;
 
 /// <summary>
-/// Fires a synthetic memory-trigger agent turn immediately before session compaction.
-/// Gives the agent an opportunity to write important context to disk before history is
-/// summarised and truncated.
+/// Fires a synthetic memory-flush agent turn immediately before session compaction by
+/// steering the existing live agent handle. Gives the agent an opportunity to write
+/// important context to disk before history is summarised and truncated.
 /// </summary>
+/// <remarks>
+/// The flush is performed via <see cref="IAgentSupervisor"/> steering into the live
+/// handle — no new session or conversation is created. If no live handle exists the
+/// flush is skipped (the agent is not running so there is nothing to save).
+/// </remarks>
 public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
 {
-    private readonly IEnumerable<IInternalTrigger> _triggers;
+    private readonly IAgentSupervisor _supervisor;
     private readonly ILogger<PreCompactionMemoryFlusher> _logger;
 
     public PreCompactionMemoryFlusher(
-        IEnumerable<IInternalTrigger> triggers,
+        IAgentSupervisor supervisor,
         ILogger<PreCompactionMemoryFlusher> logger)
     {
-        _triggers = triggers;
+        _supervisor = supervisor;
         _logger = logger;
     }
 
@@ -45,17 +50,18 @@ public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
     /// <inheritdoc/>
     public async Task FlushAsync(AgentId agentId, Session session, CompactionOptions options, CancellationToken ct = default)
     {
-        var trigger = ResolveTrigger();
-        if (trigger is null)
+        // Use the live agent handle — no new session/conversation is created.
+        var handle = _supervisor.GetHandle(agentId, session.SessionId);
+        if (handle is null)
         {
-            _logger.LogWarning(
-                "No suitable internal trigger found for memory flush on session {SessionId}. Skipping flush.",
+            _logger.LogDebug(
+                "Pre-compaction memory flush skipped for session {SessionId}: no live agent handle found.",
                 session.SessionId);
             return;
         }
 
-        var timeoutCt = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCt.CancelAfter(TimeSpan.FromSeconds(options.MemoryFlush.TimeoutSeconds));
+        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(options.MemoryFlush.TimeoutSeconds));
 
         try
         {
@@ -63,14 +69,7 @@ public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
                 "Pre-compaction memory flush starting for session {SessionId}, agent {AgentId}.",
                 session.SessionId, agentId);
 
-            await trigger.CreateSessionAsync(
-                agentId,
-                options.MemoryFlush.PromptText,
-                timeoutCt.Token,
-                new InternalTriggerRequest
-                {
-                    ConversationId = session.ConversationId
-                }).ConfigureAwait(false);
+            await handle.SteerAsync(options.MemoryFlush.PromptText, timeoutCts.Token).ConfigureAwait(false);
 
             // Record that a flush has run for this compaction cycle.
             var currentCycle = session.History.Count(e => e.IsCompactionSummary) + 1;
@@ -80,7 +79,7 @@ public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
                 "Pre-compaction memory flush completed for session {SessionId}.",
                 session.SessionId);
         }
-        catch (OperationCanceledException) when (timeoutCt.IsCancellationRequested && !ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
             _logger.LogWarning(
                 "Pre-compaction memory flush timed out after {Seconds}s for session {SessionId}. Compaction will proceed.",
@@ -94,15 +93,8 @@ public sealed class PreCompactionMemoryFlusher : IPreCompactionMemoryFlusher
         }
         finally
         {
-            timeoutCt.Dispose();
+            timeoutCts.Dispose();
         }
-    }
-
-    private IInternalTrigger? ResolveTrigger()
-    {
-        var all = _triggers.ToList();
-        return all.FirstOrDefault(t => t.Type.Equals(TriggerType.Memory))
-            ?? all.FirstOrDefault(t => t.Type.Equals(TriggerType.Cron));
     }
 
     private static int GetLastFlushCycle(Session session)

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
@@ -377,6 +377,7 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
 
         public Task StopAsync(AgentId agentId, SessionId sessionId, CancellationToken ct) => Task.CompletedTask;
         public AgentInstance? GetInstance(AgentId agentId, SessionId sessionId) => null;
+        public IAgentHandle? GetHandle(AgentId agentId, SessionId sessionId) => null;
         public IReadOnlyList<AgentInstance> GetAllInstances() => [];
         public Task StopAllAsync(CancellationToken ct) => Task.CompletedTask;
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -971,6 +971,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         public AgentInstance? GetInstance(AgentId requestedAgentId, SessionId requestedSessionId)
             => requestedAgentId == agentId && requestedSessionId == sessionId ? _instance : null;
 
+        public IAgentHandle? GetHandle(AgentId requestedAgentId, SessionId requestedSessionId) => null;
+
         public IReadOnlyList<AgentInstance> GetAllInstances() => [_instance];
 
         public Task StopAllAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
@@ -1,7 +1,7 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
-using BotNexus.Gateway.Abstractions.Triggers;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -11,6 +11,7 @@ namespace BotNexus.Gateway.Tests.Sessions;
 public sealed class PreCompactionMemoryFlusherTests
 {
     private static readonly AgentId TestAgent = AgentId.From("agent-a");
+    private static readonly SessionId TestSessionId = SessionId.From("session-1");
 
     // ─── ShouldFlush ───────────────────────────────────────────────────────────
 
@@ -79,42 +80,56 @@ public sealed class PreCompactionMemoryFlusherTests
     // ─── FlushAsync ────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task FlushAsync_WhenTriggerAvailable_CallsCreateSessionAsync()
+    public async Task FlushAsync_WhenLiveHandleAvailable_CallsSteerAsync()
     {
         var session = BuildInteractiveSession();
-        var triggerMock = new Mock<IInternalTrigger>();
-        triggerMock.SetupGet(t => t.Type).Returns(TriggerType.Memory);
-        triggerMock.Setup(t => t.CreateSessionAsync(
-                It.IsAny<AgentId>(),
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>(),
-                It.IsAny<InternalTriggerRequest?>()))
-            .ReturnsAsync(SessionId.From("flush-session"));
+        var handleMock = new Mock<IAgentHandle>();
+        handleMock.Setup(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
-        var flusher = CreateFlusher(triggerMock.Object);
+        var supervisorMock = new Mock<IAgentSupervisor>();
+        supervisorMock.Setup(s => s.GetHandle(TestAgent, TestSessionId))
+            .Returns(handleMock.Object);
+
+        var flusher = new PreCompactionMemoryFlusher(supervisorMock.Object, NullLogger<PreCompactionMemoryFlusher>.Instance);
         var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
 
         await flusher.FlushAsync(TestAgent, session, options);
 
-        triggerMock.Verify(t => t.CreateSessionAsync(
-            TestAgent,
-            It.Is<string>(s => s.Contains("compaction")),
-            It.IsAny<CancellationToken>(),
-            It.IsAny<InternalTriggerRequest?>()), Times.Once);
+        handleMock.Verify(h => h.SteerAsync(
+            It.Is<string>(s => s.Length > 0),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task FlushAsync_WhenTriggerThrows_DoesNotRethrow()
+    public async Task FlushAsync_WhenNoLiveHandle_DoesNotThrow()
     {
         var session = BuildInteractiveSession();
-        var triggerMock = new Mock<IInternalTrigger>();
-        triggerMock.SetupGet(t => t.Type).Returns(TriggerType.Memory);
-        triggerMock.Setup(t => t.CreateSessionAsync(
-                It.IsAny<AgentId>(), It.IsAny<string>(),
-                It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
-            .ThrowsAsync(new InvalidOperationException("agent not found"));
+        var supervisorMock = new Mock<IAgentSupervisor>();
+        supervisorMock.Setup(s => s.GetHandle(It.IsAny<AgentId>(), It.IsAny<SessionId>()))
+            .Returns((IAgentHandle?)null);
 
-        var flusher = CreateFlusher(triggerMock.Object);
+        var flusher = new PreCompactionMemoryFlusher(supervisorMock.Object, NullLogger<PreCompactionMemoryFlusher>.Instance);
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        // No live handle — should skip silently without throwing
+        var act = async () => await flusher.FlushAsync(TestAgent, session, options);
+        await act.ShouldNotThrowAsync();
+    }
+
+    [Fact]
+    public async Task FlushAsync_WhenSteerThrows_DoesNotRethrow()
+    {
+        var session = BuildInteractiveSession();
+        var handleMock = new Mock<IAgentHandle>();
+        handleMock.Setup(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("agent failed"));
+
+        var supervisorMock = new Mock<IAgentSupervisor>();
+        supervisorMock.Setup(s => s.GetHandle(TestAgent, TestSessionId))
+            .Returns(handleMock.Object);
+
+        var flusher = new PreCompactionMemoryFlusher(supervisorMock.Object, NullLogger<PreCompactionMemoryFlusher>.Instance);
         var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
 
         // Non-fatal: should not throw
@@ -123,28 +138,18 @@ public sealed class PreCompactionMemoryFlusherTests
     }
 
     [Fact]
-    public async Task FlushAsync_WhenNoTriggerAvailable_DoesNotThrow()
-    {
-        var session = BuildInteractiveSession();
-        var flusher = CreateFlusher(); // no triggers
-        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
-
-        var act = async () => await flusher.FlushAsync(TestAgent, session, options);
-        await act.ShouldNotThrowAsync();
-    }
-
-    [Fact]
     public async Task FlushAsync_WhenSucceeds_RecordsFlushCycleInMetadata()
     {
         var session = BuildInteractiveSession();
-        var triggerMock = new Mock<IInternalTrigger>();
-        triggerMock.SetupGet(t => t.Type).Returns(TriggerType.Memory);
-        triggerMock.Setup(t => t.CreateSessionAsync(
-                It.IsAny<AgentId>(), It.IsAny<string>(),
-                It.IsAny<CancellationToken>(), It.IsAny<InternalTriggerRequest?>()))
-            .ReturnsAsync(SessionId.From("flush-session"));
+        var handleMock = new Mock<IAgentHandle>();
+        handleMock.Setup(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
-        var flusher = CreateFlusher(triggerMock.Object);
+        var supervisorMock = new Mock<IAgentSupervisor>();
+        supervisorMock.Setup(s => s.GetHandle(TestAgent, TestSessionId))
+            .Returns(handleMock.Object);
+
+        var flusher = new PreCompactionMemoryFlusher(supervisorMock.Object, NullLogger<PreCompactionMemoryFlusher>.Instance);
         var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
 
         await flusher.FlushAsync(TestAgent, session, options);
@@ -155,15 +160,20 @@ public sealed class PreCompactionMemoryFlusherTests
 
     // ─── Helpers ───────────────────────────────────────────────────────────────
 
-    private static PreCompactionMemoryFlusher CreateFlusher(params IInternalTrigger[] triggers)
-        => new(triggers, NullLogger<PreCompactionMemoryFlusher>.Instance);
+    private static PreCompactionMemoryFlusher CreateFlusher()
+    {
+        var supervisorMock = new Mock<IAgentSupervisor>();
+        supervisorMock.Setup(s => s.GetHandle(It.IsAny<AgentId>(), It.IsAny<SessionId>()))
+            .Returns((IAgentHandle?)null);
+        return new PreCompactionMemoryFlusher(supervisorMock.Object, NullLogger<PreCompactionMemoryFlusher>.Instance);
+    }
 
     private static Session BuildInteractiveSession()
         => BuildSession(SessionType.UserAgent);
 
     private static Session BuildSession(SessionType type) => new()
     {
-        SessionId = SessionId.From(Guid.NewGuid().ToString("N")),
+        SessionId = TestSessionId,
         AgentId = TestAgent,
         SessionType = type
     };

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
@@ -310,6 +310,8 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
         public AgentInstance? GetInstance(AgentId requestedAgentId, SessionId requestedSessionId)
             => requestedAgentId == _instance.AgentId && requestedSessionId == _instance.SessionId ? _instance : null;
 
+        public IAgentHandle? GetHandle(AgentId requestedAgentId, SessionId requestedSessionId) => null;
+
         public IReadOnlyList<AgentInstance> GetAllInstances() => [_instance];
 
         public Task StopAllAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

Three compaction UX bugs fixed — all triggered by the 'SafeFly V2 API Update' conversation hitting the auto-compact threshold.

### Bug 1 — Rogue 'Cron…' conversation in portal

**Root cause:** `PreCompactionMemoryFlusher.ResolveTrigger()` fell back to `CronTrigger` when no Memory trigger was registered. `CronTrigger.CreateSessionAsync` always creates or finds a cron conversation titled `cron:{jobId}`, creating an unexpected portal entry.

**Fix:** `PreCompactionMemoryFlusher` now injects `IAgentSupervisor` and steers the existing live handle directly via `SteerAsync`. No new session or conversation is ever created. If no live handle exists (agent not running), the flush is silently skipped.

### Bug 2 — No user notification in the conversation

**Root cause:** Auto-compaction in `GatewayHost` was purely silent — no feedback to the user.

**Fix:** After a successful auto-compaction, a system-level notification is sent through the channel adapter:
`_[Session context compacted: N older messages summarised, M recent messages preserved. Continuing…]_`

### Bug 3 — Agent had no knowledge of the summary after compaction

**Root cause:** Auto-compaction runs before `_supervisor.GetOrCreateAsync` in `GatewayHost`. If a handle was already cached (second+ message in session), the cached handle's in-memory message list was built from pre-compaction history and never saw the summary.

**Fix:** After successful compaction, `_supervisor.StopAsync` evicts the cached handle. The immediate `GetOrCreateAsync` call then creates a fresh handle from post-compaction history, which includes the compaction summary via `SessionContextProjector.IsVisibleOnResume`.

## Files changed
- `IAgentSupervisor` — adds `GetHandle(AgentId, SessionId)` to the interface (implementation already had it)
- `PreCompactionMemoryFlusher` — rewrites to use supervisor steering instead of trigger sessions
- `GatewayHost` — adds handle eviction and user notification after auto-compact
- Tests — `PreCompactionMemoryFlusherTests` rewritten for new behavior; 3 test supervisor stubs updated
