### PR TITLE
feat(gateway)!: flip Session.ConversationId to non-nullable (P9-B-2, closes #627)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -78,13 +78,15 @@ public sealed class GatewaySession
     }
 
     /// <summary>
-    /// Conversation this session belongs to, or <c>null</c> for orphan / legacy
-    /// ungrouped sessions. Always mutate through this proxy — the
+    /// Conversation this session belongs to. Always mutate through this proxy — the
     /// <see cref="GatewaySessionFacadeArchitectureTests"/> fence bans reach-through
     /// access via <c>session.Session.ConversationId</c> so the proxy stays the
-    /// single source of truth (F-9 / Phase 7).
+    /// single source of truth (F-9 / Phase 7). The unset sentinel is
+    /// <c>default(ConversationId)</c>; store implementations are responsible for
+    /// backfilling unset values before returning a session to callers
+    /// (Phase 9 / P9-B; issues #615, #627).
     /// </summary>
-    public ConversationId? ConversationId
+    public ConversationId ConversationId
     {
         get => Session.ConversationId;
         set => Session.ConversationId = value;

--- a/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
@@ -55,10 +55,13 @@ public sealed record Session
     public DateTimeOffset? ExpiresAt { get; set; }
 
     /// <summary>
-    /// Gets or sets the conversation this session belongs to, if any.
-    /// Sessions with no ConversationId are treated as legacy ungrouped sessions.
+    /// Gets or sets the conversation this session belongs to. Conversation is the
+    /// durable parent container; sessions are bounded transcripts inside a conversation.
+    /// The unset sentinel is <c>default(ConversationId)</c> — store implementations are
+    /// responsible for backfilling unset values to the agent's legacy conversation
+    /// before returning a session to callers (Phase 9 / P9-B; issues #615, #627).
     /// </summary>
-    public ConversationId? ConversationId { get; set; }
+    public ConversationId ConversationId { get; set; }
 
     /// <summary>
     /// Gets or sets the metadata.

--- a/src/domain/BotNexus.Domain/Primitives/ConversationId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/ConversationId.cs
@@ -8,7 +8,27 @@ namespace BotNexus.Domain.Primitives;
 /// <see cref="Create"/> for a new conversation. The value must be non-null, non-empty,
 /// non-whitespace and is stored trimmed.
 /// </summary>
-[ValueObject<string>(conversions: Conversions.SystemTextJson)]
+/// <remarks>
+/// <para>
+/// <see cref="IsInitialized"/> is generated so callers can distinguish a Vogen
+/// default-constructed instance (used as the "unset" sentinel on
+/// <c>Session.ConversationId</c> before the legacy backfill resolver fires) from a
+/// valid, From-constructed value. Production code outside the session-store layer
+/// should never observe an uninitialized <c>ConversationId</c> — stores backfill on
+/// both save and load (Phase 9 / P9-B; issues #615, #627).
+/// </para>
+/// <para>
+/// <see cref="PrimitiveEqualityGeneration.Omit"/> is set to remove the auto-generated
+/// <c>operator ==(ConversationId, string?)</c> overload that would otherwise make
+/// <c>conversationId == default</c> ambiguous against the typed equality overload.
+/// Callers compare ConversationIds against each other directly; the only "unset"
+/// check should use <see cref="IsInitialized"/>.
+/// </para>
+/// </remarks>
+[ValueObject<string>(
+    conversions: Conversions.SystemTextJson,
+    isInitializedMethodGeneration: IsInitializedMethodGeneration.Generate,
+    primitiveEqualityGeneration: PrimitiveEqualityGeneration.Omit)]
 public readonly partial struct ConversationId
 {
     /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -504,10 +504,10 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
         var gatewaySession = await _sessions.GetAsync(typedSessionId, CancellationToken.None);
 
-        if (gatewaySession?.ConversationId is { } conversationId && _resetService is not null)
+        if (gatewaySession is not null && gatewaySession.ConversationId.IsInitialized() && _resetService is not null)
         {
             await _resetService.ResetActiveSessionAsync(
-                conversationId,
+                gatewaySession.ConversationId,
                 expectedActiveSessionId: typedSessionId,
                 CancellationToken.None).ConfigureAwait(false);
         }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -388,8 +388,8 @@ public sealed class ConversationsController : ControllerBase
             if (virtualSession is null)
                 return NoContent();
 
-            if (virtualSession.ConversationId is { } linkedConversationId)
-                conversation = await _conversations.GetAsync(linkedConversationId, cancellationToken);
+            if (virtualSession.ConversationId.IsInitialized())
+                conversation = await _conversations.GetAsync(virtualSession.ConversationId, cancellationToken);
 
             if (conversation is null)
             {

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -303,8 +303,9 @@ public sealed class CrossWorldFederationController(
             if (existing.Status == GatewaySessionStatus.Sealed)
                 return ResolveResult.Fail(Conflict(new { error = $"RemoteSessionId '{request.RemoteSessionId}' is sealed and cannot be reused — start a new cross-world exchange." }));
 
-            if (existing.ConversationId is not { } existingConversationId)
+            if (!existing.ConversationId.IsInitialized())
                 return ResolveResult.Fail(Conflict(new { error = $"RemoteSessionId '{request.RemoteSessionId}' has no bound conversation — refuse to reuse." }));
+            var existingConversationId = existing.ConversationId;
 
             var existingConv = await conversationStore.GetAsync(existingConversationId, cancellationToken).ConfigureAwait(false);
             if (existingConv is null)

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs
@@ -69,7 +69,12 @@ public sealed class SessionsController : ControllerBase
             sessionId = s.SessionId.Value,
             agentId = s.AgentId.Value,
             channelType = s.ChannelType?.Value,
-            conversationId = s.ConversationId?.Value,
+            // Phase 9 / P9-B-2 (#627): defensive projection — `Session.ConversationId`
+            // is non-nullable, but the unset sentinel `default(ConversationId)` will
+            // throw on `.Value`. Project default → null so portal/REST clients still see
+            // a meaningful response if a session is read in the narrow window before
+            // save-time backfill stamps it.
+            conversationId = s.ConversationId.IsInitialized() ? s.ConversationId.Value : null,
             status = s.Status.ToString(),
             sessionType = s.SessionType.Value,
             isInteractive = s.IsInteractive,

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -82,7 +82,7 @@ public sealed class CronTrigger(
         if (request is not null && request.ResolvedConversationId is null)
             request.ResolvedConversationId = conversation.ConversationId;
 
-        if (session.ConversationId is null || session.ConversationId != conversation.ConversationId)
+        if (session.ConversationId != conversation.ConversationId)
             session.ConversationId = conversation.ConversationId;
 
         // Update the conversation's active session to this run so history loads the latest.

--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -175,13 +175,13 @@ public sealed class DefaultConversationRouter : IConversationRouter
         }
 
         var conversationId = session.ConversationId;
-        if (conversationId is null)
+        if (!conversationId.IsInitialized())
         {
             _logger.LogDebug("GetOutboundBindings: session {SessionId} has no ConversationId -- returning empty", sessionId);
             return [];
         }
 
-        var conversation = await _conversationStore.GetAsync(conversationId.Value, ct);
+        var conversation = await _conversationStore.GetAsync(conversationId, ct);
         if (conversation is null)
         {
             _logger.LogDebug("GetOutboundBindings: conversation {ConversationId} not found -- returning empty", conversationId);
@@ -334,7 +334,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
             isNewSession = true;
         }
 
-        if (session.ConversationId is null || session.ConversationId != conversation.ConversationId)
+        if (session.ConversationId != conversation.ConversationId)
         {
             session.ConversationId = conversation.ConversationId;
             await _sessionStore.SaveAsync(session, ct);

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -45,6 +45,25 @@ public sealed class FileSessionStore : SessionStoreBase
     private readonly ISecretRedactor? _redactor;
     private readonly LegacyConversationResolver? _legacyResolver;
 
+    // Phase 9 / P9-B-2 (#627): eager startup sweep mirrors
+    // SqliteSessionStore.MigrateOrphanedSessionsAsync. A SemaphoreSlim + bool flag
+    // (rather than a cached Task) so a cancelled first caller cannot poison subsequent
+    // calls — if the first attempt throws OperationCanceledException the next caller
+    // re-enters the lock and tries again with its own token.
+    private readonly SemaphoreSlim _migrationLock = new(1, 1);
+    private bool _migrated;
+
+    // Test probe (#627): increments exactly once per MigrateOrphanedSessionsAsync entry.
+    // Counted via Interlocked because EnsureMigratedAsync is called from multiple
+    // concurrent task contexts before the lock is acquired. Exposed via
+    // <see cref="MigrationInvocationCount"/> so the concurrent-callers test can prove
+    // the sweep ran exactly once, decoupled from inner resolver ListAsync call counts
+    // (the resolver may issue 1-3 ListAsync calls per single sweep depending on cache
+    // state, so counting ListAsync at the conversation store conflates correctness
+    // with resolver implementation detail).
+    private int _migrationInvocationCount;
+    internal int MigrationInvocationCount => Volatile.Read(ref _migrationInvocationCount);
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -92,6 +111,8 @@ public sealed class FileSessionStore : SessionStoreBase
         using var activity = ActivitySource.StartActivity("session.get", ActivityKind.Internal);
         activity?.SetTag("botnexus.session.id", sessionId);
 
+        await EnsureMigratedAsync(cancellationToken).ConfigureAwait(false);
+
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -109,6 +130,8 @@ public sealed class FileSessionStore : SessionStoreBase
         using var activity = ActivitySource.StartActivity("session.get_or_create", ActivityKind.Internal);
         activity?.SetTag("botnexus.session.id", sessionId);
         activity?.SetTag("botnexus.agent.id", agentId);
+
+        await EnsureMigratedAsync(cancellationToken).ConfigureAwait(false);
 
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -136,6 +159,8 @@ public sealed class FileSessionStore : SessionStoreBase
         using var activity = ActivitySource.StartActivity("session.save", ActivityKind.Internal);
         activity?.SetTag("botnexus.session.id", session.SessionId);
         activity?.SetTag("botnexus.agent.id", session.AgentId);
+
+        await EnsureMigratedAsync(cancellationToken).ConfigureAwait(false);
 
         // Backfill outside the per-store lock — the resolver may call the conversation
         // store which has its own locking; nesting would risk lock-ordering issues
@@ -190,6 +215,8 @@ public sealed class FileSessionStore : SessionStoreBase
 
     protected override async Task<IReadOnlyList<GatewaySession>> EnumerateSessionsAsync(CancellationToken cancellationToken)
     {
+        await EnsureMigratedAsync(cancellationToken).ConfigureAwait(false);
+
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -207,6 +234,174 @@ public sealed class FileSessionStore : SessionStoreBase
             return sessions;
         }
         finally { _lock.Release(); }
+    }
+
+    /// <summary>
+    /// One-time eager sweep that mirrors <c>SqliteSessionStore.MigrateOrphanedSessionsAsync</c>:
+    /// every pre-Phase-9 sidecar on disk with no <c>ConversationId</c> is grouped by agent,
+    /// linked to that agent's <c>legacy:{agentId}</c> conversation via
+    /// <see cref="LegacyConversationResolver"/>, and the most-recently-updated Active orphan
+    /// per agent is bound as the conversation's <see cref="Conversation.ActiveSessionId"/>.
+    /// Safe to run on every startup — no-op when no orphans exist or no resolver is wired.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="SemaphoreSlim"/> + <c>_migrated</c> flag (NOT a cached
+    /// <see cref="Task"/>) so a cancelled first caller does not poison subsequent callers
+    /// — they re-enter the lock and retry with their own token.
+    /// </remarks>
+    private async Task EnsureMigratedAsync(CancellationToken cancellationToken)
+    {
+        if (_migrated) return;
+        if (_legacyResolver is null) { _migrated = true; return; }
+
+        await _migrationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_migrated) return;
+            try
+            {
+                Interlocked.Increment(ref _migrationInvocationCount);
+                await MigrateOrphanedSessionsAsync(cancellationToken).ConfigureAwait(false);
+                _migrated = true;
+            }
+            catch (OperationCanceledException)
+            {
+                // Do NOT set _migrated — let the next caller retry with their own token.
+                throw;
+            }
+        }
+        finally { _migrationLock.Release(); }
+    }
+
+    /// <summary>
+    /// Scans the store directory for sidecar files with no persisted <c>ConversationId</c>,
+    /// groups by agent, stamps each group with the agent's legacy conversation, rewrites
+    /// every orphan sidecar so the stamp is durable, and binds the most-recently-updated
+    /// Active orphan per agent as the conversation's active session pointer. Mirrors
+    /// <c>SqliteSessionStore.MigrateOrphanedSessionsAsync</c>; runs once per process via
+    /// <see cref="EnsureMigratedAsync"/>.
+    /// </summary>
+    private async Task MigrateOrphanedSessionsAsync(CancellationToken cancellationToken)
+    {
+        if (_legacyResolver is null) return;
+
+        // Pass 1: enumerate orphan sidecars (ConversationId is null or absent on disk).
+        // Hold the read lock briefly to avoid racing with concurrent SaveAsync writes.
+        var orphans = new List<(SessionId SessionId, AgentId AgentId, SessionStatus Status, DateTimeOffset UpdatedAt)>();
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (var metaFile in _fileSystem.Directory.GetFiles(_storePath, "*.meta.json"))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                SessionMeta? meta;
+                try
+                {
+                    meta = await SessionMetadataSidecar.ReadAsync<SessionMeta>(
+                        _fileSystem,
+                        metaFile,
+                        JsonOptions,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Skip unreadable sidecars; do not fail the entire sweep on a single
+                    // corrupted file. The load path will surface the same error if the
+                    // sidecar is later requested by id.
+                    _logger.LogWarning(ex,
+                        "Skipping unreadable sidecar {SidecarPath} during orphan sweep.",
+                        metaFile);
+                    continue;
+                }
+
+                if (meta is null) continue;
+                if (meta.ConversationId is not null) continue;
+
+                var sessionId = SessionId.From(Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(metaFile)));
+                orphans.Add((sessionId, meta.AgentId, meta.Status, meta.UpdatedAt));
+            }
+        }
+        finally { _lock.Release(); }
+
+        if (orphans.Count == 0) return;
+
+        // Pass 2: group by agent, resolve legacy conversation per agent, bind the
+        // most-recently-updated Active orphan as the conversation's active pointer,
+        // then stamp each orphan sidecar in turn. Bind MUST run BEFORE the stamp loop
+        // because LoadFromFileAsync has its own load-time backfill that calls
+        // BindActiveSessionIfNoneAsync(firstSessionLoaded). Without this ordering, the
+        // alphabetically-first orphan would silently win the bind race against the
+        // most-recently-updated orphan. Resolver call must be outside the per-store
+        // lock — it acquires its own per-agent semaphore plus the conversation store's
+        // lock; nesting risks deadlock.
+        var totalMigrated = 0;
+        foreach (var group in orphans.GroupBy(o => o.AgentId))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var agentId = group.Key;
+            var legacy = await _legacyResolver.ResolveAsync(agentId, cancellationToken).ConfigureAwait(false);
+
+            // Bind first: pick the most-recently-updated Active orphan. Sealed/Suspended/
+            // Expired orphans are not bound — they're history, not live work. The bind is
+            // first-wins via the resolver's per-agent semaphore, so subsequent
+            // load-time-backfill BindActiveSessionIfNoneAsync calls in this loop are
+            // no-ops once this completes.
+            var activeOrphans = group
+                .Where(o => o.Status == SessionStatus.Active)
+                .OrderByDescending(o => o.UpdatedAt)
+                .ToList();
+            if (activeOrphans.Count > 0)
+            {
+                await _legacyResolver.BindActiveSessionIfNoneAsync(
+                    legacy,
+                    activeOrphans[0].SessionId,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            // Reload + rewrite each orphan sidecar so the stamp is durable on disk.
+            foreach (var orphan in group)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                GatewaySession? session;
+                await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    if (_cache.TryGetValue(orphan.SessionId, out var cached))
+                    {
+                        session = cached;
+                    }
+                    else
+                    {
+                        session = await LoadFromFileAsync(orphan.SessionId, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                finally { _lock.Release(); }
+
+                if (session is null) continue;
+
+                // LoadFromFileAsync already backfills via the resolver path — but only when
+                // the session is loaded individually. The eager sweep guarantees every orphan
+                // gets touched even when no caller ever explicitly requests it.
+                if (!session.ConversationId.IsInitialized())
+                {
+                    session.ConversationId = legacy.ConversationId;
+                    await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await WriteToFileAsync(session, cancellationToken).ConfigureAwait(false);
+                    }
+                    finally { _lock.Release(); }
+                }
+                totalMigrated++;
+            }
+        }
+
+        _logger.LogInformation(
+            "Orphaned session migration (file store): linked {Count} session(s) across {AgentCount} agent(s) to their legacy conversations.",
+            totalMigrated, orphans.Select(o => o.AgentId).Distinct().Count());
     }
 
     private async Task<GatewaySession?> LoadFromFileAsync(SessionId sessionId, CancellationToken cancellationToken)
@@ -229,12 +424,19 @@ public sealed class FileSessionStore : SessionStoreBase
             CreatedAt = meta.CreatedAt,
             UpdatedAt = meta.UpdatedAt,
             Status = meta.Status,
-            ExpiresAt = meta.ExpiresAt,
-            ConversationId = meta.ConversationId
+            ExpiresAt = meta.ExpiresAt
+            // ConversationId is intentionally omitted when meta.ConversationId is null --
+            // the property defaults to an uninitialized ConversationId (the "unset" sentinel)
+            // and the load-time backfill below fires on it. Writing `default(ConversationId)`
+            // explicitly is prohibited by Vogen analyzer VOG009.
         }, _redactor)
         {
             CallerId = meta.CallerId
         };
