### PR TITLE
feat(channels)!: replace string conversationId with typed ChannelStreamTarget on stream adapter methods

### DIFF
--- a/docs/architecture/system-flows.md
+++ b/docs/architecture/system-flows.md
@@ -209,7 +209,8 @@ AgentHandle → ChannelAdapter.SendAsync(OutboundMessage) → SignalR Group Broa
 
 1. **Agent emits `AgentEvent`** (e.g., `ContentDelta`, `ToolStart`, `MessageEnd`)
 2. **Handle wraps as `AgentStreamEvent`** with sessionId
-3. **Channel adapter receives event**: `IChannelAdapter.SendStreamDeltaAsync(conversationId, delta, ct)`
+3. **Channel adapter receives event**: `IChannelAdapter.SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken ct)`
+   The `ChannelStreamTarget` carries the typed `SessionId`, `ChannelAddress`, and optional `BindingId` the adapter needs to route delivery — each adapter consumes whichever field matches its native routing model (SignalR groups by `SessionId`, Telegram looks up by `ChannelAddress`, etc.).
 4. **Adapter broadcasts to session group**: `Clients.Group("session:{sessionId}").SendAsync(method, data)`
 5. **All clients in group receive event** in real-time
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/ChannelStreamTarget.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/ChannelStreamTarget.cs
@@ -1,0 +1,63 @@
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Typed routing token passed to <c>IChannelAdapter.SendStreamDeltaAsync</c> and
+/// <c>IStreamEventChannelAdapter.SendStreamEventAsync</c>. Each channel adapter
+/// consumes the field that matches its routing semantics:
+/// </summary>
+/// <remarks>
+/// <para>
+/// Replaces the historical <c>string conversationId</c> parameter that grew out of
+/// pre-Phase 9 channel modelling. That string was an opaque per-channel token —
+/// SignalR interpreted it as a <see cref="SessionId"/>, Telegram parsed it back to
+/// a <see cref="ChannelAddress"/>, the internal fan-out path passed each binding's
+/// channel address. The misleading parameter name and overloaded semantics were a
+/// recurring source of routing bugs; this record names the three facets explicitly
+/// so each adapter picks the one it needs.
+/// </para>
+/// <para>
+/// Field consumption per built-in adapter:
+/// <list type="bullet">
+///   <item><b>SignalR</b> — uses <see cref="SessionId"/> to address the SignalR
+///   group. Stream events that carry their own <c>SessionId</c> still take
+///   precedence so cross-session enrichment continues to work.</item>
+///   <item><b>Telegram</b> — uses <see cref="ChannelAddress"/> to recover the
+///   native <c>chatId</c>/<c>messageThreadId</c> via
+///   <c>TelegramChannelAddress.TryDecode</c>.</item>
+///   <item><b>TUI</b> — uses <see cref="SessionId"/> only as a display label.</item>
+///   <item><b>Internal</b> — uses <see cref="SessionId"/> to resolve the parent
+///   session's original channel adapter and forwards the same target verbatim.</item>
+///   <item><b>Observer fan-out</b> — caller constructs one target per observer
+///   binding so the originating <see cref="BindingId"/> can be excluded from echo
+///   and per-binding addresses are preserved.</item>
+/// </list>
+/// </para>
+/// <para>
+/// The record mirrors the shape of <see cref="OutboundMessage"/>'s addressing
+/// fields so callers can lift the same values across delivery and streaming
+/// paths without re-deriving anything.
+/// </para>
+/// </remarks>
+/// <param name="SessionId">
+/// The session the stream events belong to. Always set — channels that route by
+/// session use this directly; channels that route by channel address still need
+/// the session id for logging and event enrichment.
+/// </param>
+/// <param name="ChannelAddress">
+/// The channel-native address the stream is being written to. For Portal/SignalR
+/// this is typically the agent id (one binding per agent), for Telegram it is
+/// <c>chatId[:threadId]</c>, for TUI it is <c>"console"</c>, and for observer
+/// fan-out it is the observing binding's address rather than the originating
+/// binding's address.
+/// </param>
+/// <param name="BindingId">
+/// The originating channel binding when known. Used by fan-out paths to suppress
+/// echo back to the source binding. <c>null</c> when the stream is not bound to
+/// an explicit channel binding (e.g. internal sub-agent wake-ups).
+/// </param>
+public sealed record ChannelStreamTarget(
+    SessionId SessionId,
+    ChannelAddress ChannelAddress,
+    BindingId? BindingId = null);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -55,32 +55,33 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
     }
 
     /// <summary>
-    /// Executes send stream delta async.
+    /// Sends a streaming delta to the SignalR group for the target session.
     /// </summary>
-    /// <param name="conversationId">The conversation id.</param>
+    /// <param name="target">Typed stream target — SignalR routes by <c>target.SessionId</c>.</param>
     /// <param name="delta">The delta.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The send stream delta async result.</returns>
-    public override Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    public override Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
     {
-        var normalizedSessionId = NormalizeSessionId(conversationId);
-        return _hubContext.Clients.Group(GetSessionGroup(normalizedSessionId))
-            .ContentDelta(new ContentDeltaPayload(normalizedSessionId, delta));
+        var sessionIdValue = target.SessionId.Value;
+        return _hubContext.Clients.Group(GetSessionGroup(sessionIdValue))
+            .ContentDelta(new ContentDeltaPayload(sessionIdValue, delta));
     }
 
     /// <summary>
-    /// Executes send stream event async.
+    /// Sends a structured stream event to the SignalR group for the target session.
     /// </summary>
-    /// <param name="conversationId">The conversation id.</param>
+    /// <param name="target">Typed stream target — SignalR routes by <c>target.SessionId</c>.</param>
     /// <param name="streamEvent">The stream event.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The send stream event async result.</returns>
-    public Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
+    public Task SendStreamEventAsync(ChannelStreamTarget target, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
     {
-        // Prefer the session ID stamped on the event (set by GatewayHost) over the conversationId
-        // parameter, which may be the channel address (e.g. agentId for SignalR) rather than a session ID.
-        var sessionIdStr = streamEvent.SessionId?.Value ?? NormalizeSessionId(conversationId);
-        var typedSessionId = SessionId.From(sessionIdStr);
+        // Prefer the session ID stamped on the event (set by GatewayHost) over the target,
+        // so observer fan-out — which addresses each observer by their own binding — still
+        // surfaces the originating session id to the client.
+        var typedSessionId = streamEvent.SessionId ?? target.SessionId;
+        var sessionIdStr = typedSessionId.Value;
 
         logger.LogInformation("SignalR → group session:{SessionId} method {Method}", sessionIdStr, streamEvent.Type);
         var enrichedEvent = streamEvent with { SessionId = typedSessionId };

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -172,16 +172,17 @@ public sealed class TelegramChannelAdapter(
     }
 
     /// <inheritdoc />
-    public override async Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    public override async Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         EnsureBotsInitialized();
-        if (string.IsNullOrEmpty(delta) || !TelegramChannelAddress.TryDecode(ChannelAddress.From(conversationId), out var chatId, out var messageThreadId))
+        if (string.IsNullOrEmpty(delta) || !TelegramChannelAddress.TryDecode(target.ChannelAddress, out var chatId, out var messageThreadId))
             return;
 
         var runtime = ResolveSingleConfiguredBot();
         EnsureChatAllowed(runtime.Config, chatId);
-        var state = runtime.StreamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId, messageThreadId));
+        var stateKey = target.ChannelAddress.Value;
+        var state = runtime.StreamingStates.GetOrAdd(stateKey, _ => new StreamingState(chatId, messageThreadId));
 
         await state.Lock.WaitAsync(cancellationToken);
         try
@@ -200,16 +201,17 @@ public sealed class TelegramChannelAdapter(
     }
 
     /// <inheritdoc />
