### PR TITLE
refactor(gateway)!: move Participants from Session to Conversation (P9-F, closes #657)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -92,4 +92,29 @@ public sealed record Conversation
     /// ids.
     /// </remarks>
     public ConversationKind Kind { get; set; } = ConversationKind.HumanAgent;
+
+    /// <summary>
+    /// Gets or sets the citizens currently participating in this conversation. Populated as
+    /// a side effect of inbound message routing and the agent-exchange handshake — see
+    /// <c>IConversationStore.AddParticipantsAsync</c>, which is the only sanctioned mutation
+    /// path (the <c>ConversationParticipantsMutationArchitectureTests</c> fence bans direct
+    /// list mutation outside of conversation-store implementations and the one-shot backfill
+    /// migration). Direct read access is fine.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Replaces the pre-P9-F <c>Session.Participants</c> field. The conversation is the
+    /// durable owner of the participant set; a session is just a bounded transcript window
+    /// inside it. Storing the set on the conversation means a citizen's "what am I in?"
+    /// query (used by channels for inbox-style views) is one indexed lookup against this
+    /// list rather than a fan-out scan over every session.
+    /// </para>
+    /// <para>
+    /// The list deduplicates by <c>SessionParticipant.CitizenId</c>; the role on the first
+    /// add for a given citizen is the role that wins (subsequent adds for the same citizen
+    /// are merged-as-no-op so concurrent producers don't fight over a role label). See
+    /// <c>SqliteConversationStore.AddParticipantsAsync</c> for the canonical implementation.
+    /// </para>
+    /// </remarks>
+    public List<SessionParticipant> Participants { get; set; } = [];
 }

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -95,12 +95,9 @@ public sealed class GatewaySession
     /// <summary>Computed interactivity marker.</summary>
     public bool IsInteractive => Session.IsInteractive;
 
-    /// <summary>Participants in this session.</summary>
-    public List<SessionParticipant> Participants
-    {
-        get => Session.Participants;
-        init => Session.Participants = value;
-    }
+    // P9-F (#657): GatewaySession.Participants facade was deleted along with the
+    // underlying Session.Participants field. Participants now live on Conversation; see
+    // IConversationStore.AddParticipantsAsync and ListForCitizenAsync for the new APIs.
 
     /// <summary>When the session was created.</summary>
     public DateTimeOffset CreatedAt

--- a/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
@@ -52,10 +52,11 @@ public sealed record Session
         && (!ChannelType.HasValue
             || !string.Equals(ChannelType.Value.Value, "cron", StringComparison.OrdinalIgnoreCase));
 
-    /// <summary>
-    /// Gets or sets the participants.
-    /// </summary>
-    public List<SessionParticipant> Participants { get; set; } = [];
+    // P9-F (#657): Session.Participants was deleted. Participants are now durably owned
+    // by the parent Conversation (Conversation.Participants), mutated only via
+    // IConversationStore.AddParticipantsAsync, and queried via
+    // IConversationStore.ListForCitizenAsync. This eliminates the duplicated ownership
+    // that made channel-side "what conversations is this citizen in?" queries quadratic.
 
     /// <summary>
     /// Gets or sets the created at.

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -145,18 +145,24 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         }
 
         session.SessionType = SessionType.UserAgent;
-        if (session.Participants.Count == 0)
-        {
-            session.Participants.Add(new SessionParticipant
-            {
-                CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
-            });
-            needsSave = true;
-        }
-
         if (needsSave)
         {
             await _sessions.SaveAsync(session, Context.ConnectionAborted);
+        }
+
+        // P9-F: Participants live on the Conversation, not the Session. The user-citizen
+        // for this SignalR connection is registered against the conversation pinned to the
+        // session. Skipped when the session has not yet been pinned (rare; resolution
+        // usually fires before JoinSession).
+        if (_conversationStore is not null && session.ConversationId.IsInitialized())
+        {
+            await _conversationStore.AddParticipantsAsync(
+                session.ConversationId,
+                [new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
+                }],
+                Context.ConnectionAborted);
         }
 
         return new JoinSessionResult(
@@ -749,17 +755,23 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             needsSave = true;
         }
 
-        if (session.Participants.Count == 0)
-        {
-            session.Participants.Add(new SessionParticipant
-            {
-                CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
-            });
-            needsSave = true;
-        }
-
         if (needsSave)
             await _sessions.SaveAsync(session, Context.ConnectionAborted);
+
+        // P9-F: Participants live on the Conversation, not the Session — register the
+        // user-citizen against the conversation pinned to this session. Skipped when the
+        // session has not yet been pinned or the conversation store isn't wired (legacy
+        // composition roots).
+        if (_conversationStore is not null && session.ConversationId.IsInitialized())
+        {
+            await _conversationStore.AddParticipantsAsync(
+                session.ConversationId,
+                [new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
+                }],
+                Context.ConnectionAborted);
+        }
 
         return session;
     }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -347,17 +347,27 @@ public sealed class CrossWorldFederationController(
         session.ChannelType = CrossWorldChannel;
         session.CallerId = null;
         session.Status = GatewaySessionStatus.Active;
-        session.Participants.Clear();
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(AgentId.From(request.SourceAgentId)),
-            Role = "initiator"
-        });
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(targetAgentId),
-            Role = "target"
-        });
+
+        // P9-F: Participants live on the Conversation, not the Session. Register the
+        // source-side initiator and the local target as conversation participants so the
+        // local IConversationStore.ListForCitizenAsync surfaces this exchange to both
+        // species.
+        await conversationStore.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(AgentId.From(request.SourceAgentId)),
+                    Role = "initiator"
+                },
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(targetAgentId),
+                    Role = "target"
+                }
+            ],
+            cancellationToken).ConfigureAwait(false);
+
         session.Metadata["sourceWorldId"] = request.SourceWorldId;
         session.Metadata["sourceAgentId"] = request.SourceAgentId;
         session.Metadata["sourceConversationId"] = request.ConversationId;

--- a/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/SoulTrigger.cs
@@ -1,4 +1,5 @@
 using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Triggers;
@@ -17,11 +18,13 @@ public sealed class SoulTrigger(
     IAgentRegistry registry,
     ISessionStore sessions,
     ILogger<SoulTrigger> logger,
-    TimeProvider? timeProvider = null) : IInternalTrigger
+    TimeProvider? timeProvider = null,
+    IConversationStore? conversationStore = null) : IInternalTrigger
 {
     private static readonly TimeSpan DefaultDayBoundary = TimeSpan.Zero;
     private static readonly TimeZoneInfo DefaultTimeZone = TimeZoneInfo.Utc;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly IConversationStore? _conversationStore = conversationStore;
 
     /// <summary>
     /// Gets the trigger type identifier.
@@ -59,6 +62,19 @@ public sealed class SoulTrigger(
 
         var session = await sessions.GetOrCreateAsync(sessionId, agentId, ct).ConfigureAwait(false);
         InitializeSoulSession(session, agentId, soulDate);
+
+        // P9-F: Participants live on the Conversation, not the Session. Register the agent
+        // citizen against the conversation pinned to this soul session. Skipped when no
+        // conversation store is wired (legacy unit-test compositions) — the participant
+        // would have nowhere to live and the fence pins direct Session.Participants
+        // mutations as removed.
+        if (_conversationStore is not null && session.ConversationId.IsInitialized())
+        {
+            await _conversationStore.AddParticipantsAsync(
+                session.ConversationId,
+                [new SessionParticipant { CitizenId = CitizenId.Of(agentId) }],
+                ct).ConfigureAwait(false);
+        }
 
         if (string.IsNullOrWhiteSpace(request?.ModelOverride))
             session.Metadata.Remove("modelOverride");
@@ -141,15 +157,9 @@ public sealed class SoulTrigger(
         session.CallerId ??= $"soul:{agentId.Value}";
         session.Status = GatewaySessionStatus.Active;
         session.Metadata["soulDate"] = soulDate.ToString("yyyy-MM-dd");
-
-        var agentCitizenId = CitizenId.Of(agentId);
-        if (!session.Participants.Any(participant => participant.CitizenId == agentCitizenId))
-        {
-            session.Participants.Add(new SessionParticipant
-            {
-                CitizenId = agentCitizenId
-            });
-        }
+        // P9-F: participant registration moved to CreateSessionAsync (after this method) so it
+        // can be routed through IConversationStore.AddParticipantsAsync — Participants no
+        // longer live on Session.
     }
 
     private static bool TryGetSoulDate(GatewaySession session, out DateOnly soulDate)

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
@@ -41,13 +41,47 @@ public interface IConversationStore
     ///     conversations <em>owned</em> by this agent. There is no symmetric owner relationship
     ///     for User citizens (owning-by-user is not modelled), which makes this method
     ///     intentionally asymmetric across species.</item>
+    ///   <item><b>Participant-match</b> (P9-F, issue #657): conversations whose
+    ///     <see cref="Conversation.Participants"/> include this citizen. Replaces the
+    ///     pre-P9-F per-session participant scan with a single indexed lookup against the
+    ///     conversation-level participant set, and is the channel-facing "what is this
+    ///     citizen in?" query.</item>
     /// </list>
-    /// <para>"Any session participant" semantics — which would require iterating each conversation's
-    /// active session participants — are not provided here; that query lives one layer up.</para>
+    /// <para>The union is materialised as a distinct-by-<see cref="ConversationId"/> set;
+    /// matching on more than one criterion does not produce duplicates.</para>
     /// </remarks>
     /// <param name="citizen">The citizen identity to query for; must be <see cref="CitizenId.IsValid"/>.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically merges the supplied participants into the conversation's
+    /// <see cref="Conversation.Participants"/> set. The operation is idempotent: existing
+    /// participants (matched by <c>SessionParticipant.CitizenId</c>) are left untouched, and
+    /// re-supplying the same participant on a subsequent call is a no-op. The role on the
+    /// first add wins; later calls do not overwrite the role label.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the only sanctioned mutation path for
+    /// <see cref="Conversation.Participants"/>. <see cref="SaveAsync"/> does not persist
+    /// participant changes — implementations must treat the participant set as conversation
+    /// state that is mutated only through this method so concurrent producers (multiple
+    /// channels, agent exchanges, soul/cron triggers) cannot clobber each other or the
+    /// rest of the conversation row.
+    /// </para>
+    /// <para>
+    /// Each implementation is responsible for performing the merge atomically with respect
+    /// to its own concurrency model (SQLite transaction, file lock, in-memory lock).
+    /// </para>
+    /// </remarks>
+    /// <param name="conversationId">The conversation identifier.</param>
+    /// <param name="participants">Participants to add. Empty enumerables are valid and produce no work.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task AddParticipantsAsync(
+        ConversationId conversationId,
+        IEnumerable<SessionParticipant> participants,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Creates a new conversation. Throws if the ConversationId already exists.

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -87,15 +87,14 @@ public sealed class FileConversationStore : IConversationStore
         if (!citizen.IsValid)
             throw new ArgumentException("Citizen must be a valid (non-default) CitizenId.", nameof(citizen));
 
-        // Scope: when the citizen is an Agent we can narrow the enumeration to that agent's
-        // directory because owner-match guarantees AgentId == citizen.AsAgent. For User citizens
-        // we have to scan everything since they could have initiated conversations under any agent.
-        AgentId? scope = citizen.Kind == CitizenKind.Agent ? citizen.AsAgent : null;
-
+        // P9-F: cannot scope-narrow by agent dir even when citizen is an Agent. Participant
+        // matches can land on conversations owned by *another* agent, so the pre-P9-F
+        // narrowing (scope = citizen.AsAgent) would silently drop them. The optimisation
+        // is gone until/unless an index supplements the scan.
         await _lock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            var all = await EnumerateAsync(scope, ct).ConfigureAwait(false);
+            var all = await EnumerateAsync(agentId: null, ct).ConfigureAwait(false);
             IReadOnlyList<Conversation> filtered = [.. all.Where(c => MatchesCitizen(c, citizen))];
             return filtered;
         }
@@ -108,6 +107,11 @@ public sealed class FileConversationStore : IConversationStore
             return true;
 
         if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
+            return true;
+
+        // Participant-match (P9-F): the conversation includes this citizen in its
+        // participant set persisted in the JSON sidecar.
+        if (conversation.Participants.Any(p => p.CitizenId == citizen))
             return true;
 
         return false;
@@ -151,6 +155,53 @@ public sealed class FileConversationStore : IConversationStore
             await WriteFileAsync(
                 conversation with { Status = ConversationStatus.Archived, ActiveSessionId = null, UpdatedAt = DateTimeOffset.UtcNow },
                 ct).ConfigureAwait(false);
+        }
+        finally { _lock.Release(); }
+    }
+
+    /// <inheritdoc />
+    public async Task AddParticipantsAsync(
+        ConversationId conversationId,
+        IEnumerable<SessionParticipant> participants,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+        var snapshot = participants as IReadOnlyCollection<SessionParticipant> ?? participants.ToArray();
+        if (snapshot.Count == 0)
+            return;
+
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var existing = await FindByConversationIdAsync(conversationId, ct).ConfigureAwait(false);
+            if (existing is null)
+                return;
+
+            var byCitizen = new Dictionary<CitizenId, SessionParticipant>(existing.Participants.Count);
+            foreach (var p in existing.Participants)
+                byCitizen[p.CitizenId] = p;
+
+            var changed = false;
+            foreach (var participant in snapshot)
+            {
+                if (!participant.CitizenId.IsValid)
+                    continue;
+                // First-add wins on role.
+                if (byCitizen.ContainsKey(participant.CitizenId))
+                    continue;
+                byCitizen[participant.CitizenId] = new SessionParticipant
+                {
+                    CitizenId = participant.CitizenId,
+                    Role = participant.Role
+                };
+                changed = true;
+            }
+
+            if (!changed)
+                return;
+
+            existing.Participants = byCitizen.Values.ToList();
+            await WriteFileAsync(existing, ct).ConfigureAwait(false);
         }
         finally { _lock.Release(); }
     }

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -15,6 +15,7 @@ namespace BotNexus.Gateway.Conversations;
 public sealed class InMemoryConversationStore : IConversationStore
 {
     private readonly ConcurrentDictionary<string, Conversation> _conversations = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _participantLocks = new(StringComparer.Ordinal);
     private readonly IWorldContext? _worldContext;
 
     /// <summary>Initialises a new <see cref="InMemoryConversationStore"/> without world stamping.</summary>
@@ -69,6 +70,11 @@ public sealed class InMemoryConversationStore : IConversationStore
         if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
             return true;
 
+        // Participant-match (P9-F): the conversation includes this citizen in its
+        // participant set.
+        if (conversation.Participants.Any(p => p.CitizenId == citizen))
+            return true;
+
         return false;
     }
 
