### PR TITLE
feat(#777): add `doctor config` sub-command for guided config migration

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/Doctor/ConfigChecks.cs
+++ b/src/gateway/BotNexus.Cli/Commands/Doctor/ConfigChecks.cs
@@ -1,0 +1,138 @@
+using System.Text.Json.Nodes;
+
+namespace BotNexus.Cli.Commands.Doctor;
+
+/// <summary>
+/// Checks that <c>gateway.extensions</c> block exists and is enabled.
+/// </summary>
+public sealed class ExtensionsBlockCheck : IConfigCheck
+{
+    public string Id => "extensions-block";
+    public string Description => "gateway.extensions block is absent or has extensions disabled.";
+    public string FixDescription => "Add gateway.extensions = { enabled: true }";
+
+    public bool IsApplicable(JsonObject root)
+    {
+        var gateway = root["gateway"] as JsonObject;
+        if (gateway is null) return true;
+        var extensions = gateway["extensions"] as JsonObject;
+        if (extensions is null) return true;
+        // present — only flag if explicitly disabled
+        if (extensions["enabled"] is JsonValue ev && ev.TryGetValue<bool>(out var enabled))
+            return !enabled;
+        return false;
+    }
+
+    public void Apply(JsonObject root)
+    {
+        var gateway = root["gateway"] as JsonObject ?? new JsonObject();
+        root["gateway"] = gateway;
+
+        if (gateway["extensions"] is not JsonObject extensions)
+        {
+            extensions = new JsonObject();
+            gateway["extensions"] = extensions;
+        }
+        extensions["enabled"] = true;
+    }
+}
+
+/// <summary>
+/// Checks that <c>gateway.extensions.defaults["botnexus-skills"]</c> is present and enabled.
+/// </summary>
+public sealed class SkillsWorldDefaultCheck : IConfigCheck
+{
+    public string Id => "skills-world-default";
+    public string Description => "Skills extension has no world-level default in gateway.extensions.defaults.";
+    public string FixDescription => "Add gateway.extensions.defaults[\"botnexus-skills\"].enabled = true";
+
+    public bool IsApplicable(JsonObject root)
+    {
+        var defaults = GetDefaults(root);
+        if (defaults is null) return true;
+        var skills = defaults["botnexus-skills"] as JsonObject;
+        if (skills is null) return true;
+        if (skills["enabled"] is JsonValue ev && ev.TryGetValue<bool>(out var enabled))
+            return !enabled;
+        return false;
+    }
+
+    public void Apply(JsonObject root)
+    {
+        var gateway = root["gateway"] as JsonObject ?? new JsonObject();
+        root["gateway"] = gateway;
+
+        var extensions = gateway["extensions"] as JsonObject ?? new JsonObject();
+        gateway["extensions"] = extensions;
+        extensions["enabled"] = true;
+
+        var defaults = extensions["defaults"] as JsonObject ?? new JsonObject();
+        extensions["defaults"] = defaults;
+
+        var skills = defaults["botnexus-skills"] as JsonObject ?? new JsonObject();
+        defaults["botnexus-skills"] = skills;
+        skills["enabled"] = true;
+    }
+
+    private static JsonObject? GetDefaults(JsonObject root)
+        => (root["gateway"] as JsonObject)?["extensions"] as JsonObject is { } ext
+            ? ext["defaults"] as JsonObject
+            : null;
+}
+
+/// <summary>
+/// Checks that the top-level <c>cron</c> block exists with scheduler enabled.
+/// </summary>
+public sealed class CronCheck : IConfigCheck
+{
+    public string Id => "cron-enabled";
+    public string Description => "cron scheduler block is absent from config.";
+    public string FixDescription => "Add cron = { enabled: true, tickIntervalSeconds: 60 }";
+
+    public bool IsApplicable(JsonObject root)
+        => root["cron"] is not JsonObject;
+
+    public void Apply(JsonObject root)
+    {
+        if (root["cron"] is JsonObject) return;
+        root["cron"] = new JsonObject
+        {
+            ["enabled"] = true,
+            ["tickIntervalSeconds"] = 60
+        };
+    }
+}
+
+/// <summary>
+/// Checks that <c>agents.defaults.memory</c> block is present.
+/// </summary>
+public sealed class MemoryAgentDefaultCheck : IConfigCheck
+{
+    public string Id => "memory-agent-default";
+    public string Description => "agents.defaults.memory block is absent — memory indexing will not be enabled by default.";
+    public string FixDescription => "Add agents.defaults.memory = { enabled: true, indexing: \"auto\" }";
+
+    public bool IsApplicable(JsonObject root)
+    {
+        var agents = root["agents"] as JsonObject;
+        if (agents is null) return false; // no agents block at all — not our concern
+        var defaults = agents["defaults"] as JsonObject;
+        return defaults?["memory"] is not JsonObject;
+    }
+
+    public void Apply(JsonObject root)
+    {
+        var agents = root["agents"] as JsonObject;
+        if (agents is null) return;
+
+        var defaults = agents["defaults"] as JsonObject ?? new JsonObject();
+        agents["defaults"] = defaults;
+
+        if (defaults["memory"] is JsonObject) return;
+        defaults["memory"] = new JsonObject
+        {
+            ["enabled"] = true,
+            ["indexing"] = "auto"
+        };
+    }
+}

--- a/src/gateway/BotNexus.Cli/Commands/Doctor/IConfigCheck.cs
+++ b/src/gateway/BotNexus.Cli/Commands/Doctor/IConfigCheck.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Nodes;
+
+namespace BotNexus.Cli.Commands.Doctor;
+
+/// <summary>
+/// Represents a single configuration migration/health check for <c>botnexus doctor config</c>.
+/// </summary>
+public interface IConfigCheck
+{
+    /// <summary>Stable identifier used in output and dry-run reporting.</summary>
+    string Id { get; }
+
+    /// <summary>Human-readable description of what this check validates.</summary>
+    string Description { get; }
+
+    /// <summary>One-line explanation of what the fix will apply.</summary>
+    string FixDescription { get; }
+
+    /// <summary>Returns true when the config is missing this check's expected value.</summary>
+    bool IsApplicable(JsonObject root);
+
+    /// <summary>Applies the fix to the config object in-place.</summary>
+    void Apply(JsonObject root);
+}

--- a/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
@@ -26,6 +26,7 @@ internal sealed class DoctorCommand
         });
 
         command.AddCommand(locationsCommand);