-    public async Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
+    public async Task SendStreamEventAsync(ChannelStreamTarget target, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         EnsureBotsInitialized();
-        if (!TelegramChannelAddress.TryDecode(ChannelAddress.From(conversationId), out var chatId, out var messageThreadId))
+        if (!TelegramChannelAddress.TryDecode(target.ChannelAddress, out var chatId, out var messageThreadId))
             return;
 
         var runtime = ResolveSingleConfiguredBot();
         EnsureChatAllowed(runtime.Config, chatId);
-        var state = runtime.StreamingStates.GetOrAdd(conversationId, _ => new StreamingState(chatId, messageThreadId));
+        var stateKey = target.ChannelAddress.Value;
+        var state = runtime.StreamingStates.GetOrAdd(stateKey, _ => new StreamingState(chatId, messageThreadId));
 
         await state.Lock.WaitAsync(cancellationToken);
         try

--- a/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
@@ -97,11 +97,11 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
     /// <summary>
     /// Sends a streaming delta to the terminal without appending a newline.
     /// </summary>
-    /// <param name="conversationId">Target conversation identifier.</param>
+    /// <param name="target">Typed stream target — TUI uses <c>target.SessionId</c> only as a display label.</param>
     /// <param name="delta">Streaming text delta.</param>
     /// <param name="cancellationToken">Cancellation token for send operations.</param>
     /// <returns>A task that completes when the delta has been written.</returns>
-    public override Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    public override Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -116,29 +116,30 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
     /// <summary>
     /// Sends a structured stream event to the terminal.
     /// </summary>
-    /// <param name="conversationId">Target conversation identifier.</param>
+    /// <param name="target">Typed stream target — TUI uses <c>target.SessionId</c> only as a display label.</param>
     /// <param name="streamEvent">Structured stream event payload.</param>
     /// <param name="cancellationToken">Cancellation token for send operations.</param>
     /// <returns>A task that completes when the event has been rendered.</returns>
     public Task SendStreamEventAsync(
-        string conversationId,
+        ChannelStreamTarget target,
         AgentStreamEvent streamEvent,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var label = target.SessionId.Value;
         return streamEvent.Type switch
         {
             AgentStreamEventType.ContentDelta when streamEvent.ContentDelta is not null
-                => SendStreamDeltaAsync(conversationId, streamEvent.ContentDelta, cancellationToken),
+                => SendStreamDeltaAsync(target, streamEvent.ContentDelta, cancellationToken),
             AgentStreamEventType.ThinkingDelta when streamEvent.ThinkingContent is not null
                 => Console.Out.WriteAsync($"\n💭 {streamEvent.ThinkingContent}"),
             AgentStreamEventType.ToolStart when streamEvent.ToolName is not null
-                => Console.Out.WriteLineAsync($"\n🔧 [{DisplayName}:{conversationId}] Tool start: {streamEvent.ToolName}"),
+                => Console.Out.WriteLineAsync($"\n🔧 [{DisplayName}:{label}] Tool start: {streamEvent.ToolName}"),
             AgentStreamEventType.ToolEnd
-                => Console.Out.WriteLineAsync($"\n✅ [{DisplayName}:{conversationId}] Tool complete: {streamEvent.ToolCallId ?? "unknown"}"),
+                => Console.Out.WriteLineAsync($"\n✅ [{DisplayName}:{label}] Tool complete: {streamEvent.ToolCallId ?? "unknown"}"),
             AgentStreamEventType.Error when streamEvent.ErrorMessage is not null
-                => Console.Out.WriteLineAsync($"\n❌ [{DisplayName}:{conversationId}] {streamEvent.ErrorMessage}"),
+                => Console.Out.WriteLineAsync($"\n❌ [{DisplayName}:{label}] {streamEvent.ErrorMessage}"),
             _ => Task.CompletedTask
         };
     }

--- a/src/gateway/BotNexus.Gateway.Channels/ChannelAdapterBase.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/ChannelAdapterBase.cs
@@ -86,7 +86,7 @@ public abstract class ChannelAdapterBase : IChannelAdapter
     public abstract Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default);
 
     /// <inheritdoc />