@@ -101,6 +107,52 @@ public sealed class InMemoryConversationStore : IConversationStore
             };
         return Task.CompletedTask;
     }
+
+    /// <inheritdoc />
+    public async Task AddParticipantsAsync(
+        ConversationId conversationId,
+        IEnumerable<SessionParticipant> participants,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+        var snapshot = participants as IReadOnlyCollection<SessionParticipant> ?? participants.ToArray();
+        if (snapshot.Count == 0)
+            return;
+
+        var conversationLock = GetParticipantLock(conversationId.Value);
+        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!_conversations.TryGetValue(conversationId.Value, out var existing))
+                return;
+
+            var byCitizen = new Dictionary<CitizenId, SessionParticipant>(existing.Participants.Count);
+            foreach (var p in existing.Participants)
+                byCitizen[p.CitizenId] = p;
+
+            foreach (var participant in snapshot)
+            {
+                if (!participant.CitizenId.IsValid)
+                    continue;
+                // First-add wins on role to match the SQLite semantics.
+                if (!byCitizen.ContainsKey(participant.CitizenId))
+                    byCitizen[participant.CitizenId] = new SessionParticipant
+                    {
+                        CitizenId = participant.CitizenId,
+                        Role = participant.Role
+                    };
+            }
+
+            existing.Participants = byCitizen.Values.ToList();
+        }
+        finally
+        {
+            conversationLock.Release();
+        }
+    }
+
+    private SemaphoreSlim GetParticipantLock(string conversationId)
+        => _participantLocks.GetOrAdd(conversationId, static _ => new SemaphoreSlim(1, 1));
 
     /// <inheritdoc />
     public Task<Conversation?> ResolveByBindingAsync(

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -165,18 +165,25 @@ public sealed class SqliteConversationStore : IConversationStore
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
         await using var command = connection.CreateCommand();
-        // Union semantics: rows whose initiator matches, plus (only for Agent species) rows
-        // whose owning agent matches. The $isAgent flag short-circuits the owner-match for users.
+        // Union semantics (P9-F, issue #657): rows whose initiator matches, plus (only for
+        // Agent species) rows whose owning agent matches, plus rows where the citizen is in
+        // the conversation_participants set. The DISTINCT collapses duplicates when a citizen
+        // matches under more than one criterion (e.g. an agent that owns + participates).
         command.CommandText = """
-            SELECT id FROM conversations
-            WHERE initiator = $initiator
-               OR ($isAgent = 1 AND agent_id = $agentMatch)
-            ORDER BY updated_at DESC
+            SELECT DISTINCT c.id
+            FROM conversations c
+            LEFT JOIN conversation_participants p ON p.conversation_id = c.id
+            WHERE c.initiator = $initiator
+               OR ($isAgent = 1 AND c.agent_id = $agentMatch)
+               OR (p.citizen_kind = $citizenKind AND p.citizen_id = $citizenIdValue)
+            ORDER BY c.updated_at DESC
             """;
         command.Parameters.AddWithValue("$initiator", citizen.ToString());
         command.Parameters.AddWithValue("$isAgent", citizen.Kind == CitizenKind.Agent ? 1 : 0);
         command.Parameters.AddWithValue("$agentMatch",
             citizen.Kind == CitizenKind.Agent ? (object)citizen.AsAgent!.Value.Value : DBNull.Value);
+        command.Parameters.AddWithValue("$citizenKind", citizen.Kind.ToString());
+        command.Parameters.AddWithValue("$citizenIdValue", citizen.Value);
 
         var conversations = new List<Conversation>();
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
@@ -199,6 +206,66 @@ public sealed class SqliteConversationStore : IConversationStore
         }
 
         return conversations;
+    }
+
+    /// <inheritdoc />
+    public async Task AddParticipantsAsync(
+        ConversationId conversationId,
+        IEnumerable<SessionParticipant> participants,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+
+        // Snapshot once so a streaming enumerable isn't reread under the lock.
+        var snapshot = participants as IReadOnlyCollection<SessionParticipant> ?? participants.ToArray();
+        if (snapshot.Count == 0)
+            return;
+
+        using var activity = ActivitySource.StartActivity("conversation.add_participants", ActivityKind.Internal);
+        activity?.SetTag("botnexus.conversation.id", conversationId.Value);
+        activity?.SetTag("botnexus.participants.count", snapshot.Count);
+
+        await EnsureCreatedAsync(ct).ConfigureAwait(false);
+        var conversationLock = GetConversationLock(conversationId.Value);
+        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+
+            foreach (var participant in snapshot)
+            {
+                if (!participant.CitizenId.IsValid)
+                    continue;
+
+                await using var insertCommand = connection.CreateCommand();
+                insertCommand.Transaction = transaction;
+                // INSERT OR IGNORE preserves the existing role label when a citizen is already
+                // registered as a participant (first-add wins). New citizens are inserted with
+                // the supplied role.
+                insertCommand.CommandText = """
+                    INSERT OR IGNORE INTO conversation_participants
+                        (conversation_id, citizen_kind, citizen_id, role)
+                    VALUES ($conversationId, $citizenKind, $citizenId, $role)
+                    """;
+                insertCommand.Parameters.AddWithValue("$conversationId", conversationId.Value);
+                insertCommand.Parameters.AddWithValue("$citizenKind", participant.CitizenId.Kind.ToString());
+                insertCommand.Parameters.AddWithValue("$citizenId", participant.CitizenId.Value);
+                insertCommand.Parameters.AddWithValue("$role", (object?)participant.Role ?? DBNull.Value);
+                await insertCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+
+            // Invalidate cache entry — the next read will repopulate Participants via the
+            // LoadParticipantsAsync join. Cheaper than mutating the cached list in place.
+            _cache.TryRemove(conversationId.Value, out _);
+        }
+        finally
+        {
+            conversationLock.Release();
+        }
     }
 
     public async Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
@@ -466,9 +533,19 @@ public sealed class SqliteConversationStore : IConversationStore
                     FOREIGN KEY (conversation_id) REFERENCES conversations(id)
                 );
 
+                CREATE TABLE IF NOT EXISTS conversation_participants (
+                    conversation_id TEXT NOT NULL,
+                    citizen_kind TEXT NOT NULL,
+                    citizen_id TEXT NOT NULL,
+                    role TEXT,
+                    PRIMARY KEY (conversation_id, citizen_kind, citizen_id),
+                    FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+                );
+
                 CREATE INDEX IF NOT EXISTS idx_conversations_agent_id ON conversations(agent_id);
                 CREATE INDEX IF NOT EXISTS idx_bindings_conversation_id ON conversation_bindings(conversation_id);
                 CREATE INDEX IF NOT EXISTS idx_bindings_lookup ON conversation_bindings(channel_type, channel_address);
+                CREATE INDEX IF NOT EXISTS idx_conversation_participants_citizen ON conversation_participants(citizen_kind, citizen_id);
                 """;
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
@@ -854,7 +931,56 @@ public sealed class SqliteConversationStore : IConversationStore
 
         await reader.DisposeAsync().ConfigureAwait(false);
         conversation.ChannelBindings = await LoadBindingsAsync(connection, conversation.ConversationId, ct).ConfigureAwait(false);
+        conversation.Participants = await LoadParticipantsAsync(connection, conversation.ConversationId, ct).ConfigureAwait(false);
         return conversation;
+    }
+
+    private static async Task<List<SessionParticipant>> LoadParticipantsAsync(SqliteConnection connection, ConversationId conversationId, CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT citizen_kind, citizen_id, role
+            FROM conversation_participants
+            WHERE conversation_id = $conversationId
+            ORDER BY citizen_kind ASC, citizen_id ASC
+            """;
+        command.Parameters.AddWithValue("$conversationId", conversationId.Value);
+
+        var participants = new List<SessionParticipant>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var kindRaw = reader.GetString(0);
+            var idValue = reader.GetString(1);
+            var role = reader.IsDBNull(2) ? null : reader.GetString(2);
+            if (!TryComposeCitizen(kindRaw, idValue, out var citizen))
+                continue;
+            participants.Add(new SessionParticipant
+            {
+                CitizenId = citizen,
+                Role = role
+            });
+        }
+
+        return participants;
+    }
+
+    private static bool TryComposeCitizen(string kindRaw, string idValue, out CitizenId citizen)
+    {
+        citizen = default;
+        if (!Enum.TryParse<CitizenKind>(kindRaw, ignoreCase: true, out var kind))
+            return false;
+        switch (kind)
+        {
+            case CitizenKind.User:
+                citizen = CitizenId.Of(UserId.From(idValue));
+                return true;
+            case CitizenKind.Agent:
+                citizen = CitizenId.Of(AgentId.From(idValue));
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static async Task<List<ChannelBinding>> LoadBindingsAsync(SqliteConnection connection, ConversationId conversationId, CancellationToken ct)
@@ -1030,6 +1156,14 @@ public sealed class SqliteConversationStore : IConversationStore
                 BoundAt = binding.BoundAt,
                 LastInboundAt = binding.LastInboundAt,
                 LastOutboundAt = binding.LastOutboundAt
-            }).ToList()
+            }).ToList(),
+            // Participants are conversation state but are mutated exclusively through
+            // AddParticipantsAsync — CloneConversation keeps the snapshot consistent so
+            // callers reading a clone see the loaded list, but SaveAsync intentionally does
+            // not write Participants back to disk (the conversation_participants table is the
+            // authoritative store for them).
+            Participants = conversation.Participants
+                .Select(p => new SessionParticipant { CitizenId = p.CitizenId, Role = p.Role })
+                .ToList()
         };
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -44,6 +44,7 @@ public sealed class FileSessionStore : SessionStoreBase
     private readonly ILogger<FileSessionStore> _logger;
     private readonly ISecretRedactor? _redactor;
     private readonly LegacyConversationResolver? _legacyResolver;
+    private readonly IConversationStore? _conversationStore;
 
     // Phase 9 / P9-B-2 (#627): eager startup sweep mirrors
     // SqliteSessionStore.MigrateOrphanedSessionsAsync. A SemaphoreSlim + bool flag
@@ -94,11 +95,13 @@ public sealed class FileSessionStore : SessionStoreBase
         IFileSystem fileSystem,
         IConversationStore? conversationStore,
         ISecretRedactor? redactor = null)
+        : base(conversationStore)
     {
         _storePath = storePath;
         _logger = logger;
         _fileSystem = fileSystem;
         _redactor = redactor;
+        _conversationStore = conversationStore;
         _legacyResolver = conversationStore is not null
             ? new LegacyConversationResolver(conversationStore, logger: null)
             : null;
@@ -262,6 +265,11 @@ public sealed class FileSessionStore : SessionStoreBase
             {
                 Interlocked.Increment(ref _migrationInvocationCount);
                 await MigrateOrphanedSessionsAsync(cancellationToken).ConfigureAwait(false);
+                // P9-F (#657): forward legacy sidecar Participants entries into the
+                // conversation store's normalised participant set. Idempotent — runs once
+                // per process, mirrors the Sqlite-side backfill.
+                if (_conversationStore is not null)
+                    await BackfillParticipantsToConversationsAsync(_conversationStore, cancellationToken).ConfigureAwait(false);
                 _migrated = true;
             }
             catch (OperationCanceledException)
@@ -404,6 +412,68 @@ public sealed class FileSessionStore : SessionStoreBase
             totalMigrated, orphans.Select(o => o.AgentId).Distinct().Count());
     }
 
