### PR TITLE
refactor(signalr): slim GatewayHub.ResolveOrCreateSessionAsync to pure resolution (#721)

### DIFF
--- a/docs/development/message-flow.md
+++ b/docs/development/message-flow.md
@@ -40,30 +40,39 @@ User → SignalR Client → GatewayHub.SubscribeAll()
 Client → SendMessage(agentId, channelType, content) → Auto-Session → Dispatch
 ```
 
-**SendMessage Flow (New Model):**
+**SendMessage Flow (Current Model — #721):**
 
-1. Client calls `SendMessage(agentId, channelType, content)`
-2. Hub calls `ResolveOrCreateSessionAsync(agentId, channelType)`
-   - Looks for existing active session for agent + channel
-   - Creates new session if none exists (auto-session)
-3. Hub subscribes caller to session group (if not already)
-4. Hub dispatches inbound message via `IChannelDispatcher`
+1. Client calls `SendMessage(agentId, channelType, content, conversationId?)`
+2. Hub calls `ResolveOrCreateSessionAsync(agentId, channelType, conversationId?)`
+   - Delegates to `IConversationDispatcher.DispatchAsync(context)` which runs the
+     conversation router → routes via explicit `conversationId`, channel-binding
+     reuse, or initiator-pin to produce `(sessionId, conversationId)`.
+   - Side-effect: the router internally calls `SessionStore.GetOrCreate + SaveAsync`
+     as it materialises bindings, so the session row exists by the time RoCSA returns.
+   - **Hub no longer mutates session state** (Status, ChannelType, SessionType,
+     Participants). Those are owned by `GatewayHost.ProcessAsync` downstream in the
+     orchestrator's per-session worker.
+3. Hub subscribes caller to **conversation** group (not session) so streams reach the
+   caller even if the active session id later changes via compaction. See #682.
+4. Hub fires-and-forgets the inbound message via `IInboundMessageOrchestrator.AcceptAsync`.
 
-**Session Creation (Auto-Session on Send):**
+**Session Mutation (owned by GatewayHost):**
 
 ```csharp
-var session = await ResolveOrCreateSessionAsync(agentId, channelType);
-// Sets:
-// - SessionId: auto-generated or resolved
-// - AgentId: from request
-// - ChannelType: from request
-// - SessionType: UserAgent
-// - Participants: [User: connectionId]
-// - Status: Active
-
-await SubscribeInternalAsync(session.SessionId);
-await DispatchMessageAsync(agentId, session.SessionId, content, "message");
+// GatewayHost.ProcessAsync (orchestrator worker):
+var session = await _sessions.GetOrCreateAsync(sessionId, agentId, ct);
+session.ChannelType ??= channelType;
+session.SessionType = ResolveSessionType(inbound, conversation);
+if (session.Status == SessionStatus.Expired) session.Status = SessionStatus.Active;
+await _sessions.SaveAsync(session, ct);
+await EnsureCallerParticipantAsync(conversation, inbound, ct);
 ```
+
+**Eventual-consistency note:** because session mutation moved to the worker, a reused
+Expired session is reactivated *eventually* after `SendMessage` returns rather than
+synchronously. The window is small (worker wake) and SignalR streaming is unaffected
+because the agent only emits after reactivation; polling REST callers that fire within
+the wake window may briefly observe the pre-reactivation row.
 
 ### 3. Message Dispatch
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -12,9 +12,7 @@ using SessionId = BotNexus.Domain.Primitives.SessionId;
 using UserId = BotNexus.Domain.Primitives.UserId;
 using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
-using SessionParticipant = BotNexus.Domain.Primitives.SessionParticipant;
 using BotNexus.Domain.World;
-using SessionType = BotNexus.Domain.Primitives.SessionType;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -152,27 +150,29 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             ? null
             : conversationId.Trim();
 
-        // Resolve/create the session using the same conversation context as the inbound message
-        // so non-default conversations stay aligned between hub subscriptions and gateway routing.
-        var session = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType, normalizedConversationId);
-        // SaveAsync inside ResolveOrCreateSessionAsync pins session.ConversationId; subscribe by
-        // conversation so streams emitted into this conversation reach this connection even if
-        // the active session id later changes (compaction). #682
-        await SubscribeConversationInternalAsync(session.ConversationId);
+        // Resolve the (sessionId, conversationId) the inbound message will land on so the
+        // caller is in the conversation group before the orchestrator's worker emits stream
+        // events. Session-row mutation (status / channel / participants) is owned by
+        // GatewayHost.ProcessAsync downstream — see #721.
+        var resolution = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType, normalizedConversationId);
+        // The router's GetOrCreate+SaveAsync (called inside the dispatcher) pins ConversationId
+        // on the session row; subscribe by conversation so streams reach this connection even
+        // if the active session id later changes (compaction). #682
+        await SubscribeConversationInternalAsync(resolution.ConversationId);
 
         var connectionId = Context.ConnectionId;
         _logger.LogInformation("Hub SendMessage: agent={AgentId} channel={ChannelType} session={SessionId} connection={ConnectionId} content={Content}",
-            typedAgentId, typedChannelType, session.SessionId, connectionId, content.Length > 50 ? content[..50] + "..." : content);
+            typedAgentId, typedChannelType, resolution.SessionId, connectionId, content.Length > 50 ? content[..50] + "..." : content);
 
         _ = SafeDispatchAsync(
-            () => DispatchMessageAsync(typedAgentId, session.SessionId, content, "message", connectionId, normalizedConversationId),
+            () => DispatchMessageAsync(typedAgentId, resolution.SessionId, content, "message", connectionId, normalizedConversationId),
             typedAgentId,
-            session.SessionId);
+            resolution.SessionId);
 
         return new SendMessageResult(
-            session.SessionId.Value,
-            session.AgentId.Value,
-            session.ChannelType?.Value);
+            resolution.SessionId.Value,
+            resolution.AgentId.Value,
+            resolution.ChannelType.Value);
     }
 
     /// <summary>
@@ -239,12 +239,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var typedChannelType = NormalizeChannelKey(channelType);
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
 
-        var session = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType);
-        await SubscribeConversationInternalAsync(session.ConversationId);
+        var resolution = await ResolveOrCreateSessionAsync(typedAgentId, typedChannelType);
+        await SubscribeConversationInternalAsync(resolution.ConversationId);
 
         _logger.LogInformation(
             "Hub SendMessageWithMedia: agent={AgentId} channel={ChannelType} session={SessionId} parts={PartCount}",
-            typedAgentId, typedChannelType, session.SessionId, contentParts.Count);
+            typedAgentId, typedChannelType, resolution.SessionId, contentParts.Count);
 
         var connectionId = Context.ConnectionId;
         var parts = contentParts.Select(ConvertToDomainContentPart).ToList();
@@ -259,7 +259,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                     ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
                     RoutingHints = new InboundMessageRoutingHints(
                         RequestedAgentId: typedAgentId,
-                        RequestedSessionId: session.SessionId,
+                        RequestedSessionId: resolution.SessionId,
                         RequestedConversationId: null),
                     Content = content,
                     ContentParts = parts,
@@ -267,12 +267,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 },
                 CancellationToken.None),
             typedAgentId,
-            session.SessionId);
+            resolution.SessionId);
 
         return new SendMessageResult(
-            session.SessionId.Value,
-            session.AgentId.Value,
-            session.ChannelType?.Value);
+            resolution.SessionId.Value,
+            resolution.AgentId.Value,
+            resolution.ChannelType.Value);
     }
 
     private Task DispatchMessageAsync(AgentId typedAgentId, SessionId typedSessionId, string content,
@@ -661,14 +661,38 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             Context.ConnectionAborted);
     }
 
-    private async Task<GatewaySession> ResolveOrCreateSessionAsync(
+    /// <summary>
+    /// Resolves the (sessionId, conversationId) pair the inbound message will land on by
+    /// delegating to the shared <see cref="IConversationDispatcher"/>. Returns a lightweight
+    /// <see cref="HubInboundResolution"/> that carries just the IDs the hub needs to
+    /// (a) populate the synchronous <see cref="SendMessageResult"/> contract and
+    /// (b) join the caller connection to the conversation group before the orchestrator's
+    /// background worker emits stream events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a pure resolution call. Session row materialisation, ChannelType / SessionType
+    /// stamping, Expired→Active reactivation, transcript SaveAsync, and caller participant
+    /// registration are owned by <c>GatewayHost.ProcessAsync</c> inside the orchestrator's
+    /// per-session worker (#721). The router invoked by the dispatcher already calls
+    /// <c>SessionStore.GetOrCreateAsync</c> + <c>SaveAsync</c> as a side-effect of binding
+    /// resolution, so the session row exists by the time this method returns.
+    /// </para>
+    /// <para>
+    /// One eventual-consistency window survives this slim-down: a reused Expired session
+    /// stays Expired until the orchestrator's worker reactivates it. SignalR streaming is
+    /// unaffected because the agent only emits after reactivation; polling REST callers
+    /// that fire within the small worker-wake window may observe the pre-reactivation row.
+    /// </para>
+    /// </remarks>
+    private async Task<HubInboundResolution> ResolveOrCreateSessionAsync(
         AgentId agentId,
         ChannelKey channelType,
         string? conversationId = null)
     {
-        // Conversation-first routing: resolve/create via IConversationDispatcher.
-        // Use agentId as the channel address so every connection from the same agent
-        // routes to the same portal conversation, regardless of SignalR connection ID.
+        // Conversation-first routing: use agentId as the channel address so every connection
+        // from the same agent routes to the same portal conversation, regardless of SignalR
+        // connection ID.
         var channelAddress = ChannelAddress.From(agentId.Value);
         var typedConversationId = string.IsNullOrWhiteSpace(conversationId)
             ? (ConversationId?)null
@@ -683,10 +707,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 Sender = CitizenId.Of(UserId.From(Context.ConnectionId)),
                 Content = string.Empty,
                 // RoutingHints intentionally omitted — the outer InboundMessageContext below
-                // carries the typed RequestedAgentId + RequestedConversationId explicitly;
-                // the positional-record constructor does not re-derive hints from the message
-                // (only FromInboundMessage does that). Sub-PR 6.3 (#586) deleted the legacy
-                // string override fields, so the inner message carries no routing payload.
+                // carries the typed RequestedAgentId + RequestedConversationId explicitly.
             },
             new ChannelSource(
                 channelType,
@@ -694,60 +715,26 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 Context.ConnectionId),
             RequestedConversationId: typedConversationId,
             RequestedAgentId: agentId);
+
         var dispatchResult = await _conversationDispatcher.DispatchAsync(context, Context.ConnectionAborted);
-
-        var session = await _sessions.GetOrCreateAsync(dispatchResult.Resolution.SessionId, agentId, Context.ConnectionAborted);
-
-        var needsSave = false;
-        if (session.Status == SessionStatus.Expired)
-        {
-            session.Status = SessionStatus.Active;
-            session.ExpiresAt = null;
-            needsSave = true;
-        }
-
-        if (!session.ChannelType.HasValue || !ChannelMatches(session.ChannelType.Value, channelType))
-        {
-            session.ChannelType = channelType;
-            needsSave = true;
-        }
-
-        if (!session.SessionType.Equals(SessionType.UserAgent))
-        {
-            session.SessionType = SessionType.UserAgent;
-            needsSave = true;
-        }
-
-        if (needsSave)
-            await _sessions.SaveAsync(session, Context.ConnectionAborted);
-
-        // P9-F: Participants live on the Conversation, not the Session — register the
-        // user-citizen against the conversation pinned to this session. Skipped when the
-        // session has not yet been pinned or the conversation store isn't wired (legacy
-        // composition roots).
-        if (_conversationStore is not null && session.ConversationId.IsInitialized())
-        {
-            await _conversationStore.AddParticipantsAsync(
-                session.ConversationId,
-                [new SessionParticipant
-                {
-                    CitizenId = CitizenId.Of(UserId.From(Context.ConnectionId))
-                }],
-                Context.ConnectionAborted);
-        }
-
-        return session;
+        return new HubInboundResolution(
+            dispatchResult.Resolution.SessionId,
+            dispatchResult.Resolution.ConversationId,
+            agentId,
+            channelType);
     }
 
-    private static bool ChannelMatches(ChannelKey? candidate, ChannelKey target)
-    {
-        if (!candidate.HasValue)
-            return target.Equals(ChannelKey.From("signalr"));
-
-        return ChannelMatches(candidate.Value, target);
-    }
-
-    private static bool ChannelMatches(ChannelKey candidate, ChannelKey target)
-        => candidate.Equals(target);
+    /// <summary>
+    /// Resolved identifiers returned by <see cref="ResolveOrCreateSessionAsync"/>. Carries
+    /// only what the hub needs synchronously to subscribe the caller connection to the
+    /// conversation group and to return <see cref="SendMessageResult"/>. Heavier session
+    /// mutation (status, channel stamp, participant add) is owned by
+    /// <c>GatewayHost.ProcessAsync</c> downstream.
+    /// </summary>
+    private readonly record struct HubInboundResolution(
+        SessionId SessionId,
+        ConversationId ConversationId,
+        AgentId AgentId,
+        ChannelKey ChannelType);
 }
 


### PR DESCRIPTION
## Summary

PR5 of the W-5 cleanup arc (#676): slim `GatewayHub.ResolveOrCreateSessionAsync` (RoCSA) from ~80 lines of session-mutation logic down to a thin dispatcher call that returns just the IDs the hub needs synchronously.

Closes #721.

## What changed

The hub used to duplicate every step that `GatewayHost.ProcessAsync` already does:

| Concern | Old hub | New hub | Owner now |
|---|---|---|---|
| `SessionStore.GetOrCreate` | ✅ | ❌ | `GatewayHost.ProcessAsync` (line 320) — also done as side effect of `IConversationRouter.ResolveInboundAsync` |
| `SessionStore.SaveAsync` | ✅ | ❌ | `GatewayHost.ProcessAsync` (line 412) |
| `ChannelType` stamp | ✅ | ❌ | `GatewayHost.ProcessAsync` (line 327) |
| `SessionType` resolution | blanket `UserAgent` | ❌ | `GatewayHost.ResolveSessionType` (line 334) — smarter than the hub's blanket value |
| Expired → Active reactivation | synchronous | eventual | `GatewayHost.ProcessAsync` (line 351) |
| `EnsureCallerParticipantAsync` | inline `AddParticipantsAsync` | ❌ | `GatewayHost.EnsureCallerParticipantAsync` (line 418) |

The hub now returns `HubInboundResolution(SessionId, ConversationId, AgentId, ChannelType)` — exactly what's needed to build `SendMessageResult` and join the conversation group.

## Why it's safe

- The router invoked by `DefaultConversationDispatcher` already calls `SessionStore.GetOrCreate + SaveAsync` as a side effect of binding resolution, so the session row exists by the time RoCSA returns.
- The architecture fences in `ConversationParticipantsMutationArchitectureTests` already enforce that `.Participants` may only be mutated by stores and via `AddParticipantsAsync`; this PR doesn't loosen that contract — it just stops calling it from the hub since `GatewayHost.EnsureCallerParticipantAsync` already does so downstream.
- `RespondToAskUser` uses `ChannelBindings`-based authentication, not `Participants`, so dropping the hub-side participant add doesn't break ask-user permissions.

## Eventual-consistency note (explicit)

A reused Expired session is now reactivated **eventually** when the orchestrator's per-session worker fires `GatewayHost.ProcessAsync` — not synchronously inside the hub call. SignalR streaming is unaffected because the agent only emits after reactivation. Polling REST callers that fire within the small worker-wake window (typically <10ms) may briefly observe the pre-reactivation row.

No existing test asserts synchronous reactivation visible from the hub path. `GatewayHostTests.DispatchAsync_ExpiredSession_ReactivatesAndProcesses` (line 317) and `_ClearsExpiresAt` (line 397) exercise `GatewayHost` directly and continue to pass.

## What's deferred

- **PR6**: introduce `IInboundConversationResolvedObserver` hook in `GatewayHost.ProcessAsync` fired after resolution + before streaming. SignalR registers an observer that joins the connection to the conversation group, allowing the hub to drop the pre-resolution dispatcher call entirely and remove `IConversationDispatcher` from its constructor.
- **PR7+**: extract `ResetSession`, `CompactSession`, `RespondToAskUser`, and `OnDisconnectedAsync` into dedicated services so `ISessionStore`, `IConversationStore`, `IConversationRouter`, `ISessionCompactionCoordinator`, and `IConversationResetService` can be dropped from the hub constructor.

## Test results

- Build: 0 warnings, 0 errors.
- `BotNexus.Gateway.Tests`: 2001 passed, 1 skipped (pre-existing).

## Refs

- Tracking: #676 (W-5 umbrella)
- Issue: #721
- Prior PR in the chain: #715 (PR4 — wire hub onto `IInboundMessageOrchestrator`)
