### PR TITLE
feat(#743): add MessageRole.Notification, TurnInterrupted event, and InterruptedTurnNotificationService

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentExecution.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentExecution.cs
@@ -109,5 +109,7 @@ public enum AgentStreamEventType
     /// <summary>A turn (LLM call + tool cycle) has completed. Used for mid-run persistence checkpoints.</summary>
     TurnEnd,
     /// <summary>Agent execution is paused while awaiting interactive user input.</summary>
-    UserInputRequired
+    UserInputRequired,
+    /// <summary>The gateway restarted mid-turn; the interrupted session has been flagged and the user notified.</summary>
+    TurnInterrupted
 }

--- a/src/domain/BotNexus.Domain/Primitives/MessageRole.cs
+++ b/src/domain/BotNexus.Domain/Primitives/MessageRole.cs
@@ -17,6 +17,9 @@ public sealed class MessageRole : IEquatable<MessageRole>
     public static readonly MessageRole System = Register("system");
     public static readonly MessageRole Tool = Register("tool");
 
+    /// <summary>Gateway-generated notification messages (e.g. restart interruption notices). Not forwarded to the LLM.</summary>
+    public static readonly MessageRole Notification = Register("notification");
+
     /// <summary>
     /// Gets the value.
     /// </summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayEventHandler.cs
@@ -23,4 +23,7 @@ public interface IGatewayEventHandler
     void HandleReconnecting();
     Task HandleReconnectedAsync(CancellationToken cancellationToken = default);
     void HandleDisconnected();
+
+    /// <summary>Handles a <c>TurnInterrupted</c> event received from the server after a gateway restart.</summary>
+    void HandleTurnInterrupted(AgentStreamEvent evt);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -39,6 +39,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnMessageEnd += HandleMessageEnd;
         _hub.OnError += HandleError;
         _hub.OnUserInputRequired += HandleUserInputRequired;
+        _hub.OnTurnInterrupted += HandleTurnInterrupted;
         _hub.OnSessionReset += HandleSessionReset;
         _hub.OnSubAgentSpawned += HandleSubAgentSpawned;
         _hub.OnSubAgentCompleted += HandleSubAgentCompleted;
@@ -299,6 +300,34 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
             DrainPendingConversationRefreshes(agentId);
     }
 
