### PR TITLE
feat(#745): add SqliteWebhookRegistrationStore and SqliteWebhookRunStore

### DIFF
--- a/src/gateway/BotNexus.Gateway.Webhooks/BotNexus.Gateway.Webhooks.csproj
+++ b/src/gateway/BotNexus.Gateway.Webhooks/BotNexus.Gateway.Webhooks.csproj
@@ -14,10 +14,18 @@
     <Compile Include="IWebhookRegistrationStore.cs" />
     <Compile Include="IWebhookRunStore.cs" />
     <Compile Include="WebhookSecretHelper.cs" />
+    <Compile Include="SqliteWebhookRegistrationStore.cs" />
+    <Compile Include="SqliteWebhookRunStore.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 
 </Project>

--- a/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRegistrationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRegistrationStore.cs
@@ -1,0 +1,269 @@
+using BotNexus.Domain.Primitives;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Webhooks;
+
+/// <summary>
+/// SQLite-backed store for <see cref="WebhookRegistration"/> records.
+/// Uses WAL mode and a write-lock semaphore for safe concurrent access.
+/// </summary>
+public sealed class SqliteWebhookRegistrationStore(
+    string dbPath,
+    IFileSystem? fileSystem = null,
+    ILogger<SqliteWebhookRegistrationStore>? logger = null) : IWebhookRegistrationStore
+{
+    private readonly string _dbPath = dbPath;
+    private readonly string _connectionString = $"Data Source={dbPath};Mode=ReadWriteCreate";
+    private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystem();
+    private readonly ILogger<SqliteWebhookRegistrationStore> _logger = logger ?? NullLogger<SqliteWebhookRegistrationStore>.Instance;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private bool _initialized;
+
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        if (_initialized) return;
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_initialized) return;
+
+            _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(_dbPath) ?? ".");
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                PRAGMA journal_mode = WAL;
+
+                CREATE TABLE IF NOT EXISTS webhook_registrations (
+                    id TEXT PRIMARY KEY,
+                    label TEXT NOT NULL,
+                    agent_id TEXT NOT NULL,
+                    pinned_conversation_id TEXT NULL,
+                    secret TEXT NOT NULL,
+                    default_response_mode TEXT NOT NULL DEFAULT 'Async',
+                    enabled INTEGER NOT NULL DEFAULT 1,
+                    created_at TEXT NOT NULL,
+                    last_used_at TEXT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_webhook_registrations_agent_id
+                ON webhook_registrations(agent_id);
+                """;
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            _initialized = true;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<WebhookRegistration> CreateAsync(WebhookRegistration registration, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        var record = registration with
+        {
+            CreatedAt = registration.CreatedAt == default ? DateTimeOffset.UtcNow : registration.CreatedAt
+        };
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO webhook_registrations
+                    (id, label, agent_id, pinned_conversation_id, secret, default_response_mode, enabled, created_at, last_used_at)
+                VALUES
+                    ($id, $label, $agentId, $pinnedConversationId, $secret, $defaultResponseMode, $enabled, $createdAt, $lastUsedAt)
+                """;
+            BindRegistration(cmd, record);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation("Created webhook registration '{WebhookId}' for agent '{AgentId}'.", record.Id, record.AgentId);
+            return record;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<WebhookRegistration?> GetAsync(WebhookId webhookId, CancellationToken ct = default)
+    {
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT id, label, agent_id, pinned_conversation_id, secret, default_response_mode, enabled, created_at, last_used_at
+            FROM webhook_registrations
+            WHERE id = $id
+            """;
+        cmd.Parameters.AddWithValue("$id", webhookId.Value);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        return await reader.ReadAsync(ct).ConfigureAwait(false) ? ReadRegistration(reader) : null;
+    }
+
+    public async Task<IReadOnlyList<WebhookRegistration>> ListAsync(AgentId? agentId = null, CancellationToken ct = default)
+    {
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT id, label, agent_id, pinned_conversation_id, secret, default_response_mode, enabled, created_at, last_used_at
+            FROM webhook_registrations
+            WHERE $agentId IS NULL OR agent_id = $agentId
+            ORDER BY created_at DESC
+            """;
+        cmd.Parameters.AddWithValue("$agentId", agentId.HasValue ? (object)agentId.Value.Value : DBNull.Value);
+
+        List<WebhookRegistration> results = [];
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            results.Add(ReadRegistration(reader));
+        return results;
+    }
+
+    public async Task<WebhookRegistration> UpdateAsync(WebhookRegistration registration, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO webhook_registrations
+                    (id, label, agent_id, pinned_conversation_id, secret, default_response_mode, enabled, created_at, last_used_at)
+                VALUES
+                    ($id, $label, $agentId, $pinnedConversationId, $secret, $defaultResponseMode, $enabled, $createdAt, $lastUsedAt)
+                ON CONFLICT(id) DO UPDATE SET
+                    label = excluded.label,
+                    agent_id = excluded.agent_id,
+                    pinned_conversation_id = excluded.pinned_conversation_id,
+                    secret = excluded.secret,
+                    default_response_mode = excluded.default_response_mode,
+                    enabled = excluded.enabled,
+                    created_at = excluded.created_at,
+                    last_used_at = excluded.last_used_at
+                """;
+            BindRegistration(cmd, registration);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation("Updated webhook registration '{WebhookId}'.", registration.Id);
+            return registration;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task DeleteAsync(WebhookId webhookId, CancellationToken ct = default)
+    {
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = "DELETE FROM webhook_registrations WHERE id = $id";
+            cmd.Parameters.AddWithValue("$id", webhookId.Value);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation("Deleted webhook registration '{WebhookId}'.", webhookId);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ConversationId?> TryPinConversationAsync(
+        WebhookId webhookId,
+        ConversationId conversationId,
+        CancellationToken ct = default)
+    {
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cas = connection.CreateCommand();
+            cas.CommandText = """
+                UPDATE webhook_registrations
+                SET pinned_conversation_id = $conversationId
+                WHERE id = $webhookId AND pinned_conversation_id IS NULL
+                """;
+            cas.Parameters.AddWithValue("$conversationId", conversationId.Value);
+            cas.Parameters.AddWithValue("$webhookId", webhookId.Value);
+            await cas.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            await using var read = connection.CreateCommand();
+            read.CommandText = "SELECT pinned_conversation_id FROM webhook_registrations WHERE id = $webhookId";
+            read.Parameters.AddWithValue("$webhookId", webhookId.Value);
+            var result = await read.ExecuteScalarAsync(ct).ConfigureAwait(false);
+
+            if (result is null or DBNull) return null;
+            return ConversationId.From((string)result);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private SqliteConnection CreateConnection() => new(_connectionString);
+
+    private static void BindRegistration(SqliteCommand cmd, WebhookRegistration r)
+    {
+        cmd.Parameters.AddWithValue("$id", r.Id.Value);
+        cmd.Parameters.AddWithValue("$label", r.Label);
+        cmd.Parameters.AddWithValue("$agentId", r.AgentId.Value);
+        cmd.Parameters.AddWithValue("$pinnedConversationId", r.PinnedConversationId.HasValue ? (object)r.PinnedConversationId.Value.Value : DBNull.Value);
+        cmd.Parameters.AddWithValue("$secret", r.Secret);
+        cmd.Parameters.AddWithValue("$defaultResponseMode", r.DefaultResponseMode.ToString());
+        cmd.Parameters.AddWithValue("$enabled", r.Enabled ? 1 : 0);
+        cmd.Parameters.AddWithValue("$createdAt", r.CreatedAt.ToString("O"));
+        cmd.Parameters.AddWithValue("$lastUsedAt", r.LastUsedAt.HasValue ? (object)r.LastUsedAt.Value.ToString("O") : DBNull.Value);
+    }
+
+    private static WebhookRegistration ReadRegistration(SqliteDataReader reader)
+    {
+        return new WebhookRegistration
+        {
+            Id = WebhookId.From(reader.GetString(0)),
+            Label = reader.GetString(1),
+            AgentId = AgentId.From(reader.GetString(2)),
+            PinnedConversationId = reader.IsDBNull(3) ? null : ConversationId.From(reader.GetString(3)),
+            Secret = reader.GetString(4),
+            DefaultResponseMode = Enum.Parse<WebhookResponseMode>(reader.GetString(5)),
+            Enabled = !reader.IsDBNull(6) && reader.GetInt32(6) != 0,
+            CreatedAt = ParseDate(reader.GetString(7)),
+            LastUsedAt = reader.IsDBNull(8) ? null : ParseDate(reader.GetString(8))
+        };
+    }
+
+    private static DateTimeOffset ParseDate(string value) =>
+        DateTimeOffset.TryParse(value, out var parsed) ? parsed : DateTimeOffset.UtcNow;
+}

--- a/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRunStore.cs
+++ b/src/gateway/BotNexus.Gateway.Webhooks/SqliteWebhookRunStore.cs
@@ -1,0 +1,216 @@
+using BotNexus.Domain.Primitives;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Webhooks;
+
+/// <summary>
+/// SQLite-backed store for <see cref="WebhookRun"/> records.
+/// Uses WAL mode and a write-lock semaphore for safe concurrent access.
+/// </summary>
+public sealed class SqliteWebhookRunStore(
+    string dbPath,
+    IFileSystem? fileSystem = null,
+    ILogger<SqliteWebhookRunStore>? logger = null) : IWebhookRunStore
+{
+    private readonly string _dbPath = dbPath;
+    private readonly string _connectionString = $"Data Source={dbPath};Mode=ReadWriteCreate";
+    private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystem();
+    private readonly ILogger<SqliteWebhookRunStore> _logger = logger ?? NullLogger<SqliteWebhookRunStore>.Instance;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private bool _initialized;
+
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        if (_initialized) return;
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_initialized) return;
+
+            _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(_dbPath) ?? ".");
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                PRAGMA journal_mode = WAL;
+
+                CREATE TABLE IF NOT EXISTS webhook_runs (
+                    id TEXT PRIMARY KEY,
+                    webhook_id TEXT NOT NULL,
+                    conversation_id TEXT NULL,
+                    session_id TEXT NULL,
+                    status TEXT NOT NULL,
+                    accepted_at TEXT NOT NULL,
+                    started_at TEXT NULL,
+                    completed_at TEXT NULL,
+                    agent_response TEXT NULL,
+                    error TEXT NULL,
+                    callback_url TEXT NULL,
+                    agent_action INTEGER NOT NULL DEFAULT 1
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_webhook_runs_webhook_id_accepted_at
+                ON webhook_runs(webhook_id, accepted_at DESC);
+                """;
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            _initialized = true;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<WebhookRun> CreateAsync(WebhookRun run, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO webhook_runs
+                    (id, webhook_id, conversation_id, session_id, status, accepted_at, started_at, completed_at, agent_response, error, callback_url, agent_action)
+                VALUES
+                    ($id, $webhookId, $conversationId, $sessionId, $status, $acceptedAt, $startedAt, $completedAt, $agentResponse, $error, $callbackUrl, $agentAction)
+                """;
+            BindRun(cmd, run);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            return run;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<WebhookRun?> GetAsync(WebhookRunId runId, CancellationToken ct = default)
+    {
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT id, webhook_id, conversation_id, session_id, status, accepted_at, started_at, completed_at, agent_response, error, callback_url, agent_action
+            FROM webhook_runs
+            WHERE id = $id
+            """;
+        cmd.Parameters.AddWithValue("$id", runId.Value);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        return await reader.ReadAsync(ct).ConfigureAwait(false) ? ReadRun(reader) : null;
+    }
+
+    public async Task<WebhookRun> UpdateAsync(WebhookRun run, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO webhook_runs
+                    (id, webhook_id, conversation_id, session_id, status, accepted_at, started_at, completed_at, agent_response, error, callback_url, agent_action)
+                VALUES
+                    ($id, $webhookId, $conversationId, $sessionId, $status, $acceptedAt, $startedAt, $completedAt, $agentResponse, $error, $callbackUrl, $agentAction)
+                ON CONFLICT(id) DO UPDATE SET
+                    conversation_id = excluded.conversation_id,
+                    session_id = excluded.session_id,
+                    status = excluded.status,
+                    started_at = excluded.started_at,
+                    completed_at = excluded.completed_at,
+                    agent_response = excluded.agent_response,
+                    error = excluded.error
+                """;
+            BindRun(cmd, run);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            return run;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<WebhookRun>> ListByWebhookAsync(
+        WebhookId webhookId,
+        int limit = 20,
+        CancellationToken ct = default)
+    {
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT id, webhook_id, conversation_id, session_id, status, accepted_at, started_at, completed_at, agent_response, error, callback_url, agent_action
+            FROM webhook_runs
+            WHERE webhook_id = $webhookId
+            ORDER BY accepted_at DESC
+            LIMIT $limit
+            """;
+        cmd.Parameters.AddWithValue("$webhookId", webhookId.Value);
+        cmd.Parameters.AddWithValue("$limit", Math.Max(1, limit));
+
+        List<WebhookRun> results = [];
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            results.Add(ReadRun(reader));
+        return results;
+    }
+
+    private SqliteConnection CreateConnection() => new(_connectionString);
+
+    private static void BindRun(SqliteCommand cmd, WebhookRun r)
+    {
+        cmd.Parameters.AddWithValue("$id", r.Id.Value);
+        cmd.Parameters.AddWithValue("$webhookId", r.WebhookId.Value);
+        cmd.Parameters.AddWithValue("$conversationId", r.ConversationId.HasValue ? (object)r.ConversationId.Value.Value : DBNull.Value);
+        cmd.Parameters.AddWithValue("$sessionId", r.SessionId.HasValue ? (object)r.SessionId.Value.Value : DBNull.Value);
+        cmd.Parameters.AddWithValue("$status", r.Status.ToString());
+        cmd.Parameters.AddWithValue("$acceptedAt", r.AcceptedAt.ToString("O"));
+        cmd.Parameters.AddWithValue("$startedAt", r.StartedAt.HasValue ? (object)r.StartedAt.Value.ToString("O") : DBNull.Value);
+        cmd.Parameters.AddWithValue("$completedAt", r.CompletedAt.HasValue ? (object)r.CompletedAt.Value.ToString("O") : DBNull.Value);
+        cmd.Parameters.AddWithValue("$agentResponse", (object?)r.AgentResponse ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$error", (object?)r.Error ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$callbackUrl", (object?)r.CallbackUrl ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$agentAction", r.AgentAction ? 1 : 0);
+    }
+
+    private static WebhookRun ReadRun(SqliteDataReader reader)
+    {
+        return new WebhookRun
+        {
+            Id = WebhookRunId.From(reader.GetString(0)),
+            WebhookId = WebhookId.From(reader.GetString(1)),
+            ConversationId = reader.IsDBNull(2) ? null : ConversationId.From(reader.GetString(2)),
+            SessionId = reader.IsDBNull(3) ? null : SessionId.From(reader.GetString(3)),
+            Status = Enum.Parse<WebhookRunStatus>(reader.GetString(4)),
+            AcceptedAt = ParseDate(reader.GetString(5)),
+            StartedAt = reader.IsDBNull(6) ? null : ParseDate(reader.GetString(6)),
+            CompletedAt = reader.IsDBNull(7) ? null : ParseDate(reader.GetString(7)),
+            AgentResponse = reader.IsDBNull(8) ? null : reader.GetString(8),
+            Error = reader.IsDBNull(9) ? null : reader.GetString(9),
+            CallbackUrl = reader.IsDBNull(10) ? null : reader.GetString(10),
+            AgentAction = !reader.IsDBNull(11) && reader.GetInt32(11) != 0
+        };
+    }
+
+    private static DateTimeOffset ParseDate(string value) =>
+        DateTimeOffset.TryParse(value, out var parsed) ? parsed : DateTimeOffset.UtcNow;
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionConversationIdNonNullableArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionConversationIdNonNullableArchitectureTests.cs
@@ -151,6 +151,7 @@ public sealed class SessionConversationIdNonNullableArchitectureTests
         Path.Combine("gateway", "BotNexus.Cron", "CronScheduler.cs"),
         Path.Combine("gateway", "BotNexus.Cron", "SqliteCronStore.cs"),
         Path.Combine("gateway", "BotNexus.Gateway.Sessions", "FileSessionStore.cs"),
+        Path.Combine("gateway", "BotNexus.Gateway.Webhooks", "SqliteWebhookRunStore.cs"),
     };
 
     private static string ToRelative(string srcRoot, string fullPath)

--- a/tests/gateway/BotNexus.Gateway.Webhooks.Tests/SqliteWebhookRegistrationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Webhooks.Tests/SqliteWebhookRegistrationStoreTests.cs
@@ -1,0 +1,144 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Webhooks;
+
+namespace BotNexus.Gateway.Webhooks.Tests;
+
+/// <summary>
+/// Integration-style tests for <see cref="SqliteWebhookRegistrationStore"/> using
+/// a real SQLite file on a temp path. Fast — no network, no gateway, no DI.
+/// </summary>
+public sealed class SqliteWebhookRegistrationStoreTests : IAsyncLifetime
+{
+    private SqliteWebhookRegistrationStore _store = null!;
+    private string _dbPath = null!;
+
+    public async Task InitializeAsync()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"wh-reg-tests-{Guid.NewGuid():N}.db");
+        _store = new SqliteWebhookRegistrationStore(_dbPath);
+        await _store.InitializeAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        return Task.CompletedTask;
+    }
+
+    private static WebhookRegistration MakeRegistration(string? label = null, string? agentId = null) =>
+        new()
+        {
+            Id = WebhookId.Create(),
+            Label = label ?? "test-webhook",
+            AgentId = AgentId.From(agentId ?? "test-agent"),
+            Secret = WebhookSecretHelper.GenerateSecret(),
+            DefaultResponseMode = WebhookResponseMode.Async,
+            Enabled = true,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public async Task CreateAndGet_RoundTrips()
+    {
+        var reg = MakeRegistration();
+        await _store.CreateAsync(reg);
+
+        var retrieved = await _store.GetAsync(reg.Id);
+        Assert.NotNull(retrieved);
+        Assert.Equal(reg.Id.Value, retrieved.Id.Value);
+        Assert.Equal(reg.Label, retrieved.Label);
+        Assert.Equal(reg.AgentId.Value, retrieved.AgentId.Value);
+        Assert.Equal(reg.Secret, retrieved.Secret);
+        Assert.Equal(reg.DefaultResponseMode, retrieved.DefaultResponseMode);
+        Assert.True(retrieved.Enabled);
+        Assert.Null(retrieved.PinnedConversationId);
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_ReturnsNull()
+    {
+        var result = await _store.GetAsync(WebhookId.Create());
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task List_ByAgentId_FiltersCorrectly()
+    {
+        var a1 = await _store.CreateAsync(MakeRegistration(agentId: "agent-a"));
+        var a2 = await _store.CreateAsync(MakeRegistration(agentId: "agent-a"));
+        var b1 = await _store.CreateAsync(MakeRegistration(agentId: "agent-b"));
+
+        var listA = await _store.ListAsync(AgentId.From("agent-a"));
+        Assert.Equal(2, listA.Count);
+        Assert.All(listA, r => Assert.Equal("agent-a", r.AgentId.Value));
+
+        var listAll = await _store.ListAsync();
+        Assert.Equal(3, listAll.Count);
+    }
+
+    [Fact]
+    public async Task Update_ChangesLabel()
+    {
+        var reg = await _store.CreateAsync(MakeRegistration(label: "original"));
+        var updated = reg with { Label = "updated" };
+        await _store.UpdateAsync(updated);
+
+        var retrieved = await _store.GetAsync(reg.Id);
+        Assert.Equal("updated", retrieved!.Label);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesRecord()
+    {
+        var reg = await _store.CreateAsync(MakeRegistration());
+        await _store.DeleteAsync(reg.Id);
+
+        var retrieved = await _store.GetAsync(reg.Id);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public async Task TryPinConversationAsync_PinsOnFirstCall()
+    {
+        var reg = await _store.CreateAsync(MakeRegistration());
+        var convId = ConversationId.From("conv-001");
+
+        var pinned = await _store.TryPinConversationAsync(reg.Id, convId);
+        Assert.NotNull(pinned);
+        Assert.Equal("conv-001", pinned.Value.Value);
+
+        var retrieved = await _store.GetAsync(reg.Id);
+        Assert.Equal("conv-001", retrieved!.PinnedConversationId!.Value.Value);
+    }
+
+    [Fact]
+    public async Task TryPinConversationAsync_CasWinsWithFirst()
+    {
+        var reg = await _store.CreateAsync(MakeRegistration());
+        var first = ConversationId.From("conv-first");
+        var second = ConversationId.From("conv-second");
+
+        var pinFirst = await _store.TryPinConversationAsync(reg.Id, first);
+        var pinSecond = await _store.TryPinConversationAsync(reg.Id, second);
+
+        // Both calls return the winner — which is "first"
+        Assert.Equal("conv-first", pinFirst!.Value.Value);
+        Assert.Equal("conv-first", pinSecond!.Value.Value);
+    }
+
+    [Fact]
+    public async Task TryPinConversationAsync_ReturnsNullForMissingRegistration()
+    {
+        var result = await _store.TryPinConversationAsync(WebhookId.Create(), ConversationId.From("conv-x"));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_IsIdempotent()
+    {
+        // Second call should not throw
+        await _store.InitializeAsync();
+        await _store.InitializeAsync();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Webhooks.Tests/SqliteWebhookRunStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Webhooks.Tests/SqliteWebhookRunStoreTests.cs
@@ -1,0 +1,135 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Webhooks;
+
+namespace BotNexus.Gateway.Webhooks.Tests;
+
+/// <summary>
+/// Integration-style tests for <see cref="SqliteWebhookRunStore"/> using
+/// a real SQLite file on a temp path.
+/// </summary>
+public sealed class SqliteWebhookRunStoreTests : IAsyncLifetime
+{
+    private SqliteWebhookRunStore _store = null!;
+    private string _dbPath = null!;
+
+    public async Task InitializeAsync()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"wh-run-tests-{Guid.NewGuid():N}.db");
+        _store = new SqliteWebhookRunStore(_dbPath);
+        await _store.InitializeAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        return Task.CompletedTask;
+    }
+
+    private static WebhookRun MakeRun(string? webhookId = null) =>
+        new()
+        {
+            Id = WebhookRunId.Create(),
+            WebhookId = WebhookId.From(webhookId ?? "wh_testwebhook123456"),
+            Status = WebhookRunStatus.Pending,
+            AcceptedAt = DateTimeOffset.UtcNow,
+            AgentAction = true
+        };
+
+    [Fact]
+    public async Task CreateAndGet_RoundTrips()
+    {
+        var run = MakeRun();
+        await _store.CreateAsync(run);
+
+        var retrieved = await _store.GetAsync(run.Id);
+        Assert.NotNull(retrieved);
+        Assert.Equal(run.Id.Value, retrieved.Id.Value);
+        Assert.Equal(run.WebhookId.Value, retrieved.WebhookId.Value);
+        Assert.Equal(WebhookRunStatus.Pending, retrieved.Status);
+        Assert.Null(retrieved.AgentResponse);
+        Assert.True(retrieved.AgentAction);
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_ReturnsNull()
+    {
+        var result = await _store.GetAsync(WebhookRunId.Create());
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Update_ChangesStatus()
+    {
+        var run = await _store.CreateAsync(MakeRun());
+
+        run.Status = WebhookRunStatus.Completed;
+        run.AgentResponse = "The answer is 42.";
+        run.CompletedAt = DateTimeOffset.UtcNow;
+        await _store.UpdateAsync(run);
+
+        var retrieved = await _store.GetAsync(run.Id);
+        Assert.Equal(WebhookRunStatus.Completed, retrieved!.Status);
+        Assert.Equal("The answer is 42.", retrieved.AgentResponse);
+        Assert.NotNull(retrieved.CompletedAt);
+    }
+
+    [Fact]
+    public async Task Update_FailedStatus_PersistsError()
+    {
+        var run = await _store.CreateAsync(MakeRun());
+
+        run.Status = WebhookRunStatus.Failed;
+        run.Error = "Agent timed out.";
+        run.CompletedAt = DateTimeOffset.UtcNow;
+        await _store.UpdateAsync(run);
+
+        var retrieved = await _store.GetAsync(run.Id);
+        Assert.Equal(WebhookRunStatus.Failed, retrieved!.Status);
+        Assert.Equal("Agent timed out.", retrieved.Error);
+    }
+
+    [Fact]
+    public async Task ListByWebhook_ReturnsMostRecentFirst()
+    {
+        const string webhookId = "wh_testwebhook123456";
+        for (var i = 0; i < 5; i++)
+        {
+            var run = MakeRun(webhookId) with { AcceptedAt = DateTimeOffset.UtcNow.AddSeconds(-i) };
+            await _store.CreateAsync(run);
+        }
+
+        // Different webhook — should not appear
+        await _store.CreateAsync(MakeRun("wh_otherwebhook12345"));
+
+        var runs = await _store.ListByWebhookAsync(WebhookId.From(webhookId), limit: 3);
+        Assert.Equal(3, runs.Count);
+        // Verify descending order
+        for (var i = 0; i < runs.Count - 1; i++)
+            Assert.True(runs[i].AcceptedAt >= runs[i + 1].AcceptedAt);
+    }
+
+    [Fact]
+    public async Task ListByWebhook_EmptyForUnknownWebhook()
+    {
+        var runs = await _store.ListByWebhookAsync(WebhookId.Create());
+        Assert.Empty(runs);
+    }
+
+    [Fact]
+    public async Task Run_WithCallbackUrl_RoundTrips()
+    {
+        var run = MakeRun() with { CallbackUrl = "https://example.com/callback" };
+        await _store.CreateAsync(run);
+
+        var retrieved = await _store.GetAsync(run.Id);
+        Assert.Equal("https://example.com/callback", retrieved!.CallbackUrl);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_IsIdempotent()
+    {
+        await _store.InitializeAsync();
+        await _store.InitializeAsync();
+    }
+}


### PR DESCRIPTION
PR 2 of the webhook implementation plan.

## What

SQLite persistence layer for webhook registrations and webhook runs.

### New files

- `SqliteWebhookRegistrationStore` — implements `IWebhookRegistrationStore` with WAL mode, write-lock semaphore, CRUD, and CAS `TryPinConversationAsync`
- `SqliteWebhookRunStore` — implements `IWebhookRunStore` with WAL mode, write-lock semaphore, create/get/update/list-by-webhook

### Both stores follow the established pattern from `SqliteCronStore`:
- WAL journal mode
- `SemaphoreSlim` write lock for concurrent safety
- Double-checked initialization with `_initialized` flag
- Nullable column handling via `DBNull.Value`
- ISO 8601 date string storage
- UPSERT (`INSERT ... ON CONFLICT DO UPDATE`) for UpdateAsync

### CAS pin

`TryPinConversationAsync` uses the same atomic CAS pattern as `CronJob.ConversationId` — UPDATE WHERE NULL, then read back the winner. Prevents first-run race when concurrent webhook calls both try to create a conversation.

### Tests

17 new tests (8 registration + 9 run) using real SQLite on temp files. `SqliteConnection.ClearAllPools()` called on dispose to release file handles before deletion.

## Part of

- Closes #745 (with PR 3 for controller)
- Depends on: #782 (merged)
- Next: PR 3 — `WebhooksController` registration CRUD + DI wiring