+        command.AddCommand(new DoctorConfigCommand().Build(verboseOption));
         return command;
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/DoctorConfigCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorConfigCommand.cs
@@ -1,0 +1,163 @@
+using System.CommandLine;
+using System.Text.Json.Nodes;
+using BotNexus.Cli.Commands.Doctor;
+using BotNexus.Gateway.Configuration;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// Implements <c>botnexus doctor config</c> — guided config migration.
+/// Compares the existing config.json against registered <see cref="IConfigCheck"/> implementations,
+/// reports gaps, and optionally applies fixes via <see cref="PlatformConfigWriter"/>.
+/// </summary>
+internal sealed class DoctorConfigCommand
+{
+    /// <summary>All registered checks, evaluated in order.</summary>
+    private static readonly IReadOnlyList<IConfigCheck> Checks =
+    [
+        new ExtensionsBlockCheck(),
+        new SkillsWorldDefaultCheck(),
+        new CronCheck(),
+        new MemoryAgentDefaultCheck(),
+    ];
+
+    public Command Build(Option<bool> verboseOption)
+    {
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
+        var yesOption = new Option<bool>("--yes", "Apply all applicable fixes without prompting.");
+        var dryRunOption = new Option<bool>("--dry-run", "Report what would change but do not write anything.");
+
+        var command = new Command("config", "Guided config migration — detect and apply missing settings.")
+        {
+            targetOption,
+            yesOption,
+            dryRunOption
+        };
+
+        command.SetHandler(async context =>
+        {
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var yes = context.ParseResult.GetValueForOption(yesOption);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteAsync(configPath, yes, dryRun, verbose, CancellationToken.None);
+        });
+
+        return command;
+    }
+
+    public async Task<int> ExecuteAsync(
+        string configPath,
+        bool autoApply,
+        bool dryRun,
+        bool verbose,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(configPath))
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Config not found at [dim]{Markup.Escape(configPath)}[/]. Run [green]botnexus init[/] first.");
+            return 1;
+        }
+
+        PlatformConfig config;
+        try
+        {
+            config = await PlatformConfigLoader.LoadAsync(configPath, cancellationToken, validateOnLoad: false);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] Unable to load config: {Markup.Escape(ex.Message)}");
+            return 1;
+        }
+
+        AnsiConsole.MarkupLine($"  Checking config at [dim]{Markup.Escape(configPath)}[/]...\n");
+
+        // Load raw JSON so checks operate on the actual persisted nodes
+        var rawJson = await File.ReadAllTextAsync(configPath, cancellationToken);
+        var root = JsonNode.Parse(rawJson)?.AsObject() ?? new JsonObject();
+
+        var applicable = Checks.Where(c => c.IsApplicable(root)).ToList();
+
+        if (applicable.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]✓[/] Config is up to date — no changes needed.");
+            return 0;
+        }
+
+        var interactive = AnsiConsole.Profile.Capabilities.Interactive && !autoApply;
+        var appliedCount = 0;
+        var skippedCount = 0;
+        var alreadyOkCount = Checks.Count - applicable.Count;
+
+        for (var i = 0; i < applicable.Count; i++)
+        {
+            var check = applicable[i];
+            AnsiConsole.MarkupLine($"  [bold]{Markup.Escape($"[{i + 1}/{applicable.Count}]")}[/] [bold]{Markup.Escape(check.Id)}[/]");
+            AnsiConsole.MarkupLine($"        {Markup.Escape(check.Description)}");
+            AnsiConsole.MarkupLine($"        [dim]Suggested fix:[/] {Markup.Escape(check.FixDescription)}");
+
+            if (dryRun)
+            {
+                AnsiConsole.MarkupLine("        [yellow]--dry-run[/]: would apply\n");
+                appliedCount++;
+                continue;
+            }
+
+            bool apply;
+            if (interactive)
+            {
+                apply = AnsiConsole.Confirm("        Apply?", defaultValue: true);
+            }
+            else
+            {
+                apply = true;
+                AnsiConsole.MarkupLine("        [dim]--yes: applying...[/]");
+            }
+
+            if (apply)
+            {
+                check.Apply(root);
+                appliedCount++;
+                AnsiConsole.MarkupLine("        [green]✓ applied[/]\n");
+            }
+            else
+            {
+                skippedCount++;
+                AnsiConsole.MarkupLine("        [dim]— skipped[/]\n");
+            }
+        }
+
+        // Write back if anything was applied (and not dry-run)
+        if (!dryRun && appliedCount > 0)
+        {
+            var fileSystem = new System.IO.Abstractions.FileSystem();
+            var backupsDir = Path.Combine(Path.GetDirectoryName(configPath) ?? PlatformConfigLoader.DefaultHomePath, "backups");
+            var writer = new PlatformConfigWriter(configPath, fileSystem, new ConfigBackupService(backupsDir, fileSystem));
+            var updatedJson = root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            await writer.MutateAsync(rootNode =>
+            {
+                var replacement = JsonNode.Parse(updatedJson)?.AsObject() ?? new JsonObject();
+                rootNode.Clear();
+                foreach (var kvp in replacement)
+                    rootNode[kvp.Key] = kvp.Value?.DeepClone();
+            }, "doctor-config", cancellationToken);
+        }
+
+        AnsiConsole.WriteLine();
+        var dryRunNote = dryRun ? " [dim](dry-run — nothing written)[/]" : string.Empty;
+        AnsiConsole.Write(new Rule(
+            $"[green]{appliedCount} fix{(appliedCount == 1 ? "" : "es")} applied[/]  " +
+            $"[yellow]{skippedCount} skipped[/]  " +
+            $"[dim]{alreadyOkCount} already correct[/]" +
+            dryRunNote)
+        { Justification = Justify.Left });
+
+        if (verbose)
+            AnsiConsole.MarkupLine($"\n[dim]Config path: {Markup.Escape(configPath)}[/]");
+
+        return 0;
+    }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/Doctor/ConfigChecksTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/Doctor/ConfigChecksTests.cs
@@ -1,0 +1,166 @@
+using System.Text.Json.Nodes;
+using BotNexus.Cli.Commands.Doctor;
+using Shouldly;
+
+namespace BotNexus.Cli.Tests.Commands.Doctor;
+
+public sealed class ConfigChecksTests
+{
+    // ── ExtensionsBlockCheck ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ExtensionsBlockCheck_ApplicableWhenGatewayAbsent()
+    {
+        var root = new JsonObject();
+        new ExtensionsBlockCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExtensionsBlockCheck_ApplicableWhenExtensionsAbsent()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{}}") !.AsObject();
+        new ExtensionsBlockCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExtensionsBlockCheck_NotApplicableWhenEnabled()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{\"extensions\":{\"enabled\":true}}}") !.AsObject();
+        new ExtensionsBlockCheck().IsApplicable(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ExtensionsBlockCheck_ApplicableWhenExplicitlyDisabled()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{\"extensions\":{\"enabled\":false}}}") !.AsObject();
+        new ExtensionsBlockCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExtensionsBlockCheck_Apply_SetsEnabled()
+    {
+        var root = new JsonObject();
+        new ExtensionsBlockCheck().Apply(root);
+        var enabled = root["gateway"]!["extensions"]!["enabled"]!.GetValue<bool>();
+        enabled.ShouldBeTrue();
+    }
+
+    // ── SkillsWorldDefaultCheck ───────────────────────────────────────────────
+
+    [Fact]
+    public void SkillsWorldDefaultCheck_ApplicableWhenDefaultsAbsent()
+    {
+        var root = new JsonObject();
+        new SkillsWorldDefaultCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SkillsWorldDefaultCheck_ApplicableWhenSkillsKeyAbsent()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{\"extensions\":{\"defaults\":{}}}}") !.AsObject();
+        new SkillsWorldDefaultCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SkillsWorldDefaultCheck_NotApplicableWhenPresent()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{\"extensions\":{\"defaults\":{\"botnexus-skills\":{\"enabled\":true}}}}}") !.AsObject();
+        new SkillsWorldDefaultCheck().IsApplicable(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SkillsWorldDefaultCheck_ApplicableWhenExplicitlyDisabled()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{\"extensions\":{\"defaults\":{\"botnexus-skills\":{\"enabled\":false}}}}}") !.AsObject();
+        new SkillsWorldDefaultCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SkillsWorldDefaultCheck_Apply_SetsFullPath()
+    {
+        var root = new JsonObject();
+        new SkillsWorldDefaultCheck().Apply(root);
+        var enabled = root["gateway"]!["extensions"]!["defaults"]!["botnexus-skills"]!["enabled"]!.GetValue<bool>();
+        enabled.ShouldBeTrue();
+        // extensions block should also be enabled
+        root["gateway"]!["extensions"]!["enabled"]!.GetValue<bool>().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SkillsWorldDefaultCheck_Apply_PreservesExistingDefaults()
+    {
+        var root = JsonNode.Parse("{\"gateway\":{\"extensions\":{\"enabled\":true,\"defaults\":{\"other-ext\":{\"enabled\":true}}}}}") !.AsObject();
+        new SkillsWorldDefaultCheck().Apply(root);
+        var defaults = root["gateway"]!["extensions"]!["defaults"]!.AsObject();
+        defaults.ContainsKey("other-ext").ShouldBeTrue();
+        defaults.ContainsKey("botnexus-skills").ShouldBeTrue();
+    }
+
+    // ── CronCheck ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CronCheck_ApplicableWhenAbsent()
+    {
+        var root = new JsonObject();
+        new CronCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CronCheck_NotApplicableWhenPresent()
+    {
+        var root = JsonNode.Parse("{\"cron\":{\"enabled\":true}}") !.AsObject();
+        new CronCheck().IsApplicable(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CronCheck_Apply_AddsCronBlock()
+    {
+        var root = new JsonObject();
+        new CronCheck().Apply(root);
+        root["cron"]!["enabled"]!.GetValue<bool>().ShouldBeTrue();
+        root["cron"]!["tickIntervalSeconds"]!.GetValue<int>().ShouldBe(60);
+    }
+
+    [Fact]
+    public void CronCheck_Apply_DoesNotOverwriteExisting()
+    {
+        var root = JsonNode.Parse("{\"cron\":{\"enabled\":true,\"tickIntervalSeconds\":30}}") !.AsObject();
+        new CronCheck().Apply(root);
+        // already present — Apply is a no-op
+        root["cron"]!["tickIntervalSeconds"]!.GetValue<int>().ShouldBe(30);
+    }
+
+    // ── MemoryAgentDefaultCheck ───────────────────────────────────────────────
+
+    [Fact]
+    public void MemoryAgentDefaultCheck_NotApplicableWhenNoAgentsBlock()
+    {
+        var root = new JsonObject();
+        // no agents at all — check should be silent
+        new MemoryAgentDefaultCheck().IsApplicable(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MemoryAgentDefaultCheck_ApplicableWhenDefaultsMemoryAbsent()
+    {
+        var root = JsonNode.Parse("{\"agents\":{\"defaults\":{}}}") !.AsObject();
+        new MemoryAgentDefaultCheck().IsApplicable(root).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MemoryAgentDefaultCheck_NotApplicableWhenPresent()
+    {
+        var root = JsonNode.Parse("{\"agents\":{\"defaults\":{\"memory\":{\"enabled\":true,\"indexing\":\"auto\"}}}}") !.AsObject();
+        new MemoryAgentDefaultCheck().IsApplicable(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MemoryAgentDefaultCheck_Apply_SetsMemoryBlock()
+    {
+        var root = JsonNode.Parse("{\"agents\":{\"defaults\":{}}}") !.AsObject();
+        new MemoryAgentDefaultCheck().Apply(root);
+        var memory = root["agents"]!["defaults"]!["memory"]!.AsObject();
+        memory["enabled"]!.GetValue<bool>().ShouldBeTrue();
+        memory["indexing"]!.GetValue<string>().ShouldBe("auto");
+    }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/DoctorConfigCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/DoctorConfigCommandTests.cs
@@ -1,0 +1,136 @@
+using BotNexus.Cli.Commands;
+using Shouldly;
+using System.Text.Json.Nodes;
+
+namespace BotNexus.Cli.Tests.Commands;
+
+public sealed class DoctorConfigCommandTests
+{
+    private static async Task<string> WriteTempConfigAsync(string json)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"botnexus-doctor-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "config.json");
+        await File.WriteAllTextAsync(path, json);
+        return path;
+    }
+
+    [Fact]
+    public async Task DoctorConfig_ReturnsMissingFileError_WhenConfigAbsent()
+    {
+        var cmd = new DoctorConfigCommand();
+        var result = await cmd.ExecuteAsync(
+            "/nonexistent/path/config.json",
+            autoApply: true, dryRun: false, verbose: false,
+            CancellationToken.None);
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task DoctorConfig_ReturnsZero_WhenConfigAlreadyComplete()
+    {
+        var fullConfig = """
+            {
+              "gateway": {
+                "extensions": {
+                  "enabled": true,
+                  "defaults": {
+                    "botnexus-skills": { "enabled": true }
+                  }
+                }
+              },
+              "cron": { "enabled": true, "tickIntervalSeconds": 60 },
+              "agents": {
+                "defaults": {
+                  "memory": { "enabled": true, "indexing": "auto" }
+                }
+              }
+            }
+            """;
+        var configPath = await WriteTempConfigAsync(fullConfig);
+        try
+        {
+            var cmd = new DoctorConfigCommand();
+            var result = await cmd.ExecuteAsync(
+                configPath,
+                autoApply: false, dryRun: false, verbose: false,
+                CancellationToken.None);
+            result.ShouldBe(0);
+        }
+        finally
+        {
+            File.Delete(configPath);
+            Directory.Delete(Path.GetDirectoryName(configPath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorConfig_AppliesSkillsDefaultToMinimalConfig()
+    {
+        // Minimal config — missing extensions, skills default, and cron
+        var minimal = """
+            {
+              "gateway": {
+                "listenUrl": "http://0.0.0.0:5005"
+              },
+              "agents": {
+                "defaults": {}
+              }
+            }
+            """;
+        var configPath = await WriteTempConfigAsync(minimal);
+        try
+        {
+            var cmd = new DoctorConfigCommand();
+            var result = await cmd.ExecuteAsync(
+                configPath,
+                autoApply: true, dryRun: false, verbose: false,
+                CancellationToken.None);
+            result.ShouldBe(0);
+
+            var written = await File.ReadAllTextAsync(configPath);
+            var root = JsonNode.Parse(written)!.AsObject();
+
+            // skills default applied
+            var skillsEnabled = root["gateway"]!["extensions"]!["defaults"]!["botnexus-skills"]!["enabled"]!.GetValue<bool>();
+            skillsEnabled.ShouldBeTrue();
+
+            // cron applied
+            root["cron"]!["enabled"]!.GetValue<bool>().ShouldBeTrue();
+
+            // memory applied
+            root["agents"]!["defaults"]!["memory"]!["enabled"]!.GetValue<bool>().ShouldBeTrue();
+
+            // existing gateway setting preserved
+            written.ShouldContain("0.0.0.0");
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(configPath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorConfig_DryRun_DoesNotWriteChanges()
+    {
+        var minimal = "{\"gateway\":{\"listenUrl\":\"http://0.0.0.0:5005\"}}";
+        var configPath = await WriteTempConfigAsync(minimal);
+        try
+        {
+            var originalContent = await File.ReadAllTextAsync(configPath);
+
+            var cmd = new DoctorConfigCommand();
+            await cmd.ExecuteAsync(
+                configPath,
+                autoApply: true, dryRun: true, verbose: false,
+                CancellationToken.None);
+
+            var afterContent = await File.ReadAllTextAsync(configPath);
+            afterContent.ShouldBe(originalContent);
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(configPath)!, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `botnexus doctor config` — a guided config migration command that detects gaps in an existing `config.json` and optionally applies fixes.

## Why

As BotNexus evolves, new config sections and extension defaults accumulate. There was no supported path for operators on older installs to discover and adopt them. This fills that gap with a self-describing, safe, incremental update workflow.

## New Commands

```
botnexus doctor config              # interactive Y/n per check
botnexus doctor config --yes        # auto-apply all
botnexus doctor config --dry-run    # report only, no writes
botnexus doctor config --target /path/to/home
```

## Architecture

- **`IConfigCheck`** — extensible interface. Adding new checks requires zero changes to the command itself.
- **Initial checks (4)**:
  - `extensions-block` — `gateway.extensions` absent or disabled
  - `skills-world-default` — `gateway.extensions.defaults["botnexus-skills"]` absent or disabled  
  - `cron-enabled` — `cron` block absent
  - `memory-agent-default` — `agents.defaults.memory` absent
- All writes go through `PlatformConfigWriter.MutateAsync` (atomic + backup, same as `init` and `provider setup`)
- `--dry-run` is completely non-destructive

## Tests

- 19 unit tests for all 4 `IConfigCheck` implementations (edge cases: absent, explicit-disabled, already-present, apply-preserves-siblings)
- 4 integration tests for `DoctorConfigCommand.ExecuteAsync` including `DoctorConfig_AppliesSkillsDefaultToMinimalConfig`
- **23/23 passing**

## Related

Closes #777
Related: #776 (PR #779) — the `skills-world-default` check mirrors what `init` now writes for new installs