+
+    /// <summary>
+    /// Handles a <c>TurnInterrupted</c> event signalling that a gateway restart cut the previous turn short.
+    /// Appends a notification message to the affected conversation so the user sees the context.
+    /// </summary>
+    public void HandleTurnInterrupted(AgentStreamEvent evt)
+    {
+        if (!ResolveAgent(evt.SessionId, out var agentId, out var agent, evt.ConversationId)) return;
+        var convId = ResolveConversationId(agentId!, agent!, evt.SessionId, evt.ConversationId) ?? agent!.ActiveConversationId;
+
+        if (convId is not null && agent!.Conversations.GetValueOrDefault(convId) is { } conv)
+        {
+            conv.Messages.Add(new ChatMessage("Notification",
+                evt.ErrorMessage ?? "The gateway was restarted while your last message was being processed.",
+                DateTimeOffset.UtcNow));
+            conv.StreamState.Buffer = "";
+            conv.StreamState.ThinkingBuffer = "";
+            conv.StreamState.IsStreaming = false;
+        }
+
+        if (agent is not null)
+        {
+            agent.IsStreaming = false;
+            agent.ProcessingStage = null;
+        }
+
+        _store.NotifyChanged();
+    }
     public void HandleUserInputRequired(AgentStreamEvent evt)
     {
         if (!ResolveAgent(evt.SessionId, out var agentId, out var agent, evt.ConversationId))
@@ -832,6 +861,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnMessageEnd -= HandleMessageEnd;
         _hub.OnError -= HandleError;
         _hub.OnUserInputRequired -= HandleUserInputRequired;
+        _hub.OnTurnInterrupted -= HandleTurnInterrupted;
         _hub.OnSessionReset -= HandleSessionReset;
         _hub.OnSubAgentSpawned -= HandleSubAgentSpawned;
         _hub.OnSubAgentCompleted -= HandleSubAgentCompleted;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
@@ -43,6 +43,9 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     /// <summary>Raised when the agent requires interactive user input mid-turn.</summary>
     public event Action<AgentStreamEvent>? OnUserInputRequired;
 
+    /// <summary>Raised when the gateway notifies that a previous turn was interrupted by a restart.</summary>
+    public event Action<AgentStreamEvent>? OnTurnInterrupted;
+
     /// <summary>Raised when a sub-agent is spawned.</summary>
     public event Action<SubAgentEventPayload>? OnSubAgentSpawned;
 
@@ -114,6 +117,7 @@ public sealed class GatewayHubConnection : IAsyncDisposable
         _connection.On<AgentStreamEvent>("MessageEnd", e => OnMessageEnd?.Invoke(e));
         _connection.On<AgentStreamEvent>("Error", e => OnError?.Invoke(e));
         _connection.On<AgentStreamEvent>("UserInputRequired", e => OnUserInputRequired?.Invoke(e));
+        _connection.On<AgentStreamEvent>("TurnInterrupted", e => OnTurnInterrupted?.Invoke(e));
         _connection.On<SubAgentEventPayload>("SubAgentSpawned", p => OnSubAgentSpawned?.Invoke(p));
         _connection.On<SubAgentEventPayload>("SubAgentCompleted", p => OnSubAgentCompleted?.Invoke(p));
         _connection.On<SubAgentEventPayload>("SubAgentFailed", p => OnSubAgentFailed?.Invoke(p));

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
@@ -27,4 +27,7 @@ public interface IGatewayHubClient
 
     Task SteeringFeedback(SteeringFeedbackPayload payload);
     Task CanvasUpdated(string agentId, string conversationId, string html);
+
+    /// <summary>Server notifies the client that a gateway restart interrupted its active agent turn.</summary>
+    Task TurnInterrupted(AgentStreamEvent evt);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -111,6 +111,7 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
             AgentStreamEventType.MessageEnd => client.MessageEnd(enrichedEvent),
             AgentStreamEventType.Error => client.Error(enrichedEvent),
             AgentStreamEventType.UserInputRequired => client.UserInputRequired(enrichedEvent),
+            AgentStreamEventType.TurnInterrupted => client.TurnInterrupted(enrichedEvent),
             _ => Task.CompletedTask
         };
     }

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs
@@ -56,7 +56,7 @@ public static class SessionContextProjector
     /// excluded.
     /// </summary>
     public static bool IsVisibleInLiveContext(SessionEntry entry) =>
-        !entry.IsHistory && !entry.IsCrashSentinel;
+        !entry.IsHistory && !entry.IsCrashSentinel && !entry.Role.Equals(MessageRole.Notification);
 
     /// <summary>
     /// Eager projection used by isolation strategies to build the initial LLM

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -189,6 +189,7 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IHostedService>(serviceProvider => serviceProvider.GetRequiredService<GatewayHost>());
         services.AddSingleton<IHostedService>(serviceProvider =>
             serviceProvider.GetRequiredService<SessionWarmupService>());
+        services.AddHostedService<InterruptedTurnNotificationService>();
         services.AddHostedService<SessionCleanupService>();
         services.AddHostedService<MemoryIndexer>();
 

