### PR TITLE
fix(portal): replace literal x buttons with icons; title-case agent ID fallback

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/PortalSettingsPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/PortalSettingsPanel.razor
@@ -8,7 +8,7 @@
         <div class="portal-settings-panel" @onclick:stopPropagation="true">
             <div class="portal-settings-header">
                 <h3>Portal Settings</h3>
-                <button class="portal-settings-close" @onclick="Close" title="Close">x</button>
+                <button class="portal-settings-close" @onclick="Close" title="Close" data-testid="settings-close-btn">&#x2715;</button>
             </div>
             <div class="portal-settings-body">
                 <div class="portal-settings-row">

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -22,7 +22,7 @@
             </button>
             <span class="banner-logo">🤖</span>
             <span class="banner-title">BotNexus</span>
-            <button class="banner-settings-btn" @onclick="OpenSettings" title="Portal settings">x</button>
+            <button class="banner-settings-btn" @onclick="OpenSettings" title="Portal settings" data-testid="banner-settings-btn">&#x2699;&#xFE0F;</button>
         </div>
     </header>
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Home.razor
@@ -55,7 +55,7 @@ else
                 return "BotNexus";
 
             var agentLabel = string.IsNullOrWhiteSpace(agent.DisplayName)
-                ? activeAgentId
+                ? System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(activeAgentId.Replace("-", " "))
                 : agent.DisplayName;
 
             if (agent.ActiveConversationId is not { Length: > 0 } convId ||


### PR DESCRIPTION
## Summary
Three small portal UI bug fixes.

## Changes

### MainLayout.razor — closes #630
Banner settings button was rendering `x`. Now uses `&#x2699;&#xFE0F;` (gear icon) and adds `data-testid="banner-settings-btn`.

### PortalSettingsPanel.razor — closes #634
Close button was rendering `x`. Now uses `&#x2715;` (times/close symbol) and adds `data-testid="settings-close-btn"`.

### Home.razor — closes #635
When an agent has no DisplayName set, the page title was showing the raw agent ID (e.g. `nexus-web-tester`). Now title-cases the hyphen-separated ID as a readable fallback (e.g. `Nexus Web Tester`).

## Files changed
- `Layout/MainLayout.razor`
- `Components/PortalSettingsPanel.razor`
- `Pages/Home.razor`

All under `src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/`.