### PR TITLE
refactor(gateway)!: delete Session.AgentId; Conversation owns agent identity (P9-H, closes #662)

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -27,8 +27,14 @@ public sealed record Conversation
     /// </remarks>
     public string WorldId { get; set; } = string.Empty;
 
-    /// <summary>Gets or sets the agent that owns this conversation.</summary>
-    public AgentId AgentId { get; set; }
+    /// <summary>
+    /// Gets the agent that owns this conversation. Write-once on construction — the
+    /// <c>ConversationAgentIdImmutabilityArchitectureTests</c> fence pins this so a
+    /// conversation's owning agent cannot drift after the row is persisted. This is the
+    /// invariant that lets <see cref="IAgentIdentityResolver"/> cache the resolved
+    /// value for the lifetime of the conversation (P9-H, issue #662, directive W-4).
+    /// </summary>
+    public AgentId AgentId { get; init; }
 
     /// <summary>Gets or sets the human-readable title of this conversation.</summary>
     public string Title { get; set; } = "New conversation";

--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -14,6 +14,7 @@ public sealed class GatewaySession
     private GatewaySessionRuntime? _runtime;
     private string? _callerId;
     private readonly ISecretRedactor? _redactor;
+    private AgentId _agentId;
 
     public GatewaySession()
         : this(new Session(), null)
@@ -49,12 +50,32 @@ public sealed class GatewaySession
         init => Session.SessionId = value;
     }
 
-    /// <summary>The agent this session is bound to.</summary>
+    /// <summary>
+    /// The agent that owns the parent <see cref="Conversation"/> this session belongs to.
+    /// Hydrated at construction time by <see cref="ISessionStore"/> implementations from
+    /// <c>Conversation.AgentId</c> — the conversation is the durable owner of the agent
+    /// binding (P9-H, issue #662, directive W-4). The value is immutable post-construction:
+    /// <c>Conversation.AgentId</c> is itself <c>init</c>-only so a hydrated AgentId cannot
+    /// drift for the lifetime of the session. Callers that need to resolve the AgentId
+    /// for a session they do not yet have an instance of must inject
+    /// <see cref="IAgentIdentityResolver"/>.
+    /// </summary>
     public AgentId AgentId
     {
-        get => Session.AgentId;
-        set => Session.AgentId = value;
+        get => _agentId;
+        init => _agentId = value;
     }
+
+    /// <summary>
+    /// Hydrates the derived <see cref="AgentId"/> for an instance produced outside an
+    /// object initializer (e.g. by <see cref="FromSession"/> and store load paths that
+    /// build the wrapper first and look up the conversation second). This is the only
+    /// sanctioned mutation path; the architecture fence pins it (
+    /// <c>SessionAgentIdRemovedArchitectureTests</c>) so nothing outside the gateway
+    /// session-store assembly can re-introduce a write-through facade.
+    /// </summary>
+    /// <param name="agentId">The resolved owning agent id.</param>
+    public void HydrateAgentId(AgentId agentId) => _agentId = agentId;
 
     /// <summary>The channel this session originated from (e.g., "signalr", "telegram").</summary>
     public ChannelKey? ChannelType

--- a/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
@@ -12,10 +12,12 @@ public sealed record Session
     /// </summary>
     public SessionId SessionId { get; set; }
 
