### PR TITLE
feat(gateway): auto-archive A↔A conversations on exchange end (P9-C)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/CrossWorldRelayModels.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/CrossWorldRelayModels.cs
@@ -34,6 +34,17 @@ public sealed record CrossWorldRelayRequest
     /// Gets or sets the remote session id.
     /// </summary>
     public string? RemoteSessionId { get; init; }
+
+    /// <summary>
+    /// Sender-determined finality signal (Phase 9 / P9-C). When <c>true</c>, the sender has
+    /// decided this is the final relay turn for the exchange — either because the request
+    /// was single-shot (no <c>Objective</c>) or because <c>turn == MaxTurns - 1</c>. The
+    /// receiver MUST archive its local conversation when the relay completes regardless of
+    /// whether the target agent invoked <c>finish_agent_exchange</c>. Defaults to <c>false</c>
+    /// so older senders without the signal preserve existing behaviour (receiver archives
+    /// only when <c>ExchangeFinished</c> is true).
+    /// </summary>
+    public bool CloseAfterResponse { get; init; }
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -218,12 +218,19 @@ public sealed class CrossWorldFederationController(
             }
             await sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
 
-            // Leave the session Active so the sender can continue the exchange by supplying
-            // RemoteSessionId on the next turn; clear ActiveSessionId so portal stops rendering
-            // the conversation as "in flight" while the sender pauses between turns. When the
-            // exchange has finished, the session is already Sealed above and ResolveSessionAsync
-            // will reject any further reuse.
-            await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            // P9-C: when the exchange is ending — either because the target invoked
+            // finish_agent_exchange (exchangeFinished) OR the sender signalled this is the
+            // final turn via CloseAfterResponse (single-shot / max-turns) — archive the
+            // receiver-side conversation. Otherwise just clear ActiveSessionId so the portal
+            // stops rendering it as "in flight" while the sender pauses between turns.
+            if (exchangeFinished || request.CloseAfterResponse)
+            {
+                await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            }
 
             return Ok(new CrossWorldRelayResponse
             {
@@ -262,7 +269,10 @@ public sealed class CrossWorldFederationController(
             session.Status = GatewaySessionStatus.Sealed;
             session.Metadata["error"] = ex.Message;
             await sessionStore.SaveAsync(session, CancellationToken.None).ConfigureAwait(false);
-            await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            // P9-C: failed exchanges are terminal — archive rather than just clearing the
+            // pointer. The session is already sealed; the conversation should not linger as
+            // Active in portal/list APIs after a failure.
+            await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
             throw;
         }
     }
@@ -430,10 +440,61 @@ public sealed class CrossWorldFederationController(
         => string.Equals(left, right, StringComparison.Ordinal);
 
     /// <summary>
+    /// Archives the cross-world A↔A <see cref="Conversation"/> when its receiver-side
+    /// exchange terminates (Phase 9 / P9-C). Mirror of
+    /// <c>AgentExchangeService.ArchiveOnExchangeEndAsync</c>: A↔A conversations are bounded
+    /// by their exchange — when the exchange ends, the conversation is done.
+    /// </summary>
+    /// <remarks>
+    /// Subsumes <see cref="ClearActiveSessionAsync"/> on the success-finished and error
+    /// paths because <see cref="IConversationStore.ArchiveAsync"/> atomically sets
+    /// <c>Status = Archived</c> AND <c>ActiveSessionId = null</c>. Strict pointer guard:
+    /// only archives when latest <c>ActiveSessionId</c> equals
+    /// <paramref name="expectedSessionId"/> (any other state — null, different SessionId,
+    /// already-Archived — is skipped). Always uses <see cref="CancellationToken.None"/>
+    /// so caller cancellation cannot skip the archive after the session is sealed.
+    /// Helper-level dedup with <see cref="AgentExchangeService"/>'s identical method is
+    /// intentional for P9-C scope; W-3 may consolidate into a shared lifecycle service.
+    /// </remarks>
+    private async Task ArchiveOnExchangeEndAsync(
+        Conversation conversation,
+        SessionId expectedSessionId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var latest = await conversationStore.GetAsync(conversation.ConversationId, cancellationToken).ConfigureAwait(false);
+            if (latest is null)
+                return;
+            if (latest.Status == ConversationStatus.Archived)
+                return;
+            if (latest.ActiveSessionId != expectedSessionId)
+            {
+                logger.LogDebug(
+                    "Skipping archive for cross-world conversation '{ConversationId}': ActiveSessionId is '{Current}', expected '{Expected}'.",
+                    conversation.ConversationId, latest.ActiveSessionId, expectedSessionId);
+                return;
+            }
+            await conversationStore.ArchiveAsync(conversation.ConversationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to archive cross-world conversation '{ConversationId}' after exchange end.",
+                conversation.ConversationId);
+        }
+    }
+
+    /// <summary>
     /// Clears <see cref="Conversation.ActiveSessionId"/> only if it still points at the
     /// session this call started. Avoids clobbering a newer concurrent relay's pointer.
     /// Failure is swallowed — ActiveSessionId is a diagnostic, not a correctness contract.
     /// </summary>
+    /// <remarks>
+    /// P9-C: still required for the non-final relay branch (exchange continuing — sender
+    /// will resume with the same <c>RemoteSessionId</c>). The terminal-archive case is
+    /// covered by <see cref="ArchiveOnExchangeEndAsync"/>.
+    /// </remarks>
     private async Task ClearActiveSessionAsync(
         Conversation conversation,
         SessionId expectedSessionId,

--- a/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
@@ -55,6 +55,10 @@ public sealed class CrossWorldChannelAdapter(
         var sourceSessionId = TryGetMetadata(message.Metadata, "sourceSessionId");
         var remoteSessionId = TryGetMetadata(message.Metadata, "remoteSessionId");
         var apiKey = TryGetMetadata(message.Metadata, "apiKey");
+        // P9-C: lift sender-determined finality signal off OutboundMessage.Metadata so the
+        // receiver can archive its conversation on the final turn even when the target agent
+        // never invokes finish_agent_exchange (single-shot + max-turns cases).
+        var closeAfterResponse = TryGetMetadataBool(message.Metadata, "closeAfterResponse");
 
         var requestUri = BuildRelayUri(endpoint);
         using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -67,7 +71,8 @@ public sealed class CrossWorldChannelAdapter(
                 Message = message.Content,
                 ConversationId = conversationId,
                 SourceSessionId = sourceSessionId,
-                RemoteSessionId = remoteSessionId
+                RemoteSessionId = remoteSessionId,
+                CloseAfterResponse = closeAfterResponse
             }, options: JsonOptions)
         };
 
@@ -110,6 +115,19 @@ public sealed class CrossWorldChannelAdapter(
             return null;
 
         return value.ToString();
+    }
+
+    private static bool TryGetMetadataBool(IReadOnlyDictionary<string, object?> metadata, string key)
+    {
+        if (!metadata.TryGetValue(key, out var value) || value is null)
+            return false;
+
+        return value switch
+        {
+            bool b => b,
+            string s => bool.TryParse(s, out var parsed) && parsed,
+            _ => false
+        };
     }
 }
 

--- a/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/CrossWorldChannelAdapter.cs
@@ -117,6 +117,14 @@ public sealed class CrossWorldChannelAdapter(
         return value.ToString();
     }
 
