### PR TITLE
feat(channels): drop hardcoded RequestedSessionId from TuiChannelAdapter (#691)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Tui/README.md
+++ b/src/extensions/BotNexus.Extensions.Channels.Tui/README.md
@@ -35,7 +35,7 @@ This package provides a terminal/console channel adapter for the BotNexus Gatewa
 - **Input Loop**: Reads from `Console.In` and dispatches user input as `InboundMessage` instances
   - `/quit` — stops the input loop and shuts down the adapter
   - `/clear` — clears the console
-  - Other input → dispatched as inbound messages with `SenderId = Environment.UserName` (wire token for audit/allow-list) and `Sender = CitizenId.Of(UserId.From(Environment.UserName))` (typed domain identity), `ChannelAddress = "console"`
+  - Other input → dispatched as inbound messages with `SenderId = Environment.UserName` (wire token for audit/allow-list) and `Sender = CitizenId.Of(UserId.From(Environment.UserName))` (typed domain identity), `ChannelAddress = "console"`, and **no `RoutingHints`** — the conversation router resolves the `(channelType=tui, channelAddress=console)` binding to the active conversation and reuses or opens a session through the standard post-P9 path. The adapter no longer fabricates a session id.
 
 ### What's Planned
 

--- a/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Tui/TuiChannelAdapter.cs
@@ -197,10 +197,9 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
                     SenderId = Environment.UserName,
                     Sender = CitizenId.Of(UserId.From(Environment.UserName)),
                     ChannelAddress = ChannelAddress.From("console"),
-                    RoutingHints = new InboundMessageRoutingHints(
-                        RequestedAgentId: null,
-                        RequestedSessionId: SessionId.From("tui-console"),
-                        RequestedConversationId: null),
+                    // PR2 of W-5 (#691): no RoutingHints — the conversation router
+                    // resolves the (tui, console) binding to the active conversation
+                    // and reuses or opens a session through the normal P9 path.
                     Content = steerContent,
                     Metadata = new Dictionary<string, object?>
                     {
@@ -216,10 +215,7 @@ public sealed class TuiChannelAdapter(ILogger<TuiChannelAdapter> logger)
                 SenderId = Environment.UserName,
                 Sender = CitizenId.Of(UserId.From(Environment.UserName)),
                 ChannelAddress = ChannelAddress.From("console"),
-                RoutingHints = new InboundMessageRoutingHints(
-                    RequestedAgentId: null,
-                    RequestedSessionId: SessionId.From("tui-console"),
-                    RequestedConversationId: null),
+                // PR2 of W-5 (#691): no RoutingHints — see comment in the steer branch.
                 Content = line
             }, cancellationToken);
         }

--- a/src/gateway/BotNexus.Cli/CliApp.cs
+++ b/src/gateway/BotNexus.Cli/CliApp.cs
@@ -21,6 +21,26 @@ internal static class CliApp
         return await root.InvokeAsync(args);
     }
 
+    /// <summary>
+    /// Picks the writer that should receive the decorative startup banner. The banner
+    /// is rendered only when the CLI is connected to an interactive terminal — when
+    /// stdout is redirected to a pipe, a file, or a process capture the banner would
+    /// pollute machine-readable output (and the box-drawing characters break tests
+    /// that diff exact strings). Returns <see cref="TextWriter.Null"/> when redirected
+    /// so the banner is suppressed, otherwise the supplied console writer.
+    /// </summary>
+    /// <param name="consoleOut">The CLI's normal stdout writer (typically <see cref="Console.Out"/>).</param>
+    /// <param name="isOutputRedirected">
+    /// Whether stdout is currently redirected. Pass <see cref="Console.IsOutputRedirected"/>
+    /// from <c>Program.cs</c>; tests supply an explicit value.
+    /// </param>
+    /// <returns>The writer the banner should be sent to.</returns>
+    internal static TextWriter ResolveBannerWriter(TextWriter consoleOut, bool isOutputRedirected)
+    {
+        ArgumentNullException.ThrowIfNull(consoleOut);
+        return isOutputRedirected ? TextWriter.Null : consoleOut;
+    }
+
     private static void ConfigureOutputEncoding()
     {
         try

--- a/src/gateway/BotNexus.Cli/Program.cs
+++ b/src/gateway/BotNexus.Cli/Program.cs
@@ -1,1 +1,1 @@
-return await BotNexus.Cli.CliApp.RunAsync(args, Console.Out);
+return await BotNexus.Cli.CliApp.RunAsync(args, BotNexus.Cli.CliApp.ResolveBannerWriter(Console.Out, Console.IsOutputRedirected));

--- a/tests/gateway/BotNexus.Cli.Tests/CliBannerTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/CliBannerTests.cs
@@ -44,4 +44,35 @@ public sealed class CliBannerTests
         var output = writer.ToString();
         output.ShouldStartWith(CliBanner.Text);
     }
