### PR TITLE
feat(skills): add Skills Explorer portal section with gateway API

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
@@ -103,6 +103,18 @@ public interface IGatewayRestClient
         string conversationId,
         CancellationToken ct = default);
 
+    /// <summary>GET /api/extensions/details — lists all loaded extensions with full manifest detail.</summary>
+    Task<IReadOnlyList<ExtensionDetailDto>> GetExtensionDetailsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>GET /api/skills or /api/skills/{path} — browse the global skills directory.</summary>
+    Task<WorkspaceResponseDto?> GetSkillsAsync(string? path = null, CancellationToken cancellationToken = default);
+
+    /// <summary>PUT /api/skills/{path} — write text content to a skills-relative file.</summary>
+    Task<bool> WriteSkillFileAsync(string path, string content, CancellationToken cancellationToken = default);
+
+    /// <summary>DELETE /api/skills/{path}?force={force} — delete a file or directory from the skills dir.</summary>
+    Task<bool> DeleteSkillItemAsync(string path, bool force = false, CancellationToken cancellationToken = default);
+
     /// <summary>Current API base URL (set via Configure). Null if not yet configured.</summary>
     string? ApiBaseUrl { get; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ExtensionFeatureService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ExtensionFeatureService.cs
@@ -1,0 +1,38 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Tracks whether optional BotNexus extensions are loaded.
+/// Populated once the portal is ready via <see cref="LoadAsync"/>.
+/// </summary>
+public sealed class ExtensionFeatureService
+{
+    private readonly IGatewayRestClient _restClient;
+    private bool _skillsEnabled;
+
+    public ExtensionFeatureService(IGatewayRestClient restClient)
+    {
+        _restClient = restClient;
+    }
+
+    /// <summary>Whether the botnexus-skills extension is loaded and enabled.</summary>
+    public bool SkillsEnabled => _skillsEnabled;
+
+    /// <summary>Raised when extension feature state changes.</summary>
+    public event Action? OnChanged;
+
+    /// <summary>Fetches the extension list from the gateway and updates feature flags.</summary>
+    public async Task LoadAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var extensions = await _restClient.GetExtensionDetailsAsync(ct);
+            _skillsEnabled = extensions.Any(e =>
+                string.Equals(e.Id, "botnexus-skills", StringComparison.OrdinalIgnoreCase) && e.Enabled);
+            OnChanged?.Invoke();
+        }
+        catch
+        {
+            // Non-fatal — leave flags at defaults
+        }
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
@@ -258,4 +258,73 @@ public sealed class GatewayRestClient : IGatewayRestClient
         return $"{requestPath}/{string.Join("/", encodedSegments)}";
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ExtensionDetailDto>> GetExtensionDetailsAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        try
+        {
+            var result = await _http.GetFromJsonAsync<List<ExtensionDetailDto>>(
+                $"{_apiBaseUrl}extensions/details",
+                cancellationToken);
+            return result as IReadOnlyList<ExtensionDetailDto> ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<WorkspaceResponseDto?> GetSkillsAsync(
+        string? path = null,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        var requestPath = BuildSkillsRequestPath(path);
+        return await _http.GetFromJsonAsync<WorkspaceResponseDto>(requestPath, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> WriteSkillFileAsync(
+        string path,
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        var requestPath = BuildSkillsRequestPath(path);
+        var response = await _http.PutAsJsonAsync(requestPath, new { content }, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteSkillItemAsync(
+        string path,
+        bool force = false,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        var requestPath = BuildSkillsRequestPath(path);
+        if (force)
+            requestPath += "?force=true";
+        var response = await _http.DeleteAsync(requestPath, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    private string BuildSkillsRequestPath(string? path)
+    {
+        var requestPath = $"{_apiBaseUrl}skills";
+        if (string.IsNullOrWhiteSpace(path))
+            return requestPath;
+
+        var normalizedPath = path.Trim().Replace('\\', '/').Trim('/');
+        if (normalizedPath.Length == 0)
+            return requestPath;
+
+        var encodedSegments = normalizedPath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Select(Uri.EscapeDataString);
+        return $"{requestPath}/{string.Join("/", encodedSegments)}";
+    }
+
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/WorkspaceContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/WorkspaceContracts.cs
@@ -34,3 +34,13 @@ public sealed record WorkspaceResponseDto(
     [property: JsonPropertyName("encoding")] string? Encoding,
     [property: JsonPropertyName("isTruncated")] bool? IsTruncated,
     [property: JsonPropertyName("binary")] bool? Binary);
+
+/// <summary>Loaded extension detail response from GET /api/extensions/details.</summary>
+public sealed record ExtensionDetailDto(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("enabled")] bool Enabled,
+    [property: JsonPropertyName("extensionTypes")] IReadOnlyList<string>? ExtensionTypes,
+    [property: JsonPropertyName("registeredServices")] IReadOnlyList<string>? RegisteredServices,
+    [property: JsonPropertyName("assemblyFileName")] string? AssemblyFileName);

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SkillsExplorerPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SkillsExplorerPanel.razor
@@ -1,0 +1,352 @@
+@inject IGatewayRestClient GatewayRestClient
+@inject IJSRuntime JS
+@implements IDisposable
+
+<div id="skills-explorer-panel" class="workspace-panel" data-testid="skills-explorer-panel">
+    <section class="workspace-tree-pane">
+        @if (_isLoadingRoot)
+        {
+            <div class="workspace-state">Loading skills…</div>
+        }
+        else if (!string.IsNullOrWhiteSpace(_rootError))
+        {
+            <div class="workspace-state workspace-state-error">@_rootError</div>
+        }
+        else
+        {
+            <WorkspaceFileTree Entries="@GetDirectoryEntries(string.Empty)"
+                               ExpandedPaths="_expandedDirectories"
+                               SelectedFilePath="_selectedFilePath"
+                               OnDirectoryToggled="ToggleDirectoryAsync"
+                               OnFileSelected="SelectFileAsync"
+                               OnDeleteRequested="RequestDeleteAsync"
+                               DirectoryEntriesProvider="GetDirectoryEntries"
+                               DirectoryLoadingProvider="IsDirectoryLoading"
+                               DirectoryErrorProvider="GetDirectoryError" />
+        }
+    </section>
+
+    <div class="panel-splitter" role="separator" aria-orientation="vertical" aria-label="Resize skills panels" title="Drag to resize"></div>
+
+    <section class="workspace-viewer-pane">
+        <WorkspaceFileViewer IsLoading="_isLoadingFile"
+                             ErrorMessage="@_selectedFileError"
+                             FileResponse="@_selectedFile"
+                             ShowBackButton="false"
+                             IsEditing="_isEditing"
+                             EditContent="@_editContent"
+                             OnEditRequested="BeginEdit"
+                             OnSaveRequested="SaveEditAsync"
+                             OnDiscardRequested="DiscardEdit"
+                             OnEditContentChanged="OnEditContentChanged" />
+    </section>
+
+    @if (_deleteConfirmPath is not null)
+    {
+        <div class="workspace-delete-confirm" role="dialog" aria-modal="true">
+            <div class="workspace-delete-confirm-box">
+                @if (_deleteIsNonEmptyDir)
+                {
+                    <p class="workspace-delete-warning">
+                        ⚠️ <strong>@_deleteConfirmPath</strong> is a non-empty directory. All contents will be permanently deleted.
+                    </p>
+                }
+                else
+                {
+                    <p>Delete <strong>@_deleteConfirmPath</strong>? This cannot be undone.</p>
+                }
+                <div class="workspace-delete-confirm-actions">
+                    <button type="button" class="workspace-btn workspace-btn-danger" @onclick="ConfirmDeleteAsync">
+                        @(_deleteIsNonEmptyDir ? "Delete All" : "Delete")
+                    </button>
+                    <button type="button" class="workspace-btn" @onclick="CancelDelete">Cancel</button>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(_deleteError))
+                {
+                    <p class="workspace-state workspace-state-error">@_deleteError</p>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private readonly Dictionary<string, WorkspaceResponseDto> _directoryResponses = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _expandedDirectories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _loadingDirectories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _directoryErrors = new(StringComparer.OrdinalIgnoreCase);
+    private readonly CancellationTokenSource _cts = new();
+
+    private bool _isLoadingRoot = true;
+    private bool _isLoadingFile;
+    private string? _rootError;
+    private string? _selectedFilePath;
+    private WorkspaceResponseDto? _selectedFile;
+    private string? _selectedFileError;
+
+    // Edit state
+    private bool _isEditing;
+    private string? _editContent;
+
+    // Delete state
+    private string? _deleteConfirmPath;
+    private bool _deleteIsNonEmptyDir;
+    private string? _deleteError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadRootAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("BotNexus.splitter.init", "skills-explorer-panel", "bn-skills-explorer-width", 384, 120, 0.7, 0.33);
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+
+    private async Task LoadRootAsync()
+    {
+        _isLoadingRoot = true;
+        _rootError = null;
+        await LoadDirectoryAsync(string.Empty, isRoot: true);
+        _isLoadingRoot = false;
+    }
+
+    private async Task ToggleDirectoryAsync(string directoryPath)
+    {
+        if (_expandedDirectories.Contains(directoryPath))
+        {
+            _expandedDirectories.Remove(directoryPath);
+            return;
+        }
+
+        _expandedDirectories.Add(directoryPath);
+        if (_directoryResponses.ContainsKey(directoryPath) || _loadingDirectories.Contains(directoryPath))
+            return;
+
+        await LoadDirectoryAsync(directoryPath, isRoot: false);
+    }
+
+    private async Task SelectFileAsync(string filePath)
+    {
+        if (_isEditing && !string.Equals(_selectedFilePath, filePath, StringComparison.OrdinalIgnoreCase))
+            DiscardEdit();
+
+        _selectedFilePath = filePath;
+        _selectedFile = null;
+        _selectedFileError = null;
+        _isLoadingFile = true;
+
+        try
+        {
+            var response = await GatewayRestClient.GetSkillsAsync(filePath, _cts.Token);
+            if (response is null)
+            {
+                _selectedFileError = "Unable to load file content.";
+                return;
+            }
+
+            if (!string.Equals(response.Type, "file", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(response.Type, "text", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(response.Type, "binary", StringComparison.OrdinalIgnoreCase))
+            {
+                _selectedFileError = "Selected item is not a file.";
+                return;
+            }
+
+            _selectedFile = response;
+        }
+        catch (OperationCanceledException) { }
+        catch
+        {
+            _selectedFileError = "Unable to load file content.";
+        }
+        finally
+        {
+            _isLoadingFile = false;
+        }
+    }
+
+    private async Task LoadDirectoryAsync(string path, bool isRoot)
+    {
+        _loadingDirectories.Add(path);
+        _directoryErrors.Remove(path);
+
+        try
+        {
+            var requestPath = string.IsNullOrWhiteSpace(path) ? null : path;
+            var response = await GatewayRestClient.GetSkillsAsync(requestPath, _cts.Token);
+            if (response is null || !string.Equals(response.Type, "directory", StringComparison.OrdinalIgnoreCase))
+            {
+                SetDirectoryError(path, isRoot);
+                return;
+            }
+
+            _directoryResponses[path] = response;
+        }
+        catch (OperationCanceledException) { }
+        catch
+        {
+            SetDirectoryError(path, isRoot);
+        }
+        finally
+        {
+            _loadingDirectories.Remove(path);
+        }
+    }
+
+    private void SetDirectoryError(string path, bool isRoot)
+    {
+        const string msg = "Unable to load skills directory.";
+        if (isRoot) _rootError = msg;
+        else _directoryErrors[path] = msg;
+    }
+
+    private IReadOnlyList<WorkspaceEntryDto> GetDirectoryEntries(string path)
+    {
+        if (_directoryResponses.TryGetValue(path, out var response))
+            return response.Entries ?? [];
+        return [];
+    }
+
+    private bool IsDirectoryLoading(string path) => _loadingDirectories.Contains(path);
+
+    private string? GetDirectoryError(string path) =>
+        _directoryErrors.TryGetValue(path, out var error) ? error : null;
+
+    // ── Edit ──────────────────────────────────────────────────────────────────
+
+    private void BeginEdit()
+    {
+        _isEditing = true;
+        _editContent = _selectedFile?.Content ?? string.Empty;
+    }
+
+    private void OnEditContentChanged(string value) => _editContent = value;
+
+    private void DiscardEdit()
+    {
+        _isEditing = false;
+        _editContent = null;
+    }
+
+    private async Task SaveEditAsync(string content)
+    {
+        if (_selectedFilePath is null || _selectedFile is null)
+            return;
+
+        try
+        {
+            var success = await GatewayRestClient.WriteSkillFileAsync(_selectedFilePath, content, _cts.Token);
+            if (!success)
+            {
+                _selectedFileError = "Failed to save file.";
+                return;
+            }
+
+            _isEditing = false;
+            _editContent = null;
+            await SelectFileAsync(_selectedFilePath);
+        }
+        catch (OperationCanceledException) { }
+        catch
+        {
+            _selectedFileError = "Failed to save file.";
+        }
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    private void RequestDeleteAsync(string path)
+    {
+        _deleteConfirmPath = path;
+        _deleteError = null;
+        _deleteIsNonEmptyDir = IsNonEmptyDirectory(path);
+    }
+
+    private bool IsNonEmptyDirectory(string path)
+    {
+        if (_directoryResponses.TryGetValue(path, out var dir))
+            return dir.Entries?.Count > 0;
+
+        var parentPath = GetParentPath(path);
+        var parentEntries = GetDirectoryEntries(parentPath);
+        foreach (var entry in parentEntries)
+        {
+            var entryPath = BuildPath(parentPath, entry.Name);
+            if (string.Equals(entryPath, path, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(entry.Type, "directory", StringComparison.OrdinalIgnoreCase))
+            {
+                if (_directoryResponses.TryGetValue(path, out var loaded))
+                    return loaded.Entries?.Count > 0;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void CancelDelete()
+    {
+        _deleteConfirmPath = null;
+        _deleteError = null;
+        _deleteIsNonEmptyDir = false;
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (_deleteConfirmPath is null)
+            return;
+
+        var pathToDelete = _deleteConfirmPath;
+        try
+        {
+            var success = await GatewayRestClient.DeleteSkillItemAsync(pathToDelete, _deleteIsNonEmptyDir, _cts.Token);
+            if (!success)
+            {
+                _deleteError = "Delete failed. The server rejected the request.";
+                return;
+            }
+
+            if (string.Equals(_selectedFilePath, pathToDelete, StringComparison.OrdinalIgnoreCase))
+            {
+                _selectedFile = null;
+                _selectedFilePath = null;
+                _selectedFileError = null;
+                DiscardEdit();
+            }
+
+            _directoryResponses.Remove(pathToDelete);
+            _expandedDirectories.Remove(pathToDelete);
+
+            var parentPath = GetParentPath(pathToDelete);
+            _directoryResponses.Remove(parentPath);
+            await LoadDirectoryAsync(parentPath, isRoot: string.IsNullOrEmpty(parentPath));
+
+            CancelDelete();
+        }
+        catch (OperationCanceledException) { }
+        catch
+        {
+            _deleteError = "Delete failed unexpectedly.";
+        }
+    }
+
+    private static string GetParentPath(string path)
+    {
+        var trimmed = path.TrimEnd('/');
+        var lastSlash = trimmed.LastIndexOf('/');
+        return lastSlash < 0 ? string.Empty : trimmed[..lastSlash];
+    }
+
+    private static string BuildPath(string parent, string name) =>
+        string.IsNullOrWhiteSpace(parent) ? name : $"{parent.TrimEnd('/')}/{name}";
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -1,9 +1,10 @@
-@inherits LayoutComponentBase
+﻿@inherits LayoutComponentBase
 @inject NavigationManager Nav
 @inject IClientStateStore Store
 @inject IAgentInteractionService Interaction
 @inject IPortalLoadService PortalLoad
 @inject GatewayInfoService GatewayInfo
+@inject ExtensionFeatureService ExtensionFeatures
 @inject GatewayHubConnection Hub
 @inject IUpdateStatusService UpdateStatus
 @inject IJSRuntime JS
@@ -196,6 +197,19 @@
                     </div>
                 }
 
+                @if (ExtensionFeatures.SkillsEnabled)
+                {
+                    <a href="skills" class="sidebar-nav-item @NavClass("skills")" @onclick="OnNavClick">🧠 Skills</a>
+
+                    @* Skills sub-nav -- shown when on the skills page *@
+                    @if (IsOnPage("skills"))
+                    {
+                        <div class="sidebar-subnav">
+                            <a href="skills/explorer" class="sidebar-subnav-item" @onclick="CloseSidebar">🗂️ Explorer</a>
+                        </div>
+                    }
+                }
+
                 <a href="agents" class="sidebar-nav-item @NavClass("agents")" @onclick="OnNavClick">🤖 Agents</a>
             </nav>
 
@@ -277,6 +291,7 @@
         Nav.LocationChanged += OnLocationChanged;
         PortalLoad.OnReadyChanged += HandleReadyChanged;
         UpdateStatus.StatusChanged += HandleStateChanged;
+        ExtensionFeatures.OnChanged += HandleStateChanged;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -335,6 +350,7 @@
     {
         _gatewayInfoLoaded = true;
         await GatewayInfo.LoadAsync();
+        await ExtensionFeatures.LoadAsync();
     }
 
     private void HandleStateChanged() => InvokeAsync(StateHasChanged);
@@ -572,6 +588,7 @@
         Nav.LocationChanged -= OnLocationChanged;
         PortalLoad.OnReadyChanged -= HandleReadyChanged;
         UpdateStatus.StatusChanged -= HandleStateChanged;
+        ExtensionFeatures.OnChanged -= HandleStateChanged;
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Skills.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Skills.razor
@@ -1,0 +1,29 @@
+@page "/skills"
+@page "/skills/{Section}"
+
+<PageTitle>BotNexus &mdash; Skills</PageTitle>
+
+<div class="platform-config-page">
+    <header class="platform-config-toolbar">
+        <h2>&#x1F9E0; Skills</h2>
+    </header>
+
+    <div class="config-page">
+        <div class="config-panel-canvas skills-panel-canvas">
+            @switch (Section?.ToLowerInvariant() ?? "explorer")
+            {
+                case "explorer":
+                    <SkillsExplorerPanel />
+                    break;
+                default:
+                    <SkillsExplorerPanel />
+                    break;
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public string? Section { get; set; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Program.cs
@@ -17,6 +17,7 @@ builder.Services.AddScoped<IAgentInteractionService, AgentInteractionService>();
 builder.Services.AddScoped<IPortalLoadService, PortalLoadService>();
 builder.Services.AddScoped<PlatformConfigService>();
 builder.Services.AddScoped<GatewayInfoService>();
+builder.Services.AddScoped<ExtensionFeatureService>();
 builder.Services.AddScoped<IUpdateStatusService, UpdateStatusService>();
 builder.Services.AddScoped<LocationsApiClient>();
 builder.Services.AddScoped<CronApiClient>();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -1,4 +1,4 @@
-/* ── BotNexus Blazor Client — Dark Theme ─────────────────────────────── */
+﻿/* ── BotNexus Blazor Client — Dark Theme ─────────────────────────────── */
 
 :root {
     --bg-primary: #1a1a2e;
@@ -3955,4 +3955,13 @@ h3.conversation-title.editable:hover {
     color: var(--text-muted, #999);
     padding-bottom: 0.5rem;
 
+}
+
+/* == Skills Explorer == */
+.skills-panel-canvas {
+    padding: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/SkillsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/SkillsController.cs
@@ -1,0 +1,298 @@
+using System.IO.Abstractions;
+using System.Text;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Api.Models;
+using BotNexus.Gateway.Security;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+/// <summary>
+/// Exposes filesystem access to the global BotNexus skills directory
+/// (<c>~/.botnexus/skills</c>).  Used by the portal Skills Explorer.
+/// </summary>
+[ApiController]
+[Route("api/skills")]
+public sealed class SkillsController : ControllerBase
+{
+    private const int DefaultTreeDepthLimit = 2;
+    private const int MaximumTreeDepthLimit = 5;
+    private const int MaximumFileReadBytes = 512 * 1024;
+
+    private static bool IsAbsolutePath(string path) =>
+        System.IO.Path.IsPathRooted(path)
+        || (path.Length >= 3 && path[1] == ':' && (path[2] == '/' || path[2] == '\\'))
+        || path.StartsWith('/')
+        || path.StartsWith('\\');
+
+    private readonly IFileSystem _fileSystem;
+    private readonly string _skillsRoot;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SkillsController"/>.
+    /// </summary>
+    public SkillsController(IFileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        _skillsRoot = System.IO.Path.Combine(home, ".botnexus", "skills");
+    }
+
+    /// <summary>
+    /// Returns a depth-limited directory listing of the global skills root.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(WorkspaceDirectoryResponse), StatusCodes.Status200OK)]
+    public ActionResult<WorkspaceDirectoryResponse> GetSkills([FromQuery] int depth = DefaultTreeDepthLimit)
+    {
+        if (depth is < 0 or > MaximumTreeDepthLimit)
+            return BadRequest(new { error = $"depth must be between 0 and {MaximumTreeDepthLimit}." });
+
+        var normalizedRoot = WorkspacePathSecurity.NormalizePath(_fileSystem, _skillsRoot);
+
+        if (!_fileSystem.Directory.Exists(normalizedRoot))
+        {
+            return Ok(new WorkspaceDirectoryResponse
+            {
+                Path = string.Empty,
+                DepthLimit = depth,
+                Entries = []
+            });
+        }
+
+        var validator = new DefaultPathValidator(policy: null, normalizedRoot);
+        var entries = BuildTreeEntries(normalizedRoot, normalizedRoot, validator, depth, 0);
+        return Ok(new WorkspaceDirectoryResponse
+        {
+            Path = string.Empty,
+            DepthLimit = depth,
+            Entries = entries
+        });
+    }
+
+    /// <summary>
+    /// Returns file content or a directory listing for a skills-relative path.
+    /// </summary>
+    [HttpGet("{**path}")]
+    [ProducesResponseType(typeof(WorkspaceDirectoryResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(WorkspaceFileResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult<object> GetFile(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return BadRequest(new { error = "path is required." });
+
+        if (IsAbsolutePath(path))
+            return BadRequest(new { error = "path must be skills-relative." });
+
+        if (path.Contains('\0'))
+            return BadRequest(new { error = "path contains invalid characters." });
+
+        var normalizedRoot = WorkspacePathSecurity.NormalizePath(_fileSystem, _skillsRoot);
+        var validator = new DefaultPathValidator(policy: null, normalizedRoot);
+        var normalizedRelPath = WorkspacePathSecurity.NormalizeRelativePath(_fileSystem, path);
+        var resolvedPath = validator.ValidateAndResolve(normalizedRelPath, FileAccessMode.Read);
+        if (resolvedPath is null)
+            return Forbid();
+
+        var resolvedFinalPath = WorkspacePathSecurity.ResolveFinalTargetPath(_fileSystem, resolvedPath);
+        if (!validator.CanRead(resolvedFinalPath))
+            return Forbid();
+
+        if (_fileSystem.Directory.Exists(resolvedFinalPath))
+        {
+            return Ok(new WorkspaceDirectoryResponse
+            {
+                Type = "directory",
+                Path = WorkspacePathSecurity.ToWorkspaceRelativePath(_fileSystem, normalizedRoot, resolvedFinalPath),
+                DepthLimit = 0,
+                Entries = BuildTreeEntries(normalizedRoot, resolvedFinalPath, validator, depthLimit: 0, currentDepth: 0)
+            });
+        }
+
+        if (!_fileSystem.File.Exists(resolvedFinalPath))
+            return NotFound();
+
+        var relativePath = WorkspacePathSecurity.ToWorkspaceRelativePath(_fileSystem, normalizedRoot, resolvedFinalPath);
+        var fileInfo = _fileSystem.FileInfo.New(resolvedFinalPath);
+        var fileSize = fileInfo.Length;
+        var bytesToRead = (int)Math.Min(fileSize, MaximumFileReadBytes);
+        var buffer = new byte[bytesToRead];
+        using var stream = _fileSystem.File.OpenRead(resolvedFinalPath);
+        var bytesRead = stream.Read(buffer, 0, bytesToRead);
+        var truncated = fileSize > MaximumFileReadBytes;
+
+        if (IsBinary(buffer, bytesRead))
+        {
+            return Ok(new WorkspaceFileResponse
+            {
+                Path = relativePath,
+                Type = "binary",
+                Size = fileSize,
+                IsTruncated = truncated
+            });
+        }
+
+        return Ok(new WorkspaceFileResponse
+        {
+            Path = relativePath,
+            Type = "text",
+            Size = fileSize,
+            Encoding = "utf-8",
+            Content = Encoding.UTF8.GetString(buffer, 0, bytesRead),
+            IsTruncated = truncated
+        });
+    }
+
+    /// <summary>
+    /// Writes text content to a skills-relative file path.
+    /// </summary>
+    [HttpPut("{**path}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public ActionResult WriteFile(string path, [FromBody] WorkspaceWriteRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return BadRequest(new { error = "path is required." });
+
+        if (IsAbsolutePath(path))
+            return BadRequest(new { error = "path must be skills-relative." });
+
+        if (path.Contains('\0'))
+            return BadRequest(new { error = "path contains invalid characters." });
+
+        var normalizedRoot = WorkspacePathSecurity.NormalizePath(_fileSystem, _skillsRoot);
+        var validator = new DefaultPathValidator(policy: null, normalizedRoot);
+        var normalizedRelPath = WorkspacePathSecurity.NormalizeRelativePath(_fileSystem, path);
+        var resolvedPath = validator.ValidateAndResolve(normalizedRelPath, FileAccessMode.Write);
+        if (resolvedPath is null)
+            return Forbid();
+
+        var resolvedFinalPath = WorkspacePathSecurity.ResolveFinalTargetPath(_fileSystem, resolvedPath);
+        if (!validator.CanWrite(resolvedFinalPath))
+            return Forbid();
+
+        if (_fileSystem.Directory.Exists(resolvedFinalPath))
+            return BadRequest(new { error = "Path refers to a directory, not a file." });
+
+        var parentDir = _fileSystem.Path.GetDirectoryName(resolvedFinalPath);
+        if (!string.IsNullOrEmpty(parentDir) && !_fileSystem.Directory.Exists(parentDir))
+            return BadRequest(new { error = "Parent directory does not exist." });
+
+        _fileSystem.File.WriteAllText(resolvedFinalPath, request.Content, Encoding.UTF8);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes a file or directory at a skills-relative path.
+    /// </summary>
+    [HttpDelete("{**path}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public ActionResult DeleteItem(string path, [FromQuery] bool force = false)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return BadRequest(new { error = "path is required." });
+
+        if (IsAbsolutePath(path))
+            return BadRequest(new { error = "path must be skills-relative." });
+
+        if (path.Contains('\0'))
+            return BadRequest(new { error = "path contains invalid characters." });
+
+        var normalizedRoot = WorkspacePathSecurity.NormalizePath(_fileSystem, _skillsRoot);
+        var validator = new DefaultPathValidator(policy: null, normalizedRoot);
+        var normalizedRelPath = WorkspacePathSecurity.NormalizeRelativePath(_fileSystem, path);
+        var resolvedPath = validator.ValidateAndResolve(normalizedRelPath, FileAccessMode.Write);
+        if (resolvedPath is null)
+            return Forbid();
+
+        var resolvedFinalPath = WorkspacePathSecurity.ResolveFinalTargetPath(_fileSystem, resolvedPath);
+        if (!validator.CanWrite(resolvedFinalPath))
+            return Forbid();
+
+        if (_fileSystem.Directory.Exists(resolvedFinalPath))
+        {
+            var isEmpty = !_fileSystem.Directory.EnumerateFileSystemEntries(resolvedFinalPath).Any();
+            if (!isEmpty && !force)
+                return Conflict(new { error = "Directory is not empty. Use force=true to delete recursively." });
+            _fileSystem.Directory.Delete(resolvedFinalPath, recursive: true);
+            return NoContent();
+        }
+
+        if (!_fileSystem.File.Exists(resolvedFinalPath))
+            return NotFound();
+
+        _fileSystem.File.Delete(resolvedFinalPath);
+        return NoContent();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private IReadOnlyList<WorkspaceEntryDto> BuildTreeEntries(
+        string root,
+        string currentDirectory,
+        DefaultPathValidator validator,
+        int depthLimit,
+        int currentDepth)
+    {
+        var entries = new List<WorkspaceEntryDto>();
+        var items = _fileSystem.Directory
+            .EnumerateFileSystemEntries(currentDirectory)
+            .OrderBy(p => _fileSystem.Directory.Exists(p) ? 0 : 1)
+            .ThenBy(p => _fileSystem.Path.GetFileName(p), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var itemPath in items)
+        {
+            var finalPath = WorkspacePathSecurity.ResolveFinalTargetPath(_fileSystem, itemPath);
+            if (!validator.CanRead(finalPath))
+                continue;
+
+            var isDir = _fileSystem.Directory.Exists(itemPath);
+            var relativePath = WorkspacePathSecurity.ToWorkspaceRelativePath(_fileSystem, root, itemPath);
+            if (isDir)
+            {
+                var children = currentDepth < depthLimit
+                    ? BuildTreeEntries(root, itemPath, validator, depthLimit, currentDepth + 1)
+                    : [];
+                entries.Add(new WorkspaceEntryDto
+                {
+                    Name = _fileSystem.Path.GetFileName(itemPath),
+                    Path = relativePath,
+                    Type = "directory",
+                    Children = children
+                });
+                continue;
+            }
+
+            var info = _fileSystem.FileInfo.New(itemPath);
+            entries.Add(new WorkspaceEntryDto
+            {
+                Name = _fileSystem.Path.GetFileName(itemPath),
+                Path = relativePath,
+                Type = "file",
+                Size = info.Length
+            });
+        }
+
+        return entries;
+    }
+
+    private static bool IsBinary(byte[] buffer, int length)
+    {
+        for (var i = 0; i < length; i++)
+        {
+            if (buffer[i] == 0)
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.AspNetCore.Components;
@@ -39,6 +39,7 @@ public sealed class MainLayoutTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(http);
+        _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using Bunit.TestDoubles;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
@@ -26,8 +26,10 @@ public sealed class ProbeRound2ComponentTests : IDisposable
 
         _ctx.Services.AddSingleton<IClientStateStore>(_store);
         _ctx.Services.AddSingleton(_interaction);
-        _ctx.Services.AddSingleton(Substitute.For<IGatewayRestClient>());
+        var restClient = Substitute.For<IGatewayRestClient>();
+        _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(new HttpClient());
+        _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
         _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
         _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -178,6 +180,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         ctx.Services.AddSingleton(gatewayInfo);
         ctx.Services.AddSingleton(restClient);
         ctx.Services.AddSingleton(http);
+        ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
         ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
         ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -217,8 +220,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         _ctx.Services.AddSingleton(portalLoad);
         _ctx.Services.AddSingleton(hub);
         _ctx.Services.AddSingleton(gatewayInfo);
-        _ctx.Services.AddSingleton(restClient);
-        _ctx.Services.AddSingleton(http);
+        _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
 
         _store.SeedAgents([new AgentSummary("a-1", "Agent One")]);
         _store.SeedConversations("a-1", []);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
@@ -42,6 +42,7 @@ public sealed class UpdateBadgeTests : IDisposable
         _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(_updateSvc);
+        _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
         _ctx.Services.AddSingleton(Substitute.For<IPortalPreferencesService>());
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }


### PR DESCRIPTION
## Summary

Adds a **Skills** section to the Blazor portal sidebar, visible only when the `botnexus-skills` extension is loaded. The section contains a single sub-page — **Explorer** — that provides a tree/editor view of the global skills directory (`~/.botnexus/skills`), using the same workspace controls already in the portal.

## Changes

### Gateway API
- **`SkillsController`** — new `GET/PUT/DELETE /api/skills/{**path}` controller backed by `~/.botnexus/skills`. Uses the same `WorkspacePathSecurity` primitives as `WorkspaceController`, including path traversal protection.

### Blazor Client Core
- **`ExtensionFeatureService`** — lightweight service that calls `GET /api/extensions/details` and exposes `SkillsEnabled` (true when `botnexus-skills` is loaded and enabled). Loaded when the portal becomes ready.
- **`IGatewayRestClient`** — added `GetExtensionDetailsAsync`, `GetSkillsAsync`, `WriteSkillFileAsync`, `DeleteSkillItemAsync`
- **`GatewayRestClient`** — implementations of the above
- **`ExtensionDetailDto`** — deserialization target for the `/api/extensions/details` response

### Blazor Client UI
- **`SkillsExplorerPanel.razor`** — tree + editor panel, reuses `WorkspaceFileTree` and `WorkspaceFileViewer` directly. No duplication of tree/viewer logic.
- **`Skills.razor`** — page at `/skills` and `/skills/{Section}` with a toolbar and panel canvas.
- **`MainLayout.razor`** — Skills nav item inserted between Configuration and Agents. Gated on `ExtensionFeatures.SkillsEnabled`. Explorer sub-nav expands when on the skills page.
- **`Program.cs`** — registers `ExtensionFeatureService`
- **`app.css`** — `.skills-panel-canvas` override for full-height workspace layout

### Tests
- Fixed `MainLayoutTests`, `UpdateBadgeTests`, `ProbeRound2ComponentTests` bUnit setups to register `ExtensionFeatureService` (required by the updated `MainLayout`)

## Test results
- 335/335 BlazorClient unit tests passing
- 2006+/2007 Gateway tests passing (1 pre-existing skip)
- All other unit test suites clean
- `Cli_Install_ClonesCurrentRepoIntoSandbox` pre-existing worktree-clone failure on `main`, not caused by this PR

## Notes
- Skills Explorer currently shows only the **global** `~/.botnexus/skills` directory. Per-agent and workspace skills dirs are future scope — the API and UI can be extended without breaking changes.
- Delete is guarded with a confirmation dialog (same as WorkspacePanel).