### PR TITLE
feat(domain): add WorldId to Conversation (#613 P9-A)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -12,6 +12,21 @@ public sealed record Conversation
     /// <summary>Gets or sets the unique conversation identifier.</summary>
     public ConversationId ConversationId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the id of the world this conversation belongs to. Stamped by the
+    /// conversation store on persistence using the gateway's resolved <see cref="WorldIdentity"/>
+    /// (see <c>IWorldContext</c>). Defaults to empty string so pre-Phase-9 rows and in-memory
+    /// constructs deserialise unchanged — stores lazily backfill the field on read when empty so
+    /// older data converges to the current world id without an explicit migration script.
+    /// </summary>
+    /// <remarks>
+    /// Cross-world relayed conversations (see <c>CrossWorldFederationController</c>) carry the
+    /// receiving world id here; the source world id is preserved on <see cref="Metadata"/>
+    /// (<c>sourceWorldId</c>). This keeps the typed field locally meaningful (the world that
+    /// owns this row) while still allowing federation traces to be reconstructed from metadata.
+    /// </remarks>
+    public string WorldId { get; set; } = string.Empty;
+
     /// <summary>Gets or sets the agent that owns this conversation.</summary>
     public AgentId AgentId { get; set; }
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Configuration/IWorldContext.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Configuration/IWorldContext.cs
@@ -1,0 +1,31 @@
+using BotNexus.Domain;
+
+namespace BotNexus.Gateway.Abstractions.Configuration;
+
+/// <summary>
+/// Resolves the current gateway's <see cref="WorldIdentity"/> so domain components — stores,
+/// routers, triggers, controllers — can stamp the world id on outbound records without depending
+/// on <c>PlatformConfig</c> or the static <c>WorldIdentityResolver</c> directly. Introduced as
+/// part of Phase 9 (issue #613, work item P9-A) when <c>Conversation.WorldId</c> became a
+/// first-class field; expected to be used by all later P9 work items that touch world-stamped
+/// records (sessions, citizens, channel bindings).
+/// </summary>
+/// <remarks>
+/// Why an interface rather than re-using <c>IOptionsMonitor&lt;PlatformConfig&gt;</c> at every
+/// site: world identity is a single, stable answer for the running gateway, and the indirection
+/// keeps store/router/trigger implementations free of platform-configuration shape changes.
+/// </remarks>
+public interface IWorldContext
+{
+    /// <summary>
+    /// Gets the current world's full identity (id, name, description, emoji). Resolved from
+    /// configuration, with a deterministic fallback if not configured. Never <c>null</c>.
+    /// </summary>
+    WorldIdentity Current { get; }
+
+    /// <summary>
+    /// Gets the current world's id — shorthand for <see cref="Current"/>.<see cref="WorldIdentity.Id"/>.
+    /// Always a non-empty string.
+    /// </summary>
+    string CurrentWorldId => Current.Id;
+}

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions;
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Configuration;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using Microsoft.Extensions.Logging;
@@ -21,6 +22,7 @@ public sealed class FileConversationStore : IConversationStore
     private readonly string _rootPath;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<FileConversationStore> _logger;
+    private readonly IWorldContext? _worldContext;
     private readonly SemaphoreSlim _lock = new(1, 1);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -30,16 +32,36 @@ public sealed class FileConversationStore : IConversationStore
     };
 
     /// <summary>
-    /// Initialises a new <see cref="FileConversationStore"/> with the given root path.
+    /// Initialises a new <see cref="FileConversationStore"/> with the given root path. No world
+    /// stamping — kept for tests and bare wire-ups; production callers should use the
+    /// world-aware overload.
     /// </summary>
     /// <param name="rootPath">Base directory under which <c>{agentId}/{conversationId}.json</c> files are stored.</param>
     /// <param name="logger">Logger.</param>
     /// <param name="fileSystem">Abstracted file system.</param>
     public FileConversationStore(string rootPath, ILogger<FileConversationStore> logger, IFileSystem fileSystem)
+        : this(rootPath, logger, fileSystem, worldContext: null)
+    {
+    }
+
+    /// <summary>
+    /// Initialises a new <see cref="FileConversationStore"/> that stamps and lazy-backfills the
+    /// current world id on <see cref="Conversation.WorldId"/>.
+    /// </summary>
+    /// <param name="rootPath">Base directory under which <c>{agentId}/{conversationId}.json</c> files are stored.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="fileSystem">Abstracted file system.</param>
+    /// <param name="worldContext">Resolves the gateway's current world identity for stamping; <c>null</c> disables stamping.</param>
+    public FileConversationStore(
+        string rootPath,
+        ILogger<FileConversationStore> logger,
+        IFileSystem fileSystem,
+        IWorldContext? worldContext)
     {
         _rootPath = rootPath;
         _logger = logger;
         _fileSystem = fileSystem;
+        _worldContext = worldContext;
         _fileSystem.Directory.CreateDirectory(rootPath);
     }
 
@@ -47,7 +69,7 @@ public sealed class FileConversationStore : IConversationStore
     public async Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default)
     {
         await _lock.WaitAsync(ct).ConfigureAwait(false);
-        try { return await LoadFileAsync(conversationId, ct).ConfigureAwait(false); }
+        try { return BackfillWorldId(await LoadFileAsync(conversationId, ct).ConfigureAwait(false)); }
         finally { _lock.Release(); }
     }
 
