### PR TITLE
refactor(gateway): unify compaction paths + add /compact E2E + exclude integration tests from PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Test
-        run: dotnet test --no-build --collect:"XPlat Code Coverage"
+        run: dotnet test --no-build --collect:"XPlat Code Coverage" --filter "FullyQualifiedName!~BotNexus.Integration."
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -138,12 +138,16 @@ public sealed class AgentInteractionService : IAgentInteractionService
         try
         {
             var result = await _hub.CompactSessionAsync(agentId, agent.ActiveConversationSessionId!);
+            // Inject the canonical compaction notification locally so the user
+            // sees the same _[Session context compacted: ...]_ text regardless of
+            // which path (auto-compact via channel push, or this RPC) triggered
+            // compaction. The gateway no longer fans this out via the SignalR
+            // channel for hub-initiated compactions, so we render it here.
             var convId = agent.ActiveConversationId;
             if (convId is not null && agent.Conversations.GetValueOrDefault(convId) is { } conv)
             {
                 conv.Messages.Add(new ChatMessage("System",
-                    $"Session compacted: {result.Summarized} messages summarized, {result.Preserved} preserved. " +
-                    $"Tokens: {result.TokensBefore} → {result.TokensAfter}",
+                    $"_[Session context compacted: {result.Summarized} older messages summarised, {result.Preserved} recent messages preserved. Continuing…]_",
                     DateTimeOffset.UtcNow));
                 _store.NotifyChanged();
             }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -140,7 +140,7 @@
         </div>
     }
 
