### PR TITLE
fix(canvas): remove duplicate /api/ prefix in GetConversationCanvasAsync URL

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
@@ -25,7 +25,7 @@ public sealed class GatewayRestClient : IGatewayRestClient
         string conversationId,
         CancellationToken ct = default)
     {
-        var url = $"{_apiBaseUrl}/api/agents/{Uri.EscapeDataString(agentId)}/conversations/{Uri.EscapeDataString(conversationId)}/canvas";
+        var url = $"{_apiBaseUrl}agents/{Uri.EscapeDataString(agentId)}/conversations/{Uri.EscapeDataString(conversationId)}/canvas";
         try
         {
             var response = await _http.GetAsync(url, ct);


### PR DESCRIPTION
Fixes #628

## Problem
`GetConversationCanvasAsync` in `GatewayRestClient` constructed the URL as `{_apiBaseUrl}/api/agents/...`. All other methods use `{_apiBaseUrl}agents/...` (no `/api/` prefix) because `_apiBaseUrl` already includes the `/api/` segment. The extra prefix produced a double `/api//api/` path, causing 404s when the portal tries to load persisted canvas HTML on conversation select.

## Fix
Removed the spurious `/api/` from the URL template — one line change, consistent with every other method in the file.

## Testing
- Build: clean
- 335/335 BlazorClient unit tests pass
- 5 `LocalCli` integration failures are pre-existing file-locking flakes unrelated to this change