@@ -93,6 +115,8 @@ public sealed class FileConversationStore : IConversationStore
 
     public async Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
     {
+        StampWorldId(conversation);
+
         await _lock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
@@ -108,6 +132,7 @@ public sealed class FileConversationStore : IConversationStore
     /// <inheritdoc />
     public async Task SaveAsync(Conversation conversation, CancellationToken ct = default)
     {
+        StampWorldId(conversation);
         conversation = conversation with { UpdatedAt = DateTimeOffset.UtcNow };
         await _lock.WaitAsync(ct).ConfigureAwait(false);
         try { await WriteFileAsync(conversation, ct).ConfigureAwait(false); }
@@ -188,7 +213,10 @@ public sealed class FileConversationStore : IConversationStore
                     var json = await _fileSystem.File.ReadAllTextAsync(file, ct).ConfigureAwait(false);
                     var conversation = JsonSerializer.Deserialize<Conversation>(json, JsonOptions);
                     if (conversation is not null)
+                    {
+                        BackfillWorldId(conversation);
                         results.Add(conversation);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -247,6 +275,28 @@ public sealed class FileConversationStore : IConversationStore
 
     private string GetPath(AgentId agentId, ConversationId conversationId)
         => Path.Combine(_rootPath, agentId.Value, $"{conversationId.Value}.json");
+
+    // Stamps the current world id onto a conversation being persisted (Create/Save). Only
+    // fills an empty WorldId — explicit non-empty values are preserved so cross-world relays
+    // can hold the source world's id even when this gateway is the receiver. No-op when no
+    // world context is wired (e.g. test setups using the parameterless ctor).
+    private void StampWorldId(Conversation conversation)
+    {
+        if (string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
+            conversation.WorldId = _worldContext.CurrentWorldId;
+    }
+
+    // Read-time projection: legacy JSON sidecars persisted before #613 deserialise with an
+    // empty WorldId. This projects them to the current world on the way out. The file on
+    // disk is not rewritten — the next SaveAsync round-trip will durably persist via
+    // StampWorldId. Treating backfill as projection-only keeps the read path single-pass
+    // and avoids touching disk on every Get/List.
+    private Conversation? BackfillWorldId(Conversation? conversation)
+    {
+        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
+            conversation.WorldId = _worldContext.CurrentWorldId;
+        return conversation;
+    }
 
     private static ConversationSummary ToSummary(Conversation c) =>
         new(

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Configuration;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 
@@ -14,17 +15,36 @@ namespace BotNexus.Gateway.Conversations;
 public sealed class InMemoryConversationStore : IConversationStore
 {
     private readonly ConcurrentDictionary<string, Conversation> _conversations = new(StringComparer.Ordinal);
+    private readonly IWorldContext? _worldContext;
+
+    /// <summary>Initialises a new <see cref="InMemoryConversationStore"/> without world stamping.</summary>
+    /// <remarks>
+    /// Kept for tests and bare wire-ups that don't have a world context available; production
+    /// callers should always provide <see cref="IWorldContext"/> via the world-aware overload so
+    /// <c>Conversation.WorldId</c> is stamped on persistence.
+    /// </remarks>
+    public InMemoryConversationStore() { }
+
+    /// <summary>Initialises a new <see cref="InMemoryConversationStore"/> that stamps the current world id.</summary>
+    /// <param name="worldContext">Resolves the gateway's current <see cref="WorldIdentity"/> for stamping.</param>
+    public InMemoryConversationStore(IWorldContext worldContext)
+    {
+        _worldContext = worldContext;
+    }
 
     /// <inheritdoc />
     public Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default)
-        => Task.FromResult(_conversations.GetValueOrDefault(conversationId.Value));
+    {
+        var conversation = _conversations.GetValueOrDefault(conversationId.Value);
+        return Task.FromResult(BackfillWorldId(conversation));
+    }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<Conversation>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
     {
         IReadOnlyList<Conversation> results = agentId is null
-            ? [.. _conversations.Values]
-            : [.. _conversations.Values.Where(c => c.AgentId == agentId.Value)];
+            ? [.. _conversations.Values.Select(c => BackfillWorldId(c)!)]
+            : [.. _conversations.Values.Where(c => c.AgentId == agentId.Value).Select(c => BackfillWorldId(c)!)];
         return Task.FromResult(results);
     }
 
@@ -34,7 +54,9 @@ public sealed class InMemoryConversationStore : IConversationStore
         if (!citizen.IsValid)
             throw new ArgumentException("Citizen must be a valid (non-default) CitizenId.", nameof(citizen));
 
-        IReadOnlyList<Conversation> results = [.. _conversations.Values.Where(c => MatchesCitizen(c, citizen))];
+        IReadOnlyList<Conversation> results = [.. _conversations.Values
+            .Where(c => MatchesCitizen(c, citizen))
+            .Select(c => BackfillWorldId(c)!)];
         return Task.FromResult(results);
     }
 
@@ -52,6 +74,7 @@ public sealed class InMemoryConversationStore : IConversationStore
 
     public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
     {
+        StampWorldId(conversation);
         if (!_conversations.TryAdd(conversation.ConversationId.Value, conversation))
             throw new InvalidOperationException($"A conversation with id '{conversation.ConversationId}' already exists.");
         return Task.FromResult(conversation);
@@ -60,6 +83,7 @@ public sealed class InMemoryConversationStore : IConversationStore
     /// <inheritdoc />
     public Task SaveAsync(Conversation conversation, CancellationToken ct = default)
     {
+        StampWorldId(conversation);
         conversation = conversation with { UpdatedAt = DateTimeOffset.UtcNow };
         _conversations[conversation.ConversationId.Value] = conversation;
         return Task.CompletedTask;
@@ -92,7 +116,7 @@ public sealed class InMemoryConversationStore : IConversationStore
                 b.ChannelType == channelType &&
                 b.ChannelAddress == channelAddress));
 
-        return Task.FromResult(match);
+        return Task.FromResult(BackfillWorldId(match));
     }
 
     /// <inheritdoc />
@@ -109,6 +133,28 @@ public sealed class InMemoryConversationStore : IConversationStore
         return Task.FromResult(summaries);
     }
 
+    // Stamps the current world id onto a conversation being persisted (Create/Save). Only
+    // fills an empty WorldId — explicit non-empty values are preserved so cross-world relays
+    // can hold the source world's id even when this gateway is the receiver. No-op when no
+    // world context is wired (e.g. test setups using the parameterless ctor).
+    private void StampWorldId(Conversation conversation)
+    {
+        if (string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
+            conversation.WorldId = _worldContext.CurrentWorldId;
+    }
+
+    // Read-time projection: any conversation stored before the world context was wired
+    // (e.g. via the parameterless ctor) carries an empty WorldId. This projects it to the
+    // current world on the way out. The in-memory dictionary itself is not mutated to
+    // "repair" the value — kept identical to the Sqlite/File semantics so the three stores
+    // behave the same way under tests and under the lazy upgrade path.
+    private Conversation? BackfillWorldId(Conversation? conversation)
+    {
+        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
+            conversation.WorldId = _worldContext.CurrentWorldId;
+        return conversation;
+    }
+
     private static ConversationSummary ToSummary(Conversation c) =>
         new(
             c.ConversationId.Value,
@@ -123,3 +169,4 @@ public sealed class InMemoryConversationStore : IConversationStore
             c.Purpose,
             c.Kind.ToString());
 }
+

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Configuration;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using Microsoft.Data.Sqlite;
@@ -26,20 +27,60 @@ public sealed class SqliteConversationStore : IConversationStore
 
     private readonly string _connectionString;
     private readonly ILogger<SqliteConversationStore> _logger;
+    private readonly IWorldContext? _worldContext;
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _conversationLocks = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, Conversation> _cache = new(StringComparer.Ordinal);
     private bool _initialized;
 
     /// <summary>
-    /// Initialises a new instance of the <see cref="SqliteConversationStore"/> class.
+    /// Initialises a new instance of the <see cref="SqliteConversationStore"/> class without
+    /// world stamping. Kept for tests and bare wire-ups; production callers should use the
+    /// world-aware overload so <see cref="Conversation.WorldId"/> is stamped on persistence.
     /// </summary>
     /// <param name="connectionString">The SQLite connection string.</param>
     /// <param name="logger">Logger instance.</param>
     public SqliteConversationStore(string connectionString, ILogger<SqliteConversationStore> logger)
+        : this(connectionString, logger, worldContext: null)
+    {
+    }
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="SqliteConversationStore"/> class that
+    /// stamps the current world id on persisted conversations and lazy-backfills the field for
+    /// pre-Phase-9 rows loaded with an empty <see cref="Conversation.WorldId"/>.
+    /// </summary>
+    /// <param name="connectionString">The SQLite connection string.</param>
+    /// <param name="logger">Logger instance.</param>
+    /// <param name="worldContext">Resolves the gateway's current world identity; <c>null</c> disables stamping.</param>
+    public SqliteConversationStore(string connectionString, ILogger<SqliteConversationStore> logger, IWorldContext? worldContext)
     {
         _connectionString = connectionString;
         _logger = logger;
+        _worldContext = worldContext;
+    }
+
+    // Stamps the current world id onto a conversation being persisted (Create/Save). Only
+    // fills an empty WorldId — explicit non-empty values are preserved so cross-world relays
+    // can hold the source world's id even when this gateway is the receiver. No-op when no
+    // world context is wired (e.g. test setups using the parameterless ctor).
+    private void StampWorldId(Conversation conversation)
+    {
+        if (string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
+            conversation.WorldId = _worldContext.CurrentWorldId;
+    }
+
+    // Read-time projection: legacy rows persisted before #613 carry empty WorldId from the
+    // schema default. This projects them as belonging to the current world on the way out.
+    // The disk row itself is not rewritten — the next SaveAsync (or any in-place mutation
+    // that round-trips through SaveConversationAsync) will durably persist via StampWorldId.
+    // Treating backfill as projection-only avoids touching disk on every read and keeps
+    // ArchiveAsync's lighter "status-only" persistence path simple.
+    private Conversation? BackfillWorldId(Conversation? conversation)
+    {
+        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
+            conversation.WorldId = _worldContext.CurrentWorldId;
+        return conversation;
     }
 
     /// <inheritdoc />
@@ -54,13 +95,13 @@ public sealed class SqliteConversationStore : IConversationStore
         try
         {
             if (_cache.TryGetValue(conversationId.Value, out var cached))
-                return CloneConversation(cached);
+                return BackfillWorldId(CloneConversation(cached));
 
             var loaded = await LoadConversationAsync(conversationId, ct).ConfigureAwait(false);
             if (loaded is not null)
                 _cache[conversationId.Value] = CloneConversation(loaded);
 
-            return loaded;
+            return BackfillWorldId(loaded);
         }
         finally
         {
@@ -103,7 +144,7 @@ public sealed class SqliteConversationStore : IConversationStore
                 _cache[id] = CloneConversation(conversation);
             }
 
-            conversations.Add(conversation);
+            conversations.Add(BackfillWorldId(conversation)!);
         }
 
         return conversations;
@@ -154,7 +195,7 @@ public sealed class SqliteConversationStore : IConversationStore
                 _cache[id] = CloneConversation(conversation);
             }
 
-            conversations.Add(conversation);
+            conversations.Add(BackfillWorldId(conversation)!);
         }
 
         return conversations;