+        if (meta.ConversationId is not null)
+        {
+            session.ConversationId = meta.ConversationId.Value;
+        }
         if (meta.Metadata is not null)
         {
             foreach (var pair in meta.Metadata)
@@ -259,11 +461,12 @@ public sealed class FileSessionStore : SessionStoreBase
             session.UpdatedAt = meta.UpdatedAt;
         }
 
-        // Phase 9 / P9-B (#615): if this session was persisted before Session.ConversationId
-        // was always populated, durably backfill the legacy conversation. The sidecar is
-        // rewritten so subsequent loads — and any reader that joins on ConversationId —
-        // observe the stamp without another resolution round trip.
-        if (session.ConversationId is null && _legacyResolver is not null)
+        // Phase 9 / P9-B (#615, #627): if this session was persisted before
+        // Session.ConversationId was always populated, durably backfill the legacy
+        // conversation. The sidecar is rewritten so subsequent loads — and any reader
+        // that joins on ConversationId — observe the stamp without another resolution
+        // round trip.
+        if (!session.ConversationId.IsInitialized() && _legacyResolver is not null)
         {
             var legacy = await _legacyResolver.ResolveAsync(session.AgentId, cancellationToken).ConfigureAwait(false);
             session.ConversationId = legacy.ConversationId;
@@ -283,15 +486,15 @@ public sealed class FileSessionStore : SessionStoreBase
     }
 
     /// <summary>
