### PR TITLE
feat!: collapse SessionType — delete Cron/Soul/Heartbeat values (P9-E, closes #645)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -269,6 +269,20 @@ public sealed record SessionEntry
     /// <summary>When this entry was recorded.</summary>
     public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
 
+    /// <summary>
+    /// Optional proxy-trigger origin for this entry. <c>null</c> for normal
+    /// channel-driven user turns (the default). Internal triggers stamp the
+    /// kind of proxy they are: <see cref="TriggerType.Cron"/> for scheduled
+    /// jobs (proxy for the citizen who scheduled them, per directive W-2),
+    /// <see cref="TriggerType.Soul"/> for daily reflection ticks,
+    /// <see cref="TriggerType.Heartbeat"/> for system liveness checks. The
+    /// trigger lives on the entry — not on the session — because directives
+    /// G-3/G-4 collapse <c>SessionType.Soul/Cron/Heartbeat</c> in P9-E; the
+    /// session is just "what kind of conversation" (AgentSelf, UserAgent,
+    /// AgentSubAgent, AgentAgent) and the trigger is per-turn metadata.
+    /// </summary>
+    public TriggerType? Trigger { get; init; }
+
     /// <summary>Tool name (when Role is <see cref="MessageRole.Tool"/>).</summary>
     public string? ToolName { get; init; }
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Messages.cs
@@ -85,6 +85,16 @@ public sealed record InboundMessage
     /// when the consumer needs to default null to <see cref="InboundMessageRoutingHints.Empty"/>.
     /// </remarks>
     public InboundMessageRoutingHints? RoutingHints { get; init; }
+
+    /// <summary>
+    /// Optional proxy-trigger origin for this message. <c>null</c> for normal
+    /// channel-driven user messages (the default). Internal triggers stamp the
+    /// kind of proxy they are (<see cref="TriggerType.Cron"/>,
+    /// <see cref="TriggerType.Soul"/>, <see cref="TriggerType.Heartbeat"/>) so
+    /// downstream handlers can fan-out the same trigger onto the persisted
+    /// <see cref="SessionEntry.Trigger"/>. See P9-E (#645) / directive G-3.
+    /// </summary>
+    public TriggerType? Trigger { get; init; }
 }
 
 /// <summary>

--- a/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
@@ -32,7 +32,25 @@ public sealed record Session
     /// </summary>
     public SessionStatus Status { get; set; } = SessionStatus.Active;
 
-    public bool IsInteractive => SessionType.Equals(SessionType.UserAgent);
+    /// <summary>
+    /// True for user-facing turns that should drive memory flushes, warmup
+    /// surfacing, and other interactive-only side-effects. Returns <c>false</c>
+    /// when:
+    /// <list type="bullet">
+    /// <item>The session is not a <see cref="SessionType.UserAgent"/> conversation
+    /// (agent-self / sub-agent / agent-agent are all considered non-interactive).</item>
+    /// <item>The session is routed through the <c>cron</c> channel — P9-E (#645)
+    /// collapses <c>SessionType.Cron</c> onto <see cref="SessionType.UserAgent"/>
+    /// (cron is a proxy for the citizen who scheduled the job, per directive W-2),
+    /// so the channel key is the durable cron-vs-interactive signal. Without this
+    /// exclusion <see cref="SessionEndMemoryFlusher"/>/<see cref="PreCompactionMemoryFlusher"/>
+    /// would start firing on every scheduled job.</item>
+    /// </list>
+    /// </summary>
+    public bool IsInteractive =>
+        SessionType.Equals(SessionType.UserAgent)
+        && (!ChannelType.HasValue
+            || !string.Equals(ChannelType.Value.Value, "cron", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Gets or sets the participants.

--- a/src/domain/BotNexus.Domain/Primitives/SessionId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/SessionId.cs
@@ -76,11 +76,6 @@ public readonly partial struct SessionId
     /// </summary>
     public bool IsAgentConversation => Value.Contains("::agent-agent::", StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>
-    /// True when this id matches the <see cref="ForSoul(AgentId, DateOnly)"/> shape.
-    /// </summary>
-    public bool IsSoul => Value.Contains("::soul::", StringComparison.OrdinalIgnoreCase);
-
     private static Validation Validate(string value) =>
         string.IsNullOrWhiteSpace(value)
             ? Validation.Invalid("SessionId cannot be null, empty, or whitespace.")

--- a/src/domain/BotNexus.Domain/Primitives/SessionType.cs
+++ b/src/domain/BotNexus.Domain/Primitives/SessionType.cs
@@ -16,9 +16,22 @@ public sealed class SessionType : IEquatable<SessionType>
     public static readonly SessionType AgentSelf = Register("agent-self");
     public static readonly SessionType AgentSubAgent = Register("agent-subagent");
     public static readonly SessionType AgentAgent = Register("agent-agent");
-    public static readonly SessionType Soul = Register("soul");
-    public static readonly SessionType Cron = Register("cron");
-    public static readonly SessionType Heartbeat = Register("heartbeat");
+
+    /// <summary>
+    /// P9-E (issue #645): legacy persisted values that get remapped at the registry
+    /// layer so <see cref="FromString"/> returns the canonical replacement uniformly
+    /// across every serializer path. <c>"soul"</c> and <c>"heartbeat"</c> were proxy
+    /// triggers stamped onto agent-self sessions; <c>"cron"</c> was a proxy trigger
+    /// for a user-scheduled job. The trigger kind now lives on
+    /// <see cref="BotNexus.Gateway.Abstractions.Models.SessionEntry.Trigger"/>; the
+    /// session itself is just the conversation kind.
+    /// </summary>
+    private static readonly Dictionary<string, SessionType> LegacyAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["soul"] = AgentSelf,
+        ["heartbeat"] = AgentSelf,
+        ["cron"] = UserAgent
+    };
 
     /// <summary>
     /// Gets the value.
@@ -37,7 +50,18 @@ public sealed class SessionType : IEquatable<SessionType>
         if (string.IsNullOrWhiteSpace(value))
             throw new ArgumentException("SessionType cannot be empty", nameof(value));
 
-        return Registry.GetOrAdd(value.Trim().ToLowerInvariant(), static v => new SessionType(v));
+        var normalized = value.Trim().ToLowerInvariant();
+
+        // P9-E (issue #645): transparent legacy-value migration. JSON deserialization,
+        // direct string -> SessionType conversion, and any other read path hit FromString,
+        // so applying the alias map here means every store benefits from the same migration
+        // without a per-store hook. Pre-collapse values "soul"/"heartbeat"/"cron" land on
+        // the canonical replacement (AgentSelf/AgentSelf/UserAgent); the proxy-trigger kind
+        // now lives on SessionEntry.Trigger.
+        if (LegacyAliases.TryGetValue(normalized, out var migrated))
+            return migrated;
+
+        return Registry.GetOrAdd(normalized, static v => new SessionType(v));
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -63,7 +63,11 @@ public sealed class CronTrigger(
         var session = await sessions.GetOrCreateAsync(sessionId, agentId, ct).ConfigureAwait(false);
         session.ChannelType ??= ChannelKey.From(Type.Value);
         session.CallerId ??= $"{Type.Value}:{agentId.Value}";
-        session.SessionType = SessionType.Cron;
+        // P9-E (#645): cron is a proxy for the citizen who scheduled it (directive W-2),
+        // so the session shape is UserAgent — the Cron trigger kind is per-turn and
+        // lives on SessionEntry.Trigger below. Session.IsInteractive excludes the
+        // "cron" channel so memory flushers / warmup still ignore cron sessions.
+        session.SessionType = SessionType.UserAgent;
         session.ConversationId = conversation.ConversationId;
         session.Metadata["triggerType"] = Type.Value;
 
@@ -84,7 +88,15 @@ public sealed class CronTrigger(
             await conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
         }
 
-        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = prompt });
+        // P9-E (#645): stamp Cron on the user entry. Cron is a proxy for the citizen
+        // who scheduled the job — the persisted trigger marks the originating proxy
+        // so audit/UI can render the right badge without sniffing SessionType.
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = prompt,
+            Trigger = TriggerType.Cron
+        });
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);
 
         var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/HeartbeatTrigger.cs