@@ -174,6 +215,7 @@ public sealed class SqliteConversationStore : IConversationStore
             if (_cache.ContainsKey(conversation.ConversationId.Value))
                 throw new InvalidOperationException($"A conversation with id '{conversation.ConversationId}' already exists.");
 
+            StampWorldId(conversation);
             await using var connection = CreateConnection();
             await connection.OpenAsync(ct).ConfigureAwait(false);
             await SaveConversationAsync(connection, conversation, upsert: false, ct).ConfigureAwait(false);
@@ -200,6 +242,7 @@ public sealed class SqliteConversationStore : IConversationStore
         {
             var updated = CloneConversation(conversation);
             updated.UpdatedAt = DateTimeOffset.UtcNow;
+            StampWorldId(updated);
 
             await using var connection = CreateConnection();
             await connection.OpenAsync(ct).ConfigureAwait(false);
@@ -405,7 +448,8 @@ public sealed class SqliteConversationStore : IConversationStore
                     active_session_id TEXT,
                     metadata TEXT NOT NULL DEFAULT '{}',
                     created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
+                    updated_at TEXT NOT NULL,
+                    world_id TEXT NOT NULL DEFAULT ''
                 );
 
                 CREATE TABLE IF NOT EXISTS conversation_bindings (
@@ -433,6 +477,7 @@ public sealed class SqliteConversationStore : IConversationStore
             await EnsureCanvasHtmlColumnAsync(connection, ct).ConfigureAwait(false);
             await EnsureInitiatorColumnAsync(connection, ct).ConfigureAwait(false);
             await EnsureKindColumnAsync(connection, ct).ConfigureAwait(false);
+            await EnsureWorldIdColumnAsync(connection, ct).ConfigureAwait(false);
             await MigrateThreadIdIntoChannelAddressAsync(connection, ct).ConfigureAwait(false);
 
             // One-time migration: archive stale signalr:connection-id conversations created
@@ -601,6 +646,52 @@ public sealed class SqliteConversationStore : IConversationStore
         }
     }
 
