### PR TITLE
fix(ui): remove tool processing status bar from chat panel

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -159,8 +159,6 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
 
         if (convId != agent.ActiveConversationId)
             conv.UnreadCount++;
-
-        agent.ProcessingStage = $"🔧 Using tool: {evt.ToolName}";
         _store.NotifyChanged();
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -1,4 +1,4 @@
-﻿@inject IJSRuntime JS
+@inject IJSRuntime JS
 @inject IClientStateStore Store
 @inject IAgentInteractionService Interaction
 @inject IPortalPreferencesService Prefs
@@ -130,13 +130,6 @@
             <span class="read-only-badge">🔍 Sub-agent session</span>
             <span class="read-only-status @(IsStreaming ? "" : "completed")">@GetSubAgentStatus()</span>
             <span class="read-only-label">Read-only — you can observe but not interact</span>
-        </div>
-    }
-
-    @if (IsStreaming && ProcessingStage is not null)
-    {
-        <div class="processing-status-bar">
-            @ProcessingStage
         </div>
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -2045,17 +2045,6 @@ html, body, #app {
     }
 }
 
-/* ── Processing status bar ──────────────────────────────────────────── */
-
-.processing-status-bar {
-    padding: 0.35rem 1rem;
-    background: rgba(0, 180, 216, 0.08);
-    border-bottom: 1px solid rgba(0, 180, 216, 0.2);
-    color: var(--accent);
-    font-size: 0.78rem;
-    animation: pulse 1.5s ease-in-out infinite;
-}
-
 /* ── Thinking blocks ────────────────────────────────────────────────── */
 
 .thinking-block {


### PR DESCRIPTION
## Summary

Removes the status bar that popped up during agent tool execution showing messages like `Using tool: exec`. It adds no user value and creates visual noise.

## Changes

- **`ChatPanel.razor`**: Removed the `processing-status-bar` div block shown when `IsStreaming && ProcessingStage != null`
- **`GatewayEventHandler.cs`**: Removed the `ProcessingStage = "Using tool: {toolName}"` assignment on tool start
- **`app.css`**: Removed the `.processing-status-bar` CSS rule and section comment

The `ProcessingStage` property remains on the agent model and is still used for thinking/responding states elsewhere. Only the tool-specific assignment and UI render block are removed.