+    // P9-C bool-metadata lift. Handles the in-process shape (raw `bool`) and the
+    // JsonElement shape that surfaces when OutboundMessage.Metadata round-trips through
+    // System.Text.Json (e.g. when the message originates from a stored session via
+    // SqliteSessionStore / FileSessionStore — see PR #549 critique fold on Session.Metadata).
+    // String-shaped truthy values are accepted defensively but never emitted by callers.
+    // Any unknown shape (or missing key) falls back to false, which reverts the receiver
+    // to pre-P9-C behaviour (archive only on ExchangeFinished) — a functional regression,
+    // not a correctness break.
     private static bool TryGetMetadataBool(IReadOnlyDictionary<string, object?> metadata, string key)
     {
         if (!metadata.TryGetValue(key, out var value) || value is null)
@@ -125,6 +133,10 @@ public sealed class CrossWorldChannelAdapter(
         return value switch
         {
             bool b => b,
+            JsonElement el when el.ValueKind == JsonValueKind.True => true,
+            JsonElement el when el.ValueKind == JsonValueKind.False => false,
+            JsonElement el when el.ValueKind == JsonValueKind.String
+                && bool.TryParse(el.GetString(), out var parsedEl) => parsedEl,
             string s => bool.TryParse(s, out var parsed) && parsed,
             _ => false
         };

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -196,7 +196,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
             session.Status = GatewaySessionStatus.Sealed;
             session.Metadata["conversationStatus"] = "sealed";
             await _sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
-            await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -213,7 +213,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
             session.Metadata["conversationStatus"] = "error";
             session.Metadata["error"] = ex.Message;
             await _sessionStore.SaveAsync(session, CancellationToken.None).ConfigureAwait(false);
-            await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
             throw;
         }
 
@@ -309,6 +309,13 @@ public sealed class AgentExchangeService : IAgentExchangeService
             {
                 AddTurn(MessageRole.User, message, transcript, session);
 
+                // P9-C: tell the receiver this is the final relay turn so it archives its local
+                // conversation. Without this signal the receiver only archives when the target
+                // agent invokes finish_agent_exchange, which leaves the receiver-side conversation
+                // Active forever for single-shot (no objective) and max-turns-reached exchanges.
+                var isFinalTurn = string.IsNullOrWhiteSpace(request.Objective)
+                                  || turn == request.MaxTurns - 1;
+
                 var relayResponse = await _crossWorldChannelAdapter.ExchangeAsync(
                     new OutboundMessage
                     {
@@ -325,7 +332,8 @@ public sealed class AgentExchangeService : IAgentExchangeService
                             ["targetAgentId"] = resolvedTarget.AgentId.Value,
                             ["conversationId"] = conversation.ConversationId.Value,
                             ["sourceSessionId"] = sessionId.Value,
-                            ["remoteSessionId"] = remoteSessionId
+                            ["remoteSessionId"] = remoteSessionId,
+                            ["closeAfterResponse"] = isFinalTurn
                         }
                     },
                     cancellationToken).ConfigureAwait(false);
@@ -364,7 +372,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
             session.Metadata["conversationStatus"] = "sealed";
             session.Metadata["remoteSessionId"] = remoteSessionId;
             await _sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
-            await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -379,7 +387,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
             session.Metadata["conversationStatus"] = "error";
             session.Metadata["error"] = ex.Message;
             await _sessionStore.SaveAsync(session, CancellationToken.None).ConfigureAwait(false);
-            await ClearActiveSessionAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
+            await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
             throw;
         }
 
@@ -455,41 +463,65 @@ public sealed class AgentExchangeService : IAgentExchangeService
     }
 
     /// <summary>
-    /// Clears <see cref="Conversation.ActiveSessionId"/> after the exchange loop terminates so the
-    /// conversation is no longer reported as "in flight". The conversation itself stays
-    /// <see cref="ConversationStatus.Active"/> so it remains visible to the portal/list APIs —
-    /// archiving is a separate operator-driven action.
+    /// Archives the agent-agent <see cref="Conversation"/> when its exchange loop terminates
+    /// (Phase 9 / P9-C). Per the W-3 directive, A↔A conversations are inherently bounded by
+    /// their exchange — when the exchange ends (any reason except caller cancellation), the
+    /// conversation is done and stops appearing as Active in portal/list APIs.
     /// </summary>
     /// <remarks>
-    /// Only clears if the latest persisted <see cref="Conversation.ActiveSessionId"/> still equals
-    /// <paramref name="expectedSessionId"/>. If a newer caller has already reassigned the pointer
-    /// (concurrent <see cref="ConverseAsync"/> call sharing the same conversation), we must NOT
-    /// clobber their newer pointer — that would mark a live exchange as not-in-flight.
+    /// <para>
+    /// <strong>Subsumes <c>ClearActiveSessionAsync</c>:</strong> all three
+    /// <see cref="IConversationStore"/> impls implement <see cref="IConversationStore.ArchiveAsync"/>
+    /// as an atomic update that sets <c>Status = Archived</c> AND <c>ActiveSessionId = null</c>
+    /// in the same write — so the prior in-flight-clear is redundant.
+    /// </para>
+    /// <para>
+    /// <strong>Pointer guard (strict).</strong> Only archives if the latest persisted
+    /// <see cref="Conversation.ActiveSessionId"/> still equals <paramref name="expectedSessionId"/>.
+    /// Any other state — null (someone else cleared it), different SessionId (newer caller
+    /// reassigned it), already-Archived — is skipped without write. This is the rubber-duck
+    /// NB-2 tightening: a null-tolerant guard would archive on the receiver between-turn state.
+    /// </para>
+    /// <para>
+    /// <strong>Race window:</strong> the check (<see cref="IConversationStore.GetAsync"/>) and
+    /// the archive (<see cref="IConversationStore.ArchiveAsync"/>) are NOT atomic. A theoretical
+    /// race exists where a parallel actor mutates <c>ActiveSessionId</c> between the two calls.
+    /// For A↔A conversations this is implausible — <see cref="AgentExchangeService"/> creates
+    /// a fresh conversation per <see cref="ConverseAsync"/> call (never reused across calls)
+    /// and the receiver-side session is serialised by the sender per-relay-turn. W-3 may add
+    /// an atomic <c>ArchiveIfActiveSessionAsync</c> primitive when HumanAgent conversations
+    /// need the same auto-archive.
+    /// </para>
+    /// <para>
+    /// <strong>Always uses <see cref="CancellationToken.None"/></strong> — invoked from the
+    /// seal sites which themselves use <see cref="CancellationToken.None"/> for the seal write,
+    /// so caller cancellation cannot leak in and skip the archive after the session is sealed.
+    /// </para>
     /// </remarks>