-    public virtual Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    public virtual Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway.Channels/README.md
+++ b/src/gateway/BotNexus.Gateway.Channels/README.md
@@ -43,9 +43,11 @@ public sealed class DiscordChannelAdapter(ILogger<DiscordChannelAdapter> logger)
     }
 
     public override async Task SendStreamDeltaAsync(
-        string conversationId, string delta, CancellationToken cancellationToken = default)
+        ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
     {
-        // Edit the last message to append the delta (Discord supports message editing)
+        // Edit the last message to append the delta (Discord supports message editing).
+        // Use target.ChannelAddress for the chat lookup; target.SessionId is available
+        // if your channel needs to disambiguate concurrent sessions on the same chat.
     }
 }
 ```

--- a/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Channels/IChannelAdapter.cs
@@ -86,10 +86,15 @@ public interface IChannelAdapter
     /// Sends a streaming delta to a conversation on this channel.
     /// Only called if <see cref="SupportsStreaming"/> is <c>true</c>.
     /// </summary>
-    /// <param name="conversationId">The target conversation.</param>
+    /// <param name="target">
+    /// Typed routing target identifying the session, channel address, and originating
+    /// binding for this stream. Each adapter consumes the field that matches its
+    /// routing semantics — see <see cref="ChannelStreamTarget"/> for the per-channel
+    /// contract.
+    /// </param>
     /// <param name="delta">The incremental content.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default);
+    Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -114,5 +119,12 @@ public interface IStreamEventChannelAdapter
     /// <summary>
     /// Sends a structured stream event to a target conversation.
     /// </summary>
-    Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default);
+    /// <param name="target">
+    /// Typed routing target identifying the session, channel address, and originating
+    /// binding for this stream. See <see cref="ChannelStreamTarget"/> for the
+    /// per-channel contract.
+    /// </param>
+    /// <param name="streamEvent">The stream event to deliver.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SendStreamEventAsync(ChannelStreamTarget target, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Channels/InternalChannelAdapter.cs
+++ b/src/gateway/BotNexus.Gateway/Channels/InternalChannelAdapter.cs
@@ -55,13 +55,13 @@ public sealed class InternalChannelAdapter : ChannelAdapterBase, IStreamEventCha
         await targetAdapter.SendAsync(remapped, cancellationToken);
     }
 
-    public override async Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    public override async Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
     {
-        var targetAdapter = await ResolveTargetAdapterForConversationAsync(conversationId, cancellationToken);
+        var targetAdapter = await ResolveTargetAdapterForSessionAsync(target.SessionId, cancellationToken);
         if (targetAdapter is null)
             return;
 
-        await targetAdapter.SendStreamDeltaAsync(conversationId, delta, cancellationToken);
+        await targetAdapter.SendStreamDeltaAsync(target, delta, cancellationToken);
     }
 
     /// <summary>
@@ -69,34 +69,34 @@ public sealed class InternalChannelAdapter : ChannelAdapterBase, IStreamEventCha
     /// lifecycle events (start/end, thinking, and tool notifications) are preserved when parent agents are resumed.
     /// If the target channel only supports plain deltas, content events degrade gracefully to delta forwarding.
     /// </summary>
-    /// <param name="conversationId">The target conversation or session identifier.</param>
+    /// <param name="target">Typed stream target — the parent session and its originating address.</param>
     /// <param name="streamEvent">The structured stream event to deliver to the resolved channel.</param>
     /// <param name="cancellationToken">Cancellation token for the async send operation.</param>
     public async Task SendStreamEventAsync(
-        string conversationId,
+        ChannelStreamTarget target,
         AgentStreamEvent streamEvent,
         CancellationToken cancellationToken = default)
     {
-        var targetAdapter = await ResolveTargetAdapterForConversationAsync(conversationId, cancellationToken);
+        var targetAdapter = await ResolveTargetAdapterForSessionAsync(target.SessionId, cancellationToken);
         if (targetAdapter is null)
         {
             Logger.LogWarning(
-                "Internal adapter: no target channel resolved for conversation '{ConversationId}'. Stream event '{EventType}' was not delivered.",
-                conversationId,
+                "Internal adapter: no target channel resolved for session '{SessionId}'. Stream event '{EventType}' was not delivered.",
+                target.SessionId,
                 streamEvent.Type);
             return;
         }
 
         if (targetAdapter is IStreamEventChannelAdapter streamTarget)
         {
-            await streamTarget.SendStreamEventAsync(conversationId, streamEvent, cancellationToken);
+            await streamTarget.SendStreamEventAsync(target, streamEvent, cancellationToken);
             return;
         }
 
         if (streamEvent.Type == AgentStreamEventType.ContentDelta
             && streamEvent.ContentDelta is not null)
         {
-            await targetAdapter.SendStreamDeltaAsync(conversationId, streamEvent.ContentDelta, cancellationToken);
+            await targetAdapter.SendStreamDeltaAsync(target, streamEvent.ContentDelta, cancellationToken);
         }
     }
 
@@ -128,24 +128,21 @@ public sealed class InternalChannelAdapter : ChannelAdapterBase, IStreamEventCha
         return null;
     }
 
-    private async Task<IChannelAdapter?> ResolveTargetAdapterForConversationAsync(string conversationId, CancellationToken cancellationToken)
+    private async Task<IChannelAdapter?> ResolveTargetAdapterForSessionAsync(SessionId sessionId, CancellationToken cancellationToken)
     {
-        if (!string.IsNullOrWhiteSpace(conversationId))
+        try
         {
-            try
+            var session = await _sessionStore.GetAsync(sessionId, cancellationToken);
+            if (session?.ChannelType is { } channelType)
             {
-                var session = await _sessionStore.GetAsync(SessionId.From(conversationId), cancellationToken);
-                if (session?.ChannelType is { } channelType)
-                {
-                    var adapter = GetChannelManager().Get(channelType);
-                    if (adapter is not null && !adapter.ChannelType.Equals(ChannelType))
-                        return adapter;
-                }
+                var adapter = GetChannelManager().Get(channelType);
+                if (adapter is not null && !adapter.ChannelType.Equals(ChannelType))
+                    return adapter;
             }
-            catch
-            {
-                // Best effort — fall through to signalr.
-            }
+        }
+        catch
+        {
+            // Best effort — fall through to signalr.
         }
 
         var fallback = GetChannelManager().Get(ChannelKey.From("signalr"));

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -538,7 +538,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                     // When the originating channel is not SignalR (e.g. Telegram), any SignalR
                     // bindings on the conversation receive stream events so connected web
                     // clients update in real-time without a page reload.
-                    IReadOnlyList<(IStreamEventChannelAdapter Adapter, string SessionAddress)> signalRObservers = [];
+                    IReadOnlyList<(IStreamEventChannelAdapter Adapter, ChannelStreamTarget Target)> signalRObservers = [];
                     if (_conversationRouter is not null && message.ChannelType.Value != "signalr")
                     {
                         try
@@ -553,7 +553,11 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                                 .Select(b =>
                                 {
                                     var adapter = ResolveChannelAdapter(b.ChannelType) as IStreamEventChannelAdapter;
-                                    return (Adapter: adapter!, Address: b.ChannelAddress.Value);
+                                    var observerTarget = new ChannelStreamTarget(
+                                        Domain.Primitives.SessionId.From(sessionId),
+                                        b.ChannelAddress,
+                                        b.BindingId);
+                                    return (Adapter: adapter!, Target: observerTarget);
                                 })
                                 .Where(x => x.Adapter is not null)
                                 .ToList();
@@ -583,11 +587,13 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                                     }
                                     : evt;
 
-                                // Build the conversationId that the channel adapter uses to
-                                // route the stream. The address is opaque to the gateway —
-                                // adapters encode native sub-addresses (e.g. Telegram forum
-                                // topics) into it themselves.
-                                var streamConversationId = message.ChannelAddress.Value;
+                                // Build the typed stream target the channel adapter uses to
+                                // route this delta or event. Each adapter consumes the field
+                                // that matches its routing semantics — see ChannelStreamTarget.
+                                var streamTarget = new ChannelStreamTarget(
+                                    Domain.Primitives.SessionId.From(sessionId),
+                                    message.ChannelAddress,
+                                    message.BindingId);
 
                                 if (enriched.Type == AgentStreamEventType.UserInputRequired)
                                 {
@@ -601,22 +607,22 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
                                 }
 
                                 if (channel is IStreamEventChannelAdapter streamEventChannel)
-                                    await streamEventChannel.SendStreamEventAsync(streamConversationId, enriched, ct);
+                                    await streamEventChannel.SendStreamEventAsync(streamTarget, enriched, ct);
                                 else if (evt.Type == AgentStreamEventType.ContentDelta && evt.ContentDelta is not null)
-                                    await channel.SendStreamDeltaAsync(streamConversationId, evt.ContentDelta, ct);
+                                    await channel.SendStreamDeltaAsync(streamTarget, evt.ContentDelta, ct);
 
                                 // Fan-out stream events to SignalR observer bindings (#332).
-                                // Each observer gets the event keyed by its own channel address
-                                // (SignalR connection/session ID) so the portal can route it correctly.
-                                foreach (var (observerAdapter, observerAddress) in signalRObservers)
+                                // Each observer gets the event keyed by its own typed target so the
+                                // portal can route it correctly and exclude its own originating binding.
+                                foreach (var (observerAdapter, observerTarget) in signalRObservers)
                                 {
                                     try
                                     {
-                                        await observerAdapter.SendStreamEventAsync(observerAddress, enriched, ct);
+                                        await observerAdapter.SendStreamEventAsync(observerTarget, enriched, ct);
                                     }
                                     catch (Exception ex)
                                     {
-                                        _logger.LogWarning(ex, "SignalR observer fan-out failed for address {Address}. Skipping.", observerAddress);
+                                        _logger.LogWarning(ex, "SignalR observer fan-out failed for address {Address}. Skipping.", observerTarget.ChannelAddress);
                                     }
                                 }
                             }),
@@ -913,10 +919,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
         CancellationToken cancellationToken)
     {
         var request = streamEvent.UserInputRequest;
-        var sourceConversationId = message.ChannelAddress.Value;
 
         if (ResolveChannelAdapter(message.ChannelType) is { } sourceAdapter)
-            await SendAskUserToBindingAsync(sourceAdapter, sourceConversationId, source, sessionId, streamEvent, request, cancellationToken);
+            await SendAskUserToBindingAsync(sourceAdapter, source, sessionId, streamEvent, request, cancellationToken);
 
         if (_conversationRouter is null)
             return;
@@ -932,20 +937,18 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
             if (adapter is null)
                 continue;
 
-            var bindingConversationId = binding.ChannelAddress.Value;
             var bindingSource = new ChannelSource(
                 binding.ChannelType,
                 binding.ChannelAddress,
                 message.SenderId,
                 binding.BindingId,
                 binding.DisplayPrefix);
-            await SendAskUserToBindingAsync(adapter, bindingConversationId, bindingSource, sessionId, streamEvent, request, cancellationToken);
+            await SendAskUserToBindingAsync(adapter, bindingSource, sessionId, streamEvent, request, cancellationToken);
         }
     }
 
     private static async Task SendAskUserToBindingAsync(
         IChannelAdapter adapter,
-        string conversationId,
         ChannelSource source,
         string sessionId,
         AgentStreamEvent streamEvent,
@@ -954,7 +957,11 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IAsyncD
     {
         if (adapter is IStreamEventChannelAdapter streamAdapter)
         {
-            await streamAdapter.SendStreamEventAsync(conversationId, streamEvent, cancellationToken);
+            var target = new ChannelStreamTarget(
+                SessionId.From(sessionId),
+                source.ChannelAddress,
+                source.BindingId);
+            await streamAdapter.SendStreamEventAsync(target, streamEvent, cancellationToken);
             return;
         }
 

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -94,9 +94,16 @@ public interface IChannelAdapter
     Task StartAsync(IChannelDispatcher dispatcher, CancellationToken cancellationToken = default);
     Task StopAsync(CancellationToken cancellationToken = default);
     Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default);
-    Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default);
+    Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default);
 }
 ```
+
+`ChannelStreamTarget` is a typed record (`SessionId`, `ChannelAddress`, optional `BindingId`) that mirrors the addressing fields on `OutboundMessage`. Each adapter consumes whichever field matches its native routing model:
+
+- **SignalR** keys outbound by `target.SessionId` (clients are grouped per session)
+- **Telegram** keys by `target.ChannelAddress` (chat id, optionally with a `/topic:NN` suffix)
+- **TUI** uses `target.SessionId` purely as a display label
+- **InternalChannelAdapter** resolves the parent's originating adapter via `target.SessionId`
 
 #### Channel Capability Flags
 

