### PR TITLE
feat(portal): update browser tab title to agent - conversation name

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
@@ -8,7 +8,7 @@
 @inject NavigationManager Nav
 @implements IDisposable
 
-<PageTitle>BotNexus</PageTitle>
+<PageTitle>@PageTitle</PageTitle>
 
 @if (!PortalLoad.IsReady)
 {
@@ -42,6 +42,32 @@ else
     [Parameter] public string? AgentId { get; set; }
     [Parameter] public string? ConversationId { get; set; }
     private string? _appliedRouteKey;
+
+    private string PageTitle
+    {
+        get
+        {
+            if (Store.ActiveAgentId is not { Length: > 0 } activeAgentId)
+                return "BotNexus";
+
+            var agent = Store.GetAgent(activeAgentId);
+            if (agent is null)
+                return "BotNexus";
+
+            var agentLabel = string.IsNullOrWhiteSpace(agent.DisplayName)
+                ? activeAgentId
+                : agent.DisplayName;
+
+            if (agent.ActiveConversationId is not { Length: > 0 } convId ||
+                !agent.Conversations.TryGetValue(convId, out var conv) ||
+                string.IsNullOrWhiteSpace(conv.Title))
+            {
+                return $"{agentLabel} - BotNexus";
+            }
+
+            return $"{agentLabel} - {conv.Title}";
+        }
+    }
 
     protected override void OnInitialized()
     {


### PR DESCRIPTION
## Summary

Updates the `<PageTitle>` in `Home.razor` from the static string `BotNexus` to a dynamic computed property that reflects the currently active agent and conversation.

## Behaviour

- No agent selected → `BotNexus`
- Agent selected, no conversation → `Farnsworth - BotNexus`
- Agent + conversation selected → `Farnsworth - My conversation`

The title re-evaluates on every `Store.OnChanged` event, so it updates automatically when the user switches agents, switches conversations, or a conversation is renamed via a hub event.

## Changes

- `Pages/Home.razor` — replaced static `<PageTitle>BotNexus</PageTitle>` with `<PageTitle>@PageTitle</PageTitle>` and added a `PageTitle` computed property that reads `Store.ActiveAgentId` → `AgentState.DisplayName` + active `ConversationState.Title`.
