### PR TITLE
fix(#736): multi-target net9.0;net10.0 so CLI tool installs on .NET 9 SDK

### DIFF
--- a/.github/workflows/ci-tool-install.yml
+++ b/.github/workflows/ci-tool-install.yml
@@ -1,0 +1,72 @@
+name: "CI: Tool Install Compatibility"
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Directory.Build.props'
+      - 'src/gateway/BotNexus.Cli/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Directory.Build.props'
+      - 'src/gateway/BotNexus.Cli/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  # Validate the packed nupkg contains DotnetToolSettings.xml for each TFM
+  # and that dotnet tool install succeeds from a local source on .NET 9 and .NET 10.
+  tool-install-matrix:
+    name: "Tool install on .NET ${{ matrix.dotnet-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet-version: [ '9.0.x', '10.0.x' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Restore
+        run: dotnet restore src/gateway/BotNexus.Cli/BotNexus.Cli.csproj --nologo
+      - name: Pack CLI
+        run: |
+          dotnet pack src/gateway/BotNexus.Cli \
+            -c Release \
+            --no-restore \
+            --nologo \
+            -p:Version=0.0.0-ci-install-test \
+            -p:SourceRevisionId=${{ github.sha }} \
+            -o /tmp/botnexus-pkg
+      - name: Verify DotnetToolSettings.xml present in nupkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          NUPKG=$(find /tmp/botnexus-pkg -name "*.nupkg" | head -1)
+          echo "Inspecting: $NUPKG"
+          unzip -l "$NUPKG"
+          # Must have DotnetToolSettings.xml for both TFMs
+          for tfm in net9.0 net10.0; do
+            ENTRY="tools/${tfm}/any/DotnetToolSettings.xml"
+            if unzip -l "$NUPKG" | grep -q "$ENTRY"; then
+              echo "PASS: $ENTRY found"
+            else
+              echo "FAIL: $ENTRY NOT found in nupkg"
+              exit 1
+            fi
+          done
+      - name: Install from local source
+        run: |
+          export DOTNET_CLI_TELEMETRY_OPTOUT=1
+          dotnet tool install -g BotNexus.Cli \
+            --version 0.0.0-ci-install-test \
+            --add-source /tmp/botnexus-pkg
+      - name: Verify botnexus binary is runnable
+        run: |
+          export PATH="$HOME/.dotnet/tools:$PATH"
+          botnexus --version
+      - name: Uninstall
+        if: always()
+        run: dotnet tool uninstall -g BotNexus.Cli || true

--- a/src/agent/Directory.Build.props
+++ b/src/agent/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!-- Import the root Directory.Build.props -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Multi-target agent components for .NET 9 and .NET 10.
+         Required so that the CLI tool can reference these components and be installed
+         on .NET 9 SDK. See issue #736. -->
+    <TargetFramework />
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/src/domain/Directory.Build.props
+++ b/src/domain/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!-- Import the root Directory.Build.props -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Multi-target domain components for .NET 9 and .NET 10.
+         Required so that the CLI tool can reference these components and be installed
+         on .NET 9 SDK. See issue #736. -->
+    <TargetFramework />
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
+++ b/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
@@ -13,6 +13,10 @@
     <RepositoryUrl>https://github.com/sytone/botnexus</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>ai;agent;botnexus;dotnet;cli</PackageTags>
+    <!-- Multi-target so users on .NET 9 SDK can install the tool.
+         dotnet tool install picks the highest matching TFM for the installed SDK.
+         TargetFrameworks=net9.0;net10.0 is set by src/gateway/Directory.Build.props.
+         See issue #736. -->
     <!-- When the CLI invokes 'dotnet build' on the solution, it passes SkipCli=true
          so the CLI project skips rebuilding itself (the DLL is already loaded and locked). -->
     <IsExcludedFromBuild Condition="'$(SkipCli)' == 'true'">true</IsExcludedFromBuild>

--- a/src/gateway/Directory.Build.props
+++ b/src/gateway/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <!-- Import the root Directory.Build.props (required by MSBuild conventions) -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Multi-target gateway components for .NET 9 and .NET 10.
+         This allows the CLI tool (PackAsTool) to be installed on .NET 9 SDK users.
+         dotnet tool install picks the highest matching TFM for the installed SDK.
+         None of the gateway components use net10.0-specific APIs.
+         See issue #736.
+         Note: TargetFramework (singular) is cleared so the SDK uses TargetFrameworks
+         (plural) for multi-TFM dispatch. Without this, the root's TargetFramework=net10.0
+         would suppress multi-targeting. -->
+    <TargetFramework />
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/tests/gateway/BotNexus.Cli.Tests/ToolPackageTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/ToolPackageTests.cs
@@ -1,0 +1,112 @@
+using System.Xml.Linq;
+
+namespace BotNexus.Cli.Tests;
+
+/// <summary>
+/// Validates the CLI NuGet tool package is installable on supported .NET SDK versions.
+///
+/// Issue #736: Users on .NET 9 received "DotnetToolSettings.xml was not found in the package"
+/// because BotNexus.Cli only shipped a net10.0 TFM. The fix adds Directory.Build.props files
+/// to src/gateway/, src/agent/, and src/domain/ with TargetFrameworks=net9.0;net10.0 so that
+/// dotnet tool install succeeds on any SDK >= 9.
+/// </summary>
+public sealed class ToolPackageTests
+{
+    [Fact]
+    public void CliCsproj_does_not_override_TargetFramework_singular()
+    {
+        var assemblyDir = Path.GetDirectoryName(typeof(ToolPackageTests).Assembly.Location)!;
+        var csprojPath = FindCliCsproj(assemblyDir);
+        csprojPath.ShouldNotBeNull("Could not find BotNexus.Cli.csproj relative to repo root");
+
+        var doc = XDocument.Load(csprojPath!);
+
+        // The CLI csproj must NOT set <TargetFramework> (singular) which would override the
+        // per-subtree multi-targeting and break install on .NET 9.
+        var singleTfm = doc.Descendants("TargetFramework").FirstOrDefault();
+        Assert.True(
+            singleTfm == null,
+            "BotNexus.Cli.csproj must not set <TargetFramework> (singular) — " +
+            "that would override the gateway multi-target and break install on .NET 9 (issue #736)");
+    }
+
+    [Fact]
+    public void GatewayDirectoryBuildProps_TargetFrameworks_includes_net9_and_net10()
+    {
+        var assemblyDir = Path.GetDirectoryName(typeof(ToolPackageTests).Assembly.Location)!;
+        var repoRoot = FindRepoRoot(assemblyDir);
+        repoRoot.ShouldNotBeNull("Could not find repo root (Directory.Build.props with Version property)");
+
+        var propsPath = Path.Combine(repoRoot!, "src", "gateway", "Directory.Build.props");
+        Assert.True(
+            File.Exists(propsPath),
+            $"src/gateway/Directory.Build.props must exist to multi-target gateway projects. " +
+            $"Expected at: {propsPath} (issue #736)");
+
+        var doc = XDocument.Load(propsPath);
+        var tfms = doc.Descendants("TargetFrameworks").FirstOrDefault()?.Value ?? string.Empty;
+
+        Assert.True(
+            tfms.Contains("net9.0", StringComparison.Ordinal),
+            $"src/gateway/Directory.Build.props must include net9.0 in <TargetFrameworks> so dotnet tool install " +
+            $"succeeds on .NET 9 SDK (issue #736). Actual value: '{tfms}'");
+
+        Assert.True(
+            tfms.Contains("net10.0", StringComparison.Ordinal),
+            $"src/gateway/Directory.Build.props must include net10.0 in <TargetFrameworks>. Actual value: '{tfms}'");
+    }
+
+    [Fact]
+    public void GatewayDirectoryBuildProps_does_not_set_singular_TargetFramework()
+    {
+        var assemblyDir = Path.GetDirectoryName(typeof(ToolPackageTests).Assembly.Location)!;
+        var repoRoot = FindRepoRoot(assemblyDir);
+        repoRoot.ShouldNotBeNull("Could not find repo root");
+
+        var propsPath = Path.Combine(repoRoot!, "src", "gateway", "Directory.Build.props");
+        if (!File.Exists(propsPath))
+            return; // Covered by other test
+
+        var doc = XDocument.Load(propsPath);
+
+        // We allow <TargetFramework /> (empty value) as a deliberate "clear" pattern so the SDK
+        // uses <TargetFrameworks> (plural). What we disallow is a non-empty TargetFramework
+        // value that would override the multi-targeting. (Issue #736)
+        var singleTfmWithValue = doc.Descendants("TargetFramework")
+            .FirstOrDefault(e => !string.IsNullOrWhiteSpace(e.Value));
+
+        Assert.True(
+            singleTfmWithValue == null,
+            "src/gateway/Directory.Build.props must not set a non-empty <TargetFramework> (singular) — " +
+            "that would override multi-targeting and break install on .NET 9 (issue #736). " +
+            "An empty <TargetFramework /> to clear the root value is acceptable.");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static string? FindRepoRoot(string startDir)
+    {
+        var dir = new DirectoryInfo(startDir);
+        while (dir != null)
+        {
+            var propsFile = Path.Combine(dir.FullName, "Directory.Build.props");
+            if (File.Exists(propsFile))
+            {
+                var doc = XDocument.Load(propsFile);
+                // Root props has the Version element; subtree props only import it.
+                if (doc.Descendants("Version").Any())
+                    return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static string? FindCliCsproj(string startDir)
+    {
+        var repoRoot = FindRepoRoot(startDir);
+        if (repoRoot == null) return null;
+        var csproj = Path.Combine(repoRoot, "src", "gateway", "BotNexus.Cli", "BotNexus.Cli.csproj");
+        return File.Exists(csproj) ? csproj : null;
+    }
+}


### PR DESCRIPTION
## Problem

Users on .NET 9 SDK could not install the CLI tool:
```
dotnet tool install -g botnexus.cli
# Tool failed to install. DotnetToolSettings.xml was not found in the package.
```

The NuGet tool package only contained a `tools/net10.0/any/` folder. When a .NET 9 SDK tries to install it, there is no compatible TFM entry and the install fails entirely.

## Root cause

`Directory.Build.props` set `<TargetFramework>net10.0</TargetFramework>` (singular) globally. Since the Blazor/SignalR extensions use packages that only support `net10.0`, we cannot simply flip the whole solution to multi-target.

## Fix

Add per-subtree `Directory.Build.props` files to the three subtrees that form the CLI's dependency chain — `src/gateway/`, `src/agent/`, and `src/domain/` — each setting:

```xml
<TargetFramework />
<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
```

Clearing `<TargetFramework>` (singular) is required because the root props sets it to `net10.0`, and without clearing it the SDK would ignore `<TargetFrameworks>` (plural) during outer-build dispatch.

The Blazor, SignalR, and extension projects inherit the root `net10.0` and are unaffected.

## Pack output

The resulting `.nupkg` now contains:
```
tools/net9.0/any/DotnetToolSettings.xml   ✅
tools/net10.0/any/DotnetToolSettings.xml  ✅
```

`dotnet tool install` on .NET 9 SDK picks `tools/net9.0/any/`. On .NET 10 SDK it picks `tools/net10.0/any/`.

## Testing

- Added `tests/gateway/BotNexus.Cli.Tests/ToolPackageTests.cs` — 3 tests that validate `src/gateway/Directory.Build.props` has `net9.0;net10.0` and that the CLI csproj does not re-override it
- Added `.github/workflows/ci-tool-install.yml` — matrix CI job that packs the CLI and runs `dotnet tool install` on both .NET 9 and .NET 10 containers
- All 100 `BotNexus.Cli.Tests` pass (net10.0)
- `LocalCliInstallFixture` pack+install tests pass

## Notes

The `CliInstallAndInitWorkflowTests.Cli_Install_ClonesCurrentRepoIntoSandbox` test failure is a **pre-existing** worktree-path cloning issue unrelated to this fix.

Closes #736
