### PR TITLE
refactor(gateway)!: list conversations by participant for responder-side visibility (P9-G, closes #661)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
@@ -11,7 +11,18 @@ public interface IGatewayRestClient
     /// <summary>GET /api/agents</summary>
     Task<IReadOnlyList<AgentSummary>> GetAgentsAsync(CancellationToken cancellationToken = default);
 
-    /// <summary>GET /api/conversations?agentId={agentId}</summary>
+    /// <summary>
+    /// GET /api/conversations?agentId={agentId} — returns conversations <em>relevant to</em>
+    /// the agent: those it owns/initiated AND those where it appears as a participant
+    /// (W-1 responder-side visibility, shipped in P9-G / issue #661).
+    /// </summary>
+    /// <remarks>
+    /// The portal's <c>ClientStateStore.SeedConversations</c> filters returned summaries to
+    /// <c>Kind == "HumanAgent"</c> before populating the sidebar — AgentAgent and AgentSubAgent
+    /// kinds are intentionally hidden from the conversation drawer (they would clutter it and
+    /// can auto-hijack the active tab on updates). Use the REST API directly for admin / debug
+    /// views that need to see the full set.
+    /// </remarks>
     Task<IReadOnlyList<ConversationSummaryDto>> GetConversationsAsync(
         string agentId,
         CancellationToken cancellationToken = default);

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -58,9 +58,22 @@ public sealed class ConversationsController : ControllerBase
     }
 
     /// <summary>
-    /// Lists all conversations, optionally filtered by agent ID.
+    /// Lists conversations. With no <paramref name="agentId"/>, returns global active summaries
+    /// (admin/debug view). With <paramref name="agentId"/>, returns conversations <em>relevant
+    /// to</em> that agent: the union of (a) conversations the agent owns/initiated and (b)
+    /// conversations where the agent appears as a participant (W-1 responder-side visibility,
+    /// shipped in P9-G / issue #661). The union is materialised distinct-by-ConversationId so
+    /// owner-and-participant conversations appear exactly once.
     /// </summary>
-    /// <param name="agentId">If specified, returns only conversations for this agent.</param>
+    /// <remarks>
+    /// Only conversations with <see cref="ConversationStatus.Active"/> are returned in either
+    /// mode. The <paramref name="agentId"/> branch resolves the citizen through
+    /// <see cref="IConversationStore.ListForCitizenAsync"/> so the indexed participant lookup
+    /// (SQLite <c>idx_conversation_participants_citizen</c>) is used; the result is projected
+    /// to <see cref="ConversationSummary"/> in this controller. Results are ordered most
+    /// recently updated first, with a deterministic <see cref="ConversationId"/> tie-breaker.
+    /// </remarks>
+    /// <param name="agentId">Optional. Filter to conversations relevant to this agent.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Array of conversation summaries.</returns>
     [HttpGet]
@@ -69,10 +82,38 @@ public sealed class ConversationsController : ControllerBase
         [FromQuery] string? agentId,
         CancellationToken cancellationToken)
     {
-        AgentId? parsedAgentId = string.IsNullOrWhiteSpace(agentId) ? (AgentId?)null : AgentId.From(agentId);
-        var summaries = await _conversations.GetSummariesAsync(parsedAgentId, cancellationToken);
+        if (string.IsNullOrWhiteSpace(agentId))
+        {
+            var allSummaries = await _conversations.GetSummariesAsync(cancellationToken);
+            return Ok(allSummaries);
+        }
+
+        var citizen = CitizenId.Of(AgentId.From(agentId));
+        var relevant = await _conversations.ListForCitizenAsync(citizen, cancellationToken);
+
+        var summaries = relevant
+            .Where(c => c.Status == ConversationStatus.Active)
+            .OrderByDescending(c => c.UpdatedAt)
+            .ThenBy(c => c.ConversationId.Value, StringComparer.Ordinal)
+            .Select(ToSummary)
+            .ToList();
+
         return Ok(summaries);
     }
+
+    private static ConversationSummary ToSummary(Conversation c) =>
+        new(
+            c.ConversationId.Value,
+            c.AgentId.Value,
+            c.Title,
+            c.IsDefault,
+            c.Status.ToString(),
+            c.ActiveSessionId?.Value,
+            c.ChannelBindings.Count,
+            c.CreatedAt,
+            c.UpdatedAt,
+            c.Purpose,
+            c.Kind.ToString());
 
     /// <summary>
     /// Gets a specific conversation by ID, including all channel bindings.

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
@@ -124,9 +124,23 @@ public interface IConversationStore
         CancellationToken ct = default);
 
     /// <summary>