-    private async Task ClearActiveSessionAsync(Conversation conversation, SessionId expectedSessionId, CancellationToken cancellationToken)
+    private async Task ArchiveOnExchangeEndAsync(Conversation conversation, SessionId expectedSessionId, CancellationToken cancellationToken)
     {
         try
         {
             var latest = await _conversationStore.GetAsync(conversation.ConversationId, cancellationToken).ConfigureAwait(false);
             if (latest is null)
                 return;
+            if (latest.Status == ConversationStatus.Archived)
+                return;
             if (latest.ActiveSessionId != expectedSessionId)
             {
                 _logger.LogDebug(
-                    "Skipping ActiveSessionId clear for conversation '{ConversationId}': pointer is now '{Current}', expected '{Expected}'.",
+                    "Skipping archive for conversation '{ConversationId}': ActiveSessionId is '{Current}', expected '{Expected}'.",
                     conversation.ConversationId, latest.ActiveSessionId, expectedSessionId);
                 return;
             }
-            latest.ActiveSessionId = null;
-            latest.UpdatedAt = DateTimeOffset.UtcNow;
-            await _conversationStore.SaveAsync(latest, cancellationToken).ConfigureAwait(false);
+            await _conversationStore.ArchiveAsync(conversation.ConversationId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            // ActiveSessionId is a derived diagnostic; failing to clear it must not propagate as a
-            // ConverseAsync failure — the conversation is still queryable through the session store.
+            // Archive is a derived state; failing must not propagate as a ConverseAsync failure —
+            // the session is already sealed by the caller and ListByConversationAsync still works.
             _logger.LogWarning(ex,
-                "Failed to clear ActiveSessionId on conversation '{ConversationId}' after exchange.",
+                "Failed to archive conversation '{ConversationId}' after exchange end.",
                 conversation.ConversationId);
         }
     }

--- a/tests/architecture/BotNexus.Architecture.Tests/AgentExchangeArchiveArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/AgentExchangeArchiveArchitectureTests.cs
@@ -1,0 +1,319 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-C contract: every
+/// terminal A↔A exchange path (both success-seal AND error-catch) in the three
+/// sealing methods MUST invoke <c>ArchiveOnExchangeEndAsync</c> so the per-call
+/// conversation is archived (not just have its <c>ActiveSessionId</c> cleared).
+///
+/// Driven by W-3 directive — <em>"A-A conversations should have an end and then
+/// the conversation is done as that topic of conversation is over"</em>.
+///
+/// The fence covers three production methods:
+/// <list type="bullet">
+///   <item><c>AgentExchangeService.ConverseAsync</c> (local A↔A path)</item>
+///   <item><c>AgentExchangeService.ConverseCrossWorldAsync</c> (cross-world sender path)</item>
+///   <item><c>CrossWorldFederationController.ExecuteRelayAsync</c> (cross-world receiver path)</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>The fence is a <strong>structural smoke test</strong>: each method body must
+/// contain at least one <c>ArchiveOnExchangeEndAsync(</c> invocation. A regression that
+/// retained the literal but inverted the call order (archiving on success but not on
+/// error, or vice versa) would pass this fence and fail the behavioural pins in
+/// <c>AgentExchangeArchiveTests</c> + <c>CrossWorldFederationControllerTests.RelayAsync_*ArchivesReceiverConversation</c>.
+/// The two layers complement; neither alone is sufficient.</para>
+///
+/// <para>A separate counter-fence asserts each file contains the helper definition
+/// itself (so the per-method fence is not vacuous against a refactor that deletes
+/// the helper but leaves stale call sites uncompilable).</para>
+/// </remarks>
+public sealed class AgentExchangeArchiveArchitectureTests
+{
+    private const string HelperName = "ArchiveOnExchangeEndAsync";
+
+    [Fact]
+    public void AgentExchangeService_ConverseAsync_InvokesArchiveHelper()
+    {
+        var (source, methods) = LoadAndSplit(LocateAgentExchangeServiceFile());
+
+        AssertMethodInvokesHelper(methods, source, "ConverseAsync",
+            "P9-C: the local A↔A path in AgentExchangeService.ConverseAsync MUST invoke " +
+            $"{HelperName}(...) on its terminal seal paths (success + error catch). " +
+            "Without this, A↔A conversations stay Active forever in portal/list APIs " +
+            "after the exchange ends.");
+    }
+
+    [Fact]
+    public void AgentExchangeService_ConverseCrossWorldAsync_InvokesArchiveHelper()
+    {
+        var (source, methods) = LoadAndSplit(LocateAgentExchangeServiceFile());
+
+        AssertMethodInvokesHelper(methods, source, "ConverseCrossWorldAsync",
+            "P9-C: the cross-world sender path in AgentExchangeService.ConverseCrossWorldAsync " +
+            $"MUST invoke {HelperName}(...) on its terminal seal paths (success + error catch). " +
+            "Without this, sender-side A↔A conversations stay Active forever after the " +
+            "exchange ends.");
+    }
+
+    [Fact]
+    public void CrossWorldFederationController_ExecuteRelayAsync_InvokesArchiveHelper()
+    {
+        var (source, methods) = LoadAndSplit(LocateCrossWorldFederationControllerFile());
+
+        AssertMethodInvokesHelper(methods, source, "ExecuteRelayAsync",
+            "P9-C: the cross-world receiver path in CrossWorldFederationController.ExecuteRelayAsync " +
+            $"MUST invoke {HelperName}(...) on its terminal paths " +
+            "(exchangeFinished, CloseAfterResponse, and error catch). Without this, " +
+            "receiver-side A↔A conversations stay Active forever after the exchange ends.");
+    }
+
+    [Fact]
+    public void AgentExchangeService_DefinesArchiveHelper()
+    {
+        // Counter-fence: the helper must be defined in the file. If a refactor deletes the
+        // helper (e.g. extracts it to a shared service), the per-method fence above passes
+        // vacuously if the call sites also get refactored. This pin forces an author who
+        // deletes the helper to ALSO update the per-method regex to track the new shape.
+        var path = LocateAgentExchangeServiceFile();
+        var source = File.ReadAllText(path);
+
+        var definitionPattern = new Regex(
+            @"\bprivate\s+(?:async\s+)?(?:static\s+)?(?:async\s+)?Task\s+" + Regex.Escape(HelperName) + @"\s*\(",
+            RegexOptions.Compiled);
+
+        definitionPattern.IsMatch(source).ShouldBeTrue(
+            $"AgentExchangeService.cs must define a `private (async) Task {HelperName}(...)` " +
+            "helper. If you have moved this helper to a shared service, the per-method " +
+            $"fences (`*_InvokesArchiveHelper`) will become vacuous because the literal " +
+            $"`{HelperName}(` no longer appears in the call sites. Either keep the helper " +
+            "here OR update the fence regex to track the new shape (e.g. " +
+            "`_archiveService.ArchiveOnExchangeEndAsync(`).\nFile: " + path);
+    }
+
+    [Fact]
+    public void CrossWorldFederationController_DefinesArchiveHelper()
+    {
+        var path = LocateCrossWorldFederationControllerFile();
+        var source = File.ReadAllText(path);
+
+        var definitionPattern = new Regex(
+            @"\bprivate\s+(?:async\s+)?(?:static\s+)?(?:async\s+)?Task\s+" + Regex.Escape(HelperName) + @"\s*\(",
+            RegexOptions.Compiled);
+
+        definitionPattern.IsMatch(source).ShouldBeTrue(
+            $"CrossWorldFederationController.cs must define a `private (async) Task {HelperName}(...)` " +
+            "helper. See the rationale in AgentExchangeService_DefinesArchiveHelper.\nFile: " + path);
+    }
+
+    /// <summary>
+    /// Self-test for <see cref="SplitIntoMethodBodies"/> (REQUIRED per stored architecture-fence
+    /// memory). If the splitter regex regresses and stops matching any of the three target
+    /// methods, the per-method fences above silently pass without policing anything. This test
+    /// asserts the splitter finds every target method by name.
+    /// </summary>
+    [Fact]
+    public void SplitIntoMethodBodies_FindsAllThreeTargetMethods()
+    {
+        var (_, exchangeMethods) = LoadAndSplit(LocateAgentExchangeServiceFile());
+        var exchangeNames = exchangeMethods.Select(m => m.Name).ToList();
+
+        exchangeNames.ShouldContain("ConverseAsync",
+            "Method splitter must find ConverseAsync in AgentExchangeService.cs — otherwise " +
+            "the local A↔A fence is vacuous. Splitter found: " + string.Join(", ", exchangeNames));
+        exchangeNames.ShouldContain("ConverseCrossWorldAsync",
+            "Method splitter must find ConverseCrossWorldAsync in AgentExchangeService.cs — " +
+            "otherwise the cross-world sender fence is vacuous. Splitter found: " +
+            string.Join(", ", exchangeNames));
+
+        var (_, controllerMethods) = LoadAndSplit(LocateCrossWorldFederationControllerFile());
+        var controllerNames = controllerMethods.Select(m => m.Name).ToList();
+
+        controllerNames.ShouldContain("ExecuteRelayAsync",
+            "Method splitter must find ExecuteRelayAsync in CrossWorldFederationController.cs " +
+            "— otherwise the cross-world receiver fence is vacuous. Splitter found: " +
+            string.Join(", ", controllerNames));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticRegression_NoArchiveCall()
+    {
+        // Synthetic regression shape: a target method that seals the session on success but
+        // does NOT invoke the archive helper. This is the pre-P9-C behaviour shape. The
+        // detection helper must flag it.
+        const string syntheticMissingArchive = """
+            private async Task ExecuteRelayAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    var response = await handle.PromptAsync(message, cancellationToken);
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    await ClearActiveSessionAsync(session, conversation);
+                }
+                catch (Exception ex)
+                {
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    throw;
+                }
+            }
+            """;
+
+        var methods = SplitIntoMethodBodies(syntheticMissingArchive);
+        var executeRelay = methods.FirstOrDefault(m => m.Name == "ExecuteRelayAsync");
+        executeRelay.Name.ShouldBe("ExecuteRelayAsync",
+            "Vacuity guard precondition: splitter must find the synthetic method.");
+
+        var invokesHelper = MethodInvokesHelper(executeRelay.Body);
+        invokesHelper.ShouldBeFalse(
+            "Vacuity guard: a synthetic method that seals but does NOT call " +
+            $"{HelperName}(...) MUST be detected as a violation. If this assertion fails, " +
+            "the detection helper is broken and the per-method fences are silently passing.");
+    }
+
+    [Fact]
+    public void Fence_PositivePin_DetectsCanonicalCleanShape()
+    {
+        // Synthetic positive: a method that DOES call the archive helper. The detection
+        // helper must accept it. Pins the regex against accidental over-tightening.
+        const string syntheticCleanShape = """
+            private async Task ExecuteRelayAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    var response = await handle.PromptAsync(message, cancellationToken);
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    await ArchiveOnExchangeEndAsync(session, conversation);
+                }
+                catch (Exception ex)
+                {
+                    session.Status = GatewaySessionStatus.Sealed;
+                    await sessionStore.SaveAsync(session, CancellationToken.None);
+                    await ArchiveOnExchangeEndAsync(session, conversation);
+                    throw;
+                }
+            }
+            """;
+
+        var methods = SplitIntoMethodBodies(syntheticCleanShape);
+        var executeRelay = methods.FirstOrDefault(m => m.Name == "ExecuteRelayAsync");
+        executeRelay.Name.ShouldBe("ExecuteRelayAsync");
+
+        MethodInvokesHelper(executeRelay.Body).ShouldBeTrue(
+            "Positive pin: a method that calls " + HelperName + "(...) at least once must be " +
+            "accepted. If this assertion fails, the regex is over-tight and would false-positive " +
+            "against the real production code.");
+    }
+
+    // ---- helpers ----
+
+    private static void AssertMethodInvokesHelper(
+        List<(string Name, string Body, int StartIndex)> methods,
+        string source,
+        string methodName,
+        string failureMessage)
+    {
+        var method = methods.FirstOrDefault(m => m.Name == methodName);
+        method.Name.ShouldBe(methodName,
+            $"Splitter did not find `{methodName}` — fence cannot run. If the method has been " +
+            "renamed or refactored away, update this test accordingly. Found methods: " +
+            string.Join(", ", methods.Select(m => m.Name)));
+
+        MethodInvokesHelper(method.Body).ShouldBeTrue(failureMessage);
+    }
+
+    private static bool MethodInvokesHelper(string body)
+    {
+        var pattern = new Regex(@"\b" + Regex.Escape(HelperName) + @"\s*\(", RegexOptions.Compiled);
+        return pattern.IsMatch(body);
+    }
+
+    private static (string Source, List<(string Name, string Body, int StartIndex)> Methods)
+        LoadAndSplit(string path)
+    {
+        var source = File.ReadAllText(path);
+        return (source, SplitIntoMethodBodies(source));
+    }
+
+    /// <summary>
+    /// Splits the source file into top-level method bodies (each as a substring of the
+    /// original source plus its start index in the file). Identical pattern to the
+    /// splitter in <see cref="AgentExchangeConversationArchitectureTests"/>; the regex
+    /// supports generic return types like <c>Task&lt;AgentExchangeResult&gt;</c>.
+    /// </summary>
+    private static List<(string Name, string Body, int StartIndex)> SplitIntoMethodBodies(string source)
+    {
+        var methods = new List<(string, string, int)>();
+        var headerPattern = new Regex(
+            @"^\s*(?:public|private|protected|internal)(?:\s+(?:async|static|override|virtual|sealed|new|partial|readonly|extern|unsafe))*\s+[\w<>?,\.\[\]\s]+?\s+(?<name>\w+)\s*\(",
+            RegexOptions.Multiline | RegexOptions.Compiled);
+
+        foreach (Match header in headerPattern.Matches(source))
+        {
+            var bodyOpen = source.IndexOf('{', header.Index + header.Length);
+            if (bodyOpen < 0)
+                continue;
+
+            var depth = 1;
+            var i = bodyOpen + 1;
+            while (i < source.Length && depth > 0)
+            {
+                var c = source[i];
+                if (c == '{') depth++;
+                else if (c == '}') depth--;
+                i++;
+            }
+
+            if (depth != 0)
+                continue;
+
+            var bodyEnd = i;
+            methods.Add((header.Groups["name"].Value, source[bodyOpen..bodyEnd], bodyOpen));
+        }
+
+        return methods;
+    }
+
+    private static string LocateAgentExchangeServiceFile()
+    {
+        var path = Path.Combine(
+            FindSourceRoot(),
+            "gateway",
+            "BotNexus.Gateway",
+            "Agents",
+            "AgentExchangeService.cs");
+        File.Exists(path).ShouldBeTrue("Expected AgentExchangeService.cs at " + path);
+        return path;
+    }
+
+    private static string LocateCrossWorldFederationControllerFile()
+    {
+        var path = Path.Combine(
+            FindSourceRoot(),
+            "gateway",
+            "BotNexus.Gateway.Api",
+            "Controllers",
+            "CrossWorldFederationController.cs");
+        File.Exists(path).ShouldBeTrue("Expected CrossWorldFederationController.cs at " + path);
+        return path;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current!.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -1,0 +1,415 @@
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Gateway.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+/// <summary>
+/// Phase 9 / P9-C contract pins on <see cref="AgentExchangeService"/>:
+/// local A↔A conversations auto-archive when the exchange terminates (driven by
+/// W-3 directive — "A-A conversations should have an end and then the conversation
+/// is done as that topic of conversation is over"). Cross-world sender behaviour
+/// is exercised end-to-end in
+/// <c>CrossWorldFederationControllerTests</c> via the receiver pins; this file
+/// focuses on the local single-process <c>ConverseAsync</c> path.
+/// </summary>
+public sealed class AgentExchangeArchiveTests
+{
+    [Fact]
+    public async Task ConverseAsync_OnSuccessfulExchangeFinish_ArchivesConversation()
+    {
+        // The target invokes finish_agent_exchange on turn 2 (simulated by writing the
+        // matching finishedAgentExchangeId payload + surfacing the tool-call entry).
+        var (service, conversationStore, _) = BuildExchangeWithFinishOnSecondTurn();
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = AgentId.From("initiator-agent"),
+            TargetId = AgentId.From("target-agent"),
+            Message = "Solve this",
+            Objective = "ship it",
+            MaxTurns = 3
+        });
+
+        result.CompletionReason.ShouldBe("exchangeFinished");
+
+        var conv = await conversationStore.GetAsync(result.ConversationId);
+        conv.ShouldNotBeNull();
+        conv!.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: ConverseAsync MUST archive the A↔A conversation when the " +
+                "exchange terminates normally. A↔A conversations are bounded by their exchange — " +
+                "if left Active they accumulate forever in portal/list APIs.");
+        conv.ActiveSessionId.ShouldBeNull(
+            customMessage: "ArchiveAsync atomically clears ActiveSessionId.");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_SingleShotNoObjective_ArchivesConversation()
+    {
+        // Single-shot: no Objective + MaxTurns=1 → one prompt, no finish-tool needed,
+        // CompletionReason becomes "singleShot" / "objectiveMet" via ResolveCompletionReason.
+        var (service, conversationStore, _, _) = BuildService();
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = AgentId.From("initiator-agent"),
+            TargetId = AgentId.From("target-agent"),
+            Message = "Do a thing",
+            MaxTurns = 1
+        });
+
+        var conv = await conversationStore.GetAsync(result.ConversationId);
+        conv.ShouldNotBeNull();
+        conv!.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: single-shot exchanges (no Objective, one prompt) MUST also " +
+                "archive — they're as terminal as exchange-finished. Without this, every " +
+                "AgentConverseTool invocation leaves an Active stub conversation.");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_MaxTurnsReachedWithoutFinish_ArchivesConversation()
+    {
+        // Max turns reached without the target ever invoking finish_agent_exchange.
+        // CompletionReason becomes "maxTurnsReached" — exchange still terminal, conversation
+        // still must archive (W-3 — the exchange ended, the topic is done).
+        var (service, conversationStore, _, _) = BuildService(initialReply: "still working");
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = AgentId.From("initiator-agent"),
+            TargetId = AgentId.From("target-agent"),
+            Message = "tell me a long story",
+            Objective = "narrate something",
+            MaxTurns = 3
+        });
+
+        result.CompletionReason.ShouldBe("maxTurnsReached");
+
+        var conv = await conversationStore.GetAsync(result.ConversationId);
+        conv.ShouldNotBeNull();
+        conv!.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: MaxTurns-reached is a terminal exchange end — conversation " +
+                "must archive. Without this, abandoned exchanges accumulate as Active forever.");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_OnPromptFailure_ArchivesConversation()
+    {
+        // Failure path: target prompt throws; error catch seals session AND must archive.
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+        var initiator = AgentId.From("initiator-agent");
+        var target = AgentId.From("target-agent");
+        var registry = CreateRegistry(initiator, target);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("LLM upstream went bang"));
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var action = () => service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "trigger failure",
+            MaxTurns = 3
+        });
+        await action.ShouldThrowAsync<InvalidOperationException>();
+
+        var conv = (await conversationStore.ListAsync()).ShouldHaveSingleItem();
+        conv.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: error catch path MUST archive — terminal failure is still " +
+                "a terminal exchange end. Leaving the conversation Active after a failure " +
+                "would show it as 'in flight' indefinitely in portal/list APIs.");
+    }
+
+    [Fact]
+    public async Task ConverseAsync_FailureDuringArchive_DoesNotPropagateException()
+    {
+        // The archive write is a derived-state side-effect; if it fails (e.g. transient DB issue)
+        // the caller must still observe ConverseAsync as successful — the session is already
+        // sealed and the conversation is still queryable through ListByConversationAsync.
+        // Failure-isolation: ArchiveOnExchangeEndAsync swallows exceptions and logs a warning.
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new ThrowingArchiveStore();
+        var initiator = AgentId.From("initiator-agent");
+        var target = AgentId.From("target-agent");
+        var registry = CreateRegistry(initiator, target);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Do a thing",
+            MaxTurns = 1
+        });
+
+        // The exchange itself succeeded — caller does not see the archive failure as a top-level
+        // ConverseAsync failure.
+        result.ShouldNotBeNull();
+        conversationStore.ArchiveCallCount.ShouldBe(1,
+            customMessage: "ArchiveOnExchangeEndAsync was called exactly once and threw; the " +
+                "exception was swallowed so ConverseAsync still returned its successful result.");
+
+        // The session is still sealed regardless of the archive failure.
+        var session = await sessionStore.GetAsync(result.SessionId);
+        session.ShouldNotBeNull();
+        session!.Status.ShouldBe(GatewaySessionStatus.Sealed);
+    }
+
+    [Fact]
+    public async Task ConverseAsync_AfterArchive_DoesNotClobber_NewerOwnerConversation()
+    {
+        // Concurrent-actor pointer guard: if some other actor reassigns ActiveSessionId on this
+        // conversation between our GetAsync and our ArchiveAsync, we must NOT clobber it. The
+        // archive's strict pointer guard requires latest.ActiveSessionId == expectedSessionId,
+        // and the failed exchange operates on its OWN conversation (CreateExchangeConversationAsync
+        // mints one per call) so it can never archive a conversation it didn't create.
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var initiator = AgentId.From("initiator-agent");
+        var target = AgentId.From("target-agent");
+        var registry = CreateRegistry(initiator, target);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "ok" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var firstResult = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "first",
+            MaxTurns = 1
+        });
+
+        // First conversation should already be Archived (P9-C).
+        var firstAfter = await conversationStore.GetAsync(firstResult.ConversationId);
+        firstAfter!.Status.ShouldBe(ConversationStatus.Archived);
+
+        // Simulate a hypothetical external mutator that resurrects the conversation by hand:
+        // unarchive it AND reassign ActiveSessionId to a new owner. (This is the worst-case
+        // shape — production code never does this, but it pins the contract.)
+        var newerOwner = SessionId.Create();
+        firstAfter.Status = ConversationStatus.Active;
+        firstAfter.ActiveSessionId = newerOwner;
+        await conversationStore.SaveAsync(firstAfter);
+
+        // A second ConverseAsync mints its own NEW conversation. After it archives ITS OWN
+        // conversation, the first conversation's manually-reassigned ActiveSessionId must remain
+        // intact — the archive helper's strict pointer guard skips when ActiveSessionId no
+        // longer equals the expected SessionId, AND the second call operates on a different
+        // ConversationId entirely.
+        var secondResult = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "second",
+            MaxTurns = 1
+        });
+
+        secondResult.ConversationId.ShouldNotBe(firstResult.ConversationId,
+            customMessage: "ConverseAsync must mint a fresh conversation per call.");
+
+        var firstFinal = await conversationStore.GetAsync(firstResult.ConversationId);
+        firstFinal!.ActiveSessionId.ShouldBe(newerOwner,
+            customMessage: "P9-C strict pointer guard: a second ConverseAsync archives only " +
+                "ITS OWN conversation; it must never touch a different conversation's pointer. " +
+                "The manually-reassigned newerOwner on the first conversation must survive.");
+
+        var secondConv = await conversationStore.GetAsync(secondResult.ConversationId);
+        secondConv!.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "Second exchange archived its OWN conversation as expected.");
+    }
+
+    // ---- helpers ----
+
+    private static (AgentExchangeService Service, InMemoryConversationStore ConversationStore,
+        InMemorySessionStore SessionStore, Mock<IAgentSupervisor> Supervisor)
+        BuildService(string initialReply = "ok")
+    {
+        var initiator = AgentId.From("initiator-agent");
+        var target = AgentId.From("target-agent");
+        var registry = CreateRegistry(initiator, target);
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = initialReply });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        return (service, conversationStore, sessionStore, supervisor);
+    }
+
+    private static (AgentExchangeService Service, InMemoryConversationStore ConversationStore,
+        InMemorySessionStore SessionStore)
+        BuildExchangeWithFinishOnSecondTurn()
+    {
+        var initiator = AgentId.From("initiator-agent");
+        var target = AgentId.From("target-agent");
+        var registry = CreateRegistry(initiator, target);
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+
+        SessionId? capturedSessionId = null;
+        var turnCounter = 0;
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                turnCounter++;
+                if (turnCounter == 1)
+                    return new AgentResponse { Content = "still working" };
+
+                // Simulate the finish_agent_exchange tool by writing the matching payload
+                // BEFORE returning the tool-call entry — mirrors the real tool's behaviour.
+                if (capturedSessionId is { } sid)
+                {
+                    var s = sessionStore.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
+                    if (s is not null
+                        && s.Metadata.TryGetValue(FinishAgentExchangeTool.ActiveExchangeIdKey, out var v)
+                        && v is string activeId)
+                    {
+                        s.Metadata[FinishAgentExchangeTool.FinishedExchangeIdKey] = activeId;
+                        s.Metadata[FinishAgentExchangeTool.FinishedReasonKey] = "shipped";
+                        sessionStore.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
+                    }
+                }
+                return new AgentResponse
+                {
+                    Content = "Done.",
+                    ToolCalls = [new AgentToolCallInfo("call-1", "finish_agent_exchange", IsError: false)]
+                };
+            });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentId, SessionId, CancellationToken>((_, sid, _) => capturedSessionId = sid)
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        return (service, conversationStore, sessionStore);
+    }
+
+    private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = initiator.Value,
+            ApiProvider = "openai",
+            ModelId = "gpt-test",
+            SubAgentIds = [target.Value]
+        });
+        registry.Setup(r => r.Get(target)).Returns(new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = target.Value,
+            ApiProvider = "openai",
+            ModelId = "gpt-test"
+        });
+        registry.Setup(r => r.Contains(initiator)).Returns(true);
+        registry.Setup(r => r.Contains(target)).Returns(true);
+        return registry;
+    }
+
+    /// <summary>
+    /// A conversation store that succeeds at everything except <see cref="ArchiveAsync"/>,
+    /// which throws. Used to prove <c>ArchiveOnExchangeEndAsync</c> swallows archive
+    /// failures (failure isolation: archive is derived state, must not propagate).
+    /// </summary>
+    private sealed class ThrowingArchiveStore : IConversationStore
+    {
+        private readonly InMemoryConversationStore _inner = new();
+        public int ArchiveCallCount { get; private set; }
+
+        public Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default)
+            => _inner.GetAsync(conversationId, ct);
+        public Task<IReadOnlyList<Conversation>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
+            => _inner.ListAsync(agentId, ct);
+        public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default)
+            => _inner.ListForCitizenAsync(citizen, ct);
+        public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
+            => _inner.CreateAsync(conversation, ct);
+        public Task SaveAsync(Conversation conversation, CancellationToken ct = default)
+            => _inner.SaveAsync(conversation, ct);
+        public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default)
+        {
+            ArchiveCallCount++;
+            throw new InvalidOperationException("simulated archive failure");
+        }
+        public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
+            => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
+        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+            => _inner.GetSummariesAsync(agentId, ct);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Net.Http.Json;
+using BotNexus.Domain;
 using BotNexus.Domain.AgentExchange;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