+
+    [Fact]
+    public void ResolveBannerWriter_returns_supplied_writer_when_output_is_a_terminal()
+    {
+        var consoleOut = new StringWriter();
+
+        var resolved = CliApp.ResolveBannerWriter(consoleOut, isOutputRedirected: false);
+
+        resolved.ShouldBeSameAs(consoleOut);
+    }
+
+    [Fact]
+    public void ResolveBannerWriter_returns_null_writer_when_output_is_redirected()
+    {
+        var consoleOut = new StringWriter();
+
+        var resolved = CliApp.ResolveBannerWriter(consoleOut, isOutputRedirected: true);
+
+        // Suppresses the banner so piped / captured / tee'd CLI output stays
+        // machine-readable. Cross-OS test fixtures (ConfigPathResolverTests,
+        // CliTestFixture) and shell pipelines depend on this contract.
+        resolved.ShouldBeSameAs(TextWriter.Null);
+    }
+
+    [Fact]
+    public void ResolveBannerWriter_throws_when_console_writer_is_null()
+    {
+        Action act = () => CliApp.ResolveBannerWriter(null!, isOutputRedirected: false);
+
+        Should.Throw<ArgumentNullException>(act);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj
+++ b/tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj
@@ -25,6 +25,21 @@
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
     <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.Tui\BotNexus.Extensions.Channels.Tui.csproj" />
     <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.Telegram\BotNexus.Extensions.Channels.Telegram.csproj" />
+    <!--
+      Build-only reference: CliTestFixture and ConfigPathResolverTests' CliConfigFixture
+      shell out to `dotnet <repo>/src/gateway/BotNexus.Cli/bin/Debug/net10.0/BotNexus.Cli.dll`
+      via Process.Start. They need the CLI binary to exist before the tests run.
+
+      Without this reference, running this test project on its own (e.g. via
+      scripts/repo/test-impacted.ps1 when BotNexus.Cli is not in the impacted set)
+      throws FileNotFoundException at fixture startup. The reference guarantees MSBuild
+      builds the CLI alongside this test project; ReferenceOutputAssembly=false +
+      Private=false stop the Exe's assembly from being copied into the test bin folder
+      (which would interfere with xUnit test discovery on the test assembly).
+    -->
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Cli\BotNexus.Cli.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/gateway/BotNexus.Gateway.Tests/TuiChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/TuiChannelAdapterTests.cs
@@ -69,6 +69,13 @@ public sealed class TuiChannelAdapterTests
 
         steerDispatchCount.ShouldBe(1);
         output.ToString().ShouldContain("Steering queued");
+
+        // PR2 of W-5 (#691): TUI must NOT fabricate a session id; the binding system
+        // resolves (channelType=tui, channelAddress=console) to the correct conversation
+        // and session naturally. A hardcoded RequestedSessionId here would shadow the
+        // P9 binding resolution path and bypass the natural session lifecycle.
+        var steerMessage = dispatchedMessages.Single(m => m.Content == "adjust please");
+        steerMessage.RoutingHints.ShouldBeNull();
     }
 
     [Fact]
@@ -114,5 +121,11 @@ public sealed class TuiChannelAdapterTests
         dispatchedMessages.Where(m => m.Content == "hello world").ShouldHaveSingleItem();
         dispatchedMessages.ShouldAllBe(m => !m.Metadata.ContainsKey("control"));
         output.ToString().ShouldNotContain("Steering queued");
+
+        // PR2 of W-5 (#691): TUI must NOT fabricate a session id on regular input either.
+        // The conversation router will look up the (tui, console) binding for the resolved
+        // agent and reuse / open a session — that's the post-P9 contract.
+        var regularMessage = dispatchedMessages.Single(m => m.Content == "hello world");
+        regularMessage.RoutingHints.ShouldBeNull();
     }
 }


### PR DESCRIPTION
## Summary

Closes #691. PR2 of the W-5 channel-binding cleanup arc (umbrella #676).