+    /// <summary>
+    /// P9-F (#657): one-shot startup backfill that forwards legacy sidecar
+    /// <c>SessionMeta.Participants</c> entries into the conversation store's normalised
+    /// participant set. Mirrors the SqliteSessionStore-side scan; reads each sidecar,
+    /// groups by ConversationId and dispatches to
+    /// <see cref="IConversationStore.AddParticipantsAsync"/>. Idempotent — safe to re-run.
+    /// Sidecars with no <c>ConversationId</c> are skipped here because the orphan
+    /// migration immediately preceding this call already stamps a legacy conversation
+    /// onto them.
+    /// </summary>
+    private async Task BackfillParticipantsToConversationsAsync(
+        IConversationStore conversationStore,
+        CancellationToken cancellationToken)
+    {
+        var byConversation = new Dictionary<string, List<SessionParticipant>>(StringComparer.Ordinal);
+
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (var metaFile in _fileSystem.Directory.GetFiles(_storePath, "*.meta.json"))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var meta = await SessionMetadataSidecar.ReadAsync<SessionMeta>(
+                    _fileSystem,
+                    metaFile,
+                    JsonOptions,
+                    cancellationToken).ConfigureAwait(false);
+                if (meta is null) continue;
+                if (meta.ConversationId is null) continue;
+                if (meta.Participants is null || meta.Participants.Count == 0) continue;
+
+                var key = meta.ConversationId.Value.Value;
+                if (!byConversation.TryGetValue(key, out var list))
+                {
+                    list = [];
+                    byConversation[key] = list;
+                }
+                list.AddRange(meta.Participants);
+            }
+        }
+        finally { _lock.Release(); }
+
+        if (byConversation.Count == 0)
+            return;
+
+        var totalRows = 0;
+        foreach (var (convIdString, participants) in byConversation)
+        {
+            var convId = ConversationId.From(convIdString);
+            var deduped = participants
+                .GroupBy(p => p.CitizenId)
+                .Select(g => g.First())
+                .ToList();
+            await conversationStore.AddParticipantsAsync(convId, deduped, cancellationToken).ConfigureAwait(false);
+            totalRows += deduped.Count;
+        }
+
+        _logger.LogInformation(
+            "Participant backfill (file session store): forwarded {Count} participant entries across {ConvCount} conversation(s).",
+            totalRows, byConversation.Count);
+    }
+
     private async Task<GatewaySession?> LoadFromFileAsync(SessionId sessionId, CancellationToken cancellationToken)
     {
         var metaPath = GetMetaPath(sessionId);
@@ -420,7 +490,9 @@ public sealed class FileSessionStore : SessionStoreBase
             AgentId = meta.AgentId,
             ChannelType = meta.ChannelType,
             SessionType = meta.SessionType ?? InferSessionType(sessionId, meta.ChannelType),
-            Participants = meta.Participants ?? [],
+            // P9-F (#657): meta.Participants is read-and-discarded. The legacy field is
+            // retained on SessionMeta for the one-shot backfill into the conversation
+            // store; participants are no longer assigned to Session.
             CreatedAt = meta.CreatedAt,
             UpdatedAt = meta.UpdatedAt,
             Status = meta.Status,
@@ -531,7 +603,11 @@ public sealed class FileSessionStore : SessionStoreBase
             session.ChannelType,
             session.CallerId,
             session.SessionType,
-            session.Participants,
+            // P9-F (#657): never write Participants on new sidecars — the legacy field is
+            // retained on the record for back-compat reads (and the backfill scan) but
+            // not populated. Sending `null` preserves the JSON shape without re-emitting
+            // stale data on every save.
+            null,
             session.CreatedAt,
             session.UpdatedAt,
             session.Status,

--- a/src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/InMemorySessionStore.cs
@@ -42,6 +42,7 @@ public sealed class InMemorySessionStore : SessionStoreBase
         ISecretRedactor? redactor,
         IConversationStore? conversationStore,
         ILogger<InMemorySessionStore>? logger = null)
+        : base(conversationStore)
     {
         _redactor = redactor;
         _legacyResolver = conversationStore is not null

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -1,5 +1,6 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -8,6 +9,20 @@ namespace BotNexus.Gateway.Sessions;
 
 public abstract class SessionStoreBase : ISessionStore
 {
+    private readonly IConversationStore? _conversationStoreForExistence;
+
+    /// <summary>
+    /// Initialises the base. Concrete subclasses pass through the optional
+    /// <see cref="IConversationStore"/> so <see cref="GetExistenceAsync"/> can resolve a
+    /// citizen's participation via the conversation-level Participants set instead of
+    /// scanning every session's legacy <c>Participants</c> field. When <c>null</c>, the
+    /// existence query falls back to an AgentId-owner match only.
+    /// </summary>
+    protected SessionStoreBase(IConversationStore? conversationStoreForExistence = null)
+    {
+        _conversationStoreForExistence = conversationStoreForExistence;
+    }
+
     public abstract Task<GatewaySession?> GetAsync(SessionId sessionId, CancellationToken cancellationToken = default);
 
     public abstract Task<GatewaySession> GetOrCreateAsync(SessionId sessionId, AgentId agentId, CancellationToken cancellationToken = default);
@@ -78,9 +93,32 @@ public abstract class SessionStoreBase : ISessionStore
     {
         query ??= new ExistenceQuery();
 
+        // Conversation-first lookup (P9-F, #657): a citizen "exists" in a session if they
+        // own it (Session.AgentId match) OR if they participate in its Conversation
+        // (Conversation.Participants set). Pre-P9-F this used a per-session
+        // Session.Participants scan; the conversation-level set is the durable source of
+        // truth and is indexed in SqliteConversationStore. When no conversation store is
+        // wired (older test fixtures), participation falls back to owner-only.
+        HashSet<ConversationId>? participantConversationIds = null;
+        if (_conversationStoreForExistence is not null)
+        {
+            var citizen = CitizenId.Of(agentId);
+            var conversations = await _conversationStoreForExistence
+                .ListForCitizenAsync(citizen, cancellationToken)
+                .ConfigureAwait(false);
+            participantConversationIds = new HashSet<ConversationId>(
+                conversations
+                    .Select(c => c.ConversationId)
+                    .Where(id => id.IsInitialized()));
+        }
+
         var sessions = await EnumerateSessionsAsync(cancellationToken).ConfigureAwait(false);
         IEnumerable<GatewaySession> result = sessions
-            .Where(session => session.AgentId == agentId || IsParticipant(session, agentId))
+            .Where(session =>
+                session.AgentId == agentId
+                || (participantConversationIds is not null
+                    && session.ConversationId.IsInitialized()
+                    && participantConversationIds.Contains(session.ConversationId)))
             .Where(session => !query.From.HasValue || session.CreatedAt >= query.From.Value)
             .Where(session => !query.To.HasValue || session.CreatedAt <= query.To.Value)
             .Where(session => query.TypeFilter is null || session.SessionType == query.TypeFilter)
@@ -121,10 +159,4 @@ public abstract class SessionStoreBase : ISessionStore
 
     private static IEnumerable<GatewaySession> ApplyAgentFilter(IEnumerable<GatewaySession> sessions, AgentId? agentId)
         => agentId is null ? sessions : sessions.Where(session => session.AgentId == agentId);
-
-    private static bool IsParticipant(GatewaySession session, AgentId agentId)
-    {
-        var citizenId = CitizenId.Of(agentId);
-        return session.Participants.Any(participant => participant.CitizenId == citizenId);
-    }
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -61,6 +61,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
         ILogger<SqliteSessionStore> logger,
         IConversationStore? conversationStore = null,
         ISecretRedactor? redactor = null)
+        : base(conversationStore)
     {
         _connectionString = connectionString;
         _logger = logger;
@@ -344,6 +345,13 @@ public sealed class SqliteSessionStore : SessionStoreBase
             if (_conversationStore is not null)
                 await MigrateOrphanedSessionsAsync(connection, _conversationStore, cancellationToken).ConfigureAwait(false);
 
+            // P9-F (#657): forward any legacy participants_json into the conversation
+            // store's normalised participant set. Idempotent (INSERT OR IGNORE inside
+            // AddParticipantsAsync). Runs on every startup; cheap when the legacy column
+            // has aged out across deployments.
+            if (_conversationStore is not null)
+                await BackfillParticipantsToConversationsAsync(connection, _conversationStore, cancellationToken).ConfigureAwait(false);
+
             _initialized = true;
         }
         finally { _initLock.Release(); }
@@ -489,6 +497,73 @@ public sealed class SqliteSessionStore : SessionStoreBase
     }
 
     /// <summary>
+    /// P9-F (#657): one-shot startup backfill that forwards legacy
+    /// <c>sessions.participants_json</c> entries into the conversation store's normalised
+    /// participant set. Sessions are grouped by <c>conversation_id</c> and each group is
+    /// dispatched to <see cref="IConversationStore.AddParticipantsAsync"/> — idempotent
+    /// (<c>INSERT OR IGNORE</c>) so safe to re-run on every startup. Sessions with a NULL
+    /// <c>conversation_id</c> are skipped here because the orphan migration immediately
+    /// preceding this call already stamps a legacy conversation onto them, so by the time
+    /// this scan runs every row that has participants has a destination.
+    /// </summary>
+    private async Task BackfillParticipantsToConversationsAsync(
+        SqliteConnection connection,
+        IConversationStore conversationStore,
+        CancellationToken cancellationToken)
+    {
+        await using var scanCmd = connection.CreateCommand();
+        scanCmd.CommandText = """
+            SELECT conversation_id, participants_json
+            FROM sessions
+            WHERE participants_json IS NOT NULL
+              AND participants_json != ''
+              AND participants_json != '[]'
+              AND conversation_id IS NOT NULL
+            """;
+
+        var byConversation = new Dictionary<string, List<SessionParticipant>>(StringComparer.Ordinal);
+        await using (var reader = await scanCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var convId = reader.GetString(0);
+                var json = reader.GetString(1);
+                var participants = DeserializeParticipants(json);
+                if (participants.Count == 0)
+                    continue;
+
+                if (!byConversation.TryGetValue(convId, out var list))
+                {
+                    list = [];
+                    byConversation[convId] = list;
+                }
+                list.AddRange(participants);
+            }
+        }
+
+        if (byConversation.Count == 0)
+            return;
+
+        var totalRows = 0;
+        foreach (var (convIdString, participants) in byConversation)
+        {
+            var convId = ConversationId.From(convIdString);
+            // Pre-dedupe by CitizenId. AddParticipantsAsync dedupes again, but a smaller
+            // payload keeps the conversation-store transaction lighter.
+            var deduped = participants
+                .GroupBy(p => p.CitizenId)
+                .Select(g => g.First())
+                .ToList();
+            await conversationStore.AddParticipantsAsync(convId, deduped, cancellationToken).ConfigureAwait(false);
+            totalRows += deduped.Count;
+        }
+
+        _logger.LogInformation(
+            "Participant backfill (Sqlite session store): forwarded {Count} participant entries across {ConvCount} conversation(s).",
+            totalRows, byConversation.Count);
+    }
+
+    /// <summary>
     /// Defensively backfills a session whose <see cref="Session.ConversationId"/> is null
     /// at save time by stamping it with the agent's legacy conversation. This catches the
     /// narrow window between <see cref="EnsureCreatedAsync"/> startup migration completing
@@ -599,7 +674,10 @@ public sealed class SqliteSessionStore : SessionStoreBase
         if (!reader.IsDBNull(2))
             channelType = ChannelKey.From(reader.GetString(2));
         var sessionType = ParseSessionType(reader.IsDBNull(4) ? null : reader.GetString(4), sessionId, channelType);
-        var participants = DeserializeParticipants(reader.IsDBNull(5) ? null : reader.GetString(5));
+        // P9-F (#657): participants_json column is intentionally read-and-discarded — the
+        // legacy column is preserved for the one-shot startup backfill into the
+        // conversation store (BackfillParticipantsToConversationsAsync) and as a rollback
+        // source. Participants are no longer persisted on Session.
         var agentIdValue = reader.IsDBNull(1) ? null : reader.GetString(1);
         if (string.IsNullOrWhiteSpace(agentIdValue))
             return null;
@@ -610,7 +688,6 @@ public sealed class SqliteSessionStore : SessionStoreBase
             AgentId = AgentId.From(agentIdValue),
             ChannelType = channelType,
             SessionType = sessionType,
-            Participants = participants,
             Status = status,
             CreatedAt = createdAt,
             UpdatedAt = updatedAt,
@@ -697,7 +774,9 @@ public sealed class SqliteSessionStore : SessionStoreBase
         command.Parameters.AddWithValue("$channelType", session.ChannelType.HasValue ? session.ChannelType.Value.Value : DBNull.Value);
         command.Parameters.AddWithValue("$callerId", (object?)session.CallerId ?? DBNull.Value);
         command.Parameters.AddWithValue("$sessionType", session.SessionType.Value);
-        command.Parameters.AddWithValue("$participantsJson", JsonSerializer.Serialize(session.Participants, JsonOptions));
+        // P9-F (#657): write `[]` so the backfill scan's "non-empty" filter excludes
+        // new rows. The column is retained for one phase as a rollback source.
+        command.Parameters.AddWithValue("$participantsJson", "[]");
         command.Parameters.AddWithValue("$status", session.Status.ToString());
         command.Parameters.AddWithValue("$metadata", JsonSerializer.Serialize(session.Metadata, JsonOptions));
         command.Parameters.AddWithValue("$createdAt", session.CreatedAt.ToString("O"));

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -103,17 +103,26 @@ public sealed class AgentExchangeService : IAgentExchangeService
         session.ChannelType = null;
         session.CallerId = null;
         session.Status = GatewaySessionStatus.Active;
-        session.Participants.Clear();
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(request.InitiatorId),
-            Role = "initiator"
-        });
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(request.TargetId),
-            Role = "target"
-        });
+
+        // P9-F: Participants live on the Conversation, not the Session. The agent-exchange
+        // handshake pre-registers the initiator + target so any later participant-based
+        // query (e.g. portal's responder-side inbox via IConversationStore.ListForCitizenAsync)
+        // resolves the conversation for both citizens.
+        await _conversationStore.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(request.InitiatorId),
+                    Role = "initiator"
+                },
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(request.TargetId),
+                    Role = "target"
+                }
+            ],
+            cancellationToken).ConfigureAwait(false);
 
         session.Metadata["callChain"] = normalizedChain
             .Select(id => id.Value)
@@ -267,17 +276,25 @@ public sealed class AgentExchangeService : IAgentExchangeService
         session.ChannelType = ChannelKey.From("cross-world");
         session.CallerId = null;
         session.Status = GatewaySessionStatus.Active;