@@ -6,6 +9,7 @@ using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Channels;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
@@ -21,10 +25,11 @@ namespace BotNexus.Gateway.Tests.Agents;
 /// Phase 9 / P9-C contract pins on <see cref="AgentExchangeService"/>:
 /// local A↔A conversations auto-archive when the exchange terminates (driven by
 /// W-3 directive — "A-A conversations should have an end and then the conversation
-/// is done as that topic of conversation is over"). Cross-world sender behaviour
-/// is exercised end-to-end in
-/// <c>CrossWorldFederationControllerTests</c> via the receiver pins; this file
-/// focuses on the local single-process <c>ConverseAsync</c> path.
+/// is done as that topic of conversation is over"). The cross-world sender path
+/// (<c>ConverseCrossWorldAsync</c>) is exercised here too via a stubbed
+/// <see cref="CrossWorldChannelAdapter"/> so both seal-paths (success + error catch)
+/// are pinned end-to-end on the sender side; the receiver-side equivalents live in
+/// <c>CrossWorldFederationControllerTests</c>.
 /// </summary>
 public sealed class AgentExchangeArchiveTests
 {
@@ -271,6 +276,86 @@ public sealed class AgentExchangeArchiveTests
             customMessage: "Second exchange archived its OWN conversation as expected.");
     }
 