Drops the pre-P9 escape hatch in `TuiChannelAdapter` that fabricated a `RequestedSessionId = SessionId.From("tui-console")` on every inbound dispatch. The TUI now lets `(channelType=tui, channelAddress=console)` resolve naturally via `DefaultConversationRouter.ResolveByBindingAsync` — the same post-P9 path every other channel uses.

While validating the change, surfaced and fixed two unrelated, pre-existing test failures (filed as #694, closed by this PR). Details in the second commit.

## Commits

### 1. `feat(channels): drop hardcoded RequestedSessionId from TuiChannelAdapter (#691)`

- `TuiChannelAdapter.cs` — removed the two `RoutingHints = new InboundMessageRoutingHints(...)` blocks from the steer and regular dispatch paths.
- `TuiChannelAdapterTests.cs` — extended both tests to pin `RoutingHints is null`.
- `README.md` — updated the input-loop section to describe the new natural-resolution behaviour.

**Why this is safe (already verified during scoping):**

- `DefaultMessageRouter` Priority 2 (session-bound agent) currently looks up `SessionId.From("tui-console")` → no session exists → falls through to Priority 3 (default agent). Removing the hint produces the same fall-through.
- `GatewayHost.GetQueueKey` falls from the literal `"tui-console"` to `$"{ChannelType}:{ChannelAddress}"` = `"tui:console"`. Same per-channel-address serialisation guarantee.
- `DefaultConversationRouter` then resolves the binding `(tui, console)` to the per-agent conversation — the correct post-P9 path.

### 2. `fix(cli): suppress banner on redirected stdout and stabilise test fixture build order (#691)`

Two infra problems surfaced by the impacted-tests sweep, neither caused by the TUI change but both blocking a clean test run. Folded in per the instruction *"no tests should be failing"*.

**Problem A — missing `BotNexus.Cli.dll`:** `ConfigPathResolverTests.CliConfigFixture` and `Cli/CliTestFixture` shell out to the CLI via `Process.Start`, expecting the binary at `src/gateway/BotNexus.Cli/bin/Debug/net10.0/BotNexus.Cli.dll`. Under narrow `dotnet test` (e.g. `test-impacted.ps1` without the CLI in the impacted set), the binary was missing and the fixture threw `FileNotFoundException`.

  *Fix:* added a build-only `<ProjectReference>` from `BotNexus.Gateway.Tests` to `BotNexus.Cli` with `ReferenceOutputAssembly="false"` and `Private="false"`. MSBuild now guarantees the CLI is built alongside the test project; the Exe assembly is not copied into the test output (which would interfere with xUnit discovery).

**Problem B — branded banner pollutes captured stdout:** After fixing A, the same tests began failing because PR #683 added a branded banner that was always written to stdout. `result.StdOut.Trim()` returned the banner instead of the expected config payload.

  *Fix:* introduced `CliApp.ResolveBannerWriter(consoleOut, isOutputRedirected)`. When stdout is a pipe / file / captured subprocess (`Console.IsOutputRedirected == true`), returns `TextWriter.Null` and the banner is suppressed. Interactive terminals see the banner unchanged. Standard CLI convention (mirrors `man --help`, `dotnet`, etc.).

  `Program.cs` now calls `ResolveBannerWriter(Console.Out, Console.IsOutputRedirected)`. `CliBannerTests` adds three test cases pinning the helper.

## Tests

- `dotnet test BotNexus.Gateway.Tests` → **2006/2007** (1 unrelated pre-existing skip).
- `dotnet test BotNexus.Cli.Tests` → **97/97** (including 3 new `ResolveBannerWriter` cases).
- `scripts/repo/test-impacted.ps1` → **all 5 impacted test projects pass**.
- Repro for the FileNotFoundException: `git clean -xdf src/gateway/BotNexus.Cli/{bin,obj}` then `dotnet test tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj --filter "FullyQualifiedName~ConfigPathResolverTests"` — passes on this branch, fails on `main`.

## What's deliberately deferred

- The duplicated `ResolveCliAssemblyPath` / `FindRepositoryRoot` helpers in `CliTestFixture` and `ConfigPathResolverTests` should be consolidated. Out of scope here; the build-only ProjectReference fixes the immediate failure mode without invasive refactoring.

## Refs

- Parent umbrella: #676
- Previous PRs in the arc: #679 (PR1 — typed `ChannelStreamTarget`), #684 (PR1.5 — `ConversationId` routing)
- Closes #691
- Closes #694 (pre-existing CLI fixture flake, fixed here)