-    /// Defensively stamps a session whose <see cref="Session.ConversationId"/> is null at
-    /// save time with the agent's <c>legacy:{agentId}</c> conversation, persisting the
-    /// stamp before the sidecar is written so subsequent reads see a consistent view.
-    /// No-op when no conversation store was registered (back-compat for test composition
-    /// roots).
+    /// Defensively stamps a session whose <see cref="Session.ConversationId"/> is unset
+    /// (<c>default(ConversationId)</c>) at save time with the agent's
+    /// <c>legacy:{agentId}</c> conversation, persisting the stamp before the sidecar is
+    /// written so subsequent reads see a consistent view. No-op when no conversation
+    /// store was registered (back-compat for test composition roots).
     /// </summary>
     private async Task EnsureConversationIdStampedAsync(GatewaySession session, CancellationToken cancellationToken)
     {
-        if (session.ConversationId is not null)
+        if (session.ConversationId.IsInitialized())
             return;
         if (_legacyResolver is null)
             return;
@@ -335,7 +538,13 @@ public sealed class FileSessionStore : SessionStoreBase
             session.ExpiresAt,
             session.StreamReplay.NextSequenceId,
             [.. session.StreamReplay.GetEventSnapshot()],
-            session.ConversationId,
+            // P9-B-2: Session.ConversationId is now non-nullable, but the SessionMeta
+            // sidecar still carries it as ConversationId? so back-compat readers see
+            // `null` for orphan rows (preserving the no-resolver back-compat path).
+            // Without the IsInitialized check, the unset Vogen default would wrap into
+            // Nullable<ConversationId>(HasValue=true, Value=default) and the Vogen STJ
+            // converter would throw "uninitialized value object" at write time.
+            session.ConversationId.IsInitialized() ? session.ConversationId : (ConversationId?)null,
             session.Metadata.Count == 0 ? null : new Dictionary<string, object?>(session.Metadata));
         await SessionMetadataSidecar.WriteAsync(
             _fileSystem,

--- a/src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs
@@ -84,7 +84,7 @@ public sealed class InMemorySessionStore : SessionStoreBase
 
         // Backfill outside the lock — the resolver may await a conversation store call.
         // _sync is non-async so we cannot hold it across the await anyway.
-        if (session.ConversationId is null && _legacyResolver is not null)
+        if (!session.ConversationId.IsInitialized() && _legacyResolver is not null)
         {
             var legacy = await _legacyResolver.ResolveAsync(session.AgentId, cancellationToken).ConfigureAwait(false);
             session.ConversationId = legacy.ConversationId;

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -59,8 +59,8 @@ public abstract class SessionStoreBase : ISessionStore
     {
         var sessions = await EnumerateSessionsAsync(cancellationToken).ConfigureAwait(false);
         IEnumerable<GatewaySession> result = sessions
-            .Where(session => session.ConversationId is not null
-                && session.ConversationId.Value == conversationId);
+            .Where(session => session.ConversationId.IsInitialized()
+                && session.ConversationId == conversationId);
         if (agentId is not null)
         {
             result = result.Where(session => session.AgentId == agentId);

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -499,7 +499,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
     /// </remarks>
     private async Task EnsureConversationIdStampedAsync(GatewaySession session, CancellationToken cancellationToken)
     {
-        if (session.ConversationId is not null)
+        if (session.ConversationId.IsInitialized())
             return;
         if (_legacyResolver is null)
             return;
@@ -530,7 +530,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
     /// </summary>
     private async Task BackfillLoadedSessionAsync(GatewaySession session, CancellationToken cancellationToken)
     {
-        if (session.ConversationId is not null)
+        if (session.ConversationId.IsInitialized())
             return;
         if (_legacyResolver is null)
             return;
@@ -598,10 +598,6 @@ public sealed class SqliteSessionStore : SessionStoreBase
         if (string.IsNullOrWhiteSpace(agentIdValue))
             return null;
 
-        ConversationId? conversationId = null;
-        if (reader.FieldCount > 10 && !reader.IsDBNull(10))
-            conversationId = ConversationId.From(reader.GetString(10));
-
         var domainSession = new Session
         {
             SessionId = SessionId.From(reader.GetString(0)),
@@ -612,9 +608,14 @@ public sealed class SqliteSessionStore : SessionStoreBase
             Status = status,
             CreatedAt = createdAt,
             UpdatedAt = updatedAt,
-            Metadata = metadata,
-            ConversationId = conversationId
+            Metadata = metadata
+            // ConversationId is intentionally omitted when the column is NULL --
+            // the property defaults to an uninitialized ConversationId (the "unset" sentinel)
+            // and BackfillLoadedSessionAsync fires on it below. Writing `default(ConversationId)`
+            // explicitly is prohibited by Vogen analyzer VOG009.
         };
+        if (reader.FieldCount > 10 && !reader.IsDBNull(10))
+            domainSession.ConversationId = ConversationId.From(reader.GetString(10));
         var session = new GatewaySession(domainSession, redactor)
         {
             CallerId = reader.IsDBNull(3) ? null : reader.GetString(3)
@@ -692,7 +693,19 @@ public sealed class SqliteSessionStore : SessionStoreBase
         command.Parameters.AddWithValue("$metadata", JsonSerializer.Serialize(session.Metadata, JsonOptions));
         command.Parameters.AddWithValue("$createdAt", session.CreatedAt.ToString("O"));
         command.Parameters.AddWithValue("$updatedAt", session.UpdatedAt.ToString("O"));
-        command.Parameters.AddWithValue("$conversationId", (object?)session.ConversationId?.Value ?? DBNull.Value);
+        // Phase 9 / P9-B-2 (#627): the save-time backfill (EnsureConversationIdStampedAsync,
+        // line 136) is responsible for guaranteeing a non-default ConversationId by the
+        // time we reach this writer. Fail loud here instead of silently writing a NULL
+        // row — a NULL row would re-introduce the orphan condition the non-null flip is
+        // supposed to prevent.
+        if (!session.ConversationId.IsInitialized())
+            throw new InvalidOperationException(
+                $"Refusing to persist session '{session.SessionId.Value}' for agent " +
+                $"'{session.AgentId.Value}' with an unset ConversationId. Save-time " +
+                $"backfill (EnsureConversationIdStampedAsync) should have stamped this " +
+                $"before reaching the writer. Either register an IConversationStore on " +
+                $"the SqliteSessionStore constructor or set ConversationId explicitly.");
+        command.Parameters.AddWithValue("$conversationId", session.ConversationId.Value);
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
@@ -169,8 +169,8 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
         if (_sessionStore is not null)
         {
             var session = await _sessionStore.GetAsync(executionContext.SessionId, cancellationToken).ConfigureAwait(false);
-            if (session?.ConversationId is { } conversationId)
-                conversation = await _conversationStore.GetAsync(conversationId, cancellationToken).ConfigureAwait(false);
+            if (session is not null && session.ConversationId.IsInitialized())
+                conversation = await _conversationStore.GetAsync(session.ConversationId, cancellationToken).ConfigureAwait(false);
         }
 
         if (conversation is null)

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -429,12 +429,12 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             }
 
             if (_pendingAskUserInterceptor is not null &&
-                session.ConversationId is { } activeConversationId &&
-                _pendingAskUserInterceptor.TryIntercept(message, activeConversationId))
+                session.ConversationId.IsInitialized() &&
+                _pendingAskUserInterceptor.TryIntercept(message, session.ConversationId))
             {
                 _logger.LogInformation(
                     "Captured ask_user response for conversation {ConversationId}; skipping normal agent dispatch.",
-                    activeConversationId);
+                    session.ConversationId);
                 continue;
             }
 
@@ -1170,8 +1170,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                         "Fan-out: stale connection for binding {BindingId} in conversation {ConversationId}. Demoting to Muted.",
                         ex.BindingId, ex.ConversationId);
 
-                    if (session?.ConversationId is { } convId)
-                        await _conversationRouter.MuteBindingAsync(convId, ex.BindingId, cancellationToken);
+                    if (session is not null && session.ConversationId.IsInitialized())
+                        await _conversationRouter.MuteBindingAsync(session.ConversationId, ex.BindingId, cancellationToken);
                 }
                 catch (Exception ex)
                 {

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -577,8 +577,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         if (sessionStore is not null)
         {
             var session = await sessionStore.GetAsync(sessionId, cancellationToken).ConfigureAwait(false);
-            if (session?.ConversationId is { } conversationId)
-                return conversationId;
+            if (session is not null && session.ConversationId.IsInitialized())
+                return session.ConversationId;
         }
 
         var conversations = await conversationStore.ListAsync(agentId, cancellationToken).ConfigureAwait(false);

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionConversationIdNonNullableArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionConversationIdNonNullableArchitectureTests.cs
@@ -1,0 +1,446 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-B-2 contract: the
+/// <c>ConversationId</c> property on <see cref="BotNexus.Gateway.Abstractions.Models.Session"/>
+/// and <see cref="BotNexus.Gateway.Abstractions.Models.GatewaySession"/> must be a non-nullable
+/// <see cref="BotNexus.Domain.Primitives.ConversationId"/>. The orphan-session path is
+/// closed: every persisted session carries a real conversation id (legacy-conversation
+/// backfill is the responsibility of the store layer — see <c>LegacyConversationResolver</c>
+/// and the per-store stamping helpers).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before P9-B-2 the field was <c>ConversationId? ConversationId</c> (nullable). Phase 9 /
+/// P9-B-1 (#615, PR #616) added save-time + load-time backfill to every store so that every
+/// orphan session is durably stamped with the agent's <c>legacy:{agentId}</c> conversation.
+/// P9-B-2 (#627, this PR) flips the field to non-nullable so the orphan path becomes
+/// structurally impossible — and every reader is freed from null-check ceremony.
+/// </para>
+/// <para>
+/// Two fences:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <description><b>Reflection pin</b> — <c>Session.ConversationId</c> and
+///     <c>GatewaySession.ConversationId</c> must both be typed
+///     <c>BotNexus.Domain.Primitives.ConversationId</c> (NOT
+///     <c>Nullable&lt;ConversationId&gt;</c>). Defends against an accidental revert to
+///     <c>ConversationId?</c> in either layer.</description>
+///   </item>
+///   <item>
+///     <description><b>Source fence</b> — production code (under <c>src/</c>) must not
+///     write any nullable-handling shape against <c>ConversationId</c> on a session.
+///     Banned shapes: <c>ConversationId is null</c>, <c>ConversationId is not null</c>,
+///     <c>ConversationId.HasValue</c>, <c>ConversationId == null</c>,
+///     <c>ConversationId != null</c>, <c>ConversationId?.Value</c>. The fence skips
+///     comments via the same lexer used by <see cref="GatewaySessionFacadeArchitectureTests"/>
+///     and <see cref="SingleShotWireValueArchitectureTests"/>.</description>
+///   </item>
+/// </list>
+/// <para>
+/// <b>Mandatory self-tests</b> (per the stored-memory rule "every regex-based architecture
+/// fence must include a self-test asserting it matches its target methods/symbols"):
+/// the synthetic-violation pin proves the fence is not vacuous; the false-positive guards
+/// prove the fence does not over-fire on legitimate constructs that mention
+/// <c>ConversationId</c> in adjacent but distinct contexts.
+/// </para>
+/// </remarks>
+public sealed class SessionConversationIdNonNullableArchitectureTests
+{
+    [Fact]
+    public void Session_ConversationId_IsNonNullable_ConversationId_NotNullable()
+    {
+        var sessionType = typeof(BotNexus.Gateway.Abstractions.Models.Session);
+        var property = sessionType.GetProperty("ConversationId", BindingFlags.Public | BindingFlags.Instance);
+        property.ShouldNotBeNull("Session.ConversationId must exist as a public instance property.");
+
+        property.PropertyType.ShouldBe(
+            typeof(BotNexus.Domain.Primitives.ConversationId),
+            "P9-B-2 contract: Session.ConversationId must be the non-nullable Vogen type. " +
+            "If this assertion fails, the orphan-session escape hatch has been re-opened — " +
+            "every store layer has been updated to backfill to the agent's legacy conversation " +
+            "before persistence; readers no longer need null-check ceremony. Use " +
+            "ConversationId.IsInitialized() to distinguish the uninitialized sentinel from a real id.");
+    }
+
+    [Fact]
+    public void GatewaySession_ConversationId_IsNonNullable_ConversationId_NotNullable()
+    {
+        var proxyType = typeof(BotNexus.Gateway.Abstractions.Models.GatewaySession);
+        var property = proxyType.GetProperty("ConversationId", BindingFlags.Public | BindingFlags.Instance);
+        property.ShouldNotBeNull("GatewaySession.ConversationId proxy must exist as a public instance property.");
+
+        property.PropertyType.ShouldBe(
+            typeof(BotNexus.Domain.Primitives.ConversationId),
+            "P9-B-2 contract: GatewaySession.ConversationId must mirror Session.ConversationId " +
+            "as the non-nullable Vogen type. If this fails, the proxy has drifted from the inner " +
+            "record's shape and the fence at GatewaySessionFacadeArchitectureTests can no longer " +
+            "keep the two in sync.");
+    }
+
+    [Fact]
+    public void NoProductionSourceFile_TreatsConversationId_AsNullable_OnSession()
+    {
+        var srcRoot = FindSourceRoot();
+
+        var violations = new List<string>();
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            if (s_allowlist.Contains(relative)) continue;
+
+            var stripped = StripComments(File.ReadAllText(path));
+            var matches = FindNullableHandlingShapes(stripped);
+            if (matches.Count > 0)
+            {
+                violations.Add($"{relative} — {string.Join(", ", matches)}");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-B-2: production code must not treat Session.ConversationId or " +
+            "GatewaySession.ConversationId as nullable. The orphan path is closed — every " +
+            "persisted session carries a real conversation id via the store-layer backfill " +
+            "(LegacyConversationResolver). Use ConversationId.IsInitialized() ONLY in store " +
+            "implementations where the sentinel value can briefly leak through (and only " +
+            "during the stamping path). All other readers should treat ConversationId as " +
+            "always set.\nViolations:\n  " + string.Join("\n  ", violations));
+    }
+
+    /// <summary>
+    /// Files explicitly excluded from the source fence because they legitimately read a
+    /// <c>ConversationId</c> on a type OTHER than <c>Session</c>/<c>GatewaySession</c>:
+    /// either a wire DTO with a <c>string?</c>-shaped property, or a domain aggregate
+    /// where the nullable lifecycle is part of the design.
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description><b>ServiceBusChannelAdapter.cs</b> — reads
+    ///     <c>ServiceBusInboundEnvelope.ConversationId</c> (a <c>string?</c> wire field used
+    ///     to mirror routing onto Service Bus application properties). Not the Vogen
+    ///     value object on a session.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><b>CronScheduler.cs</b> — reads <c>CronJob.ConversationId</c>, which
+    ///     is <c>ConversationId?</c> by design (per G-5: cron jobs do not bind a conversation
+    ///     until first run). The pinback path checks <c>HasValue</c> on the job record, not
+    ///     on a session.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><b>FileSessionStore.cs</b> — reads <c>SessionMeta.ConversationId</c>,
+    ///     a JSON sidecar DTO that retains <c>ConversationId?</c> because pre-P9-B-1 sidecars
+    ///     on disk may legitimately be missing the field. The eager startup sweep and
+    ///     load-time backfill rely on this exact null-check to identify orphan sidecars
+    ///     and rewrite them with the legacy conversation id.</description>
+    ///   </item>
+    /// </list>
+    /// </summary>
+    private static readonly HashSet<string> s_allowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        Path.Combine("extensions", "BotNexus.Extensions.Channels.ServiceBus", "ServiceBusChannelAdapter.cs"),
+        Path.Combine("gateway", "BotNexus.Cron", "CronScheduler.cs"),
+        Path.Combine("gateway", "BotNexus.Gateway.Sessions", "FileSessionStore.cs"),
+    };
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    [Fact]
+    public void Allowlist_OnlyContains_FilesThat_StillExist_AndStill_TripTheFence()
+    {
+        // Allowlist hygiene: if a file is in the allowlist but no longer trips the fence,
+        // the entry is stale and must be removed (otherwise it permanently exempts a real
+        // future regression in the same file). If a file no longer exists, the path is
+        // wrong.
+        var srcRoot = FindSourceRoot();
+        var stale = new List<string>();
+
+        foreach (var relative in s_allowlist)
+        {
+            var full = Path.Combine(srcRoot, relative);
+            if (!File.Exists(full))
+            {
+                stale.Add($"{relative} — file does not exist (delete this allowlist entry)");
+                continue;
+            }
+
+            var stripped = StripComments(File.ReadAllText(full));
+            if (FindNullableHandlingShapes(stripped).Count == 0)
+            {
+                stale.Add($"{relative} — file no longer trips the fence (delete this allowlist entry)");
+            }
+        }
+
+        stale.ShouldBeEmpty(
+            "Allowlist hygiene: every entry must still match an existing file AND still " +
+            "trip the fence; otherwise it grants a permanent exemption to future " +
+            "regressions in the same file.\nStale entries:\n  " + string.Join("\n  ", stale));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReverts()
+    {
+        // If P9-B-2 were reverted to `ConversationId?` and a caller wrote a typical null
+        // check, the fence must trip. This synthetic input mirrors what a regression PR
+        // would look like — guard against the fence going silent under a refactor.
+        var syntheticRevertShapes = new[]
+        {
+            "if (session.ConversationId is null) { stamp(session); }",
+            "if (session.ConversationId is not null) return;",
+            "var cid = session.ConversationId?.Value;",
+            "if (session.ConversationId == null) throw new Exception();",
+            "if (session.ConversationId != null) Console.WriteLine(\"set\");",
+            "if (session.ConversationId.HasValue) Use(session.ConversationId.Value);",
+        };
+
+        foreach (var shape in syntheticRevertShapes)
+        {
+            FindNullableHandlingShapes(StripComments(shape)).Count.ShouldBeGreaterThan(
+                0,
+                $"Vacuity guard: the fence must detect the canonical revert shape `{shape}`. " +
+                "If this assertion fails, the regex no longer recognises the very pattern it " +
+                "exists to prevent.");
+        }
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedNullChecksAndMembers()
+    {
+        // Banned shapes are scoped to a `ConversationId` member access. Independent null
+        // checks on other members and `ConversationId` mentions inside parameter or type
+        // declarations must not trip the fence.
+        var cleanShapes = new[]
+        {
+            // Different member with the same shape.
+            "if (session.AgentId is null) return;",
+            "var sid = session.SessionId?.Value;",
+            // Parameter/type declaration — the type token itself, not a runtime check.
+            "public void Resolve(ConversationId conversationId) { }",
+            "public ConversationId? FindConversation() => null;",
+            // The legitimate post-P9-B-2 read site — bare member access, no nullable shape.
+            "var cid = session.ConversationId;",
+            "store.GetByConversationAsync(session.ConversationId, ct);",
+            // IsInitialized() is the sanctioned sentinel check — must NOT be banned.
+            "if (session.ConversationId.IsInitialized()) return;",
+            "if (!session.ConversationId.IsInitialized()) StampLegacy(session);",
+        };
+
+        foreach (var shape in cleanShapes)
+        {
+            FindNullableHandlingShapes(StripComments(shape)).Count.ShouldBe(
+                0,
+                $"False-positive guard: shape `{shape}` is legitimate and must not trip the " +
+                "fence. If this fails, the regex is too broad — adjust the pattern, not the " +
+                "calling code.");
+        }
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        // Comments and XML docs that mention the banned shape for historical reference
+        // (e.g. documenting the migration) must not trip the fence — the comment-stripping
+        // lexer removes them before regex matching.
+        const string syntheticClean = """
+            /// <summary>
+            /// Pre-P9-B-2, the legacy code was: if (session.ConversationId is null) backfill();
+            /// Post-P9-B-2: use ConversationId.IsInitialized() for the sentinel discriminator.
+            /// </summary>
+            public void Documented(GatewaySession session) => Use(session.ConversationId);
+            // Historical: session.ConversationId.HasValue used to gate the orphan branch.
+            /* Block comment: session.ConversationId == null was the legacy null check. */
+            """;
+
+        FindNullableHandlingShapes(StripComments(syntheticClean)).Count.ShouldBe(
+            0,
+            "False-positive guard: XML doc, line comments, and block comments referencing " +
+            "the banned shapes for historical context must not trip the fence. If this fails, " +
+            "the comment-stripping lexer has regressed.");
+    }
+
+    /// <summary>
+    /// Detects the six banned nullable-handling shapes around a <c>ConversationId</c>
+    /// member access. The regex is intentionally scoped to <c>ConversationId</c> as the
+    /// member name immediately preceding the nullable operator so unrelated null checks
+    /// on other properties (e.g. <c>AgentId is null</c>) do not match.
+    /// </summary>
+    private static IReadOnlyList<string> FindNullableHandlingShapes(string source)
+    {
+        var matches = new List<string>();
+
+        // `ConversationId is null` / `ConversationId is not null`
+        foreach (Match m in Regex.Matches(source, @"\bConversationId\s+is\s+(?:not\s+)?null\b"))
+            matches.Add(m.Value.Trim());
+
+        // `ConversationId == null` / `ConversationId != null`
+        foreach (Match m in Regex.Matches(source, @"\bConversationId\s*[!=]=\s*null\b"))
+            matches.Add(m.Value.Trim());
+
+        // `ConversationId.HasValue` — Nullable<T>.HasValue accessor.
+        foreach (Match m in Regex.Matches(source, @"\bConversationId\.HasValue\b"))
+            matches.Add(m.Value.Trim());
+
+        // `ConversationId?.Value` — null-conditional access on a nullable shape.
+        foreach (Match m in Regex.Matches(source, @"\bConversationId\?\."))
+            matches.Add(m.Value.Trim());
+
+        return matches;
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar);
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Identical lexer to
+    /// <c>SingleShotWireValueArchitectureTests.StripComments</c> (PR #569) and
+    /// <c>GatewaySessionFacadeArchitectureTests.StripComments</c> (PR #571).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                if (i + 1 < n)
+                {
+                    i += 2;
+                }
+                else
+                {
+                    i = n;
+                }
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -97,8 +97,8 @@ public sealed class DefaultConversationRouterTests
 
         var session = await sessionStore.GetAsync(result.SessionId);
         session.ShouldNotBeNull();
-        session!.Session.ConversationId.ShouldNotBeNull();
-        session.Session.ConversationId!.Value.ShouldBe(result.Conversation.ConversationId);
+        session!.Session.ConversationId.IsInitialized().ShouldBeTrue();
+        session.Session.ConversationId.ShouldBe(result.Conversation.ConversationId);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeConversationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeConversationTests.cs
@@ -255,7 +255,7 @@ public sealed class AgentExchangeConversationTests
         sessions.ShouldHaveSingleItem();
         sessions[0].Status.ShouldBe(GatewaySessionStatus.Sealed,
             customMessage: "Failure path must still seal the session — no half-active orphans.");
-        sessions[0].Session.ConversationId.ShouldNotBeNull(
+        sessions[0].Session.ConversationId.IsInitialized().ShouldBeTrue(
             customMessage: "Even on failure the child session must carry its ConversationId, " +
                 "otherwise the bug is reintroduced behind the catch block.");
 
@@ -263,7 +263,7 @@ public sealed class AgentExchangeConversationTests
         conversations.ShouldHaveSingleItem(
             customMessage: "Conversation must persist on failure too — losing the convo on " +
                 "failure would mean the error transcript is unrecoverable.");
-        conversations[0].ConversationId.ShouldBe(sessions[0].Session.ConversationId!.Value);
+        conversations[0].ConversationId.ShouldBe(sessions[0].Session.ConversationId);
     }
 
     [Fact]
@@ -358,7 +358,7 @@ public sealed class AgentExchangeConversationTests
 
         var session = await sessionStore.GetAsync(result.SessionId);
         session.ShouldNotBeNull();
-        session!.Session.ConversationId!.Value.ShouldBe(result.ConversationId,
+        session!.Session.ConversationId.ShouldBe(result.ConversationId,
             customMessage: "result.ConversationId must match what was actually pinned — " +
                 "otherwise callers chase a phantom id that never lands in the store.");
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentEagerConversationPinTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentEagerConversationPinTests.cs
@@ -127,10 +127,10 @@ public sealed class SubAgentEagerConversationPinTests
 
         // Assert: the moment SpawnAsync returns, the child session must already be
         // pinned to the parent conversation. NO Task.Delay needed.
-        pinnedSession.Session.ConversationId.ShouldNotBeNull(
+        pinnedSession.Session.ConversationId.IsInitialized().ShouldBeTrue(
             "After SpawnAsync returns, the child session must already be bound to the parent conversation. " +
             "If you needed Task.Delay(...) here, pinning is still lazy and the orphan-window bug remains.");
-        pinnedSession.Session.ConversationId!.Value.Value.ShouldBe("conv-99");
+        pinnedSession.Session.ConversationId.Value.ShouldBe("conv-99");
     }
 
     [Fact]
@@ -147,7 +147,7 @@ public sealed class SubAgentEagerConversationPinTests
         sessionStore
             .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
             .Callback<GatewaySession, CancellationToken>((sess, _) =>
-                events.Add($"pin:{sess.Session.ConversationId?.Value ?? "<null>"}"))
+                events.Add($"pin:{(sess.Session.ConversationId.IsInitialized() ? sess.Session.ConversationId.Value : "<unset>")}"))
             .Returns(Task.CompletedTask);
 
         var promptInvoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -339,7 +339,7 @@ public sealed class ConversationsControllerHistoryTests
         var listResult = await controller.List("assistant", CancellationToken.None);
         var list = (listResult as OkObjectResult)?.Value as IReadOnlyList<ConversationSummary>;
         list.ShouldNotBeNull();
-        list!.ShouldNotContain(summary => summary.ConversationId == conversationId);
+        list!.ShouldNotContain(summary => summary.ConversationId == conversationId.Value);
 
         var sessionsController = new SessionsController(sessions);
         var defaultSessionsResult = await sessionsController.List("assistant", cancellationToken: CancellationToken.None);

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -412,7 +412,7 @@ public sealed class CrossWorldFederationControllerTests
         stored[0].Status.ShouldBe(GatewaySessionStatus.Sealed,
             customMessage: "Failure must seal the session — otherwise it lingers as Active and " +
                 "blocks new relays from reusing the binding/agent slot.");
-        stored[0].Session.ConversationId.ShouldNotBeNull(
+        stored[0].Session.ConversationId.IsInitialized().ShouldBeTrue(
             customMessage: "Even on failure the session must keep its ConversationId — losing it " +
                 "in the catch block re-introduces the orphan bug.");
 

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -1,7 +1,9 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
@@ -28,18 +30,20 @@ public sealed class FileSessionStoreTests
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-with-conv"));
 
         reloaded.ShouldNotBeNull();
-        reloaded.Session.ConversationId.ShouldNotBeNull(
+        reloaded.Session.ConversationId.IsInitialized().ShouldBeTrue(
             "FileSessionStore lost ConversationId on round-trip — sessions go orphan on restart (F-7)");
-        reloaded.Session.ConversationId!.Value.ShouldBe(
+        reloaded.Session.ConversationId.ShouldBe(
             conversationId,
             "FileSessionStore corrupted ConversationId on round-trip");
     }
 
     [Fact]
-    public async Task SaveAsync_PreservesNullConversationId_AcrossReload()
+    public async Task SaveAsync_UnsetConversationId_BackfillsLegacyOnRoundTrip()
     {
-        // Companion to the above — a session saved with null ConversationId must
-        // round-trip as null (not as some sentinel string, not as an exception).
+        // Phase 9 / P9-B-2 (#627): Session.ConversationId is non-nullable. The historical
+        // "null round-trip" behaviour is replaced by the resolver-backed backfill: an unset
+        // ConversationId on save is stamped with the agent's legacy:{agentId} conversation
+        // before the sidecar is written, and round-trips as that stamped value.
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
 
@@ -49,7 +53,8 @@ public sealed class FileSessionStoreTests
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-no-conv"));
 
         reloaded.ShouldNotBeNull();
-        reloaded.Session.ConversationId.ShouldBeNull();
+        reloaded.Session.ConversationId.IsInitialized().ShouldBeTrue(
+            "Unset ConversationId must be backfilled by the legacy resolver on save (#627).");
     }
 
     [Fact]
@@ -526,13 +531,15 @@ public sealed class FileSessionStoreTests
                 "FileSessionStoreTests",
                 Guid.NewGuid().ToString("N"));
             FileSystem.Directory.CreateDirectory(StorePath);
+            Conversations = new InMemoryConversationStore();
         }
 
         public string StorePath { get; }
         public MockFileSystem FileSystem { get; }
+        public InMemoryConversationStore Conversations { get; }
 
-        public FileSessionStore CreateStore()
-            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem);
+        public FileSessionStore CreateStore(IConversationStore? conversationStore = null)
+            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem, conversationStore ?? Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -1686,8 +1686,8 @@ public sealed class GatewayHostTests
 
         var savedSession = await sessions.GetAsync(expectedSessionId, CancellationToken.None);
         savedSession.ShouldNotBeNull();
-        savedSession!.Session.ConversationId.ShouldNotBeNull("Session.ConversationId must be stamped after inbound message");
-        savedSession.Session.ConversationId!.Value.Value.ShouldBe("c_stamptest1");
+        savedSession!.Session.ConversationId.IsInitialized().ShouldBeTrue("Session.ConversationId must be stamped after inbound message");
+        savedSession.Session.ConversationId.Value.ShouldBe("c_stamptest1");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
@@ -163,17 +163,36 @@ public sealed class GatewaySessionBehaviorSnapshotTests
     }
 
     [Fact]
-    public void ConversationId_ProxyAcceptsNull_ForOrphanSessions()
+    public void ConversationId_DefaultsToUninitialized_OnNewSession()
     {
+        // Phase 9 / P9-B-2 (#627): Session.ConversationId is non-nullable. A brand-new
+        // session has an UNINITIALIZED ConversationId (the unset sentinel) until either
+        // the legacy resolver fires on save or the conversation router stamps it.
+        // IsInitialized() is the typed predicate; we never compare to `default(ConversationId)`
+        // literally (banned by Vogen analyzer VOG009).
         var session = CreateSession();
-        session.ConversationId = ConversationId.From("conv-set");
-        session.ConversationId = null;
 
-        session.ConversationId.ShouldBeNull(
-            "F-9 / Phase 7: the ConversationId proxy must accept null assignment for " +
-            "orphan / legacy ungrouped sessions. If this fails, the proxy lost null-" +
-            "tolerance and callers cannot clear the binding.");
-        session.Session.ConversationId.ShouldBeNull();
+        session.ConversationId.IsInitialized().ShouldBeFalse(
+            "F-9 / Phase 9: a freshly constructed GatewaySession must expose an " +
+            "uninitialized ConversationId so the storage layer can detect it and " +
+            "backfill the legacy conversation. If this fails, the unset sentinel " +
+            "has been lost.");
+        session.Session.ConversationId.IsInitialized().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ConversationId_AssignedValue_IsInitialized()
+    {
+        // Phase 9 / P9-B-2 (#627): when a ConversationId has been stamped on the session,
+        // IsInitialized() returns true and Value.Value is the assigned string.
+        var session = CreateSession();
+        var convId = ConversationId.From("conv-pinned");
+
+        session.ConversationId = convId;
+
+        session.ConversationId.IsInitialized().ShouldBeTrue();
+        session.ConversationId.ShouldBe(convId);
+        session.Session.ConversationId.ShouldBe(convId);
     }
 
     private static GatewaySession CreateSession()

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
@@ -2,8 +2,10 @@ using BotNexus.Domain.Primitives;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
@@ -579,9 +581,10 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         public string DirectoryPath { get; }
         public string DatabasePath { get; }
         public string ConnectionString { get; }
+        public InMemoryConversationStore Conversations { get; } = new();
 
         public SqliteSessionStore CreateStore()
-            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance);
+            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance, Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
@@ -138,7 +138,7 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
         var session = await sessionStore.GetAsync(SessionId.From(sessionId), cts.Token);
 
         session.ShouldNotBeNull();
-        session!.Session.ConversationId.ShouldNotBeNull(
+        session!.Session.ConversationId.IsInitialized().ShouldBeTrue(
             "SendMessage without explicit conversationId should still stamp the session with the default conversation's ID");
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
@@ -83,8 +83,8 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
 
         firstSession.ShouldNotBeNull();
         secondSession.ShouldNotBeNull();
-        firstSession!.Session.ConversationId.ShouldNotBeNull("first connection must resolve a conversation; #441");
-        secondSession!.Session.ConversationId.ShouldNotBeNull("reconnect must resolve a conversation; #441");
+        firstSession!.Session.ConversationId.IsInitialized().ShouldBeTrue("first connection must resolve a conversation; #441");
+        secondSession!.Session.ConversationId.IsInitialized().ShouldBeTrue("reconnect must resolve a conversation; #441");
         secondSession.Session.ConversationId.ShouldBe(
             firstSession.Session.ConversationId,
             "reconnect must resolve to the same conversation as the original session; #441");
@@ -221,8 +221,8 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
 
         novaSession.ShouldNotBeNull();
         quillSession.ShouldNotBeNull();
-        novaSession!.Session.ConversationId.ShouldNotBeNull("nova send must resolve a conversation");
-        quillSession!.Session.ConversationId.ShouldNotBeNull("quill send must resolve a conversation");
+        novaSession!.Session.ConversationId.IsInitialized().ShouldBeTrue("nova send must resolve a conversation");
+        quillSession!.Session.ConversationId.IsInitialized().ShouldBeTrue("quill send must resolve a conversation");
         quillSession.Session.ConversationId.ShouldNotBe(
             novaSession.Session.ConversationId,
             "agent switch must route into the new agent's conversation, not the previous agent's; #314");

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
@@ -161,11 +161,11 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
         var targetedSession = await sessionStore.GetAsync(SessionId.From(newSessionId), cts.Token);
         defaultSession.ShouldNotBeNull();
         targetedSession.ShouldNotBeNull();
-        defaultSession!.Session.ConversationId.ShouldNotBeNull();
-        targetedSession!.Session.ConversationId.ShouldNotBeNull();
+        defaultSession!.Session.ConversationId.IsInitialized().ShouldBeTrue();
+        targetedSession!.Session.ConversationId.IsInitialized().ShouldBeTrue();
         targetedSession.Session.ConversationId.ShouldNotBe(defaultSession.Session.ConversationId,
             "targeted conversation should preserve a distinct ConversationId on its resolved session");
-        targetedSession.Session.ConversationId!.Value.Value.ShouldBe(newConvId,
+        targetedSession.Session.ConversationId.Value.ShouldBe(newConvId,
             "resolved session should keep the requested conversationId");
 
         // And the dispatched message for the new conversation should carry the conversationId

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreBaseContractTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreBaseContractTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
@@ -202,13 +203,14 @@ public sealed class SessionStoreBaseContractTests
     private sealed class SqliteHarness : IStoreHarness
     {
         private readonly string _directoryPath;
+        private readonly InMemoryConversationStore _conversations = new();
 
         public SqliteHarness()
         {
             _directoryPath = Path.Combine(AppContext.BaseDirectory, "SessionStoreBaseContractTests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_directoryPath);
             var dbPath = Path.Combine(_directoryPath, "sessions.db");
-            Store = new SqliteSessionStore($"Data Source={dbPath};Pooling=False", NullLogger<SqliteSessionStore>.Instance);
+            Store = new SqliteSessionStore($"Data Source={dbPath};Pooling=False", NullLogger<SqliteSessionStore>.Instance, _conversations);
         }
 
         public ISessionStore Store { get; }

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
@@ -2,6 +2,7 @@ using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
@@ -242,13 +243,14 @@ public sealed class SessionStoreExistenceQueryTests
     private sealed class SqliteHarness : IStoreHarness
     {
         private readonly string _directoryPath;
+        private readonly InMemoryConversationStore _conversations = new();
 
         public SqliteHarness()
         {
             _directoryPath = Path.Combine(AppContext.BaseDirectory, "SessionStoreExistenceQueryTests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_directoryPath);
             var dbPath = Path.Combine(_directoryPath, "sessions.db");
-            Store = new SqliteSessionStore($"Data Source={dbPath};Pooling=False", NullLogger<SqliteSessionStore>.Instance);
+            Store = new SqliteSessionStore($"Data Source={dbPath};Pooling=False", NullLogger<SqliteSessionStore>.Instance, _conversations);
         }
 
         public ISessionStore Store { get; }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Conversations;
@@ -39,13 +40,13 @@ public sealed class LegacyConversationBackfillTests
         var sessionId = SessionId.From("s-in-memory-orphan");
 
         var session = await store.GetOrCreateAsync(sessionId, agentId);
-        session.ConversationId.ShouldBeNull();
+        session.ConversationId.IsInitialized().ShouldBeFalse();
         await store.SaveAsync(session);
 
-        session.ConversationId.ShouldNotBeNull();
+        session.ConversationId.IsInitialized().ShouldBeTrue();
         var legacy = (await conversations.ListAsync(agentId))
             .Single(c => c.Title == $"legacy:{agentId.Value}");
-        session.ConversationId!.Value.ShouldBe(legacy.ConversationId);
+        session.ConversationId.ShouldBe(legacy.ConversationId);
     }
 
     [Fact]
@@ -62,7 +63,7 @@ public sealed class LegacyConversationBackfillTests
         session.ConversationId = bound;
         await store.SaveAsync(session);
 
-        session.ConversationId!.Value.ShouldBe(bound);
+        session.ConversationId.ShouldBe(bound);
         var legacies = (await conversations.ListAsync(agentId))
             .Where(c => c.Title == $"legacy:{agentId.Value}")
             .ToList();
@@ -72,14 +73,17 @@ public sealed class LegacyConversationBackfillTests
     }
 
     [Fact]
-    public async Task InMemory_SaveAsync_NoResolver_PreservesNullConversationId()
+    public async Task InMemory_SaveAsync_NoResolver_PreservesUnsetConversationId()
     {
         // Back-compat for test composition roots that don't wire IConversationStore.
+        // Without a resolver the InMemory store has nothing to backfill against, so the
+        // ConversationId stays uninitialized. (SQLite fails loud in the same scenario —
+        // see Sqlite_SaveAsync_NoResolver_ThrowsInvalidOperation.)
         var store = new InMemorySessionStore();
         var session = await store.GetOrCreateAsync(SessionId.From("s-no-resolver"), AgentId.From("a"));
         await store.SaveAsync(session);
 
-        session.ConversationId.ShouldBeNull();
+        session.ConversationId.IsInitialized().ShouldBeFalse();
     }
 
     [Fact]
@@ -98,7 +102,7 @@ public sealed class LegacyConversationBackfillTests
         }));
         await Task.WhenAll(sessions.Select(s => store.SaveAsync(s)));
 
-        var stampedIds = sessions.Select(s => s.ConversationId!.Value).Distinct().ToList();
+        var stampedIds = sessions.Select(s => s.ConversationId).Distinct().ToList();
         stampedIds.Count.ShouldBe(1);
         (await conversations.ListAsync(agentId))
             .Count(c => c.Title == $"legacy:{agentId.Value}")
@@ -118,7 +122,7 @@ public sealed class LegacyConversationBackfillTests
         var session = await store.GetOrCreateAsync(SessionId.From("s-file-orphan"), agentId);
         await store.SaveAsync(session);
 
-        session.ConversationId.ShouldNotBeNull();
+        session.ConversationId.IsInitialized().ShouldBeTrue();
 
         // Reload from a fresh store instance against the same disk fixture — the stamp
         // must survive without re-invoking the resolver.
@@ -141,39 +145,43 @@ public sealed class LegacyConversationBackfillTests
         var preStore = fixture.CreateStore(conversationStore: null);
         var prePhase9 = await preStore.GetOrCreateAsync(SessionId.From("s-orphan-side"), agentId);
         await preStore.SaveAsync(prePhase9);
-        prePhase9.ConversationId.ShouldBeNull();
+        prePhase9.ConversationId.IsInitialized().ShouldBeFalse();
 
         // Now load through a Phase-9-aware store; the load path must backfill.
         var loadStore = fixture.CreateStore(conversations);
         var loaded = await loadStore.GetAsync(SessionId.From("s-orphan-side"));
         loaded.ShouldNotBeNull();
-        loaded!.ConversationId.ShouldNotBeNull();
+        loaded!.ConversationId.IsInitialized().ShouldBeTrue();
         var legacy = (await conversations.ListAsync(agentId))
             .Single(c => c.Title == $"legacy:{agentId.Value}");
-        loaded.ConversationId!.Value.ShouldBe(legacy.ConversationId);
+        loaded.ConversationId.ShouldBe(legacy.ConversationId);
 
         // A third store instance (no cache; no resolver) must still see the durable stamp
         // — proves the load path rewrote the sidecar, not just the in-memory projection.
         var verifyStore = fixture.CreateStore(conversationStore: null);
         var reverified = await verifyStore.GetAsync(SessionId.From("s-orphan-side"));
         reverified.ShouldNotBeNull();
-        reverified!.ConversationId.ShouldNotBeNull(
+        reverified!.ConversationId.IsInitialized().ShouldBeTrue(
             "Load-time backfill must rewrite the sidecar so a resolver-less store " +
             "still observes the stamp — otherwise every load round-trips through the " +
             "conversation store.");
-        reverified.ConversationId!.Value.ShouldBe(legacy.ConversationId);
+        reverified.ConversationId.ShouldBe(legacy.ConversationId);
     }
 
     [Fact]
-    public async Task File_SaveAsync_NoResolver_PreservesNullConversationId()
+    public async Task File_SaveAsync_NoResolver_PreservesUnsetConversationId()
     {
+        // Back-compat for test composition roots / older deployments that don't wire an
+        // IConversationStore into the File session store. Without a resolver, orphan
+        // sessions stay unset. (SQLite fails loud in the same scenario — see
+        // Sqlite_SaveAsync_NoResolver_ThrowsInvalidOperation.)
         using var fixture = new FileFixture();
         var store = fixture.CreateStore(conversationStore: null);
         var session = await store.GetOrCreateAsync(SessionId.From("s-no-conv"), AgentId.From("a"));
         await store.SaveAsync(session);
 
         var reloaded = await fixture.CreateStore(conversationStore: null).GetAsync(SessionId.From("s-no-conv"));
-        reloaded!.ConversationId.ShouldBeNull();
+        reloaded!.ConversationId.IsInitialized().ShouldBeFalse();
     }
 
     // --- SqliteSessionStore (save-time + load-time + UPDATE row) ---
@@ -189,14 +197,14 @@ public sealed class LegacyConversationBackfillTests
         var session = await store.GetOrCreateAsync(SessionId.From("s-sqlite-orphan"), agentId);
         await store.SaveAsync(session);
 
-        session.ConversationId.ShouldNotBeNull();
+        session.ConversationId.IsInitialized().ShouldBeTrue();
         var legacy = (await conversations.ListAsync(agentId))
             .Single(c => c.Title == $"legacy:{agentId.Value}");
 
         // Brand-new store (no cache) — the stamp must be persisted at the row level.
         var verifyStore = fixture.CreateStore(conversationStore: null);
         var reloaded = await verifyStore.GetAsync(SessionId.From("s-sqlite-orphan"));
-        reloaded!.ConversationId!.Value.ShouldBe(legacy.ConversationId);
+        reloaded!.ConversationId.ShouldBe(legacy.ConversationId);
     }
 
     [Fact]
@@ -209,17 +217,16 @@ public sealed class LegacyConversationBackfillTests
         var conversations = new InMemoryConversationStore();
         var agentId = AgentId.From("agent-sqlite-listby");
 
-        // 1) Save an orphan row via a no-resolver store (simulates pre-Phase-9 state).
-        var orphanStore = fixture.CreateStore(conversationStore: null);
-        var orphan = await orphanStore.GetOrCreateAsync(SessionId.From("s-orphan-row"), agentId);
-        await orphanStore.SaveAsync(orphan);
+        // 1) Seed an orphan row directly (simulates pre-Phase-9 state on disk; bypasses
+        // the post-P9-B-2 fail-loud writer that would refuse to persist an unset row).
+        await fixture.SeedOrphanRowAsync(SessionId.From("s-orphan-row"), agentId);
 
         // 2) Reload through a Phase-9-aware store. The instance LoadSessionAsync path
         // must call BackfillLoadedSessionAsync which UPDATEs the row.
         var phase9Store = fixture.CreateStore(conversations);
         var reloaded = await phase9Store.GetAsync(SessionId.From("s-orphan-row"));
         reloaded.ShouldNotBeNull();
-        reloaded!.ConversationId.ShouldNotBeNull();
+        reloaded!.ConversationId.IsInitialized().ShouldBeTrue();
         var legacy = (await conversations.ListAsync(agentId))
             .Single(c => c.Title == $"legacy:{agentId.Value}");
 
@@ -245,28 +252,28 @@ public sealed class LegacyConversationBackfillTests
         session.ConversationId = bound;
         await store.SaveAsync(session);
 
-        session.ConversationId!.Value.ShouldBe(bound);
+        session.ConversationId.ShouldBe(bound);
         (await conversations.ListAsync(agentId))
             .Where(c => c.Title == $"legacy:{agentId.Value}")
             .ShouldBeEmpty();
     }
 
     [Fact]
-    public async Task Sqlite_SaveAsync_NoResolver_PreservesNullConversationId()
+    public async Task Sqlite_SaveAsync_NoResolver_ThrowsInvalidOperation()
     {
-        // Back-compat for test composition roots / older deployments that don't wire an
-        // IConversationStore into the SQLite session store. Without a resolver, orphan
-        // sessions stay orphan (no stamping). Plan-vs-impl SHOULD-CONSIDER #3.
+        // Phase 9 / P9-B-2 (#627): the SQLite writer is the durable backstop and must
+        // fail loud when no resolver is configured and the session has no ConversationId.
+        // Silently writing NULL would re-introduce the orphan condition the non-nullable
+        // flip is supposed to prevent. (InMemory + File still tolerate this because they
+        // are typically used in tests / lightweight composition roots where missing
+        // ConversationIds are surfaced elsewhere.)
         using var fixture = new SqliteFixture();
         var store = fixture.CreateStore(conversationStore: null);
         var session = await store.GetOrCreateAsync(SessionId.From("s-sq-no-resolver"), AgentId.From("a"));
-        await store.SaveAsync(session);
 
-        session.ConversationId.ShouldBeNull();
-
-        // Reloading through another no-resolver store must still observe null.
-        var reload = await fixture.CreateStore(conversationStore: null).GetAsync(SessionId.From("s-sq-no-resolver"));
-        reload!.ConversationId.ShouldBeNull();
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => store.SaveAsync(session));
+        ex.Message.ShouldContain("ConversationId");
+        ex.Message.ShouldContain("s-sq-no-resolver");
     }
 
     // --- Cross-store parity ---
@@ -305,9 +312,9 @@ public sealed class LegacyConversationBackfillTests
             .ToList();
         legacies.Count.ShouldBe(1, "All stores must converge on the same legacy conversation per agent.");
         var legacyId = legacies[0].ConversationId;
-        inMemSession.ConversationId!.Value.ShouldBe(legacyId);
-        fileSession.ConversationId!.Value.ShouldBe(legacyId);
-        sqliteSession.ConversationId!.Value.ShouldBe(legacyId);
+        inMemSession.ConversationId.ShouldBe(legacyId);
+        fileSession.ConversationId.ShouldBe(legacyId);
+        sqliteSession.ConversationId.ShouldBe(legacyId);
     }
 
     // --- ActiveSessionId binding (Hub reset regression for #615) ---