+    [Fact]
+    public async Task ConverseCrossWorldAsync_OnSuccessfulRelay_ArchivesSenderConversation()
+    {
+        // Sender-side cross-world archive pin: when the remote gateway returns a normal relay
+        // response (status="active"), the sender still archives its local conversation because
+        // single-shot (MaxTurns=1) means the sender has decided this is the final turn.
+        var (service, conversationStore, sessionStore, _) = BuildCrossWorldService(
+            handler: (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new CrossWorldRelayResponse
+                {
+                    Response = "Remote response",
+                    Status = "active",
+                    SessionId = "remote-session-1"
+                })
+            }));
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = AgentId.From("initiator-agent"),
+            TargetId = AgentId.From("world-b:agent-c"),
+            Message = "hello remote",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+
+        var conv = await conversationStore.GetAsync(result.ConversationId);
+        conv.ShouldNotBeNull();
+        conv!.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: ConverseCrossWorldAsync MUST archive the sender-side A↔A " +
+                "conversation when the relay completes. Without this, sender-side cross-world " +
+                "conversations leak as Active in portal/list APIs.");
+
+        var session = await sessionStore.GetAsync(result.SessionId);
+        session.ShouldNotBeNull();
+        session!.Status.ShouldBe(GatewaySessionStatus.Sealed);
+    }
+
+    [Fact]
+    public async Task ConverseCrossWorldAsync_OnRelayFailure_ArchivesSenderConversation()
+    {
+        // Sender-side cross-world error catch pin: when the remote gateway throws (HTTP 500),
+        // the catch-all in ConverseCrossWorldAsync MUST still archive the sender's local
+        // conversation. Without this, a transient remote failure would leak the sender's
+        // conversation as Active forever.
+        var (service, conversationStore, sessionStore, _) = BuildCrossWorldService(
+            handler: (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("boom")
+            }));
+
+        ConversationId? observedConversationId = null;
+        try
+        {
+            await service.ConverseAsync(new AgentExchangeRequest
+            {
+                InitiatorId = AgentId.From("initiator-agent"),
+                TargetId = AgentId.From("world-b:agent-c"),
+                Message = "hello remote",
+                MaxTurns = 1
+            });
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected — relay surfaces as InvalidOperationException after the seal+archive.
+        }
+
+        // Find the most-recently-created conversation (the one the failed exchange minted).
+        var all = await conversationStore.ListAsync();
+        var lastConv = all.OrderByDescending(c => c.UpdatedAt).FirstOrDefault();
+        lastConv.ShouldNotBeNull();
+        observedConversationId = lastConv!.ConversationId;
+
+        lastConv.Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: ConverseCrossWorldAsync error catch MUST archive the " +
+                "sender-side A↔A conversation. Without this, a remote-gateway failure leaks " +
+                "the conversation as Active.");
+    }
+
     // ---- helpers ----
 
     private static (AgentExchangeService Service, InMemoryConversationStore ConversationStore,
@@ -380,6 +465,87 @@ public sealed class AgentExchangeArchiveTests
         registry.Setup(r => r.Contains(initiator)).Returns(true);
         registry.Setup(r => r.Contains(target)).Returns(true);
         return registry;
+    }
+
+    private static (AgentExchangeService Service, InMemoryConversationStore ConversationStore,
+        InMemorySessionStore SessionStore, Mock<IAgentRegistry> Registry)
+        BuildCrossWorldService(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+    {
+        var initiator = AgentId.From("initiator-agent");
+        var crossWorldTarget = AgentId.From("world-b:agent-c");
+        var localResolved = AgentId.From("agent-c");
+
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = initiator.Value,
+            ApiProvider = "openai",
+            ModelId = "gpt-test",
+            SubAgentIds = ["world-b:agent-c"]
+        });
+        registry.Setup(r => r.Get(localResolved)).Returns(new AgentDescriptor
+        {
+            AgentId = localResolved,
+            DisplayName = localResolved.Value,
+            ApiProvider = "openai",
+            ModelId = "gpt-test"
+        });
+        registry.Setup(r => r.Contains(initiator)).Returns(true);
+        registry.Setup(r => r.Contains(crossWorldTarget)).Returns(false);
+
+        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+        var adapter = new CrossWorldChannelAdapter(
+            NullLogger<CrossWorldChannelAdapter>.Instance,
+            new HttpClient(new StubHttpMessageHandler(handler)));
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            Mock.Of<IAgentSupervisor>(),
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance,
+            Options.Create(new PlatformConfig
+            {
+                Gateway = new GatewaySettingsConfig
+                {
+                    World = new WorldIdentity { Id = "world-a", Name = "World A" },
+                    CrossWorldPermissions =
+                    [
+                        new CrossWorldPermissionConfig
+                        {
+                            TargetWorldId = "world-b",
+                            AllowOutbound = true,
+                            AllowedAgents = ["initiator-agent"]
+                        }
+                    ],
+                    CrossWorld = new CrossWorldFederationConfig
+                    {
+                        Peers = new Dictionary<string, CrossWorldPeerConfig>
+                        {
+                            ["world-b"] = new()
+                            {
+                                Endpoint = "https://gateway-b.internal",
+                                ApiKey = "peer-key",
+                                Enabled = true
+                            }
+                        }
+                    }
+                }
+            }),
+            adapter);
+
+        return (service, conversationStore, sessionStore, registry);
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => responder(request, cancellationToken);
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/CrossWorldChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/CrossWorldChannelAdapterTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+/// <summary>
+/// Pins the metadata lift behaviour of <see cref="CrossWorldChannelAdapter"/>, especially the
+/// <c>closeAfterResponse</c> bool lift introduced in P9-C. The lift must tolerate every shape the
+/// underlying <see cref="OutboundMessage.Metadata"/> dictionary might carry — raw
+/// <see cref="bool"/> (in-process call), <see cref="JsonElement"/> (round-tripped through
+/// <see cref="System.Text.Json"/> when sourced from a persisted session), and string fallback.
+/// Any unknown shape MUST fall back to <c>false</c> (= receiver reverts to pre-P9-C archive
+/// behaviour) — a functional regression, never a wire-protocol corruption.
+/// </summary>
+public sealed class CrossWorldChannelAdapterTests
+{
+    [Fact]
+    public Task ExchangeAsync_LiftsRawBoolTrue_AsCloseAfterResponseTrue()
+        => AssertCloseAfterResponseLift(metadataValue: true, expectedWire: true);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsRawBoolFalse_AsCloseAfterResponseFalse()
+        => AssertCloseAfterResponseLift(metadataValue: false, expectedWire: false);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsJsonElementTrue_AsCloseAfterResponseTrue()
+        => AssertCloseAfterResponseLift(
+            metadataValue: ParseJson("true"),
+            expectedWire: true);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsJsonElementFalse_AsCloseAfterResponseFalse()
+        => AssertCloseAfterResponseLift(
+            metadataValue: ParseJson("false"),
+            expectedWire: false);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsJsonElementStringTrue_AsCloseAfterResponseTrue()
+        => AssertCloseAfterResponseLift(
+            metadataValue: ParseJson("\"true\""),
+            expectedWire: true);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsStringTrue_AsCloseAfterResponseTrue()
+        => AssertCloseAfterResponseLift(metadataValue: "true", expectedWire: true);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsMissingMetadata_AsCloseAfterResponseFalse()
+        => AssertCloseAfterResponseLift(metadataValue: null, expectedWire: false);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsUnknownShape_AsCloseAfterResponseFalse()
+        => AssertCloseAfterResponseLift(metadataValue: 42, expectedWire: false);
+
+    [Fact]
+    public Task ExchangeAsync_LiftsJsonElementGarbageString_AsCloseAfterResponseFalse()
+        => AssertCloseAfterResponseLift(
+            metadataValue: ParseJson("\"not-a-bool\""),
+            expectedWire: false);
+
+    // ---- helpers ----
+
+    private static async Task AssertCloseAfterResponseLift(object? metadataValue, bool expectedWire)
+    {
+        CrossWorldRelayRequest? wire = null;
+        var handler = new StubHttpMessageHandler(async (req, _) =>
+        {
+            wire = await req.Content!.ReadFromJsonAsync<CrossWorldRelayRequest>();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new CrossWorldRelayResponse
+                {
+                    Response = "ok",
+                    Status = "active",
+                    SessionId = "remote-session-1"
+                })
+            };
+        });
+
+        var adapter = new CrossWorldChannelAdapter(
+            NullLogger<CrossWorldChannelAdapter>.Instance,
+            new HttpClient(handler));
+
+        var metadata = new Dictionary<string, object?>
+        {
+            ["endpoint"] = "https://gateway-b.internal",
+            ["sourceWorldId"] = "world-a",
+            ["sourceAgentId"] = "init",
+            ["targetAgentId"] = "tgt",
+            ["conversationId"] = ConversationId.Create().Value,
+            ["apiKey"] = "peer-key"
+        };
+        if (metadataValue is not null)
+        {
+            metadata["closeAfterResponse"] = metadataValue;
+        }
+
+        var outbound = new OutboundMessage
+        {
+            ChannelType = ChannelKey.From("cross-world"),
+            ChannelAddress = ChannelAddress.From("gateway-b"),
+            Content = "hello",
+            Metadata = metadata
+        };
+
+        await adapter.ExchangeAsync(outbound);
+
+        wire.ShouldNotBeNull();
+        wire!.CloseAfterResponse.ShouldBe(expectedWire,
+            customMessage: $"TryGetMetadataBool must lift `{metadataValue ?? "<null>"}` " +
+                $"(shape: {metadataValue?.GetType().Name ?? "null"}) as CloseAfterResponse={expectedWire} " +
+                "on the wire request. P9-C contract: missing/unknown shapes silently fall back to " +
+                "false so the receiver reverts to pre-P9-C archive behaviour; recognised truthy " +
+                "shapes (bool true, JsonElement(True), JsonElement(String \"true\"), string \"true\") " +
+                "must all surface as true.");
+    }
+
+    private static JsonElement ParseJson(string json)
+        => JsonDocument.Parse(json).RootElement.Clone();
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => responder(request, cancellationToken);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1065,6 +1065,153 @@ public sealed class CrossWorldFederationControllerTests
         xResponse.Result.ShouldBeOfType<OkObjectResult>();
     }
 