--- a/tests/architecture/BotNexus.Architecture.Tests/ChannelStreamTargetArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ChannelStreamTargetArchitectureTests.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using System.Reflection;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fence pinning the typed <see cref="ChannelStreamTarget"/> contract on the
+/// streaming surface of <see cref="IChannelAdapter"/> and <see cref="IStreamEventChannelAdapter"/>
+/// (PR #677). Previously these methods accepted a loosely-typed <c>string conversationId</c>
+/// that meant different things per adapter (SessionId for SignalR, ChannelAddress for Telegram,
+/// ignored for TUI). The typed record removes the ambiguity. This fence prevents a future
+/// refactor from silently reintroducing a string-based overload alongside the typed one.
+/// </summary>
+public sealed class ChannelStreamTargetArchitectureTests
+{
+    [Fact]
+    public void IChannelAdapter_SendStreamDeltaAsync_FirstParameter_IsChannelStreamTarget()
+    {
+        var method = typeof(IChannelAdapter).GetMethod(nameof(IChannelAdapter.SendStreamDeltaAsync))
+            ?? throw new InvalidOperationException("IChannelAdapter.SendStreamDeltaAsync not found");
+
+        var firstParam = method.GetParameters().FirstOrDefault()
+            ?? throw new InvalidOperationException("SendStreamDeltaAsync has no parameters");
+
+        firstParam.ParameterType.ShouldBe(typeof(ChannelStreamTarget),
+            "SendStreamDeltaAsync must take the typed ChannelStreamTarget as its first parameter — never a raw string. " +
+            "Mixing string and typed overloads brings back the per-adapter routing ambiguity PR #677 removed.");
+    }
+
+    [Fact]
+    public void IStreamEventChannelAdapter_SendStreamEventAsync_FirstParameter_IsChannelStreamTarget()
+    {
+        var method = typeof(IStreamEventChannelAdapter).GetMethod(nameof(IStreamEventChannelAdapter.SendStreamEventAsync))
+            ?? throw new InvalidOperationException("IStreamEventChannelAdapter.SendStreamEventAsync not found");
+
+        var firstParam = method.GetParameters().FirstOrDefault()
+            ?? throw new InvalidOperationException("SendStreamEventAsync has no parameters");
+
+        firstParam.ParameterType.ShouldBe(typeof(ChannelStreamTarget),
+            "SendStreamEventAsync must take the typed ChannelStreamTarget as its first parameter — never a raw string. " +
+            "Mixing string and typed overloads brings back the per-adapter routing ambiguity PR #677 removed.");
+    }
+
+    [Fact]
+    public void IChannelAdapter_DoesNotExposeStringConversationIdOverloads_OnStreamingMethods()
+    {
+        var streamMethods = typeof(IChannelAdapter).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.Name == nameof(IChannelAdapter.SendStreamDeltaAsync))
+            .ToList();
+
+        streamMethods.Count.ShouldBe(1,
+            "IChannelAdapter must expose exactly one SendStreamDeltaAsync method — adding a string-based overload would " +
+            "reintroduce the routing-ambiguity bug PR #677 fixed.");
+
+        var firstParamType = streamMethods[0].GetParameters()[0].ParameterType;
+        firstParamType.ShouldNotBe(typeof(string),
+            "SendStreamDeltaAsync must not take a raw string as its first parameter.");
+    }
+
+    [Fact]
+    public void IStreamEventChannelAdapter_DoesNotExposeStringConversationIdOverloads_OnStreamingMethods()
+    {
+        var streamMethods = typeof(IStreamEventChannelAdapter).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.Name == nameof(IStreamEventChannelAdapter.SendStreamEventAsync))
+            .ToList();
+
+        streamMethods.Count.ShouldBe(1,
+            "IStreamEventChannelAdapter must expose exactly one SendStreamEventAsync method — adding a string-based overload would " +
+            "reintroduce the routing-ambiguity bug PR #677 fixed.");
+
+        var firstParamType = streamMethods[0].GetParameters()[0].ParameterType;
+        firstParamType.ShouldNotBe(typeof(string),
+            "SendStreamEventAsync must not take a raw string as its first parameter.");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/GatewayHostBindingRoutingTests.cs
@@ -165,8 +165,8 @@ public sealed class GatewayHostBindingRoutingTests
         channel.SetupGet(c => c.ChannelType).Returns(ChannelKey.From("telegram"));
         channel.SetupGet(c => c.DisplayName).Returns("telegram");
         channel.SetupGet(c => c.SupportsStreaming).Returns(true);
-        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<string, string, CancellationToken>((cid, _, _) => capturedStreamConversationIds.Add(cid))
+        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<ChannelStreamTarget, string, CancellationToken>((target, _, _) => capturedStreamConversationIds.Add(target.ChannelAddress.Value))
             .Returns(Task.CompletedTask);
 
         await using var host = CreateHost(supervisor.Object, sessions, convRouter.Object, CreateChannelManager(channel.Object));
@@ -182,11 +182,11 @@ public sealed class GatewayHostBindingRoutingTests
         });
 
         capturedStreamConversationIds.ShouldNotBeEmpty("SendStreamDeltaAsync must be called");
-        // The conversationId is the composite ChannelAddress verbatim — adapters fold the
-        // topic suffix into it themselves before the gateway ever sees it.
+        // The ChannelAddress on the stream target is the composite ChannelAddress verbatim —
+        // adapters fold the topic suffix into it themselves before the gateway ever sees it.
         capturedStreamConversationIds.ShouldAllBe(
             cid => cid == "chat-200/topic:99",
-            "Streaming conversationId must be the composite ChannelAddress so the adapter can route to the correct topic");
+            "Streaming target's ChannelAddress must be the composite address so the adapter can route to the correct topic");
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -281,7 +281,7 @@ public sealed class GatewayHostBindingRoutingTests
         channel.SetupGet(c => c.DisplayName).Returns(channelType);
         channel.SetupGet(c => c.SupportsStreaming).Returns(supportsStreaming);
         channel.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         return channel;
     }
 

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/MultiChannelFanOutTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/MultiChannelFanOutTests.cs
@@ -385,7 +385,7 @@ public sealed class MultiChannelFanOutTests
         adapter.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>()))
             .Callback<OutboundMessage, CancellationToken>((m, _) => messages.Add(m))
             .Returns(Task.CompletedTask);