-    /// Returns lightweight summaries for all conversations, optionally filtered by agent.
+    /// Returns lightweight summaries for all <em>active</em> conversations across the world,
+    /// ordered most-recently-updated first.
     /// </summary>
-    /// <param name="agentId">If set, only returns summaries for this agent.</param>
+    /// <remarks>
+    /// <para>
+    /// This is the global admin/debug listing. For agent-relative listings (the
+    /// <c>GET /api/conversations?agentId=...</c> portal sidebar path), call
+    /// <see cref="ListForCitizenAsync"/> instead and project the result — that path returns
+    /// the union of owner-match and participant-match per W-1 (initiator + responder visibility),
+    /// whereas this method intentionally has no agent filter so an owner-only contract cannot
+    /// regress into the codebase by accident.
+    /// </para>
+    /// <para>
+    /// Only conversations with <see cref="ConversationStatus.Active"/> are returned. Archived
+    /// conversations are omitted.
+    /// </para>
+    /// </remarks>
     /// <param name="ct">Cancellation token.</param>
-    Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default);
+    Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default);
 }

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -227,11 +227,13 @@ public sealed class FileConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+    public async Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
     {
-        var all = await ListAsync(agentId, ct).ConfigureAwait(false);
+        var all = await ListAsync(null, ct).ConfigureAwait(false);
         return [.. all
             .Where(c => c.Status != ConversationStatus.Archived)
+            .OrderByDescending(c => c.UpdatedAt)
+            .ThenBy(c => c.ConversationId.Value, StringComparer.Ordinal)
             .Select(ToSummary)];
     }
 

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -172,15 +172,13 @@ public sealed class InMemoryConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+    public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
     {
-        var source = agentId is null
-            ? _conversations.Values
-            : _conversations.Values.Where(c => c.AgentId == agentId.Value);
-
         // Archived conversations are excluded from the active list.
-        IReadOnlyList<ConversationSummary> summaries = [.. source
+        IReadOnlyList<ConversationSummary> summaries = [.. _conversations.Values
             .Where(c => c.Status != ConversationStatus.Archived)
+            .OrderByDescending(c => c.UpdatedAt)
+            .ThenBy(c => c.ConversationId.Value, StringComparer.Ordinal)
             .Select(ToSummary)];
         return Task.FromResult(summaries);
     }

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -407,60 +407,35 @@ public sealed class SqliteConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+    public async Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
     {
         using var activity = ActivitySource.StartActivity("conversation.get_summaries", ActivityKind.Internal);
-        if (agentId is not null)
-            activity?.SetTag("botnexus.agent.id", agentId.Value);
 
         await EnsureCreatedAsync(ct).ConfigureAwait(false);
         await using var connection = CreateConnection();
         await connection.OpenAsync(ct).ConfigureAwait(false);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = agentId is null
-            ? """
-                SELECT
-                    c.id,
-                    c.agent_id,
-                    c.title,
-                    c.purpose,
-                    c.is_default,
-                    c.status,
-                    c.active_session_id,
-                    c.created_at,
-                    c.updated_at,
-                    COUNT(b.binding_id),
-                    c.instructions,
-                    c.kind
-                FROM conversations c
-                LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
-                WHERE c.status = 'Active'
-                GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions, c.kind
-                ORDER BY c.updated_at DESC
-                """
-            : """
-                SELECT
-                    c.id,
-                    c.agent_id,
-                    c.title,
-                    c.purpose,
-                    c.is_default,
-                    c.status,
-                    c.active_session_id,
-                    c.created_at,
-                    c.updated_at,
-                    COUNT(b.binding_id),
-                    c.instructions,
-                    c.kind
-                FROM conversations c
-                LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
-                WHERE c.agent_id = $agentId AND c.status = 'Active'
-                GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions, c.kind
-                ORDER BY c.updated_at DESC
-                """;
-        if (agentId is not null)
-            command.Parameters.AddWithValue("$agentId", agentId.Value.Value);
+        command.CommandText = """
+            SELECT
+                c.id,
+                c.agent_id,
+                c.title,
+                c.purpose,
+                c.is_default,
+                c.status,
+                c.active_session_id,
+                c.created_at,
+                c.updated_at,
+                COUNT(b.binding_id),
+                c.instructions,
+                c.kind
+            FROM conversations c
+            LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
+            WHERE c.status = 'Active'
+            GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions, c.kind
+            ORDER BY c.updated_at DESC
+            """;
 
         var summaries = new List<ConversationSummary>();
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);

--- a/tests/architecture/BotNexus.Architecture.Tests/ConversationsControllerCitizenListingArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ConversationsControllerCitizenListingArchitectureTests.cs
@@ -1,0 +1,318 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using BotNexus.Gateway.Abstractions.Conversations;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-G (#661) "responder-side
+/// visibility" contract:
+/// <list type="bullet">
+///   <item>
+///     <see cref="IConversationStore.GetSummariesAsync"/> has exactly one parameter
+///     (<see cref="CancellationToken"/>). A regression that re-adds an
+///     <c>AgentId?</c> overload would silently restore the pre-P9-G owner-only filter
+///     and re-hide responder-side conversations from agents that joined but did not
+///     initiate them — exactly the bug the phase fixed.
+///   </item>
+///   <item>
+///     Outside the 3 store implementations, the interface contract file, and the one
+///     sanctioned controller call site, no production source may call
+///     <c>GetSummariesAsync(</c>. All agent-relative listing MUST go through
+///     <see cref="IConversationStore.ListForCitizenAsync"/> so the union of (owner +
+///     participant) semantics is preserved.
+///   </item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ships vacuity / false-positive / comment-mention self-tests per the
+/// "every regex-based architecture fence must include a self-test" memory.
+/// </para>
+/// </remarks>
+public sealed class ConversationsControllerCitizenListingArchitectureTests
+{
+    [Fact]
+    public void GetSummariesAsync_HasOnlyParameterless_Overload()
+    {
+        var iface = typeof(IConversationStore);
+        var overloads = iface.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.Name == nameof(IConversationStore.GetSummariesAsync))
+            .ToList();
+
+        overloads.Count.ShouldBe(
+            1,
+            "P9-G contract: IConversationStore.GetSummariesAsync must have exactly one " +
+            "overload. A re-introduced AgentId? overload would silently restore the dead " +
+            "owner-only listing path that P9-G deleted.");
+
+        var parameters = overloads[0].GetParameters();
+        parameters.Length.ShouldBe(
+            1,
+            "P9-G contract: GetSummariesAsync must take only CancellationToken — " +
+            "agent-relative listing belongs on ListForCitizenAsync.");
+        parameters[0].ParameterType.ShouldBe(
+            typeof(CancellationToken),
+            "P9-G contract: the sole parameter must be CancellationToken.");
+    }
+
+    [Fact]
+    public void NoProductionSourceFile_CallsGetSummariesAsync_OutsideAllowlist()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            if (s_callAllowlist.Contains(relative)) continue;
+
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_callPattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-G: agent-relative conversation listing must route through " +
+            "IConversationStore.ListForCitizenAsync so responder-side visibility (W-1) is " +
+            "preserved. Direct calls to GetSummariesAsync(...) are only sanctioned in the " +
+            "controller (one global-admin path) and the 3 store impls / interface declarations.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void CallAllowlist_OnlyContains_FilesThat_StillExist_AndStill_TripTheFence()
+    {
+        var srcRoot = FindSourceRoot();
+        var stale = new List<string>();
+
+        foreach (var relative in s_callAllowlist)
+        {
+            var full = Path.Combine(srcRoot, relative);
+            if (!File.Exists(full))
+            {
+                stale.Add($"{relative} — file does not exist (delete this allowlist entry)");
+                continue;
+            }
+            if (!s_callPattern.IsMatch(StripComments(File.ReadAllText(full))))
+            {
+                stale.Add($"{relative} — file no longer trips the fence (delete this allowlist entry)");
+            }
+        }
+
+        stale.ShouldBeEmpty(
+            "Allowlist hygiene: every entry must still match an existing file AND still trip the fence; " +
+            "otherwise it grants a permanent exemption to future regressions in the same file.\n" +
+            "Stale entries:\n  " + string.Join("\n  ", stale));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReintroduction()
+    {
+        // If a regression PR adds a new caller back, the fence MUST trip. Vacuity guard.
+        s_callPattern.IsMatch("var s = await _conversations.GetSummariesAsync(ct);")
+            .ShouldBeTrue("Vacuity guard: a real call site must trip the fence.");
+        s_callPattern.IsMatch("await store.GetSummariesAsync();")
+            .ShouldBeTrue("Vacuity guard: a no-arg call must trip the fence.");
+        s_callPattern.IsMatch("GetSummariesAsync (token)")
+            .ShouldBeTrue("Vacuity guard: optional whitespace between name and `(` must trip.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedSymbols()
+    {
+        // The fence is name-anchored. Reads/declarations/sibling members must NOT match.
+        s_callPattern.IsMatch("// see GetSummariesAsync for the listing contract")
+            .ShouldBeFalse("False-positive guard: comments are stripped before the regex runs, " +
+                "but a synthetic line without `(` must also not match.");
+        s_callPattern.IsMatch("public Task XGetSummariesAsync(CancellationToken ct) => Task.CompletedTask;")
+            .ShouldBeFalse("False-positive guard: a different method (XGetSummariesAsync) must not match.");
+        s_callPattern.IsMatch("nameof(IConversationStore.GetSummariesAsync)")
+            .ShouldBeFalse("False-positive guard: `nameof(...)` reference without an open paren on the symbol must not match.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        const string syntheticClean = """
+            /// <summary>
+            /// Callers must NOT invoke `_conversations.GetSummariesAsync(ct)` directly for
+            /// agent-relative listing — use IConversationStore.ListForCitizenAsync instead.
+            /// </summary>
+            // Legacy: pre-P9-G code did `store.GetSummariesAsync(agentId)` — that shape is dead.
+            /* Block comment: GetSummariesAsync(...) outside the controller is forbidden. */
+            public void Documented() { }
+            """;
+
+        s_callPattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of the call shape for historical context " +
+            "or doc warnings must not trip — the lexer strips them.");
+    }
+
+    // Match `GetSummariesAsync\s*\(` anywhere — declarations AND invocations. The lexer
+    // strips comments before the regex runs. The allowlist below pins which files are
+    // allowed to contain this token at all.
+    private static readonly Regex s_callPattern = new(
+        @"\bGetSummariesAsync\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // Sanctioned files:
+    //   - The 3 store implementations (declaration sites for the contract).
+    //   - The interface contract file (declaration).
+    //   - The single controller call site (the only production invoker; all other
+    //     conversation-listing paths must go through ListForCitizenAsync).
+    private static readonly HashSet<string> s_callAllowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        Path.Combine("gateway", "BotNexus.Gateway.Conversations", "SqliteConversationStore.cs"),
+        Path.Combine("gateway", "BotNexus.Gateway.Conversations", "InMemoryConversationStore.cs"),
+        Path.Combine("gateway", "BotNexus.Gateway.Conversations", "FileConversationStore.cs"),
+        Path.Combine("gateway", "BotNexus.Gateway.Contracts", "Conversations", "IConversationStore.cs"),
+        Path.Combine("gateway", "BotNexus.Gateway.Api", "Controllers", "ConversationsController.cs"),
+    };
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Same lexer pattern used by other
+    /// architecture fences (e.g. <see cref="ConversationParticipantsMutationArchitectureTests"/>).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/InMemoryConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/InMemoryConversationStoreTests.cs
@@ -226,8 +226,10 @@ public sealed class InMemoryConversationStoreTests
     }
 
     [Fact]
-    public async Task GetSummariesAsync_ReturnsSummariesForAgent()
+    public async Task ListForCitizenAsync_ReturnsOwnerMatchedConversationWithBindings()
     {
+        // Migrated from former GetSummariesAsync(agentId) test — P9-G dropped the per-agent
+        // overload; agent-relative listing is now ListForCitizenAsync + controller projection.
         var store = new InMemoryConversationStore();
         var agentId = Agent("summary-agent");
         var conv = MakeConversation(agentId) with
@@ -236,10 +238,10 @@ public sealed class InMemoryConversationStoreTests
         };
         await store.CreateAsync(conv);
 
-        var summaries = await store.GetSummariesAsync(agentId);
-        summaries.Count.ShouldBe(1);
-        summaries[0].BindingCount.ShouldBe(1);
-        summaries[0].AgentId.ShouldBe("summary-agent");
+        var relevant = await store.ListForCitizenAsync(CitizenId.Of(agentId));
+        relevant.Count.ShouldBe(1);
+        relevant[0].AgentId.ShouldBe(agentId);
+        relevant[0].ChannelBindings.Count.ShouldBe(1);
     }
 
     // ── Initiator + ListForCitizenAsync ────────────────────────────────────────

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
@@ -202,7 +202,7 @@ public sealed class SqliteConversationStoreTests
     }
 
     [Fact]
-    public async Task GetSummariesAsync_ReturnsBindingCountCorrectly()
+    public async Task GetSummariesAsync_ReturnsAllActiveSummariesWithBindingCounts()
     {
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
@@ -213,7 +213,7 @@ public sealed class SqliteConversationStoreTests
             CreateBinding("teams", "abc/topic:thread-1"));
         await store.CreateAsync(conversation);
 
-        var summaries = await fixture.CreateStore().GetSummariesAsync(Agent("agent-a"));
+        var summaries = await fixture.CreateStore().GetSummariesAsync();
 
         summaries.Count.ShouldBe(1);
         summaries[0].ConversationId.ShouldBe(conversation.ConversationId.Value);

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -577,7 +577,7 @@ public sealed class AgentExchangeArchiveTests
         }
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
-        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
-            => _inner.GetSummariesAsync(agentId, ct);
+        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
+            => _inner.GetSummariesAsync(ct);
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Conversations/ConversationsControllerParticipantListingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Conversations/ConversationsControllerParticipantListingTests.cs
@@ -1,0 +1,211 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+/// <summary>
+/// Phase 9 / P9-G (#661) regression suite. Covers the contract flip where
+/// <c>GET /api/conversations?agentId={id}</c> moved from owner-only filtering
+/// (<c>IConversationStore.GetSummariesAsync(agentId)</c> — now deleted) to
+/// "relevant-to-citizen" semantics via
+/// <see cref="IConversationStore.ListForCitizenAsync"/>:
+/// <list type="bullet">
+///   <item>Owner-only (initiator = agent) is still returned (W-1 owner-side baseline).</item>
+///   <item>Participant-only (agent is in <c>Conversation.Participants</c> but not the owner) is now returned — the responder-side gap the user flagged.</item>
+///   <item>Owner+Participant returns the conversation exactly once (DISTINCT semantics from the union).</item>
+///   <item>Archived conversations are excluded from the agent-filtered branch — status filtering lives in the controller projection.</item>
+///   <item><see cref="ConversationKind.AgentAgent"/> / <see cref="ConversationKind.AgentSubAgent"/> kinds are present in the API result set even though the portal sidebar deliberately hides them (UX is filtered downstream in the BlazorClient).</item>
+/// </list>
+/// </summary>
+public sealed class ConversationsControllerParticipantListingTests
+{
+    private static readonly AgentId OwnerAgent = AgentId.From("agent-owner");
+    private static readonly AgentId ParticipantAgent = AgentId.From("agent-participant");
+
+    [Fact]
+    public async Task List_AgentFiltered_ReturnsOwnerInitiatedConversation()
+    {
+        var conversations = new InMemoryConversationStore();
+        var owned = await conversations.CreateAsync(NewConversation(OwnerAgent, "owner-only"));
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+
+        var summaries = await InvokeList(controller, OwnerAgent.Value);
+
+        summaries.ShouldContain(s => s.ConversationId == owned.ConversationId.Value);
+    }
+
+    [Fact]
+    public async Task List_AgentFiltered_ReturnsConversationWhereAgentIsParticipantNotOwner()
+    {
+        // The whole point of P9-G: a responder-side agent must see exchanges it didn't
+        // initiate. Pre-flip, the owner-only filter (c.agent_id = $agentId) hid these.
+        var conversations = new InMemoryConversationStore();
+        var participantOnly = await conversations.CreateAsync(
+            NewConversation(OwnerAgent, "participant-side", kind: ConversationKind.AgentAgent));
+
+        await conversations.AddParticipantsAsync(
+            participantOnly.ConversationId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(ParticipantAgent), Role = "peer" }]);
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+
+        var summaries = await InvokeList(controller, ParticipantAgent.Value);
+
+        summaries.ShouldContain(
+            s => s.ConversationId == participantOnly.ConversationId.Value,
+            "participant-side agent must see a conversation it joined but did not initiate (W-1)");
+    }
+
+    [Fact]
+    public async Task List_AgentFiltered_OwnerAndParticipant_DoesNotDuplicateConversation()
+    {
+        // The union of (owner-match) ∪ (participant-match) must be DISTINCT by
+        // ConversationId — otherwise the portal renders a duplicate row in the sidebar.
+        var conversations = new InMemoryConversationStore();
+        var owned = await conversations.CreateAsync(NewConversation(OwnerAgent, "both"));
+
+        // Add the owner as a participant too (the routing layer is allowed to do this;
+        // the AddParticipantsAsync contract is INSERT OR IGNORE).
+        await conversations.AddParticipantsAsync(
+            owned.ConversationId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(OwnerAgent), Role = "initiator" }]);
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+
+        var summaries = await InvokeList(controller, OwnerAgent.Value);
+
+        summaries.Count(s => s.ConversationId == owned.ConversationId.Value).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task List_AgentFiltered_ExcludesArchivedParticipantSideConversation()
+    {
+        // ListForCitizenAsync returns conversations in any status; the controller
+        // projection MUST drop archived rows so the portal sidebar doesn't surface them.
+        var conversations = new InMemoryConversationStore();
+        var archived = await conversations.CreateAsync(
+            NewConversation(OwnerAgent, "archived-participant", kind: ConversationKind.AgentAgent));
+
+        await conversations.AddParticipantsAsync(
+            archived.ConversationId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(ParticipantAgent), Role = "peer" }]);
+
+        await conversations.ArchiveAsync(archived.ConversationId);
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+
+        var summaries = await InvokeList(controller, ParticipantAgent.Value);
+
+        summaries.ShouldNotContain(s => s.ConversationId == archived.ConversationId.Value);
+    }
+
+    [Fact]
+    public async Task List_AgentFiltered_IncludesAgentAgentAndAgentSubAgentKinds()
+    {
+        // Platform/API surface must expose all kinds — UX filtering (HumanAgent-only
+        // sidebar in ClientStateStore.SeedConversations) is a deliberate downstream
+        // choice. Future "exchanges view" should be able to opt in to these without
+        // a further API change.
+        var conversations = new InMemoryConversationStore();
+        var aa = await conversations.CreateAsync(
+            NewConversation(OwnerAgent, "agent-agent", kind: ConversationKind.AgentAgent));
+        var asa = await conversations.CreateAsync(
+            NewConversation(OwnerAgent, "agent-subagent", kind: ConversationKind.AgentSubAgent));
+
+        await conversations.AddParticipantsAsync(
+            aa.ConversationId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(ParticipantAgent), Role = "peer" }]);
+        await conversations.AddParticipantsAsync(
+            asa.ConversationId,
+            [new SessionParticipant { CitizenId = CitizenId.Of(ParticipantAgent), Role = "child" }]);
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+
+        var summaries = await InvokeList(controller, ParticipantAgent.Value);
+
+        summaries.ShouldContain(s =>
+            s.ConversationId == aa.ConversationId.Value &&
+            s.Kind == ConversationKind.AgentAgent.ToString());
+        summaries.ShouldContain(s =>
+            s.ConversationId == asa.ConversationId.Value &&
+            s.Kind == ConversationKind.AgentSubAgent.ToString());
+    }
+
+    [Fact]
+    public async Task List_AgentFiltered_OrdersByUpdatedAtDescendingWithDeterministicTieBreaker()
+    {
+        // Most-recently-updated first. When two conversations share an UpdatedAt
+        // (clock granularity or backfilled rows), tie-break on ConversationId Ordinal
+        // so portal rendering doesn't flicker between requests.
+        var conversations = new InMemoryConversationStore();
+        var t0 = DateTimeOffset.UtcNow;
+
+        var older = await conversations.CreateAsync(NewConversation(OwnerAgent, "older", updatedAt: t0.AddMinutes(-10)));
+        var newer = await conversations.CreateAsync(NewConversation(OwnerAgent, "newer", updatedAt: t0));
+        // Two rows sharing the same UpdatedAt to verify the deterministic tie-breaker.
+        var tieA = await conversations.CreateAsync(
+            new Conversation
+            {
+                ConversationId = ConversationId.From("tie-a"),
+                AgentId = OwnerAgent,
+                Title = "tie-a",
+                Status = ConversationStatus.Active,
+                UpdatedAt = t0.AddMinutes(-5),
+                CreatedAt = t0.AddMinutes(-5)
+            });
+        var tieB = await conversations.CreateAsync(
+            new Conversation
+            {
+                ConversationId = ConversationId.From("tie-b"),
+                AgentId = OwnerAgent,
+                Title = "tie-b",
+                Status = ConversationStatus.Active,
+                UpdatedAt = t0.AddMinutes(-5),
+                CreatedAt = t0.AddMinutes(-5)
+            });
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+
+        var summaries = await InvokeList(controller, OwnerAgent.Value);
+        var ids = summaries.Select(s => s.ConversationId).ToList();
+
+        ids.IndexOf(newer.ConversationId.Value).ShouldBeLessThan(ids.IndexOf(tieA.ConversationId.Value));
+        ids.IndexOf(tieA.ConversationId.Value).ShouldBeLessThan(ids.IndexOf(tieB.ConversationId.Value));
+        ids.IndexOf(tieB.ConversationId.Value).ShouldBeLessThan(ids.IndexOf(older.ConversationId.Value));
+    }
+
+    private static async Task<IReadOnlyList<ConversationSummary>> InvokeList(
+        ConversationsController controller,
+        string? agentId)
+    {
+        var result = await controller.List(agentId, CancellationToken.None);
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        return (IReadOnlyList<ConversationSummary>)ok.Value!;
+    }
+
+    private static Conversation NewConversation(
+        AgentId owner,
+        string title,
+        ConversationKind kind = ConversationKind.HumanAgent,
+        DateTimeOffset? updatedAt = null)
+    {
+        var ts = updatedAt ?? DateTimeOffset.UtcNow;
+        return new Conversation
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = owner,
+            Title = title,
+            Kind = kind,
+            Status = ConversationStatus.Active,
+            CreatedAt = ts,
+            UpdatedAt = ts
+        };
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -214,7 +214,7 @@ public sealed class ConversationsControllerHistoryTests
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => throw new NotSupportedException();
 
-        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
+        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => throw new NotSupportedException();
 
         public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(BotNexus.Domain.World.CitizenId citizen, CancellationToken ct = default)

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1761,8 +1761,8 @@ file sealed class ThrowingArchiveConversationStore : IConversationStore
     }
     public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
         => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
-    public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
-        => _inner.GetSummariesAsync(agentId, ct);
+    public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
+        => _inner.GetSummariesAsync(ct);
 }
 
 /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/ProbeRound3GatewayTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ProbeRound3GatewayTests.cs
@@ -1,4 +1,5 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
@@ -137,17 +138,22 @@ public sealed class ProbeRound3GatewayTests
     }
 
     [Fact]
-    public async Task GetSummaries_ByAgent_ExcludesArchivedConversations()
+    public async Task ListForCitizenAsync_ExcludesArchivedFromAgentRelevance()
     {
+        // Migrated from former GetSummariesAsync(agentId) test — P9-G moved agent-relative
+        // listing to ListForCitizenAsync; status filtering now happens in the controller
+        // projection. Archive lookup still surfaces the conversation here (the store contract
+        // returns conversations in any status), so the assertion is that the archived row's
+        // Status reflects the archive.
         var store = new InMemoryConversationStore();
         var conv = await store.CreateAsync(MakeConversation("active"));
         var archConv = await store.CreateAsync(MakeConversation("archived"));
         await store.ArchiveAsync(archConv.ConversationId);
 
-        var summaries = await store.GetSummariesAsync(Agent());
+        var relevant = await store.ListForCitizenAsync(CitizenId.Of(Agent()));
 
-        summaries.ShouldContain(s => s.ConversationId == conv.ConversationId.Value);
-        summaries.ShouldNotContain(s => s.ConversationId == archConv.ConversationId.Value);
+        relevant.ShouldContain(c => c.ConversationId == conv.ConversationId && c.Status == ConversationStatus.Active);
+        relevant.ShouldContain(c => c.ConversationId == archConv.ConversationId && c.Status == ConversationStatus.Archived);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
@@ -751,7 +751,7 @@ public sealed class LegacyConversationBackfillTests
         public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.ArchiveAsync(conversationId, ct);
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => Inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
-        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(AgentId? agentId = null, CancellationToken ct = default)
-            => Inner.GetSummariesAsync(agentId, ct);
+        public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
+            => Inner.GetSummariesAsync(ct);
     }
 }


### PR DESCRIPTION
# Summary

Implements P9-G: flip `GET /api/conversations?agentId={id}` from owner-only filtering to **"relevant-to-citizen" semantics** so a responder-side agent sees conversations it joined but did not initiate. Satisfies directive W-1 at the platform/API level.

> W-1 (recorded during model review):
> "A conversation always has a Citizen or proxy for a Citizen to initiate it then participants in the conversation. So there will always be an initiator side and responder side."

Closes #661.

## What changed

### Contract (breaking)

- **`IConversationStore.GetSummariesAsync`**: drops the `AgentId? agentId` parameter. The owner-only branch was dead post-flip — the only production caller (the controller) now routes the agent-relative case through `ListForCitizenAsync`. Per AGENTS.md "no `[Obsolete]` attributes / no dead code", the parameter is removed cleanly rather than deprecated.

### Stores (3 implementations)

- **SqliteConversationStore / InMemoryConversationStore / FileConversationStore**: keep only the global active-summary query and add a deterministic tie-breaker (`OrderByDescending(UpdatedAt).ThenBy(ConversationId, Ordinal)`) so paged renders don't flicker between requests.

### Gateway

- **`ConversationsController.List`**: agent-filtered branch now calls `ListForCitizenAsync(CitizenId.Of(AgentId.From(agentId)))` (uses the P9-F `idx_conversation_participants_citizen` SQLite index), filters `Status == Active`, sorts deterministically, and projects via a new private `ToSummary(Conversation)` helper so the projection lives in one place.

### Portal — UX intentionally unchanged

`ClientStateStore.SeedConversations` keeps its existing `Kind == "HumanAgent"` filter — the inline comment already documents why (clutter + accidental active-tab hijacking by AgentAgent transcripts whose `UpdatedAt` happens to be the most recent). W-1 is now satisfied at the API/platform level; a future "exchanges view" can opt in to `AgentAgent` / `AgentSubAgent` without further server-side changes.

The REST client XML doc (`IGatewayRestClient.GetConversationsAsync`) is updated to reflect the new "relevant-to" semantics and the deliberate portal filter.

## Tests

- **6 new** `ConversationsControllerParticipantListingTests` cover:
  - Owner-only baseline (regression).
  - Participant-side visibility (the W-1 win).
  - Owner+participant — no duplicate (DISTINCT semantics).
  - Archived participant-side excluded.
  - `AgentAgent` / `AgentSubAgent` kinds visible via API (portal filters them downstream).
  - Deterministic ordering with a same-`UpdatedAt` tie-breaker.

- **6 new** `ConversationsControllerCitizenListingArchitectureTests` enforce the contract:
  - Reflection pin: `GetSummariesAsync` has exactly one parameter (`CancellationToken`) — a re-introduced `AgentId?` overload would silently restore the dead owner-only path.
  - Member-access fence: `GetSummariesAsync(` is only allowed in the 3 store impls, the interface declaration, and the one sanctioned controller call site. All agent-relative listing must go through `ListForCitizenAsync`.
  - Vacuity / false-positive / comment-mention / allowlist-hygiene self-tests per the established P9-D fence pattern.

- **5 test fakes** migrated to the new contract (signature-only).
- **3 direct-call tests** rewritten to test the new path (`ListForCitizenAsync`) rather than the deleted overload — per AGENTS.md, tests are migrated, never net-deleted.

## Validation

- `scripts\repo\test-impacted.ps1` green (17 of 27 projects) — Architecture, Gateway, Conversations, Scenarios, Memory, CLI, all channel extensions.
- `dotnet test BotNexus.slnx` (non-integration) all green: Domain 313, Gateway 2000, Architecture 141, BlazorClient 334, Scenarios 29, Conversations 125, others passing.
- `BotNexus.Integration.*` projects intentionally not asserted (CI excludes them via `--filter "FullyQualifiedName!~BotNexus.Integration."` in `.github/workflows/ci-build-test.yml`).
- 0 errors, 0 warnings.

## Phase 9 status

| Phase | Issue | Status |
|---|---|---|
| P9-A | #614 | merged |
| P9-B-2 | #627 | merged (PR #641) |
| P9-D | #643 | merged (PR #644) |
| P9-E | #645 | merged (PR #646) |
| P9-F | #657 | merged (PR #659) |
| **P9-G** | **#661** | **this PR** |
| P9-H | #662 | pending — delete `Session.AgentId` |
