### PR TITLE
chore(tests): omit unvalidated loose tests/ projects from slnx (#617)

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -46,14 +46,6 @@
   <Folder Name="/src/domain/">
     <Project Path="src/domain/BotNexus.Domain/BotNexus.Domain.csproj" />
   </Folder>
-  <Folder Name="/tests/">
-    <Project Path="tests/BotNexus.CodingAgent.Tests/BotNexus.CodingAgent.Tests.csproj" />
-    <Project Path="tests/BotNexus.Conversation.Tests/BotNexus.Conversation.Tests.csproj" />
-    <Project Path="tests/BotNexus.E2E.Tests/BotNexus.E2E.Tests.csproj" />
-    <Project Path="tests/BotNexus.Gateway.Conversation.Tests/BotNexus.Gateway.Conversation.Tests.csproj" />
-    <Project Path="tests/BotNexus.Integration.Tests/BotNexus.Integration.Tests.csproj" />
-    <Project Path="tests/BotNexus.Providers.Conformance.Tests/BotNexus.Providers.Conformance.Tests.csproj" />
-  </Folder>
   <Folder Name="/tests/agent/">
     <Project Path="tests/agent/BotNexus.Agent.Core.Tests/BotNexus.Agent.Core.Tests.csproj" />
     <Project Path="tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/BotNexus.Agent.Providers.Anthropic.Tests.csproj" />

--- a/tests/integration/BotNexus.Integration.E2E.Tests/CompactionFlowTests.cs
+++ b/tests/integration/BotNexus.Integration.E2E.Tests/CompactionFlowTests.cs
@@ -126,7 +126,11 @@ public sealed class CompactionFlowTests
 
     private static async Task WaitForAssistantTextAsync(IPage page, string substring, TimeSpan timeout)
     {
-        var locator = page.Locator(".message.assistant .message-content")
+        // ChatPanel.razor renders assistant messages with two different content classes:
+        //   - `msg-content` for markdown-rendered turns (the normal completed path)
+        //   - `message-content` for plain-text and active streaming buffer
+        // Match either so the test does not silently time out on rendered markdown.
+        var locator = page.Locator(".message.assistant .msg-content, .message.assistant .message-content")
             .Filter(new LocatorFilterOptions { HasTextString = substring })
             .First;
         try


### PR DESCRIPTION
Closes #617. Refs #618 (follow-up bug surfaced by this PR).

## Summary

Two commits answering the maintainer's directive *""are you running and updating the integration tests with Playwright? Also we need to check there are no duplicates, all the integration tests should now be under the integration folder. Any others should be omitted from testing until we know if they are valid or not.""*

### Commit 1 — `chore(tests): omit unvalidated loose tests/ projects from slnx`

A prior cleanup moved unit tests under `tests/<area>/` and heavyweight end-to-end suites under `tests/integration/`. Six leftover projects at the `tests/` root predate that move and are unaudited. Per the maintainer directive, they are now omitted from `BotNexus.slnx` (and therefore from `dotnet test BotNexus.slnx`). Files are preserved on disk; per-project follow-up decisions tracked under #617's Phase B.

| Project (omitted) | Type | Facts | Verdict |
|---|---|---|---|
| `tests/BotNexus.CodingAgent.Tests` | xunit Library | 187 | Misplaced — belongs under `tests/examples/` |
| `tests/BotNexus.Conversation.Tests` | xunit + `LiveGatewayFixture` | 28 | Heavyweight live-gateway — belongs under `tests/integration/` |
| `tests/BotNexus.E2E.Tests` | xunit + Playwright | 12 | **Duplicate** of canonical `tests/integration/BotNexus.Integration.E2E.Tests` |
| `tests/BotNexus.Gateway.Conversation.Tests` (singular) | xunit Library, 1 .cs | 9 | Confusingly named vs canonical plural `tests/gateway/BotNexus.Gateway.Conversations.Tests` |
| `tests/BotNexus.Integration.Tests` | `Microsoft.NET.Sdk.Web` **Exe** | 0 | Container scenario runner (Program.cs + 13 JSON scenarios); NOT a unit-test project |
| `tests/BotNexus.Providers.Conformance.Tests` | xunit **Exe** | 9 | Provider conformance suite — belongs under `tests/agent/` |

**Workflow safety:** `.github/workflows/container-integration.yml` is `workflow_dispatch`-only and builds `BotNexus.Integration.Tests` via direct csproj path (not via slnx). **Unaffected** by this change.

**No cross-project csproj references** to any of the six omitted projects (verified via grep).

### Commit 2 — `fix(tests): match both msg-content and message-content classes in CompactionFlowTests selector`

Incidental in-scope fix surfaced by the audit. `ChatPanel.razor` renders assistant message bodies with two different CSS classes depending on rendering path:

- `.msg-content` — markdown-rendered turns (line 257, the normal completed assistant path)
- `.message-content` — plain-text turns and active streaming buffer (lines 261 + 285)

`CompactionFlowTests.WaitForAssistantTextAsync` selected only the latter, so any markdown-rendered assistant reply (i.e. the normal completed path) was silently invisible to the test, causing a 30s timeout at **Phase 1** of the test (the Hello-world seed message). The fix matches either class.

After this fix, **Phase 1** of the test passes (the assistant ""Hello"" reply is found). **Phase 2** (the `/compact` slash command → canonical compaction notification) now fails with a separate, deeper pre-existing bug — `/compact` is no longer intercepted as a slash command, but routed to the LLM as a plain user message. Filed as **#618** for follow-up; out of scope for this PR.

## Baseline after this PR (full `dotnet test BotNexus.slnx`)

- **27 test projects build** (down from 33), **0 warnings / 0 errors** under `TreatWarningsAsErrors`
- `Architecture.Tests` — 94/94 pass
- `Gateway.Tests` — 1935 pass / 1 skip (#383, pre-existing, unchanged)
- `Gateway.Conversations.Tests` — 110/110 pass
- `AgentCore.Tests` — 130/130 pass
- All other production test projects pass
- `Integration.Cli.Tests` — 9 pass on retry (5 fail cold is a pre-existing `dotnet pack` 5-min timeout flake)
- `Integration.E2E.Tests` — 5 pass / 3 skip / **1 fail** (`CompactionFlowTests` Phase 2 — #618)

The single Playwright failure is documented and tracked. All other tests across the slnx are green.

## Out of scope (Phase B — follow-up issues per project)

Each of the six omitted projects gets its own dedicated triage issue with one of three verdicts: MOVE+RE-LIST (relocate under the right folder and add back to slnx), MERGE (fold into a sibling canonical project), or DELETE (if duplicated). Tracked under #617's Phase B section.

## Out of scope (filed)

- **#618** — `[Gateway] CompactionFlowTests: /compact slash command no longer intercepted; user message routed to LLM as plain prompt`. Likely PR #608 regression (`refactor(gateway): unify compaction paths behind ISessionCompactionCoordinator`).