-        adapter.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        adapter.Setup(c => c.SendStreamDeltaAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         return new ChannelRecorder(adapter, messages);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentCompletionWakeDeliveryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentCompletionWakeDeliveryTests.cs
@@ -11,6 +11,8 @@ using BotNexus.Gateway.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
+using BotNexus.Gateway.Tests;
+
 namespace BotNexus.Gateway.Tests.Agents;
 
 public sealed class SubAgentCompletionWakeDeliveryTests
@@ -34,7 +36,7 @@ public sealed class SubAgentCompletionWakeDeliveryTests
         targetAdapter.SetupGet(a => a.SupportsStreaming).Returns(true);
         var targetStreamAdapter = targetAdapter.As<IStreamEventChannelAdapter>();
         targetStreamAdapter
-            .Setup(a => a.SendStreamEventAsync("parent-session", It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Setup(a => a.SendStreamEventAsync(StreamTargets.For("parent-session"), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var channelManager = new Mock<IChannelManager>();
@@ -47,14 +49,12 @@ public sealed class SubAgentCompletionWakeDeliveryTests
 
         streamAdapter.ShouldNotBeNull();
 
-        await streamAdapter!.SendStreamEventAsync(
-            "parent-session",
+        await streamAdapter!.SendStreamEventAsync(StreamTargets.For("parent-session"),
             new AgentStreamEvent { Type = AgentStreamEventType.MessageStart },
             CancellationToken.None);
 
         targetStreamAdapter.Verify(
-            a => a.SendStreamEventAsync(
-                "parent-session",
+            a => a.SendStreamEventAsync(StreamTargets.For("parent-session"),
                 It.Is<AgentStreamEvent>(e => e.Type == AgentStreamEventType.MessageStart),
                 CancellationToken.None),
             Times.Once);

--- a/tests/gateway/BotNexus.Gateway.Tests/ChannelManagerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ChannelManagerTests.cs
@@ -119,6 +119,6 @@ public sealed class ChannelManagerTests
         public Task StartAsync(IChannelDispatcher dispatcher, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/InternalChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/InternalChannelAdapterTests.cs
@@ -6,6 +6,8 @@ using BotNexus.Domain.Primitives;
 using Microsoft.Extensions.Logging;
 using Moq;
 
+using BotNexus.Gateway.Tests;
+
 namespace BotNexus.Gateway.Tests.Channels;
 
 public sealed class InternalChannelAdapterTests
@@ -168,7 +170,7 @@ public sealed class InternalChannelAdapterTests
 
         var signalrAdapter = new Mock<IChannelAdapter>();
         signalrAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("signalr"));
-        signalrAdapter.Setup(a => a.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        signalrAdapter.Setup(a => a.SendStreamDeltaAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var channelManager = new Mock<IChannelManager>();
@@ -176,9 +178,64 @@ public sealed class InternalChannelAdapterTests
 
         var sut = CreateAdapter(channelManager.Object, sessionStore.Object);
 
-        await sut.SendStreamDeltaAsync("session-1", "delta-text", CancellationToken.None);
+        await sut.SendStreamDeltaAsync(StreamTargets.For("session-1"), "delta-text", CancellationToken.None);
 
-        signalrAdapter.Verify(a => a.SendStreamDeltaAsync("session-1", "delta-text", CancellationToken.None), Times.Once);
+        signalrAdapter.Verify(a => a.SendStreamDeltaAsync(StreamTargets.For("session-1"), "delta-text", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendStreamEventAsync_ResolvesByTypedSessionId_AndRoutesToParentsNonSignalRChannel()
+    {
+        // Behaviour fix introduced with ChannelStreamTarget (#677): the resolver now uses the
+        // typed SessionId from the stream target instead of trying to parse the previous
+        // string "conversationId" parameter (which was actually a ChannelAddress). The old code
+        // silently fell through to the SignalR fallback for any non-SignalR parent session,
+        // so a sub-agent wake-up event for a Telegram-rooted session would have been
+        // misdelivered to SignalR. This test pins the correct typed-resolution behaviour.
+        var parentSession = SessionId.From("parent-session-telegram");
+        var sessionStore = new Mock<ISessionStore>();
+        sessionStore.Setup(s => s.GetAsync(parentSession, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GatewaySession
+            {
+                SessionId = parentSession,
+                AgentId = AgentId.From("agent-a"),
+                ChannelType = ChannelKey.From("telegram")
+            });
+
+        var telegramAdapter = new Mock<IChannelAdapter>();
+        telegramAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("telegram"));
+        var telegramStream = telegramAdapter.As<IStreamEventChannelAdapter>();
+        telegramStream.Setup(a => a.SendStreamEventAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // SignalR fallback adapter — it must NOT be called for a Telegram-rooted parent session.
+        var signalrAdapter = new Mock<IChannelAdapter>();
+        signalrAdapter.SetupGet(a => a.ChannelType).Returns(ChannelKey.From("signalr"));
+        var signalrStream = signalrAdapter.As<IStreamEventChannelAdapter>();
+        signalrStream.Setup(a => a.SendStreamEventAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var channelManager = new Mock<IChannelManager>();
+        channelManager.Setup(m => m.Get(ChannelKey.From("telegram"))).Returns(telegramAdapter.Object);
+        channelManager.Setup(m => m.Get(ChannelKey.From("signalr"))).Returns(signalrAdapter.Object);
+
+        var sut = CreateAdapter(channelManager.Object, sessionStore.Object);
+        var target = new ChannelStreamTarget(
+            parentSession,
+            ChannelAddress.From("telegram-chat-99"),
+            null);
+        var wakeEvent = new AgentStreamEvent { Type = AgentStreamEventType.MessageStart };
+
+        await sut.SendStreamEventAsync(target, wakeEvent, CancellationToken.None);
+
+        telegramStream.Verify(
+            a => a.SendStreamEventAsync(target, wakeEvent, CancellationToken.None),
+            Times.Once,
+            "wake-up stream event must be delivered to the parent's true channel (Telegram), not the SignalR fallback");
+        signalrStream.Verify(
+            a => a.SendStreamEventAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "SignalR fallback must not receive the event when the parent session has a non-SignalR channel");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramChannelAdapterTests.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 
+using BotNexus.Gateway.Tests;
+
 namespace BotNexus.Gateway.Tests.Channels;
 
 public sealed class TelegramChannelAdapterTests
@@ -315,9 +317,9 @@ public sealed class TelegramChannelAdapterTests
             StreamingBufferMs = 60000
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('a', 101) });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('b', 101) });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('a', 101) });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('b', 101) });
 
         calls.Count(c => c.MethodName == "sendMessage").ShouldBe(1);
         calls.Count(c => c.MethodName == "editMessageText").ShouldBeGreaterThan(0);
@@ -358,8 +360,8 @@ public sealed class TelegramChannelAdapterTests
         // Composite address — adapter must decode "/topic:42" and route the initial
         // streaming sendMessage to the originating forum topic.
         const string compositeAddress = "42/topic:42";
-        await adapter.SendStreamEventAsync(compositeAddress, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
-        await adapter.SendStreamEventAsync(compositeAddress, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('x', 101) });
+        await adapter.SendStreamEventAsync(StreamTargets.For(compositeAddress), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For(compositeAddress), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = new string('x', 101) });
 
         var firstSend = calls.FirstOrDefault(c => c.MethodName == "sendMessage");
         firstSend.ShouldNotBeNull("streaming flow must issue exactly one initial sendMessage");
@@ -393,7 +395,7 @@ public sealed class TelegramChannelAdapterTests
         }, handler);
 
         // Send a delta large enough to cross the flush threshold and force a sendMessage.
-        await adapter.SendStreamDeltaAsync("42/topic:67", new string('y', 200));
+        await adapter.SendStreamDeltaAsync(StreamTargets.For("42/topic:67"), new string('y', 200));
 
         var firstSend = calls.FirstOrDefault(c => c.MethodName == "sendMessage");
         firstSend.ShouldNotBeNull();
@@ -605,10 +607,10 @@ public sealed class TelegramChannelAdapterTests
             StreamingBufferMs = 60_000
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "first" });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "second" });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "first" });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "second" });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCalls.Count.ShouldBe(1);
         sendCalls[0].Text.ShouldNotBeNull();
@@ -1614,9 +1616,9 @@ public sealed class TelegramChannelAdapterTests
             StreamingBufferMs = 60_000 // prevent time-based flush during test
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "**hello**" });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "**hello**" });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCall.ShouldNotBeNull();
         // Raw markdown **hello** must be converted to MarkdownV2 *hello* at flush time.
@@ -1646,11 +1648,11 @@ public sealed class TelegramChannelAdapterTests
             StreamingBufferMs = 60_000 // prevent time-based flush; only flush at MessageEnd
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
         // Simulate streaming where **bold** arrives split across two deltas
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "**bol" });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "d**" });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "**bol" });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "d**" });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCall.ShouldNotBeNull();
         var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
@@ -1677,7 +1679,7 @@ public sealed class TelegramChannelAdapterTests
         // Send 100 chars of markdown — this hits the StreamingFlushThresholdChars (100) and triggers flush.
         var boldContent = new string('x', 96);
         var delta = $"**{boldContent}**"; // 100 chars total: 2 + 96 + 2
-        await adapter.SendStreamDeltaAsync("42", delta);
+        await adapter.SendStreamDeltaAsync(StreamTargets.For("42"), delta);
 
         sendCall.ShouldNotBeNull();
         // The raw ** must be converted to * (Telegram bold) at flush time, not escaped as \*.
@@ -1708,9 +1710,9 @@ public sealed class TelegramChannelAdapterTests
             StreamingBufferMs = 60_000
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolName = "memory_save" });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolName = "memory_save" });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCall.ShouldNotBeNull();
         var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
@@ -1737,14 +1739,14 @@ public sealed class TelegramChannelAdapterTests
             StreamingBufferMs = 60_000
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ToolEnd,
             ToolName = "read_file",
             ToolIsError = true
         });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCall.ShouldNotBeNull();
         var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");
@@ -1772,13 +1774,13 @@ public sealed class TelegramChannelAdapterTests
             ErrorCooldownMs = 0
         }, handler);
 
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageStart });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent
         {
             Type = AgentStreamEventType.Error,
             ErrorMessage = "Connection failed. Retry 1/3"
         });
-        await adapter.SendStreamEventAsync("42", new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
+        await adapter.SendStreamEventAsync(StreamTargets.For("42"), new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd });
 
         sendCall.ShouldNotBeNull();
         var text = sendCall!.Text ?? throw new InvalidOperationException("Expected message text.");

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -85,8 +85,20 @@ public sealed class GatewayHostTests
         await host.DispatchAsync(CreateMessage("hello", sessionId: "session-1"));
 
         session.History.ShouldContain(e => e.Role == MessageRole.Assistant && e.Content == "hello world");