@@ -62,9 +62,12 @@ public sealed class HeartbeatTrigger(
         InternalTriggerRequest? request,
         CancellationToken ct)
     {
+        // P9-E (#645): soul sessions no longer carry SessionType.Soul. Discovery uses
+        // the canonical Metadata["soulDate"] tag that SoulTrigger.InitializeSoulSession
+        // stamps on every soul session, gated on Active status.
         var allSessions = await sessions.ListAsync(agentId, ct).ConfigureAwait(false);
         var soulSession = allSessions
-            .Where(s => s.SessionType == SessionType.Soul && s.Status == GatewaySessionStatus.Active)
+            .Where(s => s.Status == GatewaySessionStatus.Active && s.Metadata.ContainsKey("soulDate"))
             .OrderByDescending(s => s.UpdatedAt)
             .FirstOrDefault();
 
@@ -95,7 +98,9 @@ public sealed class HeartbeatTrigger(
 
         session.ChannelType = null;
         session.CallerId ??= $"heartbeat:{agentId.Value}";
-        session.SessionType = SessionType.Heartbeat;
+        // P9-E (#645): heartbeat is agent-self (the agent pings itself); the Heartbeat
+        // proxy-trigger kind lives on SessionEntry.Trigger below.
+        session.SessionType = SessionType.AgentSelf;
         session.ConversationId = conversation.ConversationId;
         session.Metadata["triggerType"] = Type.Value;
 
@@ -155,8 +160,17 @@ public sealed class HeartbeatTrigger(
         // The heartbeat path (RunInHeartbeatSessionAsync) mints a unique
         // sessionId per run so concurrent activity is impossible; the same
         // shared helper applies harmlessly stricter semantics there.
+        // P9-E (#645): stamp Heartbeat on the user entry. The Phase-2 ack prune
+        // removes both the user and assistant entries when the response is a
+        // pure heartbeat ack, so the Trigger stamp disappears together with the
+        // text — no audit residue, no observable change for ack-only ticks.
         var appendResult = session.AddEntryAndSnapshot(
-            new SessionEntry { Role = MessageRole.User, Content = prompt });
+            new SessionEntry
+            {
+                Role = MessageRole.User,
+                Content = prompt,
+                Trigger = TriggerType.Heartbeat
+            });
         var snapshotWithHeartbeat = appendResult.Snapshot;
         var preHeartbeatUpdatedAt = appendResult.PriorUpdatedAt;
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
@@ -70,7 +70,15 @@ public sealed class SoulTrigger(
         else
             session.Metadata["cronJobId"] = request.CronJobId.Value.Value;
 
-        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = prompt });
+        // P9-E (#645): stamp the proxy-trigger origin on the user entry instead of
+        // discriminating via SessionType — the session itself is AgentSelf because
+        // soul is an agent-talking-to-itself flow; the Soul trigger kind is per-turn.
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = prompt,
+            Trigger = TriggerType.Soul
+        });
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);
         var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);
         var response = await handle.PromptAsync(prompt, ct).ConfigureAwait(false);