+    // Adds the `world_id` column to existing databases for the Phase 9 / P9-A discriminator
+    // (issue #613). Pre-Phase-9 rows have empty-string here; the loader lazy-backfills empty
+    // values to the current world id via BackfillWorldId on read, so back-compat is automatic.
+    // The NOT NULL DEFAULT '' constraint keeps the column safe to leave unbound in legacy
+    // INSERT statements that haven't yet been migrated.
+    private static async Task EnsureWorldIdColumnAsync(SqliteConnection connection, CancellationToken ct)
+    {
+        await using var tableInfoCommand = connection.CreateCommand();
+        tableInfoCommand.CommandText = "PRAGMA table_info(conversations);";
+
+        var hasColumn = false;
+        await using (var reader = await tableInfoCommand.ExecuteReaderAsync(ct).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                if (string.Equals(reader.GetString(1), "world_id", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasColumn)
+            return;
+
+        await using var alterCommand = connection.CreateCommand();
+        alterCommand.CommandText = "ALTER TABLE conversations ADD COLUMN world_id TEXT NOT NULL DEFAULT '';";
+        try
+        {
+            await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        catch (SqliteException ex) when (ex.SqliteErrorCode == 1 &&
+                                         ex.Message.Contains("duplicate column", StringComparison.OrdinalIgnoreCase))
+        {
+            // Cross-process race: another gateway instance hit EnsureCreatedAsync between our
+            // PRAGMA-table_info read and our ALTER TABLE. _initLock only serialises within one
+            // process; the loser of the race observes the column missing, races to ALTER, and
+            // gets back SQLite generic error 1 with "duplicate column name: world_id". The
+            // column already exists with the schema we'd have created (NOT NULL DEFAULT ''),
+            // so swallow and continue. Same shape used by EnsureInitiatorColumnAsync should it
+            // ever hit the same race — kept inline (not extracted to a helper) because the
+            // duplicate-column tolerance is the only thing different from a plain ALTER.
+        }
+    }
+
     // Migrates legacy conversation_bindings rows with a thread_id column into the composite
     // channel_address scheme adopted in PR #512 (refactor: drop ThreadId from core contracts).
     // Idempotent: if the thread_id column has already been dropped, the method is a no-op.
@@ -731,7 +822,7 @@ public sealed class SqliteConversationStore : IConversationStore
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind
+            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id
             FROM conversations
             WHERE id = $id
             """;
@@ -755,7 +846,8 @@ public sealed class SqliteConversationStore : IConversationStore
             Instructions = reader.IsDBNull(10) ? null : reader.GetString(10),
             CanvasHtml = reader.FieldCount > 11 && !reader.IsDBNull(11) ? reader.GetString(11) : null,
             Initiator = reader.FieldCount > 12 ? DeserializeInitiator(reader.IsDBNull(12) ? null : reader.GetString(12)) : null,
-            Kind = reader.FieldCount > 13 ? ParseConversationKind(reader.IsDBNull(13) ? null : reader.GetString(13)) : ConversationKind.HumanAgent
+            Kind = reader.FieldCount > 13 ? ParseConversationKind(reader.IsDBNull(13) ? null : reader.GetString(13)) : ConversationKind.HumanAgent,
+            WorldId = reader.FieldCount > 14 && !reader.IsDBNull(14) ? reader.GetString(14) : string.Empty
         };
         if (!reader.IsDBNull(6))
             conversation.ActiveSessionId = SessionId.From(reader.GetString(6));
@@ -805,8 +897,8 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Transaction = transaction;
         conversationCommand.CommandText = upsert
             ? """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind, $worldId)
                 ON CONFLICT(id) DO UPDATE SET
                     agent_id = excluded.agent_id,
                     title = excluded.title,
@@ -820,11 +912,12 @@ public sealed class SqliteConversationStore : IConversationStore
                     instructions = excluded.instructions,
                     canvas_html = excluded.canvas_html,
                     initiator = excluded.initiator,
-                    kind = excluded.kind
+                    kind = excluded.kind,
+                    world_id = excluded.world_id
                 """
             : """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind, $worldId)
                 """;
         conversationCommand.Parameters.AddWithValue("$id", conversation.ConversationId.Value);
         conversationCommand.Parameters.AddWithValue("$agentId", conversation.AgentId.Value);
@@ -840,6 +933,7 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Parameters.AddWithValue("$canvasHtml", conversation.CanvasHtml is null ? (object)DBNull.Value : conversation.CanvasHtml);
         conversationCommand.Parameters.AddWithValue("$initiator", (object?)SerializeInitiator(conversation.Initiator) ?? DBNull.Value);
         conversationCommand.Parameters.AddWithValue("$kind", conversation.Kind.ToString());
+        conversationCommand.Parameters.AddWithValue("$worldId", conversation.WorldId ?? string.Empty);
         await conversationCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         await using var deleteBindingsCommand = connection.CreateCommand();
@@ -918,6 +1012,7 @@ public sealed class SqliteConversationStore : IConversationStore
             CanvasHtml = conversation.CanvasHtml,
             Initiator = conversation.Initiator,
             Kind = conversation.Kind,
+            WorldId = conversation.WorldId,
             IsDefault = conversation.IsDefault,
             Status = conversation.Status,
             CreatedAt = conversation.CreatedAt,

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformWorldContext.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformWorldContext.cs
@@ -1,0 +1,25 @@
+using BotNexus.Domain;
+using BotNexus.Gateway.Abstractions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Default <see cref="IWorldContext"/> backed by the live <see cref="PlatformConfig"/>.
+/// Delegates to <see cref="WorldIdentityResolver"/> on every read so configuration reloads
+/// (e.g. operator edits to <c>config.json</c>) take effect without restarting the gateway.
+/// </summary>
+public sealed class PlatformWorldContext : IWorldContext
+{
+    private readonly IOptionsMonitor<PlatformConfig> _platformConfig;
+
+    /// <summary>Initialises a new <see cref="PlatformWorldContext"/>.</summary>
+    /// <param name="platformConfig">Monitor for live platform configuration.</param>
+    public PlatformWorldContext(IOptionsMonitor<PlatformConfig> platformConfig)
+    {
+        _platformConfig = platformConfig;
+    }
+
+    /// <inheritdoc />
+    public WorldIdentity Current => WorldIdentityResolver.Resolve(_platformConfig.CurrentValue);
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -116,6 +116,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IAgentSupervisor, DefaultAgentSupervisor>();
         services.AddSingleton<IAgentExchangeService, AgentExchangeService>();
         services.AddSingleton<CrossWorldInboundAuthService>();
+        services.TryAddSingleton<IWorldContext, PlatformWorldContext>();
         services.TryAddSingleton<CrossWorldChannelOptions>();
         services.AddSingleton<CrossWorldChannelAdapter>(serviceProvider =>
             new CrossWorldChannelAdapter(
@@ -473,7 +474,8 @@ public static class GatewayServiceCollectionExtensions
                 return new FileConversationStore(
                     conversationsPath,
                     serviceProvider.GetRequiredService<ILogger<FileConversationStore>>(),
-                    fs);
+                    fs,
+                    serviceProvider.GetService<IWorldContext>());
             }));
             return;
         }
@@ -487,7 +489,8 @@ public static class GatewayServiceCollectionExtensions
             services.Replace(ServiceDescriptor.Singleton<IConversationStore>(serviceProvider =>
                 new SqliteConversationStore(
                     connectionString,
-                    serviceProvider.GetRequiredService<ILogger<SqliteConversationStore>>())));
+                    serviceProvider.GetRequiredService<ILogger<SqliteConversationStore>>(),
+                    serviceProvider.GetService<IWorldContext>())));
             return;
         }
 

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationWorldIdTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationWorldIdTests.cs
@@ -1,0 +1,258 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Phase 9 / P9-A (issue #613) — pins the world-id stamping and lazy-backfill contract across all
+/// three <c>IConversationStore</c> implementations. Each store must:
+/// <list type="number">
+///   <item>Stamp <c>Conversation.WorldId</c> with the current world's id when a caller creates or
+///         saves a conversation with an empty WorldId (so callers never need to know about it).</item>
+///   <item>Lazy-backfill <c>WorldId</c> on read when a legacy row was persisted before the column
+///         existed (post-migration, the row exists but the field is empty).</item>
+///   <item>Round-trip an explicit non-empty WorldId verbatim (cross-world relays surface the source
+///         world id via metadata; the conversation's own WorldId stays the receiver's).</item>
+/// </list>
+/// </summary>
+public sealed class ConversationWorldIdTests
+{
+    private static AgentId Agent(string id) => AgentId.From(id);
+
+    private static Conversation NewConversation(string title)
+        => new()
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = Agent("agent-a"),
+            Title = title,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+    // ---------------------------------------------------------------------
+    // InMemoryConversationStore
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task InMemory_WorldId_StampedOnCreate_FromInjectedWorldContext()
+    {
+        var ctx = new FakeWorldContext("world-x");
+        var store = new InMemoryConversationStore(ctx);
+
+        var conv = NewConversation("stamp-on-create");
+        conv.WorldId.ShouldBe(string.Empty,
+            customMessage: "Test should construct a fresh conversation with no WorldId so the stamp is observable.");
+
+        await store.CreateAsync(conv);
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.WorldId.ShouldBe("world-x",
+            customMessage: "InMemoryConversationStore.CreateAsync must stamp WorldId from the injected IWorldContext.");
+    }
+
+    [Fact]
+    public async Task InMemory_WorldId_ExplicitValuePreservedThroughCreate()
+    {
+        var ctx = new FakeWorldContext("world-x");
+        var store = new InMemoryConversationStore(ctx);
+
+        var conv = NewConversation("explicit-preserve");
+        conv.WorldId = "world-y"; // Caller explicitly sets it (e.g. cross-world receiver scenario).
+        await store.CreateAsync(conv);
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded!.WorldId.ShouldBe("world-y",
+            customMessage: "Stamp must only fill an EMPTY WorldId; an explicit value must round-trip verbatim.");
+    }
+
+    [Fact]
+    public async Task InMemory_WorldId_StampedOnSave_WhenCallerClearsToEmpty()
+    {
+        // Validates that SaveAsync stamps the world id BEFORE the value is durably stored —
+        // distinguishable from read-time backfill by mutating the world-context after the save.
+        // If SaveAsync forgot to stamp, the empty value would be stored, then BackfillWorldId
+        // on GetAsync would refill it with the CURRENT world id (world-y), causing the assertion
+        // to fail. With a correct save-time stamp the value is locked to world-x.
+        var ctx = new FakeWorldContext("world-x");
+        var store = new InMemoryConversationStore(ctx);
+        var conv = NewConversation("save-stamp");
+        await store.CreateAsync(conv);
+
+        conv.Title = "save-stamp-updated";
+        conv.WorldId = string.Empty;
+        await store.SaveAsync(conv);
+
+        // Flip world context so read-time backfill would produce a different value if save-stamp didn't fire.
+        ctx.Set("world-y");
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded!.WorldId.ShouldBe("world-x",
+            customMessage: "SaveAsync must stamp WorldId before persistence; relying on read-time backfill is wrong.");
+    }
+
+    [Fact]
+    public async Task InMemory_WorldId_NoWorldContext_LeavesEmpty()
+    {
+        // Tests / boot-strap scenarios where no IWorldContext is wired: the conversation stays as
+        // the caller set it (string.Empty by default). No NullReferenceException; no surprise stamp.
+        var store = new InMemoryConversationStore();
+        var conv = NewConversation("no-context");
+        await store.CreateAsync(conv);
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded!.WorldId.ShouldBe(string.Empty);
+    }
+
+    // ---------------------------------------------------------------------
+    // SqliteConversationStore
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Sqlite_WorldId_RoundTrips_AcrossProcessRestart()
+    {
+        using var fixture = new StoreFixture();
+        var ctx = new FakeWorldContext("world-prod-1");
+        var store = fixture.CreateStore(ctx);
+        var conv = NewConversation("roundtrip");
+        await store.CreateAsync(conv);
+
+        // Fresh store instance (different cache, fresh SQLite connection) — proves the value
+        // is persisted at the SQL level, not just retained in the in-memory clone cache.
+        var fresh = fixture.CreateStore(ctx);
+        var loaded = await fresh.GetAsync(conv.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.WorldId.ShouldBe("world-prod-1",
+            customMessage: "WorldId must round-trip through the SQLite schema. If empty here, INSERT/SELECT " +
+                "is missing the world_id binding -- the field is dropping on the floor at the SQL boundary.");
+    }
+
+    [Fact]
+    public async Task Sqlite_WorldId_StampedOnCreate_WhenCallerLeavesEmpty()
+    {
+        using var fixture = new StoreFixture();
+        var ctx = new FakeWorldContext("world-stamp");
+        var store = fixture.CreateStore(ctx);
+        var conv = NewConversation("stamp");
+        conv.WorldId.ShouldBe(string.Empty);
+        await store.CreateAsync(conv);
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded!.WorldId.ShouldBe("world-stamp");
+    }
+
+    [Fact]
+    public async Task Sqlite_WorldId_ExplicitValuePreservedThroughSave()
+    {
+        using var fixture = new StoreFixture();
+        var ctx = new FakeWorldContext("world-default");
+        var store = fixture.CreateStore(ctx);
+        var conv = NewConversation("explicit");
+        conv.WorldId = "world-other";
+        await store.CreateAsync(conv);
+
+        // Round through SaveAsync (the upsert path).
+        conv.Title = "explicit-updated";
+        await store.SaveAsync(conv);
+
+        var fresh = fixture.CreateStore(ctx);
+        var loaded = await fresh.GetAsync(conv.ConversationId);
+        loaded!.WorldId.ShouldBe("world-other",
+            customMessage: "SaveAsync must not overwrite an explicit non-empty WorldId.");
+    }
+
+    [Fact]
+    public async Task Sqlite_Migration_AddsWorldIdColumn_AndBackfillsCurrentWorldId_ForLegacyRows()
+    {
+        // Seed a database with the schema as it existed BEFORE the world_id column was added.
+        using var fixture = new StoreFixture();
+
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var seed = connection.CreateCommand();
+            seed.CommandText = """
+                CREATE TABLE conversations (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    purpose TEXT,
+                    is_default INTEGER NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL DEFAULT 'Active',
+                    active_session_id TEXT,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    instructions TEXT,
+                    canvas_html TEXT,
+                    initiator TEXT,
+                    kind TEXT NOT NULL DEFAULT 'HumanAgent'
+                );
+
+                CREATE TABLE conversation_bindings (
+                    binding_id TEXT PRIMARY KEY,
+                    conversation_id TEXT NOT NULL,
+                    channel_type TEXT NOT NULL,
+                    channel_address TEXT NOT NULL,
+                    mode TEXT NOT NULL DEFAULT 'Interactive',
+                    threading_mode TEXT NOT NULL DEFAULT 'Single',
+                    display_prefix TEXT,
+                    bound_at TEXT NOT NULL,
+                    last_inbound_at TEXT,
+                    last_outbound_at TEXT
+                );
+
+                INSERT INTO conversations (id, agent_id, title, status, metadata, created_at, updated_at, kind)
+                VALUES ('legacy-w', 'agent-a', 'before-worldid', 'Active', '{}', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', 'HumanAgent');
+                """;
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        var ctx = new FakeWorldContext("world-backfill");
+        var store = fixture.CreateStore(ctx);
+        // First access triggers EnsureCreatedAsync -> EnsureWorldIdColumnAsync.
+        var loaded = await store.GetAsync(ConversationId.From("legacy-w"));
+
+        loaded.ShouldNotBeNull();
+        loaded!.Title.ShouldBe("before-worldid");
+        loaded.WorldId.ShouldBe("world-backfill",
+            customMessage: "Legacy rows missing world_id must be lazy-backfilled to the current world id on read. " +
+                "If this fails with empty string, BackfillWorldId is not being applied to the load path.");
+
+        // Save back and re-read from a fresh store to confirm the backfilled value persists.
+        await store.SaveAsync(loaded);
+        var fresh = fixture.CreateStore(ctx);
+        var roundTrip = await fresh.GetAsync(ConversationId.From("legacy-w"));
+        roundTrip!.WorldId.ShouldBe("world-backfill");
+    }
+
+    [Fact]
+    public async Task Sqlite_Kind_RoundTrips_ThroughSaveAsync_AfterCreateAsync_RegressionPin()
+    {
+        // PRE-EXISTING BUG FIXED IN P9-A: SqliteConversationStore.SaveConversationAsync's UPSERT
+        // branch did not bind $kind, so a SaveAsync following a CreateAsync silently set kind=NULL,
+        // which the loader mapped back to ConversationKind.HumanAgent (silent demotion). The
+        // existing Kind_RoundTrips_AllValues_AcrossProcessRestart test only exercised CreateAsync
+        // (the non-upsert branch), missing this. This pin uses SaveAsync after CreateAsync.
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var conv = NewConversation("kind-bug");
+        conv.Kind = ConversationKind.AgentAgent;
+        await store.CreateAsync(conv);
+
+        // The Save path that previously demoted Kind: title-only mutation triggers the UPSERT.
+        conv.Title = "kind-bug-saved";
+        await store.SaveAsync(conv);
+
+        var fresh = fixture.CreateStore();
+        var loaded = await fresh.GetAsync(conv.ConversationId);
+        loaded!.Kind.ShouldBe(ConversationKind.AgentAgent,
+            customMessage: "SaveAsync (upsert path) must bind $kind. If this returns HumanAgent, the kind " +
+                "is being demoted on every save -- regression of the latent bug P9-A fixed.");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/StoreFixture.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/StoreFixture.cs
@@ -1,3 +1,5 @@
+using BotNexus.Domain;
+using BotNexus.Gateway.Abstractions.Configuration;
 using BotNexus.Gateway.Conversations;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -19,6 +21,9 @@ internal sealed class StoreFixture : IDisposable
     public SqliteConversationStore CreateStore()
         => new(ConnectionString, NullLogger<SqliteConversationStore>.Instance);
 
+    public SqliteConversationStore CreateStore(IWorldContext worldContext)
+        => new(ConnectionString, NullLogger<SqliteConversationStore>.Instance, worldContext);
+
     public void Dispose()
     {
         if (File.Exists(DatabasePath))
@@ -27,4 +32,23 @@ internal sealed class StoreFixture : IDisposable
 
     private static string TempDb()
         => Path.Combine(Path.GetTempPath(), $"botnexus-test-{Guid.NewGuid():N}.db");
+}
+
+/// <summary>
+/// Deterministic <see cref="IWorldContext"/> for tests. Mutable: tests can flip the world id
+/// mid-execution to distinguish save-time stamping from read-time backfill (a fixed id would
+/// let a missed save-stamp silently pass because the read-side backfill would refill it with
+/// the same value).
+/// </summary>
+internal sealed class FakeWorldContext : IWorldContext
+{
+    public FakeWorldContext(string worldId = "test-world", string? name = null)
+    {
+        Current = new WorldIdentity { Id = worldId, Name = name ?? worldId };
+    }
+
+    public WorldIdentity Current { get; set; }
+
+    public void Set(string worldId, string? name = null)
+        => Current = new WorldIdentity { Id = worldId, Name = name ?? worldId };
 }


### PR DESCRIPTION
First sub-PR of the **Phase 9 structural campaign** (umbrella #613). Adds `WorldId` to `Conversation` with stamp-on-persist + lazy-backfill semantics, and folds in a fix for a pre-existing kind-upsert bug surfaced while implementing this work.

## Why

`World` is the BotNexus deployment boundary. `AgentDescriptor` already carries world identity, but `Conversation` did not — so cross-world relays had to stash source identity in `Conversation.Metadata` with no typed accessor and no provenance guarantee. P9-A is the foundational addition: every conversation now records the world it belongs to, stamped at persist time, with backwards-compatible repair for rows that pre-date the column.

Per maintainer decision **G-6 / W-6** ([#612 addendum](https://github.com/sytone/botnexus/issues/612#issuecomment-4569422852)): _"Add the world if it is missing. It is not a large change and good to have in place. Agents have it already."_

## Changes

**New types:**
- `IWorldContext` (Gateway.Contracts/Configuration) — small contract resolving the current `WorldIdentity`. Homed in Contracts so stores can depend on it without pulling in PlatformConfig or static `WorldIdentityResolver`.
- `PlatformWorldContext` (Gateway/Configuration) — `IOptionsMonitor<PlatformConfig>` + `WorldIdentityResolver.Resolve` implementation, registered as singleton.

**Domain:**
- `Conversation.WorldId` — `string` (matches existing `WorldIdentity.Id` / `CrossWorldAgentReference.WorldId` pattern). Vogen migration deferred to a separate campaign. Default `string.Empty` is intentional sentinel — stores treat empty as "needs stamping".

**Stores (three implementations, identical semantics):**
- Two-ctor pattern: existing parameterless/3-arg + new `IWorldContext`-accepting overload. Production DI uses the world-aware overload; tests can continue with the original.
- **Stamp on write** (`CreateAsync` / `SaveAsync`): fills empty `WorldId` from `IWorldContext.CurrentWorldId`. Explicit non-empty values are **never** overwritten — preserves source identity on cross-world relay rows.
- **Read-time projection backfill** (`GetAsync` / `ListAsync` / `ListForCitizenAsync` / `ResolveByBindingAsync`): legacy rows persisted before #613 project to current world on read. Disk row not rewritten; next `SaveAsync` durably persists. Comment-documented so the projection-vs-persistence boundary is visible.
- `SqliteConversationStore` schema: `world_id TEXT NOT NULL DEFAULT ''` in `CREATE TABLE`; `EnsureWorldIdColumnAsync` migration helper (mirror of `EnsureInitiatorColumnAsync`) detects via `PRAGMA table_info` + idempotent `ALTER TABLE ADD COLUMN`. **Tolerates `SqliteException` error 1 ("duplicate column name")** so a cross-process race between two first-init gateways doesn't crash either one (rubber-duck BLOCKING fold-in).

**Pre-existing kind-upsert bug fix (folded into same edit):**
`SqliteConversationStore.SaveConversationAsync`'s UPSERT branch had `kind = excluded.kind` in `ON CONFLICT DO UPDATE SET` but `kind` was missing from the INSERT col list + VALUES. Effect: `SaveAsync` following `CreateAsync` silently demoted `Kind` to NULL, which the loader mapped back to `ConversationKind.HumanAgent`. The existing `Kind_RoundTrips_AllValues_AcrossProcessRestart` test missed this because it only exercised the `CreateAsync` (non-upsert) branch. New regression pin `Sqlite_Kind_RoundTrips_ThroughSaveAsync_AfterCreateAsync_RegressionPin` exercises the upsert path.

**DI:**
- `TryAddSingleton<IWorldContext, PlatformWorldContext>()` in `GatewayServiceCollectionExtensions`.
- Sqlite + File factories now resolve via `serviceProvider.GetService<IWorldContext>()` — graceful degradation if the host wires a different lifetime.

## Tests

New file `ConversationWorldIdTests` (9 facts):
- InMemory: stamp on create / explicit-preserve / save-stamps-before-backfill (uses mutable `FakeWorldContext` to distinguish save-time stamp from read-time projection per rubber-duck NB-2) / no-context graceful no-op.
- Sqlite: roundtrip across process restart / stamp on create / explicit value preserved through SaveAsync / legacy schema migration with backfill verification.
- Sqlite: kind-upsert regression pin.

`StoreFixture` gains `CreateStore(IWorldContext)` overload; `FakeWorldContext` is mutable (`Current` has a setter + `Set(...)` helper).

## Critique sweep (rubber-duck)

- **BLOCKING — SQLite migration cross-process race:** addressed by tolerating `SqliteException` error 1 in `EnsureWorldIdColumnAsync` (the loser of a race observes the column exists post-ALTER).
- **NB — read-time projection vs durable repair:** addressed by tightening XML doc comments on the helper pair so the semantics ("project on read, persist on next save") are explicit, not implied.
- **NB — InMemory save-stamp test was weak:** addressed by making `FakeWorldContext.Current` mutable; the test now flips world id mid-execution so read-time backfill can't mask a missing save-stamp.
- **NB — config hot-reload for cross-world federation:** noted as follow-up (out of scope here).
- **Confirmed solid:** kind-upsert fix correctness.
- **Suggestion (deferred):** REST/SignalR DTOs don't surface `WorldId` — intentional for P9-A; can be added in a follow-up if portal needs world-aware filtering.

## Verification

- `dotnet build BotNexus.slnx --nologo --tl:off` — **0 warnings, 0 errors** under `TreatWarningsAsErrors`.
- `dotnet test tests/gateway/BotNexus.Gateway.Conversations.Tests` — **110/110 pass**.
- `dotnet test BotNexus.slnx` — all suites pass (CLI integration tests flaked on the cold run; pass on retry — known timing-sensitivity pattern noted in prior PRs).

## Follow-ups (out of scope for this PR)

- Refactor direct `WorldIdentityResolver.Resolve()` callers to use `IWorldContext` (`CrossWorldFederationController`, `AgentExchangeService`, `CrossWorldInboundAuthService`) — sweeping cleanup deferred to a later mechanical pass.
- Vogen `WorldId` value object — separate campaign aligned with broader Vogen migration.
- Surface `WorldId` on REST `ConversationResponse` + `ConversationSummary` if portal needs world-aware filtering.
- P9-B (legacy-conversation backfill for orphan sessions) — blocked on this PR; will land next.

Refs #613 (P9-A).