-        channel.Verify(c => c.SendStreamDeltaAsync("conv-1", "hello ", It.IsAny<CancellationToken>()), Times.Once);
-        channel.Verify(c => c.SendStreamDeltaAsync("conv-1", "world", It.IsAny<CancellationToken>()), Times.Once);
+        channel.Verify(c => c.SendStreamDeltaAsync(
+            It.Is<ChannelStreamTarget>(t =>
+                t.SessionId == SessionId.From("session-1") &&
+                t.ChannelAddress == ChannelAddress.From("conv-1")),
+            "hello ",
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        channel.Verify(c => c.SendStreamDeltaAsync(
+            It.Is<ChannelStreamTarget>(t =>
+                t.SessionId == SessionId.From("session-1") &&
+                t.ChannelAddress == ChannelAddress.From("conv-1")),
+            "world",
+            It.IsAny<CancellationToken>()),
+            Times.Once);
         // Write-ahead (user msg + sentinel) + ProcessAndSaveAsync final = at least 3 saves
         sessions.Verify(s => s.SaveAsync(session, It.IsAny<CancellationToken>()), Times.AtLeast(1));
     }
@@ -1543,7 +1555,7 @@ public sealed class GatewayHostTests
         channel.SetupGet(c => c.DisplayName).Returns(channelType);
         channel.SetupGet(c => c.SupportsStreaming).Returns(supportsStreaming);
         channel.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        channel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         return channel;
     }
 
@@ -1814,10 +1826,10 @@ public sealed class GatewayHostTests
         telegramChannel.SetupGet(c => c.DisplayName).Returns("Telegram");
         telegramChannel.SetupGet(c => c.SupportsStreaming).Returns(true);
         telegramChannel.As<IStreamEventChannelAdapter>()
-            .Setup(c => c.SendStreamEventAsync(It.IsAny<string>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.SendStreamEventAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         telegramChannel.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        telegramChannel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        telegramChannel.Setup(c => c.SendStreamDeltaAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         // SignalR is an observer binding
         var signalrChannel = new Mock<IChannelAdapter>();
@@ -1825,7 +1837,7 @@ public sealed class GatewayHostTests
         signalrChannel.SetupGet(c => c.DisplayName).Returns("SignalR");
         signalrChannel.SetupGet(c => c.SupportsStreaming).Returns(true);
         signalrChannel.As<IStreamEventChannelAdapter>()
-            .Setup(c => c.SendStreamEventAsync(It.IsAny<string>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.SendStreamEventAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         signalrChannel.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -1877,22 +1889,31 @@ public sealed class GatewayHostTests
         var message = CreateMessage("hello", sessionId: "session-1", channelType: "telegram");
         await host.DispatchAsync(message);
 
-        // Assert: SignalR observer received stream events (3 events: MessageStart, ContentDelta, MessageEnd)
+        // Assert: SignalR observer received stream events (3 events: MessageStart, ContentDelta, MessageEnd).
+        // The stream target is built from the resolved session ID and the observer binding's
+        // ChannelAddress + BindingId — not the originating Telegram address. This is the
+        // typed-target contract introduced with ChannelStreamTarget (#677).
         signalrChannel.As<IStreamEventChannelAdapter>().Verify(
             c => c.SendStreamEventAsync(
-                "signalr-session-abc",
+                It.Is<ChannelStreamTarget>(t =>
+                    t.SessionId == SessionId.From("session-1") &&
+                    t.ChannelAddress == ChannelAddress.From("signalr-session-abc")),
                 It.Is<AgentStreamEvent>(e => e.Type == AgentStreamEventType.MessageStart),
                 It.IsAny<CancellationToken>()),
             Times.Once);
         signalrChannel.As<IStreamEventChannelAdapter>().Verify(
             c => c.SendStreamEventAsync(
-                "signalr-session-abc",
+                It.Is<ChannelStreamTarget>(t =>
+                    t.SessionId == SessionId.From("session-1") &&
+                    t.ChannelAddress == ChannelAddress.From("signalr-session-abc")),
                 It.Is<AgentStreamEvent>(e => e.Type == AgentStreamEventType.ContentDelta),
                 It.IsAny<CancellationToken>()),
             Times.Once);
         signalrChannel.As<IStreamEventChannelAdapter>().Verify(
             c => c.SendStreamEventAsync(
-                "signalr-session-abc",
+                It.Is<ChannelStreamTarget>(t =>
+                    t.SessionId == SessionId.From("session-1") &&
+                    t.ChannelAddress == ChannelAddress.From("signalr-session-abc")),
                 It.Is<AgentStreamEvent>(e => e.Type == AgentStreamEventType.MessageEnd),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -1927,7 +1948,7 @@ public sealed class GatewayHostTests
         signalrChannel.SetupGet(c => c.DisplayName).Returns("SignalR");
         signalrChannel.SetupGet(c => c.SupportsStreaming).Returns(true);
         signalrChannel.As<IStreamEventChannelAdapter>()
-            .Setup(c => c.SendStreamEventAsync(It.IsAny<string>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.SendStreamEventAsync(It.IsAny<ChannelStreamTarget>(), It.IsAny<AgentStreamEvent>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         signalrChannel.Setup(c => c.SendAsync(It.IsAny<OutboundMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
@@ -1974,7 +1995,7 @@ public sealed class GatewayHostTests
         // Since GetOutboundBindings returns [], no additional observer fan-out occurs.
         signalrChannel.As<IStreamEventChannelAdapter>().Verify(
             c => c.SendStreamEventAsync(
-                It.IsAny<string>(),
+                It.IsAny<ChannelStreamTarget>(),
                 It.IsAny<AgentStreamEvent>(),
                 It.IsAny<CancellationToken>()),
             Times.Once); // exactly once as the primary channel, not doubled via observer fan-out

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
@@ -433,7 +433,7 @@ public sealed class CopilotIntegrationTests
             return Task.CompletedTask;
         }
 
-        public Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+        public Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
         {
             StreamDeltas.Add(delta);
             return Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
@@ -353,7 +353,7 @@ public sealed class Phase5IntegrationTests
         public Task StartAsync(IChannelDispatcher dispatcher, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendAsync(OutboundMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+        public Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
         {
             StreamDeltas.Add(delta);
             return Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -26,6 +26,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
+using BotNexus.Gateway.Tests;
+
 namespace BotNexus.Gateway.Tests.Integration;
 
 [Trait("Category", "Integration")]
@@ -102,8 +104,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         });
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionA, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "all-a" }, cts.Token);
-        await adapter.SendStreamEventAsync(sessionB, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "all-b" }, cts.Token);
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionA), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "all-a" }, cts.Token);
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionB), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "all-b" }, cts.Token);
 
         (await eventA.Task.WaitAsync(cts.Token)).ContentDelta.ShouldBe("all-a");
         (await eventB.Task.WaitAsync(cts.Token)).ContentDelta.ShouldBe("all-b");
@@ -138,8 +140,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         });
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionTarget, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "target-only" }, cts.Token);
-        await adapter.SendStreamEventAsync(sessionOther, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "other-should-not-arrive" }, cts.Token);
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionTarget), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "target-only" }, cts.Token);
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionOther), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "other-should-not-arrive" }, cts.Token);
 
         (await targetReceived.Task.WaitAsync(cts.Token)).ContentDelta.ShouldBe("target-only");
         (await otherReceived.Task.WaitAsync(cts.Token)).ContentDelta.ShouldBe("other-should-not-arrive");
@@ -192,8 +194,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         });
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(joinedSession, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "legacy-join-event" }, cts.Token);
-        await adapter.SendStreamEventAsync(subscribedSession, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "subscribe-all-event" }, cts.Token);
+        await adapter.SendStreamEventAsync(StreamTargets.For(joinedSession), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "legacy-join-event" }, cts.Token);
+        await adapter.SendStreamEventAsync(StreamTargets.For(subscribedSession), new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "subscribe-all-event" }, cts.Token);
 
         (await joinedTcs.Task.WaitAsync(cts.Token)).ContentDelta.ShouldBe("legacy-join-event");
         (await subscribedTcs.Task.WaitAsync(cts.Token)).ContentDelta.ShouldBe("subscribe-all-event");
@@ -516,12 +518,12 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         });
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionA, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionA), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "event-a"
         }, cts.Token);