-        session.Participants.Clear();
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(request.InitiatorId),
-            Role = "initiator"
-        });
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(resolvedTarget.AgentId),
-            Role = "target"
-        });
+
+        // P9-F: Participants live on the Conversation (cross-world variant). The remote
+        // target is identified by its in-world AgentId so the local
+        // IConversationStore.ListForCitizenAsync lookup works without cross-world plumbing.
+        await _conversationStore.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(request.InitiatorId),
+                    Role = "initiator"
+                },
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(resolvedTarget.AgentId),
+                    Role = "target"
+                }
+            ],
+            cancellationToken).ConfigureAwait(false);
 
         session.Metadata["callChain"] = normalizedChain
             .Select(id => id.Value)

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -59,6 +59,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     private readonly PendingAskUserInterceptor? _pendingAskUserInterceptor;
     private readonly IPreCompactionMemoryFlusher? _memoryFlusher;
     private readonly ISessionCompactionCoordinator _compactionCoordinator;
+    private readonly IConversationStore? _conversationStore;
     private readonly ConcurrentDictionary<string, SessionQueueState> _sessionQueues = new(StringComparer.OrdinalIgnoreCase);
 
     public GatewayHost(
@@ -78,7 +79,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         PendingAskUserInterceptor? pendingAskUserInterceptor = null,
         IPreCompactionMemoryFlusher? memoryFlusher = null,
         IAgentRegistry? registry = null,
-        ISessionCompactionCoordinator? compactionCoordinator = null)
+        ISessionCompactionCoordinator? compactionCoordinator = null,
+        IConversationStore? conversationStore = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -95,6 +97,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         _pendingAskUserInterceptor = pendingAskUserInterceptor;
         _memoryFlusher = memoryFlusher;
         _registry = registry;
+        _conversationStore = conversationStore;
         // The coordinator is the single source of truth for compaction (PR #602
         // followup). Tests that construct GatewayHost directly may not provide
         // one; build a fallback from the deps we already have so behaviour
@@ -386,7 +389,11 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                 session.ConversationId = resolution.ConversationId;
             session.CallerId ??= message.SenderId;
             session.SessionType = ResolveSessionType(session, message, isNewSession: createdSession);
-            EnsureCallerParticipant(session, message.Sender);
+            // P9-F (#657): participant add must run AFTER SaveAsync below so that the
+            // legacy-conversation resolver inside SaveAsync has stamped session.ConversationId
+            // (and CreateAsync'd the row in the conversation store). Adding before save would
+            // race the orphan-stamp and silently no-op when the dispatcher hasn't resolved a
+            // conversation up front.
             if (ShouldInitializeSystemPrompt(session))
             {
                 // Force fresh handle creation so isolation strategy rebuilds system prompt from workspace files.
@@ -460,6 +467,12 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             // Write-ahead Layer 1: persist user message before starting the LLM call.
             // Ensures user input survives a gateway restart mid-turn (#363).
             await _sessions.SaveAsync(session, cancellationToken);
+
+            // P9-F (#657): now that SaveAsync has run the legacy resolver and stamped
+            // session.ConversationId (creating the row in the conversation store if needed),
+            // it is safe to add the caller participant. AddParticipantsAsync no-ops when the
+            // target conversation doesn't exist, so this MUST follow the first SaveAsync.
+            await EnsureCallerParticipantAsync(session, message.Sender, cancellationToken).ConfigureAwait(false);
 
             if (_compactor.ShouldCompact(session.Session, _compactionOptions.CurrentValue))
             {
@@ -1053,18 +1066,23 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         base.Dispose();
     }
 
-    private static void EnsureCallerParticipant(GatewaySession session, CitizenId callerCitizenId)
+    private async Task EnsureCallerParticipantAsync(GatewaySession session, CitizenId callerCitizenId, CancellationToken cancellationToken)
     {
         if (!callerCitizenId.IsValid)
             return;
 
-        if (session.Participants.Any(p => p.CitizenId == callerCitizenId))
+        // Skip when the conversation has not yet been pinned to the session (legacy/dispatch
+        // races) — without a ConversationId we have nothing to merge against. Skip when no
+        // conversation store is wired (legacy unit-test compositions); the architecture fence
+        // pins direct Session.Participants mutations as removed, so the no-store path simply
+        // becomes a no-op rather than reaching back into the deleted field.
+        if (!session.ConversationId.IsInitialized() || _conversationStore is null)
             return;
 
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = callerCitizenId
-        });
+        await _conversationStore.AddParticipantsAsync(
+            session.ConversationId,
+            [new SessionParticipant { CitizenId = callerCitizenId }],
+            cancellationToken).ConfigureAwait(false);
     }
 
     private SessionType ResolveSessionType(GatewaySession session, InboundMessage message, bool isNewSession)

