### PR TITLE
feat(#776): include skills world-default in generated config.json

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -62,6 +62,14 @@ internal sealed class InitCommand
                 {
                     Type = "Sqlite",
                     ConnectionString = $"Data Source={Path.Combine(homePath, "sessions.sqlite")}"
+                },
+                Extensions = new ExtensionsConfig
+                {
+                    Enabled = true,
+                    Defaults = new Dictionary<string, JsonElement>
+                    {
+                        ["botnexus-skills"] = JsonDocument.Parse("{\"enabled\":true}").RootElement.Clone()
+                    }
                 }
             },
             Cron = new CronConfig

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/InitCommandTests.cs
@@ -9,6 +9,33 @@ namespace BotNexus.Cli.Tests.Commands;
 public sealed class InitCommandTests
 {
     [Fact]
+    public async Task Init_DefaultConfig_IncludesSkillsWorldDefault()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), $"botnexus-init-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+
+        try
+        {
+            var cmd = new InitCommand();
+
+            // Act
+            await cmd.ExecuteAsync(tempHome, force: false, verbose: false, CancellationToken.None);
+
+            // Assert — skills world default must be present for discoverability
+            var configPath = Path.Combine(tempHome, "config.json");
+            var json = await File.ReadAllTextAsync(configPath);
+            json.ShouldContain("botnexus-skills");
+            json.ShouldContain("\"enabled\": true");
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+                Directory.Delete(tempHome, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Init_DefaultConfig_ListenUrl_BindsToAllInterfaces()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Injects `gateway.extensions.defaults["botnexus-skills"].enabled = true` into the `PlatformConfig` produced by `InitCommand` so that a fresh install explicitly surfaces the Skills extension default in `config.json`.

## Why

Without this, `botnexus init` generates a minimal config with no `extensions` block at all. Operators have no visibility into available extensions or their defaults — they only discover them when things break or by reading the source. The skills default is opt-in for creation/deletion (those gates remain `false` by default in `SkillsConfig`), but the extension itself should be clearly present in a new install.

## Changes

- `InitCommand.cs` — adds `Extensions` block to `GatewaySettingsConfig` with `botnexus-skills` enabled
- `InitCommandTests.cs` — adds `Init_DefaultConfig_IncludesSkillsWorldDefault` test (2/2 pass)

## Related

Closes #776
Related: #777 (`doctor config` — the `skills-world-default` check mirrors this for existing installs)