@@ -93,9 +101,12 @@ public sealed class SoulTrigger(
         SoulAgentConfig? soulConfig,
         CancellationToken ct)
     {
+        // P9-E (#645): soul sessions no longer carry SessionType.Soul. Discovery is now
+        // driven by the canonical Metadata["soulDate"] tag that InitializeSoulSession
+        // stamps on every soul session; status must still be Active.
         var agentSessions = await sessions.ListAsync(agentId, ct).ConfigureAwait(false);
         var oldActiveSoulSessions = agentSessions
-            .Where(session => session.SessionType == SessionType.Soul && session.Status == GatewaySessionStatus.Active)
+            .Where(session => session.Status == GatewaySessionStatus.Active && session.Metadata.ContainsKey("soulDate"))
             .Where(session => TryGetSoulDate(session, out var soulDate) && soulDate < todaySoulDate)
             .ToArray();
 
@@ -123,7 +134,9 @@ public sealed class SoulTrigger(
 
     private static void InitializeSoulSession(GatewaySession session, AgentId agentId, DateOnly soulDate)
     {
-        session.SessionType = SessionType.Soul;
+        // P9-E (#645): soul is an agent-self conversation; the "Soul" proxy-trigger
+        // kind lives on SessionEntry.Trigger, not on the SessionType.
+        session.SessionType = SessionType.AgentSelf;
         session.ChannelType = null;
         session.CallerId ??= $"soul:{agentId.Value}";
         session.Status = GatewaySessionStatus.Active;

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -103,17 +103,16 @@ public abstract class SessionStoreBase : ISessionStore
 
     protected static SessionType InferSessionType(SessionId sessionId, ChannelKey? channelType)
     {
+        // P9-E (#645): the legacy Soul/Cron/Heartbeat SessionType discriminators are
+        // collapsed. Triggers stamp the proxy origin onto SessionEntry.Trigger; here
+        // we classify the conversation shape only. Soul sessions become AgentSelf;
+        // cron sessions stay UserAgent (the cron channel keeps the interactive-gate
+        // exclusion via Session.IsInteractive — see Session.cs).
         if (sessionId.IsSubAgent)
             return SessionType.AgentSubAgent;
 
         if (sessionId.IsAgentConversation)
             return SessionType.AgentAgent;
-
-        if (sessionId.IsSoul)
-            return SessionType.Soul;
-
-        if (channelType.HasValue && string.Equals(channelType.Value, "cron", StringComparison.OrdinalIgnoreCase))
-            return SessionType.Cron;
 
         return SessionType.UserAgent;
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -7,6 +7,7 @@ using MessageRole = BotNexus.Domain.Primitives.MessageRole;
 using SessionType = BotNexus.Domain.Primitives.SessionType;
 using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using ConversationId = BotNexus.Domain.Primitives.ConversationId;
+using TriggerType = BotNexus.Domain.Primitives.TriggerType;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Security;
@@ -319,7 +320,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
                     tool_call_id TEXT,
                     is_compaction_summary INTEGER NOT NULL DEFAULT 0,
                     is_crash_sentinel INTEGER NOT NULL DEFAULT 0,
-                    is_history INTEGER NOT NULL DEFAULT 0
+                    is_history INTEGER NOT NULL DEFAULT 0,
+                    trigger_type TEXT
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_session_history_session_id ON session_history(session_id);
@@ -360,7 +362,11 @@ public sealed class SqliteSessionStore : SessionStoreBase
                      ("tool_args", "TEXT"),
                      ("tool_is_error", "INTEGER NOT NULL DEFAULT 0"),
                      ("is_crash_sentinel", "INTEGER NOT NULL DEFAULT 0"),
-                     ("is_history", "INTEGER NOT NULL DEFAULT 0")
+                     ("is_history", "INTEGER NOT NULL DEFAULT 0"),
+                     // P9-E (#645): trigger_type captures the proxy origin of a turn
+                     // (Cron/Soul/Heartbeat/Memory). Idempotent ALTER guarantees existing
+                     // pre-P9-E DBs gain the column on the first post-upgrade open.
+                     ("trigger_type", "TEXT")
                  })
         {
             try
@@ -625,7 +631,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
         await using var historyCommand = connection.CreateCommand();
         historyCommand.CommandText = """
-            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history
+            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history, trigger_type
             FROM session_history
             WHERE session_id = $sessionId
             ORDER BY id ASC
@@ -647,7 +653,10 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 ToolArgs = historyReader.FieldCount > 6 && !historyReader.IsDBNull(6) ? historyReader.GetString(6) : null,
                 ToolIsError = historyReader.FieldCount > 7 && !historyReader.IsDBNull(7) && historyReader.GetInt64(7) != 0,
                 IsCrashSentinel = historyReader.FieldCount > 8 && !historyReader.IsDBNull(8) && historyReader.GetInt64(8) != 0,
-                IsHistory = historyReader.FieldCount > 9 && !historyReader.IsDBNull(9) && historyReader.GetInt64(9) != 0
+                IsHistory = historyReader.FieldCount > 9 && !historyReader.IsDBNull(9) && historyReader.GetInt64(9) != 0,
+                Trigger = historyReader.FieldCount > 10 && !historyReader.IsDBNull(10)
+                    ? TriggerType.FromString(historyReader.GetString(10))
+                    : null
             });
         }
 
@@ -725,8 +734,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
             await using var insertCommand = connection.CreateCommand();
             insertCommand.Transaction = transaction;
             insertCommand.CommandText = """
-                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history)
-                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError, $isCrashSentinel, $isHistory)
+                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history, trigger_type)
+                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError, $isCrashSentinel, $isHistory, $triggerType)
                 """;
             insertCommand.Parameters.AddWithValue("$sessionId", session.SessionId.Value);
             insertCommand.Parameters.AddWithValue("$role", entry.Role.Value);
@@ -739,6 +748,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
             insertCommand.Parameters.AddWithValue("$toolIsError", entry.ToolIsError ? 1 : 0);
             insertCommand.Parameters.AddWithValue("$isCrashSentinel", entry.IsCrashSentinel ? 1 : 0);
             insertCommand.Parameters.AddWithValue("$isHistory", entry.IsHistory ? 1 : 0);
+            insertCommand.Parameters.AddWithValue("$triggerType", (object?)entry.Trigger?.Value ?? DBNull.Value);
             await insertCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -43,9 +43,6 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private const string ControlSteer = "steer";
     private const string ControlCompact = "compact";
 
-    // Cached to avoid per-dispatch allocation in ResolveSessionType's hot path.
-    private static readonly ChannelKey CronChannelKey = ChannelKey.From("cron");
-
     private readonly IAgentSupervisor _supervisor;
     private readonly IMessageRouter _router;
     private readonly ISessionStore _sessions;
@@ -1093,12 +1090,10 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         if (!isNewSession && descriptor is null && session.SessionType == SessionType.AgentSubAgent)
             return SessionType.AgentSubAgent;
 
-        if (session.SessionId.IsSoul)
-            return SessionType.Soul;
-
-        if (message.ChannelType.Equals(CronChannelKey))
-            return SessionType.Cron;
-
+        // P9-E (#645): Soul/Cron/Heartbeat SessionType discriminators collapsed.
+        // The Soul/Cron channel and SessionId.IsSoul substring branches are deleted
+        // here too — triggers stamp their proxy origin on SessionEntry.Trigger, and
+        // Session.IsInteractive carries the cron-channel exclusion downstream.
         return SessionType.UserAgent;
     }
 

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionTypeCollapseArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionTypeCollapseArchitectureTests.cs
@@ -1,0 +1,350 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using BotNexus.Domain.Primitives;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-E contract: <c>SessionType</c>
+/// describes only the long-lived classification of who is talking to whom
+/// (UserAgent / AgentSelf / AgentAgent / AgentSubAgent). The pre-P9-E proxy-trigger
+/// values — <c>SessionType.Soul</c>, <c>SessionType.Cron</c>, and
+/// <c>SessionType.Heartbeat</c> — must never reappear in production code, and the
+/// substring predicate <c>SessionId.IsSoul</c> (G-4) must stay deleted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before P9-E, the "kind of trigger" that produced a session leaked into its
+/// classification: SoulTrigger stamped <c>Soul</c>, CronTrigger stamped <c>Cron</c>,
+/// HeartbeatTrigger stamped <c>Heartbeat</c>. That conflated two orthogonal axes
+/// (classification vs. trigger) and meant every consumer that cared about
+/// interactivity had to enumerate every trigger value. P9-E collapses the
+/// classification axis onto its natural shape — Soul/Heartbeat → <c>AgentSelf</c>
+/// (the agent talking to itself), Cron → <c>UserAgent</c> (proxy for the citizen
+/// who scheduled the job, directive W-2) — and moves the trigger kind onto a new
+/// nullable <c>SessionEntry.Trigger</c> field (a <see cref="TriggerType"/>) so the
+/// origin is recorded per-entry without polluting the session shape.
+/// </para>
+/// <para>
+/// Two source fences (grep-based, lexer-stripped) and one reflection pin defend the
+/// invariant. Each fence ships a vacuity-guard self-test (per the stored memory
+/// "every regex-based architecture fence must include a self-test asserting it matches
+/// its target methods/symbols").
+/// </para>
+/// </remarks>
+public sealed class SessionTypeCollapseArchitectureTests
+{
+    [Fact]
+    public void SessionId_IsSoul_PredicateIsDeleted()
+    {
+        // G-4: soul-session classification no longer rides on a substring of the
+        // session id. SoulTrigger stamps SessionType.AgentSelf and writes
+        // Metadata["soulDate"]; discovery queries the metadata key directly.
+        var idType = typeof(SessionId);
+        var member = idType.GetMember(
+            "IsSoul",
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+
+        member.ShouldBeEmpty(
+            "P9-E (#645) / G-4: SessionId.IsSoul must NOT exist. Soul-session discovery " +
+            "queries Session.Metadata.ContainsKey(\"soulDate\") (the canonical signal set " +
+            "by SoulTrigger.InitializeSoulSession). If this fails: a previously-deleted " +
+            "substring predicate has been re-added — remove it and route the caller " +
+            "through the metadata probe instead.");
+    }
+
+    [Fact]
+    public void SessionType_Soul_Cron_Heartbeat_RegistryFieldsAreDeleted()
+    {
+        // Reflection pin on the registry — complements the source-fence below.
+        // The registry layer is the canonical surface for new SessionType values;
+        // their absence here proves the type was actually collapsed, not just
+        // shadowed.
+        var sessionTypeType = typeof(SessionType);
+        foreach (var name in new[] { "Soul", "Cron", "Heartbeat" })
+        {
+            var member = sessionTypeType.GetMember(
+                name,
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.GetField | BindingFlags.GetProperty);
+            member.ShouldBeEmpty(
+                $"P9-E (#645): SessionType.{name} was a proxy-trigger value and is deleted. " +
+                "Soul/Heartbeat collapse onto AgentSelf; Cron collapses onto UserAgent " +
+                "(proxy for the citizen who scheduled the job — directive W-2). The trigger " +
+                "kind moved to SessionEntry.Trigger (TriggerType?). If you need to record " +
+                "the trigger origin, set Trigger on the user entry; do NOT reintroduce the " +
+                "discriminator.");
+        }
+    }
+
+    [Fact]
+    public void NoProductionSourceFile_References_DeletedSessionTypeValues()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_deletedSessionTypePattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-E (#645): production code must not reference the deleted member-access " +
+            "patterns SessionType.Soul, SessionType.Cron, or SessionType.Heartbeat. The " +
+            "classification axis was collapsed (Soul/Heartbeat → AgentSelf, Cron → " +
+            "UserAgent) and the trigger axis moved to SessionEntry.Trigger (TriggerType?). " +
+            "If you need a trigger-origin signal, stamp Trigger on the user entry; if you " +
+            "need a non-interactive signal, drive it off Session.IsInteractive (which " +
+            "already excludes UserAgent + ChannelType==\"cron\" and the AgentSelf shape).\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void NoProductionSourceFile_References_DeletedSessionIdIsSoul()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_isSoulPattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-E (#645) / G-4: production code must not call any `.IsSoul` predicate on a " +
+            "session id. Route soul-session discovery through Session.Metadata.ContainsKey" +
+            "(\"soulDate\") instead. If a legitimate non-SessionId `.IsSoul` exists in a " +
+            "future model, scope this fence to the SessionId receiver explicitly.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReintroduction()
+    {
+        // Each of these mirrors the literal we removed in P9-E — if a regression PR
+        // added one back, the fence MUST trip. Vacuity guard per the stored memory.
+        s_deletedSessionTypePattern.IsMatch(@"session.SessionType = SessionType.Soul;")
+            .ShouldBeTrue("Vacuity guard: SessionType.Soul member access must trip the fence.");
+        s_deletedSessionTypePattern.IsMatch(@"if (session.SessionType == SessionType.Cron) return;")
+            .ShouldBeTrue("Vacuity guard: SessionType.Cron member access must trip the fence.");
+        s_deletedSessionTypePattern.IsMatch(@"return SessionType.Heartbeat;")
+            .ShouldBeTrue("Vacuity guard: SessionType.Heartbeat member access must trip the fence.");
+
+        s_isSoulPattern.IsMatch(@"if (sessionId.IsSoul) return;")
+            .ShouldBeTrue("Vacuity guard: sessionId.IsSoul property access must trip the fence.");
+        s_isSoulPattern.IsMatch(@"sessions.Where(s => s.SessionId.IsSoul)")
+            .ShouldBeTrue("Vacuity guard: chained .SessionId.IsSoul access must trip the fence.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedTokens()
+    {
+        // Member-access is the legitimate use site for SessionType.UserAgent/AgentSelf,
+        // the TriggerType registry still has Soul/Cron/Heartbeat values, and string
+        // literals like "cron" (channel type), "soul" (file path segments), and
+        // "heartbeat" (text tokens) must all remain valid.
+        s_deletedSessionTypePattern.IsMatch(@"session.SessionType = SessionType.UserAgent;")
+            .ShouldBeFalse("False-positive guard: SessionType.UserAgent (live value) must NOT trip.");
+        s_deletedSessionTypePattern.IsMatch(@"session.SessionType = SessionType.AgentSelf;")
+            .ShouldBeFalse("False-positive guard: SessionType.AgentSelf (live value) must NOT trip.");
+        s_deletedSessionTypePattern.IsMatch(@"entry.Trigger = TriggerType.Soul;")
+            .ShouldBeFalse("False-positive guard: TriggerType.Soul (live value on TriggerType) must NOT trip.");
+        s_deletedSessionTypePattern.IsMatch(@"entry.Trigger = TriggerType.Cron;")
+            .ShouldBeFalse("False-positive guard: TriggerType.Cron (live value on TriggerType) must NOT trip.");
+        s_deletedSessionTypePattern.IsMatch(@"if (channelType == ""cron"") return;")
+            .ShouldBeFalse("False-positive guard: string literal \"cron\" (channel key) must NOT trip.");
+
+        s_isSoulPattern.IsMatch(@"if (session.IsInteractive) return;")
+            .ShouldBeFalse("False-positive guard: IsInteractive must NOT match.");
+        s_isSoulPattern.IsMatch(@"var nameIsSoulful = true;")
+            .ShouldBeFalse("False-positive guard: substring 'IsSoul' inside another identifier must NOT match.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        // Comments and XML docs explaining the historical shape (e.g. the migration
+        // notes in SessionType.cs / GatewayHost.cs / triggers) must not trip — the
+        // lexer strips them.
+        const string syntheticClean = """
+            /// <summary>
+            /// Pre-P9-E this branch returned SessionType.Soul; collapsed onto AgentSelf.
+            /// </summary>
+            // Legacy: SessionType.Cron was a proxy-trigger value, now UserAgent.
+            /* Block comment: SessionId.IsSoul predicate was deleted in P9-E. */
+            public void Documented() { }
+            """;
+
+        s_deletedSessionTypePattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of SessionType.Soul/Cron/Heartbeat for " +
+            "historical context must not trip.");
+        s_isSoulPattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of SessionId.IsSoul for historical " +
+            "context must not trip.");
+    }
+
+    // Match the deleted SessionType member-access values only — not string literals
+    // ("cron"/"soul"/"heartbeat" remain legitimate channel keys / trigger names) and
+    // not TriggerType.Soul/Cron/Heartbeat (those are the live values that replaced
+    // the SessionType discriminator).
+    private static readonly Regex s_deletedSessionTypePattern = new(
+        @"\bSessionType\.(Soul|Cron|Heartbeat)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // Match any receiver `.IsSoul` token-bounded — the only place this lived was on
+    // SessionId; scoping by trailing word-boundary keeps NameIsSoulful etc. clean.
+    private static readonly Regex s_isSoulPattern = new(
+        @"\.IsSoul\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Same lexer pattern used by other
+    /// architecture fences (e.g. <see cref="CronConversationOwnershipArchitectureTests"/>).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/domain/BotNexus.Domain.Tests/PrimitiveBoundaryTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/PrimitiveBoundaryTests.cs
@@ -153,10 +153,13 @@ public sealed class PrimitiveBoundaryTests
     }
 
     [Fact]
-    public void SessionId_IsSoul_DetectsPattern()
+    public void SessionId_ForSoul_StillProducesStablePinnedFormat()
     {
-        var id = SessionId.ForSoul(AgentId.From("my-agent"), DateOnly.FromDateTime(DateTime.UtcNow));
-        id.IsSoul.ShouldBeTrue();
+        // P9-E (#645): the IsSoul substring predicate is deleted (directive G-4); the
+        // SessionId.ForSoul factory remains the canonical id mint and is still used by
+        // SoulTrigger to build today's soul session id deterministically.
+        var id = SessionId.ForSoul(AgentId.From("my-agent"), new DateOnly(2026, 3, 1));
+        id.Value.ShouldBe("my-agent::soul::2026-03-01");
         id.IsSubAgent.ShouldBeFalse();
         id.IsAgentConversation.ShouldBeFalse();
     }

--- a/tests/domain/BotNexus.Domain.Tests/SessionIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/SessionIdTests.cs
@@ -96,7 +96,9 @@ public sealed class SessionIdTests
         var sessionId = SessionId.ForSoul(AgentId.From("agent-a"), new DateOnly(2026, 1, 15));
 
         sessionId.Value.ShouldBe("agent-a::soul::2026-01-15");
-        sessionId.IsSoul.ShouldBeTrue();
+        // P9-E (#645): the IsSoul substring predicate is deleted per directive G-4 — callers
+        // must not sniff soul-ness off the session id. The canonical signal is now
+        // Session.Metadata["soulDate"] (set by SoulTrigger.InitializeSoulSession).
     }
 
     [Fact]

--- a/tests/domain/BotNexus.Domain.Tests/SessionTypeTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/SessionTypeTests.cs
@@ -36,8 +36,24 @@ public sealed class SessionTypeTests
     [Fact]
     public void SessionType_ImplicitConversion_WhenConvertedToString_ShouldReturnValue()
     {
-        string value = SessionType.Cron;
-        value.ShouldBe("cron");
+        string value = SessionType.AgentSelf;
+        value.ShouldBe("agent-self");
+    }
+
+    [Theory]
+    [InlineData("soul", "agent-self")]
+    [InlineData("SOUL", "agent-self")]
+    [InlineData("heartbeat", "agent-self")]
+    [InlineData("cron", "user-agent")]
+    public void SessionType_FromString_WhenValueIsLegacyTriggerName_ShouldMigrateToCanonical(string legacy, string canonical)
+    {
+        // P9-E (#645): the old SessionType.Soul/Cron/Heartbeat values were proxy-trigger
+        // discriminators; the registry now collapses them to the canonical session shape
+        // ("agent-self"/"agent-self"/"user-agent" respectively). The proxy origin lives
+        // on SessionEntry.Trigger. FromString carries the migration so every JSON path
+        // and string-keyed lookup benefits uniformly.
+        var migrated = SessionType.FromString(legacy);
+        migrated.Value.ShouldBe(canonical);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -74,7 +74,10 @@ public sealed class CronTriggerTests
         // Cron metadata on the session.
         sessionStore.Verify(s => s.SaveAsync(
             It.Is<GatewaySession>(gs =>
-                gs.SessionType == SessionType.Cron &&
+                // P9-E (#645): cron sessions are now SessionType.UserAgent (proxy for the
+                // user who scheduled the job); the "cron" ChannelType + per-turn Trigger
+                // stamp carry the proxy-origin signal that used to live on SessionType.
+                gs.SessionType == SessionType.UserAgent &&
                 gs.ChannelType == ChannelKey.From("cron") &&
                 gs.Metadata.ContainsKey("cronJobId") &&
                 gs.Metadata["cronJobId"] != null &&

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/HeartbeatTriggerTests.cs
@@ -49,7 +49,10 @@ public sealed class HeartbeatTriggerTests
         var (trigger, mocks) = BuildTriggerWithMocks(soul: true);
 
         var existingSoulSession = new GatewaySession { SessionId = soulSessionId, AgentId = agentId, Status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Active, UpdatedAt = DateTimeOffset.UtcNow };
-        existingSoulSession.SessionType = SessionType.Soul;
+        // P9-E (#645): heartbeat discovers today's soul session via Metadata["soulDate"]
+        // rather than the deleted SessionType.Soul discriminator. The shape is AgentSelf.
+        existingSoulSession.SessionType = SessionType.AgentSelf;
+        existingSoulSession.Metadata["soulDate"] = "2026-05-18";
 
         mocks.Sessions.Setup(s => s.ListAsync(agentId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([existingSoulSession]);
@@ -162,7 +165,9 @@ public sealed class HeartbeatTriggerTests
             AgentId = agentId,
             Status = GatewaySessionStatus.Active,
             UpdatedAt = preHeartbeatTime,
-            SessionType = SessionType.Soul,
+            // P9-E (#645): soul sessions carry SessionType.AgentSelf + Metadata["soulDate"].
+            SessionType = SessionType.AgentSelf,
+            Metadata = new Dictionary<string, object?> { ["soulDate"] = "2026-05-31" }
         };
         soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
         soulSession.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a1" });
@@ -202,7 +207,8 @@ public sealed class HeartbeatTriggerTests
             AgentId = agentId,
             Status = GatewaySessionStatus.Active,
             UpdatedAt = preHeartbeatTime,
-            SessionType = SessionType.Soul,
+            SessionType = SessionType.AgentSelf,
+            Metadata = new Dictionary<string, object?> { ["soulDate"] = "2026-05-31" }
         };
         soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
         soulSession.UpdatedAt = preHeartbeatTime;
@@ -256,7 +262,8 @@ public sealed class HeartbeatTriggerTests
             AgentId = agentId,
             Status = GatewaySessionStatus.Active,
             UpdatedAt = DateTimeOffset.UtcNow,
-            SessionType = SessionType.Soul,
+            SessionType = SessionType.AgentSelf,
+            Metadata = new Dictionary<string, object?> { ["soulDate"] = "2026-05-31" }
         };
         soulSession.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "u1" });
         soulSession.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a1" });

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/SoulTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/SoulTriggerTests.cs
@@ -54,7 +54,12 @@ public sealed class SoulTriggerTests
 
         result.ShouldBe(expectedSessionId);
         savedSession.ShouldNotBeNull();
-        savedSession!.SessionType.ShouldBe(SessionType.Soul);
+        // P9-E (#645): soul sessions now carry SessionType.AgentSelf; the Soul proxy
+        // origin is stamped on the user entry's Trigger field instead.
+        savedSession!.SessionType.ShouldBe(SessionType.AgentSelf);
+        savedSession.GetHistorySnapshot()
+            .Any(e => e.Role == MessageRole.User && e.Trigger == TriggerType.Soul)
+            .ShouldBeTrue();
         savedSession.CallerId.ShouldBe("soul:agent-a");
         savedSession.Metadata["soulDate"].ShouldBe("2026-01-10");
     }
@@ -73,7 +78,9 @@ public sealed class SoulTriggerTests
         {
             SessionId = previousSessionId,
             AgentId = agentId,
-            SessionType = SessionType.Soul,
+            // P9-E (#645): soul sessions now carry SessionType.AgentSelf and are
+            // discovered via Metadata["soulDate"] rather than the deleted SessionType.Soul.
+            SessionType = SessionType.AgentSelf,
             Status = GatewaySessionStatus.Active,
             Metadata = new Dictionary<string, object?> { ["soulDate"] = "2026-01-09" }
         };

--- a/tests/gateway/BotNexus.Gateway.Tests/Conversations/DefaultConversationResetServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Conversations/DefaultConversationResetServiceTests.cs
@@ -225,7 +225,7 @@ public sealed class DefaultConversationResetServiceTests
     {
         var fixture = new Fixture();
         var conversation = new Conversation { ConversationId = TestConversation, AgentId = TestAgent, ActiveSessionId = TestSession };
-        var session = BuildSession(SessionType.Heartbeat); // ShouldFlush returns false.
+        var session = BuildSession(SessionType.AgentSelf); // P9-E (#645): SessionType.Heartbeat collapsed; AgentSelf is still non-interactive. ShouldFlush returns false.
         fixture.SetupConversation(conversation);
         fixture.SetupSession(session);
         // Default Flusher.ShouldFlush mock returns based on real semantics; for Heartbeat the

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -495,7 +495,9 @@ public sealed class FileSessionStoreTests
         {
             SessionId = BotNexus.Domain.Primitives.SessionId.From("participant"),
             AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b"),
-            SessionType = BotNexus.Domain.Primitives.SessionType.Cron,
+            // P9-E (#645): SessionType.Cron is deleted; the test uses AgentSubAgent so
+            // the TypeFilter still discriminates this row from the "owned" UserAgent row.
+            SessionType = BotNexus.Domain.Primitives.SessionType.AgentSubAgent,
             Participants =
             [
                 new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }
@@ -507,7 +509,7 @@ public sealed class FileSessionStoreTests
             BotNexus.Domain.Primitives.AgentId.From("agent-a"),
             new ExistenceQuery
             {
-                TypeFilter = BotNexus.Domain.Primitives.SessionType.Cron,
+                TypeFilter = BotNexus.Domain.Primitives.SessionType.AgentSubAgent,
                 From = now.AddDays(-1.5),
                 Limit = 10
             });

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostResolveSessionTypeTests.cs
@@ -36,8 +36,11 @@ namespace BotNexus.Gateway.Tests;
 /// (4) a PERSISTED <see cref="SessionType.AgentSubAgent"/> session survives a
 /// transient registry-deregister / gateway restart and is not silently
 /// downgraded (defense against the bug-hunt HIGH finding);
-/// (5) <see cref="SessionType.Soul"/> and <see cref="SessionType.Cron"/>
-/// classifications remain intact (regression-pin for the other branches).
+/// (5) P9-E (#645): the legacy <c>SessionType.Soul</c>/<c>Cron</c> dispatch
+/// branches are gone — soul-shaped session ids that arrive through dispatch
+/// (rather than through <c>SoulTrigger</c>) and the "cron" channel both
+/// classify as <see cref="SessionType.UserAgent"/>. Internal triggers stamp
+/// the proxy origin on <c>SessionEntry.Trigger</c> instead.
 /// </para>
 /// </remarks>
 public sealed class GatewayHostResolveSessionTypeTests
@@ -123,11 +126,14 @@ public sealed class GatewayHostResolveSessionTypeTests
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenSessionIdIsSoul_StampsAsSoul()
+    public async Task DispatchAsync_WhenSessionIdIsSoul_ClassifiesAsUserAgent_PostP9E()
     {
-        // Regression pin: Soul bucketing is preserved. The Soul predicate
-        // (SessionId.IsSoul) is unrelated to the AgentKind migration and
-        // remains in place.
+        // P9-E (#645) regression pin: dispatch ignores the soul-shaped session id
+        // and classifies as UserAgent. Soul sessions are created exclusively by
+        // SoulTrigger (which sets SessionType.AgentSelf + Metadata["soulDate"]);
+        // a soul-shaped id that somehow arrives via a channel falls through to
+        // the default UserAgent branch — proves the IsSoul substring back door
+        // is gone (directive G-4).
         var soulId = SessionId.ForSoul(AgentId.From(AgentIdValue), DateOnly.FromDateTime(DateTime.UtcNow));
         var registry = new Mock<IAgentRegistry>();
         registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
@@ -139,14 +145,16 @@ public sealed class GatewayHostResolveSessionTypeTests
 
         var reloaded = await sessions.GetAsync(soulId);
         reloaded.ShouldNotBeNull();
-        reloaded!.SessionType.ShouldBe(SessionType.Soul);
+        reloaded!.SessionType.ShouldBe(SessionType.UserAgent);
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenChannelTypeIsCron_StampsAsCron()
+    public async Task DispatchAsync_WhenChannelTypeIsCron_ClassifiesAsUserAgent_PostP9E()
     {
-        // Regression pin: Cron bucketing is preserved (driven by channel type,
-        // not by the descriptor or the SessionId).
+        // P9-E (#645) regression pin: cron is a proxy for the citizen who scheduled
+        // the job (directive W-2), so the session shape is UserAgent. The non-
+        // interactive signal lives on the channel — Session.IsInteractive excludes
+        // the "cron" ChannelType so memory flushers / warmup still skip these.
         const string sessionIdValue = "cron-session-1";
         var registry = new Mock<IAgentRegistry>();
         registry.Setup(r => r.Get(AgentId.From(AgentIdValue)))
@@ -158,7 +166,8 @@ public sealed class GatewayHostResolveSessionTypeTests
 
         var reloaded = await sessions.GetAsync(SessionId.From(sessionIdValue));
         reloaded.ShouldNotBeNull();
-        reloaded!.SessionType.ShouldBe(SessionType.Cron);
+        reloaded!.SessionType.ShouldBe(SessionType.UserAgent);
+        reloaded.IsInteractive.ShouldBeFalse("cron-channel UserAgent sessions stay non-interactive — Session.IsInteractive enforces the channel exclusion (P9-E #645).");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
@@ -162,7 +162,9 @@ public sealed class InMemorySessionStoreTests
         {
             SessionId = SessionId.From("participant"),
             AgentId = AgentId.From("agent-b"),
-            SessionType = SessionType.Cron,
+            // P9-E (#645): SessionType.Cron deleted; use AgentSubAgent so the TypeFilter
+            // still discriminates this row from the "owned" UserAgent row above.
+            SessionType = SessionType.AgentSubAgent,
             Participants =
             [
                 new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }
@@ -174,7 +176,7 @@ public sealed class InMemorySessionStoreTests
             AgentId.From("agent-a"),
             new ExistenceQuery
             {
-                TypeFilter = SessionType.Cron,
+                TypeFilter = SessionType.AgentSubAgent,
                 From = now.AddDays(-1.5),
                 Limit = 10
             });

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
@@ -101,7 +101,10 @@ public sealed class SessionStoreExistenceQueryTests
             AgentId.From("agent-a"),
             new ExistenceQuery
             {
-                TypeFilter = SessionType.Cron
+                // P9-E (#645): SessionType.Cron deleted; the seeded "participant" row
+                // (line ~180) uses AgentAgent so the TypeFilter still isolates it
+                // (distinct from "owned"/UserAgent and "both"/AgentSubAgent).
+                TypeFilter = SessionType.AgentAgent
             });
 
         sessions.Select(s => s.SessionId.Value).ShouldHaveSingleItem().ShouldBe("participant");
@@ -172,7 +175,10 @@ public sealed class SessionStoreExistenceQueryTests
         {
             SessionId = SessionId.From("participant"),
             AgentId = AgentId.From("agent-b"),
-            SessionType = SessionType.Cron,
+            // P9-E (#645): SessionType.Cron deleted. Use AgentAgent here — it's distinct
+            // from "owned"/UserAgent and "both"/AgentSubAgent so the TypeFilter test
+            // (which selects participant via SessionType) still isolates this row.
+            SessionType = SessionType.AgentAgent,
             Participants =
             [
                 new SessionParticipant

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
@@ -38,7 +38,23 @@ public sealed class PreCompactionMemoryFlusherTests
     [Fact]
     public void ShouldFlush_WhenNonInteractiveSession_ReturnsFalse()
     {
-        var session = BuildSession(SessionType.Heartbeat);
+        // P9-E (#645): SessionType.Heartbeat is collapsed onto AgentSelf; the
+        // non-interactive classification is unchanged.
+        var session = BuildSession(SessionType.AgentSelf);
+        var flusher = CreateFlusher();
+        var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenUserAgentSessionDeliveredViaCronChannel_ReturnsFalse()
+    {
+        // P9-E (#645): cron sessions are now SessionType.UserAgent + ChannelType="cron".
+        // Session.IsInteractive's channel exclusion keeps them out of the pre-compaction
+        // memory-flush path.
+        var session = BuildSession(SessionType.UserAgent);
+        session.ChannelType = ChannelKey.From("cron");
         var flusher = CreateFlusher();
         var options = new CompactionOptions { MemoryFlush = new MemoryFlushOptions { Enabled = true } };
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionEndMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionEndMemoryFlusherTests.cs
@@ -37,7 +37,25 @@ public sealed class SessionEndMemoryFlusherTests
     [Fact]
     public void ShouldFlush_WhenNonInteractiveSession_ReturnsFalse()
     {
-        var session = BuildSession(SessionType.Heartbeat);
+        // P9-E (#645): SessionType.Heartbeat is gone; heartbeat sessions now carry
+        // SessionType.AgentSelf which is still classified as non-interactive by
+        // Session.IsInteractive. Migrated to AgentSelf to verify the same gate.
+        var session = BuildSession(SessionType.AgentSelf);
+        session.History.Add(new SessionEntry { Role = MessageRole.User, Content = "hello" });
+        var flusher = CreateFlusher();
+        var options = EnabledOptions();
+
+        flusher.ShouldFlush(session, options).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldFlush_WhenUserAgentSessionDeliveredViaCronChannel_ReturnsFalse()
+    {
+        // P9-E (#645): cron sessions are now SessionType.UserAgent (proxy for the
+        // citizen who scheduled the job). The "cron" channel keeps them out of the
+        // interactive memory-flush path via Session.IsInteractive's channel exclusion.
+        var session = BuildSession(SessionType.UserAgent);
+        session.ChannelType = ChannelKey.From("cron");
         session.History.Add(new SessionEntry { Role = MessageRole.User, Content = "hello" });
         var flusher = CreateFlusher();
         var options = EnabledOptions();

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionModelWave2Tests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionModelWave2Tests.cs
@@ -98,10 +98,15 @@ public sealed class SessionModelWave2Tests
     }
 
     [Fact]
-    public void SessionType_Cron_IsNonInteractive()
+    public void SessionType_CronChannel_IsNonInteractive()
     {
+        // P9-E (#645): cron sessions are now SessionType.UserAgent (proxy for the
+        // citizen who scheduled the job, per directive W-2). The non-interactive
+        // signal moved to the channel — Session.IsInteractive excludes the "cron"
+        // ChannelType so memory flushers / warmup still skip these sessions.
         var session = CreateSession();
-        session.SessionType = SessionType.Cron;
+        session.SessionType = SessionType.UserAgent;
+        session.ChannelType = ChannelKey.From("cron");
 
         session.IsInteractive.ShouldBeFalse();
     }
@@ -118,14 +123,16 @@ public sealed class SessionModelWave2Tests
     [Fact]
     public void SessionType_SetAtCreation_PersistsOnModel()
     {
+        // P9-E (#645): exercise AgentSubAgent here since SessionType.Cron was deleted.
+        // The intent is to prove the model round-trips a non-default SessionType.
         var session = new GatewaySession
         {
             SessionId = BotNexus.Domain.Primitives.SessionId.From("s-typed"),
             AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a"),
-            SessionType = SessionType.Cron
+            SessionType = SessionType.AgentSubAgent
         };
 
-        session.SessionType.ShouldBe(SessionType.Cron);
+        session.SessionType.ShouldBe(SessionType.AgentSubAgent);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWarmupServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionWarmupServiceTests.cs
@@ -56,8 +56,10 @@ public sealed class SessionWarmupServiceTests
     {
         var now = DateTimeOffset.UtcNow;
         var userAgent = CreateSession("user-agent", "agent-a", SessionStatus.Active, now, BotNexus.Domain.Primitives.SessionType.UserAgent);
-        var soul = CreateSession("soul", "agent-a", SessionStatus.Active, now.AddMinutes(-1), BotNexus.Domain.Primitives.SessionType.Soul);
-        var cron = CreateSession("cron", "agent-a", SessionStatus.Active, now.AddMinutes(-2), BotNexus.Domain.Primitives.SessionType.Cron);
+        // P9-E (#645): soul sessions now type-shape as AgentSelf; cron sessions are
+        // UserAgent + "cron" channel. Both must still be hidden by warmup.
+        var soul = CreateSession("soul", "agent-a", SessionStatus.Active, now.AddMinutes(-1), BotNexus.Domain.Primitives.SessionType.AgentSelf);
+        var cron = CreateSession("cron", "agent-a", SessionStatus.Active, now.AddMinutes(-2), BotNexus.Domain.Primitives.SessionType.UserAgent, BotNexus.Domain.Primitives.ChannelKey.From("cron"));
         var subAgent = CreateSession("sub-agent", "agent-a", SessionStatus.Active, now.AddMinutes(-3), BotNexus.Domain.Primitives.SessionType.AgentSubAgent);
         var agentSelf = CreateSession("agent-self", "agent-a", SessionStatus.Active, now.AddMinutes(-4), BotNexus.Domain.Primitives.SessionType.AgentSelf);
         var agentAgent = CreateSession("agent-agent", "agent-a", SessionStatus.Active, now.AddMinutes(-5), BotNexus.Domain.Primitives.SessionType.AgentAgent);
@@ -76,8 +78,9 @@ public sealed class SessionWarmupServiceTests
     {
         var now = DateTimeOffset.UtcNow;
         var userAgent = CreateSession("user-agent", "agent-a", SessionStatus.Active, now, BotNexus.Domain.Primitives.SessionType.UserAgent);
-        var soul = CreateSession("soul", "agent-a", SessionStatus.Active, now.AddMinutes(-1), BotNexus.Domain.Primitives.SessionType.Soul);
-        var cron = CreateSession("cron", "agent-a", SessionStatus.Active, now.AddMinutes(-2), BotNexus.Domain.Primitives.SessionType.Cron);
+        // P9-E (#645): same migration as above — soul → AgentSelf, cron → UserAgent + "cron" channel.
+        var soul = CreateSession("soul", "agent-a", SessionStatus.Active, now.AddMinutes(-1), BotNexus.Domain.Primitives.SessionType.AgentSelf);
+        var cron = CreateSession("cron", "agent-a", SessionStatus.Active, now.AddMinutes(-2), BotNexus.Domain.Primitives.SessionType.UserAgent, BotNexus.Domain.Primitives.ChannelKey.From("cron"));
         var subAgent = CreateSession("sub-agent", "agent-a", SessionStatus.Active, now.AddMinutes(-3), BotNexus.Domain.Primitives.SessionType.AgentSubAgent);
 
         var store = CreateSessionStore(userAgent, soul, cron, subAgent);

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionsControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionsControllerTests.cs
@@ -1005,14 +1005,14 @@ public sealed class SessionsControllerTests
     }
 
     [Fact]
-    public async Task Seal_WhenSessionTypeIsSoul_Returns400()
+    public async Task Seal_WhenSessionTypeIsAgentSelf_Returns400()
     {
-        // Regression pin: Soul sessions are not sealable. Pre-migration this was
-        // enforced by !IsSubAgent (Soul sessionIds don't contain "::subagent::").
-        // Post-migration this is enforced by SessionType != AgentSubAgent.
+        // P9-E (#645) migrated from Seal_WhenSessionTypeIsSoul_Returns400. SessionType.Soul
+        // is collapsed onto AgentSelf — the Seal control-plane operation rejects every
+        // non-AgentSubAgent SessionType, which still excludes the old soul shape.
         var store = new InMemorySessionStore();
         var session = await store.GetOrCreateAsync(SessionId.From("soul-session"), AgentId.From("agent-a"));
-        session.SessionType = SessionType.Soul;
+        session.SessionType = SessionType.AgentSelf;
         session.Status = SessionStatus.Expired;
         await store.SaveAsync(session);
         var controller = new SessionsController(store);

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -474,7 +474,9 @@ public sealed class SqliteSessionStoreTests
         {
             SessionId = BotNexus.Domain.Primitives.SessionId.From("participant"),
             AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b"),
-            SessionType = BotNexus.Domain.Primitives.SessionType.Cron,
+            // P9-E (#645): SessionType.Cron deleted; use AgentSubAgent so the TypeFilter
+            // discriminates this row from the "owned" UserAgent row above.
+            SessionType = BotNexus.Domain.Primitives.SessionType.AgentSubAgent,
             Participants =
             [
                 new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }
@@ -486,7 +488,7 @@ public sealed class SqliteSessionStoreTests
             BotNexus.Domain.Primitives.AgentId.From("agent-a"),
             new ExistenceQuery
             {
-                TypeFilter = BotNexus.Domain.Primitives.SessionType.Cron,
+                TypeFilter = BotNexus.Domain.Primitives.SessionType.AgentSubAgent,
                 From = now.AddDays(-1.5),
                 Limit = 10
             });
@@ -685,6 +687,105 @@ public sealed class SqliteSessionStoreTests
         var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-migrate"));
         reloaded.ShouldNotBeNull();
         reloaded!.History[0].ToolArgs.ShouldBe("{}");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithTriggerStampedEntries_RoundTripsTriggerAcrossReload()
+    {
+        // P9-E (#645) rubber-duck B1 regression: the new session_history.trigger_type
+        // column must persist + read back for every TriggerType value that triggers
+        // can stamp (Cron, Soul, Heartbeat). Without this pin, a future refactor of
+        // SqliteSessionStore's manual column mapping could silently drop the field —
+        // breaking soul-session discovery and per-entry origin attribution.
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var session = await store.GetOrCreateAsync(SessionId.From("s-trig"), AgentId.From("agent-a"));
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "cron run", Trigger = TriggerType.Cron });
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "soul tick", Trigger = TriggerType.Soul });
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "heartbeat", Trigger = TriggerType.Heartbeat });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "ack" }); // no trigger
+
+        await store.SaveAsync(session);
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-trig"));
+
+        reloaded.ShouldNotBeNull();
+        reloaded!.History.Count.ShouldBe(4);
+
+        var byContent = reloaded.History.ToDictionary(e => e.Content!);
+        byContent["cron run"].Trigger.ShouldBe(TriggerType.Cron);
+        byContent["soul tick"].Trigger.ShouldBe(TriggerType.Soul);
+        byContent["heartbeat"].Trigger.ShouldBe(TriggerType.Heartbeat);
+        byContent["ack"].Trigger.ShouldBeNull(
+            "Entries without a stamped Trigger must round-trip as null — not coerce to a default.");
+    }
+
+    [Fact]
+    public async Task GetAsync_WithLegacySchema_MissingTriggerTypeColumn_ReadsNullTriggerWithoutThrowing()
+    {
+        // P9-E (#645) rubber-duck B1 regression: pre-P9-E databases do not have the
+        // session_history.trigger_type column. The store's MigrateAsync must add it
+        // idempotently, AND the SessionEntry projection must guard with FieldCount
+        // so older read paths cannot AV / IndexOutOfRange. Without this pin, a
+        // long-lived deployment upgrading from a pre-P9-E binary would fail to read
+        // existing sessions on the first dispatch after upgrade.
+        using var fixture = new StoreFixture();
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT,
+                    channel_type TEXT,
+                    caller_id TEXT,
+                    status TEXT,
+                    metadata TEXT,
+                    created_at TEXT,
+                    updated_at TEXT
+                );
+
+                CREATE TABLE session_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT,
+                    role TEXT,
+                    content TEXT,
+                    timestamp TEXT,
+                    tool_name TEXT,
+                    tool_call_id TEXT,
+                    is_compaction_summary INTEGER NOT NULL DEFAULT 0
+                );
+
+                INSERT INTO sessions (id, agent_id, status, created_at, updated_at)
+                VALUES ('s-legacy', 'agent-a', 'Active', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z');
+
+                INSERT INTO session_history (session_id, role, content, timestamp)
+                VALUES ('s-legacy', 'user', 'pre-p9e message', '2025-01-01T00:00:00Z');
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Reading via the current store should silently migrate (add trigger_type column)
+        // AND project the missing column as a null Trigger — no throw, no data loss.
+        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("s-legacy"));
+
+        reloaded.ShouldNotBeNull();
+        reloaded!.History.Count.ShouldBe(1);
+        reloaded.History[0].Content.ShouldBe("pre-p9e message");
+        reloaded.History[0].Trigger.ShouldBeNull(
+            "Pre-P9-E rows have no trigger value; the projection must yield null, not throw.");
+
+        // Verify the migration actually added the column.
+        await using var verifyConnection = new SqliteConnection(fixture.ConnectionString);
+        await verifyConnection.OpenAsync();
+        await using var colCmd = verifyConnection.CreateCommand();
+        colCmd.CommandText = "PRAGMA table_info(session_history)";
+        var columns = new List<string>();
+        await using var colReader = await colCmd.ExecuteReaderAsync();
+        while (await colReader.ReadAsync())
+            columns.Add(colReader.GetString(1));
+        columns.ShouldContain("trigger_type", "MigrateAsync must add session_history.trigger_type idempotently.");
     }
 
     // --- ListByConversationAsync: F-7 contract pins (SqliteSessionStore) ---


### PR DESCRIPTION
# Phase 9-E — collapse `SessionType` (delete Cron / Soul / Heartbeat values)

Part of #613 (P9 umbrella). Driven by directives **G-3**, **G-4**, **W-2** in the [#612 addendum](https://github.com/sytone/botnexus/issues/612#issuecomment-4569422852).

## Maintainer directives

> **G-3** — Sessions are really just that, they belong to a conversation and that states what sort of conversation it is. A conversation kicked off or added to by a cron job on initial run or regular occurrence is a **proxy message** from the citizen who requested or created the cron job. Same for soul or heartbeat, that is a proxy of the agent sending a message to check or do things.

> **G-4** — Soul should not be handled via sub string.

> **W-2** — When a cron runs it is a proxy for the citizen who requested it to be created.

## Problem

`SessionType` is currently overloaded — it carries both **what kind of conversation** the session belongs to (`UserAgent`, `AgentAgent`, `AgentSubAgent`, `AgentSelf`) **and** **what triggered the inbound message** (`Soul`, `Cron`, `Heartbeat`). Triggers are not types — they are the citizen-proxy that initiated a particular turn. Mixing them produces:

- `SessionId.IsSoul` substring sniffing in `SessionId.cs` (G-4 violation)
- Branchy `InferSessionType` in `SessionStoreBase.cs` and `ResolveSessionType` in `GatewayHost.cs` to re-derive type from id shape and channel keys
- Triggers (`SoulTrigger`, `CronTrigger`, `HeartbeatTrigger`) explicitly setting `session.SessionType = SessionType.Soul/Cron/Heartbeat` even though those sessions are still "agent-self" or "user-agent" conversations underneath
- `SessionType.Heartbeat` and `SessionType.Cron` enum values that exist only so the gateway can answer "where did this turn originate?"

## Solution

**`SessionType` represents the conversation kind, full stop.** Three values disappear; the trigger lives on the inbound message (and gets persisted on `SessionEntry` so audit/UI can render it).

### Domain changes

1. **`SessionType.cs`**: delete `Soul`, `Cron`, `Heartbeat` registry entries. Keep `UserAgent`, `AgentSelf`, `AgentSubAgent`, `AgentAgent`. The two-way `Registry` lookup remains so stored sessions with the deleted values are still loadable (legacy migration in `InferSessionType`).
2. **`SessionId.cs`**: delete `IsSoul` (G-4). The factory `ForSoul(agentId, date)` stays (it's how soul sessions are named); only the substring predicate goes.
3. **`SessionEntry`** (or `InboundMessage`): add `Trigger` field. Values: `User` (default), `Cron`, `Soul`, `Heartbeat`, `AgentReply`. New `Trigger` value-object in `BotNexus.Domain.Primitives`.

### Trigger changes

4. **`SoulTrigger`**: set `session.SessionType = SessionType.AgentSelf`; stamp `Trigger = Trigger.Soul` on the prompt entry.
5. **`CronTrigger`**: set `session.SessionType = SessionType.UserAgent` (cron is proxy for the user who scheduled it, per W-2); stamp `Trigger = Trigger.Cron` on the prompt entry.
6. **`HeartbeatTrigger`**: set `session.SessionType = SessionType.AgentSelf`; stamp `Trigger = Trigger.Heartbeat` on the prompt entry.

### Store changes

7. **`SessionStoreBase.InferSessionType`**: drop the `IsSoul → Soul` and `channelType == "cron" → Cron` branches. Migrate legacy persisted sessions: `Soul → AgentSelf`, `Cron → UserAgent`, `Heartbeat → AgentSelf` (one-shot read-side migration, written back on next save).
8. **`GatewayHost.ResolveSessionType`**: same — drop the Soul/Cron branches.

### Architecture fence

9. New `SessionTypeCollapseArchitectureTests`:
   - Reflection pin: `SessionType.Soul`, `SessionType.Cron`, `SessionType.Heartbeat` no longer exist as static fields.
   - Literal fence: no production file references the deleted names.
   - `SessionId.IsSoul` no longer exists (per G-4).
   - Hygiene self-test on the allowlist (`SessionStoreBase.cs` will be allowlisted for the legacy-migration string literals).

## Tests

- `SessionTypeTests.cs` — assert the three values are gone; `FromString("soul")` round-trips to the migration target.
- `SoulTriggerTests` / `CronTriggerTests` / `HeartbeatTriggerTests` — assert `SessionType` is now `AgentSelf`/`UserAgent`/`AgentSelf` and the entry carries the correct `Trigger`.
- `SessionStoreBase` migration test — a persisted session with `SessionType=soul` reads back as `AgentSelf` with no data loss.
- All existing tests with `.SessionType == SessionType.Soul` etc. updated to `.SessionType == SessionType.AgentSelf && entry.Trigger == Trigger.Soul`.

## Acceptance

- [ ] `SessionType.Cron`, `SessionType.Soul`, `SessionType.Heartbeat` deleted from `SessionType.cs`.
- [ ] `SessionId.IsSoul` deleted (G-4).
- [ ] Triggers stamp `Trigger` on `SessionEntry`/`InboundMessage` instead of mutating `SessionType`.
- [ ] Architecture fitness test pins the invariants.
- [ ] Legacy persisted sessions migrate on load (no manual DB op required).
- [ ] All tests green.
- [ ] Net production LOC delta is negative.

## Sequencing

After #644 (P9-D) — done. Before P9-F (#646 to be filed) which deletes `Session.AgentId` and `Session.Participants`.

## Out of scope

- `Session.AgentId` / `Session.Participants` removal — P9-F.
- Portal responder-side list-by-participant query — P9-G.
- Any cleanup of the larger #612 audit umbrella.