--- a/tests/architecture/BotNexus.Architecture.Tests/ConversationParticipantsMutationArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ConversationParticipantsMutationArchitectureTests.cs
@@ -1,0 +1,287 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-F atomic-merge contract:
+/// <see cref="BotNexus.Gateway.Abstractions.Models.Conversation.Participants"/> may only
+/// be mutated by the three persistence stores; every other producer must go through
+/// <c>IConversationStore.AddParticipantsAsync</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// P9-F introduced <c>AddParticipantsAsync</c> as the only atomic-merge entry point for
+/// participants. The danger if callers reach past it is the same as before P9-F: a
+/// read-modify-write race against <c>SaveAsync</c> clobbers bindings, metadata, or
+/// concurrent participant additions. The 3 store implementations are the only places
+/// that need direct mutation (initial materialisation + the atomic-merge body itself).
+/// </para>
+/// <para>
+/// The fence ships vacuity / false-positive / comment-mention self-tests per the
+/// "every regex-based architecture fence must include a self-test" memory.
+/// </para>
+/// </remarks>
+public sealed class ConversationParticipantsMutationArchitectureTests
+{
+    [Fact]
+    public void NoProductionSourceFile_MutatesParticipantsList_OutsideAllowlist()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            if (s_mutationAllowlist.Contains(relative)) continue;
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_participantsMutationPattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-F atomic-merge contract: only the conversation stores may mutate " +
+            "`.Participants` directly. Producers must call IConversationStore.AddParticipantsAsync " +
+            "so the merge is atomic against concurrent SaveAsync / binding writes.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void MutationAllowlist_OnlyContains_FilesThat_StillExist_AndStill_TripTheFence()
+    {
+        var srcRoot = FindSourceRoot();
+        var stale = new List<string>();
+
+        foreach (var relative in s_mutationAllowlist)
+        {
+            var full = Path.Combine(srcRoot, relative);
+            if (!File.Exists(full))
+            {
+                stale.Add($"{relative} — file does not exist (delete this allowlist entry)");
+                continue;
+            }
+            if (!s_participantsMutationPattern.IsMatch(StripComments(File.ReadAllText(full))))
+            {
+                stale.Add($"{relative} — file no longer trips the fence (delete this allowlist entry)");
+            }
+        }
+
+        stale.ShouldBeEmpty(
+            "Allowlist hygiene: every entry must still match an existing file AND still trip the fence; " +
+            "otherwise it grants a permanent exemption to future regressions in the same file.\n" +
+            "Stale entries:\n  " + string.Join("\n  ", stale));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReintroduction()
+    {
+        // If a regression PR adds a mutation back, the fence MUST trip. Vacuity guard.
+        s_participantsMutationPattern.IsMatch("conversation.Participants.Add(participant);")
+            .ShouldBeTrue("Vacuity guard: `.Participants.Add(...)` must trip the fence.");
+        s_participantsMutationPattern.IsMatch("conv.Participants.Clear();")
+            .ShouldBeTrue("Vacuity guard: `.Participants.Clear()` must trip the fence.");
+        s_participantsMutationPattern.IsMatch("conversation.Participants.Remove(p);")
+            .ShouldBeTrue("Vacuity guard: `.Participants.Remove(...)` must trip the fence.");
+        s_participantsMutationPattern.IsMatch("conversation.Participants.RemoveAll(p => p.CitizenId == citizen);")
+            .ShouldBeTrue("Vacuity guard: `.Participants.RemoveAll(...)` must trip the fence.");
+        s_participantsMutationPattern.IsMatch("conversation.Participants.Insert(0, participant);")
+            .ShouldBeTrue("Vacuity guard: `.Participants.Insert(...)` must trip the fence.");
+        s_participantsMutationPattern.IsMatch("conversation.Participants.AddRange(more);")
+            .ShouldBeTrue("Vacuity guard: `.Participants.AddRange(...)` must trip the fence.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnRead()
+    {
+        // Reads must NOT match — the fence guards mutation only.
+        s_participantsMutationPattern.IsMatch("var count = conversation.Participants.Count;")
+            .ShouldBeFalse("False-positive guard: reading `.Participants.Count` must NOT match.");
+        s_participantsMutationPattern.IsMatch("foreach (var p in conv.Participants) { }")
+            .ShouldBeFalse("False-positive guard: iterating `.Participants` must NOT match.");
+        s_participantsMutationPattern.IsMatch("var participants = conversation.Participants.ToList();")
+            .ShouldBeFalse("False-positive guard: snapshot `.Participants.ToList()` must NOT match.");
+        s_participantsMutationPattern.IsMatch("if (conv.Participants.Any()) { }")
+            .ShouldBeFalse("False-positive guard: predicate `.Participants.Any()` must NOT match.");
+        s_participantsMutationPattern.IsMatch("var matched = conv.Participants.FirstOrDefault(p => p.CitizenId == citizen);")
+            .ShouldBeFalse("False-positive guard: LINQ over `.Participants` must NOT match.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        // Comments referencing the mutation shape must not trip — the lexer strips them.
+        const string syntheticClean = """
+            /// <summary>
+            /// Producers must NOT call `conversation.Participants.Add(...)` directly. Use
+            /// IConversationStore.AddParticipantsAsync instead so the merge is atomic.
+            /// </summary>
+            // Legacy: pre-P9-F, callers did `session.Participants.Add(p)` — that shape is dead.
+            /* Block comment: `.Participants.Clear()` is forbidden outside the conversation stores. */
+            public void Documented() { }
+            """;
+
+        s_participantsMutationPattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of the mutation shape for historical context " +
+            "or doc warnings must not trip — the lexer strips them.");
+    }
+
+    // Match `.Participants.(Add|Clear|Remove|RemoveAll|Insert|AddRange)\b` — the open paren
+    // disambiguates from property access and assignment. The lexer strips comments before
+    // the regex runs.
+    private static readonly Regex s_participantsMutationPattern = new(
+        @"\.Participants\.(?:Add|Clear|Remove|RemoveAll|Insert|AddRange)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // No production code is permitted to mutate the in-place Participants list — the
+    // conversation stores themselves don't either: they materialise the list via
+    // wholesale assignment (existing.Participants = byCitizen.Values.ToList()) inside
+    // AddParticipantsAsync, never `.Add(...)`. If that implementation strategy changes
+    // (e.g. a future store decides to use `.Add(...)` instead of wholesale-replace), add
+    // that file here and the allowlist-hygiene test will pin the exemption real.
+    private static readonly HashSet<string> s_mutationAllowlist = new(StringComparer.OrdinalIgnoreCase);
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Same lexer pattern used by other
+    /// architecture fences (e.g. <see cref="CronConversationOwnershipArchitectureTests"/>).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionParticipantsRemovedArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionParticipantsRemovedArchitectureTests.cs
@@ -1,0 +1,297 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-F contract: participants
+/// live on <see cref="Conversation"/>, never on <see cref="Session"/> or
+/// <see cref="GatewaySession"/>. The pre-P9-F duplication — every session carrying its
+/// own <c>Participants</c> list and producers writing both shapes — must never reappear
+/// in production code.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before P9-F, <c>Session.Participants</c> was the durable list and 6 producer sites
+/// mutated it directly. The conversation was the natural owner (long-lived; one
+/// participant list per topic); the session is just an active window of work. Channel
+/// queries like "what conversations is this citizen in?" became O(sessions) scans.
+/// P9-F deletes the field on Session + GatewaySession, adds
+/// <see cref="Conversation.Participants"/>, and routes all writes through
+/// <c>IConversationStore.AddParticipantsAsync</c> for atomic merge.
+/// </para>
+/// <para>
+/// Three reflection pins (field-existence) plus a source-text fence (call-site shape)
+/// defend the invariant. Each fence ships vacuity / false-positive / comment-mention
+/// self-tests, per the stored memory "every regex-based architecture fence must include
+/// a self-test asserting it matches its target methods/symbols".
+/// </para>
+/// </remarks>
+public sealed class SessionParticipantsRemovedArchitectureTests
+{
+    [Fact]
+    public void Session_DoesNotExpose_ParticipantsProperty()
+    {
+        var sessionType = typeof(Session);
+        var participants = sessionType.GetProperty("Participants", BindingFlags.Public | BindingFlags.Instance);
+        participants.ShouldBeNull(
+            "P9-F: Session.Participants is deleted. The list lives on Conversation now and " +
+            "is mutated via IConversationStore.AddParticipantsAsync. If this fails, either " +
+            "the field was re-added (regression — re-delete) or the ownership model has " +
+            "shifted (update this fence and re-write the contract).");
+    }
+
+    [Fact]
+    public void GatewaySession_DoesNotExpose_ParticipantsFacade()
+    {
+        var gatewaySessionType = typeof(GatewaySession);
+        var participants = gatewaySessionType.GetProperty("Participants", BindingFlags.Public | BindingFlags.Instance);
+        participants.ShouldBeNull(
+            "P9-F: GatewaySession.Participants facade is deleted alongside Session.Participants. " +
+            "Producers must resolve the conversation by id and call AddParticipantsAsync " +
+            "instead of pretending the session owns the list.");
+    }
+
+    [Fact]
+    public void Conversation_ExposesParticipantsList_OfTypeListOfSessionParticipant()
+    {
+        var conversationType = typeof(Conversation);
+        var participants = conversationType.GetProperty("Participants", BindingFlags.Public | BindingFlags.Instance);
+        participants.ShouldNotBeNull(
+            "P9-F: Conversation.Participants is the canonical participant list. If this fails, " +
+            "either the field was deleted (regression — restore) or the P9-F migration has been " +
+            "rolled back. Either way: stop and reconcile before continuing.");
+        participants!.PropertyType.ShouldBe(
+            typeof(List<SessionParticipant>),
+            "Conversation.Participants must be List<SessionParticipant> so stores can replay " +
+            "the list when materialising a Conversation from a join.");
+    }
+
+    [Fact]
+    public void NoProductionSourceFile_AccessesLegacy_SessionParticipantsProperty()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_sessionParticipantsAccessPattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-F: production code must not read or write `Session.Participants` / " +
+            "`GatewaySession.Participants` / `session.Participants`. The field is deleted; " +
+            "mutate the list through IConversationStore.AddParticipantsAsync against the " +
+            "owning Conversation, and read by materialising the Conversation.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReintroduction()
+    {
+        // If a regression PR adds either shape back, the fence MUST trip. Vacuity guard.
+        s_sessionParticipantsAccessPattern.IsMatch("session.Participants.Add(p);")
+            .ShouldBeTrue("Vacuity guard: instance access `session.Participants` must trip the fence.");
+        s_sessionParticipantsAccessPattern.IsMatch("var p = gatewaySession.Participants;")
+            .ShouldBeTrue("Vacuity guard: instance access `gatewaySession.Participants` must trip the fence.");
+        s_sessionParticipantsAccessPattern.IsMatch("Session.Participants = new List<SessionParticipant>();")
+            .ShouldBeTrue("Vacuity guard: static-style access `Session.Participants` must trip the fence.");
+        s_sessionParticipantsAccessPattern.IsMatch("var x = GatewaySession.Participants.Count;")
+            .ShouldBeTrue("Vacuity guard: static-style access `GatewaySession.Participants` must trip the fence.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedAccess()
+    {
+        // The fence is keyed on `(GatewaySession|Session|session|gatewaySession).Participants` —
+        // accesses against other identifiers (Conversation, conversation, conv) must not match.
+        s_sessionParticipantsAccessPattern.IsMatch("var list = conversation.Participants;")
+            .ShouldBeFalse("False-positive guard: `conversation.Participants` is the canonical access — must NOT match.");
+        s_sessionParticipantsAccessPattern.IsMatch("var list = Conversation.Participants;")
+            .ShouldBeFalse("False-positive guard: `Conversation.Participants` (the new canonical owner) must NOT match.");
+        s_sessionParticipantsAccessPattern.IsMatch("var conv = await store.GetAsync(id); var count = conv.Participants.Count;")
+            .ShouldBeFalse("False-positive guard: `conv.Participants` (Conversation alias) must NOT match.");
+        s_sessionParticipantsAccessPattern.IsMatch("var participantsList = new List<SessionParticipant>();")
+            .ShouldBeFalse("False-positive guard: declaring a local list of SessionParticipant must NOT match.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        // Comments that historically reference the deleted shape (e.g. the P9-F migration
+        // marker in Session.cs / GatewaySession.cs) must not trip the fence.
+        const string syntheticClean = """
+            /// <summary>
+            /// Pre-P9-F, Session.Participants was the durable list. The field is deleted;
+            /// participants live on Conversation.Participants now. See gatewaySession.Participants
+            /// references for the migration markers in Session.cs and GatewaySession.cs.
+            /// </summary>
+            // Legacy: session.Participants was migrated to Conversation.Participants in P9-F.
+            /* Block comment: Session.Participants / GatewaySession.Participants were removed in P9-F. */
+            public void Documented() { }
+            """;
+
+        s_sessionParticipantsAccessPattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of the deleted `Session.Participants` shape for " +
+            "historical context must not trip — the lexer strips them.");
+    }
+
+    // Match `(Session|GatewaySession|session|gatewaySession).Participants` where the dot
+    // is immediately followed by `Participants` (word-boundary), so adjacent identifiers
+    // like `Participants` as a parameter name don't trigger. Lexer-stripped at call time
+    // so comments don't match.
+    private static readonly Regex s_sessionParticipantsAccessPattern = new(
+        @"\b(?:GatewaySession|Session|session|gatewaySession)\.Participants\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Same lexer pattern used by other
+    /// architecture fences (e.g. <see cref="CronConversationOwnershipArchitectureTests"/>).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreParticipantsContractTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreParticipantsContractTests.cs
@@ -1,0 +1,227 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// P9-F contract tests for <c>IConversationStore.AddParticipantsAsync</c> and the
+/// participant-inclusion contract on <c>ListForCitizenAsync</c>. Runs against all three
+/// store implementations (in-memory, file, SQLite) via a theory so each store gets
+/// identical contract coverage.
+/// </summary>
+/// <remarks>
+/// The 5 invariants verified per store:
+/// <list type="number">
+///   <item>Round-trip: <c>AddParticipantsAsync</c> followed by <c>GetAsync</c> returns the participants.</item>
+///   <item>Idempotence: re-adding the same citizen is a no-op (no duplicates).</item>
+///   <item>Multi-citizen merge: subsequent calls accumulate, they don't replace.</item>
+///   <item>ListForCitizenAsync includes conversations where the citizen is a participant.</item>
+///   <item>Concurrent <c>AddParticipantsAsync</c> from N tasks produces the union, not a race-condition subset.</item>
+/// </list>
+/// </remarks>
+public sealed class ConversationStoreParticipantsContractTests
+{
+    public static IEnumerable<object[]> StoreHarnesses()
+    {
+        yield return ["in-memory", () => new InMemoryStoreHarness()];
+        yield return ["file", () => new FileStoreHarness()];
+        yield return ["sqlite", () => new SqliteStoreHarness()];
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
+    public async Task AddParticipantsAsync_RoundTripsThrough_GetAsync(string _, Func<IStoreHarness> create)
+    {
+        using var harness = create();
+        var store = harness.Store;
+        var convoId = ConversationId.Create();
+        await store.CreateAsync(NewConversation(convoId, AgentId.From("owner")));
+
+        var participant = new SessionParticipant
+        {
+            CitizenId = CitizenId.Of(AgentId.From("agent-alpha"))
+        };
+        await store.AddParticipantsAsync(convoId, [participant]);
+
+        var loaded = await store.GetAsync(convoId);
+        loaded.ShouldNotBeNull();
+        loaded!.Participants.Count.ShouldBe(1);
+        loaded.Participants[0].CitizenId.ShouldBe(CitizenId.Of(AgentId.From("agent-alpha")));
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
+    public async Task AddParticipantsAsync_IsIdempotent_ForSameCitizen(string _, Func<IStoreHarness> create)
+    {
+        using var harness = create();
+        var store = harness.Store;
+        var convoId = ConversationId.Create();
+        await store.CreateAsync(NewConversation(convoId, AgentId.From("owner")));
+
+        var participant = new SessionParticipant
+        {
+            CitizenId = CitizenId.Of(AgentId.From("agent-alpha"))
+        };
+        // P9-F: AddParticipantsAsync uses INSERT OR IGNORE / dedupe-by-citizen so the
+        // second call must be a no-op rather than producing a duplicate row.
+        await store.AddParticipantsAsync(convoId, [participant]);
+        await store.AddParticipantsAsync(convoId, [participant]);
+
+        var loaded = await store.GetAsync(convoId);
+        loaded.ShouldNotBeNull();
+        loaded!.Participants.Count.ShouldBe(1);
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
+    public async Task AddParticipantsAsync_AccumulatesAcrossCalls(string _, Func<IStoreHarness> create)
+    {
+        using var harness = create();
+        var store = harness.Store;
+        var convoId = ConversationId.Create();
+        await store.CreateAsync(NewConversation(convoId, AgentId.From("owner")));
+
+        await store.AddParticipantsAsync(convoId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-alpha")) }]);
+        await store.AddParticipantsAsync(convoId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-beta")) }]);
+
+        var loaded = await store.GetAsync(convoId);
+        loaded.ShouldNotBeNull();
+        loaded!.Participants.Count.ShouldBe(2);
+        loaded.Participants.Select(p => p.CitizenId).ShouldContain(CitizenId.Of(AgentId.From("agent-alpha")));
+        loaded.Participants.Select(p => p.CitizenId).ShouldContain(CitizenId.Of(AgentId.From("agent-beta")));
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
+    public async Task ListForCitizenAsync_IncludesConversationsWhereCitizenIsParticipant(
+        string _,
+        Func<IStoreHarness> create)
+    {
+        using var harness = create();
+        var store = harness.Store;
+
+        // Conversation #1: agent-alpha owns it, agent-beta initiates — must show up for both.
+        var ownedByAlpha = NewConversation(ConversationId.Create(), AgentId.From("agent-alpha"));
+        await store.CreateAsync(ownedByAlpha);
+
+        // Conversation #2: agent-gamma owns it, agent-beta is added as a participant.
+        // Pre-P9-F, ListForCitizenAsync(beta) would NOT have included this; the new
+        // contract says it MUST.
+        var ownedByGamma = NewConversation(ConversationId.Create(), AgentId.From("agent-gamma"));
+        await store.CreateAsync(ownedByGamma);
+        await store.AddParticipantsAsync(
+            ownedByGamma.ConversationId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-beta")) }]);
+
+        // Conversation #3: unrelated — must NOT show up for beta.
+        var unrelated = NewConversation(ConversationId.Create(), AgentId.From("agent-delta"));
+        await store.CreateAsync(unrelated);
+
+        var betaConversations = await store.ListForCitizenAsync(CitizenId.Of(AgentId.From("agent-beta")));
+        var ids = betaConversations.Select(c => c.ConversationId).ToList();
+        ids.ShouldContain(ownedByGamma.ConversationId,
+            "P9-F: ListForCitizenAsync must include conversations where the citizen is a participant.");
+        ids.ShouldNotContain(unrelated.ConversationId,
+            "ListForCitizenAsync must NOT include unrelated conversations.");
+    }
+
+    [Theory]
+    [MemberData(nameof(StoreHarnesses))]
+    public async Task AddParticipantsAsync_ConcurrentCalls_ProduceUnion_NotRaceSubset(
+        string _,
+        Func<IStoreHarness> create)
+    {
+        using var harness = create();
+        var store = harness.Store;
+        var convoId = ConversationId.Create();
+        await store.CreateAsync(NewConversation(convoId, AgentId.From("owner")));
+
+        // P9-F: AddParticipantsAsync MUST be atomic. The pre-P9-F shape was
+        // read-modify-write through SaveAsync which could clobber concurrent additions.
+        // This test fans out N parallel additions of distinct citizens and asserts the
+        // final state is the union.
+        const int N = 16;
+        var tasks = Enumerable.Range(0, N).Select(i =>
+            store.AddParticipantsAsync(
+                convoId,
+                [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From($"agent-{i:D2}")) }])
+        ).ToArray();
+        await Task.WhenAll(tasks);
+
+        var loaded = await store.GetAsync(convoId);
+        loaded.ShouldNotBeNull();
+        loaded!.Participants.Count.ShouldBe(N,
+            "P9-F atomic-merge contract: concurrent AddParticipantsAsync calls must produce " +
+            "the union, not a race-condition subset (which would indicate a read-modify-write).");
+    }
+
+    private static Conversation NewConversation(ConversationId id, AgentId agentId)
+        => new()
+        {
+            ConversationId = id,
+            AgentId = agentId,
+            Title = "test-conv",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+    public interface IStoreHarness : IDisposable
+    {
+        IConversationStore Store { get; }
+    }
+
+    private sealed class InMemoryStoreHarness : IStoreHarness
+    {
+        public IConversationStore Store { get; } = new InMemoryConversationStore();
+        public void Dispose() { }
+    }
+
+    private sealed class FileStoreHarness : IStoreHarness
+    {
+        private readonly MockFileSystem _fileSystem = new();
+        private readonly string _rootPath =
+            Path.Combine(Path.GetTempPath(), "ConversationStoreParticipantsContractTests", Guid.NewGuid().ToString("N"));
+
+        public FileStoreHarness()
+        {
+            _fileSystem.Directory.CreateDirectory(_rootPath);
+            Store = new FileConversationStore(_rootPath, NullLogger<FileConversationStore>.Instance, _fileSystem);
+        }
+
+        public IConversationStore Store { get; }
+
+        public void Dispose()
+        {
+            if (_fileSystem.Directory.Exists(_rootPath))
+                _fileSystem.Directory.Delete(_rootPath, true);
+        }
+    }
+
+    private sealed class SqliteStoreHarness : IStoreHarness
+    {
+        private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"bn-p9f-conv-{Guid.NewGuid():N}.db");
+
+        public SqliteStoreHarness()
+        {
+            Store = new SqliteConversationStore(
+                $"Data Source={_dbPath};Pooling=False",
+                NullLogger<SqliteConversationStore>.Instance);
+        }
+
+        public IConversationStore Store { get; }
+
+        public void Dispose()
+        {
+            if (File.Exists(_dbPath))
+                File.Delete(_dbPath);
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -568,6 +568,8 @@ public sealed class AgentExchangeArchiveTests
             => _inner.CreateAsync(conversation, ct);
         public Task SaveAsync(Conversation conversation, CancellationToken ct = default)
             => _inner.SaveAsync(conversation, ct);
+        public Task AddParticipantsAsync(ConversationId conversationId, IEnumerable<SessionParticipant> participants, CancellationToken ct = default)
+            => _inner.AddParticipantsAsync(conversationId, participants, ct);
         public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default)
         {
             ArchiveCallCount++;

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -26,7 +26,8 @@ public sealed class AgentExchangeServiceTests
         var initiator = AgentId.From("test-agent");
         var target = AgentId.From("agent-c");
         var registry = CreateRegistry(initiator, target, ["agent-c"]);
-        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore(redactor: null, conversationStore: conversationStore);
 
         var handle = new Mock<IAgentHandle>();
         handle.Setup(h => h.PromptAsync("Review this design", It.IsAny<CancellationToken>()))
@@ -39,7 +40,7 @@ public sealed class AgentExchangeServiceTests
             registry.Object,
             supervisor.Object,
             sessionStore,
-            new InMemoryConversationStore(),
+            conversationStore,
             Options.Create(new GatewayOptions()),
             NullLogger<AgentExchangeService>.Instance);
 
@@ -60,8 +61,13 @@ public sealed class AgentExchangeServiceTests
         session.ShouldNotBeNull();
         session!.SessionType.ShouldBe(SessionType.AgentAgent);
         session.Status.ShouldBe(GatewaySessionStatus.Sealed);
-        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
-        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
+
+        // P9-F (#657): Participants now live on Conversation, not Session — assert via
+        // the conversation store using the session's ConversationId.
+        var conversation = await conversationStore.GetAsync(session.ConversationId);
+        conversation.ShouldNotBeNull();
+        conversation!.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
+        conversation.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
 
         var initiatorExistence = await sessionStore.GetExistenceAsync(initiator, new ExistenceQuery());
         var targetExistence = await sessionStore.GetExistenceAsync(target, new ExistenceQuery());
@@ -152,7 +158,8 @@ public sealed class AgentExchangeServiceTests
         var target = AgentId.From("world-b:agent-c");
         var registry = CreateRegistry(initiator, AgentId.From("agent-c"), ["world-b:agent-c"]);
         registry.Setup(r => r.Contains(target)).Returns(false);
-        var sessionStore = new InMemorySessionStore();
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore(redactor: null, conversationStore: conversationStore);
 
         HttpRequestMessage? capturedRequest = null;
         var handler = new StubHttpMessageHandler((request, _) =>
@@ -177,7 +184,7 @@ public sealed class AgentExchangeServiceTests
             registry.Object,
             Mock.Of<IAgentSupervisor>(),
             sessionStore,
-            new InMemoryConversationStore(),
+            conversationStore,
             Options.Create(new GatewayOptions()),
             NullLogger<AgentExchangeService>.Instance,
             Options.Create(new PlatformConfig
@@ -223,8 +230,12 @@ public sealed class AgentExchangeServiceTests
         var session = await sessionStore.GetAsync(result.SessionId);
         session.ShouldNotBeNull();
         session!.ChannelType.ShouldBe(ChannelKey.From("cross-world"));
-        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
-        session.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
+
+        // P9-F (#657): cross-world participants live on the conversation now.
+        var conversation = await conversationStore.GetAsync(session.ConversationId);
+        conversation.ShouldNotBeNull();
+        conversation!.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("test-agent")) && p.Role == "initiator").ShouldHaveSingleItem();
+        conversation.Participants.Where(p => p.CitizenId == CitizenId.Of(AgentId.From("agent-c")) && p.Role == "target").ShouldHaveSingleItem();
         session.Metadata["sourceWorldId"].ShouldBe("world-a");
         session.Metadata["targetWorldId"].ShouldBe("world-b");
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -205,6 +205,9 @@ public sealed class ConversationsControllerHistoryTests
         public Task SaveAsync(Conversation conversation, CancellationToken ct = default)
             => throw new NotSupportedException();
 
+        public Task AddParticipantsAsync(ConversationId conversationId, IEnumerable<SessionParticipant> participants, CancellationToken ct = default)
+            => Task.CompletedTask;
+
         public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default)
             => throw new NotSupportedException();
 

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1752,6 +1752,8 @@ file sealed class ThrowingArchiveConversationStore : IConversationStore
         => _inner.CreateAsync(conversation, ct);
     public Task SaveAsync(Conversation conversation, CancellationToken ct = default)
         => _inner.SaveAsync(conversation, ct);
+    public Task AddParticipantsAsync(ConversationId conversationId, IEnumerable<SessionParticipant> participants, CancellationToken ct = default)
+        => _inner.AddParticipantsAsync(conversationId, participants, ct);
     public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default)
     {
         ArchiveCallCount++;

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -491,17 +491,29 @@ public sealed class FileSessionStoreTests
             SessionType = BotNexus.Domain.Primitives.SessionType.UserAgent,
             CreatedAt = now.AddDays(-2)
         });
+
+        // P9-F: Participants now live on Conversation. Create the shared conversation,
+        // add agent-a as a participant, then link the AgentSubAgent session to it.
+        var sharedConvoId = ConversationId.From("conv-shared");
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = sharedConvoId,
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b"),
+            CreatedAt = now.AddDays(-1),
+            UpdatedAt = now.AddDays(-1)
+        });
+        await fixture.Conversations.AddParticipantsAsync(
+            sharedConvoId,
+            [new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }]);
+
         await store.SaveAsync(new GatewaySession
         {
             SessionId = BotNexus.Domain.Primitives.SessionId.From("participant"),
             AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b"),
+            ConversationId = sharedConvoId,
             // P9-E (#645): SessionType.Cron is deleted; the test uses AgentSubAgent so
             // the TypeFilter still discriminates this row from the "owned" UserAgent row.
             SessionType = BotNexus.Domain.Primitives.SessionType.AgentSubAgent,
-            Participants =
-            [
-                new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }
-            ],
             CreatedAt = now.AddDays(-1)
         });
 

--- a/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InMemorySessionStoreTests.cs
@@ -149,7 +149,8 @@ public sealed class InMemorySessionStoreTests
     [Fact]
     public async Task GetExistenceAsync_ReturnsOwnedAndParticipantSessions_WithFiltersApplied()
     {
-        var store = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+        var store = new InMemorySessionStore(redactor: null, conversationStore: conversations);
         var now = DateTimeOffset.UtcNow;
         await store.SaveAsync(new GatewaySession
         {
@@ -158,17 +159,29 @@ public sealed class InMemorySessionStoreTests
             SessionType = SessionType.UserAgent,
             CreatedAt = now.AddDays(-2)
         });
+
+        // P9-F: Participants now live on Conversation. Create the shared conversation,
+        // add agent-a as a participant, then link the AgentSubAgent session to it.
+        var sharedConvoId = ConversationId.From("conv-shared");
+        await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = sharedConvoId,
+            AgentId = AgentId.From("agent-b"),
+            CreatedAt = now.AddDays(-1),
+            UpdatedAt = now.AddDays(-1)
+        });
+        await conversations.AddParticipantsAsync(
+            sharedConvoId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }]);
+
         await store.SaveAsync(new GatewaySession
         {
             SessionId = SessionId.From("participant"),
             AgentId = AgentId.From("agent-b"),
+            ConversationId = sharedConvoId,
             // P9-E (#645): SessionType.Cron deleted; use AgentSubAgent so the TypeFilter
             // still discriminates this row from the "owned" UserAgent row above.
             SessionType = SessionType.AgentSubAgent,
-            Participants =
-            [
-                new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }
-            ],
             CreatedAt = now.AddDays(-1)
         });
 

--- a/tests/gateway/BotNexus.Gateway.Tests/SenderClassificationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SenderClassificationTests.cs
@@ -6,9 +6,11 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Routing;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -21,6 +23,9 @@ namespace BotNexus.Gateway.Tests;
 /// and species-correct participant tracking for User vs Agent senders (including the
 /// sub-agent wake-up case where the wire <c>SenderId</c> and typed <c>Sender</c>
 /// deliberately diverge).
+///
+/// P9-F (#657): participant assertions migrated from <c>Session.Participants</c> to
+/// <c>Conversation.Participants</c> via the shared conversation store.
 /// </summary>
 public sealed class SenderClassificationTests
 {
@@ -30,7 +35,9 @@ public sealed class SenderClassificationTests
     [Fact]
     public async Task DispatchAsync_DefaultSender_ThrowsArgumentException()
     {
-        await using var host = CreateHost(new InMemorySessionStore(), out _);
+        var conversations = new InMemoryConversationStore();
+        var sessions = new InMemorySessionStore(redactor: null, conversationStore: conversations);
+        await using var host = CreateHost(sessions, conversations, out _);
 
         var message = new InboundMessage
         {
@@ -49,8 +56,9 @@ public sealed class SenderClassificationTests
     [Fact]
     public async Task DispatchAsync_UserSender_AddsUserParticipant()
     {
-        var sessions = new InMemorySessionStore();
-        await using var host = CreateHost(sessions, out _);
+        var conversations = new InMemoryConversationStore();
+        var sessions = new InMemorySessionStore(redactor: null, conversationStore: conversations);
+        await using var host = CreateHost(sessions, conversations, out _);
 
         var senderId = UserId.From("alice");
         await host.DispatchAsync(new InboundMessage
@@ -68,7 +76,9 @@ public sealed class SenderClassificationTests
 
         var reloaded = await sessions.GetAsync(SessionId.From(SessionIdValue));
         reloaded.ShouldNotBeNull();
-        var participant = reloaded!.Participants.ShouldHaveSingleItem();
+        var conversation = await conversations.GetAsync(reloaded!.ConversationId);
+        conversation.ShouldNotBeNull();
+        var participant = conversation!.Participants.ShouldHaveSingleItem();
         participant.CitizenId.Kind.ShouldBe(CitizenKind.User);
         participant.CitizenId.AsUser.ShouldNotBeNull().ShouldBe(senderId);
     }
@@ -76,8 +86,9 @@ public sealed class SenderClassificationTests
     [Fact]
     public async Task DispatchAsync_AgentSender_AddsAgentParticipant_NotMisclassifiedAsUser()
     {
-        var sessions = new InMemorySessionStore();
-        await using var host = CreateHost(sessions, out _);
+        var conversations = new InMemoryConversationStore();
+        var sessions = new InMemorySessionStore(redactor: null, conversationStore: conversations);
+        await using var host = CreateHost(sessions, conversations, out _);
 
         // The sub-agent wake-up case: wire token is "subagent:..." but the typed
         // Sender carries the child agent id. Phase 2c regression-guard for the
@@ -98,7 +109,9 @@ public sealed class SenderClassificationTests
 
         var reloaded = await sessions.GetAsync(SessionId.From(SessionIdValue));
         reloaded.ShouldNotBeNull();
-        var participant = reloaded!.Participants.ShouldHaveSingleItem();
+        var conversation = await conversations.GetAsync(reloaded!.ConversationId);
+        conversation.ShouldNotBeNull();
+        var participant = conversation!.Participants.ShouldHaveSingleItem();
         participant.CitizenId.Kind.ShouldBe(CitizenKind.Agent);
         participant.CitizenId.AsAgent.ShouldNotBeNull().ShouldBe(childAgentId);
     }
@@ -106,8 +119,9 @@ public sealed class SenderClassificationTests
     [Fact]
     public async Task DispatchAsync_SameCitizen_DoesNotAddDuplicateParticipant()
     {
-        var sessions = new InMemorySessionStore();
-        await using var host = CreateHost(sessions, out _);
+        var conversations = new InMemoryConversationStore();
+        var sessions = new InMemorySessionStore(redactor: null, conversationStore: conversations);
+        await using var host = CreateHost(sessions, conversations, out _);
 
         var senderId = UserId.From("bob");
         var template = new InboundMessage
@@ -128,7 +142,9 @@ public sealed class SenderClassificationTests
 
         var reloaded = await sessions.GetAsync(SessionId.From(SessionIdValue));
         reloaded.ShouldNotBeNull();
-        reloaded!.Participants.Count.ShouldBe(1, "second dispatch from same citizen should not add a duplicate participant");
+        var conversation = await conversations.GetAsync(reloaded!.ConversationId);
+        conversation.ShouldNotBeNull();
+        conversation!.Participants.Count.ShouldBe(1, "second dispatch from same citizen should not add a duplicate participant");
     }
 
     [Fact]
@@ -138,8 +154,9 @@ public sealed class SenderClassificationTests
         // token (audit / allowlist / logging); Sender is the typed domain identity.
         // They are deliberately allowed to differ -- the sub-agent wake-up uses
         // "subagent:X" as the wire token while Sender carries the agent's id.
-        var sessions = new InMemorySessionStore();
-        await using var host = CreateHost(sessions, out _);
+        var conversations = new InMemoryConversationStore();
+        var sessions = new InMemorySessionStore(redactor: null, conversationStore: conversations);
+        await using var host = CreateHost(sessions, conversations, out _);
 
         var childAgentId = AgentId.From("child-agent-y");
         await host.DispatchAsync(new InboundMessage
@@ -159,12 +176,17 @@ public sealed class SenderClassificationTests
         reloaded.ShouldNotBeNull();
         // Wire token survives on the session for audit/back-compat.
         reloaded!.CallerId.ShouldBe("subagent:wake-2");
+        var conversation = await conversations.GetAsync(reloaded.ConversationId);
+        conversation.ShouldNotBeNull();
         // Typed species is used for participant tracking.
-        var participant = reloaded.Participants.ShouldHaveSingleItem();
+        var participant = conversation!.Participants.ShouldHaveSingleItem();
         participant.CitizenId.AsAgent.ShouldNotBeNull().ShouldBe(childAgentId);
     }
 
-    private static GatewayHost CreateHost(InMemorySessionStore sessions, out Mock<IAgentSupervisor> supervisor)
+    private static GatewayHost CreateHost(
+        InMemorySessionStore sessions,
+        IConversationStore conversations,
+        out Mock<IAgentSupervisor> supervisor)
     {
         var router = new Mock<IMessageRouter>();
         router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
@@ -200,6 +222,7 @@ public sealed class SenderClassificationTests
             channelManager.Object,
             Mock.Of<ISessionCompactor>(),
             new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
-            NullLogger<GatewayHost>.Instance);
+            NullLogger<GatewayHost>.Instance,
+            conversationStore: conversations);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreExistenceQueryTests.cs
@@ -1,5 +1,6 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Conversations;
@@ -25,7 +26,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(AgentId.From("agent-a"), new ExistenceQuery());
 
@@ -41,7 +42,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(AgentId.From("agent-a"), new ExistenceQuery());
 
@@ -57,7 +58,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(AgentId.From("agent-a"), new ExistenceQuery());
         var ids = sessions.Select(s => s.SessionId.Value).ToList();
@@ -75,7 +76,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        var now = await SeedExistenceDataAsync(harness.Store);
+        var now = await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(
             AgentId.From("agent-a"),
@@ -95,7 +96,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(
             AgentId.From("agent-a"),
@@ -117,7 +118,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(
             AgentId.From("agent-a"),
@@ -136,7 +137,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(AgentId.From("agent-unknown"), new ExistenceQuery());
 
@@ -150,7 +151,7 @@ public sealed class SessionStoreExistenceQueryTests
         Func<IStoreHarness> createHarness)
     {
         using var harness = createHarness();
-        await SeedExistenceDataAsync(harness.Store);
+        await SeedExistenceDataAsync(harness);
 
         var sessions = await harness.Store.GetExistenceAsync(AgentId.From("agent-a"), null!);
 
@@ -160,9 +161,38 @@ public sealed class SessionStoreExistenceQueryTests
         allIds.ShouldContain("both");
     }
 
-    private static async Task<DateTimeOffset> SeedExistenceDataAsync(ISessionStore store)
+    private static async Task<DateTimeOffset> SeedExistenceDataAsync(IStoreHarness harness)
     {
+        var store = harness.Store;
+        var conversations = harness.Conversations;
         var now = DateTimeOffset.UtcNow;
+
+        // P9-F: Participants live on Conversation now. Seed two participant conversations
+        // for agent-a, one owned by agent-b ("participant" session) and one owned by
+        // agent-a itself ("both" session).
+        var convParticipant = ConversationId.From("conv-participant");
+        var convBoth = ConversationId.From("conv-both");
+        await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convParticipant,
+            AgentId = AgentId.From("agent-b"),
+            CreatedAt = now.AddDays(-2),
+            UpdatedAt = now.AddDays(-2)
+        });
+        await conversations.AddParticipantsAsync(
+            convParticipant,
+            [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }]);
+        await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convBoth,
+            AgentId = AgentId.From("agent-a"),
+            CreatedAt = now.AddDays(-1),
+            UpdatedAt = now.AddDays(-1)
+        });
+        await conversations.AddParticipantsAsync(
+            convBoth,
+            [new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }]);
+
         await store.SaveAsync(new GatewaySession
         {
             SessionId = SessionId.From("owned"),
@@ -175,17 +205,11 @@ public sealed class SessionStoreExistenceQueryTests
         {
             SessionId = SessionId.From("participant"),
             AgentId = AgentId.From("agent-b"),
+            ConversationId = convParticipant,
             // P9-E (#645): SessionType.Cron deleted. Use AgentAgent here — it's distinct
             // from "owned"/UserAgent and "both"/AgentSubAgent so the TypeFilter test
             // (which selects participant via SessionType) still isolates this row.
             SessionType = SessionType.AgentAgent,
-            Participants =
-            [
-                new SessionParticipant
-                {
-                    CitizenId = CitizenId.Of(AgentId.From("agent-a"))
-                }
-            ],
             CreatedAt = now.AddDays(-2),
             UpdatedAt = now.AddDays(-2)
         });
@@ -193,14 +217,8 @@ public sealed class SessionStoreExistenceQueryTests
         {
             SessionId = SessionId.From("both"),
             AgentId = AgentId.From("agent-a"),
+            ConversationId = convBoth,
             SessionType = SessionType.AgentSubAgent,
-            Participants =
-            [
-                new SessionParticipant
-                {
-                    CitizenId = CitizenId.Of(AgentId.From("agent-a"))
-                }
-            ],
             CreatedAt = now.AddDays(-1),
             UpdatedAt = now.AddDays(-1)
         });
@@ -218,11 +236,19 @@ public sealed class SessionStoreExistenceQueryTests
     public interface IStoreHarness : IDisposable
     {
         ISessionStore Store { get; }
+        IConversationStore Conversations { get; }
     }
 
     private sealed class InMemoryHarness : IStoreHarness
     {
-        public ISessionStore Store { get; } = new InMemorySessionStore();
+        public IConversationStore Conversations { get; } = new InMemoryConversationStore();
+        public ISessionStore Store { get; }
+
+        public InMemoryHarness()
+        {
+            Store = new InMemorySessionStore(redactor: null, conversationStore: Conversations);
+        }
+
         public void Dispose() { }
     }
 
@@ -234,9 +260,11 @@ public sealed class SessionStoreExistenceQueryTests
         public FileHarness()
         {
             _fileSystem.Directory.CreateDirectory(_storePath);
-            Store = new FileSessionStore(_storePath, NullLogger<FileSessionStore>.Instance, _fileSystem);
+            Conversations = new InMemoryConversationStore();
+            Store = new FileSessionStore(_storePath, NullLogger<FileSessionStore>.Instance, _fileSystem, Conversations);
         }
 
+        public IConversationStore Conversations { get; }
         public ISessionStore Store { get; }
 
         public void Dispose()
@@ -249,16 +277,17 @@ public sealed class SessionStoreExistenceQueryTests
     private sealed class SqliteHarness : IStoreHarness
     {
         private readonly string _directoryPath;
-        private readonly InMemoryConversationStore _conversations = new();
 
         public SqliteHarness()
         {
             _directoryPath = Path.Combine(AppContext.BaseDirectory, "SessionStoreExistenceQueryTests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_directoryPath);
             var dbPath = Path.Combine(_directoryPath, "sessions.db");
-            Store = new SqliteSessionStore($"Data Source={dbPath};Pooling=False", NullLogger<SqliteSessionStore>.Instance, _conversations);
+            Conversations = new InMemoryConversationStore();
+            Store = new SqliteSessionStore($"Data Source={dbPath};Pooling=False", NullLogger<SqliteSessionStore>.Instance, Conversations);
         }
 
+        public IConversationStore Conversations { get; }
         public ISessionStore Store { get; }
 
         public void Dispose()

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
@@ -746,6 +746,8 @@ public sealed class LegacyConversationBackfillTests
         public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(CitizenId citizen, CancellationToken ct = default) => Inner.ListForCitizenAsync(citizen, ct);
         public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default) => Inner.CreateAsync(conversation, ct);
         public Task SaveAsync(Conversation conversation, CancellationToken ct = default) => Inner.SaveAsync(conversation, ct);
+        public Task AddParticipantsAsync(ConversationId conversationId, IEnumerable<SessionParticipant> participants, CancellationToken ct = default)
+            => Inner.AddParticipantsAsync(conversationId, participants, ct);
         public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.ArchiveAsync(conversationId, ct);
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => Inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionModelWave2Tests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionModelWave2Tests.cs
@@ -136,26 +136,62 @@ public sealed class SessionModelWave2Tests
     }
 
     [Fact]
-    public void Participants_CallerAndParticipants_CoexistDuringMigration()
+    public async Task Participants_CallerAndConversationParticipants_CoexistAfterP9F()
     {
+        // P9-F (#657): participants moved from Session to Conversation. CallerId stays
+        // on the session (channel-native wire token + audit) while Participants are now
+        // mutated via IConversationStore.AddParticipantsAsync.
         var session = CreateSession();
+        session.ConversationId = ConversationId.From($"conv-{Guid.NewGuid():N}");
         session.CallerId = "user-123";
-        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("user-123")) });
-        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) });
+
+        var conversations = new BotNexus.Gateway.Conversations.InMemoryConversationStore();
+        var conversation = await conversations.CreateAsync(new BotNexus.Gateway.Abstractions.Models.Conversation
+        {
+            ConversationId = session.ConversationId,
+            AgentId = session.AgentId,
+            Initiator = CitizenId.Of(UserId.From("user-123"))
+        });
+        await conversations.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("user-123")) },
+                new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }
+            ]);
+
+        var reloaded = await conversations.GetAsync(conversation.ConversationId);
+        reloaded.ShouldNotBeNull();
 
         session.CallerId.ShouldBe("user-123");