@@ -415,7 +422,7 @@ public sealed class LegacyConversationBackfillTests
         refreshedLegacy.ActiveSessionId.ShouldBe(firstId,
             "Stamping a second Active orphan must not clobber the existing " +
             "ActiveSessionId pointer — concurrency invariant.");
-        secondSession.ConversationId!.Value.ShouldBe(legacy.ConversationId,
+        secondSession.ConversationId.ShouldBe(legacy.ConversationId,
             "But the second orphan still gets stamped with the legacy conversation id.");
     }
 
@@ -457,6 +464,37 @@ public sealed class LegacyConversationBackfillTests
         public SqliteSessionStore CreateStore(IConversationStore? conversationStore)
             => new(_connectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore);
 
+        /// <summary>
+        /// Seeds an orphan session row (conversation_id = NULL) by writing directly via
+        /// raw SQL. Post-P9-B-2, the SqliteSessionStore writer fails loud on unset
+        /// ConversationId — but the load-time backfill path must still handle pre-Phase-9
+        /// rows that already exist on disk. Use this helper to construct the pre-existing
+        /// orphan state that the backfill is designed to repair.
+        /// </summary>
+        public async Task SeedOrphanRowAsync(SessionId sessionId, AgentId agentId)
+        {
+            // Ensure schema exists by spinning up a normal store (ListAsync triggers
+            // EnsureCreatedAsync). SqliteSessionStore holds no per-instance disposable
+            // state — the schema lives on disk and connections come from the pool.
+            var bootstrap = CreateStore(conversationStore: null);
+            _ = await bootstrap.ListAsync();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO sessions (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
+                VALUES ($id, $agentId, NULL, NULL, $sessionType, '[]', $status, '{}', $createdAt, $updatedAt, NULL)
+                """;
+            cmd.Parameters.AddWithValue("$id", sessionId.Value);
+            cmd.Parameters.AddWithValue("$agentId", agentId.Value);
+            cmd.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
+            cmd.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
+            cmd.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToString("O"));
+            cmd.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
+            await cmd.ExecuteNonQueryAsync();
+        }
+
         public void Dispose()
         {
             try
@@ -473,5 +511,245 @@ public sealed class LegacyConversationBackfillTests
             }
             catch (IOException) { /* cleanup best effort */ }
         }
+    }
+
+    // --- FileSessionStore eager startup sweep (P9-B-2 / #627) ---
+    //
+    // The sweep runs once per process (via SemaphoreSlim + bool flag) on the first
+    // GetAsync / GetOrCreateAsync / SaveAsync / EnumerateSessionsAsync call. It mirrors
+    // SqliteSessionStore.MigrateOrphanedSessionsAsync: pre-Phase-9 orphan sidecars on
+    // disk get stamped with the agent's legacy:{agentId} conversation, and the most-
+    // recently-updated Active orphan per agent is bound as the legacy conversation's
+    // ActiveSessionId.
+
+    [Fact]
+    public async Task File_EagerSweep_BindsMostRecentlyUpdatedActiveOrphan_AsConversationActiveSession()
+    {
+        // Seed three orphan sidecars for the same agent at distinct UpdatedAt timestamps
+        // (no conversation store wired, so no stamping happens). Then open a fresh store
+        // WITH a resolver; the first GetAsync triggers EnsureMigratedAsync which must
+        // pick the most-recently-updated Active orphan as the bound ActiveSessionId.
+        using var fixture = new FileFixture();
+        var agentId = AgentId.From("agent-eager-bind");
+
+        var preStore = fixture.CreateStore(conversationStore: null);
+        var oldest = await preStore.GetOrCreateAsync(SessionId.From("s-old"), agentId);
+        oldest.UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-30);
+        await preStore.SaveAsync(oldest);
+
+        var middle = await preStore.GetOrCreateAsync(SessionId.From("s-mid"), agentId);
+        middle.UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-15);
+        await preStore.SaveAsync(middle);
+
+        var newest = await preStore.GetOrCreateAsync(SessionId.From("s-new"), agentId);
+        newest.UpdatedAt = DateTimeOffset.UtcNow;
+        await preStore.SaveAsync(newest);
+
+        // Sanity: all three sidecars are orphans on disk before sweep.
+        oldest.ConversationId.IsInitialized().ShouldBeFalse();
+        middle.ConversationId.IsInitialized().ShouldBeFalse();
+        newest.ConversationId.IsInitialized().ShouldBeFalse();
+
+        var conversations = new InMemoryConversationStore();
+        var sweepStore = fixture.CreateStore(conversations);
+
+        // Trigger sweep — any public method works; pick GetAsync on an arbitrary sidecar.
+        _ = await sweepStore.GetAsync(SessionId.From("s-old"));
+
+        var legacy = (await conversations.ListAsync(agentId))
+            .Single(c => c.Title == $"legacy:{agentId.Value}");
+        legacy.ActiveSessionId.ShouldBe(
+            SessionId.From("s-new"),
+            "Eager sweep must bind the most-recently-updated Active orphan as the legacy " +
+            "conversation's ActiveSessionId — mirrors SqliteSessionStore semantics.");
+
+        // All three sidecars must also be stamped (regardless of which was bound).
+        var verifyStore = fixture.CreateStore(conversationStore: null);
+        var reloadedOld = await verifyStore.GetAsync(SessionId.From("s-old"));
+        var reloadedMid = await verifyStore.GetAsync(SessionId.From("s-mid"));
+        var reloadedNew = await verifyStore.GetAsync(SessionId.From("s-new"));
+        reloadedOld!.ConversationId.ShouldBe(legacy.ConversationId);
+        reloadedMid!.ConversationId.ShouldBe(legacy.ConversationId);
+        reloadedNew!.ConversationId.ShouldBe(legacy.ConversationId);
+    }
+
+    [Fact]
+    public async Task File_EagerSweep_DoesNotBindSealedOrSuspendedOrphans_AsActive()
+    {
+        // The most-recently-updated orphan is Sealed; an older orphan is still Active.
+        // The bind step must skip the Sealed orphan and pin the Active one as
+        // ActiveSessionId — Sealed/Suspended/Expired sessions are history, not live work.
+        // Stamping (the conversation_id field) still applies to all orphans regardless
+        // of status — that's separate from the ActiveSessionId pointer.
+        using var fixture = new FileFixture();
+        var agentId = AgentId.From("agent-eager-status");
+
+        var preStore = fixture.CreateStore(conversationStore: null);
+
+        var olderActive = await preStore.GetOrCreateAsync(SessionId.From("s-active-old"), agentId);
+        olderActive.UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-20);
+        // Status defaults to Active.
+        await preStore.SaveAsync(olderActive);
+
+        var newerSealed = await preStore.GetOrCreateAsync(SessionId.From("s-sealed-new"), agentId);
+        newerSealed.UpdatedAt = DateTimeOffset.UtcNow;
+        newerSealed.Status = SessionStatus.Sealed;
+        await preStore.SaveAsync(newerSealed);
+
+        var conversations = new InMemoryConversationStore();
+        var sweepStore = fixture.CreateStore(conversations);
+        _ = await sweepStore.GetAsync(SessionId.From("s-active-old"));
+
+        var legacy = (await conversations.ListAsync(agentId))
+            .Single(c => c.Title == $"legacy:{agentId.Value}");
+        legacy.ActiveSessionId.ShouldBe(
+            SessionId.From("s-active-old"),
+            "Sealed orphans must NOT be bound as ActiveSessionId even when more recently " +
+            "updated than Active siblings — only Active sessions are live work.");
+
+        // Stamping still applies to the Sealed sidecar — it's part of the conversation
+        // history; the bind decision is independent of the stamp decision.
+        var verifyStore = fixture.CreateStore(conversationStore: null);
+        var reloadedSealed = await verifyStore.GetAsync(SessionId.From("s-sealed-new"));
+        reloadedSealed!.ConversationId.ShouldBe(
+            legacy.ConversationId,
+            "Sealed orphans still get their conversation_id stamped — the sweep treats " +
+            "stamping (membership) and binding (active pointer) as independent decisions.");
+    }
+
+    [Fact]
+    public async Task File_EagerSweep_RunsOnceAcrossConcurrentCallers_NoDuplicateMigration()
+    {
+        // Fire N concurrent first-touch calls on a fresh store and prove the sweep
+        // executes exactly once. Probe via the internal MigrationInvocationCount
+        // counter that increments inside the per-store EnsureMigratedAsync gate;
+        // this is decoupled from any inner resolver ListAsync call counts (the
+        // resolver legitimately issues 1-3 ListAsync calls per sweep depending on
+        // cache state, so counting at the conversation store conflates correctness
+        // with resolver implementation detail).
+        using var fixture = new FileFixture();
+        var agentId = AgentId.From("agent-eager-concurrent");
+
+        // Seed one orphan so the sweep has work to do (otherwise it would short-circuit
+        // before invoking the resolver and the migration would be vacuous).
+        var preStore = fixture.CreateStore(conversationStore: null);
+        var orphan = await preStore.GetOrCreateAsync(SessionId.From("s-concurrent-orphan"), agentId);
+        await preStore.SaveAsync(orphan);
+
+        var conversations = new InMemoryConversationStore();
+        var sweepStore = fixture.CreateStore(conversations);
+
+        // 20 concurrent first-touch calls on the SAME store instance — only one should
+        // execute the sweep; the other 19 must block on _migrationLock and then short
+        // out via _migrated == true.
+        const int concurrency = 20;
+        await Task.WhenAll(Enumerable.Range(0, concurrency).Select(_ =>
+            sweepStore.GetAsync(SessionId.From("s-concurrent-orphan"))));
+
+        sweepStore.MigrationInvocationCount.ShouldBe(
+            1,
+            "Eager sweep must execute exactly once across concurrent first-touch callers. " +
+            $"Observed {sweepStore.MigrationInvocationCount} MigrateOrphanedSessionsAsync " +
+            "invocations (expected 1). If >1, the SemaphoreSlim + _migrated double-check " +
+            "gate has regressed and the sweep is racing itself.");
+
+        // Sanity: the orphan was actually migrated (stamped + bound). If the migration
+        // ran but did nothing, the count assertion alone would be vacuous.
+        var legacy = (await conversations.ListAsync(agentId))
+            .Single(c => c.Title == $"legacy:{agentId.Value}");
+        legacy.ActiveSessionId.ShouldBe(SessionId.From("s-concurrent-orphan"));
+    }
+
+    [Fact]
+    public async Task File_EagerSweep_CancellationDoesNotPoisonSubsequentCalls()
+    {
+        // First caller cancels mid-sweep (we use a delayable conversation store to wedge
+        // the resolver inside the lock). The cancelled attempt MUST NOT set _migrated —
+        // a fresh call with its own token must retry and succeed.
+        using var fixture = new FileFixture();
+        var agentId = AgentId.From("agent-eager-cancel");
+
+        // Seed one orphan so the sweep has work to do.
+        var preStore = fixture.CreateStore(conversationStore: null);
+        var orphan = await preStore.GetOrCreateAsync(SessionId.From("s-cancel-orphan"), agentId);
+        await preStore.SaveAsync(orphan);
+
+        var gate = new DelayableConversationStore(new InMemoryConversationStore());
+        var sweepStore = fixture.CreateStore(gate);
+
+        // First call: cancellation token will be cancelled while the resolver is wedged
+        // inside ListAsync.
+        using var cts = new CancellationTokenSource();
+        var firstCallStarted = gate.NextListAsyncStarted();
+        var firstCall = Task.Run(() => sweepStore.GetAsync(SessionId.From("s-cancel-orphan"), cts.Token));
+
+        // Wait until the resolver has entered ListAsync, then cancel.
+        await firstCallStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+        gate.ReleaseAll();
+
+        var firstException = await Should.ThrowAsync<OperationCanceledException>(() => firstCall);
+        firstException.ShouldNotBeNull();
+
+        // Second call with a fresh token must NOT find a stale _migrated == true and skip;
+        // it must retry the sweep and succeed. Reset the gate so the second call runs
+        // straight through without wedging.
+        gate.ResetGate();
+        gate.ReleaseAll();
+        var second = await sweepStore.GetAsync(SessionId.From("s-cancel-orphan"));
+
+        second.ShouldNotBeNull();
+        second!.ConversationId.IsInitialized().ShouldBeTrue(
+            "Cancellation of the first sweep attempt must not leave _migrated = true. " +
+            "Subsequent callers must retry the sweep with their own token and see the " +
+            "orphan stamped — otherwise a single cancellation poisons the store for the " +
+            "rest of the process lifetime.");
+
+        // Underlying store also has the legacy conversation row created.
+        (await gate.Inner.ListAsync(agentId))
+            .Count(c => c.Title == $"legacy:{agentId.Value}")
+            .ShouldBe(1);
+    }
+
+    // --- Helpers for the eager-sweep tests ---
+
+    /// <summary>
+    /// Wraps an <see cref="IConversationStore"/> with a manually-controlled gate on
+    /// <see cref="ListAsync"/>. Used by the cancellation test to wedge the resolver
+    /// inside its fast-path call so we can deterministically cancel mid-sweep.
+    /// </summary>
+    private sealed class DelayableConversationStore : IConversationStore
+    {
+        public IConversationStore Inner { get; }
+        private TaskCompletionSource<bool> _listAsyncStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource<bool> _releaseGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public DelayableConversationStore(IConversationStore inner) => Inner = inner;
+
+        public Task NextListAsyncStarted() => _listAsyncStarted.Task;
+        public void ReleaseAll() => _releaseGate.TrySetResult(true);
+        public void ResetGate()
+        {
+            _releaseGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _listAsyncStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public async Task<IReadOnlyList<Conversation>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
+        {
+            _listAsyncStarted.TrySetResult(true);
+            await Task.WhenAny(_releaseGate.Task, Task.Delay(Timeout.Infinite, ct)).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            return await Inner.ListAsync(agentId, ct).ConfigureAwait(false);
+        }
+
+        public Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.GetAsync(conversationId, ct);
+        public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default) => Inner.ListForCitizenAsync(citizen, ct);
+        public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default) => Inner.CreateAsync(conversation, ct);
+        public Task SaveAsync(Conversation conversation, CancellationToken ct = default) => Inner.SaveAsync(conversation, ct);
+        public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.ArchiveAsync(conversationId, ct);
+        public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
+            => Inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
+        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+            => Inner.GetSummariesAsync(agentId, ct);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStoreConversationIdTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStoreConversationIdTests.cs
@@ -1,5 +1,7 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Data.Sqlite;
@@ -13,6 +15,7 @@ public sealed class SqliteSessionStoreConversationIdTests : IDisposable
 {
     private readonly string _dbPath;
     private readonly string _connectionString;
+    private readonly InMemoryConversationStore _conversations = new();
 
     public SqliteSessionStoreConversationIdTests()
     {
@@ -55,8 +58,8 @@ public sealed class SqliteSessionStoreConversationIdTests : IDisposable
         }
     }
 
-    private SqliteSessionStore CreateStore()
-        => new(_connectionString, NullLogger<SqliteSessionStore>.Instance);
+    private SqliteSessionStore CreateStore(IConversationStore? conversationStore = null)
+        => new(_connectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore ?? _conversations);
 
     [Fact]
     public async Task SaveAsync_WithConversationId_PersistedAndReloadedAfterStoreRebuild()
@@ -76,26 +79,29 @@ public sealed class SqliteSessionStoreConversationIdTests : IDisposable
         var reloaded = await store2.GetAsync(sessionId);
 
         reloaded.ShouldNotBeNull();
-        reloaded!.Session.ConversationId.ShouldNotBeNull();
-        reloaded.Session.ConversationId!.Value.ShouldBe(conversationId);
+        reloaded!.Session.ConversationId.IsInitialized().ShouldBeTrue();
+        reloaded.Session.ConversationId.ShouldBe(conversationId);
     }
 
     [Fact]
-    public async Task SaveAsync_NullConversationId_LoadsAsNull()
+    public async Task SaveAsync_UnsetConversationId_BackfillsLegacyOnRoundTrip()
     {
+        // Phase 9 / P9-B-2 (#627): Session.ConversationId is non-nullable. Unset values
+        // are stamped by the legacy resolver on save and the UPDATE in BackfillLoadedSessionAsync
+        // makes the row indexed-queryable. Round-trips as a real ConversationId.
         var sessionId = SessionId.From("test-session-no-conv");
         var agentId = AgentId.From("agent-no-conv");
 
         var store1 = CreateStore();
         var session = await store1.GetOrCreateAsync(sessionId, agentId);
-        // ConversationId intentionally left null
         await store1.SaveAsync(session);
 
         var store2 = CreateStore();
         var reloaded = await store2.GetAsync(sessionId);
 
         reloaded.ShouldNotBeNull();
-        reloaded!.Session.ConversationId.ShouldBeNull();
+        reloaded!.Session.ConversationId.IsInitialized().ShouldBeTrue(
+            "Unset ConversationId must be backfilled by the legacy resolver on save (#627).");
     }
 
     [Fact]
@@ -115,7 +121,7 @@ public sealed class SqliteSessionStoreConversationIdTests : IDisposable
         var found = all.FirstOrDefault(s => s.SessionId == sessionId);
 
         found.ShouldNotBeNull();
-        found!.Session.ConversationId.ShouldNotBeNull();
-        found.Session.ConversationId!.Value.ShouldBe(conversationId);
+        found!.Session.ConversationId.IsInitialized().ShouldBeTrue();
+        found.Session.ConversationId.ShouldBe(conversationId);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionsControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionsControllerTests.cs
@@ -1135,8 +1135,8 @@ public sealed class SessionsControllerTests
 
         var okResult = actionResult.Result.ShouldBeOfType<OkObjectResult>();
         var result = okResult!.Value.ShouldBeOfType<GatewaySession>();
-        result.Session.ConversationId.ShouldNotBeNull("ConversationId must be set on the returned session");
-        result.Session.ConversationId!.Value.Value.ShouldBe("c_testconvid456");
+        result.Session.ConversationId.IsInitialized().ShouldBeTrue("ConversationId must be set on the returned session");
+        result.Session.ConversationId.Value.ShouldBe("c_testconvid456");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
@@ -1,6 +1,8 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -110,14 +112,16 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
             Directory.CreateDirectory(DirectoryPath);
             DatabasePath = Path.Combine(DirectoryPath, "sessions.db");
             ConnectionString = $"Data Source={DatabasePath};Pooling=False";
+            Conversations = new InMemoryConversationStore();
         }
 
         public string DirectoryPath { get; }
         public string DatabasePath { get; }
         public string ConnectionString { get; }
+        public InMemoryConversationStore Conversations { get; }
 
-        public SqliteSessionStore CreateStore()
-            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance);
+        public SqliteSessionStore CreateStore(IConversationStore? conversationStore = null)
+            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore ?? Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -1,7 +1,9 @@
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -856,14 +858,21 @@ public sealed class SqliteSessionStoreTests
             Directory.CreateDirectory(DirectoryPath);
             DatabasePath = Path.Combine(DirectoryPath, "sessions.db");
             ConnectionString = $"Data Source={DatabasePath};Pooling=False";
+            Conversations = new InMemoryConversationStore();
         }
 
         public string DirectoryPath { get; }
         public string DatabasePath { get; }
         public string ConnectionString { get; }
 
-        public SqliteSessionStore CreateStore()
-            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance);
+        // Shared across all CreateStore() calls in the same fixture so
+        // legacy-conversation rows resolved by one store instance are visible to
+        // subsequent stores opened on the same SQLite database — required for
+        // the post-P9-B-2 fail-loud "unset ConversationId on save" guard.
+        public InMemoryConversationStore Conversations { get; }
+
+        public SqliteSessionStore CreateStore(IConversationStore? conversationStore = null)
+            => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore ?? Conversations);
 
         public void Dispose()
         {

--- a/tests/scenarios/BotNexus.Scenarios.Harness/VirtualWorld.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/VirtualWorld.cs
@@ -371,7 +371,7 @@ public sealed class VirtualWorld : IAsyncDisposable
         return new SessionView(
             SessionId: snapshot.Session.SessionId.Value,
             AgentId: snapshot.AgentId.Value,
-            ConversationId: snapshot.Session.ConversationId?.Value,
+            ConversationId: snapshot.Session.ConversationId.IsInitialized() ? snapshot.Session.ConversationId.Value : null,
             Status: snapshot.Session.Status.ToString(),
             HistoryCount: snapshot.Session.History.Count);
     }


### PR DESCRIPTION
## Summary

Closes #627. Refs umbrella #613 (P9).

P9-B-2 flips Session.ConversationId from ConversationId? to **non-nullable** ConversationId per maintainer directive G-1: every session in the system MUST belong to a conversation. The unset sentinel default(ConversationId) is short-lived (in-memory construction only) and is distinguished from a stamped value via ConversationId.IsInitialized(). The save path stamps via LegacyConversationResolver before the writer runs; the writer fails loud if it ever sees an uninitialized value.

## Commits

1. `feat(domain)!: flip Session.ConversationId to non-nullable (P9-B-2)` — domain shape change
2. `feat(sessions): SQLite fail-loud guard + save-time ConversationId backfill` — writer enforces invariant, save path stamps via resolver
3. `feat(sessions): FileStore eager startup sweep + pre-bind ordering invariant` — MigrateOrphanedSessionsAsync with pre-bind-most-recent-Active ordering
4. `fix(gateway): use IsInitialized() guard instead of nullable pattern` — 10 callsites that became silent always-true after the flip
5. `test(architecture): pin Session.ConversationId non-nullable invariant` — new arch fitness function (7/7)
6. `test(gateway): migrate fixtures + add eager-sweep tests` — 19 test files migrated + 21 new eager-sweep tests

## The `?.ConversationId is { }` regression we caught

Pre-flip, session.ConversationId is { } convId was a nullable pattern that correctly unwrapped the Some-case. **Post-flip**, the pattern silently became ALWAYS-TRUE because the property is a non-nullable Vogen struct. The orphan-fallback / unset-fallback branches at 10 callsites were unreachable. The hub test `ResetSession_OrphanSession_NoConversation_SealsInPlace_DoesNotArchive` caught this via Moq Strict on `IConversationResetService.ResetActiveSessionAsync` — without that test the regression would have shipped silently.

Fixed pattern is uniform: `session is not null && session.ConversationId.IsInitialized()` then read session.ConversationId directly. The new arch fitness function pins this against revert.

## Critique sweep

- **security-review (gpt-5.5)**: clean. Verified XPIA boundaries, fail-loud DoS surface, CrossWorldFederation 5 ownership invariants, `LegacyConversationResolver` hardening from PR #616 still holds.
- **bug-hunt (gpt-5.3-codex)**: clean. Verified every callsite migrated (zero grep hits on the regression pattern), `MigrationInvocationCount` increments inside the lock-gated path, `InMemoryConversationStore` correctly shared per-fixture, SQLite reload reads from disk not cache, `INSERT INTO sessions` only appears at one writer, Vogen-null sidecar handling correct.

## Validation

- `dotnet build BotNexus.slnx --nologo --tl:off` — **0 warnings / 0 errors** (under `TreatWarningsAsErrors=true`)
- `dotnet test tests/gateway/BotNexus.Gateway.Tests/` — **1995 / 0 / 1-skip** GREEN (skip is #383, unrelated)
- Full slnx test run — only pre-existing flakes documented (Mcp stdio transport timing 6/6 PASS on retry; dotnet-pack CLI cold-run 9/9 PASS on retry; `CompactionFlowTests.SlashCompact_NotifiesUser_NoCronConversation_ContinuesNormally` = pre-existing #618 PR #608 regression, out of scope)
- New arch fitness function `SessionConversationIdNonNullableArchitectureTests` — 7/7 GREEN

## Out of scope (separate follow-ups)

- Cross-process duplicate legacy rows — `(agent_id, title)` unique constraint missing (future work)
- `LegacyConversationResolver` logger wiring through store ctors (future work)
- #618 (PR #608 `/compact` regression — separate issue)
- #626 receiver state-machine quirk (P9-C follow-up)
