### PR TITLE
fix(#383): fetch canvas for auto-selected conversation on initial load

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -603,6 +603,23 @@ public sealed class AgentInteractionService : IAgentInteractionService
             foreach (var session in sessionsTask.Result)
                 _store.RegisterSession(session.AgentId, session.SessionId, session.ChannelType, session.SessionType);
 
+            // Fetch canvas for the auto-selected conversation on initial load (#383)
+            var agent = _store.GetAgent(agentId);
+            var activeConvId = agent?.ActiveConversationId;
+            if (activeConvId is not null && agent!.Conversations.TryGetValue(activeConvId, out var activeConv))
+            {
+                try
+                {
+                    var canvasHtml = await _restClient.GetConversationCanvasAsync(agentId, activeConvId);
+                    if (canvasHtml is not null)
+                    {
+                        activeConv.CanvasHtml = canvasHtml;
+                        activeConv.CanvasUpdatedAt = DateTimeOffset.UtcNow;
+                    }
+                }
+                catch { /* canvas fetch is best-effort */ }
+            }
+
             _store.NotifyChanged();
         }
         catch (Exception ex)


### PR DESCRIPTION
## Problem

`RefreshConversationsForAgentAsync` seeds conversations and auto-selects one via `SeedConversations`, but never triggered the canvas REST fetch. The canvas fetch was only wired inside `SelectConversationAsync` (user-initiated conversation switches).

Result: on page load or refresh, `conv.CanvasHtml` was always `null` — nothing ever called `GetConversationCanvasAsync` for the initial active conversation, so `CanvasPanel` showed the empty state even though the DB had HTML.

## Fix

After `SeedConversations`, resolve the auto-selected conversation and fetch its canvas via `GetConversationCanvasAsync` before `NotifyChanged()`. Canvas now renders on first paint.

## Tests

335/335 BlazorClient unit tests pass. Full solution build clean.

Closes #383