### PR TITLE
refactor(gateway)!: hydrate Session AgentId from Conversation; drop legacy agent_id column (P9-I, closes #674)

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
@@ -1,7 +1,9 @@
 using System.CommandLine;
 using System.IO.Abstractions;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using BotNexus.Memory;
 using Microsoft.Extensions.Logging;
@@ -62,6 +64,7 @@ internal sealed class MemoryCommands
                 : "InMemory";
 
         Gateway.Abstractions.Sessions.ISessionStore store;
+        IConversationStore conversationStore;
 
         if (resolvedType.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
         {
@@ -72,9 +75,15 @@ internal sealed class MemoryCommands
                 return 1;
             }
 
+            // P9-I (#674): IConversationStore is mandatory on SqliteSessionStore.
+            // The conversation store shares the same SQLite database (separate tables).
+            conversationStore = new SqliteConversationStore(
+                connectionString,
+                NullLoggerFactory.Instance.CreateLogger<SqliteConversationStore>());
             store = new SqliteSessionStore(
                 connectionString,
-                NullLoggerFactory.Instance.CreateLogger<SqliteSessionStore>());
+                NullLoggerFactory.Instance.CreateLogger<SqliteSessionStore>(),
+                conversationStore);
         }
         else if (resolvedType.Equals("File", StringComparison.OrdinalIgnoreCase))
         {
@@ -89,10 +98,20 @@ internal sealed class MemoryCommands
                 ? configuredPath
                 : Path.Combine(home.RootPath, configuredPath);
 
+            // P9-I (#674): IConversationStore is mandatory on FileSessionStore.
+            // Mirror the wiring in GatewayServiceCollectionExtensions: conversations live
+            // in a `conversations/` subdirectory of the configured sessions path.
+            var conversationsPath = Path.Combine(sessionsPath, "conversations");
+            fileSystem.Directory.CreateDirectory(conversationsPath);
+            conversationStore = new FileConversationStore(
+                conversationsPath,
+                NullLoggerFactory.Instance.CreateLogger<FileConversationStore>(),
+                fileSystem);
             store = new FileSessionStore(
                 sessionsPath,
                 NullLoggerFactory.Instance.CreateLogger<FileSessionStore>(),
-                fileSystem);
+                fileSystem,
+                conversationStore);
         }
         else
         {

--- a/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/FileSessionStore.cs
@@ -43,8 +43,9 @@ public sealed class FileSessionStore : SessionStoreBase
     private readonly Dictionary<SessionId, GatewaySession> _cache = [];
     private readonly ILogger<FileSessionStore> _logger;
     private readonly ISecretRedactor? _redactor;
-    private readonly LegacyConversationResolver? _legacyResolver;
-    private readonly IConversationStore? _conversationStore;
+    private readonly LegacyConversationResolver _legacyResolver;
+    private readonly IConversationStore _conversationStore;
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<ConversationId, AgentId> _agentIdCache = new();
 
     // Phase 9 / P9-B-2 (#627): eager startup sweep mirrors
     // SqliteSessionStore.MigrateOrphanedSessionsAsync. A SemaphoreSlim + bool flag
@@ -70,11 +71,6 @@ public sealed class FileSessionStore : SessionStoreBase
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public FileSessionStore(string storePath, ILogger<FileSessionStore> logger, IFileSystem fileSystem, ISecretRedactor? redactor = null)
-        : this(storePath, logger, fileSystem, conversationStore: null, redactor: redactor)
-    {
-    }
-
     /// <summary>
     /// Initialises a new <see cref="FileSessionStore"/>.
     /// </summary>
@@ -82,18 +78,22 @@ public sealed class FileSessionStore : SessionStoreBase
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="fileSystem">Abstracted file system (real or mocked).</param>
     /// <param name="conversationStore">
-    /// When provided, sessions loaded with a null <see cref="Session.ConversationId"/> are
-    /// backfilled to the agent's <c>legacy:{agentId}</c> conversation via
-    /// <see cref="LegacyConversationResolver"/> and the sidecar is rewritten so the
-    /// stamp persists across restarts (Phase 9 / P9-B; issue #615). Save-time stamping
-    /// also defends against fresh sessions being persisted with no conversation bound.
+    /// Mandatory post-P9-I (issue #674): durable agent ownership lives on
+    /// <see cref="Conversation.AgentId"/>, and sidecar JSON no longer carries an
+    /// <c>agentId</c> field for new writes. The store uses the conversation store to
+    /// (a) backfill any legacy orphan sidecars to the agent's <c>legacy:{agentId}</c>
+    /// conversation, (b) hydrate <see cref="GatewaySession.AgentId"/> on every load
+    /// from <see cref="Conversation.AgentId"/> (cached per <see cref="ConversationId"/>;
+    /// safe because <c>Conversation.AgentId</c> is init-only per
+    /// <c>ConversationAgentIdImmutabilityArchitectureTests</c>), and (c) stamp
+    /// <see cref="Session.ConversationId"/> defensively at save time.
     /// </param>
     /// <param name="redactor">When provided, secrets in content are redacted before storage.</param>
     public FileSessionStore(
         string storePath,
         ILogger<FileSessionStore> logger,
         IFileSystem fileSystem,
-        IConversationStore? conversationStore,
+        IConversationStore conversationStore,
         ISecretRedactor? redactor = null)
         : base(conversationStore)
     {
@@ -101,10 +101,8 @@ public sealed class FileSessionStore : SessionStoreBase
         _logger = logger;
         _fileSystem = fileSystem;
         _redactor = redactor;
-        _conversationStore = conversationStore;
-        _legacyResolver = conversationStore is not null
-            ? new LegacyConversationResolver(conversationStore, logger: null)
-            : null;
+        _conversationStore = conversationStore ?? throw new ArgumentNullException(nameof(conversationStore));
+        _legacyResolver = new LegacyConversationResolver(conversationStore, logger: null);
         _fileSystem.Directory.CreateDirectory(storePath);
     }
 
@@ -291,8 +289,7 @@ public sealed class FileSessionStore : SessionStoreBase
     /// </summary>
     private async Task MigrateOrphanedSessionsAsync(CancellationToken cancellationToken)
     {
-        if (_legacyResolver is null) return;
-
+        // P9-I (#674): _legacyResolver is non-null post-P9-I (conversationStore is mandatory).
         // Pass 1: enumerate orphan sidecars (ConversationId is null or absent on disk).
         // Hold the read lock briefly to avoid racing with concurrent SaveAsync writes.
         var orphans = new List<(SessionId SessionId, AgentId AgentId, SessionStatus Status, DateTimeOffset UpdatedAt)>();
@@ -326,8 +323,20 @@ public sealed class FileSessionStore : SessionStoreBase
                 if (meta is null) continue;
                 if (meta.ConversationId is not null) continue;
 
+                // P9-I (#674): post-P9-I sidecars write AgentId=null. An orphan with no
+                // AgentId is unrecoverable here (no anchor to find a legacy conversation).
+                // Skip — LoadFromFileAsync will throw a precise error if the session is
+                // ever requested.
+                if (meta.AgentId is null)
+                {
+                    _logger.LogWarning(
+                        "Skipping sidecar {SidecarPath} during orphan sweep: ConversationId is null AND AgentId is null (unrecoverable).",
+                        metaFile);
+                    continue;
+                }
+
                 var sessionId = SessionId.From(Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(metaFile)));
-                orphans.Add((sessionId, meta.AgentId, meta.Status, meta.UpdatedAt));
+                orphans.Add((sessionId, meta.AgentId.Value, meta.Status, meta.UpdatedAt));
             }
         }
         finally { _lock.Release(); }
@@ -474,6 +483,45 @@ public sealed class FileSessionStore : SessionStoreBase
             totalRows, byConversation.Count);
     }
 
+    /// <summary>
+    /// P9-I (#674): hydrates <see cref="GatewaySession.AgentId"/> on a loaded session
+    /// from <see cref="Conversation.AgentId"/>. Uses a positive-only
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+    /// cache keyed by <see cref="ConversationId"/>; safe because
+    /// <c>Conversation.AgentId</c> is init-only.
+    /// </summary>
+    private async Task HydrateAgentIdAsync(GatewaySession session, CancellationToken cancellationToken)
+    {
+        if (!session.ConversationId.IsInitialized())
+        {
+            throw new InvalidOperationException(
+                $"Session '{session.SessionId.Value}' has an unset ConversationId after load. " +
+                "Post-P9-I, every session sidecar is guaranteed to carry a non-null conversationId " +
+                "(the eager startup sweep runs before this load could be served). " +
+                "Either the sidecar was modified externally or the migration failed silently — " +
+                "inspect FileSessionStore logs at startup.");
+        }
+
+        if (_agentIdCache.TryGetValue(session.ConversationId, out var cached))
+        {
+            session.HydrateAgentId(cached);
+            return;
+        }
+
+        var conversation = await _conversationStore.GetAsync(session.ConversationId, cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+        {
+            throw new InvalidOperationException(
+                $"Session '{session.SessionId.Value}' references conversation '{session.ConversationId.Value}' " +
+                "which does not exist in the conversation store. AgentId cannot be hydrated. " +
+                "This indicates that the conversation was deleted while the sidecar remained — " +
+                "the session is unrecoverable.");
+        }
+
+        _agentIdCache[session.ConversationId] = conversation.AgentId;
+        session.HydrateAgentId(conversation.AgentId);
+    }
+
     private async Task<GatewaySession?> LoadFromFileAsync(SessionId sessionId, CancellationToken cancellationToken)
     {
         var metaPath = GetMetaPath(sessionId);
@@ -498,15 +546,12 @@ public sealed class FileSessionStore : SessionStoreBase
             ExpiresAt = meta.ExpiresAt
             // ConversationId is intentionally omitted when meta.ConversationId is null --
             // the property defaults to an uninitialized ConversationId (the "unset" sentinel)
-            // and the load-time backfill below fires on it. Writing `default(ConversationId)`
-            // explicitly is prohibited by Vogen analyzer VOG009.
+            // and the legacy-orphan recovery below fires on it. Writing
+            // `default(ConversationId)` explicitly is prohibited by Vogen analyzer VOG009.
         }, _redactor)
         {
-            // P9-H (#662): Session.AgentId was deleted; AgentId is now a hydrated derived
-            // value on the runtime wrapper. For File-store load we still read the legacy
-            // `meta.AgentId` JSON field; agent ownership lives on Conversation.AgentId post
-            // P9-H so future loads will derive from the conversation store at hydration.
-            AgentId = meta.AgentId,
+            // P9-I (#674): CallerId is the only sidecar-sourced runtime field. AgentId is
+            // hydrated below (post legacy-orphan recovery) from Conversation.AgentId.
             CallerId = meta.CallerId
         };
         if (meta.ConversationId is not null)
@@ -537,14 +582,20 @@ public sealed class FileSessionStore : SessionStoreBase
             session.UpdatedAt = meta.UpdatedAt;
         }
 
-        // Phase 9 / P9-B (#615, #627): if this session was persisted before
-        // Session.ConversationId was always populated, durably backfill the legacy
-        // conversation. The sidecar is rewritten so subsequent loads — and any reader
-        // that joins on ConversationId — observe the stamp without another resolution
-        // round trip.
-        if (!session.ConversationId.IsInitialized() && _legacyResolver is not null)
+        // P9-I (#674): legacy-orphan recovery — pre-Phase-9 sidecars carried `agentId` but
+        // no `conversationId`. Stamp the legacy conversation using the sidecar's recorded
+        // AgentId (the ONLY legitimate read of meta.AgentId post-P9-I) and rewrite the
+        // sidecar so subsequent loads observe the stamp.
+        if (!session.ConversationId.IsInitialized())
         {
-            var legacy = await _legacyResolver.ResolveAsync(session.AgentId, cancellationToken).ConfigureAwait(false);
+            if (meta.AgentId is null)
+            {
+                throw new InvalidOperationException(
+                    $"Session sidecar '{metaPath}' has neither ConversationId nor AgentId — " +
+                    "unrecoverable orphan. Inspect the sidecar manually or delete it.");
+            }
+
+            var legacy = await _legacyResolver.ResolveAsync(meta.AgentId.Value, cancellationToken).ConfigureAwait(false);
             session.ConversationId = legacy.ConversationId;
 
             if (session.Status == SessionStatus.Active)
@@ -554,9 +605,15 @@ public sealed class FileSessionStore : SessionStoreBase
 
             await WriteToFileAsync(session, cancellationToken).ConfigureAwait(false);
             _logger.LogWarning(
-                "Backfilled orphan session {SessionId} for agent {AgentId} with legacy conversation {LegacyConversationId} on load (sidecar rewritten).",
-                session.SessionId, session.AgentId, legacy.ConversationId);
+                "Backfilled orphan sidecar for session {SessionId} (legacy AgentId {AgentId}) with conversation {LegacyConversationId} (sidecar rewritten).",
+                session.SessionId, meta.AgentId.Value, legacy.ConversationId);
         }
+
+        // P9-I (#674): hydrate AgentId from Conversation.AgentId after any legacy-orphan
+        // recovery. Every load path (GetAsync, GetOrCreateAsync, EnumerateSessionsAsync,
+        // ListByConversationAsync) routes through LoadFromFileAsync so callers always
+        // observe a hydrated AgentId.
+        await HydrateAgentIdAsync(session, cancellationToken).ConfigureAwait(false);
 
         return session;
     }
@@ -565,14 +622,11 @@ public sealed class FileSessionStore : SessionStoreBase
     /// Defensively stamps a session whose <see cref="Session.ConversationId"/> is unset
     /// (<c>default(ConversationId)</c>) at save time with the agent's
     /// <c>legacy:{agentId}</c> conversation, persisting the stamp before the sidecar is