-        await adapter.SendStreamEventAsync(sessionB, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionB), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "event-b"
@@ -554,7 +556,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         using var __ = connectionB.On<AgentStreamEvent>("ContentDelta", payload => receivedB.TrySetResult(payload));
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionId, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionId), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "group-message"
@@ -699,7 +701,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         using var _ = connection.On<AgentStreamEvent>("ContentDelta", payload => deltaTcs.TrySetResult(payload));
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionId, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionId), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "delta-text"
@@ -730,7 +732,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         using var __ = connectionB.On<AgentStreamEvent>("ContentDelta", _ => bReceived = true);
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionA, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionA), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "session-a-only"
@@ -779,7 +781,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
         foreach (var type in Enum.GetValues<AgentStreamEventType>())
         {
-            await adapter.SendStreamEventAsync(sessionId, new AgentStreamEvent
+            await adapter.SendStreamEventAsync(StreamTargets.For(sessionId), new AgentStreamEvent
             {
                 Type = type,
                 ContentDelta = type == AgentStreamEventType.ContentDelta ? "delta" : null,

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
@@ -24,6 +24,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 
+using BotNexus.Gateway.Tests;
+
 namespace BotNexus.Gateway.Tests.Integration;
 
 /// <summary>
@@ -505,7 +507,7 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
         for (var i = 0; i < burstCount; i++)
         {
-            await adapter.SendStreamEventAsync(sessionId, new AgentStreamEvent
+            await adapter.SendStreamEventAsync(StreamTargets.For(sessionId), new AgentStreamEvent
             {
                 Type = AgentStreamEventType.ContentDelta,
                 ContentDelta = $"delta-{i:D2}"

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/SessionSwitchingTests.cs
@@ -21,6 +21,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
+using BotNexus.Gateway.Tests;
+
 namespace BotNexus.Gateway.Tests.Sessions;
 
 [Trait("Category", "Integration")]
@@ -56,7 +58,7 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
         });
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(oldSession, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(oldSession), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "old-session-event"
@@ -65,7 +67,7 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
         await Task.Delay(250, cts.Token);
         oldSessionEventReceived.ShouldBeFalse();
 
-        await adapter.SendStreamEventAsync(newSession, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(newSession), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "new-session-event"
@@ -89,7 +91,7 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
         using var _ = connection.On<AgentStreamEvent>("ContentDelta", payload => eventReceived.TrySetResult(payload));
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionId, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionId), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "new-group-event"
@@ -144,12 +146,12 @@ public sealed class SessionSwitchingTests : IAsyncDisposable
         using var ____ = connectionB.On<AgentStreamEvent>("ToolStart", _ => bReceived = true);
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
-        await adapter.SendStreamEventAsync(sessionA, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionA), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ContentDelta,
             ContentDelta = "session-a-delta"
         }, cts.Token);
-        await adapter.SendStreamEventAsync(sessionA, new AgentStreamEvent
+        await adapter.SendStreamEventAsync(StreamTargets.For(sessionA), new AgentStreamEvent
         {
             Type = AgentStreamEventType.ToolStart,
             ToolCallId = "tool-1",

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRChannelAdapterTests.cs
@@ -25,7 +25,7 @@ public sealed class SignalRChannelAdapterTests
         var adapter = new SignalRChannelAdapter(NullLogger<SignalRChannelAdapter>.Instance, hubContext.Object);
         var streamEvent = new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "delta" };
 
-        await adapter.SendStreamEventAsync("  session-1  ", streamEvent, CancellationToken.None);
+        await adapter.SendStreamEventAsync(StreamTargets.For("  session-1  "), streamEvent, CancellationToken.None);
 
         clients.Verify(value => value.Group("session:session-1"), Times.Once);
         clientProxy.Verify(proxy => proxy.ContentDelta(
@@ -62,7 +62,7 @@ public sealed class SignalRChannelAdapterTests
             }
         };
 
-        await adapter.SendStreamEventAsync("session-2", streamEvent, CancellationToken.None);
+        await adapter.SendStreamEventAsync(StreamTargets.For("session-2"), streamEvent, CancellationToken.None);
 
         clientProxy.Verify(proxy => proxy.UserInputRequired(
                 It.Is<AgentStreamEvent>(evt => evt.Type == AgentStreamEventType.UserInputRequired)),

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingPipelineTests.cs
@@ -124,7 +124,7 @@ public sealed class StreamingPipelineTests
         channel.SetupGet(c => c.ChannelType).Returns(ChannelKey.From("web"));
         channel.SetupGet(c => c.DisplayName).Returns("Web");
         channel.SetupGet(c => c.SupportsStreaming).Returns(true);
-        channel.Setup(c => c.SendStreamDeltaAsync("conv-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        channel.Setup(c => c.SendStreamDeltaAsync(StreamTargets.For("conv-1"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         return channel;
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/_TestUtilities/StreamTargets.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/_TestUtilities/StreamTargets.cs
@@ -1,0 +1,21 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Convenience factory for building <see cref="ChannelStreamTarget"/> instances in unit tests
+/// where the test does not care about distinguishing the SessionId and ChannelAddress fields.
+/// Production code should always construct <see cref="ChannelStreamTarget"/> explicitly with
+/// the correct typed values from the source <c>OutboundMessage</c> / <c>ChannelBinding</c>.
+/// </summary>
+internal static class StreamTargets
+{
+    /// <summary>
+    /// Builds a <see cref="ChannelStreamTarget"/> where the same string is used for both
+    /// the SessionId and the ChannelAddress. Use this in tests where the adapter under
+    /// test only consumes one of those fields and the test does not need to distinguish.
+    /// </summary>
+    public static ChannelStreamTarget For(string value) =>
+        new(SessionId.From(value), ChannelAddress.From(value), null);
+}

--- a/tests/scenarios/BotNexus.Scenarios.Harness/VirtualChannelAdapter.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Harness/VirtualChannelAdapter.cs
@@ -52,6 +52,7 @@ public sealed class VirtualChannelAdapter : ChannelAdapterBase, IChannelAdapter,
     private readonly ConcurrentQueue<InboundMessage> _inbound = new();
     private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _streamDeltas = new();
     private readonly ConcurrentDictionary<string, ConcurrentQueue<AgentStreamEvent>> _streamEvents = new();
+    private readonly ConcurrentQueue<ChannelStreamTarget> _streamTargets = new();
     private readonly VirtualChannelAdapterOptions _options;
     private int _dispatchCount;
 
@@ -114,13 +115,16 @@ public sealed class VirtualChannelAdapter : ChannelAdapterBase, IChannelAdapter,
     /// <summary>The total number of times <see cref="SimulateInboundAsync"/> reached the gateway dispatcher.</summary>
     public int InboundDispatchCount => Volatile.Read(ref _dispatchCount);
 
-    /// <summary>Stream deltas grouped by the channel-level conversation routing key the gateway used.</summary>
+    /// <summary>Stream deltas grouped by the channel-level routing key the gateway used (the target's <see cref="ChannelAddress"/>).</summary>
     public IReadOnlyDictionary<string, IReadOnlyList<string>> StreamDeltas
         => _streamDeltas.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<string>)kvp.Value.ToArray());
 
-    /// <summary>Structured stream events grouped by the channel-level conversation routing key the gateway used.</summary>
+    /// <summary>Structured stream events grouped by the channel-level routing key the gateway used (the target's <see cref="ChannelAddress"/>).</summary>
     public IReadOnlyDictionary<string, IReadOnlyList<AgentStreamEvent>> StreamEvents
         => _streamEvents.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<AgentStreamEvent>)kvp.Value.ToArray());
+
+    /// <summary>Ordered snapshot of every <see cref="ChannelStreamTarget"/> the gateway routed through this adapter (deltas and events).</summary>
+    public IReadOnlyList<ChannelStreamTarget> StreamTargets => [.. _streamTargets];
 
     /// <summary>
     /// Drives <paramref name="message"/> through the gateway's <see cref="IChannelDispatcher"/>
@@ -169,13 +173,14 @@ public sealed class VirtualChannelAdapter : ChannelAdapterBase, IChannelAdapter,
             $"No outbound message matching predicate observed within {timeout.TotalMilliseconds:F0}ms (observed {_outbound.Count}).");
     }
 
-    /// <summary>Clears every captured outbound, inbound, stream-delta and stream-event log.</summary>
+    /// <summary>Clears every captured outbound, inbound, stream-delta, stream-event log, and stream-target list.</summary>
     public void Reset()
     {
         _outbound.Clear();
         _inbound.Clear();
         _streamDeltas.Clear();
         _streamEvents.Clear();
+        _streamTargets.Clear();
         Interlocked.Exchange(ref _dispatchCount, 0);
     }
 
@@ -194,20 +199,22 @@ public sealed class VirtualChannelAdapter : ChannelAdapterBase, IChannelAdapter,
     }
 
     /// <inheritdoc />
-    public override Task SendStreamDeltaAsync(string conversationId, string delta, CancellationToken cancellationToken = default)
+    public override Task SendStreamDeltaAsync(ChannelStreamTarget target, string delta, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(conversationId);
+        ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(delta);
-        _streamDeltas.GetOrAdd(conversationId, _ => new ConcurrentQueue<string>()).Enqueue(delta);
+        _streamTargets.Enqueue(target);
+        _streamDeltas.GetOrAdd(target.ChannelAddress.Value, _ => new ConcurrentQueue<string>()).Enqueue(delta);
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
-    public Task SendStreamEventAsync(string conversationId, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
+    public Task SendStreamEventAsync(ChannelStreamTarget target, AgentStreamEvent streamEvent, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(conversationId);
+        ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(streamEvent);
-        _streamEvents.GetOrAdd(conversationId, _ => new ConcurrentQueue<AgentStreamEvent>()).Enqueue(streamEvent);
+        _streamTargets.Enqueue(target);
+        _streamEvents.GetOrAdd(target.ChannelAddress.Value, _ => new ConcurrentQueue<AgentStreamEvent>()).Enqueue(streamEvent);
         return Task.CompletedTask;
     }
 }

--- a/tests/scenarios/BotNexus.Scenarios.Tests/Adapter/VirtualChannelAdapterConformance.cs
+++ b/tests/scenarios/BotNexus.Scenarios.Tests/Adapter/VirtualChannelAdapterConformance.cs
@@ -119,9 +119,9 @@ public sealed class VirtualChannelAdapterConformance
     public async Task SendStreamDelta_GroupsDeltas_ByConversationRoutingKey()
     {
         var adapter = new VirtualChannelAdapter();
-        await adapter.SendStreamDeltaAsync("conv-a", "Hel");
-        await adapter.SendStreamDeltaAsync("conv-a", "lo");
-        await adapter.SendStreamDeltaAsync("conv-b", "Hi");
+        await adapter.SendStreamDeltaAsync(Target("conv-a"), "Hel");
+        await adapter.SendStreamDeltaAsync(Target("conv-a"), "lo");
+        await adapter.SendStreamDeltaAsync(Target("conv-b"), "Hi");
 
         adapter.StreamDeltas["conv-a"].ShouldBe(["Hel", "lo"]);
         adapter.StreamDeltas["conv-b"].ShouldBe(["Hi"]);
@@ -137,9 +137,9 @@ public sealed class VirtualChannelAdapterConformance
         var delta = new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Hi" };
         var end = new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd };
 
-        await contract.SendStreamEventAsync("conv-a", start);
-        await contract.SendStreamEventAsync("conv-a", delta);
-        await contract.SendStreamEventAsync("conv-b", end);
+        await contract.SendStreamEventAsync(Target("conv-a"), start);
+        await contract.SendStreamEventAsync(Target("conv-a"), delta);
+        await contract.SendStreamEventAsync(Target("conv-b"), end);
 
         adapter.StreamEvents["conv-a"].Select(e => e.Type)
             .ShouldBe([AgentStreamEventType.MessageStart, AgentStreamEventType.ContentDelta]);
@@ -180,7 +180,7 @@ public sealed class VirtualChannelAdapterConformance
 
         await adapter.SimulateInboundAsync(NewInbound("in"));
         await adapter.SendAsync(NewOutbound("out"));
-        await adapter.SendStreamDeltaAsync("conv-a", "delta");
+        await adapter.SendStreamDeltaAsync(Target("conv-a"), "delta");
 
         adapter.Reset();
 
@@ -189,6 +189,9 @@ public sealed class VirtualChannelAdapterConformance
         adapter.StreamDeltas.ShouldBeEmpty();
         adapter.InboundDispatchCount.ShouldBe(0);
     }
+
+    private static ChannelStreamTarget Target(string addressAndSessionKey) =>
+        new(SessionId.From(addressAndSessionKey), ChannelAddress.From(addressAndSessionKey), null);
 
     private static InboundMessage NewInbound(string content) => new()
     {


### PR DESCRIPTION
**Part of W-5 / Phase 10 channel cleanup arc** — umbrella: #676. Tracking issue: #677.

## What

Replaces the loosely-typed `string conversationId` parameter on `IChannelAdapter.SendStreamDeltaAsync` and `IStreamEventChannelAdapter.SendStreamEventAsync` with a typed `ChannelStreamTarget(SessionId, ChannelAddress, BindingId?)` record.

This is **PR1 of 6** in the W-5 channel-binding cleanup. It surgically removes the per-adapter ambiguity on the streaming surface so subsequent PRs can simplify routing, dispatching, and observer fan-out without that ambiguity hiding bugs.

## Why

The old `string conversationId` meant different things to different adapters:

| Adapter | What it treated the string as |
|---|---|
| SignalR | `SessionId` (SignalR group key) |
| Telegram | `ChannelAddress` (with composite `chat-id/topic:NN` suffix) |
| TUI | Ignored — used only as a display label |
| InternalChannelAdapter | Tried to parse as a `SessionId`, then fell through to a SignalR fallback when parsing yielded "no such session" |

The cleanup directive says: *"too much complexity in the interactions between the code layers and channels."* This is one of the slop fragments. Removing it now keeps PR2–PR6 honest.

## Behaviour fix (NOT scope creep — please read)

`InternalChannelAdapter.ResolveTargetAdapterForSessionAsync(SessionId, ct)` now uses the typed `SessionId` from `ChannelStreamTarget` to look up the parent session. Previously, the parameter was a string parsed as `SessionId`, but the gateway was actually passing the *channel address* (e.g. `chat-200/topic:99`). The lookup silently failed for any non-SignalR parent session and fell through to the SignalR fallback adapter — so a sub-agent wake-up event for a Telegram-rooted parent session was getting delivered to SignalR instead of Telegram.

**The new behaviour is pinned by a dedicated test** (`InternalChannelAdapterTests.SendStreamEventAsync_ResolvesByTypedSessionId_AndRoutesToParentsNonSignalRChannel`) so a future regression would fail CI.

## How

### New
- `src/domain/BotNexus.Domain/Gateway/Models/ChannelStreamTarget.cs` — typed record, documents how each adapter consumes each field.
- `tests/architecture/.../ChannelStreamTargetArchitectureTests.cs` — 4 fence tests that prevent re-introduction of a parallel string overload.
- `tests/gateway/.../_TestUtilities/StreamTargets.cs` — internal test helper for the common "I don't care about distinguishing SessionId vs ChannelAddress in this unit test" pattern.

### Adapters updated
- `SignalRChannelAdapter` — uses `target.SessionId`.
- `TelegramChannelAdapter` — uses `target.ChannelAddress` (preserves composite topic suffix).
- `TuiChannelAdapter` — uses `target.SessionId` as display label.
- `InternalChannelAdapter` — resolves parent's true adapter via `target.SessionId` (behaviour fix above).
- `ChannelAdapterBase` — virtual signature updated.
- `VirtualChannelAdapter` (harness) — keys captured deltas/events by `target.ChannelAddress.Value`; also exposes a new `StreamTargets` snapshot for tests that want to assert the full typed payload.

### Production callers
- `GatewayHost` — both the primary streaming path and the SignalR observer fan-out now construct `ChannelStreamTarget` with the resolved `SessionId`, the originating/observer `ChannelAddress`, and the originating/observer `BindingId`. The observer tuple was widened from `(adapter, string sessionAddress)` to `(adapter, ChannelAddress, BindingId)` so the per-observer typed target can be built inside the foreach. The `SendAskUserToBindingAsync` helper is similarly updated.

### Docs
- `docs/architecture/system-flows.md`, `src/gateway/README.md`, `src/gateway/BotNexus.Gateway.Channels/README.md` — example signatures + per-field consumption table.

## Verification

```
Build:            0 errors / 0 warnings   (warnings-as-errors active)
Impacted tests:   17 projects, ALL GREEN
Gateway tests:    2005 pass / 1 skip / 0 fail   (+1 new behaviour-fix test)
Architecture:     161 pass / 0 fail              (+4 new fence tests)
Scenarios:        29 pass / 0 fail
```

Run locally:
```pwsh
scripts/repo/build.ps1
scripts/repo/test-impacted.ps1
```

## Out of scope (the remaining 5 PRs in #676)

- PR2: TUI cleanup — remove `RequestedSessionId = "tui-console"` hardcode
- PR3: Inbound message orchestrator — collapse Router → Dispatcher into a single typed entry point
- PR4: Channel-side binding ownership — channels register their preferred binding strategy declaratively
- PR5: GatewayHub slim-down — 770 → ~200 LOC by delegating to the orchestrator
- PR6: Tidy implicit ChannelAddress conventions; introduce `ChannelBindingPolicy` record

Each ships once PR1 merges so reviewers don't see overlapping diffs.

Closes #677.