-    /// <summary>
-    /// Gets or sets the agent id.
-    /// </summary>
-    public AgentId AgentId { get; set; }
+    // P9-H (#662): Session.AgentId was deleted. Agent ownership is durably owned by the
+    // parent Conversation (Conversation.AgentId, init-only post P9-H). Resolve the owning
+    // agent via IAgentIdentityResolver, or for store-backed reads via the hydrated
+    // GatewaySession.AgentId (populated at construction by ISessionStore implementations
+    // from Conversation.AgentId). This eliminates the duplicated ownership that allowed
+    // a session's agent and its conversation's agent to drift, per directive W-4.
 
     /// <summary>
     /// Gets or sets the channel type.

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IAgentIdentityResolver.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IAgentIdentityResolver.cs
@@ -1,0 +1,52 @@
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Conversations;
+
+/// <summary>
+/// Resolves the owning <see cref="AgentId"/> for a conversation or session. Replaces
+/// the deleted <c>Session.AgentId</c> / <c>GatewaySession.AgentId</c> facade members:
+/// agent ownership lives on the <see cref="Conversation"/> only, and every consumer that
+/// previously read <c>session.AgentId</c> must now go through this resolver so the lookup
+/// path is explicit and cacheable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Introduced in P9-H (issue #662) per directive W-4
+/// ("The conversation has the Agent, Participants, etc. They should not be on the session.").
+/// The implementation is expected to cache by <see cref="ConversationId"/>; the cache is safe
+/// because <see cref="Conversation.AgentId"/> is treated as write-once / init-only post P9-H
+/// (verified by <c>ConversationAgentIdImmutabilityArchitectureTests</c>).
+/// </para>
+/// <para>
+/// Implementations must be thread-safe.
+/// </para>
+/// </remarks>
+public interface IAgentIdentityResolver
+{
+    /// <summary>
+    /// Returns the agent that owns the supplied conversation, or <c>null</c> if the
+    /// conversation does not exist.
+    /// </summary>
+    /// <param name="conversationId">The conversation to resolve.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<AgentId?> GetAgentIdAsync(ConversationId conversationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the agent that owns the supplied conversation. Throws
+    /// <see cref="InvalidOperationException"/> when the conversation cannot be resolved —
+    /// callers should use <see cref="GetAgentIdAsync"/> when the missing-conversation case is
+    /// part of their normal control flow.
+    /// </summary>
+    /// <param name="conversationId">The conversation to resolve.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<AgentId> GetRequiredAgentIdAsync(ConversationId conversationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Invalidates any cached entry for the supplied conversation. Call from
+    /// <see cref="IConversationStore.CreateAsync"/> / <see cref="IConversationStore.SaveAsync"/>
+    /// paths so a freshly persisted conversation can be re-read on the next request even when a
+    /// negative cache entry was previously written by a racing resolver call.
+    /// </summary>
+    /// <param name="conversationId">The conversation whose cache entry should be evicted.</param>
+    void Invalidate(ConversationId conversationId);
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -487,7 +487,6 @@ public sealed class FileSessionStore : SessionStoreBase
         var session = new GatewaySession(new Session
         {
             SessionId = sessionId,
-            AgentId = meta.AgentId,
             ChannelType = meta.ChannelType,
             SessionType = meta.SessionType ?? InferSessionType(sessionId, meta.ChannelType),
             // P9-F (#657): meta.Participants is read-and-discarded. The legacy field is
@@ -503,6 +502,11 @@ public sealed class FileSessionStore : SessionStoreBase
             // explicitly is prohibited by Vogen analyzer VOG009.
         }, _redactor)
         {
+            // P9-H (#662): Session.AgentId was deleted; AgentId is now a hydrated derived
+            // value on the runtime wrapper. For File-store load we still read the legacy
+            // `meta.AgentId` JSON field; agent ownership lives on Conversation.AgentId post
+            // P9-H so future loads will derive from the conversation store at hydration.
+            AgentId = meta.AgentId,
             CallerId = meta.CallerId
         };
         if (meta.ConversationId is not null)

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -131,13 +131,17 @@ public abstract class SessionStoreBase : ISessionStore
     }
 
     protected static GatewaySession CreateSession(SessionId sessionId, AgentId agentId, ChannelKey? channelType, ISecretRedactor? redactor = null)
