### PR TITLE
feat(portal): show conversation ID in title tooltip for debug and e2e tests

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -24,11 +24,11 @@
                         {
                             @if (IsReadOnly)
                             {
-                                <h3 class="conversation-title">@ActiveConversationTitle</h3>
+                                <h3 class="conversation-title" title="@ActiveConversationId">@ActiveConversationTitle</h3>
                             }
                             else
                             {
-                                <h3 class="conversation-title editable" @onclick="StartEditTitle" title="Click to rename">@ActiveConversationTitle</h3>
+                                <h3 class="conversation-title editable" @onclick="StartEditTitle" title="@($"{ActiveConversationId} - click to rename")">@ActiveConversationTitle</h3>
                             }
                             @if (ActiveConversation?.IsDefault == true)
                             {


### PR DESCRIPTION
## Summary

Hovering over the conversation title in the web portal now shows the conversation ID as a native browser tooltip.

## Changes

- Read-only conversations: `title` set to the conversation ID
- Editable conversations: `title` set to `"{conversationId} - click to rename"`, preserving the rename hint

## Motivation

Easier debugging without opening DevTools. Playwright tests can assert the active conversation ID via `locator.getAttribute('title')` on the `h3.conversation-title` element.

## Pre-existing test failures (not caused by this PR)

- `Cli_Install_ClonesCurrentRepoIntoSandbox` — known worktree clone path issue on main
- `CompactionFlowTests.SlashCompact_NotifiesUser` — new test added in #608, fails on main too