-    <div class="messages-container" @ref="_messagesContainer">
+    <div class="messages-container" data-testid="chat-messages" @ref="_messagesContainer">
         @if (IsLoadingHistory)
         {
             <div class="history-loading">
@@ -168,7 +168,7 @@
             }
             else if (msg.Role == "System")
             {
-                <div class="system-message">@msg.Content</div>
+                <div class="system-message" data-testid="chat-system-message">@msg.Content</div>
             }
             else if (msg.IsToolCall)
             {
@@ -317,6 +317,7 @@
             @if (!IsReadOnly)
             {
                 <textarea class="chat-input @ExpandingInputClass"
+                          data-testid="chat-input"
                           @ref="_inputElement"
                           @bind="_inputText"
                           @bind:event="oninput"
@@ -354,6 +355,7 @@
                 else
                 {
                     <button class="send-btn"
+                            data-testid="chat-send"
                             @onclick="SendMessage"
                             disabled="@(!IsConnected || string.IsNullOrWhiteSpace(_inputText))">
                         Send

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -112,7 +112,7 @@
                                         .OrderByDescending(c => c.IsDefault)
                                         .ThenByDescending(c => c.UpdatedAt))
                                     {
-                                        <div class="conversation-list-item">
+                                        <div class="conversation-list-item" data-testid="conversation-list-item" data-conversation-id="@conversation.ConversationId">
                                             <button class="conversation-list-item-btn @(conversation.ConversationId == activeAgent.ActiveConversationId ? "active" : "")"
                                                     @onclick="() => SelectConversationAsync(activeAgent.AgentId, conversation.ConversationId)">
                                                 <span class="conversation-list-item-main">

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -44,6 +44,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
     private readonly IOptionsMonitor<CompactionOptions> _compactionOptions;
     private readonly IConversationResetService? _resetService;
+    private readonly ISessionCompactionCoordinator _compactionCoordinator;
     private readonly ILogger<GatewayHub> _logger;
 
     public GatewayHub(
@@ -60,7 +61,8 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         ILogger<GatewayHub> logger,
         IConversationStore? conversationStore = null,
         IAskUserResponseRegistry? askUserResponseRegistry = null,
-        IConversationResetService? resetService = null)
+        IConversationResetService? resetService = null,
+        ISessionCompactionCoordinator? compactionCoordinator = null)
     {
         _supervisor = supervisor;
         _registry = registry;
@@ -76,6 +78,11 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         _conversationStore = conversationStore;
         _askUserResponseRegistry = askUserResponseRegistry;
         _resetService = resetService;
+        // Required for the /compact RPC path. Tests constructing the hub directly
+        // must pass one (see SignalRHubTests.CreateHub which uses TestSessionCompactionCoordinator).
+        _compactionCoordinator = compactionCoordinator
+            ?? throw new ArgumentNullException(nameof(compactionCoordinator),
+                "ISessionCompactionCoordinator is required. Production hosts get it from DI; tests must inject one.");
     }
 
     /// <summary>
@@ -536,32 +543,24 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <returns>The compact session result.</returns>
     public async Task<CompactSessionResult> CompactSession(AgentId agentId, SessionId sessionId)
     {
-        _ = NormalizeAgentId(agentId);
+        var typedAgentId = NormalizeAgentId(agentId);
         var typedSessionId = NormalizeSessionId(sessionId);
         var session = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
         if (session is null)
             throw new HubException($"Session '{typedSessionId.Value}' not found.");
 
+        // Resolve through the request services so test hosts can substitute the
+        // coordinator. Falls back to the singleton injected at hub construction.
         var requestServices = Context.GetHttpContext()?.RequestServices;
-        var compactor = requestServices?.GetService<ISessionCompactor>() ?? _compactor;
-        var options = requestServices?.GetService<IOptionsMonitor<CompactionOptions>>()?.CurrentValue ?? _compactionOptions.CurrentValue;
+        var coordinator = requestServices?.GetService<ISessionCompactionCoordinator>() ?? _compactionCoordinator;
 
-        var result = await compactor.CompactAsync(session, options, CancellationToken.None);
-        if (result.Succeeded && result.CompactedHistory is not null)
-        {
-            var outcome = session.TryApplyCompactionResult(result);
-            if (outcome != HistoryReplaceOutcome.Aborted)
-            {
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-            }
-        }
-        await _sessions.SaveAsync(session, CancellationToken.None);
+        var outcome = await coordinator.CompactAsync(typedAgentId, session, CancellationToken.None).ConfigureAwait(false);
 
         return new CompactSessionResult(
-            result.EntriesSummarized,
-            result.EntriesPreserved,
-            result.TokensBefore,
-            result.TokensAfter);
+            outcome.EntriesSummarized,
+            outcome.EntriesPreserved,
+            outcome.TokensBefore,
+            outcome.TokensAfter);
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionCompactionCoordinator.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionCompactionCoordinator.cs
@@ -1,0 +1,77 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Abstractions.Sessions;
+
+/// <summary>
+/// Single entry point for the full session-compaction pipeline so every caller
+/// (auto-compact at the token threshold, inbound <c>control: compact</c>
+/// messages, and the SignalR <c>/compact</c> RPC from the Blazor portal) gets
+/// identical behaviour: optional pre-compaction memory flush, summarise older
+/// history, apply + persist with optimistic concurrency, and evict the cached
+/// agent handle so the next turn rebuilds from post-compaction history.
+///
+/// User notification is intentionally a separate step (<see cref="BuildNotificationText"/>
+/// + <see cref="TrySendChannelNotificationAsync"/>) so callers can deliver the
+/// canonical text through whichever transport they own — a channel adapter for
+/// inbound-channel-driven compactions, the SignalR hub return value plus a
+/// local system message for the Blazor portal — without forking the text.
+///
+/// Introduced to fix three subtly different compaction code paths that left
+/// the manual paths missing agent-handle eviction (Bug 3 in PR #602),
+/// missing the pre-compaction memory flush, and emitting inconsistent feedback.
+/// </summary>
+public interface ISessionCompactionCoordinator
+{
+    /// <summary>
+    /// Run flush + compact + save + handle-eviction. Does not emit any user
+    /// notification — callers use <see cref="BuildNotificationText"/> and
+    /// <see cref="TrySendChannelNotificationAsync"/> for that.
+    /// </summary>
+    Task<SessionCompactionOutcome> CompactAsync(
+        AgentId agentId,
+        GatewaySession session,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Build the canonical user-facing notification text for an outcome.
+    /// The same text is used by all callers so users see consistent feedback
+    /// regardless of which path triggered compaction.
+    /// </summary>
+    string BuildNotificationText(SessionCompactionOutcome outcome);
+
+    /// <summary>
+    /// Convenience helper that resolves the channel adapter for
+    /// <paramref name="channelType"/> and sends the canonical notification
+    /// text. Swallows transport failures (logs a warning) so a delivery
+    /// problem never masks a successful compaction. Returns <c>false</c> if
+    /// the adapter could not be resolved or the send threw.
+    /// </summary>
+    Task<bool> TrySendChannelNotificationAsync(
+        SessionCompactionOutcome outcome,
+        ChannelKey channelType,
+        ChannelAddress channelAddress,
+        string sessionId,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Result of <see cref="ISessionCompactionCoordinator.CompactAndNotifyAsync"/>.
+/// </summary>
+/// <param name="Succeeded">Whether <see cref="ISessionCompactor"/> returned a valid summary.</param>
+/// <param name="Applied">Whether the new history was actually applied to the session.</param>
+/// <param name="HistoryOutcome">Outcome of the optimistic-concurrency apply step.</param>
+/// <param name="EntriesSummarized">Number of older entries collapsed into the summary.</param>
+/// <param name="EntriesPreserved">Number of recent entries kept verbatim.</param>
+/// <param name="TokensBefore">Approximate token count before compaction.</param>
+/// <param name="TokensAfter">Approximate token count after compaction.</param>
+/// <param name="FailureReason">Human-readable reason when <paramref name="Applied"/> is false.</param>
+public sealed record SessionCompactionOutcome(
+    bool Succeeded,
+    bool Applied,
+    HistoryReplaceOutcome HistoryOutcome,
+    int EntriesSummarized,
+    int EntriesPreserved,
+    int TokensBefore,
+    int TokensAfter,
+    string? FailureReason);

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -145,6 +145,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IChannelAdapter>(serviceProvider => serviceProvider.GetRequiredService<InternalChannelAdapter>());
         services.AddSingleton<ISessionCompactor, LlmSessionCompactor>();
         services.AddSingleton<IPreCompactionMemoryFlusher, PreCompactionMemoryFlusher>();
+        services.AddSingleton<ISessionCompactionCoordinator, SessionCompactionCoordinator>();
         services.AddSingleton<ISessionEndMemoryFlusher, SessionEndMemoryFlusher>();
         services.AddSingleton<IConversationResetService, DefaultConversationResetService>();
         services.AddSingleton<IMediaPipeline, MediaPipeline>();

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -61,6 +61,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private readonly SessionLifecycleEvents? _sessionLifecycleEvents;
     private readonly PendingAskUserInterceptor? _pendingAskUserInterceptor;
     private readonly IPreCompactionMemoryFlusher? _memoryFlusher;
+    private readonly ISessionCompactionCoordinator _compactionCoordinator;
     private readonly ConcurrentDictionary<string, SessionQueueState> _sessionQueues = new(StringComparer.OrdinalIgnoreCase);
 
     public GatewayHost(
@@ -79,7 +80,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         IConversationRouter? conversationRouter = null,
         PendingAskUserInterceptor? pendingAskUserInterceptor = null,
         IPreCompactionMemoryFlusher? memoryFlusher = null,
-        IAgentRegistry? registry = null)
+        IAgentRegistry? registry = null,
+        ISessionCompactionCoordinator? compactionCoordinator = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -96,6 +98,19 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         _pendingAskUserInterceptor = pendingAskUserInterceptor;
         _memoryFlusher = memoryFlusher;
         _registry = registry;
+        // The coordinator is the single source of truth for compaction (PR #602
+        // followup). Tests that construct GatewayHost directly may not provide
+        // one; build a fallback from the deps we already have so behaviour
+        // matches production.
+        _compactionCoordinator = compactionCoordinator
+            ?? new BotNexus.Gateway.Sessions.SessionCompactionCoordinator(
+                compactor,
+                sessions,
+                supervisor,
+                channelManager,
+                compactionOptions,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<BotNexus.Gateway.Sessions.SessionCompactionCoordinator>.Instance,
+                memoryFlusher);
         SessionQueueCapacity = Math.Max(sessionQueueCapacity, 1);
     }
 
@@ -454,76 +469,15 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 _logger.LogInformation("Auto-compacting session {SessionId}", sessionId);
                 try
                 {
-                    if (_memoryFlusher is not null && _memoryFlusher.ShouldFlush(session.Session, _compactionOptions.CurrentValue))
+                    var outcome = await _compactionCoordinator.CompactAsync(session.AgentId, session, cancellationToken).ConfigureAwait(false);
+                    if (outcome.Applied)
                     {
-                        try
-                        {
-                            await _memoryFlusher.FlushAsync(session.AgentId, session.Session, _compactionOptions.CurrentValue, cancellationToken).ConfigureAwait(false);
-                        }
-                        catch (Exception flushEx)
-                        {
-                            _logger.LogWarning(flushEx, "Pre-compaction memory flush failed for session {SessionId}, compaction will proceed", sessionId);
-                        }
-                    }
-                    var result = await _compactor.CompactAsync(session, _compactionOptions.CurrentValue, cancellationToken);
-                    var compactionApplied = false;
-                    if (result.Succeeded && result.CompactedHistory is not null)
-                    {
-                        var outcome = session.TryApplyCompactionResult(result);
-                        switch (outcome)
-                        {
-                            case HistoryReplaceOutcome.Applied:
-                                session.UpdatedAt = DateTimeOffset.UtcNow;
-                                compactionApplied = true;
-                                break;
-                            case HistoryReplaceOutcome.Rebased:
-                                session.UpdatedAt = DateTimeOffset.UtcNow;
-                                compactionApplied = true;
-                                _logger.LogInformation(
-                                    "Session {SessionId} auto-compaction rebased over concurrent additions; " +
-                                    "TokensAfter is approximate.", sessionId);
-                                break;
-                            case HistoryReplaceOutcome.Aborted:
-                                _logger.LogWarning(
-                                    "Session {SessionId} auto-compaction aborted: history was destructively " +
-                                    "modified during the summary call. History is unchanged.", sessionId);
-                                break;
-                        }
-                    }
-                    await _sessions.SaveAsync(session, cancellationToken);
-                    _logger.LogInformation(
-                        "Session {SessionId} compacted: {Summarized} entries summarized, {Preserved} preserved",
-                        sessionId, result.EntriesSummarized, result.EntriesPreserved);
-
-                    if (compactionApplied)
-                    {
-                        // Evict the cached agent handle so the next GetOrCreateAsync (below) builds
-                        // a fresh context that includes the compaction summary. Without this, a live
-                        // handle would continue with its pre-compaction in-memory message list and
-                        // have no knowledge of the summary that was just written to the session.
-                        await _supervisor.StopAsync(Domain.Primitives.AgentId.From(agentId), Domain.Primitives.SessionId.From(sessionId), cancellationToken).ConfigureAwait(false);
-
-                        // Notify the user in the conversation that compaction occurred. This is a
-                        // system-level status message — not an agent reply — so it is sent directly
-                        // to the channel without going through the LLM.
-                        var compactionNote = $"_[Session context compacted: {result.EntriesSummarized} older messages summarised, {result.EntriesPreserved} recent messages preserved. Continuing…]_";
-                        if (ResolveChannelAdapter(message.ChannelType) is { } notifyChannel)
-                        {
-                            try
-                            {
-                                await notifyChannel.SendAsync(new OutboundMessage
-                                {
-                                    ChannelType = message.ChannelType,
-                                    ChannelAddress = message.ChannelAddress,
-                                    Content = compactionNote,
-                                    SessionId = sessionId
-                                }, cancellationToken).ConfigureAwait(false);
-                            }
-                            catch (Exception notifyEx)
-                            {
-                                _logger.LogWarning(notifyEx, "Failed to send compaction notification for session {SessionId}", sessionId);
-                            }
-                        }
+                        await _compactionCoordinator.TrySendChannelNotificationAsync(
+                            outcome,
+                            message.ChannelType,
+                            message.ChannelAddress,
+                            sessionId,
+                            cancellationToken).ConfigureAwait(false);
                     }
                 }
                 catch (Exception ex)
@@ -883,45 +837,16 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         string sessionId,
         CancellationToken cancellationToken)
     {
-        var result = await _compactor.CompactAsync(session, _compactionOptions.CurrentValue, cancellationToken);
-        var outcome = HistoryReplaceOutcome.Applied;
-        if (result.Succeeded && result.CompactedHistory is not null)
-        {
-            outcome = session.TryApplyCompactionResult(result);
-            if (outcome != HistoryReplaceOutcome.Aborted)
-            {
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-            }
-        }
-        await _sessions.SaveAsync(session, cancellationToken);
-
-        string feedback;
-        if (!result.Succeeded)
-        {
-            feedback = "Compaction aborted: the summarization model returned an empty response. Session history was not modified.";
-        }
-        else if (outcome == HistoryReplaceOutcome.Aborted)
-        {
-            feedback = "Compaction conflicted with a concurrent change to the session. Session history was not modified — please try again.";
-        }
-        else
-        {
-            var rebasedNote = outcome == HistoryReplaceOutcome.Rebased
-                ? " (rebased over concurrent additions)"
-                : string.Empty;
-            feedback = $"Session compacted: {result.EntriesSummarized} entries summarized, {result.EntriesPreserved} preserved{rebasedNote}.";
-        }
-
-        if (ResolveChannelAdapter(message.ChannelType) is { } channel)
-        {
-            await channel.SendAsync(new OutboundMessage
-            {
-                ChannelType = message.ChannelType,
-                ChannelAddress = message.ChannelAddress,
-                Content = feedback,
-                SessionId = sessionId
-            }, cancellationToken);
-        }
+        var outcome = await _compactionCoordinator.CompactAsync(session.AgentId, session, cancellationToken).ConfigureAwait(false);
+        // Always notify on this path — channel-driven /compact callers expect feedback
+        // even on failure so the user knows the command landed. Use the canonical
+        // text (including the FailureReason when applicable).
+        await _compactionCoordinator.TrySendChannelNotificationAsync(
+            outcome,
+            message.ChannelType,
+            message.ChannelAddress,
+            sessionId,
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static bool TryGetControlCommand(InboundMessage message, out string? command)

--- a/src/gateway/BotNexus.Gateway/Sessions/SessionCompactionCoordinator.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/SessionCompactionCoordinator.cs
@@ -1,0 +1,191 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <inheritdoc />
+public sealed class SessionCompactionCoordinator : ISessionCompactionCoordinator
+{
+    private readonly ISessionCompactor _compactor;
+    private readonly ISessionStore _sessions;
+    private readonly IAgentSupervisor _supervisor;
+    private readonly IChannelManager _channelManager;
+    private readonly IOptionsMonitor<CompactionOptions> _options;
+    private readonly IPreCompactionMemoryFlusher? _memoryFlusher;
+    private readonly ILogger<SessionCompactionCoordinator> _logger;
+
+    public SessionCompactionCoordinator(
+        ISessionCompactor compactor,
+        ISessionStore sessions,
+        IAgentSupervisor supervisor,
+        IChannelManager channelManager,
+        IOptionsMonitor<CompactionOptions> options,
+        ILogger<SessionCompactionCoordinator> logger,
+        IPreCompactionMemoryFlusher? memoryFlusher = null)
+    {
+        _compactor = compactor;
+        _sessions = sessions;
+        _supervisor = supervisor;
+        _channelManager = channelManager;
+        _options = options;
+        _logger = logger;
+        _memoryFlusher = memoryFlusher;
+    }
+
+    public async Task<SessionCompactionOutcome> CompactAsync(
+        AgentId agentId,
+        GatewaySession session,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        var options = _options.CurrentValue;
+        var sessionId = session.SessionId;
+
+        // 1. Optional pre-compaction memory flush. Best-effort: failures are logged
+        //    and swallowed so compaction always proceeds (mirrors auto-compact path).
+        if (_memoryFlusher is not null && _memoryFlusher.ShouldFlush(session.Session, options))
+        {
+            try
+            {
+                await _memoryFlusher.FlushAsync(agentId, session.Session, options, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Pre-compaction memory flush failed for session {SessionId}; compaction will proceed.", sessionId);
+            }
+        }
+
+        // 2. Summarise older history. Snapshots inside the compactor so the result
+        //    can be applied with optimistic-concurrency detection.
+        CompactionResult result;
+        try
+        {
+            result = await _compactor.CompactAsync(session, options, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Compaction call failed for session {SessionId}; history unchanged.", sessionId);
+            return new SessionCompactionOutcome(
+                Succeeded: false,
+                Applied: false,
+                HistoryOutcome: HistoryReplaceOutcome.Aborted,
+                EntriesSummarized: 0,
+                EntriesPreserved: 0,
+                TokensBefore: 0,
+                TokensAfter: 0,
+                FailureReason: ex.Message);
+        }
+
+        // 3. Apply + persist. Track outcome for the caller.
+        var historyOutcome = HistoryReplaceOutcome.Aborted;
+        var applied = false;
+        if (result.Succeeded && result.CompactedHistory is not null)
+        {
+            historyOutcome = session.TryApplyCompactionResult(result);
+            switch (historyOutcome)
+            {
+                case HistoryReplaceOutcome.Applied:
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    applied = true;
+                    break;
+                case HistoryReplaceOutcome.Rebased:
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    applied = true;
+                    _logger.LogInformation(
+                        "Session {SessionId} compaction rebased over concurrent additions; TokensAfter is approximate.",
+                        sessionId);
+                    break;
+                case HistoryReplaceOutcome.Aborted:
+                    _logger.LogWarning(
+                        "Session {SessionId} compaction aborted: history was destructively modified during the summary call. History is unchanged.",
+                        sessionId);
+                    break;
+            }
+        }
+
+        await _sessions.SaveAsync(session, cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation(
+            "Session {SessionId} compacted: {Summarized} entries summarized, {Preserved} preserved (applied={Applied}, outcome={Outcome}).",
+            sessionId, result.EntriesSummarized, result.EntriesPreserved, applied, historyOutcome);
+
+        // 4. Evict the cached agent handle on success so the next turn rebuilds
+        //    context from post-compaction history (PR #602 Bug 3 fix — must run
+        //    on every compaction path, not just auto-compact).
+        if (applied)
+        {
+            try
+            {
+                await _supervisor.StopAsync(agentId, sessionId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to evict cached agent handle for session {SessionId} after compaction.", sessionId);
+            }
+        }
+
+        string? failureReason = null;
+        if (!result.Succeeded)
+            failureReason = "Compaction aborted: the summarization model returned an empty response. Session history was not modified.";
+        else if (historyOutcome == HistoryReplaceOutcome.Aborted)
+            failureReason = "Compaction conflicted with a concurrent change to the session. Session history was not modified — please try again.";
+
+        return new SessionCompactionOutcome(
+            Succeeded: result.Succeeded,
+            Applied: applied,
+            HistoryOutcome: historyOutcome,
+            EntriesSummarized: result.EntriesSummarized,
+            EntriesPreserved: result.EntriesPreserved,
+            TokensBefore: result.TokensBefore,
+            TokensAfter: result.TokensAfter,
+            FailureReason: failureReason);
+    }
+
+    public string BuildNotificationText(SessionCompactionOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        if (outcome.FailureReason is { } reason)
+            return reason;
+
+        var rebased = outcome.HistoryOutcome == HistoryReplaceOutcome.Rebased
+            ? " (rebased over concurrent additions)"
+            : string.Empty;
+        return $"_[Session context compacted: {outcome.EntriesSummarized} older messages summarised, {outcome.EntriesPreserved} recent messages preserved{rebased}. Continuing…]_";
+    }
+
+    public async Task<bool> TrySendChannelNotificationAsync(
+        SessionCompactionOutcome outcome,
+        ChannelKey channelType,
+        ChannelAddress channelAddress,
+        string sessionId,
+        CancellationToken cancellationToken)
+    {
+        var adapter = _channelManager.Get(channelType);
+        if (adapter is null)
+        {
+            _logger.LogWarning("No channel adapter found for type '{ChannelType}' — compaction notification dropped for session {SessionId}.", channelType, sessionId);
+            return false;
+        }
+
+        try
+        {
+            await adapter.SendAsync(new OutboundMessage
+            {
+                ChannelType = channelType,
+                ChannelAddress = channelAddress,
+                Content = BuildNotificationText(outcome),
+                SessionId = sessionId
+            }, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send compaction notification for session {SessionId}.", sessionId);
+            return false;
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionLoaderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionLoaderTests.cs
@@ -199,6 +199,7 @@ public sealed class ExtensionLoaderTests : IDisposable
         services.AddSingleton(Mock.Of<IChannelDispatcher>());
         services.AddSingleton(Mock.Of<IActivityBroadcaster>());
         services.AddSingleton(Mock.Of<ISessionCompactor>());
+        services.AddSingleton(Mock.Of<ISessionCompactionCoordinator>());
         services.AddSingleton(Mock.Of<ISessionWarmupService>());
         services.AddSingleton(Mock.Of<IConversationDispatcher>());
         services.AddSingleton(Mock.Of<IConversationRouter>());

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -250,6 +250,15 @@ public sealed class SignalRHubTests
 
         var conversationDispatcher = new DefaultConversationDispatcher(router, conversationStore);
 
+        static SessionCompactionCoordinator NewCoordinator(ISessionStore store)
+            => new(
+                Mock.Of<ISessionCompactor>(),
+                store,
+                Mock.Of<IAgentSupervisor>(),
+                Mock.Of<IChannelManager>(),
+                new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+                NullLogger<SessionCompactionCoordinator>.Instance);
+
         // Two hubs with different connection IDs but same underlying stores/router
         var hub1 = new GatewayHub(
             Mock.Of<IAgentSupervisor>(),
@@ -262,7 +271,8 @@ public sealed class SignalRHubTests
             conversationDispatcher,
             router,
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
-            NullLogger<GatewayHub>.Instance)
+            NullLogger<GatewayHub>.Instance,
+            compactionCoordinator: NewCoordinator(sessionStore))
         {
             Clients = Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = Mock.Of<IGroupManager>(),
@@ -280,7 +290,8 @@ public sealed class SignalRHubTests
             conversationDispatcher,
             router,
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
-            NullLogger<GatewayHub>.Instance)
+            NullLogger<GatewayHub>.Instance,
+            compactionCoordinator: NewCoordinator(sessionStore))
         {
             Clients = Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = Mock.Of<IGroupManager>(),
@@ -586,21 +597,33 @@ public sealed class SignalRHubTests
             NullLogger<DefaultConversationRouter>.Instance);
         var dispatcherForHub = conversationDispatcher ?? new DefaultConversationDispatcher(router, convStore);
 
+        var supervisorImpl = supervisor ?? Mock.Of<IAgentSupervisor>();
+        var compactorImpl = compactor ?? Mock.Of<ISessionCompactor>();
+        var optionsImpl = compactionOptions ?? new TestOptionsMonitor<CompactionOptions>(new CompactionOptions());
+        var coordinator = new SessionCompactionCoordinator(
+            compactorImpl,
+            sessionStore,
+            supervisorImpl,
+            Mock.Of<IChannelManager>(),
+            optionsImpl,
+            NullLogger<SessionCompactionCoordinator>.Instance);
+
         var hub = new GatewayHub(
-            supervisor ?? Mock.Of<IAgentSupervisor>(),
+            supervisorImpl,
             registry ?? Mock.Of<IAgentRegistry>(),
             sessionStore,
             dispatcher ?? Mock.Of<IChannelDispatcher>(),
             activity ?? Mock.Of<IActivityBroadcaster>(),
-            compactor ?? Mock.Of<ISessionCompactor>(),
+            compactorImpl,
             warmup ?? Mock.Of<ISessionWarmupService>(),
             dispatcherForHub,
             router,
-            compactionOptions ?? new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            optionsImpl,
             NullLogger<GatewayHub>.Instance,
             convStore,
             askUserResponseRegistry,
-            resetService)
+            resetService,
+            coordinator)
         {
             Clients = clients ?? Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = groups ?? Mock.Of<IGroupManager>(),

--- a/tests/integration/BotNexus.Integration.E2E.Tests/CompactionFlowTests.cs
+++ b/tests/integration/BotNexus.Integration.E2E.Tests/CompactionFlowTests.cs
@@ -1,0 +1,149 @@
+using Microsoft.Playwright;
+
+namespace BotNexus.Integration.E2E.Tests;
+
+/// <summary>
+/// Verifies the user-triggered <c>/compact</c> slash command path matches the
+/// behaviour fixed in PR #602 + the unification done on top of it:
+///
+/// <list type="number">
+///   <item><description>A canonical <c>[Session context compacted: …]</c> system bubble appears in the active conversation.</description></item>
+///   <item><description>No spurious <c>cron:</c> (virtual session) conversation is created in the conversation list.</description></item>
+///   <item><description>The agent continues responding to subsequent user messages after the compact.</description></item>
+/// </list>
+///
+/// The flow exercises <c>GatewayHub.CompactSession</c> → <c>ISessionCompactionCoordinator</c>
+/// — the same coordinator the auto-compact (token threshold) path now uses,
+/// so a single E2E proves both call sites behave identically end-to-end.
+/// </summary>
+[Collection(NewUserExperienceCollection.Name)]
+public sealed class CompactionFlowTests
+{
+    private readonly NewUserExperienceFixture _fx;
+
+    public CompactionFlowTests(NewUserExperienceFixture fx) => _fx = fx;
+
+    [SkippableFact]
+    public async Task SlashCompact_NotifiesUser_NoCronConversation_ContinuesNormally()
+    {
+        Skip.IfNot(_fx.Succeeded, $"Fixture initialization failed: {_fx.Error}");
+
+        try
+        {
+            await PlaywrightBootstrap.EnsureBrowserInstalledAsync();
+        }
+        catch (Exception ex)
+        {
+            Skip.If(true, $"Playwright browser install unavailable: {ex.Message}");
+        }
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await PlaywrightBootstrap.LaunchChromiumAsync(playwright);
+        var context = await browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        var agentId = _fx.AgentIds[0];
+
+        var nav = await page.GotoAsync($"{_fx.GatewayBaseUrl}/chat/{agentId}", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 60_000,
+        });
+        Xunit.Assert.NotNull(nav);
+        Xunit.Assert.True(nav!.Ok, $"GET /chat/{agentId} returned {nav.Status}");
+
+        var composer = page.Locator("[data-testid='chat-input']").First;
+        await composer.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 30_000,
+        });
+
+        // Seed the session with one user turn so there is something to compact.
+        await SendAsync(page, composer, "HELLO_WORLD");
+        await WaitForAssistantTextAsync(page, "Hello", TimeSpan.FromSeconds(30));
+
+        // Trigger the user-initiated compaction path.
+        await SendAsync(page, composer, "/compact");
+
+        // PR #602 fix #2: the canonical notification must surface to the user.
+        var systemMessage = page.Locator("[data-testid='chat-system-message']")
+            .Filter(new LocatorFilterOptions { HasTextString = "Session context compacted" })
+            .First;
+        try
+        {
+            await systemMessage.WaitForAsync(new LocatorWaitForOptions
+            {
+                State = WaitForSelectorState.Attached,
+                Timeout = 30_000,
+            });
+        }
+        catch (TimeoutException)
+        {
+            var snapshot = await page.Locator("[data-testid='chat-messages']").First.InnerHTMLAsync();
+            Xunit.Assert.Fail($"Compaction notification did not appear within 30s. Messages container:\n{Truncate(snapshot)}");
+        }
+
+        // PR #602 fix #1: no virtual 'cron:'-kind conversation must be created.
+        var conversationTitles = await page.Locator("[data-testid='conversation-list-item'] .conversation-list-item-title")
+            .AllInnerTextsAsync();
+        foreach (var title in conversationTitles)
+        {
+            Xunit.Assert.False(
+                title.StartsWith("cron:", StringComparison.OrdinalIgnoreCase),
+                $"Unexpected cron-prefixed conversation created by /compact: '{title}'");
+        }
+
+        // PR #602 fix #3: the next user turn must reach the agent and elicit a response.
+        await SendAsync(page, composer, "HELLO_WORLD");
+        await WaitForAssistantTextAsync(page, "Hello", TimeSpan.FromSeconds(30));
+    }
+
+    private static async Task SendAsync(IPage page, ILocator composer, string text)
+    {
+        await composer.FillAsync(text);
+        var send = page.Locator("[data-testid='chat-send']").First;
+        await send.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 10_000,
+        });
+        await send.ClickAsync();
+        // Wait for the composer to clear, signalling Blazor processed the send.
+        try
+        {
+            await page.WaitForFunctionAsync(
+                "() => { var el = document.querySelector(\"[data-testid='chat-input']\"); return el && (el.value || '') === ''; }",
+                null,
+                new PageWaitForFunctionOptions { Timeout = 5_000 });
+        }
+        catch (TimeoutException)
+        {
+            // Slash commands clear synchronously too; if this races, the
+            // assertions below will surface the real failure mode.
+        }
+    }
+
+    private static async Task WaitForAssistantTextAsync(IPage page, string substring, TimeSpan timeout)
+    {
+        var locator = page.Locator(".message.assistant .message-content")
+            .Filter(new LocatorFilterOptions { HasTextString = substring })
+            .First;
+        try
+        {
+            await locator.WaitForAsync(new LocatorWaitForOptions
+            {
+                State = WaitForSelectorState.Attached,
+                Timeout = (float)timeout.TotalMilliseconds,
+            });
+        }
+        catch (TimeoutException)
+        {
+            var snapshot = await page.Locator("[data-testid='chat-messages']").First.InnerHTMLAsync();
+            Xunit.Assert.Fail($"Assistant message containing '{substring}' did not appear within {timeout}. Messages:\n{Truncate(snapshot)}");
+        }
+    }
+
+    private static string Truncate(string text) =>
+        text.Length <= 2000 ? text : text[..2000] + "…";
+}


### PR DESCRIPTION
## What

Follows up on PR #602 by collapsing the three divergent compaction code paths behind a single `ISessionCompactionCoordinator` so they share one pipeline (memory flush → compact → apply/save → agent-handle eviction → canonical user notification) and one notification text.

User direction: *compaction should work the same regardless of user calling it or it happening due to token usage being too high*.

### Unified call sites

| Caller | Before | After |
|---|---|---|
| `GatewayHost` auto-compact (token threshold) | full pipeline (had PR #602 fixes) | delegates to coordinator |
| `GatewayHost.HandleCompactionAsync` (inbound `control: compact`) | compact only, no eviction, different text | delegates to coordinator |
| `GatewayHub.CompactSession` (SignalR `/compact` RPC) | compact only, no eviction, no notification, no flush | delegates to coordinator |

### Canonical notification text

`_[Session context compacted: N older messages summarised, M recent messages preserved[ (rebased over concurrent additions)]. Continuing…]_`

The Blazor client's local optimistic system-message injection (`AgentInteractionService.CompactSessionAsync`) was updated to the same text so user-triggered `/compact` reads identically whether the gateway echo lands first or the optimistic local message does.

## Tests

- `CompactionFlowTests.SlashCompact_NotifiesUser_NoCronConversation_ContinuesNormally` — new Playwright E2E that drives the portal's `/compact` path and asserts all three PR #602 fixes via the unified coordinator:
  1. canonical `[Session context compacted: …]` system bubble appears,
  2. no `cron:`-prefixed conversation is created in the conversation list,
  3. the next `HELLO_WORLD` user turn still elicits an assistant response.
- Added `data-testid` hooks (`chat-input`, `chat-send`, `chat-messages`, `chat-system-message`, `conversation-list-item`) to back the E2E without coupling to CSS class names.
- All 4400+ unit/integration tests pass: `dotnet test BotNexus.slnx --nologo --tl:off --filter "FullyQualifiedName!~BotNexus.Integration."`.

## CI

- `.github/workflows/ci.yml` `dotnet test` step now filters out `BotNexus.Integration.*` (the heavy install + Playwright flow shouldn't run on every PR).

## Notes / follow-ups

- `GatewayHub` still has unused `_compactor` + `_compactionOptions` ctor params for backward compat; cleanup deferred to a separate PR to keep this diff focused.
- Did not touch CI `--no-build` flag per repo convention (out of scope here).

Closes follow-up work from #602.