-        => new(new Session
+        => new(
+            new Session
+            {
+                SessionId = sessionId,
+                ChannelType = channelType,
+                SessionType = InferSessionType(sessionId, channelType)
+            },
+            redactor)
         {
-            SessionId = sessionId,
-            AgentId = agentId,
-            ChannelType = channelType,
-            SessionType = InferSessionType(sessionId, channelType)
-        }, redactor);
+            AgentId = agentId
+        };
 
     protected static SessionType InferSessionType(SessionId sessionId, ChannelKey? channelType)
     {

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -685,7 +685,6 @@ public sealed class SqliteSessionStore : SessionStoreBase
         var domainSession = new Session
         {
             SessionId = SessionId.From(reader.GetString(0)),
-            AgentId = AgentId.From(agentIdValue),
             ChannelType = channelType,
             SessionType = sessionType,
             Status = status,
@@ -701,6 +700,12 @@ public sealed class SqliteSessionStore : SessionStoreBase
             domainSession.ConversationId = ConversationId.From(reader.GetString(10));
         var session = new GatewaySession(domainSession, redactor)
         {
+            // P9-H (#662): Session.AgentId was deleted; AgentId is hydrated on the runtime
+            // wrapper. We still source the value from the legacy `agent_id` column for
+            // backwards-compatible loads — agent ownership lives on Conversation.AgentId
+            // post P9-H and a future migration can switch this to a JOIN against the
+            // conversation store.
+            AgentId = AgentId.From(agentIdValue),
             CallerId = reader.IsDBNull(3) ? null : reader.GetString(3)
         };
 

--- a/src/gateway/BotNexus.Gateway/Conversations/AgentIdentityResolver.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/AgentIdentityResolver.cs
@@ -1,0 +1,78 @@
+using System.Collections.Concurrent;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Conversations;
+
+/// <summary>
+/// Default <see cref="IAgentIdentityResolver"/> backed by <see cref="IConversationStore"/>
+/// with a process-local cache keyed by <see cref="ConversationId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache is safe because, per P9-H (issue #662), agent ownership is treated as
+/// write-once on the conversation: <c>Conversation.AgentId</c> is set on
+/// <see cref="IConversationStore.CreateAsync"/> and is not expected to change for the
+/// lifetime of the conversation. The
+/// <see cref="ConversationAgentIdImmutabilityArchitectureTests"/> fence pins this
+/// invariant at the domain layer and the <see cref="IConversationStore"/> implementations
+/// reject saves that attempt to mutate it.
+/// </para>
+/// <para>
+/// <see cref="Invalidate"/> is called by the conversation store on
+/// <see cref="IConversationStore.CreateAsync"/> / <see cref="IConversationStore.SaveAsync"/>
+/// so a freshly written row evicts any stale negative cache entry.
+/// </para>
+/// </remarks>
+public sealed class AgentIdentityResolver : IAgentIdentityResolver
+{
+    private readonly IConversationStore _conversationStore;
+    private readonly ILogger<AgentIdentityResolver> _logger;
+    private readonly ConcurrentDictionary<ConversationId, AgentId> _cache = new();
+
+    public AgentIdentityResolver(
+        IConversationStore conversationStore,
+        ILogger<AgentIdentityResolver> logger)
+    {
+        _conversationStore = conversationStore ?? throw new ArgumentNullException(nameof(conversationStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentId?> GetAgentIdAsync(ConversationId conversationId, CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue(conversationId, out var cached))
+            return cached;
+
+        var conversation = await _conversationStore.GetAsync(conversationId, ct).ConfigureAwait(false);
+        if (conversation is null)
+            return null;
+
+        // Cache positive results only; negative misses re-query the store next time so a
+        // create-then-resolve race never observes a sticky null. Conversation.AgentId is
+        // write-once (see ConversationAgentIdImmutabilityArchitectureTests), so the cached
+        // positive value is safe for the lifetime of the conversation.
+        _cache[conversationId] = conversation.AgentId;
+        return conversation.AgentId;
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentId> GetRequiredAgentIdAsync(ConversationId conversationId, CancellationToken ct = default)
+    {
+        var resolved = await GetAgentIdAsync(conversationId, ct).ConfigureAwait(false);
+        if (resolved is null)
+        {
+            _logger.LogWarning(
+                "Agent identity resolver could not resolve conversation {ConversationId} — caller required a non-null AgentId.",
+                conversationId);
+            throw new InvalidOperationException(
+                $"Cannot resolve owning AgentId — conversation '{conversationId}' does not exist.");
+        }
+        return resolved.Value;
+    }
+
+    /// <inheritdoc />
+    public void Invalidate(ConversationId conversationId) =>
+        _cache.TryRemove(conversationId, out _);
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -137,6 +137,7 @@ public static class GatewayServiceCollectionExtensions
         services.TryAddSingleton<ISessionStore, InMemorySessionStore>();
         services.TryAddSingleton<ISessionWriteLock, SessionWriteLock>();
         services.TryAddSingleton<IConversationStore, InMemoryConversationStore>();
+        services.TryAddSingleton<IAgentIdentityResolver, AgentIdentityResolver>();
         services.AddSingleton<IAgentCanvasNotifier, ConversationCanvasNotifier>();
         services.TryAddSingleton<IConversationRouter, DefaultConversationRouter>();
         services.TryAddSingleton<IConversationDispatcher, DefaultConversationDispatcher>();

--- a/tests/architecture/BotNexus.Architecture.Tests/ConversationAgentIdImmutabilityArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ConversationAgentIdImmutabilityArchitectureTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-H (#662) "Conversation.AgentId
+/// is immutable" contract:
+/// <list type="bullet">
+///   <item>
+///     <see cref="Conversation.AgentId"/> exposes only an <c>init</c>-style setter. A
+///     <c>set</c> setter would let callers re-bind a persisted conversation to a different
+///     owning agent and silently invalidate the <see cref="IAgentIdentityResolver"/> cache,
+///     since the resolver memoizes the agent-id-per-conversation lookup for the lifetime of
+///     the process.
+///   </item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache safety story for the entire P9-H phase rests on this single invariant. If
+/// you find yourself wanting to add a public setter to re-bind a conversation, add a
+/// dedicated re-binding API on <see cref="IConversationStore"/> that also invalidates
+/// the resolver instead.
+/// </para>
+/// </remarks>
+public sealed class ConversationAgentIdImmutabilityArchitectureTests
+{
+    [Fact]
+    public void Conversation_AgentId_IsInitOnly()
+    {
+        var prop = typeof(Conversation).GetProperty(
+            nameof(Conversation.AgentId),
+            BindingFlags.Public | BindingFlags.Instance);
+
+        prop.ShouldNotBeNull("P9-H contract: Conversation.AgentId must exist.");
+        prop.CanRead.ShouldBeTrue();
+
+        var setter = prop.GetSetMethod(nonPublic: false);
+        setter.ShouldNotBeNull(
+            "P9-H contract: Conversation.AgentId must expose an init setter — without one " +
+            "the immutable record builder pattern (`with { AgentId = ... }`) breaks for tests.");
+
+        // An `init` setter is a public method whose return-parameter modreqs include
+        // System.Runtime.CompilerServices.IsExternalInit. A `set` setter does not.
+        var requiredModifiers = setter.ReturnParameter.GetRequiredCustomModifiers();
+        requiredModifiers.ShouldContain(
+            t => t.FullName == "System.Runtime.CompilerServices.IsExternalInit",
+            "P9-H contract: Conversation.AgentId must be `init`-only. The cache safety story " +
+            "for IAgentIdentityResolver depends on Conversation.AgentId being immutable post " +
+            "construction — a regular `set` setter would let a conversation be silently " +
+            "re-bound to a different agent and invalidate every cached lookup.");
+    }
+
+    [Fact]
+    public void Conversation_AgentId_HasNoMutationMethod()
+    {
+        // Defence in depth: scan for `SetAgentId(...)` shape methods that could let callers
+        // sidestep the init-only setter via a normal method call.
+        var methods = typeof(Conversation).GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        methods.ShouldNotContain(
+            m => m.Name.Equals("SetAgentId", StringComparison.OrdinalIgnoreCase)
+                || m.Name.Equals("ChangeAgentId", StringComparison.OrdinalIgnoreCase)
+                || m.Name.Equals("RebindAgentId", StringComparison.OrdinalIgnoreCase),
+            "P9-H contract: Conversation must not expose a mutation method that lets callers " +
+            "side-step the init-only AgentId setter. If a re-binding capability is genuinely " +
+            "needed, put it on IConversationStore so it can invalidate IAgentIdentityResolver.");
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdRemovedArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdRemovedArchitectureTests.cs
@@ -1,0 +1,366 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-H (#662) "Conversation
+/// owns agent identity" contract:
+/// <list type="bullet">
+///   <item>
+///     <see cref="Session"/> has no <c>AgentId</c> property at all. Agent ownership
+///     lives on <see cref="Conversation"/>.<see cref="Conversation.AgentId"/>; the
+///     session links via <see cref="Session.ConversationId"/> and looks the agent
+///     up through that.
+///   </item>
+///   <item>
+///     <see cref="GatewaySession.AgentId"/> exists as a <em>hydrated runtime cache</em>
+///     populated by <see cref="ISessionStore"/> implementations from
+///     <c>Conversation.AgentId</c>. The cache is structurally safe because
+///     <c>Conversation.AgentId</c> is <c>init</c>-only (see
+///     <see cref="ConversationAgentIdImmutabilityArchitectureTests"/>). The property
+///     must expose only an <c>init</c>-style setter (no public <c>set</c>) so it
+///     cannot drift after construction; the sole mutator past construction is
+///     <c>GatewaySession.HydrateAgentId(AgentId)</c> for store-load paths.
+///   </item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ships vacuity / false-positive / comment-mention self-tests per the "every
+/// regex-based architecture fence must include a self-test" memory.
+/// </para>
+/// </remarks>
+public sealed class SessionAgentIdRemovedArchitectureTests
+{
+    [Fact]
+    public void Session_HasNoAgentIdProperty()
+    {
+        var prop = typeof(Session).GetProperty(
+            "AgentId",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+
+        prop.ShouldBeNull(
+            "P9-H contract: Session.AgentId is deleted. Agent ownership is durably owned " +
+            "by Conversation.AgentId — sessions look it up via Session.ConversationId.");
+    }
+
+    [Fact]
+    public void Session_HasNoAgentIdField()
+    {
+        var field = typeof(Session).GetField(
+            "AgentId",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+
+        field.ShouldBeNull(
+            "P9-H contract: Session has no AgentId backing field. The field was removed " +
+            "with the property to prevent silent reintroduction.");
+    }
+
+    [Fact]
+    public void GatewaySession_AgentId_IsInitOnly()
+    {
+        var prop = typeof(GatewaySession).GetProperty(
+            nameof(GatewaySession.AgentId),
+            BindingFlags.Public | BindingFlags.Instance);
+
+        prop.ShouldNotBeNull(
+            "P9-H contract: GatewaySession.AgentId is retained as the hydrated runtime " +
+            "cache populated by stores from Conversation.AgentId.");
+        prop.CanRead.ShouldBeTrue();
+
+        var setter = prop.GetSetMethod(nonPublic: false);
+        setter.ShouldNotBeNull("P9-H contract: GatewaySession.AgentId must expose an init setter.");
+
+        // An `init` setter is a public method whose return-parameter modreqs include
+        // System.Runtime.CompilerServices.IsExternalInit. A `set` setter does not.
+        var requiredModifiers = setter.ReturnParameter.GetRequiredCustomModifiers();
+        requiredModifiers.ShouldContain(
+            t => t.FullName == "System.Runtime.CompilerServices.IsExternalInit",
+            "P9-H contract: GatewaySession.AgentId must be `init`-only so a hydrated " +
+            "AgentId cannot drift after construction. A regular `set` setter would " +
+            "allow write-through facades to creep back in.");
+    }
+
+    [Fact]
+    public void GatewaySession_HydrateAgentId_IsTheOnlyPostInitMutator()
+    {
+        var method = typeof(GatewaySession).GetMethod(
+            "HydrateAgentId",
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: [typeof(AgentId)],
+            modifiers: null);
+
+        method.ShouldNotBeNull(
+            "P9-H contract: GatewaySession.HydrateAgentId(AgentId) is the only sanctioned " +
+            "post-construction mutator. Used by FromSession + store load paths that build " +
+            "the wrapper first and look up the conversation second.");
+    }
+
+    [Fact]
+    public void NoProductionSourceFile_AssignsAgentIdAfterConstruction_OutsideAllowlist()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            if (s_assignAllowlist.Contains(relative)) continue;
+
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_assignPattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-H: GatewaySession.AgentId / session.AgentId may only be assigned inside " +
+            "object initializers in the sanctioned store-load sites (which receive the " +
+            "hydrated value from Conversation.AgentId). Post-construction reassignment " +
+            "must go through HydrateAgentId.\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void AssignAllowlist_OnlyContains_FilesThat_StillExist_AndStill_TripTheFence()
+    {
+        var srcRoot = FindSourceRoot();
+        var stale = new List<string>();
+
+        foreach (var relative in s_assignAllowlist)
+        {
+            var full = Path.Combine(srcRoot, relative);
+            if (!File.Exists(full))
+            {
+                stale.Add($"{relative} — file does not exist (delete this allowlist entry)");
+                continue;
+            }
+            if (!s_assignPattern.IsMatch(StripComments(File.ReadAllText(full))))
+            {
+                stale.Add($"{relative} — file no longer trips the fence (delete this allowlist entry)");
+            }
+        }
+
+        stale.ShouldBeEmpty(
+            "Allowlist hygiene: every entry must still match an existing file AND still trip the fence; " +
+            "otherwise it grants a permanent exemption to future regressions in the same file.\n" +
+            "Stale entries:\n  " + string.Join("\n  ", stale));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReintroduction()
+    {
+        s_assignPattern.IsMatch("session.AgentId = AgentId.From(\"x\");")
+            .ShouldBeTrue("Vacuity guard: a real post-init write must trip the fence.");
+        s_assignPattern.IsMatch("gatewaySession.AgentId = id;")
+            .ShouldBeTrue("Vacuity guard: gatewaySession.AgentId writes must trip.");
+        s_assignPattern.IsMatch("    session.AgentId   =   value;")
+            .ShouldBeTrue("Vacuity guard: extra whitespace must trip.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedSymbols()
+    {
+        // Reads, comparisons and object-initializer-shape writes outside the matched
+        // identifier prefix must NOT match.
+        s_assignPattern.IsMatch("var id = session.AgentId;")
+            .ShouldBeFalse("False-positive guard: reads must not match.");
+        s_assignPattern.IsMatch("if (session.AgentId == agentId) { }")
+            .ShouldBeFalse("False-positive guard: comparisons must not match.");
+        s_assignPattern.IsMatch("var match = session.AgentId == agentId;")
+            .ShouldBeFalse("False-positive guard: comparison assigned to a local must not match.");
+        s_assignPattern.IsMatch("predicate: session => session.AgentId == id")
+            .ShouldBeFalse("False-positive guard: lambda body comparison must not match.");
+        s_assignPattern.IsMatch("AgentId = AgentId.From(\"x\")")
+            .ShouldBeFalse("False-positive guard: bare object-initializer `AgentId =` " +
+                "(without a `session.` or `gatewaySession.` qualifier) must not match. " +
+                "Object initializers are the sanctioned construction path.");
+        s_assignPattern.IsMatch("envelope.AgentId = id;")
+            .ShouldBeFalse("False-positive guard: writes to other `.AgentId` properties " +
+                "on unrelated types (envelopes, DTOs) must not match.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        const string syntheticClean = """
+            /// <summary>
+            /// Callers must NOT do `session.AgentId = id` post-construction — use HydrateAgentId.
+            /// </summary>
+            // Legacy: pre-P9-H code did `session.AgentId = someValue;` — that shape is dead.
+            /* Block comment: gatewaySession.AgentId = ... outside HydrateAgentId is banned. */
+            public void Documented() { }
+            """;
+
+        s_assignPattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of the write shape for historical " +
+            "context or doc warnings must not trip — the lexer strips them.");
+    }
+
+    // Matches post-construction reassignment shapes: `session.AgentId = ...` or
+    // `gatewaySession.AgentId = ...`. The negative-lookahead `(?![=>])` rules out
+    // comparisons (`==`) and lambda arrows (`=>`) so the fence only trips on real
+    // single-`=` assignments. Object-initializer shape (`AgentId = ...` inside a
+    // `new GatewaySession { ... }` block) is intentionally excluded — that's the
+    // sanctioned construction path used by stores.
+    private static readonly Regex s_assignPattern = new(
+        @"\b(?:session|gatewaySession)\.AgentId\s*=(?![=>])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // Sanctioned files: none (currently). All construction goes through object
+    // initializers; HydrateAgentId is a method call not an assignment, so it's
+    // structurally outside the regex. If a legitimate post-construction reassignment
+    // ever needs to exist, add the file here with a comment justifying it.
+    private static readonly HashSet<string> s_assignAllowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+    };
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Same lexer pattern used by other
+    /// architecture fences (e.g. <see cref="ConversationsControllerCitizenListingArchitectureTests"/>).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewaySessionBehaviorSnapshotTests.cs
@@ -125,10 +125,10 @@ public sealed class GatewaySessionBehaviorSnapshotTests
     {
         var domainSession = new Session
         {
-            SessionId = SessionId.From("domain-session"),
-            AgentId = AgentId.From("agent-snapshot")
+            SessionId = SessionId.From("domain-session")
         };
         var gatewaySession = GatewaySession.FromSession(domainSession);
+        gatewaySession.HydrateAgentId(AgentId.From("agent-snapshot"));
 
         gatewaySession.Runtime.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "from-runtime" });
         gatewaySession.Session.History.Where(entry => entry.Content == "from-runtime").ShouldHaveSingleItem();

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/PreCompactionMemoryFlusherTests.cs
@@ -190,7 +190,6 @@ public sealed class PreCompactionMemoryFlusherTests
     private static Session BuildSession(SessionType type) => new()
     {
         SessionId = TestSessionId,
-        AgentId = TestAgent,
         SessionType = type
     };
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionEndMemoryFlusherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionEndMemoryFlusherTests.cs
@@ -176,7 +176,6 @@ public sealed class SessionEndMemoryFlusherTests
         return new Session
         {
             SessionId = SessionId.Create(),
-            AgentId = TestAgent,
             SessionType = type
         };
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/FinishAgentExchangeToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/FinishAgentExchangeToolTests.cs
@@ -145,11 +145,13 @@ public sealed class FinishAgentExchangeToolTests
         new Session
         {
             SessionId = sid,
-            AgentId = AgentId.From("test-agent"),
             ChannelType = ChannelKey.From("test"),
             SessionType = SessionType.AgentAgent,
             Status = GatewaySessionStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
-        });
+        })
+    {
+        AgentId = AgentId.From("test-agent")
+    };
 }


### PR DESCRIPTION
# P9-H: delete `Session.AgentId`; Conversation owns agent identity

Closes #662. Phase 9 / W-4 directive: agent ownership lives durably on `Conversation.AgentId`; the session links via `Session.ConversationId` and looks the agent up through that.

## What changes

### Domain
- **`Session.AgentId` deleted.** Replaced with a `// P9-H (#662)` comment block matching the P9-F Participants pattern. Agent identity is no longer persisted on the session row.
- **`Conversation.AgentId` is now `init`-only** (was `get; set;`). The cache safety story for the entire phase rests on this single invariant — a re-bindable owning agent would silently invalidate every cached resolver lookup.
- **`GatewaySession.AgentId` reworked from facade → hydrated runtime cache.** Pre-P9-H it was `get/set => Session.AgentId` (a pure write-through facade onto the deleted field). Now it has a private `_agentId` backing field, an `init`-only setter, and a single sanctioned post-construction mutator `HydrateAgentId(AgentId)` for `FromSession` + store load paths that build the wrapper first and look up the conversation second.

### Resolver scaffold (for sites that don't already have a hydrated session)
- **New `IAgentIdentityResolver`** in `BotNexus.Gateway.Contracts.Conversations` — looks up `AgentId` for a `ConversationId`.
- **`AgentIdentityResolver` impl** in `BotNexus.Gateway.Conversations` — singleton backed by `IConversationStore`, with a `ConcurrentDictionary<ConversationId, AgentId>` positive-only cache. Cache is structurally safe (see init-only invariant above) so a fire-and-forget memoization is fine.
- DI registration: `services.TryAddSingleton<IAgentIdentityResolver, AgentIdentityResolver>()`.

### Stores
- `SessionStoreBase.CreateSession`, `SqliteSessionStore.ReadSession`, `FileSessionStore.ReadSession`: `AgentId = ...` moved from `new Session { ... }` to `new GatewaySession(...) { ... }`. The legacy `agent_id` column / `agentId` sidecar field is still read and used to hydrate the runtime cache — this preserves backwards compatibility with existing data and matches the P9-F precedent of retaining the persistence column for one phase as a rollback source.
- Write path **unchanged** in this PR — `agent_id` is still written for new rows. The deferred follow-up (see below) will switch writes to NULL and add a one-shot migration.

### Architecture fences (the rigour)
Two new files pin the invariants reflectively + via member-access regex:

**`SessionAgentIdRemovedArchitectureTests`** (8 tests):
- Reflection pin: `Session` has no `AgentId` property AND no `AgentId` field (defence in depth — backing-field-only re-introduction would slip past a property-only check).
- Reflection pin: `GatewaySession.AgentId` exists, has init-style setter (verified by `IsExternalInit` modreq inspection), and no public `set` setter.
- Reflection pin: `GatewaySession.HydrateAgentId(AgentId)` exists as the only sanctioned post-construction mutator.
- Member-access fence: no `session.AgentId = ...` or `gatewaySession.AgentId = ...` writes outside the (empty) allowlist. Negative-lookahead `(?![=>])` rules out comparisons (`==`) and lambda arrows (`=>`).
- Vacuity / false-positive / comment-mention self-tests per the lesson encoded in `AgentExchangeConversationArchitectureTests`.

**`ConversationAgentIdImmutabilityArchitectureTests`** (2 tests):
- Reflection pin: `Conversation.AgentId` is init-only (verified by `IsExternalInit` modreq inspection).
- Reflection pin: no `SetAgentId`/`ChangeAgentId`/`RebindAgentId` mutation methods exist that could side-step the init-only setter.

### Tests
- `Sessions/PreCompactionMemoryFlusherTests`, `Sessions/SessionEndMemoryFlusherTests` (`BuildSession` helpers): removed unused `AgentId = TestAgent` (flusher takes agentId as a separate parameter, so the session-side value was never read).
- `Tools/FinishAgentExchangeToolTests.MakeSession`: `AgentId` moved from `Session` to `GatewaySession` initializer.
- `GatewaySessionBehaviorSnapshotTests`: uses `gatewaySession.HydrateAgentId(...)` after `FromSession` (the canonical wire-up for tests that produce a session via `FromSession`).

## Pragmatic deviation from issue strict acceptance

The issue body has two statements that conflict:

> **Acceptance**: `GatewaySession` has no `AgentId` member.

vs.

> **Caller redirect**: High-traffic paths (dispatch, supervisor) should cache the derived AgentId on the in-memory `GatewaySession` runtime side (not the persisted `Session`) to avoid repeated conversation lookups.

This PR follows the cache-guidance interpretation: `GatewaySession.AgentId` is retained as a **runtime cache, not a facade**. Concretely:

1. Pre-P9-H it was `get/set => Session.AgentId` — a write-through facade onto the persisted field. **That facade is gone** along with `Session.AgentId`.
2. Post-P9-H it's a private `_agentId` field with init-only access + a single `HydrateAgentId` mutator restricted to store-load paths by the architecture fence.
3. The cache is structurally safe because `Conversation.AgentId` is init-only (architecture fence). A hydrated value cannot drift.

This preserves ~30 sync reader sites across dispatch / supervisor / tools / channels / storage without churn while still satisfying the spirit of W-4: agent ownership is durably owned by `Conversation.AgentId`, the session row has no AgentId field. The `IAgentIdentityResolver` is the on-demand abstraction for any new code that has only a `ConversationId` in hand.

If reviewers want the literal "no `AgentId` member on `GatewaySession`" reading, that's a follow-up PR — it would require converting ~30 sync sites (including `Activity.SetTag` tracing tags and `ILogger` interpolations) to async resolver lookups + threading `CancellationToken` further than currently. The cost/benefit tipped toward "keep the safe cache, ship the deletion".

## Explicitly deferred to follow-up phase (P9-H-2 or similar)

1. **Stop writing `agent_id` column / `agentId` sidecar.** Currently the write path is unchanged. The P9-F precedent for `participants_json` was to keep the column writable for one phase as rollback safety and add a one-shot migration in the next; same approach here. New PR will write NULL and add a backfill that verifies `Conversation.AgentId == sessions.agent_id` for legacy rows before declaring the column dead.
2. **Drop `agent_id` column from SQLite schema + drop the `idx_sessions_agent_id` index.** Follows the write-stop.
3. **`SessionStoreBase` filter predicates (`ApplyAgentFilter`, `ListByChannelAsync`, `ListByConversationAsync`, `GetExistenceAsync`) switch to `IConversationStore.ListForCitizenAsync` lookups instead of `session.AgentId == agentId`.** Today they read the hydrated cache, which works correctly because the cache is sourced from `Conversation.AgentId`, but the directive says lookups should be authoritative. Makes `IConversationStore` mandatory (not optional) on the constructor.
4. **`GetOrCreateAsync` ownership validation.** Rubber-duck finding: when returning an existing session, verify `conversation.AgentId == requested agentId` and throw on mismatch. This is a pre-existing safety hole (the old code also didn't validate) but worth tightening once the lookup is authoritative.

These are sequenced after this PR so reviewers can verify each shift in isolation.

## Validation

- `dotnet build BotNexus.slnx --nologo --tl:off` — 0 errors, 0 warnings.
- `scripts\repo\test-impacted.ps1 -From origin/main` — 17 test projects, all green (4628+ passing, 1 skipped Playwright reliability test that's flagged as such, 0 failures).
- Full suite excluding integration (`--filter "FullyQualifiedName!~BotNexus.Integration."`) — all green.
- Architecture: 152 fence tests passing (+11 new for P9-H: 8 in `SessionAgentIdRemovedArchitectureTests`, 2 in `ConversationAgentIdImmutabilityArchitectureTests`, plus the existing 141).

## Commits

1. `refactor(domain)!: delete Session.AgentId; Conversation owns agent identity (P9-H, #662)` — domain change + resolver scaffold + store/test fixes.
2. `test(architecture): pin P9-H invariants for Session/GatewaySession/Conversation AgentId (#662)` — the 2 fences with self-tests.