+    // ─── P9-C auto-archive A↔A receiver pins ────────────────────────────────────────────
+    //
+    // Phase 9 / P9-C — driven by W-3 directive: "A-A conversations should have an end
+    // and then the conversation is done as that topic of conversation is over." The
+    // receiver-side conversation must auto-archive when the exchange terminates:
+    //   * target invoked finish_agent_exchange      → exchangeFinished=true  → archive
+    //   * sender signalled final turn               → CloseAfterResponse=true → archive
+    //   * non-final relay                           → both false → clear ActiveSessionId, no archive
+    //   * receiver-side exception                   → archive (terminal failure)
+
+    [Fact]
+    public async Task RelayAsync_WhenExchangeFinishedByTarget_ArchivesReceiverConversation()
+    {
+        var (controller, _, conversations, _) = BuildControllerWithToolCalledFinish(
+            replyContent: "Done.",
+            finishReason: "shipped",
+            finishSummary: null);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var response = await controller.RelayAsync(BuildRequest(), CancellationToken.None);
+
+        var ok = response.Result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<CrossWorldRelayResponse>();
+        payload.ExchangeFinished.ShouldBeTrue();
+
+        var convs = await conversations.ListAsync();
+        convs.ShouldHaveSingleItem();
+        convs[0].Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: receiver MUST archive its conversation when the target " +
+                "agent invokes finish_agent_exchange — A↔A conversations are bounded by " +
+                "their exchange.");
+        convs[0].ActiveSessionId.ShouldBeNull(
+            customMessage: "Archive must atomically clear ActiveSessionId (subsumes Clear).");
+    }
+
+    [Fact]
+    public async Task RelayAsync_WhenSenderSignalsCloseAfterResponse_ArchivesReceiverConversation_EvenWithoutFinishTool()
+    {
+        // The critical P9-C wire-protocol pin: sender computed `isFinalTurn` and set
+        // CloseAfterResponse=true on the relay. Target did NOT invoke finish_agent_exchange
+        // (no objective + no tool call → single-shot terminates on the sender side via
+        // ResolveCompletionReason). Without this signal the receiver would leave its
+        // conversation Active forever for single-shot and max-turns-reached cases.
+        var (controller, _, conversations, _) = BuildController(replyContent: "ack");
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var response = await controller.RelayAsync(
+            BuildRequest(closeAfterResponse: true), CancellationToken.None);
+
+        var ok = response.Result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<CrossWorldRelayResponse>();
+        payload.ExchangeFinished.ShouldBeFalse(
+            customMessage: "Target did not invoke finish tool — ExchangeFinished must remain false.");
+
+        var convs = await conversations.ListAsync();
+        convs.ShouldHaveSingleItem();
+        convs[0].Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: CloseAfterResponse=true is the sender's finality signal — " +
+                "receiver MUST archive even though the target never invoked finish_agent_exchange. " +
+                "Without this, single-shot and MaxTurns-reached exchanges leave receiver-side " +
+                "A↔A conversations Active indefinitely.");
+        convs[0].ActiveSessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RelayAsync_NonFinalRelay_DoesNotArchive_OnlyClearsActiveSession()
+    {
+        // Non-final relay (sender has more turns; target did not finish): the conversation
+        // remains Active so the next sender turn can reuse the RemoteSessionId. Only the
+        // pointer is cleared so the portal stops rendering "in flight" between turns.
+        var (controller, _, conversations, _) = BuildController(replyContent: "still working");
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var response = await controller.RelayAsync(
+            BuildRequest(closeAfterResponse: false), CancellationToken.None);
+
+        var ok = response.Result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<CrossWorldRelayResponse>();
+        payload.ExchangeFinished.ShouldBeFalse();
+
+        var convs = await conversations.ListAsync();
+        convs.ShouldHaveSingleItem();
+        convs[0].Status.ShouldBe(ConversationStatus.Active,
+            customMessage: "Non-final relay must keep the conversation Active so the next " +
+                "sender turn can reuse RemoteSessionId. Premature archive would break multi-turn.");
+        convs[0].ActiveSessionId.ShouldBeNull(
+            customMessage: "ActiveSessionId is still cleared between turns so the portal does " +
+                "not render the conversation as in-flight while the sender pauses.");
+    }
+
+    [Fact]
+    public async Task RelayAsync_OnPromptFailure_ArchivesReceiverConversation()
+    {
+        // Failure path: receiver session sealed by error catch; conversation also archived
+        // because terminal failure = exchange done.
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("target LLM upstream went bang"));
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(AgentId.From(TargetAgentId), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var controller = BuildControllerCore(sessions, conversations, supervisor.Object);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var action = () => controller.RelayAsync(BuildRequest(), CancellationToken.None);
+        await action.ShouldThrowAsync<InvalidOperationException>();
+
+        var convs = await conversations.ListAsync();
+        convs.ShouldHaveSingleItem();
+        convs[0].Status.ShouldBe(ConversationStatus.Archived,
+            customMessage: "P9-C: a failed exchange is terminal — receiver MUST archive its " +
+                "conversation so it does not linger as Active in portal/list APIs after a failure.");
+    }
+
+    [Fact]
+    public async Task RelayAsync_WhenArchiveCalledTwice_IsIdempotent_AndDoesNotThrow()
+    {
+        // First relay archives; a hypothetical second call with the same RemoteSessionId would
+        // hit the sealed-session 409 guard in ResolveSessionAsync. But the underlying ArchiveAsync
+        // itself MUST be idempotent — re-archiving an already-Archived conversation is a no-op.
+        var (controller, _, conversations, _) = BuildControllerWithToolCalledFinish(
+            replyContent: "Done.",
+            finishReason: "shipped",
+            finishSummary: null);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        await controller.RelayAsync(BuildRequest(), CancellationToken.None);
+
+        var convs = await conversations.ListAsync();
+        var convId = convs.ShouldHaveSingleItem().ConversationId;
+
+        // Directly invoke ArchiveAsync a second time — must not throw or change observable state.
+        await conversations.ArchiveAsync(convId, CancellationToken.None);
+
+        var reloaded = await conversations.GetAsync(convId);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(ConversationStatus.Archived);
+        reloaded.ActiveSessionId.ShouldBeNull();
+    }
+
+    // ─── end P9-C receiver pins ──────────────────────────────────────────────────────────
+
     // ---- helpers ----
 
     private static (CrossWorldFederationController Controller, InMemorySessionStore Sessions,
@@ -1497,7 +1644,8 @@ public sealed class CrossWorldFederationControllerTests
         string message = "hello",
         string? remoteSessionId = null,
         string? sourceSessionId = null,
-        string sourceAgentId = SourceAgentId)
+        string sourceAgentId = SourceAgentId,
+        bool closeAfterResponse = false)
         => new()
         {
             SourceWorldId = SourceWorldId,
@@ -1506,7 +1654,8 @@ public sealed class CrossWorldFederationControllerTests
             Message = message,
             ConversationId = "sender-conv-id",
             SourceSessionId = sourceSessionId,
-            RemoteSessionId = remoteSessionId
+            RemoteSessionId = remoteSessionId,
+            CloseAfterResponse = closeAfterResponse
         };
 }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1210,6 +1210,71 @@ public sealed class CrossWorldFederationControllerTests
         reloaded.ActiveSessionId.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task RelayAsync_OnArchiveFailure_DoesNotPropagate_AndStillReturnsSuccess()
