### PR TITLE
feat(skills): add SkillManagerTool with create/edit/patch/delete/write_file/remove_file actions (#706)

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/SkillManagerTool.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillManagerTool.cs
@@ -1,0 +1,497 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Extensions.Skills.Security;
+using System.IO.Abstractions;
+
+namespace BotNexus.Extensions.Skills;
+
+/// <summary>
+/// Agent-facing tool for creating, editing, patching, deleting, and managing supporting files
+/// for skills at runtime. Only contributed when <see cref="SkillsConfig.AllowSkillCreation"/>
+/// is enabled. Destructive actions additionally require <see cref="SkillsConfig.AllowSkillDeletion"/>.
+/// </summary>
+public sealed class SkillManagerTool(
+    string? agentSkillsDir,
+    string? workspaceSkillsDir,
+    SkillsConfig config,
+    IFileSystem? fileSystem = null) : IAgentTool
+{
+    private readonly IFileSystem _fs = fileSystem ?? new FileSystem();
+
+    // Allowed sub-directories for write_file / remove_file supporting files
+    private static readonly HashSet<string> AllowedSupportingDirs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "references", "templates", "scripts", "assets"
+    };
+
+    private const long MaxSkillFileBytes = 524_288; // 512 KB
+    private const int MaxSupportingFileBytes = 1_048_576; // 1 MB
+
+    public string Name => "skill_manage";
+    public string Label => "Skill Manager (Write)";
+
+    public Tool Definition => new(
+        Name,
+        "Create, edit, patch, and delete skills, and manage supporting files within a skill directory. Only available when skill management is enabled for this agent.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": ["create", "edit", "patch", "delete", "write_file", "remove_file"],
+                  "description": "Action to perform: 'create' — create a new skill; 'edit' — full rewrite of SKILL.md; 'patch' — targeted find-replace within a skill file; 'delete' — remove a skill; 'write_file' — write a supporting file (references/, templates/, scripts/, assets/); 'remove_file' — delete a supporting file."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Skill name (required for all actions). Must be lowercase alphanumeric + hyphens, max 64 chars."
+                },
+                "content": {
+                  "type": "string",
+                  "description": "Full SKILL.md content including YAML frontmatter (required for create and edit)."
+                },
+                "oldText": {
+                  "type": "string",
+                  "description": "Exact text to find (required for patch)."
+                },
+                "newText": {
+                  "type": "string",
+                  "description": "Replacement text (required for patch)."
+                },
+                "filePath": {
+                  "type": "string",
+                  "description": "Relative path within the skill directory for patch, write_file, and remove_file. Defaults to SKILL.md for patch."
+                },
+                "replaceAll": {
+                  "type": "boolean",
+                  "description": "Replace all occurrences in patch (default: false, replaces first occurrence only)."
+                }
+              },
+              "required": ["action", "name"]
+            }
+            """).RootElement.Clone());
+
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(arguments);
+    }
+
+    public Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!config.AllowSkillCreation)
+            return Task.FromResult(Error("Skill management is not enabled for this agent."));
+
+        var action = ReadString(arguments, "action") ?? string.Empty;
+        var name = ReadString(arguments, "name") ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(name))
+            return Task.FromResult(Error("'name' is required."));
+
+        if (!SkillParser.IsValidName(name))
+            return Task.FromResult(Error($"Invalid skill name '{name}'. Must be lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, max 64 chars."));
+
+        return action.ToLowerInvariant() switch
+        {
+            "create" => Task.FromResult(CreateSkill(name, arguments)),
+            "edit" => Task.FromResult(EditSkill(name, arguments)),
+            "patch" => Task.FromResult(PatchSkill(name, arguments)),
+            "delete" => Task.FromResult(DeleteSkill(name)),
+            "write_file" => Task.FromResult(WriteFile(name, arguments)),
+            "remove_file" => Task.FromResult(RemoveFile(name, arguments)),
+            _ => Task.FromResult(Error($"Unknown action: '{action}'. Valid: create, edit, patch, delete, write_file, remove_file."))
+        };
+    }
+
+    // ──────────────────────────── create ────────────────────────────────────
+
+    private AgentToolResult CreateSkill(string name, IReadOnlyDictionary<string, object?> arguments)
+    {
+        var content = ReadString(arguments, "content");
+        if (string.IsNullOrWhiteSpace(content))
+            return Error("'content' is required for create.");
+
+        var targetDir = ResolveWriteRoot(name);
+        if (targetDir is null)
+            return Error("No writable skill directory is configured for this agent.");
+
+        var skillDir = Path.Combine(targetDir, name);
+        var skillMdPath = Path.Combine(skillDir, "SKILL.md");
+
+        if (_fs.Directory.Exists(skillDir))
+            return Error($"Skill '{name}' already exists at '{skillDir}'. Use 'edit' to update it.");
+
+        if (content.Length > MaxSkillFileBytes)
+            return Error($"SKILL.md content exceeds maximum size of {MaxSkillFileBytes / 1024} KB.");
+
+        // Validate parseable + required fields before writing
+        var parsed = SkillParser.Parse(name, content, skillDir, SkillSource.Workspace);
+        if (string.IsNullOrWhiteSpace(parsed.Description))
+            return Error("SKILL.md frontmatter must include a non-empty 'description' field.");
+
+        if (!string.Equals(parsed.Name, name, StringComparison.Ordinal))
+            return Error($"Frontmatter 'name' field ('{parsed.Name}') must match the skill directory name '{name}'.");
+
+        _fs.Directory.CreateDirectory(skillDir);
+        _fs.File.WriteAllText(skillMdPath, content);
+
+        // Security scan post-write — roll back on critical finding
+        var scan = SkillSecurityScanner.ScanDirectory(skillDir, fileSystem: _fs);
+        if (scan.Critical > 0)
+        {
+            _fs.Directory.Delete(skillDir, recursive: true);
+            return Error($"Skill creation blocked: security scan found {scan.Critical} critical finding(s). Rolled back.\n{FormatFindings(scan)}");
+        }
+
+        return Ok($"Skill '{name}' created at '{skillDir}'.\nSecurity scan: {scan.ScannedFiles} file(s) scanned, {scan.Warn} warning(s).");
+    }
+
+    // ──────────────────────────── edit ──────────────────────────────────────
+
+    private AgentToolResult EditSkill(string name, IReadOnlyDictionary<string, object?> arguments)
+    {
+        var content = ReadString(arguments, "content");
+        if (string.IsNullOrWhiteSpace(content))
+            return Error("'content' is required for edit.");
+
+        var skillDir = FindSkillDir(name, out var source);
+        if (skillDir is null)
+            return Error($"Skill '{name}' not found in any configured skill directory.");
+
+        if (source == SkillSource.Global)
+            return Error($"Skill '{name}' is a global skill and cannot be edited by the agent. Copy it to the agent or workspace scope first.");
+
+        var skillMdPath = Path.Combine(skillDir, "SKILL.md");
+
+        if (content.Length > MaxSkillFileBytes)
+            return Error($"SKILL.md content exceeds maximum size of {MaxSkillFileBytes / 1024} KB.");
+
+        var parsed = SkillParser.Parse(name, content, skillDir, source);
+        if (string.IsNullOrWhiteSpace(parsed.Description))
+            return Error("SKILL.md frontmatter must include a non-empty 'description' field.");
+
+        if (!string.Equals(parsed.Name, name, StringComparison.Ordinal))
+            return Error($"Frontmatter 'name' field ('{parsed.Name}') must match the skill directory name '{name}'.");
+
+        // Read backup before overwrite
+        var backup = _fs.File.Exists(skillMdPath) ? _fs.File.ReadAllText(skillMdPath) : null;
+
+        _fs.File.WriteAllText(skillMdPath, content);
+
+        var scan = SkillSecurityScanner.ScanDirectory(skillDir, fileSystem: _fs);
+        if (scan.Critical > 0)
+        {
+            // Roll back
+            if (backup is not null)
+                _fs.File.WriteAllText(skillMdPath, backup);
+            else
+                _fs.File.Delete(skillMdPath);
+
+            return Error($"Skill edit blocked: security scan found {scan.Critical} critical finding(s). Rolled back.\n{FormatFindings(scan)}");
+        }
+
+        return Ok($"Skill '{name}' updated at '{skillDir}'.\nSecurity scan: {scan.ScannedFiles} file(s) scanned, {scan.Warn} warning(s).");
+    }
+
+    // ──────────────────────────── patch ─────────────────────────────────────
+
+    private AgentToolResult PatchSkill(string name, IReadOnlyDictionary<string, object?> arguments)
+    {
+        var oldText = ReadString(arguments, "oldText");
+        var newText = ReadString(arguments, "newText");
+
+        if (oldText is null)
+            return Error("'oldText' is required for patch.");
+        if (newText is null)
+            return Error("'newText' is required for patch.");
+
+        var skillDir = FindSkillDir(name, out var source);
+        if (skillDir is null)
+            return Error($"Skill '{name}' not found in any configured skill directory.");
+
+        if (source == SkillSource.Global)
+            return Error($"Skill '{name}' is a global skill and cannot be patched by the agent.");
+
+        var relPath = ReadString(arguments, "filePath") ?? "SKILL.md";
+        if (!IsAllowedFilePath(relPath, out var reason))
+            return Error(reason);
+
+        var targetPath = Path.Combine(skillDir, relPath);
+        if (!_fs.File.Exists(targetPath))
+            return Error($"File '{relPath}' not found in skill '{name}'.");
+
+        var current = _fs.File.ReadAllText(targetPath);
+
+        if (!current.Contains(oldText, StringComparison.Ordinal))
+            return Error($"'oldText' not found in '{relPath}'. No changes made.");
+
+        var replaceAll = ReadBool(arguments, "replaceAll") ?? false;
+        var updated = replaceAll
+            ? current.Replace(oldText, newText, StringComparison.Ordinal)
+            : ReplaceFirst(current, oldText, newText);
+
+        // If patching SKILL.md, validate frontmatter still intact
+        if (string.Equals(relPath, "SKILL.md", StringComparison.OrdinalIgnoreCase))
+        {
+            var parsed = SkillParser.Parse(name, updated, skillDir, source);
+            if (string.IsNullOrWhiteSpace(parsed.Description))
+                return Error("Patch would remove the required 'description' frontmatter field. Rejected.");
+        }
+
+        var backup = current;
+        _fs.File.WriteAllText(targetPath, updated);
+
+        // Security scan
+        var scan = SkillSecurityScanner.ScanDirectory(skillDir, fileSystem: _fs);
+        if (scan.Critical > 0)
+        {
+            _fs.File.WriteAllText(targetPath, backup);
+            return Error($"Patch blocked: security scan found {scan.Critical} critical finding(s). Rolled back.\n{FormatFindings(scan)}");
+        }
+
+        var occurrences = replaceAll ? CountOccurrences(current, oldText) : 1;
+        return Ok($"Patched '{relPath}' in skill '{name}' ({occurrences} replacement(s)).\nSecurity scan: {scan.ScannedFiles} file(s) scanned, {scan.Warn} warning(s).");
+    }
+
+    // ──────────────────────────── delete ────────────────────────────────────
+
+    private AgentToolResult DeleteSkill(string name)
+    {
+        if (!config.AllowSkillDeletion)
+            return Error("Skill deletion is not enabled for this agent (AllowSkillDeletion = false).");
+
+        var skillDir = FindSkillDir(name, out var source);
+        if (skillDir is null)
+            return Error($"Skill '{name}' not found.");
+
+        if (source == SkillSource.Global)
+            return Error($"Skill '{name}' is a global skill and cannot be deleted by the agent.");
+
+        _fs.Directory.Delete(skillDir, recursive: true);
+        return Ok($"Skill '{name}' deleted from '{skillDir}'.");
+    }
+
+    // ──────────────────────────── write_file ────────────────────────────────
+
+    private AgentToolResult WriteFile(string name, IReadOnlyDictionary<string, object?> arguments)
+    {
+        var relPath = ReadString(arguments, "filePath");
+        if (string.IsNullOrWhiteSpace(relPath))
+            return Error("'filePath' is required for write_file.");
+
+        if (string.Equals(relPath, "SKILL.md", StringComparison.OrdinalIgnoreCase))
+            return Error("Use 'create' or 'edit' to modify SKILL.md, not 'write_file'.");
+
+        if (!IsAllowedFilePath(relPath, out var reason))
+            return Error(reason);
+
+        var content = ReadString(arguments, "content") ?? string.Empty;
+
+        if (content.Length > MaxSupportingFileBytes)
+            return Error($"File content exceeds maximum size of {MaxSupportingFileBytes / 1024} KB.");
+
+        var skillDir = FindSkillDir(name, out var source);
+        if (skillDir is null)
+        {
+            // Skill must exist before writing supporting files
+            return Error($"Skill '{name}' not found. Create the skill first with 'create'.");
+        }
+
+        if (source == SkillSource.Global)
+            return Error($"Skill '{name}' is a global skill. Supporting files cannot be written to it by the agent.");
+
+        var targetPath = Path.Combine(skillDir, relPath);
+
+        // Ensure the supporting sub-directory exists
+        var targetDir = Path.GetDirectoryName(targetPath);
+        if (!string.IsNullOrEmpty(targetDir))
+            _fs.Directory.CreateDirectory(targetDir);
+
+        _fs.File.WriteAllText(targetPath, content);
+
+        // Security scan
+        var scan = SkillSecurityScanner.ScanDirectory(skillDir, fileSystem: _fs);
+        if (scan.Critical > 0)
+        {
+            _fs.File.Delete(targetPath);
+            return Error($"File write blocked: security scan found {scan.Critical} critical finding(s). Rolled back.\n{FormatFindings(scan)}");
+        }
+
+        return Ok($"Wrote '{relPath}' in skill '{name}'.\nSecurity scan: {scan.ScannedFiles} file(s) scanned, {scan.Warn} warning(s).");
+    }
+
+    // ──────────────────────────── remove_file ───────────────────────────────
+
+    private AgentToolResult RemoveFile(string name, IReadOnlyDictionary<string, object?> arguments)
+    {
+        if (!config.AllowSkillDeletion)
+            return Error("Skill deletion is not enabled for this agent (AllowSkillDeletion = false).");
+
+        var relPath = ReadString(arguments, "filePath");
+        if (string.IsNullOrWhiteSpace(relPath))
+            return Error("'filePath' is required for remove_file.");
+
+        if (string.Equals(relPath, "SKILL.md", StringComparison.OrdinalIgnoreCase))
+            return Error("SKILL.md cannot be removed with 'remove_file'. Use 'delete' to remove the entire skill.");
+
+        if (!IsAllowedFilePath(relPath, out var reason))
+            return Error(reason);
+
+        var skillDir = FindSkillDir(name, out var source);
+        if (skillDir is null)
+            return Error($"Skill '{name}' not found.");
+
+        if (source == SkillSource.Global)
+            return Error($"Skill '{name}' is a global skill. Files cannot be removed from it by the agent.");
+
+        var targetPath = Path.Combine(skillDir, relPath);
+        if (!_fs.File.Exists(targetPath))
+            return Error($"File '{relPath}' not found in skill '{name}'.");
+
+        _fs.File.Delete(targetPath);
+        return Ok($"Removed '{relPath}' from skill '{name}'.");
+    }
+
+    // ──────────────────────────── helpers ───────────────────────────────────
+
+    /// <summary>
+    /// Resolves the write-target root for a new skill.
+    /// Prefers workspace, falls back to agent. Never writes to global.
+    /// </summary>
+    private string? ResolveWriteRoot(string name)
+    {
+        if (!string.IsNullOrWhiteSpace(workspaceSkillsDir))
+            return workspaceSkillsDir;
+        if (!string.IsNullOrWhiteSpace(agentSkillsDir))
+            return agentSkillsDir;
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the skill directory for the given skill name across agent and workspace sources.
+    /// Global source is included for read (find) but write operations must reject it.
+    /// </summary>
+    private string? FindSkillDir(string name, out SkillSource source)
+    {
+        // Workspace overrides agent which overrides global — match SkillDiscovery priority
+        foreach (var (dir, src) in new[] {
+            (workspaceSkillsDir, SkillSource.Workspace),
+            (agentSkillsDir, SkillSource.Agent) })
+        {
+            if (string.IsNullOrWhiteSpace(dir))
+                continue;
+            var candidate = Path.Combine(dir, name);
+            if (_fs.Directory.Exists(candidate) && _fs.File.Exists(Path.Combine(candidate, "SKILL.md")))
+            {
+                source = src;
+                return candidate;
+            }
+        }
+
+        source = SkillSource.Global;
+        return null;
+    }
+
+    /// <summary>Validates a relative file path inside a skill directory.</summary>
+    private static bool IsAllowedFilePath(string relPath, out string reason)
+    {
+        reason = string.Empty;
+
+        // Normalize separators
+        var normalized = relPath.Replace('\\', '/').TrimStart('/');
+
+        // Block absolute paths and traversal
+        if (Path.IsPathRooted(normalized) || normalized.Contains("../") || normalized.Contains("..\\"))
+        {
+            reason = "Path traversal is not permitted in file paths.";
+            return false;
+        }
+
+        // SKILL.md is allowed for patch target
+        if (string.Equals(normalized, "SKILL.md", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Supporting files must be under an allowed sub-directory
+        var parts = normalized.Split('/');
+        if (parts.Length < 2 || !AllowedSupportingDirs.Contains(parts[0]))
+        {
+            reason = $"Supporting files must be under one of: {string.Join(", ", AllowedSupportingDirs)}/. Got: '{relPath}'.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string ReplaceFirst(string source, string oldText, string newText)
+    {
+        var index = source.IndexOf(oldText, StringComparison.Ordinal);
+        if (index < 0)
+            return source;
+        return string.Concat(source.AsSpan(0, index), newText, source.AsSpan(index + oldText.Length));
+    }
+
+    private static int CountOccurrences(string source, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = source.IndexOf(pattern, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+
+    private static string FormatFindings(ScanSummary scan)
+    {
+        if (scan.Findings.Count == 0)
+            return string.Empty;
+
+        var lines = scan.Findings
+            .Where(f => f.Severity == ScanSeverity.Critical)
+            .Select(f => $"  [{f.RuleId}] {f.File}:{f.Line} — {f.Message}")
+            .Take(5);
+
+        return "Critical findings:\n" + string.Join("\n", lines);
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value) || value is null) return null;
+        return value switch
+        {
+            JsonElement { ValueKind: JsonValueKind.String } el => el.GetString(),
+            JsonElement el => el.ToString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static bool? ReadBool(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value) || value is null) return null;
+        return value switch
+        {
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            JsonElement el => bool.TryParse(el.ToString(), out var b) ? b : null,
+            bool b => b,
+            _ => bool.TryParse(value.ToString(), out var parsed) ? parsed : null
+        };
+    }
+
+    private static AgentToolResult Ok(string text)
+        => new([new AgentToolContent(AgentToolContentType.Text, text)]);
+
+    private static AgentToolResult Error(string message)
+        => new([new AgentToolContent(AgentToolContentType.Text, $"Error: {message}")]);
+}

--- a/src/extensions/BotNexus.Extensions.Skills/SkillManagerToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillManagerToolContributor.cs
@@ -1,0 +1,57 @@
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Extensions.Skills;
+
+/// <summary>
+/// Contributes the session-scoped <see cref="SkillManagerTool"/> when
+/// <see cref="SkillsConfig.AllowSkillCreation"/> is enabled.
+/// The write tool is contributed alongside the existing <see cref="SkillTool"/>
+/// (contributed by <see cref="SkillsToolContributor"/>).
+/// </summary>
+public sealed class SkillManagerToolContributor : IAgentToolContributor
+{
+    /// <inheritdoc />
+    public Task<AgentToolContribution> ContributeAsync(
+        AgentToolContributionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var config = ResolveExtensionConfig<SkillsConfig>(context.Descriptor, "botnexus-skills")
+                     ?? new SkillsConfig();
+
+        // Only contribute the write tool when creation is explicitly enabled
+        if (!config.AllowSkillCreation)
+            return Task.FromResult(new AgentToolContribution(Array.Empty<IAgentTool>()));
+
+        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var agentSkillsDir = Path.Combine(homeDir, ".botnexus", "agents", context.Descriptor.AgentId.Value, "skills");
+        var workspaceSkillsDir = Path.Combine(context.WorkspacePath, "skills");
+
+        IReadOnlyList<IAgentTool> tools =
+        [
+            new SkillManagerTool(agentSkillsDir, workspaceSkillsDir, config)
+        ];
+
+        return Task.FromResult(new AgentToolContribution(tools));
+    }
+
+    private static T? ResolveExtensionConfig<T>(AgentDescriptor descriptor, string extensionId) where T : class
+    {
+        if (descriptor.ExtensionConfig.TryGetValue(extensionId, out var element))
+        {
+            try
+            {
+                return System.Text.Json.JsonSerializer.Deserialize<T>(element.GetRawText());
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Skills/SkillsConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillsConfig.cs
@@ -22,4 +22,19 @@ public sealed class SkillsConfig
 
     /// <summary>Maximum total characters of skill content in the prompt.</summary>
     public int MaxSkillContentChars { get; set; } = 100_000;
+
+    // ── SkillManagerTool gates ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Allow the agent to create and edit skills via the skill_manage tool.
+    /// When false (default), the tool is not contributed and write operations are blocked.
+    /// </summary>
+    public bool AllowSkillCreation { get; set; } = false;
+
+    /// <summary>
+    /// Allow the agent to delete skills and remove supporting files via the skill_manage tool.
+    /// When false (default), delete and remove_file actions are blocked.
+    /// Requires <see cref="AllowSkillCreation"/> to also be true.
+    /// </summary>
+    public bool AllowSkillDeletion { get; set; } = false;
 }

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillManagerToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillManagerToolTests.cs
@@ -1,0 +1,521 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Extensions.Skills;
+
+namespace BotNexus.Skills.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SkillManagerTool"/>.
+/// Covers: create, edit, patch, delete, write_file, remove_file — happy paths, error paths,
+/// security guardrail rollback, and config gate enforcement.
+/// </summary>
+public sealed class SkillManagerToolTests
+{
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private const string AgentSkillsDir = "/home/agent/.botnexus/agents/test-agent/skills";
+    private const string WorkspaceSkillsDir = "/workspace/skills";
+
+    private static SkillsConfig EnabledConfig(bool deletionAllowed = false) => new()
+    {
+        AllowSkillCreation = true,
+        AllowSkillDeletion = deletionAllowed
+    };
+
+    private static IReadOnlyDictionary<string, object?> Args(string action, string name, params (string key, object? value)[] extra)
+    {
+        var d = new Dictionary<string, object?> { ["action"] = action, ["name"] = name };
+        foreach (var (k, v) in extra)
+            d[k] = v;
+        return d;
+    }
+
+    private static string ResultText(BotNexus.Agent.Core.Types.AgentToolResult result)
+        => string.Join("", result.Content.Select(c => c.Value));
+
+    private static string ValidSkillMd(string name) => $"""
+        ---
+        name: {name}
+        description: A test skill for {name}
+        ---
+        # {name}
+        This is the body.
+        """;
+
+    // ── gate ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllActions_WhenCreationDisabled_ReturnError()
+    {
+        var fs = new MockFileSystem();
+        var config = new SkillsConfig { AllowSkillCreation = false };
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, config, fs);
+
+        foreach (var action in new[] { "create", "edit", "patch", "delete", "write_file", "remove_file" })
+        {
+            var result = await tool.ExecuteAsync("x", Args(action, "my-skill"));
+            ResultText(result).ShouldContain("Error:");
+        }
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_ValidSkill_WritesFilesAndReturnsOk()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("create", "my-skill",
+            ("content", ValidSkillMd("my-skill"))));
+
+        var text = ResultText(result);
+        text.ShouldNotContain("Error:");
+        text.ShouldContain("my-skill");
+
+        fs.File.Exists($"{WorkspaceSkillsDir}/my-skill/SKILL.md").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Create_MissingContent_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("create", "my-skill"));
+        ResultText(result).ShouldContain("Error:");
+    }
+
+    [Fact]
+    public async Task Create_DuplicateSkill_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("create", "my-skill",
+            ("content", ValidSkillMd("my-skill"))));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("already exists");
+    }
+
+    [Fact]
+    public async Task Create_InvalidName_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("create", "INVALID_NAME",
+            ("content", ValidSkillMd("INVALID_NAME"))));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("Invalid skill name");
+    }
+
+    [Fact]
+    public async Task Create_MissingDescription_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        const string noDesc = "---\nname: my-skill\n---\nBody content.";
+        var result = await tool.ExecuteAsync("call-1", Args("create", "my-skill",
+            ("content", noDesc)));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("description");
+    }
+
+    [Fact]
+    public async Task Create_NameMismatch_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        // Frontmatter name says "other-skill" but directory name arg is "my-skill"
+        const string mismatch = "---\nname: other-skill\ndescription: some desc\n---\nBody.";
+        var result = await tool.ExecuteAsync("call-1", Args("create", "my-skill",
+            ("content", mismatch)));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("match");
+    }
+
+    [Fact]
+    public async Task WriteFile_SecurityCriticalFinding_RollsBackAndReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        // A real .js file with eval() + child_process triggers the critical scanner rules
+        const string evilScript = """const cp = require('child_process'); eval(userInput);""";
+        var result = await tool.ExecuteAsync("call-1", Args("write_file", "my-skill",
+            ("filePath", "scripts/evil.js"),
+            ("content", evilScript)));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("critical");
+
+        // File should have been rolled back
+        fs.File.Exists($"{WorkspaceSkillsDir}/my-skill/scripts/evil.js").ShouldBeFalse();
+    }
+
+    // ── edit ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Edit_ExistingWorkspaceSkill_UpdatesFile()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var updatedContent = ValidSkillMd("my-skill") + "\n\nUpdated body.";
+        var result = await tool.ExecuteAsync("call-1", Args("edit", "my-skill",
+            ("content", updatedContent)));
+
+        ResultText(result).ShouldNotContain("Error:");
+        fs.File.ReadAllText($"{WorkspaceSkillsDir}/my-skill/SKILL.md").ShouldContain("Updated body.");
+    }
+
+    [Fact]
+    public async Task Edit_NonExistentSkill_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("edit", "ghost-skill",
+            ("content", ValidSkillMd("ghost-skill"))));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task Edit_WithExistingMaliciousScript_SecurityScanBlocksEdit()
+    {
+        var originalContent = ValidSkillMd("my-skill");
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill/scripts");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(originalContent));
+        // Pre-existing malicious script in the skill dir will cause the scan to fail on any edit
+        const string evilScript = """const cp = require('child_process'); eval(userInput);""";
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/scripts/evil.js", new MockFileData(evilScript));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var updatedContent = originalContent + "\n\nSome new body.";
+        var result = await tool.ExecuteAsync("call-1", Args("edit", "my-skill",
+            ("content", updatedContent)));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("critical");
+        // File should have been rolled back to original
+        fs.File.ReadAllText($"{WorkspaceSkillsDir}/my-skill/SKILL.md").ShouldBe(originalContent);
+    }
+
+    // ── patch ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Patch_ReplacesFirstOccurrenceByDefault()
+    {
+        var original = ValidSkillMd("my-skill") + "\nfoo bar foo";
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(original));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("patch", "my-skill",
+            ("oldText", "foo"),
+            ("newText", "baz")));
+
+        ResultText(result).ShouldNotContain("Error:");
+        var updated = fs.File.ReadAllText($"{WorkspaceSkillsDir}/my-skill/SKILL.md");
+        updated.ShouldContain("baz bar foo"); // only first replaced
+    }
+
+    [Fact]
+    public async Task Patch_ReplaceAll_ReplacesAllOccurrences()
+    {
+        var original = ValidSkillMd("my-skill") + "\nfoo bar foo";
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(original));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("patch", "my-skill",
+            ("oldText", "foo"),
+            ("newText", "baz"),
+            ("replaceAll", true)));
+
+        ResultText(result).ShouldNotContain("Error:");
+        var updated = fs.File.ReadAllText($"{WorkspaceSkillsDir}/my-skill/SKILL.md");
+        updated.ShouldContain("baz bar baz");
+        updated.ShouldNotContain("foo");
+    }
+
+    [Fact]
+    public async Task Patch_OldTextNotFound_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("patch", "my-skill",
+            ("oldText", "DEFINITELY_NOT_PRESENT"),
+            ("newText", "replacement")));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task Patch_PathTraversalAttempt_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("patch", "my-skill",
+            ("oldText", "foo"),
+            ("newText", "bar"),
+            ("filePath", "../other-skill/SKILL.md")));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("traversal");
+    }
+
+    [Fact]
+    public async Task Patch_SupportingFile_WorksWithAllowedSubdir()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill/references");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/references/guide.md", new MockFileData("hello world"));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("patch", "my-skill",
+            ("oldText", "hello"),
+            ("newText", "goodbye"),
+            ("filePath", "references/guide.md")));
+
+        ResultText(result).ShouldNotContain("Error:");
+        fs.File.ReadAllText($"{WorkspaceSkillsDir}/my-skill/references/guide.md").ShouldContain("goodbye world");
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_ExistingSkill_RemovesDirectory()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: true), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("delete", "my-skill"));
+        ResultText(result).ShouldNotContain("Error:");
+        fs.Directory.Exists($"{WorkspaceSkillsDir}/my-skill").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Delete_WhenDeletionDisabled_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: false), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("delete", "my-skill"));
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("AllowSkillDeletion");
+        fs.Directory.Exists($"{WorkspaceSkillsDir}/my-skill").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Delete_NonExistentSkill_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: true), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("delete", "ghost-skill"));
+        ResultText(result).ShouldContain("Error:");
+    }
+
+    // ── write_file ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WriteFile_AllowedSubdir_WritesSuccessfully()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("write_file", "my-skill",
+            ("filePath", "references/cheatsheet.md"),
+            ("content", "# Cheatsheet\nHello!")));
+
+        ResultText(result).ShouldNotContain("Error:");
+        fs.File.Exists($"{WorkspaceSkillsDir}/my-skill/references/cheatsheet.md").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WriteFile_DisallowedSubdir_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("write_file", "my-skill",
+            ("filePath", "secrets/passwords.txt"),
+            ("content", "bad stuff")));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("references, templates, scripts, assets");
+    }
+
+    [Fact]
+    public async Task WriteFile_PathTraversal_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("write_file", "my-skill",
+            ("filePath", "../other-skill/evil.sh"),
+            ("content", "rm -rf /")));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("traversal");
+    }
+
+    [Fact]
+    public async Task WriteFile_SkillNotFound_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("write_file", "ghost-skill",
+            ("filePath", "references/guide.md"),
+            ("content", "something")));
+
+        ResultText(result).ShouldContain("Error:");
+    }
+
+    // ── remove_file ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveFile_ExistingFile_DeletesIt()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill/references");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/references/guide.md", new MockFileData("content"));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: true), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("remove_file", "my-skill",
+            ("filePath", "references/guide.md")));
+
+        ResultText(result).ShouldNotContain("Error:");
+        fs.File.Exists($"{WorkspaceSkillsDir}/my-skill/references/guide.md").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RemoveFile_WhenDeletionDisabled_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill/references");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/references/guide.md", new MockFileData("content"));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: false), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("remove_file", "my-skill",
+            ("filePath", "references/guide.md")));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("AllowSkillDeletion");
+    }
+
+    [Fact]
+    public async Task RemoveFile_SkillMd_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{WorkspaceSkillsDir}/my-skill");
+        fs.AddFile($"{WorkspaceSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: true), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("remove_file", "my-skill",
+            ("filePath", "SKILL.md")));
+
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("delete");
+    }
+
+    // ── source priority ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Edit_AgentScopedSkill_WorksWhenNoWorkspaceCopy()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{AgentSkillsDir}/my-skill");
+        fs.AddFile($"{AgentSkillsDir}/my-skill/SKILL.md", new MockFileData(ValidSkillMd("my-skill")));
+
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("edit", "my-skill",
+            ("content", ValidSkillMd("my-skill") + "\nAgent update.")));
+
+        ResultText(result).ShouldNotContain("Error:");
+        fs.File.ReadAllText($"{AgentSkillsDir}/my-skill/SKILL.md").ShouldContain("Agent update.");
+    }
+
+    [Fact]
+    public async Task Create_WorkspacePreferredOverAgent_WritestoWorkspace()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        await tool.ExecuteAsync("call-1", Args("create", "new-skill",
+            ("content", ValidSkillMd("new-skill"))));
+
+        fs.File.Exists($"{WorkspaceSkillsDir}/new-skill/SKILL.md").ShouldBeTrue();
+        fs.File.Exists($"{AgentSkillsDir}/new-skill/SKILL.md").ShouldBeFalse();
+    }
+
+    // ── unknown action ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UnknownAction_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var tool = new SkillManagerTool(AgentSkillsDir, WorkspaceSkillsDir, EnabledConfig(), fs);
+
+        var result = await tool.ExecuteAsync("call-1", Args("teleport", "my-skill"));
+        ResultText(result).ShouldContain("Error:");
+        ResultText(result).ShouldContain("Unknown action");
+    }
+}


### PR DESCRIPTION
## Summary

Closes sub-issues #707, #708, #709, and partially #711 from parent #706.

Implements `SkillManagerTool` — a write-capable companion to the existing read-only `SkillTool`, enabling agents to create, edit, patch, delete and manage supporting files within skill directories at runtime. Inspired by the Hermes `skill_manager_tool` pattern.

## Changes

### `SkillsConfig` (extended)
- Added `AllowSkillCreation` (default `false`) — opt-in gate for write operations
- Added `AllowSkillDeletion` (default `false`) — opt-in gate for destructive operations

### `SkillManagerTool` (new)
Tool name: `skill_manage`

| Action | Description |
|---|---|
| `create` | Creates `<skillDir>/<name>/SKILL.md`. Validates name, frontmatter, size. Security scan post-write with rollback on Critical finding. |
| `edit` | Full rewrite of `SKILL.md`. Validates, scans, atomic rollback. Agent/Workspace scope only (Global protected). |
| `patch` | Targeted find-replace in `SKILL.md` or a supporting file. Validates frontmatter integrity post-patch. |
| `delete` | Removes the skill directory. Requires `AllowSkillDeletion = true`. Agent/Workspace scope only. |
| `write_file` | Writes a supporting file under `references/`, `templates/`, `scripts/`, or `assets/`. Security scan with rollback. |
| `remove_file` | Deletes a supporting file (not `SKILL.md`). Requires `AllowSkillDeletion = true`. |

### `SkillManagerToolContributor` (new)
Auto-discovered `IAgentToolContributor` — contributes `skill_manage` only when `AllowSkillCreation = true`. No DI registration required.

### `SkillManagerToolTests` (new)
29 unit tests covering: all 6 actions × happy path + error paths, security rollback, path traversal rejection, config gate enforcement, source priority (workspace > agent).

## Security guardrails
- All write actions run `SkillSecurityScanner.ScanDirectory()` post-write — Critical finding triggers rollback
- Path traversal rejected on all `filePath` parameters
- Global-scope skills are always read-only
- Capability gated behind explicit config flags (opt-in, default off)

## Test Results
```
Passed! - Failed: 0, Passed: 149, Skipped: 0, Total: 149
```
Full suite green (pre-commit hook ran all unit tests).