-        session.Participants.Count().ShouldBe(2);
+        reloaded!.Participants.Count().ShouldBe(2);
     }
 
     [Fact]
-    public void Participants_CallerId_MapsToFirstUserParticipant()
+    public async Task Participants_CallerId_MapsToFirstUserParticipant_OnConversation()
     {
+        // P9-F (#657): the "first User participant matches CallerId" invariant is now
+        // satisfied at the conversation level; Session.CallerId remains the audit token.
         var session = CreateSession();
+        session.ConversationId = ConversationId.From($"conv-{Guid.NewGuid():N}");
         session.CallerId = "caller-1";
-        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("caller-1")) });
-        session.Participants.Add(new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) });
 
-        var firstUser = session.Participants.First(p => p.CitizenId.Kind == CitizenKind.User);
+        var conversations = new BotNexus.Gateway.Conversations.InMemoryConversationStore();
+        var conversation = await conversations.CreateAsync(new BotNexus.Gateway.Abstractions.Models.Conversation
+        {
+            ConversationId = session.ConversationId,
+            AgentId = session.AgentId,
+            Initiator = CitizenId.Of(UserId.From("caller-1"))
+        });
+        await conversations.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("caller-1")) },
+                new SessionParticipant { CitizenId = CitizenId.Of(AgentId.From("agent-a")) }
+            ]);
+
+        var reloaded = await conversations.GetAsync(conversation.ConversationId);
+        reloaded.ShouldNotBeNull();
+        var firstUser = reloaded!.Participants.First(p => p.CitizenId.Kind == CitizenKind.User);
 
         firstUser.CitizenId.AsUser!.Value.Value.ShouldBe(session.CallerId);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