+    {
+        // Failure-isolation pin for the controller's ArchiveOnExchangeEndAsync helper (mirror of
+        // the local sender pin ConverseAsync_FailureDuringArchive_DoesNotPropagateException).
+        // The duplicate helper in the controller MUST also swallow archive failures so the
+        // receiver's successful relay response is not poisoned by a transient archive failure.
+        var sessions = new InMemorySessionStore();
+        var throwingConversations = new ThrowingArchiveConversationStore();
+
+        var handle = new Mock<IAgentHandle>();
+        SessionId? capturedSessionId = null;
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                if (capturedSessionId is { } sid)
+                {
+                    var s = sessions.GetAsync(sid, CancellationToken.None).GetAwaiter().GetResult();
+                    if (s is not null
+                        && s.Metadata.TryGetValue("activeAgentExchangeId", out var v)
+                        && v is string activeId)
+                    {
+                        s.Metadata["finishedAgentExchangeId"] = activeId;
+                        s.Metadata["finishedAgentExchangeReason"] = "shipped";
+                        sessions.SaveAsync(s, CancellationToken.None).GetAwaiter().GetResult();
+                    }
+                }
+                return new AgentResponse
+                {
+                    Content = "Done.",
+                    ToolCalls = [new AgentToolCallInfo("call-1", "finish_agent_exchange", IsError: false)]
+                };
+            });
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(AgentId.From(TargetAgentId), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentId, SessionId, CancellationToken>((_, sid, _) => capturedSessionId = sid)
+            .ReturnsAsync(handle.Object);
+
+        var controller = BuildControllerCore(sessions, throwingConversations, supervisor.Object);
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        // RelayAsync MUST NOT throw — the archive failure is swallowed and logged inside
+        // ArchiveOnExchangeEndAsync.
+        var response = await controller.RelayAsync(BuildRequest(), CancellationToken.None);
+
+        response.ShouldNotBeNull();
+        var okResult = response.Result.ShouldBeOfType<OkObjectResult>();
+        var payload = okResult.Value.ShouldBeOfType<CrossWorldRelayResponse>();
+        payload.Response.ShouldBe("Done.");
+
+        throwingConversations.ArchiveCallCount.ShouldBe(1,
+            customMessage: "Receiver-side ArchiveOnExchangeEndAsync was called exactly once; " +
+                "the simulated failure was swallowed so the relay response was unaffected.");
+
+        // Session state side-effects: session itself was sealed BEFORE the archive call, so it
+        // remains Sealed even though archive failed.
+        var existence = await sessions.GetExistenceAsync(AgentId.From(TargetAgentId), new ExistenceQuery());
+        existence.Count.ShouldBe(1);
+        var session = await sessions.GetAsync(existence[0].SessionId);
+        session.ShouldNotBeNull();
+        session!.Status.ShouldBe(GatewaySessionStatus.Sealed);
+    }
+
     // ─── end P9-C receiver pins ──────────────────────────────────────────────────────────
 
     // ---- helpers ----