--- a/src/gateway/BotNexus.Gateway/Sessions/InterruptedTurnNotificationService.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/InterruptedTurnNotificationService.cs
@@ -1,0 +1,144 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// Hosted service that runs once at gateway startup to detect and notify users whose
+/// agent turn was interrupted by a gateway restart. Any session that contains an
+/// unresolved crash-sentinel entry (written by <see cref="GatewayHost"/> before each
+/// LLM call) indicates the previous run did not complete cleanly. For each such session
+/// this service appends a <see cref="MessageRole.Notification"/> entry, removes the
+/// sentinels, persists the session, and delivers an out-of-band notification through
+/// the originating channel when possible.
+/// </summary>
+public sealed class InterruptedTurnNotificationService : IHostedService
+{
+    private const string NotificationContent =
+        "⚠️ The gateway was restarted while your last message was being processed. " +
+        "Your message was saved — please resend it to continue.";
+
+    private readonly ISessionStore _sessions;
+    private readonly IAgentRegistry _agentRegistry;
+    private readonly IActivityBroadcaster _broadcaster;
+    private readonly IChannelManager _channelManager;
+    private readonly ILogger<InterruptedTurnNotificationService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="InterruptedTurnNotificationService"/>.
+    /// </summary>
+    public InterruptedTurnNotificationService(
+        ISessionStore sessions,
+        IAgentRegistry agentRegistry,
+        IActivityBroadcaster broadcaster,
+        IChannelManager channelManager,
+        ILogger<InterruptedTurnNotificationService> logger)
+    {
+        _sessions = sessions;
+        _agentRegistry = agentRegistry;
+        _broadcaster = broadcaster;
+        _channelManager = channelManager;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var agents = _agentRegistry.GetAll();
+        var notified = 0;
+
+        foreach (var descriptor in agents)
+        {
+            var agentId = descriptor.AgentId;
+            IReadOnlyList<GatewaySession> agentSessions;
+            try
+            {
+                agentSessions = await _sessions.ListAsync(agentId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to list sessions for agent {AgentId} during interrupted-turn scan", agentId.Value);
+                continue;
+            }
+
+            foreach (var session in agentSessions)
+            {
+                if (!session.History.Any(static e => e.IsCrashSentinel))
+                    continue;
+
+                _logger.LogInformation(
+                    "Session {SessionId} (agent {AgentId}) has unresolved crash sentinels — notifying user",
+                    session.SessionId.Value, agentId.Value);
+
+                var notification = new SessionEntry
+                {
+                    Role = MessageRole.Notification,
+                    Content = NotificationContent,
+                    Timestamp = DateTimeOffset.UtcNow
+                };
+
+                session.AddEntry(notification);
+                session.RemoveCrashSentinels();
+
+                try
+                {
+                    await _sessions.SaveAsync(session, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to save session {SessionId} after removing crash sentinels", session.SessionId.Value);
+                    continue;
+                }
+
+                // Broadcast activity so dashboards and monitoring surfaces pick it up.
+                await _broadcaster.PublishAsync(new GatewayActivity
+                {
+                    Type = GatewayActivityType.System,
+                    AgentId = agentId.Value,
+                    SessionId = session.SessionId.Value,
+                    ConversationId = session.ConversationId.IsInitialized() ? session.ConversationId.Value : null,
+                    Message = NotificationContent
+                }, cancellationToken).ConfigureAwait(false);
+
+                // Deliver via channel adapter when we have enough addressing information.
+                if (session.ChannelType.HasValue
+                    && !string.IsNullOrWhiteSpace(session.CallerId)
+                    && _channelManager.Get(session.ChannelType.Value) is { } adapter)
+                {
+                    try
+                    {
+                        await adapter.SendAsync(new OutboundMessage
+                        {
+                            ChannelType = session.ChannelType.Value,
+                            ChannelAddress = ChannelAddress.From(session.CallerId),
+                            Content = NotificationContent,
+                            SessionId = session.SessionId.Value,
+                            ConversationId = session.ConversationId.IsInitialized() ? session.ConversationId.Value : null
+                        }, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "Failed to deliver interrupted-turn notification via channel {ChannelType} for session {SessionId}",
+                            session.ChannelType.Value, session.SessionId.Value);
+                    }
+                }
+
+                notified++;
+            }
+        }
+
+        _logger.LogInformation(
+            "Interrupted-turn scan complete: {NotifiedCount} session(s) found with crash sentinels and notified",
+            notified);
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -582,7 +582,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
             ["ToolEnd"] = new(TaskCreationOptions.RunContinuationsAsynchronously),
             ["MessageEnd"] = new(TaskCreationOptions.RunContinuationsAsynchronously),
             ["Error"] = new(TaskCreationOptions.RunContinuationsAsynchronously),
-            ["UserInputRequired"] = new(TaskCreationOptions.RunContinuationsAsynchronously)
+            ["UserInputRequired"] = new(TaskCreationOptions.RunContinuationsAsynchronously),
+            ["TurnInterrupted"] = new(TaskCreationOptions.RunContinuationsAsynchronously)
         };
 
         var subscriptions = new List<IDisposable>
@@ -594,7 +595,8 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
             connection.On<AgentStreamEvent>("ToolEnd", payload => handlers["ToolEnd"].TrySetResult(payload)),
             connection.On<AgentStreamEvent>("MessageEnd", payload => handlers["MessageEnd"].TrySetResult(payload)),
             connection.On<AgentStreamEvent>("Error", payload => handlers["Error"].TrySetResult(payload)),
-            connection.On<AgentStreamEvent>("UserInputRequired", payload => handlers["UserInputRequired"].TrySetResult(payload))
+            connection.On<AgentStreamEvent>("UserInputRequired", payload => handlers["UserInputRequired"].TrySetResult(payload)),
+            connection.On<AgentStreamEvent>("TurnInterrupted", payload => handlers["TurnInterrupted"].TrySetResult(payload))
         };
 
         var adapter = factory.Services.GetRequiredService<SignalRChannelAdapter>();
@@ -634,6 +636,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
                 AgentStreamEventType.MessageEnd => "MessageEnd",
                 AgentStreamEventType.Error => "Error",
                 AgentStreamEventType.UserInputRequired => "UserInputRequired",
+                AgentStreamEventType.TurnInterrupted => "TurnInterrupted",
                 AgentStreamEventType.TurnEnd => null, // internal persistence signal -- not forwarded to Hub clients
                 _ => throw new ArgumentOutOfRangeException()
             };

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/InterruptedTurnNotificationServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/InterruptedTurnNotificationServiceTests.cs
@@ -1,0 +1,168 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+public sealed class InterruptedTurnNotificationServiceTests
+{
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static GatewaySession CreateSession(
+        string sessionId,
+        string agentId,
+        bool withSentinel = false,
+        string? callerId = null,
+        ChannelKey? channelType = null)
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From(sessionId),
+            AgentId = AgentId.From(agentId),
+            Status = SessionStatus.Active,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            SessionType = SessionType.UserAgent,
+            ChannelType = channelType,
+            CallerId = callerId
+        };
+
+        if (withSentinel)
+        {
+            session.AddEntry(new SessionEntry
+            {
+                Role = MessageRole.System,
+                Content = "[agent turn in progress — gateway restarted if visible]",
+                IsCrashSentinel = true
+            });
+        }
+
+        return session;
+    }
+
+    private static IAgentRegistry CreateRegistry(params string[] agentIds)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll())
+            .Returns(agentIds.Select(id => new AgentDescriptor
+            {
+                AgentId = AgentId.From(id),
+                DisplayName = id,
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot"
+            }).ToList());
+        return registry.Object;
+    }
+
+    private static Mock<ISessionStore> CreateStore(params GatewaySession[] sessions)
+    {
+        var store = new Mock<ISessionStore>();
+        store.Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentId? agentId, CancellationToken _) =>
+                sessions.Where(s => !agentId.HasValue || s.AgentId == agentId.Value).ToList());
+        store.Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return store;
+    }
+
+    private static InterruptedTurnNotificationService CreateService(
+        ISessionStore store,
+        IAgentRegistry registry,
+        IActivityBroadcaster? broadcaster = null,
+        IChannelManager? channelManager = null)
+    {
+        broadcaster ??= Mock.Of<IActivityBroadcaster>();
+        channelManager ??= Mock.Of<IChannelManager>();
+        return new InterruptedTurnNotificationService(
+            store,
+            registry,
+            broadcaster,
+            channelManager,
+            NullLogger<InterruptedTurnNotificationService>.Instance);
+    }
+
+    // ── Tests ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StartAsync_SessionWithSentinel_AddsNotificationEntryAndRemovesSentinels()
+    {
+        var session = CreateSession("sess-1", "agent-a", withSentinel: true);
+        var store = CreateStore(session);
+        var service = CreateService(store.Object, CreateRegistry("agent-a"));
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Sentinel should be gone
+        session.History.ShouldNotContain(e => e.IsCrashSentinel);
+
+        // A notification entry should have been appended
+        session.History.ShouldContain(e => e.Role == MessageRole.Notification);
+        session.History.ShouldContain(e =>
+            e.Role == MessageRole.Notification &&
+            e.Content.Contains("gateway was restarted"));
+
+        // Session should have been persisted
+        store.Verify(s => s.SaveAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_SessionWithoutSentinel_IsNotTouched()
+    {
+        var session = CreateSession("sess-clean", "agent-a", withSentinel: false);
+        var store = CreateStore(session);
+        var service = CreateService(store.Object, CreateRegistry("agent-a"));
+
+        await service.StartAsync(CancellationToken.None);
+
+        session.History.ShouldNotContain(e => e.Role == MessageRole.Notification);
+        store.Verify(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_BroadcastsActivity_ForInterruptedSession()
+    {
+        var session = CreateSession("sess-2", "agent-b", withSentinel: true);
+        var store = CreateStore(session);
+        var broadcaster = new Mock<IActivityBroadcaster>();
+        broadcaster.Setup(b => b.PublishAsync(It.IsAny<GatewayActivity>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var service = CreateService(store.Object, CreateRegistry("agent-b"), broadcaster: broadcaster.Object);
+
+        await service.StartAsync(CancellationToken.None);
+
+        broadcaster.Verify(
+            b => b.PublishAsync(
+                It.Is<GatewayActivity>(a => a.AgentId == "agent-b" && a.SessionId == "sess-2"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_MultipleAgents_OnlyInterruptedSessionsNotified()
+    {
+        var interrupted = CreateSession("sess-int", "agent-x", withSentinel: true);
+        var clean = CreateSession("sess-clean", "agent-x", withSentinel: false);
+        var store = CreateStore(interrupted, clean);
+        var service = CreateService(store.Object, CreateRegistry("agent-x"));
+
+        await service.StartAsync(CancellationToken.None);
+
+        store.Verify(s => s.SaveAsync(interrupted, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.SaveAsync(clean, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StopAsync_IsNoOp()
+    {
+        var store = CreateStore();
+        var service = CreateService(store.Object, CreateRegistry());
+        var ex = await Record.ExceptionAsync(() => service.StopAsync(CancellationToken.None));
+        ex.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #743 (Option A — notify users when gateway restart interrupted their agent turn).

## Changes

| File | Change |
|---|---|
| `MessageRole.cs` | New `Notification` role (`"notification"`) — gateway-generated, never forwarded to LLM |
| `AgentExecution.cs` | New `AgentStreamEventType.TurnInterrupted` enum value |
| `InterruptedTurnNotificationService.cs` | New `IHostedService` — startup sweep for crash sentinels, appends notification entry, removes sentinels, broadcasts via `IActivityBroadcaster`, delivers `OutboundMessage` to originating channel |
| `SessionContextProjector.cs` | `IsVisibleInLiveContext` now excludes `MessageRole.Notification` entries from LLM token budget |
| `IGatewayHubClient.cs` | New `TurnInterrupted(AgentStreamEvent)` hub method |
| `IGatewayEventHandler.cs` | New `HandleTurnInterrupted(AgentStreamEvent)` handler contract |
| `GatewayEventHandler.cs` | Implementation — appends notification message to affected conversation, clears streaming state |
| `GatewayHubConnection.cs` | Wires `OnTurnInterrupted` event from SignalR hub |
| `SignalRChannelAdapter.cs` | Routes `TurnInterrupted` events to the hub client |
| `GatewayServiceCollectionExtensions.cs` | Registers `InterruptedTurnNotificationService` as `IHostedService` |
| `SignalRIntegrationTests.cs` | Integration test harness updated with `TurnInterrupted` handler/subscription |
| `InterruptedTurnNotificationServiceTests.cs` | 5 unit tests — sentinel detection, notification append, sentinel cleanup, activity broadcast, clean session no-op |

## Test results

- Unit tests (new): **5/5 pass**
- Full suite: all non-integration tests pass. `BotNexus.Integration.Cli.Tests` failures are pre-existing disk space / worktree clone environment issues unrelated to this change.

## Follow-up

- #744 (Option B — auto-replay) depends on this
- Portal UI for `TurnInterrupted` banner + conversation list badge is a separate follow-up