@@ -10,14 +10,22 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace BotNexus.Gateway.Tests;
 
 /// <summary>
-/// Back-compat integration tests for <see cref="SessionParticipant"/> persistence.
-/// Verifies that sessions written before Phase 1.5 (legacy <c>{type,id,worldId}</c> shape)
-/// still deserialise into the new CitizenId-based shape when re-read by the current store.
+/// P9-F (#657) back-compat tests for participant migration. Prior to P9-F, participants
+/// were persisted on each session in <c>sessions.participants_json</c>. P9-F moves them
+/// to the conversation-level <c>conversation_participants</c> table; the legacy column is
+/// preserved for one phase as a rollback source. These tests verify:
+/// <list type="bullet">
+///   <item>The one-shot startup backfill forwards legacy <c>participants_json</c> into
+///   the conversation store.</item>
+///   <item><see cref="SqliteSessionStore.SaveAsync"/> no longer writes participants onto
+///   the session — participants only land via
+///   <see cref="IConversationStore.AddParticipantsAsync"/>.</item>
+/// </list>
 /// </summary>
 public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
 {
     [Fact]
-    public async Task GetAsync_WithLegacyParticipantJson_DeserializesAsCitizenId()
+    public async Task EnsureCreatedAsync_WithLegacyParticipantJson_BackfillsConversationParticipants()
     {
         using var fixture = new StoreFixture();
 
@@ -28,10 +36,13 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
         var placeholder = await bootstrap.GetOrCreateAsync(SessionId.From("placeholder"), AgentId.From("agent-a"));
         await bootstrap.SaveAsync(placeholder);
 
+        var conversationId = placeholder.ConversationId;
+        conversationId.IsInitialized().ShouldBeTrue("placeholder save should have stamped a legacy conversation id");
+
         const string legacyParticipantsJson = """
             [
-              { "type": "User", "id": "alice", "worldId": "world-a", "role": "caller" },
-              { "type": 1, "id": "agent-b", "worldId": "world-b", "role": "target" }
+              { "citizenId": { "kind": "User", "id": "alice" }, "role": "caller" },
+              { "citizenId": { "kind": "Agent", "id": "agent-b" }, "role": "target" }
             ]
             """;
 
@@ -41,9 +52,9 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
             await using var insert = connection.CreateCommand();
             insert.CommandText = """
                 INSERT INTO sessions
-                  (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at)
+                  (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
                 VALUES
-                  ($id, $agentId, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt)
+                  ($id, $agentId, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt, $convId)
                 """;
             insert.Parameters.AddWithValue("$id", "legacy-session");
             insert.Parameters.AddWithValue("$agentId", "agent-a");
@@ -52,38 +63,48 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
             insert.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
             insert.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToString("O"));
             insert.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
+            insert.Parameters.AddWithValue("$convId", conversationId.Value);
             await insert.ExecuteNonQueryAsync();
         }
 
-        var reloaded = await fixture.CreateStore().GetAsync(SessionId.From("legacy-session"));
+        // Re-open the store: this re-runs EnsureCreatedAsync which now also triggers
+        // the participant backfill scan. The backfill must forward our hand-injected
+        // legacy participants_json into the conversation_participants table.
+        var reopened = fixture.CreateStore();
+        await reopened.GetOrCreateAsync(SessionId.From("trigger-startup"), AgentId.From("agent-a"));
 
-        reloaded.ShouldNotBeNull();
-        reloaded!.Participants.Count.ShouldBe(2);
+        var conversation = await fixture.Conversations.GetAsync(conversationId);
+        conversation.ShouldNotBeNull();
+        conversation!.Participants.Count.ShouldBe(2);
 
-        var caller = reloaded.Participants[0];
+        var caller = conversation.Participants.Single(p => p.Role == "caller");
         caller.CitizenId.Kind.ShouldBe(CitizenKind.User);
         caller.CitizenId.AsUser!.Value.Value.ShouldBe("alice");
-        caller.Role.ShouldBe("caller");
 