@@ -1664,6 +1729,38 @@ file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
     public T CurrentValue => value;
     public T Get(string? name) => value;
     public IDisposable? OnChange(Action<T, string?> listener) => null;
+}
+
+/// <summary>
+/// Conversation store that delegates everything to an internal <see cref="InMemoryConversationStore"/>
+/// except <see cref="ArchiveAsync"/>, which records the call count then throws. Used by the P9-C
+/// receiver-side failure-isolation pin to prove the controller's <c>ArchiveOnExchangeEndAsync</c>
+/// helper swallows archive failures so the relay response is not poisoned.
+/// </summary>
+file sealed class ThrowingArchiveConversationStore : IConversationStore
+{
+    private readonly InMemoryConversationStore _inner = new();
+    public int ArchiveCallCount { get; private set; }
+
+    public Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default)
+        => _inner.GetAsync(conversationId, ct);
+    public Task<IReadOnlyList<Conversation>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
+        => _inner.ListAsync(agentId, ct);
+    public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default)
+        => _inner.ListForCitizenAsync(citizen, ct);
+    public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
+        => _inner.CreateAsync(conversation, ct);
+    public Task SaveAsync(Conversation conversation, CancellationToken ct = default)
+        => _inner.SaveAsync(conversation, ct);
+    public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default)
+    {
+        ArchiveCallCount++;
+        throw new InvalidOperationException("simulated archive failure");
+    }
+    public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
+        => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
+    public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+        => _inner.GetSummariesAsync(agentId, ct);
 }
 
 /// <summary>


### PR DESCRIPTION
Implements **W-3** ("A-A conversations should have an end and then the conversation is done") by auto-archiving named↔named agent-exchange conversations when the exchange terminates. Closes #623; refs umbrella #613.

## Problem

Pre-P9-C, every named↔named exchange minted a real `Conversation` (Phase 4 / F-3, PRs #548 sender + #549 receiver) but only ever sealed the underlying session and cleared `ActiveSessionId`. The conversation itself stayed `Active` forever, accumulating dead entries in portal/list APIs.

## What this PR does

Four terminal seal paths now archive the conversation in addition to sealing the session:

| Path | File:line |
|------|-----------|
| Local A↔A success seal | `AgentExchangeService.ConverseAsync` (success branch) |
| Local A↔A error catch | `AgentExchangeService.ConverseAsync` (catch-all) |
| Cross-world sender success seal | `AgentExchangeService.ConverseCrossWorldAsync` (success branch) |
| Cross-world sender error catch | `AgentExchangeService.ConverseCrossWorldAsync` (catch-all) |
| Cross-world receiver — finish-tool branch | `CrossWorldFederationController.ExecuteRelayAsync` (split success branch) |
| Cross-world receiver — `CloseAfterResponse` branch | same (split success branch) |
| Cross-world receiver — error catch | same (catch-all) |

**Non-final cross-world relays** still take the existing `ClearActiveSessionAsync` path (no archive) — the exchange continues.

### Wire protocol addition

`CrossWorldRelayRequest.CloseAfterResponse : bool` lets the sender signal "this is the final turn" so the receiver archives even when the target agent never invokes `finish_agent_exchange` (single-shot + max-turns cases). Lifted from `OutboundMessage.Metadata["closeAfterResponse"]` by `CrossWorldChannelAdapter.TryGetMetadataBool`. Defaults to `false` so older senders preserve pre-P9-C behaviour (receiver archives only on `ExchangeFinished`).

## Test coverage matrix

| Layer | File | Count |
|---|---|---|
| Behaviour pins — local sender | `tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs` | 8 |
| Behaviour pins — cross-world receiver | `tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs` (inline) | 6 |
| Behaviour pins — adapter metadata lift | `tests/gateway/BotNexus.Gateway.Tests/Channels/CrossWorldChannelAdapterTests.cs` | 9 |
| Architecture fence | `tests/architecture/BotNexus.Architecture.Tests/AgentExchangeArchiveArchitectureTests.cs` | 8 |
| **Total new tests** | | **31** |

All pass. Full Gateway.Tests: 1990/1 skip. Full Architecture.Tests: 102/102. Build: 0 warnings / 0 errors (TreatWarningsAsErrors).

## Multi-model critique sweep applied

Three independent agents (security-review/gpt-5.5, plan-vs-impl/claude-opus-4.7, bug-hunt/gpt-5.3-codex) reviewed before merge. Fold-ins (commit ``772ccb17``):

- **HIGH** (bug-hunt + security defensive-hardening) — `TryGetMetadataBool` now handles `JsonElement(True/False/String)` shapes that arise when `OutboundMessage.Metadata` round-trips through Sqlite/File stores. Without this, a future change that persists OutboundMessages would silently regress to false → receiver wouldn't archive on the `CloseAfterResponse` path.
- **SHOULD-CONSIDER** (plan-vs-impl F1) — added 2 sender-side cross-world behaviour pins (success + error catch) that were previously fence-only.
- **SHOULD-CONSIDER** (plan-vs-impl F2) — added receiver-side failure-isolation pin via `ThrowingArchiveConversationStore`.

## Accepted limitations (deferred to W-3)

- **Helper duplication** — `ArchiveOnExchangeEndAsync` exists in both `AgentExchangeService.cs` and `CrossWorldFederationController.cs`. Consolidation deferred; intentional for P9-C scope. Helper bodies are kept literally identical to make drift easy to spot.
- **`IConversationStore.ArchiveIfActiveSessionAsync` atomic primitive** — current implementation does `GetAsync` → strict pointer guard → `ArchiveAsync`. There's a documented (and tested) TOCTOU window between the guard and the archive write. In production every caller mints its own `ConversationId`, so the window is non-exploitable today; an atomic primitive would close it for future shared-conversation flows.
- **SignalR `NotifyConversationChangedBestEffortAsync("archived")`** — the new archive sites do not emit a SignalR fan-out event. Portal currently picks up the state change via the next list-refresh. A push notification can land alongside W-3's shared lifecycle service.
- **Receiver state-machine quirk** — when `CloseAfterResponse=true && exchangeFinished=false`, the conversation archives but the session is **not** sealed. A follow-up relay against the same `RemoteSessionId` would resurrect `ActiveSessionId` on an Archived conversation. Security review flagged this as portal/UX inconsistency only (no auth bypass, no cross-tenant leak). To be filed as a separate cleanup issue.

## Commits

- `ff59a721` feat(gateway): auto-archive A↔A conversations on exchange end (P9-C)
- `4e84519a` test(gateway): pin A↔A auto-archive across local + cross-world + receiver paths (P9-C)
- `8b7bfde2` test(architecture): fence A↔A archive helper on exchange seal paths (P9-C)
- `772ccb17` fix(gateway): harden P9-C metadata lift + close coverage gaps from critique sweep

Closes #623
Refs #613
