### PR TITLE
fix(cli): scaffold agent workspace on agent add and wizard

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
@@ -222,6 +222,10 @@ internal sealed class AgentCommands
         if (saveCode != 0)
             return saveCode;
 
+        var homePath = Path.GetDirectoryName(configPath) ?? BotNexusHome.ResolveHomePath();
+        var botNexusHome = new BotNexusHome(homePath);
+        botNexusHome.GetAgentDirectory(id);
+
         AnsiConsole.MarkupLine($"[green]✓[/] Agent [green]{Markup.Escape(id)}[/] added successfully.");
         return 0;
     }
@@ -258,6 +262,10 @@ internal sealed class AgentCommands
         var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
         if (saveCode != 0)
             return saveCode;
+
+        var homePath = Path.GetDirectoryName(configPath) ?? BotNexusHome.ResolveHomePath();
+        var botNexusHome = new BotNexusHome(homePath);
+        botNexusHome.GetAgentDirectory(id);
 
         AnsiConsole.MarkupLine($"[green]\u2713[/] Added agent [green]{Markup.Escape(id)}[/].");
         return 0;

--- a/tests/gateway/BotNexus.Gateway.Tests/Cli/AgentCommandsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Cli/AgentCommandsTests.cs
@@ -41,6 +41,19 @@ public sealed class AgentCommandsTests
     }
 
     [Fact]
+    public async Task AgentAdd_ScaffoldsWorkspaceAfterAdd()
+    {
+        await using var fixture = await CliTestFixture.CreateAsync("""{ "agents": {} }""");
+
+        var result = await fixture.RunCliAsync("agent", "add", "my-bot", "--provider", "copilot", "--model", "gpt-4.1");
+
+        result.ExitCode.ShouldBe(0);
+        var workspacePath = Path.Combine(fixture.RootPath, "agents", "my-bot", "workspace");
+        Directory.Exists(workspacePath).ShouldBeTrue("workspace directory should be created");
+        File.Exists(Path.Combine(workspacePath, "SOUL.md")).ShouldBeTrue("SOUL.md should be scaffolded");
+    }
+
+    [Fact]
     public async Task AgentAdd_WhenAgentExists_ReturnsOne()
     {
         await using var fixture = await CliTestFixture.CreateAsync("""


### PR DESCRIPTION
Fixes #331

All agent creation paths now produce a consistent result. `agent add` and `agent wizard` both call `BotNexusHome.GetAgentDirectory()` after saving the config, which triggers workspace scaffolding (workspace dir, SOUL.md, AGENTS.md, IDENTITY.md, USER.md, TOOLS.md, memory/).

The Gateway API path already did this via `FileAgentConfigurationWriter`. This PR closes the gap in the CLI paths.