-        var target = reloaded.Participants[1];
+        var target = conversation.Participants.Single(p => p.Role == "target");
         target.CitizenId.Kind.ShouldBe(CitizenKind.Agent);
         target.CitizenId.AsAgent!.Value.Value.ShouldBe("agent-b");
-        target.Role.ShouldBe("target");
     }
 
     [Fact]
-    public async Task SaveAsync_PersistsParticipants_InDualShape_ForRollbackSafety()
+    public async Task SaveAsync_DoesNotWriteParticipantsOnSession_P9F()
     {
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
 
-        var session = await store.GetOrCreateAsync(SessionId.From("dual-shape"), AgentId.From("agent-a"));
-        session.Participants.Add(new SessionParticipant
-        {
-            CitizenId = CitizenId.Of(UserId.From("alice")),
-            Role = "caller",
-        });
+        // P9-F: producers route participant adds through IConversationStore.
+        var session = await store.GetOrCreateAsync(SessionId.From("post-p9f"), AgentId.From("agent-a"));
         await store.SaveAsync(session);
+
+        await fixture.Conversations.AddParticipantsAsync(
+            session.ConversationId,
+            [
+                new SessionParticipant
+                {
+                    CitizenId = CitizenId.Of(UserId.From("alice")),
+                    Role = "caller",
+                }
+            ]);
 
         string? participantsJson;
         await using (var connection = new SqliteConnection(fixture.ConnectionString))
@@ -91,14 +112,81 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
             await connection.OpenAsync();
             await using var read = connection.CreateCommand();
             read.CommandText = "SELECT participants_json FROM sessions WHERE id = $id";
-            read.Parameters.AddWithValue("$id", "dual-shape");
+            read.Parameters.AddWithValue("$id", "post-p9f");
             participantsJson = (string?)await read.ExecuteScalarAsync();
         }
 
-        participantsJson.ShouldNotBeNull();
-        participantsJson!.ShouldContain("\"citizenId\"");
-        participantsJson.ShouldContain("\"type\":\"User\"");
-        participantsJson.ShouldContain("\"id\":\"alice\"");
+        // SaveAsync now writes an empty array so the backfill scan's "non-empty" filter
+        // excludes new rows. Concrete value is "[]" (not null, not stale data).
+        participantsJson.ShouldBe("[]");
+
+        // The conversation now owns the participant set.
+        var conversation = await fixture.Conversations.GetAsync(session.ConversationId);
+        conversation.ShouldNotBeNull();
+        conversation!.Participants.ShouldHaveSingleItem()
+            .CitizenId.AsUser!.Value.Value.ShouldBe("alice");
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_RunTwice_BackfillIsIdempotent()
+    {
+        using var fixture = new StoreFixture();
+
+        // Same bootstrap as the first test: open once, save a placeholder so the schema
+        // is materialised, then hand-inject legacy participants_json. Use a stable
+        // CitizenId so re-running the backfill cannot create a "duplicate" row that
+        // looks legitimately new under any race interpretation.
+        var bootstrap = fixture.CreateStore();
+        var placeholder = await bootstrap.GetOrCreateAsync(SessionId.From("placeholder"), AgentId.From("agent-a"));
+        await bootstrap.SaveAsync(placeholder);
+
+        var conversationId = placeholder.ConversationId;
+        const string legacyParticipantsJson = """
+            [
+              { "citizenId": { "kind": "User", "id": "alice" }, "role": "caller" }
+            ]
+            """;
+
+        await using (var connection = new SqliteConnection(fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var insert = connection.CreateCommand();
+            insert.CommandText = """
+                INSERT INTO sessions
+                  (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
+                VALUES
+                  ($id, $agentId, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt, $convId)
+                """;
+            insert.Parameters.AddWithValue("$id", "legacy-session");
+            insert.Parameters.AddWithValue("$agentId", "agent-a");
+            insert.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
+            insert.Parameters.AddWithValue("$participants", legacyParticipantsJson);
+            insert.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
+            insert.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToString("O"));
+            insert.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
+            insert.Parameters.AddWithValue("$convId", conversationId.Value);
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        // Re-open the store TWICE in succession — each EnsureCreatedAsync runs the
+        // backfill scan. The legacy row still has participants_json set (we never
+        // clear it; it stays declared as a rollback source per the P9-F design), so the
+        // scan picks it up on both passes. AddParticipantsAsync MUST be idempotent.
+        var first = fixture.CreateStore();
+        await first.GetOrCreateAsync(SessionId.From("trigger-startup-1"), AgentId.From("agent-a"));
+
+        var second = fixture.CreateStore();
+        await second.GetOrCreateAsync(SessionId.From("trigger-startup-2"), AgentId.From("agent-a"));
+
+        // After two passes there must still be exactly one participant — not two,
+        // not zero. Idempotence is the contract.
+        var conversation = await fixture.Conversations.GetAsync(conversationId);
+        conversation.ShouldNotBeNull();
+        conversation!.Participants.Count.ShouldBe(
+            1,
+            "P9-F: backfill idempotence — re-running EnsureCreatedAsync must not duplicate participants. " +
+            "If this fails, the backfill is not using INSERT OR IGNORE / dedupe-by-citizen.");
+        conversation.Participants[0].CitizenId.AsUser!.Value.Value.ShouldBe("alice");
     }
 
     private sealed class StoreFixture : IDisposable

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -470,17 +470,29 @@ public sealed class SqliteSessionStoreTests
             SessionType = BotNexus.Domain.Primitives.SessionType.UserAgent,
             CreatedAt = now.AddDays(-2)
         });
+
+        // P9-F: Participants now live on Conversation. Create the shared conversation,
+        // add agent-a as a participant, then link the AgentSubAgent session to it.
+        var sharedConvoId = ConversationId.From("conv-shared");
+        await fixture.Conversations.CreateAsync(new BotNexus.Gateway.Abstractions.Models.Conversation
+        {
+            ConversationId = sharedConvoId,
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b"),
+            CreatedAt = now.AddDays(-1),
+            UpdatedAt = now.AddDays(-1)
+        });
+        await fixture.Conversations.AddParticipantsAsync(
+            sharedConvoId,
+            [new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }]);
+
         await store.SaveAsync(new GatewaySession
         {
             SessionId = BotNexus.Domain.Primitives.SessionId.From("participant"),
             AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b"),
+            ConversationId = sharedConvoId,
             // P9-E (#645): SessionType.Cron deleted; use AgentSubAgent so the TypeFilter
             // discriminates this row from the "owned" UserAgent row above.
             SessionType = BotNexus.Domain.Primitives.SessionType.AgentSubAgent,
-            Participants =
-            [
-                new BotNexus.Domain.Primitives.SessionParticipant { CitizenId = CitizenId.Of(BotNexus.Domain.Primitives.AgentId.From("agent-a")) }
-            ],
             CreatedAt = now.AddDays(-1)
         });
 


### PR DESCRIPTION
# P9-F — Move Participants from Session to Conversation

**Phase**: Phase 9 (Conversation/Session/Agent layering cleanup — umbrella #613)
**Predecessors**: P9-D (#643 → PR #644), P9-E (#645 → PR #646)
**Successor**: P9-G (portal responder-side list-by-participant)
**Deferred to P9-H**: deletion of `Session.AgentId`

## Goal

Move `Participants` ownership from `Session` to `Conversation` so that **conversations own
participants** (per directive W-4). This is the prerequisite for P9-G (portal
list-by-participant) and the first half of the W-4 split (the AgentId half is deferred
to a separate phase to keep this PR reviewable).

> W-4 (recorded earlier this session):
> "The conversation has the Agent, Participants, etc. They should not be on the
> session. This will also clean up the code base more."

## Scope

This PR moves only `Participants`. `Session.AgentId` removal is deferred to P9-H so the
two changes can be reviewed and shipped independently. (The combined PR would touch
~30-50 files and mix two different failure modes — Participants migration, persistence,
and lookup vs. AgentId derivation and routing. The rubber-duck review on the design pass
confirmed the split.)

## Design (validated by rubber-duck — blocking issues folded in)

### Domain

- Add `Conversation.Participants : List<SessionParticipant>`. Document the invariant that
  mutation must happen through the new `IConversationStore.AddParticipantsAsync` —
  never via direct `.Add` / `.Clear` / `.Remove` from consumers.
- Delete `Session.Participants` from the domain model. Delete the matching
  `GatewaySession.Participants` facade member.

### Persistence — atomic merge API

Add to `IConversationStore`:

```csharp
Task AddParticipantsAsync(
    ConversationId conversationId,
    IEnumerable<SessionParticipant> participants,
    CancellationToken cancellationToken);
```

Each implementation must merge **atomically** — never via `Get + mutate + Save`, which
would last-write-wins-clobber concurrent participant additions or unrelated
Conversation fields (bindings, ActiveSessionId, Metadata, etc.). Specifically:

- **SqliteConversationStore**: new normalized join table
  ```sql
  CREATE TABLE IF NOT EXISTS conversation_participants (
      conversation_id TEXT NOT NULL,
      citizen_kind TEXT NOT NULL,
      citizen_id TEXT NOT NULL,
      role TEXT,
      PRIMARY KEY (conversation_id, citizen_kind, citizen_id)
  );
  CREATE INDEX IF NOT EXISTS idx_conversation_participants_citizen
      ON conversation_participants(citizen_kind, citizen_id);
  ```
  - `AddParticipantsAsync` does `INSERT OR IGNORE` per row in one transaction.
  - On `GetAsync` / `ListAsync`, populate `Conversation.Participants` by joining this
    table. The index on `(citizen_kind, citizen_id)` is required because the same index
    backs `ListForCitizenAsync` participant inclusion (see below).
- **FileConversationStore**: `AddParticipantsAsync` merges under the per-conversation
  file lock that already serialises writes.
- **InMemoryConversationStore**: `AddParticipantsAsync` merges under a per-conversation
  lock.

### Cross-store lookup contract

- Update `IConversationStore.ListForCitizenAsync` to **include participants** (today the
  contract explicitly excludes them — see `IConversationStore.cs` lines 31-46). All three
  implementations must honour it.
- `SessionStoreBase.GetExistenceAsync` flips from `IsParticipant(session, agentId)` (a
  per-session-list scan) to:
  1. `conversationStore.ListForCitizenAsync(citizenId)` → `HashSet<ConversationId>`
  2. Filter sessions whose `ConversationId ∈` set
  This avoids N+1 and removes the stale-read window. `SessionStoreBase` takes an
  `IConversationStore` dependency.

### One-shot startup migration

`ParticipantBackfillMigration` runs at gateway startup:

- Enumerate all sessions; collect those with non-empty legacy `participants_json`.
- Group by `ConversationId`; union participants.
- Call `AddParticipantsAsync` (idempotent — `INSERT OR IGNORE` ensures no double-add).
- Log a one-line summary (`backfilled N conversations from M legacy session rows`).

This is **explicit and idempotent** — not implicit on every read (which would risk a
dependency cycle through `SessionStoreBase → IConversationStore` and would create lost
updates).

The legacy `sessions.participants_json` column is **not dropped** in P9-F — it stays for
one phase as a rollback target and the migration source. Stores stop writing to it; the
column simply ages out when P9-F-and-later sessions never populate it.

### Delete sites

Remove all 6 production participant-add sites (route through `AddParticipantsAsync`):

- `GatewayHost.cs` (caller as participant on dispatch)
- `AgentExchangeService.cs` (initiator + responder for A↔A — 2 sites)
- `GatewayHub.cs` (user as participant for SignalR — 2 sites)
- `SoulTrigger.cs` (agent-self as participant)
- `CrossWorldFederationController.cs` (cross-world A↔A initiator + responder)

### Architecture fences

- `SessionParticipantsRemovedArchitectureTests`:
  - Reflection pin: `Session.Participants` property must not exist.
  - Reflection pin: `GatewaySession.Participants` property must not exist.
  - Reflection pin: `Conversation.Participants` property must exist.
  - Member-access fence on production sources: `\bSession\.Participants\b` and
    `\.Session\.Participants\b` are forbidden.
  - Vacuity + false-positive + comment-mention self-tests (proven P9-D pattern).
- `ConversationParticipantsMutationArchitectureTests`:
  - Member-access fence: `\.Participants\.(Add|Clear|Remove|RemoveAll|Insert)\b` outside
    the conversation store implementations and the migration code is forbidden.
  - Allowlist: `SqliteConversationStore.cs`, `FileConversationStore.cs`,
    `InMemoryConversationStore.cs`, `ParticipantBackfillMigration.cs`.

## Out of scope (deferred)

- `Session.AgentId` deletion → **P9-H**.
- Physical drop of the SQLite `sessions.participants_json` column.
- Removing the legacy `SessionParticipantJsonConverter` dual-write — it stays for
  cross-version safety.
- Portal responder-side list-by-participant view → **P9-G** (consumes the P9-F APIs).

## Acceptance

- Full slnx test pass with 0 warnings.
- Existing tests migrated, not deleted. No net test deletion.
- New round-trip tests: Participants in all 3 conversation stores.
- New `ListForCitizenAsync` participant test in all 3 stores.
- New `GetExistenceAsync` test: returns conversations where the citizen is a participant
  but not the owner.
- New concurrent-`AddParticipantsAsync` test: two concurrent calls preserve both
  participants and don't clobber unrelated conversation fields (bindings, metadata).
- New legacy migration test: pre-P9-F data (sessions with `participants_json`) is
  backfilled into `Conversation.Participants` on first startup; second startup is a
  no-op.
- New architecture fences land in `tests/architecture/`.
- PR title follows Conventional Commits: `refactor!: move Participants from Session to Conversation (P9-F)`.

## References

- Umbrella: #613
- P9-D (cron conversation ownership): #644
- P9-E (SessionType collapse): #646
- W-4 directive: recorded in earlier session turns (October 2025).