-    /// written so subsequent reads see a consistent view. No-op when no conversation
-    /// store was registered (back-compat for test composition roots).
+    /// written so subsequent reads see a consistent view.
     /// </summary>
     private async Task EnsureConversationIdStampedAsync(GatewaySession session, CancellationToken cancellationToken)
     {
         if (session.ConversationId.IsInitialized())
-            return;
-        if (_legacyResolver is null)
             return;
 
         var legacy = await _legacyResolver.ResolveAsync(session.AgentId, cancellationToken).ConfigureAwait(false);
@@ -603,7 +657,11 @@ public sealed class FileSessionStore : SessionStoreBase
 
         var metaPath = GetMetaPath(session.SessionId);
         var meta = new SessionMeta(
-            session.AgentId,
+            // P9-I (#674): never write AgentId on new sidecars. Agent ownership is hydrated
+            // from Conversation.AgentId on load. Pre-existing sidecars that still carry it
+            // are read by LoadFromFileAsync's legacy-orphan recovery path; subsequent
+            // saves (e.g. after backfill rewrites the sidecar) drop the field.
+            null,
             session.ChannelType,
             session.CallerId,
             session.SessionType,
@@ -638,7 +696,12 @@ public sealed class FileSessionStore : SessionStoreBase
     private string GetMetaPath(SessionId sessionId) => Path.Combine(_storePath, SessionFileNames.MetadataFileName(sessionId.Value));
 
     private sealed record SessionMeta(
-        AgentId AgentId,
+        // P9-I (#674): AgentId is now NULLABLE. New writes ALWAYS pass null — durable
+        // agent ownership lives on Conversation.AgentId post-P9-I and is hydrated on
+        // load via Conversation.AgentId. The legacy field is retained for back-compat
+        // reads (pre-P9 orphan-sidecar recovery in LoadFromFileAsync) and for the
+        // one-shot orphan-migration scan in MigrateOrphanedSessionsAsync only.
+        AgentId? AgentId,
         ChannelKey? ChannelType,
         string? CallerId,
         SessionType? SessionType,

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -39,8 +39,9 @@ public sealed class SqliteSessionStore : SessionStoreBase
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    private readonly IConversationStore? _conversationStore;
-    private readonly LegacyConversationResolver? _legacyResolver;
+    private readonly IConversationStore _conversationStore;
+    private readonly LegacyConversationResolver _legacyResolver;
+    private readonly ConcurrentDictionary<ConversationId, AgentId> _agentIdCache = new();
     private readonly ILogger<SqliteSessionStore> _logger;
     private readonly ISecretRedactor? _redactor;
 
@@ -50,25 +51,27 @@ public sealed class SqliteSessionStore : SessionStoreBase
     /// <param name="connectionString">SQLite connection string for the sessions database.</param>
     /// <param name="logger">Logger for diagnostic output including migration summaries.</param>
     /// <param name="conversationStore">
-    /// When provided, a startup migration links any orphaned sessions (those with no
-    /// <c>conversation_id</c>) to their agent's <c>legacy:{agentId}</c> conversation,
-    /// and <see cref="SaveAsync"/> / <see cref="LoadSessionAsync(SessionId, CancellationToken)"/>
-    /// defensively backfill sessions that still arrive null after startup.
+    /// Mandatory post-P9-I (issue #674): durable agent ownership lives on
+    /// <see cref="Conversation.AgentId"/>, and the SQLite session row no longer carries an
+    /// <c>agent_id</c> column. The store uses the conversation store to (a) link orphaned
+    /// sessions to their agent's legacy conversation at startup, (b) hydrate
+    /// <see cref="GatewaySession.AgentId"/> on every load from <see cref="Conversation.AgentId"/>
+    /// (cached per <see cref="ConversationId"/>; safe because <c>Conversation.AgentId</c> is
+    /// init-only per <c>ConversationAgentIdImmutabilityArchitectureTests</c>), and (c) stamp
+    /// <see cref="Session.ConversationId"/> defensively at save time.
     /// </param>
     /// <param name="redactor">When provided, secrets in content are redacted before storage.</param>
     public SqliteSessionStore(
         string connectionString,
         ILogger<SqliteSessionStore> logger,
-        IConversationStore? conversationStore = null,
+        IConversationStore conversationStore,
         ISecretRedactor? redactor = null)
         : base(conversationStore)
     {
         _connectionString = connectionString;
         _logger = logger;
-        _conversationStore = conversationStore;
-        _legacyResolver = conversationStore is not null
-            ? new LegacyConversationResolver(conversationStore, logger: null)
-            : null;
+        _conversationStore = conversationStore ?? throw new ArgumentNullException(nameof(conversationStore));
+        _legacyResolver = new LegacyConversationResolver(conversationStore, logger: null);
         _redactor = redactor;
     }
 
@@ -225,7 +228,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
         {
             var sessionId = SessionId.From(reader.GetString(0));
             var session = _cache.GetValueOrDefault(sessionId)
-                ?? await LoadSessionAsync(connection, sessionId, _redactor, cancellationToken).ConfigureAwait(false);
+                ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
             if (session is not null)
             {
                 _cache[sessionId] = session;
@@ -238,7 +241,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
     /// <summary>
     /// Returns sessions for a single conversation, using the
-    /// <c>idx_sessions_conversation_agent</c> index to avoid loading the
+    /// <c>idx_sessions_conversation_created</c> index to avoid loading the
     /// full session table. Honours the same chronological-ascending /
     /// SessionId-tiebreaker contract as <see cref="SessionStoreBase.ListByConversationAsync"/>.
     /// </summary>
@@ -252,15 +255,21 @@ public sealed class SqliteSessionStore : SessionStoreBase
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         await using var command = connection.CreateCommand();
+        // P9-I (#674): agent_id predicate removed — column is dropped post-migration.
+        // The agentId argument is applied post-hydration via the inherited
+        // SessionStoreBase contract: the hydrated AgentId comes from Conversation.AgentId
+        // (resolved by HydrateAgentIdAsync) and is the authoritative owner. Note that
+        // every session in a conversation has the same AgentId by construction
+        // (Conversation.AgentId is init-only and shared across all its sessions), so
+        // the agentId filter is effectively an assertion that the conversation belongs
+        // to the requested agent — and is preserved here for API contract continuity.
         command.CommandText = """
             SELECT id
             FROM sessions
             WHERE conversation_id = $conversationId
-              AND ($agentId IS NULL OR agent_id = $agentId)
             ORDER BY created_at ASC, id ASC
             """;
         command.Parameters.AddWithValue("$conversationId", conversationId.Value);
-        command.Parameters.AddWithValue("$agentId", (object?)agentId?.Value ?? DBNull.Value);
 
         var sessions = new List<GatewaySession>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -268,11 +277,12 @@ public sealed class SqliteSessionStore : SessionStoreBase
         {
             var sessionId = SessionId.From(reader.GetString(0));
             var session = _cache.GetValueOrDefault(sessionId)
-                ?? await LoadSessionAsync(connection, sessionId, _redactor, cancellationToken).ConfigureAwait(false);
+                ?? await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
             if (session is not null)
             {
                 _cache[sessionId] = session;
-                sessions.Add(session);
+                if (agentId is null || session.AgentId == agentId)
+                    sessions.Add(session);
             }
         }
 
@@ -299,7 +309,6 @@ public sealed class SqliteSessionStore : SessionStoreBase
             command.CommandText = """
                 CREATE TABLE IF NOT EXISTS sessions (
                     id TEXT PRIMARY KEY,
-                    agent_id TEXT,
                     channel_type TEXT,
                     caller_id TEXT,
                     session_type TEXT,
@@ -326,7 +335,6 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_session_history_session_id ON session_history(session_id);
-                CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions(agent_id);
                 CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
                 """;
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -334,23 +342,41 @@ public sealed class SqliteSessionStore : SessionStoreBase
             // Migrate: add tool columns to existing databases
             await MigrateAsync(connection, cancellationToken).ConfigureAwait(false);
 
-            // Conversation-routing index. MUST run AFTER MigrateAsync because legacy
-            // schemas may lack the conversation_id column until migration adds it.
+            // P9-I (#674): the legacy idx_sessions_conversation_agent index referenced
+            // the (now-dropped) agent_id column. Migration below drops the old shape
+            // and recreates as (conversation_id, created_at, id). For fresh DBs this
+            // CREATE INDEX IF NOT EXISTS catches the new shape immediately.
             await using var convIndexCmd = connection.CreateCommand();
             convIndexCmd.CommandText =
-                "CREATE INDEX IF NOT EXISTS idx_sessions_conversation_agent ON sessions(conversation_id, agent_id, created_at);";
+                "CREATE INDEX IF NOT EXISTS idx_sessions_conversation_created ON sessions(conversation_id, created_at, id);";
             await convIndexCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-            // Migrate: link orphaned sessions to their agent's default conversation
-            if (_conversationStore is not null)
+            // P9-I (#674): orphan migration runs BEFORE the column drop because it
+            // reads the legacy agent_id column. Gated on column existence so fresh DBs
+            // skip the scan entirely.
+            var hasAgentIdColumn = await HasColumnAsync(connection, "sessions", "agent_id", cancellationToken).ConfigureAwait(false);
+            if (hasAgentIdColumn)
+            {
                 await MigrateOrphanedSessionsAsync(connection, _conversationStore, cancellationToken).ConfigureAwait(false);
+            }
 
             // P9-F (#657): forward any legacy participants_json into the conversation
             // store's normalised participant set. Idempotent (INSERT OR IGNORE inside
             // AddParticipantsAsync). Runs on every startup; cheap when the legacy column
             // has aged out across deployments.
-            if (_conversationStore is not null)
-                await BackfillParticipantsToConversationsAsync(connection, _conversationStore, cancellationToken).ConfigureAwait(false);
+            await BackfillParticipantsToConversationsAsync(connection, _conversationStore, cancellationToken).ConfigureAwait(false);
+
+            // P9-I (#674): drop the legacy agent_id column and its indexes once orphan
+            // migration has completed. The column is no longer the source of truth —
+            // Conversation.AgentId via IAgentIdentityResolver is. We log a verification
+            // summary of any row whose agent_id column disagrees with the conversation's
+            // AgentId so operators can spot pre-existing data corruption. SQLite >= 3.35
+            // supports ALTER TABLE DROP COLUMN directly. Microsoft.Data.Sqlite ships
+            // 3.46+ so this is unconditionally available.
+            if (hasAgentIdColumn)
+            {
+                await DropLegacyAgentIdColumnAsync(connection, cancellationToken).ConfigureAwait(false);
+            }
 
             _initialized = true;
         }
@@ -359,6 +385,145 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
     private SemaphoreSlim GetSessionLock(SessionId sessionId)
         => _sessionLocks.GetOrAdd(sessionId, static _ => new SemaphoreSlim(1, 1));
+
+    /// <summary>
+    /// Returns <c>true</c> when the named column exists on the given SQLite table.
+    /// Implemented via <c>PRAGMA table_info(<paramref name="table"/>)</c> which is the
+    /// portable, schema-version-independent way to introspect SQLite. Used by P9-I
+    /// migration paths to gate legacy <c>agent_id</c> reads/writes/drops so fresh DBs
+    /// skip the entire orphan-migration + column-drop dance.
+    /// </summary>
+    private static async Task<bool> HasColumnAsync(
+        SqliteConnection connection,
+        string table,
+        string column,
+        CancellationToken cancellationToken)
+    {
+        await using var cmd = connection.CreateCommand();
+        // PRAGMA does not support parameter binding for the table name in older SQLite
+        // versions; interpolation is safe here because `table` is a hardcoded literal
+        // controlled by callers (not user input).
+        cmd.CommandText = $"PRAGMA table_info({table});";
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            // table_info columns: cid, name, type, notnull, dflt_value, pk
+            var name = reader.IsDBNull(1) ? null : reader.GetString(1);
+            if (string.Equals(name, column, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// P9-I (#674): drops the legacy <c>sessions.agent_id</c> column and the two
+    /// indexes that referenced it. SQLite refuses <c>DROP COLUMN</c> on a column that
+    /// is part of any index, so the dependent <c>idx_sessions_agent_id</c> and
+    /// <c>idx_sessions_conversation_agent</c> indexes are dropped first. After the
+    /// column drop the new conversation-routing index <c>idx_sessions_conversation_created</c>
+    /// is created (the fresh-DB shape — it may already exist from the prior CREATE INDEX
+    /// IF NOT EXISTS in EnsureCreatedAsync, in which case this is a no-op).
+    /// </summary>
+    /// <remarks>
+    /// A verification scan runs first: any session whose stamped <c>conversation_id</c>
+    /// resolves to a different <see cref="Conversation.AgentId"/> than the row's
+    /// legacy <c>agent_id</c> column is logged as a warning. We log-and-proceed rather
+    /// than fail because the new source of truth (Conversation.AgentId) is the
+    /// authoritative durable value post-P9-H; the legacy column was effectively
+    /// read-only and may contain stale data from pre-migration writes.
+    /// </remarks>
+    private async Task DropLegacyAgentIdColumnAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        await VerifyAgentIdColumnConsistencyAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        await using (var dropAgentIndex = connection.CreateCommand())
+        {
+            dropAgentIndex.CommandText = "DROP INDEX IF EXISTS idx_sessions_agent_id;";
+            await dropAgentIndex.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await using (var dropConvIndex = connection.CreateCommand())
+        {
+            dropConvIndex.CommandText = "DROP INDEX IF EXISTS idx_sessions_conversation_agent;";
+            await dropConvIndex.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await using (var dropColumn = connection.CreateCommand())
+        {
+            dropColumn.CommandText = "ALTER TABLE sessions DROP COLUMN agent_id;";
+            await dropColumn.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        // Recreate the conversation-routing index in its new (no agent_id) shape.
+        // EnsureCreatedAsync ran CREATE INDEX IF NOT EXISTS earlier; that statement is
+        // a no-op when the index already exists, so we run it explicitly here too in
+        // case the database had only the old shape and nothing else.
+        await using (var newIndex = connection.CreateCommand())
+        {
+            newIndex.CommandText =
+                "CREATE INDEX IF NOT EXISTS idx_sessions_conversation_created ON sessions(conversation_id, created_at, id);";
+            await newIndex.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        _logger.LogInformation(
+            "P9-I: dropped legacy 'sessions.agent_id' column and dependent indexes. " +
+            "AgentId is now hydrated from Conversation.AgentId via IAgentIdentityResolver.");
+    }
+
+    /// <summary>
+    /// Logs a warning for every row whose legacy <c>agent_id</c> column disagrees
+    /// with the owning <see cref="Conversation.AgentId"/>. Read-only — never mutates
+    /// rows. Skipped (and logged) when a row has a non-null <c>agent_id</c> but no
+    /// resolvable conversation, which indicates pre-existing orphan data the migration
+    /// could not link.
+    /// </summary>
+    private async Task VerifyAgentIdColumnConsistencyAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        await using var scanCmd = connection.CreateCommand();
+        scanCmd.CommandText = """
+            SELECT id, agent_id, conversation_id
+            FROM sessions
+            WHERE agent_id IS NOT NULL
+            """;
+
+        var mismatches = 0;
+        var unresolvable = 0;
+        await using var reader = await scanCmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var sessionId = reader.GetString(0);
+            var legacyAgentId = reader.GetString(1);
+            var convIdValue = reader.IsDBNull(2) ? null : reader.GetString(2);
+
+            if (convIdValue is null)
+            {
+                unresolvable++;
+                continue;
+            }
+
+            var conv = await _conversationStore.GetAsync(ConversationId.From(convIdValue), cancellationToken).ConfigureAwait(false);
+            if (conv is null)
+            {
+                unresolvable++;
+                continue;
+            }
+
+            if (!string.Equals(conv.AgentId.Value, legacyAgentId, StringComparison.Ordinal))
+            {
+                mismatches++;
+                _logger.LogWarning(
+                    "P9-I verification: session {SessionId} legacy agent_id={LegacyAgentId} disagrees with Conversation.AgentId={ConversationAgentId} on {ConversationId}. Conversation.AgentId wins.",
+                    sessionId, legacyAgentId, conv.AgentId.Value, convIdValue);
+            }
+        }
+
+        if (mismatches > 0 || unresolvable > 0)
+        {
+            _logger.LogWarning(
+                "P9-I verification summary: {Mismatches} session(s) had a legacy agent_id that disagreed with the conversation, {Unresolvable} session(s) had no resolvable conversation. Authoritative AgentId is the conversation's.",
+                mismatches, unresolvable);
+        }
+    }
 
     private static async Task MigrateAsync(SqliteConnection connection, CancellationToken cancellationToken)
     {
@@ -602,61 +767,68 @@ public sealed class SqliteSessionStore : SessionStoreBase
     }
 
     /// <summary>
-    /// Defensively backfills a session loaded from storage whose
-    /// <c>conversation_id</c> column is NULL. The startup migration sweeps all such rows
-    /// at <see cref="EnsureCreatedAsync"/>, so this path is reached only if a NULL row
-    /// was inserted concurrently by another process between startup and this read.
-    /// Persists the legacy stamp back to the row so subsequent indexed queries
-    /// (e.g. <see cref="ListByConversationAsync"/>) see the session.
+    /// P9-I (#674): hydrates <see cref="GatewaySession.AgentId"/> on a loaded session
+    /// from <see cref="Conversation.AgentId"/>. Replaces the deleted load-time read of
+    /// the legacy <c>sessions.agent_id</c> column. Throws <see cref="InvalidOperationException"/>
+    /// when <c>ConversationId</c> is unset (data corruption — the orphan migration should
+    /// have stamped every row) or the conversation does not exist in the conversation
+    /// store (also corruption — the conversation row was deleted out from under the
+    /// session).
     /// </summary>
-    private async Task BackfillLoadedSessionAsync(GatewaySession session, CancellationToken cancellationToken)
+    /// <remarks>
+    /// Uses a positive-only <see cref="ConcurrentDictionary{TKey,TValue}"/> cache keyed by
+    /// <see cref="ConversationId"/>. The cache is safe because <see cref="Conversation.AgentId"/>
+    /// is init-only (verified by <c>ConversationAgentIdImmutabilityArchitectureTests</c>).
+    /// Negative results are not cached so a create-then-resolve race never observes a
+    /// sticky null.
+    /// </remarks>
+    private async Task HydrateAgentIdAsync(GatewaySession session, CancellationToken cancellationToken)
     {
-        if (session.ConversationId.IsInitialized())
-            return;
-        if (_legacyResolver is null)
-            return;
-
-        var legacy = await _legacyResolver.ResolveAsync(session.AgentId, cancellationToken).ConfigureAwait(false);
-        session.ConversationId = legacy.ConversationId;
-
-        await using var connection = CreateConnection();
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var updateCmd = connection.CreateCommand();
-        updateCmd.CommandText = """
-            UPDATE sessions
-            SET conversation_id = $convId
-            WHERE id = $sessionId
-              AND conversation_id IS NULL
-            """;
-        updateCmd.Parameters.AddWithValue("$convId", legacy.ConversationId.Value);
-        updateCmd.Parameters.AddWithValue("$sessionId", session.SessionId.Value);
-        await updateCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-
-        if (session.Status == SessionStatus.Active)
+        if (!session.ConversationId.IsInitialized())
         {
-            await _legacyResolver.BindActiveSessionIfNoneAsync(legacy, session.SessionId, cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException(
+                $"Session '{session.SessionId.Value}' has an unset ConversationId after load. " +
+                "Post-P9-I, every session row is guaranteed to carry a non-null conversation_id " +
+                "(the orphan migration runs on every startup before this load could be served). " +
+                "Either the database was modified externally or the migration failed silently — " +
+                "inspect SqliteSessionStore logs at startup.");
         }
 
-        _logger.LogWarning(
-            "Backfilled orphan session {SessionId} for agent {AgentId} with legacy conversation {LegacyConversationId} on load.",
-            session.SessionId, session.AgentId, legacy.ConversationId);
+        if (_agentIdCache.TryGetValue(session.ConversationId, out var cached))
+        {
+            session.HydrateAgentId(cached);
+            return;
+        }
+
+        var conversation = await _conversationStore.GetAsync(session.ConversationId, cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+        {
+            throw new InvalidOperationException(
+                $"Session '{session.SessionId.Value}' references conversation '{session.ConversationId.Value}' " +
+                "which does not exist in the conversation store. AgentId cannot be hydrated. " +
+                "This indicates that the conversation was deleted while the session row remained — " +
+                "the session is unrecoverable.");
+        }
+
+        _agentIdCache[session.ConversationId] = conversation.AgentId;
+        session.HydrateAgentId(conversation.AgentId);
     }
 
     private async Task<GatewaySession?> LoadSessionAsync(SessionId sessionId, CancellationToken cancellationToken)
     {
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        var loaded = await LoadSessionAsync(connection, sessionId, _redactor, cancellationToken).ConfigureAwait(false);
-        if (loaded is not null)
-            await BackfillLoadedSessionAsync(loaded, cancellationToken).ConfigureAwait(false);
-        return loaded;
+        return await LoadSessionAsync(connection, sessionId, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<GatewaySession?> LoadSessionAsync(SqliteConnection connection, SessionId sessionId, ISecretRedactor? redactor, CancellationToken cancellationToken)
+    private async Task<GatewaySession?> LoadSessionAsync(SqliteConnection connection, SessionId sessionId, CancellationToken cancellationToken)
     {
         await using var sessionCommand = connection.CreateCommand();
+        // P9-I (#674): agent_id column removed from SELECT — AgentId is hydrated via
+        // HydrateAgentIdAsync below from Conversation.AgentId. The column itself is
+        // dropped from the schema by DropLegacyAgentIdColumnAsync at startup.
         sessionCommand.CommandText = """
-            SELECT id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id
+            SELECT id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id
             FROM sessions
             WHERE id = $sessionId
             """;
@@ -666,21 +838,18 @@ public sealed class SqliteSessionStore : SessionStoreBase
         if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             return null;
 
-        var createdAt = ParseTimestamp(reader.GetString(8));
-        var updatedAt = ParseTimestamp(reader.GetString(9));
-        var metadata = DeserializeMetadata(reader.IsDBNull(7) ? null : reader.GetString(7));
-        var status = ParseStatus(reader.IsDBNull(6) ? null : reader.GetString(6));
+        var createdAt = ParseTimestamp(reader.GetString(7));
+        var updatedAt = ParseTimestamp(reader.GetString(8));
+        var metadata = DeserializeMetadata(reader.IsDBNull(6) ? null : reader.GetString(6));
+        var status = ParseStatus(reader.IsDBNull(5) ? null : reader.GetString(5));
         ChannelKey? channelType = default;
-        if (!reader.IsDBNull(2))
-            channelType = ChannelKey.From(reader.GetString(2));
-        var sessionType = ParseSessionType(reader.IsDBNull(4) ? null : reader.GetString(4), sessionId, channelType);
+        if (!reader.IsDBNull(1))
+            channelType = ChannelKey.From(reader.GetString(1));
+        var sessionType = ParseSessionType(reader.IsDBNull(3) ? null : reader.GetString(3), sessionId, channelType);
         // P9-F (#657): participants_json column is intentionally read-and-discarded — the
         // legacy column is preserved for the one-shot startup backfill into the
         // conversation store (BackfillParticipantsToConversationsAsync) and as a rollback
         // source. Participants are no longer persisted on Session.
-        var agentIdValue = reader.IsDBNull(1) ? null : reader.GetString(1);
-        if (string.IsNullOrWhiteSpace(agentIdValue))
-            return null;
 
         var domainSession = new Session
         {
@@ -693,20 +862,18 @@ public sealed class SqliteSessionStore : SessionStoreBase
             Metadata = metadata
             // ConversationId is intentionally omitted when the column is NULL --
             // the property defaults to an uninitialized ConversationId (the "unset" sentinel)
-            // and BackfillLoadedSessionAsync fires on it below. Writing `default(ConversationId)`
+            // and HydrateAgentIdAsync throws on it below. Writing `default(ConversationId)`
             // explicitly is prohibited by Vogen analyzer VOG009.
         };
-        if (reader.FieldCount > 10 && !reader.IsDBNull(10))
-            domainSession.ConversationId = ConversationId.From(reader.GetString(10));
-        var session = new GatewaySession(domainSession, redactor)
+        if (!reader.IsDBNull(9))
+            domainSession.ConversationId = ConversationId.From(reader.GetString(9));
+        var session = new GatewaySession(domainSession, _redactor)
         {
-            // P9-H (#662): Session.AgentId was deleted; AgentId is hydrated on the runtime
-            // wrapper. We still source the value from the legacy `agent_id` column for
-            // backwards-compatible loads — agent ownership lives on Conversation.AgentId
-            // post P9-H and a future migration can switch this to a JOIN against the
-            // conversation store.
-            AgentId = AgentId.From(agentIdValue),
-            CallerId = reader.IsDBNull(3) ? null : reader.GetString(3)
+            // P9-I (#674): AgentId is no longer sourced from a legacy column on the
+            // session row — it's hydrated immediately below via HydrateAgentIdAsync
+            // from Conversation.AgentId. We construct GatewaySession with the
+            // CallerId from the row and leave AgentId to HydrateAgentId(...).
+            CallerId = reader.IsDBNull(2) ? null : reader.GetString(2)
         };
 
         await reader.DisposeAsync().ConfigureAwait(false);
@@ -753,17 +920,25 @@ public sealed class SqliteSessionStore : SessionStoreBase
             session.AddEntries(entries);
 
         session.UpdatedAt = updatedAt;
+
+        // P9-I (#674): hydrate AgentId from Conversation.AgentId before returning. Every
+        // load path (GetAsync, GetOrCreateAsync, EnumerateSessionsAsync, ListByConversationAsync)
+        // routes through this method so callers always observe a hydrated AgentId.
+        await HydrateAgentIdAsync(session, cancellationToken).ConfigureAwait(false);
+
         return session;
     }
 
-    private static async Task UpsertSessionAsync(SqliteConnection connection, GatewaySession session, CancellationToken cancellationToken)
+    private async Task UpsertSessionAsync(SqliteConnection connection, GatewaySession session, CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
+        // P9-I (#674): agent_id column removed — AgentId lives on Conversation.AgentId
+        // and is hydrated on load via IAgentIdentityResolver. Writing it here is a no-op
+        // post-migration because the column has been ALTER TABLE DROP COLUMN'd.
         command.CommandText = """
-            INSERT INTO sessions (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
-            VALUES ($id, $agentId, $channelType, $callerId, $sessionType, $participantsJson, $status, $metadata, $createdAt, $updatedAt, $conversationId)
+            INSERT INTO sessions (id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
+            VALUES ($id, $channelType, $callerId, $sessionType, $participantsJson, $status, $metadata, $createdAt, $updatedAt, $conversationId)
             ON CONFLICT(id) DO UPDATE SET
-                agent_id = excluded.agent_id,
                 channel_type = excluded.channel_type,
                 caller_id = excluded.caller_id,
                 session_type = excluded.session_type,
@@ -775,7 +950,6 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 conversation_id = excluded.conversation_id
             """;
         command.Parameters.AddWithValue("$id", session.SessionId.Value);
-        command.Parameters.AddWithValue("$agentId", session.AgentId.Value);
         command.Parameters.AddWithValue("$channelType", session.ChannelType.HasValue ? session.ChannelType.Value.Value : DBNull.Value);
         command.Parameters.AddWithValue("$callerId", (object?)session.CallerId ?? DBNull.Value);
         command.Parameters.AddWithValue("$sessionType", session.SessionType.Value);

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -429,7 +429,7 @@ public static class GatewayServiceCollectionExtensions
                     sessionsPath,
                     serviceProvider.GetRequiredService<ILogger<FileSessionStore>>(),
                     fs,
-                    conversationStore: serviceProvider.GetService<IConversationStore>(),
+                    conversationStore: serviceProvider.GetRequiredService<IConversationStore>(),
                     redactor: serviceProvider.GetService<ISecretRedactor>());
             }));
             return;

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdColumnRemovedArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdColumnRemovedArchitectureTests.cs
@@ -1,0 +1,329 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness functions enforcing the Phase 9 / P9-I (#674) "agent_id column
+/// removed from sessions table" contract.
+/// </summary>
+/// <remarks>
+/// <para>
+/// P9-I deletes <c>sessions.agent_id</c> and the legacy <c>idx_sessions_agent_id</c> /
+/// <c>idx_sessions_conversation_agent</c> indexes. AgentId is hydrated on load from
+/// <c>Conversation.AgentId</c> by <c>SqliteSessionStore.HydrateAgentIdAsync</c> /
+/// <c>FileSessionStore.HydrateAgentIdAsync</c>. The only remaining references to the
+/// string <c>"agent_id"</c> in production are the migration helpers that detect and
+/// drop the legacy shape; the only remaining references to <c>"idx_sessions_agent_id"</c>
+/// / <c>"idx_sessions_conversation_agent"</c> are the <c>DROP INDEX</c> statements that
+/// run alongside the column drop.
+/// </para>
+/// <para>
+/// The fence guards against accidental re-introduction of the column or its indexes
+/// in fresh schema DDL, INSERT/UPDATE statements, SELECT lists, or read code that
+/// would resurrect the per-session agent identity. Ships vacuity / false-positive /
+/// comment-mention self-tests per the "every regex-based architecture fence must
+/// include a self-test" memory.
+/// </para>
+/// </remarks>
+public sealed class SessionAgentIdColumnRemovedArchitectureTests
+{
+    [Fact]
+    public void NoProductionSourceFile_ReferencesLegacyAgentIdColumn_OutsideAllowlist()
+    {
+        var srcRoot = FindSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var path in EnumerateProductionCsFiles(srcRoot))
+        {
+            var relative = ToRelative(srcRoot, path);
+            if (s_allowlist.Contains(relative)) continue;
+            var stripped = StripComments(File.ReadAllText(path));
+            if (s_agentIdColumnPattern.IsMatch(stripped))
+                violations.Add(relative);
+        }
+
+        violations.ShouldBeEmpty(
+            "P9-I contract: the sessions.agent_id column was deleted. AgentId is hydrated " +
+            "on load from Conversation.AgentId. References to the string \"agent_id\" or the " +
+            "legacy indexes are restricted to the migration helpers in SqliteSessionStore.cs " +
+            "(MigrateOrphanedSessionsAsync / DropLegacyAgentIdColumnAsync / VerifyAgentIdColumnConsistencyAsync).\n" +
+            "Violations:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Allowlist_OnlyContains_FilesThat_StillExist_AndStill_TripTheFence()
+    {
+        var srcRoot = FindSourceRoot();
+        var stale = new List<string>();
+
+        foreach (var relative in s_allowlist)
+        {
+            var full = Path.Combine(srcRoot, relative);
+            if (!File.Exists(full))
+            {
+                stale.Add($"{relative} — file does not exist (delete this allowlist entry)");
+                continue;
+            }
+            if (!s_agentIdColumnPattern.IsMatch(StripComments(File.ReadAllText(full))))
+            {
+                stale.Add($"{relative} — file no longer trips the fence (delete this allowlist entry)");
+            }
+        }
+
+        stale.ShouldBeEmpty(
+            "Allowlist hygiene: every entry must still match an existing file AND still trip the fence; " +
+            "otherwise it grants a permanent exemption to future regressions in the same file.\n" +
+            "Stale entries:\n  " + string.Join("\n  ", stale));
+    }
+
+    [Fact]
+    public void Fence_IsNotVacuous_AgainstSyntheticReintroduction()
+    {
+        // Each of these synthetic regressions MUST trip — if not, the fence is vacuous.
+        s_agentIdColumnPattern.IsMatch("CREATE TABLE sessions (id TEXT, agent_id TEXT);")
+            .ShouldBeTrue("Vacuity guard: re-adding agent_id column in CREATE TABLE must trip.");
+        s_agentIdColumnPattern.IsMatch("INSERT INTO sessions (id, agent_id, status) VALUES ($id, $a, 'Active');")
+            .ShouldBeTrue("Vacuity guard: writing agent_id in INSERT must trip.");
+        s_agentIdColumnPattern.IsMatch("SELECT id, agent_id FROM sessions WHERE id = $id")
+            .ShouldBeTrue("Vacuity guard: reading agent_id in SELECT must trip.");
+        s_agentIdColumnPattern.IsMatch("UPDATE sessions SET agent_id = $a WHERE id = $id")
+            .ShouldBeTrue("Vacuity guard: assigning agent_id in UPDATE must trip.");
+        s_agentIdColumnPattern.IsMatch("CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);")
+            .ShouldBeTrue("Vacuity guard: re-creating idx_sessions_agent_id must trip.");
+        s_agentIdColumnPattern.IsMatch("CREATE INDEX idx_sessions_conversation_agent ON sessions(conversation_id, agent_id);")
+            .ShouldBeTrue("Vacuity guard: re-creating idx_sessions_conversation_agent must trip.");
+        // Multi-line DDL inside a C# raw string literal must also trip — the fence
+        // operates after comment stripping and over arbitrary whitespace.
+        s_agentIdColumnPattern.IsMatch("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                agent_id TEXT,
+                status TEXT NOT NULL
+            )
+            """).ShouldBeTrue("Vacuity guard: multi-line CREATE TABLE sessions(...agent_id...) must trip.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnUnrelatedSymbols()
+    {
+        // Unrelated property names / .NET symbols must NOT trip — the fence targets only
+        // the SQL identifier "agent_id" (snake_case) appearing inside a sessions-table
+        // statement, plus the two named legacy indexes.
+        s_agentIdColumnPattern.IsMatch("session.AgentId = AgentId.From(\"x\");")
+            .ShouldBeFalse("False-positive guard: C# AgentId property accesses must NOT match.");
+        s_agentIdColumnPattern.IsMatch("var aId = conversation.AgentId;")
+            .ShouldBeFalse("False-positive guard: C# AgentId reads must NOT match.");
+        s_agentIdColumnPattern.IsMatch("AgentId agentId = session.AgentId;")
+            .ShouldBeFalse("False-positive guard: AgentId parameter declarations must NOT match.");
+        s_agentIdColumnPattern.IsMatch("private readonly AgentId _agentId;")
+            .ShouldBeFalse("False-positive guard: snake_cased private field names must NOT match.");
+        s_agentIdColumnPattern.IsMatch("WHERE conversation_id = $id ORDER BY created_at, id")
+            .ShouldBeFalse("False-positive guard: unrelated SQL columns must NOT match.");
+        // Other tables legitimately have their own agent_id column — `conversations`,
+        // `memories`, `cron_jobs`, etc. The fence MUST NOT trip on those tables.
+        s_agentIdColumnPattern.IsMatch("SELECT id FROM conversations WHERE agent_id = $agentId")
+            .ShouldBeFalse("False-positive guard: conversations.agent_id is the durable owner — MUST NOT match.");
+        s_agentIdColumnPattern.IsMatch("INSERT INTO memories (id, agent_id, session_id) VALUES ($id, $a, $s);")
+            .ShouldBeFalse("False-positive guard: memories.agent_id is a legitimate FK — MUST NOT match.");
+        s_agentIdColumnPattern.IsMatch("CREATE TABLE cron_jobs (id TEXT, agent_id TEXT NULL);")
+            .ShouldBeFalse("False-positive guard: cron_jobs.agent_id is a legitimate FK — MUST NOT match.");
+        // Statement boundary: a session SELECT followed by a separate agent_id mention
+        // in a different statement (semicolon-separated) must NOT trip.
+        s_agentIdColumnPattern.IsMatch(
+            "SELECT id FROM sessions WHERE status = 'Active';\n" +
+            "INSERT INTO memories (id, agent_id) VALUES ($id, $a);")
+            .ShouldBeFalse("False-positive guard: cross-statement co-occurrence must NOT match.");
+    }
+
+    [Fact]
+    public void Fence_DoesNotFalsePositive_OnCommentMentions()
+    {
+        // Comments referencing the legacy column for historical context must NOT trip —
+        // the lexer strips them before the regex runs.
+        const string syntheticClean = """
+            // The pre-P9-I sessions table had an agent_id column and an
+            // idx_sessions_agent_id index — both dropped in DropLegacyAgentIdColumnAsync.
+            /* Also dropped: idx_sessions_conversation_agent (composite over the now-gone column). */
+            /// <summary>Mentioning sessions.agent_id in doc comments is fine.</summary>
+            public void Documented() { }
+            """;
+
+        s_agentIdColumnPattern.IsMatch(StripComments(syntheticClean)).ShouldBeFalse(
+            "False-positive guard: comment mentions of the legacy column / indexes for " +
+            "historical context must not trip — the lexer strips them.");
+    }
+
+    // The fence trips on three precise shapes:
+    //   1. The legacy index names (unambiguous P9-I artifacts: cannot collide with anything else).
+    //   2. `sessions` ... `agent_id` co-occurring within a single SQL statement window.
+    //   3. `agent_id` ... `sessions` (the reverse order — e.g. SELECT id, agent_id FROM sessions).
+    // The window is bounded by `;` (SQL statement terminator) and `"""` (C# raw string
+    // literal terminator) so co-occurrence in *different* statements does not trip. Word
+    // boundaries on both anchors prevent matches against `session_id`, `_agentId`, etc.
+    // Other tables (`conversations`, `memories`, `cron_jobs`, ...) legitimately have their
+    // own `agent_id` columns; the `\bsessions\b` requirement keeps the fence scoped.
+    private static readonly Regex s_agentIdColumnPattern = new(
+        @"\bidx_sessions_agent_id\b" +
+        @"|\bidx_sessions_conversation_agent\b" +
+        @"|\bsessions\b(?:(?!;|"""").){0,500}?\bagent_id\b" +
+        @"|\bagent_id\b(?:(?!;|"""").){0,500}?\bsessions\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+
+    // The migration helpers in SqliteSessionStore.cs are the only production code permitted
+    // to reference the legacy column / indexes. Everything else must use the post-P9-I
+    // shape (Conversation.AgentId via HydrateAgentIdAsync; idx_sessions_conversation_created).
+    private static readonly HashSet<string> s_allowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // MigrateOrphanedSessionsAsync reads agent_id from legacy rows to find the owner;
+        // DropLegacyAgentIdColumnAsync drops both legacy indexes then the column itself;
+        // VerifyAgentIdColumnConsistencyAsync logs any pre-existing data corruption.
+        @"gateway\BotNexus.Gateway.Sessions\SqliteSessionStore.cs",
+    };
+
+    private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
+    {
+        return Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+                !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) &&
+                !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRelative(string srcRoot, string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(root.Length)
+            : full;
+    }
+
+    private static string FindSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        var srcRoot = Path.Combine(current.FullName, "src");
+        Directory.Exists(srcRoot).ShouldBeTrue("Expected src/ under " + current.FullName);
+        return srcRoot;
+    }
+
+    /// <summary>
+    /// Removes single-line (<c>//</c>, <c>///</c>) and block (<c>/* … */</c>) C# comments
+    /// while preserving string and char literals. Same lexer pattern used by other
+    /// architecture fences (e.g. <see cref="ConversationParticipantsMutationArchitectureTests"/>).
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+        var n = source.Length;
+
+        while (i < n)
+        {
+            var c = source[i];
+
+            if (c == '@' && i + 1 < n && source[i + 1] == '"')
+            {
+                sb.Append(source, i, 2);
+                i += 2;
+                while (i < n)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < n && source[i + 1] == '"')
+                        {
+                            sb.Append("\"\"");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '"')
+            {
+                sb.Append('"');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                sb.Append('\'');
+                i++;
+                while (i < n)
+                {
+                    if (source[i] == '\\' && i + 1 < n)
+                    {
+                        sb.Append(source[i]);
+                        sb.Append(source[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if (source[i] == '\'')
+                    {
+                        sb.Append('\'');
+                        i++;
+                        break;
+                    }
+                    sb.Append(source[i++]);
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < n && source[i] != '\n' && source[i] != '\r')
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < n && source[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < n && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+                i = Math.Min(n, i + 2);
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdColumnRemovedArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdColumnRemovedArchitectureTests.cs
@@ -60,7 +60,10 @@ public sealed class SessionAgentIdColumnRemovedArchitectureTests
 
         foreach (var relative in s_allowlist)
         {
-            var full = Path.Combine(srcRoot, relative);
+            // Allowlist is stored with forward slashes (portable); convert to the
+            // platform separator before resolving against the filesystem.
+            var platformRelative = relative.Replace('/', Path.DirectorySeparatorChar);
+            var full = Path.Combine(srcRoot, platformRelative);
             if (!File.Exists(full))
             {
                 stale.Add($"{relative} — file does not exist (delete this allowlist entry)");
@@ -175,12 +178,14 @@ public sealed class SessionAgentIdColumnRemovedArchitectureTests
     // The migration helpers in SqliteSessionStore.cs are the only production code permitted
     // to reference the legacy column / indexes. Everything else must use the post-P9-I
     // shape (Conversation.AgentId via HydrateAgentIdAsync; idx_sessions_conversation_created).
+    // Paths use forward-slash separators for cross-platform stability (Linux CI vs Windows
+    // dev). ToRelative normalises filesystem paths to the same shape before lookup.
     private static readonly HashSet<string> s_allowlist = new(StringComparer.OrdinalIgnoreCase)
     {
         // MigrateOrphanedSessionsAsync reads agent_id from legacy rows to find the owner;
         // DropLegacyAgentIdColumnAsync drops both legacy indexes then the column itself;
         // VerifyAgentIdColumnConsistencyAsync logs any pre-existing data corruption.
-        @"gateway\BotNexus.Gateway.Sessions\SqliteSessionStore.cs",
+        "gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs",
     };
 
     private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)
@@ -195,9 +200,13 @@ public sealed class SessionAgentIdColumnRemovedArchitectureTests
     {
         var full = Path.GetFullPath(fullPath);
         var root = Path.GetFullPath(srcRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
-        return full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+        var relative = full.StartsWith(root, StringComparison.OrdinalIgnoreCase)
             ? full.Substring(root.Length)
             : full;
+        // Normalise to forward slashes so the allowlist (and any string comparisons) are
+        // stable across Linux CI and Windows dev. Backslash is not legal in Linux paths,
+        // so the substitution is a one-way no-op on Linux and a portability fix on Windows.
+        return relative.Replace('\\', '/');
     }
 
     private static string FindSourceRoot()

--- a/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/FileSessionStoreTests.cs
@@ -22,6 +22,12 @@ public sealed class FileSessionStoreTests
         using var fixture = new StoreFixture();
         var store = fixture.CreateStore();
         var conversationId = ConversationId.Create();
+        // P9-I (#674): pre-register the conversation so AgentId hydration on reload succeeds.
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = AgentId.From("agent-a")
+        });
 
         var session = await store.GetOrCreateAsync(SessionId.From("s-with-conv"), AgentId.From("agent-a"));
         session.Session.ConversationId = conversationId;
@@ -375,11 +381,32 @@ public sealed class FileSessionStoreTests
     // the on-disk round-trip (which is exactly where F-7 originated). Two-store-reload
     // pattern proves the invariants survive a process restart.
 
-    private static async Task SeedConversationFixtureAsync(FileSessionStore store, DateTimeOffset baseTime)
+    private static async Task SeedConversationFixtureAsync(StoreFixture fixture, DateTimeOffset baseTime)
     {
         var convA = ConversationId.From("conv-a");
         var convB = ConversationId.From("conv-b");
 
+        // P9-I (#674): conversations must exist before sessions reference them — the
+        // load-time AgentId hydration resolves AgentId from Conversation.AgentId, so a
+        // dangling Session.ConversationId is treated as data corruption and throws.
+        // conv-a is owned by agent-x (s-a-other-agent participates but does not own).
+        // conv-b is owned by agent-x.
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convA,
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            UpdatedAt = baseTime
+        });
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convB,
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            UpdatedAt = baseTime
+        });
+
+        var store = fixture.CreateStore();
         await store.SaveAsync(new GatewaySession
         {
             SessionId = SessionId.From("s-a-active"),
@@ -428,7 +455,7 @@ public sealed class FileSessionStoreTests
         // survives a full second-store reload (the F-7 originating scenario).
         using var fixture = new StoreFixture();
         var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        await SeedConversationFixtureAsync(fixture.CreateStore(), baseTime);
+        await SeedConversationFixtureAsync(fixture, baseTime);
 
         var reloadedStore = fixture.CreateStore();
         var sessions = await reloadedStore.ListByConversationAsync(ConversationId.From("conv-a"));
@@ -443,7 +470,7 @@ public sealed class FileSessionStoreTests
     {
         using var fixture = new StoreFixture();
         var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        await SeedConversationFixtureAsync(fixture.CreateStore(), baseTime);
+        await SeedConversationFixtureAsync(fixture, baseTime);
 
         var sessions = await fixture.CreateStore()
             .ListByConversationAsync(ConversationId.From("conv-a"));
@@ -469,13 +496,22 @@ public sealed class FileSessionStoreTests
     {
         using var fixture = new StoreFixture();
         var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        await SeedConversationFixtureAsync(fixture.CreateStore(), baseTime);
+        await SeedConversationFixtureAsync(fixture, baseTime);
 
-        var sessions = await fixture.CreateStore()
+        // P9-I (#674): agent_id column dropped from sessions. AgentId is hydrated from
+        // Conversation.AgentId, so passing the conversation's owning agent returns ALL
+        // sessions in that conversation (the agentId arg is now a defensive assertion
+        // that the conversation belongs to the caller's agent). Passing a different
+        // agent returns an empty set.
+        var matched = await fixture.CreateStore()
             .ListByConversationAsync(ConversationId.From("conv-a"), agentId: AgentId.From("agent-x"));
+        matched.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-other-agent", "s-a-active" }, ignoreOrder: false);
 
-        sessions.Select(s => s.SessionId.Value)
-            .ShouldBe(new[] { "s-a-sealed", "s-a-active" }, ignoreOrder: false);
+        var mismatched = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"), agentId: AgentId.From("agent-y"));
+        mismatched.ShouldBeEmpty(
+            "Post-P9-I: passing a non-owner agent must return empty — Conversation.AgentId is the source of truth.");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
@@ -99,7 +99,7 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
     {
         var storePath = CreateStorePath();
         var sessionId = "raw-disk";
-        var store = new FileSessionStore(storePath, NullLogger<FileSessionStore>.Instance, new FileSystem());
+        var store = new FileSessionStore(storePath, NullLogger<FileSessionStore>.Instance, new FileSystem(), new InMemoryConversationStore());
         var session = await store.GetOrCreateAsync(SessionId.From(sessionId), AgentId.From("agent-a"));
 
         for (var i = 0; i < 6; i++)
@@ -323,7 +323,7 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         var storePath = CreateStorePath();
         const string sessionId = "compact-archive";
         var encodedSessionId = Uri.EscapeDataString(sessionId);
-        var store = new FileSessionStore(storePath, NullLogger<FileSessionStore>.Instance, new FileSystem());
+        var store = new FileSessionStore(storePath, NullLogger<FileSessionStore>.Instance, new FileSystem(), new InMemoryConversationStore());
         var session = await store.GetOrCreateAsync(SessionId.From(sessionId), AgentId.From("agent-a"));
         session.AddEntries(
         [
@@ -557,9 +557,14 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
 
         public MockFileSystem FileSystem { get; }
         public string StorePath { get; }
+        // P9-I (#674): share the conversation store across CreateStore() calls so
+        // legacy conversations created by one store instance survive simulated
+        // "restart" by a second store instance opening the same disk path.
+        // In production this is the role of the persistent ConversationStore.
+        public InMemoryConversationStore Conversations { get; } = new();
 
         public FileSessionStore CreateStore()
-            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem);
+            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem, Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionResumeIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionResumeIntegrationTests.cs
@@ -5,7 +5,9 @@ using System.Text.Json;
 using BotNexus.Gateway;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Api;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Connections;
@@ -367,8 +369,18 @@ public sealed class SessionResumeIntegrationTests : IDisposable
         return path;
     }
 
+    // P9-I (#674): share the conversation store across multiple CreateFileStore() calls
+    // on the same storePath so legacy conversations created by the "first" store survive
+    // simulated "restart" by the "second" store. In production the persistent
+    // ConversationStore plays this role; in MockFileSystem tests we use a per-path
+    // InMemoryConversationStore registry.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, InMemoryConversationStore> _conversationsByPath = new();
+
     private static FileSessionStore CreateFileStore(string storePath)
-        => new(storePath, NullLogger<FileSessionStore>.Instance, new FileSystem());
+    {
+        var conversations = _conversationsByPath.GetOrAdd(storePath, _ => new InMemoryConversationStore());
+        return new FileSessionStore(storePath, NullLogger<FileSessionStore>.Instance, new FileSystem(), conversations);
+    }
 
     private static WebApplicationFactory<Program> CreateTestFactory(string storePath)
         => new WebApplicationFactory<Program>()
@@ -386,12 +398,21 @@ public sealed class SessionResumeIntegrationTests : IDisposable
 
                     services.AddSignalRChannelForTests();
 
+                    // P9-I (#674): replace IConversationStore with the per-path shared
+                    // registry so the legacy conversation seeded by CreateFileStore() in
+                    // the seed phase is visible to the FileSessionStore that this factory
+                    // constructs in the resume phase.
+                    var conversations = _conversationsByPath.GetOrAdd(storePath, _ => new InMemoryConversationStore());
+                    services.RemoveAll<IConversationStore>();
+                    services.AddSingleton<IConversationStore>(conversations);
+
                     services.RemoveAll<ISessionStore>();
                     services.AddSingleton<ISessionStore>(sp =>
                         new FileSessionStore(
                             storePath,
                             sp.GetRequiredService<ILogger<FileSessionStore>>(),
-                            new FileSystem()));
+                            new FileSystem(),
+                            sp.GetRequiredService<IConversationStore>()));
                 });
             });
 

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionAgentIdRemovalRegressionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionAgentIdRemovalRegressionTests.cs
@@ -1,0 +1,277 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Regression tests pinning the P9-I (#674) contract: the legacy <c>sessions.agent_id</c>
+/// column and its two associated indexes are removed; AgentId is hydrated on load from
+/// <c>Conversation.AgentId</c>. Each test covers one specific failure mode that, if it
+/// regressed silently, would be hard to spot in normal end-to-end tests.
+/// </summary>
+public sealed class SessionAgentIdRemovalRegressionTests : IDisposable
+{
+    private readonly string _directoryPath;
+    private readonly string _sessionDbPath;
+    private readonly string _conversationDbPath;
+
+    public SessionAgentIdRemovalRegressionTests()
+    {
+        _directoryPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "SessionAgentIdRemovalRegressionTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directoryPath);
+        _sessionDbPath = Path.Combine(_directoryPath, "sessions.db");
+        _conversationDbPath = Path.Combine(_directoryPath, "conversations.db");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directoryPath))
+            Directory.Delete(_directoryPath, recursive: true);
+    }
+
+    // ─── Fresh DB schema ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FreshDatabase_SchemaHas_NoAgentIdColumn_OnSessionsTable()
+    {
+        // Regression pin: opening SqliteSessionStore on an EMPTY path must produce a
+        // sessions table that has never carried the agent_id column. If a future schema
+        // change re-adds it, this test catches it before any data is written.
+        var convStore = new SqliteConversationStore(
+            $"Data Source={_conversationDbPath};Pooling=False",
+            NullLogger<SqliteConversationStore>.Instance);
+        var sessionStore = new SqliteSessionStore(
+            $"Data Source={_sessionDbPath};Pooling=False",
+            NullLogger<SqliteSessionStore>.Instance,
+            convStore);
+
+        // Trigger EnsureCreatedAsync.
+        _ = await sessionStore.GetAsync(SessionId.From("probe"));
+
+        await using var connection = new SqliteConnection($"Data Source={_sessionDbPath};Pooling=False");
+        await connection.OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info(sessions)";
+        var columns = new List<string>();
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+                columns.Add(reader.GetString(1));
+        }
+
+        columns.ShouldNotBeEmpty("sessions table must exist after EnsureCreatedAsync");
+        columns.ShouldNotContain(
+            "agent_id",
+            "P9-I (#674): fresh DBs must have NO agent_id column — AgentId now lives on " +
+            "Conversation.AgentId and is hydrated on load. If this test fails, a schema " +
+            "change accidentally re-added the legacy column.");
+        // Pin the columns we DO expect, to catch accidental removals (defensive).
+        columns.ShouldContain("id");
+        columns.ShouldContain("conversation_id");
+    }
+
+    // ─── Pre-P9 DB legacy-index drop ─────────────────────────────────────────
+
+    [Fact]
+    public async Task PreP9Database_WithLegacyIndexes_HasIndexesDropped_OnOpen()
+    {
+        // Regression pin: a pre-P9 SQLite database carries the legacy composite index
+        // `idx_sessions_conversation_agent` AND the single-column index `idx_sessions_agent_id`.
+        // Opening the post-P9-I store must drop BOTH and create the replacement
+        // `idx_sessions_conversation_created`. If the DROP INDEX statements regress, the
+        // legacy indexes silently linger and waste space / mislead query planners.
+        var connString = $"Data Source={_sessionDbPath};Pooling=False";
+        await using (var seed = new SqliteConnection(connString))
+        {
+            await seed.OpenAsync();
+            await using var seedCmd = seed.CreateCommand();
+            seedCmd.CommandText = """
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT,
+                    channel_type TEXT,
+                    caller_id TEXT,
+                    session_type TEXT,
+                    participants_json TEXT,
+                    status TEXT,
+                    metadata TEXT,
+                    created_at TEXT,
+                    updated_at TEXT,
+                    conversation_id TEXT
+                );
+                CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
+                CREATE INDEX idx_sessions_conversation_agent ON sessions(conversation_id, agent_id);
+                """;
+            await seedCmd.ExecuteNonQueryAsync();
+        }
+
+        // Act: open the store; EnsureCreatedAsync runs the schema sweep + DropLegacyAgentIdColumnAsync.
+        var convStore = new SqliteConversationStore(
+            $"Data Source={_conversationDbPath};Pooling=False",
+            NullLogger<SqliteConversationStore>.Instance);
+        var sessionStore = new SqliteSessionStore(
+            connString,
+            NullLogger<SqliteSessionStore>.Instance,
+            convStore);
+        _ = await sessionStore.GetAsync(SessionId.From("probe"));
+
+        // Assert: legacy indexes are gone, replacement index is present.
+        await using var verify = new SqliteConnection(connString);
+        await verify.OpenAsync();
+        await using var cmd = verify.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'sessions'";
+        var indexes = new List<string>();
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+                indexes.Add(reader.GetString(0));
+        }
+
+        indexes.ShouldNotContain(
+            "idx_sessions_agent_id",
+            "Legacy single-column index references the dropped agent_id column — must be removed on open.");
+        indexes.ShouldNotContain(
+            "idx_sessions_conversation_agent",
+            "Legacy composite index references the dropped agent_id column — must be removed on open.");
+        indexes.ShouldContain(
+            "idx_sessions_conversation_created",
+            "P9-I replacement index for ListByConversationAsync ordering must be created.");
+    }
+
+    // ─── Missing-conversation error ──────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadingSession_WithDanglingConversationId_Throws_InvalidOperationException()
+    {
+        // Regression pin: post-P9-I, AgentId is hydrated from Conversation.AgentId. If a
+        // session row's conversation_id points at a conversation that doesn't exist (e.g.
+        // because it was deleted while the session row remained), HydrateAgentIdAsync MUST
+        // fail loudly rather than silently produce a session with default(AgentId).
+        var convStore = new SqliteConversationStore(
+            $"Data Source={_conversationDbPath};Pooling=False",
+            NullLogger<SqliteConversationStore>.Instance);
+        var sessionStore = new SqliteSessionStore(
+            $"Data Source={_sessionDbPath};Pooling=False",
+            NullLogger<SqliteSessionStore>.Instance,
+            convStore);
+        // Initialise schema.
+        _ = await sessionStore.GetAsync(SessionId.From("init"));
+
+        // Inject a session row whose conversation_id points at a missing conversation.
+        const string danglingConvId = "conv-deleted";
+        await using (var seed = new SqliteConnection($"Data Source={_sessionDbPath};Pooling=False"))
+        {
+            await seed.OpenAsync();
+            await using var insert = seed.CreateCommand();
+            insert.CommandText = """
+                INSERT INTO sessions (id, channel_type, caller_id, session_type, participants_json,
+                                       status, metadata, created_at, updated_at, conversation_id)
+                VALUES ('s-dangling', 'test', NULL, 'standard', '[]',
+                        'Active', '{}', $createdAt, $updatedAt, $convId)
+                """;
+            var now = DateTimeOffset.UtcNow.ToString("O");
+            insert.Parameters.AddWithValue("$createdAt", now);
+            insert.Parameters.AddWithValue("$updatedAt", now);
+            insert.Parameters.AddWithValue("$convId", danglingConvId);
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        // Act + Assert: loading the dangling session throws.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await sessionStore.GetAsync(SessionId.From("s-dangling")));
+
+        ex.Message.ShouldContain("AgentId cannot be hydrated",
+            customMessage: "Error must explicitly state hydration failed so operators can " +
+                           "identify the post-P9-I dangling-conversation failure mode.");
+        ex.Message.ShouldContain(danglingConvId,
+            customMessage: "Error must reference the offending conversation id for diagnosis.");
+        ex.Message.ShouldContain("s-dangling",
+            customMessage: "Error must reference the session id so operators can find the row.");
+    }
+
+    // ─── Sidecar legacy migration ────────────────────────────────────────────
+
+    [Fact]
+    public async Task FileSessionStore_OnOpen_RewritesLegacySidecar_StampingConversationAndNullingAgentId()
+    {
+        // Regression pin: a pre-P9 file sidecar carries `agentId` but no `conversationId`.
+        // On the first store open the migration sweep must:
+        //   1. resolve the legacy conversation for that agentId,
+        //   2. rewrite the sidecar with the stamped conversationId,
+        //   3. write agentId as null (the post-P9-I shape — durable AgentId lives on the
+        //      Conversation, not the session sidecar).
+        var fileSystem = new MockFileSystem();
+        var storePath = Path.Combine(Path.GetTempPath(), "P9I-sidecar-regression", Guid.NewGuid().ToString("N"));
+        fileSystem.Directory.CreateDirectory(storePath);
+
+        const string sessionId = "s-legacy";
+        var sidecarPath = Path.Combine(storePath, $"{sessionId}.meta.json");
+        var historyPath = Path.Combine(storePath, $"{sessionId}.jsonl");
+
+        // Seed a legacy sidecar — agentId set, conversationId absent — mimicking the pre-P9
+        // disk shape. Property names match the JSON wire shape (camelCase). The agentId
+        // value "agent-legacy" is what MigrateOrphanedSessionsAsync reads to resolve the
+        // legacy:agent-legacy conversation; it must round-trip into the sidecar's stamp.
+        const string legacySidecar = """
+            {
+              "agentId": "agent-legacy",
+              "channelType": null,
+              "callerId": null,
+              "sessionType": "Standard",
+              "participants": [],
+              "createdAt": "2024-01-01T00:00:00+00:00",
+              "updatedAt": "2024-01-01T00:00:00+00:00",
+              "status": "Active",
+              "nextSequenceId": 1
+            }
+            """;
+        fileSystem.File.WriteAllText(sidecarPath, legacySidecar);
+        // Empty history file is required so the store can load the session.
+        fileSystem.File.WriteAllText(historyPath, string.Empty);
+
+        // Act: open the store. EnsureMigratedAsync runs MigrateOrphanedSessionsAsync, which
+        // rewrites every orphan sidecar in place.
+        var convStore = new InMemoryConversationStore();
+        var store = new FileSessionStore(
+            storePath,
+            NullLogger<FileSessionStore>.Instance,
+            fileSystem,
+            convStore);
+        // Trigger init by performing any operation (here a List).
+        _ = await store.ListAsync();
+
+        // Assert: the sidecar was rewritten with conversationId stamped and agentId == null.
+        var rewritten = fileSystem.File.ReadAllText(sidecarPath);
+        using var doc = JsonDocument.Parse(rewritten);
+        var root = doc.RootElement;
+
+        root.TryGetProperty("conversationId", out var convProp).ShouldBeTrue(
+            "Rewritten sidecar must carry a conversationId post-migration.");
+        convProp.ValueKind.ShouldBe(JsonValueKind.String,
+            "conversationId must be a string after the migration stamps the legacy conversation.");
+        convProp.GetString().ShouldNotBeNullOrEmpty(
+            "Stamped conversationId must be non-empty.");
+
+        root.TryGetProperty("agentId", out var agentProp).ShouldBeTrue(
+            "Sidecar still carries the agentId property for back-compat reads.");
+        agentProp.ValueKind.ShouldBe(JsonValueKind.Null,
+            "P9-I (#674): post-migration sidecars MUST write agentId as JSON null — " +
+            "durable agent ownership has moved to Conversation.AgentId. The legacy " +
+            "property stays for read-time recovery only; new writes must NOT populate it.");
+
+        // Cleanup
+        if (fileSystem.Directory.Exists(storePath))
+            fileSystem.Directory.Delete(storePath, recursive: true);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionLifecycleTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionLifecycleTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -151,9 +152,12 @@ public sealed class SessionLifecycleTests
         }
 
         public string StorePath { get; }
+        // P9-I (#674): shared across CreateStore() calls so legacy conversations
+        // survive simulated restart by a second store on the same disk path.
+        public InMemoryConversationStore Conversations { get; } = new();
 
         public FileSessionStore CreateStore()
-            => new(StorePath, NullLogger<FileSessionStore>.Instance, new FileSystem());
+            => new(StorePath, NullLogger<FileSessionStore>.Instance, new FileSystem(), Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreBaseContractTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreBaseContractTests.cs
@@ -188,7 +188,7 @@ public sealed class SessionStoreBaseContractTests
         public FileHarness()
         {
             _fileSystem.Directory.CreateDirectory(_storePath);
-            Store = new FileSessionStore(_storePath, NullLogger<FileSessionStore>.Instance, _fileSystem);
+            Store = new FileSessionStore(_storePath, NullLogger<FileSessionStore>.Instance, _fileSystem, new InMemoryConversationStore());
         }
 
         public ISessionStore Store { get; }

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionStoreEdgeCaseTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionStoreEdgeCaseTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -89,9 +90,12 @@ public sealed class SessionStoreEdgeCaseTests
         }
 
         public string StorePath { get; }
+        // P9-I (#674): shared across CreateStore() calls so legacy conversations
+        // survive simulated restart by a second store on the same disk path.
+        public InMemoryConversationStore Conversations { get; } = new();
 
         public FileSessionStore CreateStore()
-            => new(StorePath, NullLogger<FileSessionStore>.Instance, new FileSystem());
+            => new(StorePath, NullLogger<FileSessionStore>.Instance, new FileSystem(), Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/CompactionModelTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/CompactionModelTests.cs
@@ -3,6 +3,7 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -209,9 +210,12 @@ public sealed class CompactionModelTests
 
         public MockFileSystem FileSystem { get; }
         public string StorePath { get; }
+        // P9-I (#674): shared across CreateStore() calls so legacy conversations
+        // survive simulated restart by a second store on the same disk path.
+        public InMemoryConversationStore Conversations { get; } = new();
 
         public FileSessionStore CreateStore()
-            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem);
+            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem, Conversations);
 
         public void Dispose()
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
@@ -135,53 +135,52 @@ public sealed class LegacyConversationBackfillTests
     [Fact]
     public async Task File_LoadFromFile_OrphanSidecar_BackfillsAndRewritesSidecar()
     {
-        // Simulate a pre-Phase-9 sidecar: save the session with NO conversation store
-        // (so no stamp), then reload with a resolver and confirm the sidecar gets
-        // durably rewritten with the legacy conversation id.
+        // Simulates a pre-Phase-9 sidecar (agentId set, conversationId null) via the
+        // SeedOrphanSidecarAsync raw-write helper, then reloads through a Phase-9-aware
+        // store and confirms the sidecar gets durably rewritten with the legacy
+        // conversation id.
         using var fixture = new FileFixture();
         var conversations = new InMemoryConversationStore();
         var agentId = AgentId.From("agent-orphan-sidecar");
+        var sessionId = SessionId.From("s-orphan-side");
 
-        var preStore = fixture.CreateStore(conversationStore: null);
-        var prePhase9 = await preStore.GetOrCreateAsync(SessionId.From("s-orphan-side"), agentId);
-        await preStore.SaveAsync(prePhase9);
-        prePhase9.ConversationId.IsInitialized().ShouldBeFalse();
+        await fixture.SeedOrphanSidecarAsync(sessionId, agentId);
 
-        // Now load through a Phase-9-aware store; the load path must backfill.
+        // Load through a Phase-9-aware store; the load path must backfill.
         var loadStore = fixture.CreateStore(conversations);
-        var loaded = await loadStore.GetAsync(SessionId.From("s-orphan-side"));
+        var loaded = await loadStore.GetAsync(sessionId);
         loaded.ShouldNotBeNull();
         loaded!.ConversationId.IsInitialized().ShouldBeTrue();
         var legacy = (await conversations.ListAsync(agentId))
             .Single(c => c.Title == $"legacy:{agentId.Value}");
         loaded.ConversationId.ShouldBe(legacy.ConversationId);
 
-        // A third store instance (no cache; no resolver) must still see the durable stamp
-        // — proves the load path rewrote the sidecar, not just the in-memory projection.
-        var verifyStore = fixture.CreateStore(conversationStore: null);
-        var reverified = await verifyStore.GetAsync(SessionId.From("s-orphan-side"));
+        // A second store instance (no cache; the SAME conversation store) must still
+        // see the durable stamp — proves the load path rewrote the sidecar, not just
+        // the in-memory projection.
+        var verifyStore = fixture.CreateStore(conversations);
+        var reverified = await verifyStore.GetAsync(sessionId);
         reverified.ShouldNotBeNull();
         reverified!.ConversationId.IsInitialized().ShouldBeTrue(
-            "Load-time backfill must rewrite the sidecar so a resolver-less store " +
-            "still observes the stamp — otherwise every load round-trips through the " +
-            "conversation store.");
+            "Load-time backfill must rewrite the sidecar so subsequent loads observe " +
+            "the stamp without re-resolving — otherwise every load round-trips through " +
+            "the conversation store.");
         reverified.ConversationId.ShouldBe(legacy.ConversationId);
     }
 
     [Fact]
-    public async Task File_SaveAsync_NoResolver_PreservesUnsetConversationId()
+    public void File_Ctor_NullConversationStore_Throws_ArgumentNullException()
     {
-        // Back-compat for test composition roots / older deployments that don't wire an
-        // IConversationStore into the File session store. Without a resolver, orphan
-        // sessions stay unset. (SQLite fails loud in the same scenario — see
-        // Sqlite_SaveAsync_NoResolver_ThrowsInvalidOperation.)
+        // P9-I (#674): IConversationStore is mandatory on FileSessionStore.
+        // Construction with a null conversation store must throw immediately rather
+        // than silently degrading to a no-op resolver path at runtime.
         using var fixture = new FileFixture();
-        var store = fixture.CreateStore(conversationStore: null);
-        var session = await store.GetOrCreateAsync(SessionId.From("s-no-conv"), AgentId.From("a"));
-        await store.SaveAsync(session);
-
-        var reloaded = await fixture.CreateStore(conversationStore: null).GetAsync(SessionId.From("s-no-conv"));
-        reloaded!.ConversationId.IsInitialized().ShouldBeFalse();
+        Should.Throw<ArgumentNullException>(() =>
+            new FileSessionStore(
+                fixture.StorePath,
+                NullLogger<FileSessionStore>.Instance,
+                fixture.FileSystem,
+                conversationStore: null!));
     }
 
     // --- SqliteSessionStore (save-time + load-time + UPDATE row) ---
@@ -202,7 +201,8 @@ public sealed class LegacyConversationBackfillTests
             .Single(c => c.Title == $"legacy:{agentId.Value}");
 
         // Brand-new store (no cache) — the stamp must be persisted at the row level.
-        var verifyStore = fixture.CreateStore(conversationStore: null);
+        // Same conversation store; post-P9-I a null conversationStore is no longer accepted.
+        var verifyStore = fixture.CreateStore(conversations);
         var reloaded = await verifyStore.GetAsync(SessionId.From("s-sqlite-orphan"));
         reloaded!.ConversationId.ShouldBe(legacy.ConversationId);
     }
@@ -221,8 +221,10 @@ public sealed class LegacyConversationBackfillTests
         // the post-P9-B-2 fail-loud writer that would refuse to persist an unset row).
         await fixture.SeedOrphanRowAsync(SessionId.From("s-orphan-row"), agentId);
 
-        // 2) Reload through a Phase-9-aware store. The instance LoadSessionAsync path
-        // must call BackfillLoadedSessionAsync which UPDATEs the row.
+        // 2) Open a Phase-9-aware store. EnsureCreatedAsync's MigrateOrphanedSessionsAsync
+        // sweep stamps the orphan row, binds the legacy conversation's ActiveSessionId,
+        // then drops the legacy agent_id column. Subsequent calls find the row via the
+        // conversation_id index.
         var phase9Store = fixture.CreateStore(conversations);
         var reloaded = await phase9Store.GetAsync(SessionId.From("s-orphan-row"));
         reloaded.ShouldNotBeNull();
@@ -231,8 +233,9 @@ public sealed class LegacyConversationBackfillTests
             .Single(c => c.Title == $"legacy:{agentId.Value}");
 
         // 3) The indexed ListByConversationAsync query must now find the backfilled row
-        // in a fresh store (no cache pollution).
-        var queryStore = fixture.CreateStore(conversationStore: null);
+        // in a fresh store (no cache pollution). Same conversation store — post-P9-I
+        // a null conversationStore is no longer accepted.
+        var queryStore = fixture.CreateStore(conversations);
         var matched = await queryStore.ListByConversationAsync(legacy.ConversationId);
         matched.ShouldContain(s => s.SessionId == SessionId.From("s-orphan-row"),
             "Load-time backfill must persist via UPDATE so ListByConversationAsync " +
@@ -259,21 +262,19 @@ public sealed class LegacyConversationBackfillTests
     }
 
     [Fact]
-    public async Task Sqlite_SaveAsync_NoResolver_ThrowsInvalidOperation()
+    public void Sqlite_Ctor_NullConversationStore_Throws_ArgumentNullException()
     {
-        // Phase 9 / P9-B-2 (#627): the SQLite writer is the durable backstop and must
-        // fail loud when no resolver is configured and the session has no ConversationId.
-        // Silently writing NULL would re-introduce the orphan condition the non-nullable
-        // flip is supposed to prevent. (InMemory + File still tolerate this because they
-        // are typically used in tests / lightweight composition roots where missing
-        // ConversationIds are surfaced elsewhere.)
+        // P9-I (#674): IConversationStore is mandatory on SqliteSessionStore. The
+        // store needs the conversation store at construction-time both for the
+        // EnsureCreatedAsync orphan-migration sweep AND for the per-load AgentId
+        // hydration that replaces the deleted agent_id column. A null conversation
+        // store cannot silently degrade — the ctor must fail loud.
         using var fixture = new SqliteFixture();
-        var store = fixture.CreateStore(conversationStore: null);
-        var session = await store.GetOrCreateAsync(SessionId.From("s-sq-no-resolver"), AgentId.From("a"));
-
-        var ex = await Should.ThrowAsync<InvalidOperationException>(() => store.SaveAsync(session));
-        ex.Message.ShouldContain("ConversationId");
-        ex.Message.ShouldContain("s-sq-no-resolver");
+        Should.Throw<ArgumentNullException>(() =>
+            new SqliteSessionStore(
+                "Data Source=:memory:",
+                NullLogger<SqliteSessionStore>.Instance,
+                conversationStore: null!));
     }
 
     // --- Cross-store parity ---
@@ -440,8 +441,50 @@ public sealed class LegacyConversationBackfillTests
         public string StorePath { get; }
         public MockFileSystem FileSystem { get; }
 
-        public FileSessionStore CreateStore(IConversationStore? conversationStore)
-            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem, conversationStore: conversationStore);
+        /// <summary>
+        /// P9-I (#674): <see cref="IConversationStore"/> is mandatory on
+        /// <see cref="FileSessionStore"/>. Tests pass a per-test
+        /// <see cref="InMemoryConversationStore"/> (or a shared one for cross-store
+        /// parity assertions).
+        /// </summary>
+        public FileSessionStore CreateStore(IConversationStore conversationStore)
+            => new(StorePath, NullLogger<FileSessionStore>.Instance, FileSystem, conversationStore);
+
+        /// <summary>
+        /// Writes a raw pre-P9 sidecar JSON directly to <see cref="MockFileSystem"/>,
+        /// bypassing the post-P9-I write path that always stamps a ConversationId.
+        /// Simulates the state of a sidecar persisted by an older deployment so the
+        /// legacy-orphan recovery code in <see cref="FileSessionStore"/>.LoadFromFileAsync
+        /// has something to repair. (Post-P9-I, the public store API can no longer
+        /// produce orphan sidecars.)
+        /// </summary>
+        public async Task SeedOrphanSidecarAsync(
+            SessionId sessionId,
+            AgentId agentId,
+            BotNexus.Gateway.Abstractions.Models.SessionStatus status = BotNexus.Gateway.Abstractions.Models.SessionStatus.Active,
+            DateTimeOffset? updatedAt = null)
+        {
+            var now = updatedAt ?? DateTimeOffset.UtcNow;
+            var json = $$"""
+                {
+                  "agentId": "{{agentId.Value}}",
+                  "channelType": null,
+                  "callerId": null,
+                  "sessionType": "UserAgent",
+                  "participants": null,
+                  "createdAt": "{{now:O}}",
+                  "updatedAt": "{{now:O}}",
+                  "status": "{{status}}",
+                  "expiresAt": null,
+                  "nextSequenceId": 1,
+                  "streamEvents": null,
+                  "conversationId": null,
+                  "metadata": null
+                }
+                """;
+            var sidecarPath = Path.Combine(StorePath, $"{sessionId.Value}.meta.json");
+            await FileSystem.File.WriteAllTextAsync(sidecarPath, json);
+        }
 
         public void Dispose()
         {
@@ -461,38 +504,60 @@ public sealed class LegacyConversationBackfillTests
             _connectionString = new SqliteConnectionStringBuilder { DataSource = _dbPath, Pooling = false }.ToString();
         }
 
-        public SqliteSessionStore CreateStore(IConversationStore? conversationStore)
+        /// <summary>
+        /// P9-I (#674): <see cref="IConversationStore"/> is mandatory on
+        /// <see cref="SqliteSessionStore"/>.
+        /// </summary>
+        public SqliteSessionStore CreateStore(IConversationStore conversationStore)
             => new(_connectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore);
 
         /// <summary>
-        /// Seeds an orphan session row (conversation_id = NULL) by writing directly via
-        /// raw SQL. Post-P9-B-2, the SqliteSessionStore writer fails loud on unset
-        /// ConversationId — but the load-time backfill path must still handle pre-Phase-9
-        /// rows that already exist on disk. Use this helper to construct the pre-existing
-        /// orphan state that the backfill is designed to repair.
+        /// P9-I (#674) revision: previously this method bootstrapped the schema via
+        /// <see cref="CreateStore"/> then inserted a row directly. Post-P9-I,
+        /// <see cref="SqliteSessionStore"/> drops the legacy <c>agent_id</c> column
+        /// during EnsureCreatedAsync — so bootstrapping via the public ctor would leave
+        /// no column to seed into. Instead we create the pre-P9 schema by hand,
+        /// INSERT the orphan row, and let the subsequent P9-I store open trigger the
+        /// MigrateOrphanedSessionsAsync sweep + column drop.
         /// </summary>
         public async Task SeedOrphanRowAsync(SessionId sessionId, AgentId agentId)
         {
-            // Ensure schema exists by spinning up a normal store (ListAsync triggers
-            // EnsureCreatedAsync). SqliteSessionStore holds no per-instance disposable
-            // state — the schema lives on disk and connections come from the pool.
-            var bootstrap = CreateStore(conversationStore: null);
-            _ = await bootstrap.ListAsync();
-
             await using var connection = new SqliteConnection(_connectionString);
             await connection.OpenAsync();
-            await using var cmd = connection.CreateCommand();
-            cmd.CommandText = """
+
+            // Pre-P9 schema (includes legacy agent_id column).
+            await using var schemaCmd = connection.CreateCommand();
+            schemaCmd.CommandText = """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT NOT NULL,
+                    channel_type TEXT,
+                    caller_id TEXT,
+                    session_type TEXT,
+                    participants_json TEXT,
+                    status TEXT NOT NULL,
+                    metadata TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    conversation_id TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions(agent_id);
+                CREATE INDEX IF NOT EXISTS idx_sessions_conversation_agent ON sessions(conversation_id, agent_id, updated_at DESC, id);
+                """;
+            await schemaCmd.ExecuteNonQueryAsync();
+
+            await using var insertCmd = connection.CreateCommand();
+            insertCmd.CommandText = """
                 INSERT INTO sessions (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
                 VALUES ($id, $agentId, NULL, NULL, $sessionType, '[]', $status, '{}', $createdAt, $updatedAt, NULL)
                 """;
-            cmd.Parameters.AddWithValue("$id", sessionId.Value);
-            cmd.Parameters.AddWithValue("$agentId", agentId.Value);
-            cmd.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
-            cmd.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
-            cmd.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToString("O"));
-            cmd.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
-            await cmd.ExecuteNonQueryAsync();
+            insertCmd.Parameters.AddWithValue("$id", sessionId.Value);
+            insertCmd.Parameters.AddWithValue("$agentId", agentId.Value);
+            insertCmd.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
+            insertCmd.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
+            insertCmd.Parameters.AddWithValue("$createdAt", DateTimeOffset.UtcNow.ToString("O"));
+            insertCmd.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
+            await insertCmd.ExecuteNonQueryAsync();
         }
 
         public void Dispose()
@@ -526,29 +591,17 @@ public sealed class LegacyConversationBackfillTests
     public async Task File_EagerSweep_BindsMostRecentlyUpdatedActiveOrphan_AsConversationActiveSession()
     {
         // Seed three orphan sidecars for the same agent at distinct UpdatedAt timestamps
-        // (no conversation store wired, so no stamping happens). Then open a fresh store
-        // WITH a resolver; the first GetAsync triggers EnsureMigratedAsync which must
-        // pick the most-recently-updated Active orphan as the bound ActiveSessionId.
+        // via direct file manipulation (the public store API can no longer produce
+        // orphan sidecars post-P9-I). Then open a fresh store WITH a resolver; the first
+        // GetAsync triggers EnsureMigratedAsync which must pick the most-recently-updated
+        // Active orphan as the bound ActiveSessionId.
         using var fixture = new FileFixture();
         var agentId = AgentId.From("agent-eager-bind");
 
-        var preStore = fixture.CreateStore(conversationStore: null);
-        var oldest = await preStore.GetOrCreateAsync(SessionId.From("s-old"), agentId);
-        oldest.UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-30);
-        await preStore.SaveAsync(oldest);
-
-        var middle = await preStore.GetOrCreateAsync(SessionId.From("s-mid"), agentId);
-        middle.UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-15);
-        await preStore.SaveAsync(middle);
-
-        var newest = await preStore.GetOrCreateAsync(SessionId.From("s-new"), agentId);
-        newest.UpdatedAt = DateTimeOffset.UtcNow;
-        await preStore.SaveAsync(newest);
-
-        // Sanity: all three sidecars are orphans on disk before sweep.
-        oldest.ConversationId.IsInitialized().ShouldBeFalse();
-        middle.ConversationId.IsInitialized().ShouldBeFalse();
-        newest.ConversationId.IsInitialized().ShouldBeFalse();
+        var now = DateTimeOffset.UtcNow;
+        await fixture.SeedOrphanSidecarAsync(SessionId.From("s-old"), agentId, updatedAt: now.AddMinutes(-30));
+        await fixture.SeedOrphanSidecarAsync(SessionId.From("s-mid"), agentId, updatedAt: now.AddMinutes(-15));
+        await fixture.SeedOrphanSidecarAsync(SessionId.From("s-new"), agentId, updatedAt: now);
 
         var conversations = new InMemoryConversationStore();
         var sweepStore = fixture.CreateStore(conversations);
@@ -564,7 +617,9 @@ public sealed class LegacyConversationBackfillTests
             "conversation's ActiveSessionId — mirrors SqliteSessionStore semantics.");
 
         // All three sidecars must also be stamped (regardless of which was bound).
-        var verifyStore = fixture.CreateStore(conversationStore: null);
+        // Use the same conversation store — post-P9-I a null conversationStore is no
+        // longer accepted.
+        var verifyStore = fixture.CreateStore(conversations);
         var reloadedOld = await verifyStore.GetAsync(SessionId.From("s-old"));
         var reloadedMid = await verifyStore.GetAsync(SessionId.From("s-mid"));
         var reloadedNew = await verifyStore.GetAsync(SessionId.From("s-new"));
@@ -584,17 +639,14 @@ public sealed class LegacyConversationBackfillTests
         using var fixture = new FileFixture();
         var agentId = AgentId.From("agent-eager-status");
 
-        var preStore = fixture.CreateStore(conversationStore: null);
-
-        var olderActive = await preStore.GetOrCreateAsync(SessionId.From("s-active-old"), agentId);
-        olderActive.UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-20);
-        // Status defaults to Active.
-        await preStore.SaveAsync(olderActive);
-
-        var newerSealed = await preStore.GetOrCreateAsync(SessionId.From("s-sealed-new"), agentId);
-        newerSealed.UpdatedAt = DateTimeOffset.UtcNow;
-        newerSealed.Status = SessionStatus.Sealed;
-        await preStore.SaveAsync(newerSealed);
+        var now = DateTimeOffset.UtcNow;
+        await fixture.SeedOrphanSidecarAsync(
+            SessionId.From("s-active-old"), agentId,
+            updatedAt: now.AddMinutes(-20));
+        await fixture.SeedOrphanSidecarAsync(
+            SessionId.From("s-sealed-new"), agentId,
+            status: BotNexus.Gateway.Abstractions.Models.SessionStatus.Sealed,
+            updatedAt: now);
 
         var conversations = new InMemoryConversationStore();
         var sweepStore = fixture.CreateStore(conversations);
@@ -609,7 +661,7 @@ public sealed class LegacyConversationBackfillTests
 
         // Stamping still applies to the Sealed sidecar — it's part of the conversation
         // history; the bind decision is independent of the stamp decision.
-        var verifyStore = fixture.CreateStore(conversationStore: null);
+        var verifyStore = fixture.CreateStore(conversations);
         var reloadedSealed = await verifyStore.GetAsync(SessionId.From("s-sealed-new"));
         reloadedSealed!.ConversationId.ShouldBe(
             legacy.ConversationId,
@@ -630,11 +682,9 @@ public sealed class LegacyConversationBackfillTests
         using var fixture = new FileFixture();
         var agentId = AgentId.From("agent-eager-concurrent");
 
-        // Seed one orphan so the sweep has work to do (otherwise it would short-circuit
-        // before invoking the resolver and the migration would be vacuous).
-        var preStore = fixture.CreateStore(conversationStore: null);
-        var orphan = await preStore.GetOrCreateAsync(SessionId.From("s-concurrent-orphan"), agentId);
-        await preStore.SaveAsync(orphan);
+        // Seed one orphan sidecar so the sweep has work to do (otherwise it would
+        // short-circuit before invoking the resolver and the migration would be vacuous).
+        await fixture.SeedOrphanSidecarAsync(SessionId.From("s-concurrent-orphan"), agentId);
 
         var conversations = new InMemoryConversationStore();
         var sweepStore = fixture.CreateStore(conversations);
@@ -669,10 +719,8 @@ public sealed class LegacyConversationBackfillTests
         using var fixture = new FileFixture();
         var agentId = AgentId.From("agent-eager-cancel");
 
-        // Seed one orphan so the sweep has work to do.
-        var preStore = fixture.CreateStore(conversationStore: null);
-        var orphan = await preStore.GetOrCreateAsync(SessionId.From("s-cancel-orphan"), agentId);
-        await preStore.SaveAsync(orphan);
+        // Seed one orphan sidecar so the sweep has work to do.
+        await fixture.SeedOrphanSidecarAsync(SessionId.From("s-cancel-orphan"), agentId);
 
         var gate = new DelayableConversationStore(new InMemoryConversationStore());
         var sweepStore = fixture.CreateStore(gate);

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStoreConversationIdTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SqliteSessionStoreConversationIdTests.cs
@@ -67,6 +67,12 @@ public sealed class SqliteSessionStoreConversationIdTests : IDisposable
         var sessionId = SessionId.From("test-session-persist-conv");
         var agentId = AgentId.From("agent-persist-test");
         var conversationId = ConversationId.Create();
+        // P9-I (#674): the conversation must exist before AgentId hydration runs on reload.
+        await _conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = agentId
+        });
 
         // Save a session with ConversationId stamped
         var store1 = CreateStore();
@@ -110,6 +116,12 @@ public sealed class SqliteSessionStoreConversationIdTests : IDisposable
         var sessionId = SessionId.From("test-session-enumerate-conv");
         var agentId = AgentId.From("agent-enumerate");
         var conversationId = ConversationId.Create();
+        // P9-I (#674): the conversation must exist before AgentId hydration runs on reload.
+        await _conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = agentId
+        });
 
         var store1 = CreateStore();
         var session = await store1.GetOrCreateAsync(sessionId, agentId);

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreMigrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreMigrationTests.cs
@@ -48,6 +48,8 @@ public sealed class SqliteSessionStoreMigrationTests : IDisposable
     /// <summary>
     /// Inserts a session row directly, bypassing the store so we can set
     /// <c>conversation_id</c> to NULL (simulating a pre-conversation-model row).
+    /// Also bootstraps the pre-P9-I schema with the legacy <c>agent_id</c> column so
+    /// the orphan-migration code path in <c>EnsureCreatedAsync</c> has work to find.
     /// </summary>
     private static async Task InsertOrphanedSessionAsync(
         string connectionString,
@@ -58,9 +60,29 @@ public sealed class SqliteSessionStoreMigrationTests : IDisposable
         await using var conn = new SqliteConnection(connectionString);
         await conn.OpenAsync();
 
-        // Ensure schema exists first by opening the store (which runs EnsureCreatedAsync).
-        // We skip that here because we call InsertOrphanedSessionAsync only after the store
-        // has been initialised at least once (via a prior store operation).
+        // P9-I (#674): bootstrap the legacy schema (with agent_id) before inserting.
+        // The post-P9-I CREATE TABLE IF NOT EXISTS DDL has no agent_id column, so a
+        // fresh table makes this INSERT fail. By creating the legacy shape here we
+        // simulate the pre-P9-I-on-disk state that migration is meant to upgrade.
+        await using var schemaCmd = conn.CreateCommand();
+        schemaCmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                agent_id TEXT,
+                channel_type TEXT,
+                caller_id TEXT,
+                session_type TEXT,
+                participants_json TEXT,
+                status TEXT,
+                metadata TEXT,
+                created_at TEXT,
+                updated_at TEXT,
+                conversation_id TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_sessions_agent_id ON sessions(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_sessions_conversation_agent ON sessions(conversation_id, agent_id);
+            """;
+        await schemaCmd.ExecuteNonQueryAsync();
 
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = """
@@ -96,12 +118,9 @@ public sealed class SqliteSessionStoreMigrationTests : IDisposable
     {
         var agentId = AgentId.From("agent-orphan");
 
-        // Arrange: bootstrap the schema, then poke in orphaned rows.
-        var convStore = CreateConversationStore();
-        var sessionStore = CreateSessionStore(convStore);
-        // Prime the schema by doing one store operation.
-        _ = await sessionStore.GetAsync(SessionId.From("probe"), CancellationToken.None);
-
+        // P9-I (#674): seed legacy-schema orphans BEFORE opening the store. Opening the
+        // store now runs the post-P9-I EnsureCreatedAsync which would drop agent_id on a
+        // fresh DB, leaving InsertOrphanedSessionAsync unable to write to that column.
         var t1 = DateTimeOffset.UtcNow.AddMinutes(-10);
         var t2 = DateTimeOffset.UtcNow.AddMinutes(-5);
         await InsertOrphanedSessionAsync(
@@ -109,15 +128,16 @@ public sealed class SqliteSessionStoreMigrationTests : IDisposable
         await InsertOrphanedSessionAsync(
             $"Data Source={_sessionDbPath};Pooling=False", "s-orphan-2", agentId.Value, t2);
 
-        // Act: create a fresh store; the migration runs during initialisation.
-        var convStore2 = CreateConversationStore();
-        var sessionStore2 = CreateSessionStore(convStore2);
+        // Act: create a store; the migration runs during initialisation, stamps a legacy
+        // conversation, then DropLegacyAgentIdColumnAsync removes the column.
+        var convStore = CreateConversationStore();
+        var sessionStore = CreateSessionStore(convStore);
         // Trigger init by loading a session (any operation calls EnsureCreatedAsync).
-        _ = await sessionStore2.GetAsync(SessionId.From("probe"), CancellationToken.None);
+        _ = await sessionStore.GetAsync(SessionId.From("probe"), CancellationToken.None);
 
         // Assert: both orphaned sessions now have the legacy conversation id.
         // The migration creates a "legacy:{agentId}" conversation for orphaned sessions.
-        var allConvs = await convStore2.ListAsync(agentId);
+        var allConvs = await convStore.ListAsync(agentId);
         var conv = allConvs.FirstOrDefault(c => c.Title == $"legacy:{agentId.Value}");
         conv.ShouldNotBeNull("Migration should have created a legacy conversation for orphaned sessions");
         var cid1 = await ReadConversationIdAsync($"Data Source={_sessionDbPath};Pooling=False", "s-orphan-1");
@@ -171,25 +191,24 @@ public sealed class SqliteSessionStoreMigrationTests : IDisposable
     {
         var agentId = AgentId.From("agent-idem");
 
-        // Arrange: orphaned sessions in the DB.
-        var convStore = CreateConversationStore();
-        var sessionStore = CreateSessionStore(convStore);
-        _ = await sessionStore.GetAsync(SessionId.From("probe"), CancellationToken.None);
-
+        // P9-I (#674): seed legacy-schema orphan BEFORE opening the store (same reason as
+        // Migration_OrphanedSessions_LinkedToDefaultConversation above).
         await InsertOrphanedSessionAsync(
             $"Data Source={_sessionDbPath};Pooling=False", "s-idem-1", agentId.Value,
             DateTimeOffset.UtcNow.AddMinutes(-10));
 
         // First migration run.
-        var convStore2 = CreateConversationStore();
-        var sessionStore2 = CreateSessionStore(convStore2);
-        _ = await sessionStore2.GetAsync(SessionId.From("probe"), CancellationToken.None);
+        var convStore = CreateConversationStore();
+        var sessionStore = CreateSessionStore(convStore);
+        _ = await sessionStore.GetAsync(SessionId.From("probe"), CancellationToken.None);
 
         var cidAfterFirst = await ReadConversationIdAsync(
             $"Data Source={_sessionDbPath};Pooling=False", "s-idem-1");
-        var convsAfterFirst = await convStore2.ListAsync(agentId);
+        var convsAfterFirst = await convStore.ListAsync(agentId);
 
         // Second migration run (new store instance, _initialized is false again).
+        // The agent_id column was dropped by the first run, so the second run's
+        // migration scan is a no-op — but we still verify post-state.
         var convStore3 = CreateConversationStore();
         var sessionStore3 = CreateSessionStore(convStore3);
         _ = await sessionStore3.GetAsync(SessionId.From("probe"), CancellationToken.None);

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreSessionParticipantBackCompatTests.cs
@@ -50,14 +50,14 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
         {
             await connection.OpenAsync();
             await using var insert = connection.CreateCommand();
+            // P9-I (#674): agent_id column dropped post-bootstrap; INSERT omits it.
             insert.CommandText = """
                 INSERT INTO sessions
-                  (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
+                  (id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
                 VALUES
-                  ($id, $agentId, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt, $convId)
+                  ($id, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt, $convId)
                 """;
             insert.Parameters.AddWithValue("$id", "legacy-session");
-            insert.Parameters.AddWithValue("$agentId", "agent-a");
             insert.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
             insert.Parameters.AddWithValue("$participants", legacyParticipantsJson);
             insert.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
@@ -151,14 +151,14 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
         {
             await connection.OpenAsync();
             await using var insert = connection.CreateCommand();
+            // P9-I (#674): agent_id column dropped post-bootstrap; INSERT omits it.
             insert.CommandText = """
                 INSERT INTO sessions
-                  (id, agent_id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
+                  (id, channel_type, caller_id, session_type, participants_json, status, metadata, created_at, updated_at, conversation_id)
                 VALUES
-                  ($id, $agentId, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt, $convId)
+                  ($id, NULL, NULL, $sessionType, $participants, $status, '{}', $createdAt, $updatedAt, $convId)
                 """;
             insert.Parameters.AddWithValue("$id", "legacy-session");
-            insert.Parameters.AddWithValue("$agentId", "agent-a");
             insert.Parameters.AddWithValue("$sessionType", SessionType.UserAgent.Value);
             insert.Parameters.AddWithValue("$participants", legacyParticipantsJson);
             insert.Parameters.AddWithValue("$status", SessionStatus.Active.ToString());
@@ -209,6 +209,8 @@ public sealed class SqliteSessionStoreSessionParticipantBackCompatTests
         public InMemoryConversationStore Conversations { get; }
 
         public SqliteSessionStore CreateStore(IConversationStore? conversationStore = null)
+            // P9-I (#674): conversationStore is mandatory on SqliteSessionStore. Default
+            // to the fixture's per-test InMemoryConversationStore when not overridden.
             => new(ConnectionString, NullLogger<SqliteSessionStore>.Instance, conversationStore ?? Conversations);
 
         public void Dispose()

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreTests.cs
@@ -808,11 +808,28 @@ public sealed class SqliteSessionStoreTests
     //     a full-scan plan would require EXPLAIN QUERY PLAN; we settle for "returns
     //     the right rows" + "index is present" which is what regression would catch).
 
-    private static async Task SeedSqliteConversationFixtureAsync(SqliteSessionStore store, DateTimeOffset baseTime)
+    private static async Task SeedSqliteConversationFixtureAsync(StoreFixture fixture, DateTimeOffset baseTime)
     {
         var convA = ConversationId.From("conv-a");
         var convB = ConversationId.From("conv-b");
 
+        // P9-I (#674): pre-register conversations so AgentId hydration succeeds on reload.
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convA,
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            UpdatedAt = baseTime
+        });
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convB,
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = baseTime,
+            UpdatedAt = baseTime
+        });
+
+        var store = fixture.CreateStore();
         await store.SaveAsync(new GatewaySession
         {
             SessionId = SessionId.From("s-a-active"),
@@ -855,9 +872,13 @@ public sealed class SqliteSessionStoreTests
     }
 
     [Fact]
-    public async Task EnsureCreatedAsync_CreatesConversationAgentIndex_ForListByConversationLookups()
+    public async Task EnsureCreatedAsync_CreatesConversationCreatedIndex_ForListByConversationLookups()
     {
         // Pin the index exists. If a future schema change removes it, this fails first.
+        // P9-I (#674): replaces idx_sessions_conversation_agent (composite was dropped
+        // alongside the agent_id column) with idx_sessions_conversation_created.
+        // The new index serves ListByConversationAsync's (conversation_id, created_at, id)
+        // ordering contract.
         using var fixture = new StoreFixture();
         // Trigger schema creation by a no-op read.
         _ = await fixture.CreateStore().GetAsync(SessionId.From("warm"));
@@ -873,8 +894,12 @@ public sealed class SqliteSessionStoreTests
             indexes.Add(reader.GetString(0));
 
         indexes.ShouldContain(
-            "idx_sessions_conversation_agent",
+            "idx_sessions_conversation_created",
             "Missing index — ListByConversationAsync degrades to a full table scan");
+        // Pin removal of the dead composite that referenced agent_id (dropped with the column).
+        indexes.ShouldNotContain(
+            "idx_sessions_conversation_agent",
+            "Stale index references the removed agent_id column");
     }
 
     [Fact]
@@ -882,7 +907,7 @@ public sealed class SqliteSessionStoreTests
     {
         using var fixture = new StoreFixture();
         var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        await SeedSqliteConversationFixtureAsync(fixture.CreateStore(), baseTime);
+        await SeedSqliteConversationFixtureAsync(fixture, baseTime);
 
         var sessions = await fixture.CreateStore()
             .ListByConversationAsync(ConversationId.From("conv-a"));
@@ -896,7 +921,7 @@ public sealed class SqliteSessionStoreTests
     {
         using var fixture = new StoreFixture();
         var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        await SeedSqliteConversationFixtureAsync(fixture.CreateStore(), baseTime);
+        await SeedSqliteConversationFixtureAsync(fixture, baseTime);
 
         var sessions = await fixture.CreateStore()
             .ListByConversationAsync(ConversationId.From("conv-a"));
@@ -922,13 +947,22 @@ public sealed class SqliteSessionStoreTests
     {
         using var fixture = new StoreFixture();
         var baseTime = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
-        await SeedSqliteConversationFixtureAsync(fixture.CreateStore(), baseTime);
+        await SeedSqliteConversationFixtureAsync(fixture, baseTime);
 
-        var sessions = await fixture.CreateStore()
+        // P9-I (#674): agent_id column dropped from sessions. AgentId is hydrated from
+        // Conversation.AgentId, so passing the conversation's owning agent returns ALL
+        // sessions in that conversation (the agentId arg is now a defensive assertion
+        // that the conversation belongs to the caller's agent). Passing a different
+        // agent returns an empty set.
+        var matched = await fixture.CreateStore()
             .ListByConversationAsync(ConversationId.From("conv-a"), agentId: AgentId.From("agent-x"));
+        matched.Select(s => s.SessionId.Value)
+            .ShouldBe(new[] { "s-a-sealed", "s-a-other-agent", "s-a-active" }, ignoreOrder: false);
 
-        sessions.Select(s => s.SessionId.Value)
-            .ShouldBe(new[] { "s-a-sealed", "s-a-active" }, ignoreOrder: false);
+        var mismatched = await fixture.CreateStore()
+            .ListByConversationAsync(ConversationId.From("conv-a"), agentId: AgentId.From("agent-y"));
+        mismatched.ShouldBeEmpty(
+            "Post-P9-I: passing a non-owner agent must return empty — Conversation.AgentId is the source of truth.");
     }
 
     [Fact]
@@ -937,6 +971,14 @@ public sealed class SqliteSessionStoreTests
         using var fixture = new StoreFixture();
         var same = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
         var convId = ConversationId.From("conv-tie");
+        // P9-I (#674): pre-register the conversation so AgentId hydration succeeds.
+        await fixture.Conversations.CreateAsync(new Conversation
+        {
+            ConversationId = convId,
+            AgentId = AgentId.From("agent-x"),
+            CreatedAt = same,
+            UpdatedAt = same
+        });
         var store = fixture.CreateStore();
 
         await store.SaveAsync(new GatewaySession


### PR DESCRIPTION
## Summary

W-4 final cleanup: **AgentId now lives durably on `Conversation.AgentId`** and is hydrated on every `Session` load. The legacy `sessions.agent_id` column and its two associated indexes (`idx_sessions_agent_id`, `idx_sessions_conversation_agent`) are dropped on first store open; the file sidecar's `agentId` field is rewritten as `null`. `IConversationStore` becomes mandatory on both stores so hydration has something to resolve against.

Closes #674. This is the final phase of the P9 cleanup arc — Session is now purely an active window of work inside a Conversation, with no durable identity ownership of its own.

## What changed

### Production (`src/`)

- **`SqliteSessionStore`**
  - `IConversationStore` constructor parameter is mandatory (no overloads).
  - `EnsureCreatedAsync` orchestrates: CREATE TABLE (no `agent_id`) → migrate-tool-columns → CREATE `idx_sessions_conversation_created` → HasColumnAsync probe → if exists: `MigrateOrphanedSessionsAsync` → `BackfillParticipantsToConversationsAsync` → if exists: `DropLegacyAgentIdColumnAsync` (drops both legacy indexes and the column).
  - `ListByConversationAsync` now served by `idx_sessions_conversation_created` (replaces the dropped `idx_sessions_conversation_agent`).
  - `LoadSessionAsync` no longer SELECTs `agent_id`.
  - `HydrateAgentIdAsync` resolves `Conversation.AgentId` on cache miss (per-store positive-only `ConcurrentDictionary<ConversationId, AgentId>`); throws `InvalidOperationException` with session id + conversation id when the conversation is missing.
- **`FileSessionStore`** (symmetric)
  - Single public ctor requires `IConversationStore`.
  - `SessionMeta.AgentId` is nullable; new sidecars write `agentId: null`.
  - `MigrateOrphanedSessionsAsync` rewrites every orphan sidecar to stamp the legacy conversation and clear `agentId`.
  - `HydrateAgentIdAsync` mirrors the Sqlite path.
- **DI**: `AddSqliteSessionStore` / `AddFileSessionStore` wire `IConversationStore`.
- **CLI**: `MemoryCommands` resolves `IConversationStore` from the host before constructing the session store.

### Test migration (no net deletions)

- **Integration tests that "restart" a session store** now share an `InMemoryConversationStore` across restarts (per-fixture field or per-`storePath` static dictionary) so conversations created in `store#1` remain visible to `store#2`.
- **Tests that hand-write a `ConversationId`** now pre-register the conversation via `Conversations.CreateAsync` before referencing it — the post-P9-I path no longer lazy-creates conversations for explicit IDs (the legacy resolver only fires when `ConversationId` is *unset*).
- **`SqliteSessionStoreMigrationTests`**: `InsertOrphanedSessionAsync` bootstraps the pre-P9-I schema (with `agent_id` column + legacy indexes) before INSERT so the orphan-migration path has something to find and drop.
- **`SqliteSessionStoreSessionParticipantBackCompatTests`**: raw INSERT statements drop `agent_id` from the column list (it's dropped at store bootstrap).
- **`LegacyConversationBackfillTests`**: `SeedOrphanRowAsync` bootstraps legacy schema before INSERT.
- **`ListByConversationAsync_AcrossReload_WithAgentFilter_NarrowsToOwner`** (Sqlite + File): rewritten for new semantics — every session in a conversation hydrates the SAME `AgentId` from `Conversation.AgentId`, so the `agentId` filter is now a defensive assertion: matching owner returns all sessions; non-owner returns empty.
- **`EnsureCreatedAsync_CreatesConversationCreatedIndex_ForListByConversationLookups`** (renamed from `..._ConversationAgentIndex_...`): pins new `idx_sessions_conversation_created` exists AND legacy `idx_sessions_conversation_agent` is gone.

### Architecture fence — `SessionAgentIdColumnRemovedArchitectureTests`

Bans:
1. `idx_sessions_agent_id` and `idx_sessions_conversation_agent` globally (unambiguous P9-I artifacts — cannot legitimately reappear).
2. Co-occurrence of `sessions` and `agent_id` within a single SQL statement window (bounded by `;` or `"""`), in either order. **This scopes the fence to the sessions-table context** — `conversations.agent_id`, `memories.agent_id`, and `cron_jobs.agent_id` (legitimate FKs on their own tables) are NOT flagged.

Allowlist contains only `SqliteSessionStore.cs` (the migration helpers `MigrateOrphanedSessionsAsync`, `DropLegacyAgentIdColumnAsync`, `VerifyAgentIdColumnConsistencyAsync` need to read/drop the legacy shape by design). Uses the proven `StripComments` lexer so historical mentions in XML/line/block comments do not trip. Ships vacuity / false-positive / comment-mention self-tests + allowlist-hygiene check per the architecture-fence convention.

### Regression tests — `SessionAgentIdRemovalRegressionTests`

1. **`FreshDatabase_SchemaHas_NoAgentIdColumn_OnSessionsTable`** — opens a `SqliteSessionStore` on an empty DB, `PRAGMA table_info(sessions)`, asserts `agent_id` is absent. Catches accidental re-addition in future CREATE TABLE DDL changes.
2. **`PreP9Database_WithLegacyIndexes_HasIndexesDropped_OnOpen`** — seeds the pre-P9 schema (with both legacy indexes) into a SQLite file before opening the post-P9-I store; asserts both legacy indexes are dropped and the replacement `idx_sessions_conversation_created` is created.
3. **`LoadingSession_WithDanglingConversationId_Throws_InvalidOperationException`** — injects a session row with a `conversation_id` pointing at a missing conversation; asserts `GetAsync` throws with a message naming both the session id and the conversation id so operators can diagnose.
4. **`FileSessionStore_OnOpen_RewritesLegacySidecar_StampingConversationAndNullingAgentId`** — writes a pre-P9 file sidecar (`agentId` set, `conversationId` absent) to disk, opens the store, then re-reads the sidecar and asserts `conversationId` is stamped AND `agentId` is JSON `null` (the post-P9-I shape).

## Test results

- **Architecture fence**: 5/5 pass.
- **Regression tests**: 4/4 pass.
- **Full Gateway suite**: 2004 passed / 1 skipped / 0 failed.
- **Full TIA sweep across 9 impacted projects**: all green.
- **Build**: 0 errors / 0 warnings (`TreatWarningsAsErrors=true`).

## Phase 9 status after this PR

| Phase | Issue | PR | Status |
|---|---|---|---|
| P9-A | #614 | — | merged |
| P9-B-2 | #627 | #641 | merged |
| P9-D | #643 | #644 | merged |
| P9-E | #645 | #646 | merged |
| P9-F | #657 | #659 | merged |
| P9-G | #661 | #663 | merged |
| P9-H | #662 | #664 | merged |
| **P9-I** | **#674** | **this PR** | **ready for review** |

## Commits

1. `refactor(gateway)!: hydrate Session AgentId from Conversation; drop legacy agent_id column (P9-I, partial #674)` — production + 11 test-file migrations.
2. `test(architecture): pin P9-I agent_id removal contract + regression tests (closes #674)` — architecture fence + 4 regression tests.
