### PR TITLE
feat(#407): add full agent editor panel with sidebar sub-tree and all config fields

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentDetailPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentDetailPanel.razor
@@ -1,0 +1,988 @@
+@using System.Text.Json
+@inject NavigationManager Nav
+@inject HttpClient Http
+
+<div class="agent-detail-panel">
+    <div class="agent-detail-header">
+        <div class="agent-detail-header-left">
+            <span class="agent-detail-id">@AgentId</span>
+            @if (IsDirty)
+            {
+                <span class="agents-dirty-indicator" title="You have unsaved changes">&#x25CF; Unsaved changes</span>
+            }
+        </div>
+        <div class="agent-detail-header-right">
+            <button class="toolbar-btn primary" @onclick="SaveAsync" disabled="@(_saving || !IsDirty)">
+                @(_saving ? "Saving..." : "Save Changes")
+            </button>
+            <button class="toolbar-btn" @onclick="GoBack">&#x2190; Back to list</button>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrEmpty(_statusMessage))
+    {
+        <div class="agents-status @_statusClass" role="status">@_statusMessage</div>
+    }
+
+    @if (_loading)
+    {
+        <div class="config-loading"><div class="loading-spinner small"></div><span>Loading agent...</span></div>
+    }
+    else if (_loadError is not null)
+    {
+        <div class="agents-error" role="alert">&#x26A0;&#xFE0F; @_loadError</div>
+    }
+    else if (_model is not null)
+    {
+        @* ── Identity & Model ──────────────────────────────────── *@
+        <details class="agent-section" open>
+            <summary class="agent-section-title">Identity &amp; Model</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Enabled</label>
+                    <input type="checkbox" checked="@_model.Enabled" @onchange="OnEnabledChange" />
+
+                    <label>Display Name</label>
+                    <input class="cfg-input" value="@_model.DisplayName" @oninput="OnDisplayNameInput" />
+
+                    <label>Description</label>
+                    <input class="cfg-input" value="@_model.Description" @oninput="OnDescriptionInput" />
+
+                    <label>Emoji</label>
+                    <input class="cfg-input" maxlength="4" value="@_model.Emoji" @oninput="OnEmojiInput" />
+
+                    <label>Provider</label>
+                    <div>
+                        @if (_providers.Count > 0)
+                        {
+                            <select class="cfg-input" value="@_model.ApiProvider" @onchange="OnProviderChange">
+                                <option value="">— select provider —</option>
+                                @foreach (var p in _providers)
+                                {
+                                    <option value="@p.Id">@p.Name</option>
+                                }
+                            </select>
+                        }
+                        else
+                        {
+                            <input class="cfg-input" value="@_model.ApiProvider" @oninput="OnProviderInput" />
+                        }
+                        @if (HasBadge("ApiProvider")) { <span class="world-default-badge">World default</span> }
+                    </div>
+
+                    <label>Model</label>
+                    <div>
+                        @if (_models.Count > 0)
+                        {
+                            <select class="cfg-input" value="@_model.ModelId" @onchange="OnModelChange">
+                                <option value="">— select model —</option>
+                                @foreach (var m in _models)
+                                {
+                                    <option value="@m.ModelId">@m.Name</option>
+                                }
+                            </select>
+                        }
+                        else if (_loadingModels)
+                        {
+                            <span class="agents-field-loading">Loading models...</span>
+                        }
+                        else
+                        {
+                            <input class="cfg-input" value="@_model.ModelId" @oninput="OnModelInput" />
+                        }
+                        @if (HasBadge("ModelId")) { <span class="world-default-badge">World default</span> }
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        @* ── System Prompt ─────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">System Prompt</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>System Prompt</label>
+                    <textarea class="cfg-textarea" rows="6" @oninput="OnSystemPromptInput">@_model.SystemPrompt</textarea>
+
+                    <label>System Prompt File</label>
+                    <input class="cfg-input" value="@_model.SystemPromptFile" @oninput="OnSystemPromptFileInput" placeholder="Legacy single file path" />
+
+                    <label>System Prompt Files</label>
+                    <div>
+                        @for (int i = 0; i < _model.SystemPromptFiles.Count; i++)
+                        {
+                            var idx = i;
+                            <div class="agent-list-row">
+                                <input class="cfg-input" value="@_model.SystemPromptFiles[idx]"
+                                       @oninput="@(e => OnSpfInput(idx, e))" />
+                                <button class="toolbar-btn" @onclick="@(() => MoveSpfUp(idx))">&#x2191;</button>
+                                <button class="toolbar-btn" @onclick="@(() => MoveSpfDown(idx))">&#x2193;</button>
+                                <button class="toolbar-btn danger" @onclick="@(() => RemoveSpf(idx))">&#x2715;</button>
+                            </div>
+                        }
+                        <button class="toolbar-btn" @onclick="AddSpf">+ Add File</button>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        @* ── Tools & Sub-Agents ────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Tools &amp; Sub-Agents</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Tool IDs</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var tool in _model.ToolIds.ToList())
+                            {
+                                var t = tool;
+                                <span class="agent-tag">@t <button @onclick="@(() => RemoveTool(t))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input" @bind="_newToolId" placeholder="tool-name" @onkeydown="OnToolIdKeyDown" />
+                            <button class="toolbar-btn" @onclick="AddToolId">+ Add</button>
+                        </div>
+                    </div>
+
+                    <label>Tool Timeout (sec)</label>
+                    <input class="cfg-input" type="number" min="0" value="@(_model.ToolTimeoutSeconds ?? 0)" @oninput="OnToolTimeoutInput" />
+
+                    <label>Sub-Agent IDs</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var sub in _model.SubAgentIds.ToList())
+                            {
+                                var s = sub;
+                                <span class="agent-tag">@s <button @onclick="@(() => RemoveSubAgent(s))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <select class="cfg-input agent-tag-input" @onchange="OnSubAgentAdd">
+                                <option value="">— add sub-agent —</option>
+                                @foreach (var a in _knownAgents.Where(a => a != AgentId && !_model.SubAgentIds.Contains(a)))
+                                {
+                                    <option value="@a">@a</option>
+                                }
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        @* ── Memory ────────────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Memory</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Enabled</label>
+                    <input type="checkbox" checked="@(_model.Memory?.Enabled ?? false)" @onchange="OnMemoryEnabledChange" />
+
+                    <label>Path</label>
+                    <input class="cfg-input" value="@(_model.Memory?.Path)" @oninput="OnMemoryPathInput" />
+
+                    <label>Indexing</label>
+                    <select class="cfg-input" value="@(_model.Memory?.Indexing ?? "auto")" @onchange="OnMemoryIndexingChange">
+                        <option value="auto">auto</option>
+                        <option value="manual">manual</option>
+                        <option value="off">off</option>
+                    </select>
+
+                    <label>Prompt Injection</label>
+                    <select class="cfg-input" value="@(_model.Memory?.PromptInjection ?? "full")" @onchange="OnMemoryPromptInjectionChange">
+                        <option value="full">full</option>
+                        <option value="summary">summary</option>
+                        <option value="none">none</option>
+                    </select>
+
+                    <label>Default Top K</label>
+                    <input class="cfg-input" type="number" min="1" value="@(_model.Memory?.Search?.DefaultTopK ?? 10)" @oninput="OnMemoryTopKInput" />
+
+                    <label>Temporal Decay</label>
+                    <input type="checkbox" checked="@(_model.Memory?.Search?.TemporalDecay?.Enabled ?? true)" @onchange="OnTemporalDecayEnabledChange" />
+
+                    <label>Half Life Days</label>
+                    <input class="cfg-input" type="number" min="1" value="@(_model.Memory?.Search?.TemporalDecay?.HalfLifeDays ?? 30)" @oninput="OnHalfLifeDaysInput" />
+                </div>
+            </div>
+        </details>
+
+        @* ── Soul ──────────────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Soul</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Enabled</label>
+                    <input type="checkbox" checked="@(_model.Soul?.Enabled ?? false)" @onchange="OnSoulEnabledChange" />
+
+                    <label>Timezone</label>
+                    <input class="cfg-input" value="@(_model.Soul?.Timezone ?? "UTC")" @oninput="OnSoulTimezoneInput" />
+
+                    <label>Day Boundary</label>
+                    <input class="cfg-input" value="@(_model.Soul?.DayBoundary ?? "00:00")" @oninput="OnSoulDayBoundaryInput" placeholder="HH:mm" />
+
+                    <label>Reflection on Seal</label>
+                    <input type="checkbox" checked="@(_model.Soul?.ReflectionOnSeal ?? false)" @onchange="OnSoulReflectionOnSealChange" />
+
+                    <label>Reflection Prompt</label>
+                    <textarea class="cfg-textarea" rows="3" @oninput="OnSoulReflectionPromptInput">@(_model.Soul?.ReflectionPrompt)</textarea>
+                </div>
+            </div>
+        </details>
+
+        @* ── Heartbeat ─────────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Heartbeat</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Enabled</label>
+                    <input type="checkbox" checked="@(_model.Heartbeat?.Enabled ?? false)" @onchange="OnHbEnabledChange" />
+
+                    <label>Interval Minutes</label>
+                    <input class="cfg-input" type="number" min="1" value="@(_model.Heartbeat?.IntervalMinutes ?? 60)" @oninput="OnHbIntervalInput" />
+
+                    <label>Custom Prompt</label>
+                    <textarea class="cfg-textarea" rows="3" @oninput="OnHbPromptInput">@(_model.Heartbeat?.Prompt)</textarea>
+
+                    <label>Quiet Hours Enabled</label>
+                    <input type="checkbox" checked="@(_model.Heartbeat?.QuietHours?.Enabled ?? false)" @onchange="OnQhEnabledChange" />
+
+                    <label>Quiet Hours Start</label>
+                    <input class="cfg-input" value="@(_model.Heartbeat?.QuietHours?.Start ?? "22:00")" @oninput="OnQhStartInput" placeholder="HH:mm" />
+
+                    <label>Quiet Hours End</label>
+                    <input class="cfg-input" value="@(_model.Heartbeat?.QuietHours?.End ?? "07:00")" @oninput="OnQhEndInput" placeholder="HH:mm" />
+
+                    <label>Quiet Hours Timezone</label>
+                    <input class="cfg-input" value="@(_model.Heartbeat?.QuietHours?.Timezone)" @oninput="OnQhTimezoneInput" />
+                </div>
+            </div>
+        </details>
+
+        @* ── File Access ───────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">File Access</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Allowed Read Paths</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var path in GetReadPaths())
+                            {
+                                var p = path;
+                                <span class="agent-tag">@p <button @onclick="@(() => RemoveReadPath(p))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input cfg-input" @bind="_newReadPath" />
+                            <button class="toolbar-btn" @onclick="AddReadPath">+ Add</button>
+                        </div>
+                    </div>
+
+                    <label>Allowed Write Paths</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var path in GetWritePaths())
+                            {
+                                var p = path;
+                                <span class="agent-tag">@p <button @onclick="@(() => RemoveWritePath(p))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input cfg-input" @bind="_newWritePath" />
+                            <button class="toolbar-btn" @onclick="AddWritePath">+ Add</button>
+                        </div>
+                    </div>
+
+                    <label>Denied Paths</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var path in GetDenyPaths())
+                            {
+                                var p = path;
+                                <span class="agent-tag">@p <button @onclick="@(() => RemoveDenyPath(p))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input cfg-input" @bind="_newDenyPath" />
+                            <button class="toolbar-btn" @onclick="AddDenyPath">+ Add</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        @* ── Access Controls ───────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Access Controls</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Session Access Level</label>
+                    <select class="cfg-input" value="@(_model.SessionAccess?.Level ?? "own")" @onchange="OnSessionLevelChange">
+                        <option value="own">own</option>
+                        <option value="allowlist">allowlist</option>
+                        <option value="all">all</option>
+                    </select>
+
+                    @if ((_model.SessionAccess?.Level ?? "own") == "allowlist")
+                    {
+                        <label>Session Allowed Agents</label>
+                        <div>
+                            <div class="agent-tag-list">
+                                @foreach (var a in (_model.SessionAccess?.AllowedAgents ?? []).ToList())
+                                {
+                                    var ag = a;
+                                    <span class="agent-tag">@ag <button @onclick="@(() => RemoveSessionAgent(ag))">&#x2715;</button></span>
+                                }
+                            </div>
+                            <select class="cfg-input" @onchange="OnSessionAgentAdd">
+                                <option value="">— add agent —</option>
+                                @foreach (var a in _knownAgents.Where(a => !(_model.SessionAccess?.AllowedAgents ?? []).Contains(a)))
+                                {
+                                    <option value="@a">@a</option>
+                                }
+                            </select>
+                        </div>
+                    }
+
+                    <label>Conversation Access Level</label>
+                    <select class="cfg-input" value="@(_model.ConversationAccess?.Level ?? "own")" @onchange="OnConversationLevelChange">
+                        <option value="own">own</option>
+                        <option value="allowlist">allowlist</option>
+                        <option value="all">all</option>
+                    </select>
+
+                    @if ((_model.ConversationAccess?.Level ?? "own") == "allowlist")
+                    {
+                        <label>Conversation Allowed Agents</label>
+                        <div>
+                            <div class="agent-tag-list">
+                                @foreach (var a in (_model.ConversationAccess?.AllowedAgents ?? []).ToList())
+                                {
+                                    var ag = a;
+                                    <span class="agent-tag">@ag <button @onclick="@(() => RemoveConversationAgent(ag))">&#x2715;</button></span>
+                                }
+                            </div>
+                            <select class="cfg-input" @onchange="OnConversationAgentAdd">
+                                <option value="">— add agent —</option>
+                                @foreach (var a in _knownAgents.Where(a => !(_model.ConversationAccess?.AllowedAgents ?? []).Contains(a)))
+                                {
+                                    <option value="@a">@a</option>
+                                }
+                            </select>
+                        </div>
+                    }
+                </div>
+            </div>
+        </details>
+
+        @* ── Runtime ───────────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Runtime</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Isolation Strategy</label>
+                    <select class="cfg-input" value="@_model.IsolationStrategy" @onchange="OnIsolationChange">
+                        <option value="in-process">in-process</option>
+                    </select>
+
+                    <label>Max Concurrent Sessions</label>
+                    <input class="cfg-input" type="number" min="0" value="@_model.MaxConcurrentSessions" @oninput="OnMaxSessionsInput" />
+                </div>
+            </div>
+        </details>
+
+        @* ── Tool Policy ───────────────────────────────────────── *@
+        <details class="agent-section">
+            <summary class="agent-section-title">Tool Policy</summary>
+            <div class="agent-section-body">
+                <div class="agents-form-grid">
+                    <label>Always Approve</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var t in GetAlwaysApprove())
+                            {
+                                var tool = t;
+                                <span class="agent-tag">@tool <button @onclick="@(() => RemoveAlwaysApprove(tool))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input cfg-input" @bind="_newAlwaysApprove" />
+                            <button class="toolbar-btn" @onclick="AddAlwaysApprove">+ Add</button>
+                        </div>
+                    </div>
+
+                    <label>Never Approve</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var t in GetNeverApprove())
+                            {
+                                var tool = t;
+                                <span class="agent-tag">@tool <button @onclick="@(() => RemoveNeverApprove(tool))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input cfg-input" @bind="_newNeverApprove" />
+                            <button class="toolbar-btn" @onclick="AddNeverApprove">+ Add</button>
+                        </div>
+                    </div>
+
+                    <label>Denied Tools</label>
+                    <div>
+                        <div class="agent-tag-list">
+                            @foreach (var t in GetDeniedTools())
+                            {
+                                var tool = t;
+                                <span class="agent-tag">@tool <button @onclick="@(() => RemoveDeniedTool(tool))">&#x2715;</button></span>
+                            }
+                        </div>
+                        <div class="agent-tag-add-row">
+                            <input class="agent-tag-input cfg-input" @bind="_newDeniedTool" />
+                            <button class="toolbar-btn" @onclick="AddDeniedTool">+ Add</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        @* ── Danger Zone ───────────────────────────────────────── *@
+        <div class="agent-danger-zone">
+            @if (!_showDeleteConfirm)
+            {
+                <button class="toolbar-btn danger" @onclick="() => _showDeleteConfirm = true">Delete Agent</button>
+            }
+            else
+            {
+                <span>Are you sure you want to delete <strong>@AgentId</strong>? This cannot be undone.</span>
+                <button class="toolbar-btn danger" @onclick="DeleteAsync" disabled="@_deleting">
+                    @(_deleting ? "Deleting..." : "Yes, Delete")
+                </button>
+                <button class="toolbar-btn" @onclick="() => _showDeleteConfirm = false">Cancel</button>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string AgentId { get; set; } = default!;
+    [Parameter] public EventCallback OnSaved { get; set; }
+    [Parameter] public EventCallback OnDeleted { get; set; }
+
+    // ── Model classes ─────────────────────────────────────────────────────
+    private sealed class AgentEditModel
+    {
+        public string? AgentId { get; set; }
+        public string DisplayName { get; set; } = "";
+        public string? Emoji { get; set; }
+        public string? Description { get; set; }
+        public bool Enabled { get; set; } = true;
+        public string ApiProvider { get; set; } = "";
+        public string ModelId { get; set; } = "";
+        public string? SystemPrompt { get; set; }
+        public string? SystemPromptFile { get; set; }
+        public List<string> SystemPromptFiles { get; set; } = [];
+        public List<string> ToolIds { get; set; } = [];
+        public int? ToolTimeoutSeconds { get; set; }
+        public List<string> SubAgentIds { get; set; } = [];
+        public string IsolationStrategy { get; set; } = "in-process";
+        public int MaxConcurrentSessions { get; set; }
+        public MemoryEditModel? Memory { get; set; }
+        public SoulEditModel? Soul { get; set; }
+        public HeartbeatEditModel? Heartbeat { get; set; }
+        public FileAccessEditModel? FileAccess { get; set; }
+        public SessionAccessEditModel? SessionAccess { get; set; }
+        public ConversationAccessEditModel? ConversationAccess { get; set; }
+        public ToolPolicyEditModel? ToolPolicy { get; set; }
+    }
+
+    private sealed class MemoryEditModel
+    {
+        public bool Enabled { get; set; }
+        public string? Path { get; set; }
+        public string Indexing { get; set; } = "auto";
+        public string? PromptInjection { get; set; } = "full";
+        public MemorySearchEditModel? Search { get; set; }
+    }
+
+    private sealed class MemorySearchEditModel
+    {
+        public int DefaultTopK { get; set; } = 10;
+        public TemporalDecayEditModel? TemporalDecay { get; set; }
+    }
+
+    private sealed class TemporalDecayEditModel
+    {
+        public bool Enabled { get; set; } = true;
+        public int HalfLifeDays { get; set; } = 30;
+    }
+
+    private sealed class SoulEditModel
+    {
+        public bool Enabled { get; set; }
+        public string Timezone { get; set; } = "UTC";
+        public string DayBoundary { get; set; } = "00:00";
+        public bool ReflectionOnSeal { get; set; }
+        public string? ReflectionPrompt { get; set; }
+    }
+
+    private sealed class HeartbeatEditModel
+    {
+        public bool Enabled { get; set; }
+        public int IntervalMinutes { get; set; } = 60;
+        public string? Prompt { get; set; }
+        public QuietHoursEditModel? QuietHours { get; set; }
+    }
+
+    private sealed class QuietHoursEditModel
+    {
+        public bool Enabled { get; set; }
+        public string Start { get; set; } = "22:00";
+        public string End { get; set; } = "07:00";
+        public string? Timezone { get; set; }
+    }
+
+    private sealed class FileAccessEditModel
+    {
+        public List<string> AllowedReadPaths { get; set; } = [];
+        public List<string> AllowedWritePaths { get; set; } = [];
+        public List<string> DeniedPaths { get; set; } = [];
+    }
+
+    private sealed class SessionAccessEditModel
+    {
+        public string Level { get; set; } = "own";
+        public List<string>? AllowedAgents { get; set; }
+    }
+
+    private sealed class ConversationAccessEditModel
+    {
+        public string Level { get; set; } = "own";
+        public List<string>? AllowedAgents { get; set; }
+    }
+
+    private sealed class ToolPolicyEditModel
+    {
+        public List<string> AlwaysApprove { get; set; } = [];
+        public List<string> NeverApprove { get; set; } = [];
+        public List<string> Denied { get; set; } = [];
+    }
+
+    private record ProviderItem(string Id, string Name);
+    private record ModelItem(string ModelId, string Name);
+
+    // ── State ─────────────────────────────────────────────────────────────
+    private AgentEditModel? _model;
+    private string _originalJson = "";
+    private bool _loading = true;
+    private bool _saving;
+    private bool _deleting;
+    private bool _showDeleteConfirm;
+    private string? _loadError;
+    private string? _statusMessage;
+    private string _statusClass = "";
+    private CancellationTokenSource? _statusCts;
+    private Dictionary<string, string> _inheritedFields = new();
+    private List<string> _knownAgents = [];
+    private List<ProviderItem> _providers = [];
+    private List<ModelItem> _models = [];
+    private bool _loadingModels;
+    private string _newToolId = "";
+    private string _newReadPath = "";
+    private string _newWritePath = "";
+    private string _newDenyPath = "";
+    private string _newAlwaysApprove = "";
+    private string _newNeverApprove = "";
+    private string _newDeniedTool = "";
+
+    private bool IsDirty => _model is not null && JsonSerializer.Serialize(_model) != _originalJson;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _loading = true;
+        _loadError = null;
+        _showDeleteConfirm = false;
+        StateHasChanged();
+        await Task.WhenAll(LoadAgentAsync(), LoadProvidersAsync(), LoadKnownAgentsAsync());
+        _ = TryLoadInheritanceBadgesAsync();
+        _loading = false;
+    }
+
+    private void MarkDirty() => StateHasChanged();
+
+    private bool HasBadge(string field) => _inheritedFields.ContainsKey(field);
+
+    // ── Input handlers ────────────────────────────────────────────────────
+    private void OnEnabledChange(ChangeEventArgs e) { _model!.Enabled = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnDisplayNameInput(ChangeEventArgs e) { _model!.DisplayName = e.Value?.ToString() ?? ""; MarkDirty(); }
+    private void OnDescriptionInput(ChangeEventArgs e) { _model!.Description = e.Value?.ToString(); MarkDirty(); }
+    private void OnEmojiInput(ChangeEventArgs e) { _model!.Emoji = e.Value?.ToString(); MarkDirty(); }
+    private void OnProviderInput(ChangeEventArgs e) { _model!.ApiProvider = e.Value?.ToString() ?? ""; MarkDirty(); }
+    private void OnModelInput(ChangeEventArgs e) { _model!.ModelId = e.Value?.ToString() ?? ""; MarkDirty(); }
+    private void OnModelChange(ChangeEventArgs e) { _model!.ModelId = e.Value?.ToString() ?? ""; MarkDirty(); }
+    private void OnSystemPromptInput(ChangeEventArgs e) { _model!.SystemPrompt = e.Value?.ToString(); MarkDirty(); }
+    private void OnSystemPromptFileInput(ChangeEventArgs e) { _model!.SystemPromptFile = e.Value?.ToString(); MarkDirty(); }
+    private void OnToolTimeoutInput(ChangeEventArgs e) { if (int.TryParse(e.Value?.ToString(), out var v)) { _model!.ToolTimeoutSeconds = v == 0 ? null : v; MarkDirty(); } }
+    private void OnIsolationChange(ChangeEventArgs e) { _model!.IsolationStrategy = e.Value?.ToString() ?? "in-process"; MarkDirty(); }
+    private void OnMaxSessionsInput(ChangeEventArgs e) { if (int.TryParse(e.Value?.ToString(), out var v)) { _model!.MaxConcurrentSessions = v; MarkDirty(); } }
+
+    // SPF handlers
+    private void OnSpfInput(int idx, ChangeEventArgs e) { _model!.SystemPromptFiles[idx] = e.Value?.ToString() ?? ""; MarkDirty(); }
+    private void MoveSpfUp(int idx) { if (idx > 0) { var t = _model!.SystemPromptFiles[idx - 1]; _model.SystemPromptFiles[idx - 1] = _model.SystemPromptFiles[idx]; _model.SystemPromptFiles[idx] = t; MarkDirty(); } }
+    private void MoveSpfDown(int idx) { if (idx < _model!.SystemPromptFiles.Count - 1) { var t = _model.SystemPromptFiles[idx + 1]; _model.SystemPromptFiles[idx + 1] = _model.SystemPromptFiles[idx]; _model.SystemPromptFiles[idx] = t; MarkDirty(); } }
+    private void RemoveSpf(int idx) { _model!.SystemPromptFiles.RemoveAt(idx); MarkDirty(); }
+    private void AddSpf() { _model!.SystemPromptFiles.Add(""); MarkDirty(); }
+
+    // Tool handlers
+    private void OnToolIdKeyDown(KeyboardEventArgs e) { if (e.Key == "Enter") AddToolId(); }
+    private void AddToolId() { if (!string.IsNullOrWhiteSpace(_newToolId) && !_model!.ToolIds.Contains(_newToolId)) { _model.ToolIds.Add(_newToolId); _newToolId = ""; MarkDirty(); } }
+    private void RemoveTool(string t) { _model!.ToolIds.Remove(t); MarkDirty(); }
+    private void OnSubAgentAdd(ChangeEventArgs e) { var v = e.Value?.ToString(); if (!string.IsNullOrEmpty(v)) { _model!.SubAgentIds.Add(v); MarkDirty(); } }
+    private void RemoveSubAgent(string s) { _model!.SubAgentIds.Remove(s); MarkDirty(); }
+
+    // Memory handlers
+    private void OnMemoryEnabledChange(ChangeEventArgs e) { EnsureMemory(); _model!.Memory!.Enabled = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnMemoryPathInput(ChangeEventArgs e) { EnsureMemory(); _model!.Memory!.Path = e.Value?.ToString(); MarkDirty(); }
+    private void OnMemoryIndexingChange(ChangeEventArgs e) { EnsureMemory(); _model!.Memory!.Indexing = e.Value?.ToString() ?? "auto"; MarkDirty(); }
+    private void OnMemoryPromptInjectionChange(ChangeEventArgs e) { EnsureMemory(); _model!.Memory!.PromptInjection = e.Value?.ToString(); MarkDirty(); }
+    private void OnMemoryTopKInput(ChangeEventArgs e) { EnsureMemorySearch(); if (int.TryParse(e.Value?.ToString(), out var v)) { _model!.Memory!.Search!.DefaultTopK = v; MarkDirty(); } }
+    private void OnTemporalDecayEnabledChange(ChangeEventArgs e) { EnsureTemporalDecay(); _model!.Memory!.Search!.TemporalDecay!.Enabled = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnHalfLifeDaysInput(ChangeEventArgs e) { EnsureTemporalDecay(); if (int.TryParse(e.Value?.ToString(), out var v)) { _model!.Memory!.Search!.TemporalDecay!.HalfLifeDays = v; MarkDirty(); } }
+
+    // Soul handlers
+    private void OnSoulEnabledChange(ChangeEventArgs e) { EnsureSoul(); _model!.Soul!.Enabled = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnSoulTimezoneInput(ChangeEventArgs e) { EnsureSoul(); _model!.Soul!.Timezone = e.Value?.ToString() ?? "UTC"; MarkDirty(); }
+    private void OnSoulDayBoundaryInput(ChangeEventArgs e) { EnsureSoul(); _model!.Soul!.DayBoundary = e.Value?.ToString() ?? "00:00"; MarkDirty(); }
+    private void OnSoulReflectionOnSealChange(ChangeEventArgs e) { EnsureSoul(); _model!.Soul!.ReflectionOnSeal = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnSoulReflectionPromptInput(ChangeEventArgs e) { EnsureSoul(); _model!.Soul!.ReflectionPrompt = e.Value?.ToString(); MarkDirty(); }
+
+    // Heartbeat handlers
+    private void OnHbEnabledChange(ChangeEventArgs e) { EnsureHeartbeat(); _model!.Heartbeat!.Enabled = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnHbIntervalInput(ChangeEventArgs e) { EnsureHeartbeat(); if (int.TryParse(e.Value?.ToString(), out var v)) { _model!.Heartbeat!.IntervalMinutes = v; MarkDirty(); } }
+    private void OnHbPromptInput(ChangeEventArgs e) { EnsureHeartbeat(); _model!.Heartbeat!.Prompt = e.Value?.ToString(); MarkDirty(); }
+    private void OnQhEnabledChange(ChangeEventArgs e) { EnsureQuietHours(); _model!.Heartbeat!.QuietHours!.Enabled = (bool)(e.Value ?? false); MarkDirty(); }
+    private void OnQhStartInput(ChangeEventArgs e) { EnsureQuietHours(); _model!.Heartbeat!.QuietHours!.Start = e.Value?.ToString() ?? "22:00"; MarkDirty(); }
+    private void OnQhEndInput(ChangeEventArgs e) { EnsureQuietHours(); _model!.Heartbeat!.QuietHours!.End = e.Value?.ToString() ?? "07:00"; MarkDirty(); }
+    private void OnQhTimezoneInput(ChangeEventArgs e) { EnsureQuietHours(); _model!.Heartbeat!.QuietHours!.Timezone = e.Value?.ToString(); MarkDirty(); }
+
+    // File access helpers
+    private List<string> GetReadPaths() { EnsureFileAccess(); return _model!.FileAccess!.AllowedReadPaths; }
+    private List<string> GetWritePaths() { EnsureFileAccess(); return _model!.FileAccess!.AllowedWritePaths; }
+    private List<string> GetDenyPaths() { EnsureFileAccess(); return _model!.FileAccess!.DeniedPaths; }
+    private void AddReadPath() { if (!string.IsNullOrWhiteSpace(_newReadPath)) { GetReadPaths().Add(_newReadPath); _newReadPath = ""; MarkDirty(); } }
+    private void AddWritePath() { if (!string.IsNullOrWhiteSpace(_newWritePath)) { GetWritePaths().Add(_newWritePath); _newWritePath = ""; MarkDirty(); } }
+    private void AddDenyPath() { if (!string.IsNullOrWhiteSpace(_newDenyPath)) { GetDenyPaths().Add(_newDenyPath); _newDenyPath = ""; MarkDirty(); } }
+    private void RemoveReadPath(string p) { GetReadPaths().Remove(p); MarkDirty(); }
+    private void RemoveWritePath(string p) { GetWritePaths().Remove(p); MarkDirty(); }
+    private void RemoveDenyPath(string p) { GetDenyPaths().Remove(p); MarkDirty(); }
+
+    // Access control handlers
+    private void OnSessionLevelChange(ChangeEventArgs e) { EnsureSessionAccess(); _model!.SessionAccess!.Level = e.Value?.ToString() ?? "own"; MarkDirty(); }
+    private void OnSessionAgentAdd(ChangeEventArgs e) { var v = e.Value?.ToString(); if (!string.IsNullOrEmpty(v)) { EnsureSessionAccess(); _model!.SessionAccess!.AllowedAgents ??= []; _model.SessionAccess.AllowedAgents.Add(v); MarkDirty(); } }
+    private void RemoveSessionAgent(string a) { _model?.SessionAccess?.AllowedAgents?.Remove(a); MarkDirty(); }
+    private void OnConversationLevelChange(ChangeEventArgs e) { EnsureConversationAccess(); _model!.ConversationAccess!.Level = e.Value?.ToString() ?? "own"; MarkDirty(); }
+    private void OnConversationAgentAdd(ChangeEventArgs e) { var v = e.Value?.ToString(); if (!string.IsNullOrEmpty(v)) { EnsureConversationAccess(); _model!.ConversationAccess!.AllowedAgents ??= []; _model.ConversationAccess.AllowedAgents.Add(v); MarkDirty(); } }
+    private void RemoveConversationAgent(string a) { _model?.ConversationAccess?.AllowedAgents?.Remove(a); MarkDirty(); }
+
+    // Tool policy helpers
+    private List<string> GetAlwaysApprove() { EnsureToolPolicy(); return _model!.ToolPolicy!.AlwaysApprove; }
+    private List<string> GetNeverApprove() { EnsureToolPolicy(); return _model!.ToolPolicy!.NeverApprove; }
+    private List<string> GetDeniedTools() { EnsureToolPolicy(); return _model!.ToolPolicy!.Denied; }
+    private void AddAlwaysApprove() { if (!string.IsNullOrWhiteSpace(_newAlwaysApprove)) { GetAlwaysApprove().Add(_newAlwaysApprove); _newAlwaysApprove = ""; MarkDirty(); } }
+    private void AddNeverApprove() { if (!string.IsNullOrWhiteSpace(_newNeverApprove)) { GetNeverApprove().Add(_newNeverApprove); _newNeverApprove = ""; MarkDirty(); } }
+    private void AddDeniedTool() { if (!string.IsNullOrWhiteSpace(_newDeniedTool)) { GetDeniedTools().Add(_newDeniedTool); _newDeniedTool = ""; MarkDirty(); } }
+    private void RemoveAlwaysApprove(string t) { GetAlwaysApprove().Remove(t); MarkDirty(); }
+    private void RemoveNeverApprove(string t) { GetNeverApprove().Remove(t); MarkDirty(); }
+    private void RemoveDeniedTool(string t) { GetDeniedTools().Remove(t); MarkDirty(); }
+
+    // ── Ensure sub-model helpers ───────────────────────────────────────────
+    private void EnsureMemory() => _model!.Memory ??= new MemoryEditModel();
+    private void EnsureMemorySearch() { EnsureMemory(); _model!.Memory!.Search ??= new MemorySearchEditModel(); }
+    private void EnsureTemporalDecay() { EnsureMemorySearch(); _model!.Memory!.Search!.TemporalDecay ??= new TemporalDecayEditModel(); }
+    private void EnsureSoul() => _model!.Soul ??= new SoulEditModel();
+    private void EnsureHeartbeat() => _model!.Heartbeat ??= new HeartbeatEditModel();
+    private void EnsureQuietHours() { EnsureHeartbeat(); _model!.Heartbeat!.QuietHours ??= new QuietHoursEditModel(); }
+    private void EnsureFileAccess() => _model!.FileAccess ??= new FileAccessEditModel();
+    private void EnsureSessionAccess() => _model!.SessionAccess ??= new SessionAccessEditModel();
+    private void EnsureConversationAccess() => _model!.ConversationAccess ??= new ConversationAccessEditModel();
+    private void EnsureToolPolicy() => _model!.ToolPolicy ??= new ToolPolicyEditModel();
+
+    // ── Data loaders ──────────────────────────────────────────────────────
+    private async Task LoadAgentAsync()
+    {
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/agents/{Uri.EscapeDataString(AgentId)}";
+            using var response = await Http.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                _loadError = $"Error {(int)response.StatusCode} loading agent.";
+                return;
+            }
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            _model = MapFromJson(doc.RootElement);
+            _originalJson = JsonSerializer.Serialize(_model);
+            if (!string.IsNullOrEmpty(_model.ApiProvider))
+                await LoadModelsAsync(_model.ApiProvider);
+        }
+        catch (Exception ex)
+        {
+            _loadError = ex.Message;
+        }
+    }
+
+    private async Task LoadProvidersAsync()
+    {
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + "/api/providers";
+            var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var items = await Http.GetFromJsonAsync<List<ProviderItem>>(url, opts);
+            _providers = items ?? [];
+        }
+        catch { _providers = []; }
+    }
+
+    private async Task LoadModelsAsync(string provider)
+    {
+        _loadingModels = true;
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/models?provider={Uri.EscapeDataString(provider)}";
+            var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var items = await Http.GetFromJsonAsync<List<ModelItem>>(url, opts);
+            _models = items ?? [];
+        }
+        catch { _models = []; }
+        finally { _loadingModels = false; }
+    }
+
+    private async Task LoadKnownAgentsAsync()
+    {
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + "/api/agents";
+            using var doc = JsonDocument.Parse(await Http.GetStringAsync(url));
+            _knownAgents = doc.RootElement.ValueKind == JsonValueKind.Array
+                ? doc.RootElement.EnumerateArray()
+                    .Select(e => e.TryGetProperty("agentId", out var p) ? p.GetString() ?? "" : "")
+                    .Where(s => s != "")
+                    .ToList()
+                : [];
+        }
+        catch { _knownAgents = []; }
+    }
+
+    private async Task TryLoadInheritanceBadgesAsync()
+    {
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/config/agents/{Uri.EscapeDataString(AgentId)}/effective";
+            using var response = await Http.GetAsync(url);
+            if (!response.IsSuccessStatusCode) return;
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            if (doc.RootElement.TryGetProperty("sources", out var sources) && sources.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in sources.EnumerateObject())
+                {
+                    if (prop.Value.GetString() == "inherited")
+                        _inheritedFields[prop.Name] = "inherited";
+                }
+            }
+        }
+        catch { /* best-effort */ }
+    }
+
+    private async Task OnProviderChange(ChangeEventArgs e)
+    {
+        if (_model is null) return;
+        _model.ApiProvider = e.Value?.ToString() ?? "";
+        _model.ModelId = "";
+        _models = [];
+        MarkDirty();
+        if (!string.IsNullOrEmpty(_model.ApiProvider))
+            await LoadModelsAsync(_model.ApiProvider);
+    }
+
+    // ── Map JSON to model ─────────────────────────────────────────────────
+    private static AgentEditModel MapFromJson(JsonElement el)
+    {
+        var m = new AgentEditModel
+        {
+            AgentId = GetStr(el, "agentId"),
+            DisplayName = GetStr(el, "displayName") ?? "",
+            Emoji = GetStr(el, "emoji"),
+            Description = GetStr(el, "description"),
+            Enabled = GetBool(el, "enabled", true),
+            ApiProvider = GetStr(el, "apiProvider") ?? "",
+            ModelId = GetStr(el, "modelId") ?? "",
+            SystemPrompt = GetStr(el, "systemPrompt"),
+            SystemPromptFile = GetStr(el, "systemPromptFile"),
+            IsolationStrategy = GetStr(el, "isolationStrategy") ?? "in-process",
+            MaxConcurrentSessions = GetInt(el, "maxConcurrentSessions", 0),
+            ToolTimeoutSeconds = el.TryGetProperty("toolTimeoutSeconds", out var tp) && tp.ValueKind != JsonValueKind.Null ? tp.GetInt32() : null,
+        };
+
+        if (el.TryGetProperty("systemPromptFiles", out var p) && p.ValueKind == JsonValueKind.Array)
+            m.SystemPromptFiles = p.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+        if (el.TryGetProperty("toolIds", out p) && p.ValueKind == JsonValueKind.Array)
+            m.ToolIds = p.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+        if (el.TryGetProperty("subAgentIds", out p) && p.ValueKind == JsonValueKind.Array)
+            m.SubAgentIds = p.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+
+        if (el.TryGetProperty("memory", out p) && p.ValueKind == JsonValueKind.Object)
+        {
+            var mem = new MemoryEditModel
+            {
+                Enabled = GetBool(p, "enabled", false),
+                Path = GetStr(p, "path"),
+                Indexing = GetStr(p, "indexing") ?? "auto",
+                PromptInjection = GetStr(p, "promptInjection") ?? "full",
+            };
+            if (p.TryGetProperty("search", out var sp) && sp.ValueKind == JsonValueKind.Object)
+            {
+                mem.Search = new MemorySearchEditModel { DefaultTopK = GetInt(sp, "defaultTopK", 10) };
+                if (sp.TryGetProperty("temporalDecay", out var td) && td.ValueKind == JsonValueKind.Object)
+                    mem.Search.TemporalDecay = new TemporalDecayEditModel { Enabled = GetBool(td, "enabled", true), HalfLifeDays = GetInt(td, "halfLifeDays", 30) };
+            }
+            m.Memory = mem;
+        }
+
+        if (el.TryGetProperty("soul", out p) && p.ValueKind == JsonValueKind.Object)
+            m.Soul = new SoulEditModel { Enabled = GetBool(p, "enabled", false), Timezone = GetStr(p, "timezone") ?? "UTC", DayBoundary = GetStr(p, "dayBoundary") ?? "00:00", ReflectionOnSeal = GetBool(p, "reflectionOnSeal", false), ReflectionPrompt = GetStr(p, "reflectionPrompt") };
+
+        if (el.TryGetProperty("heartbeat", out p) && p.ValueKind == JsonValueKind.Object)
+        {
+            var hb = new HeartbeatEditModel { Enabled = GetBool(p, "enabled", false), IntervalMinutes = GetInt(p, "intervalMinutes", 60), Prompt = GetStr(p, "prompt") };
+            if (p.TryGetProperty("quietHours", out var qh) && qh.ValueKind == JsonValueKind.Object)
+                hb.QuietHours = new QuietHoursEditModel { Enabled = GetBool(qh, "enabled", false), Start = GetStr(qh, "start") ?? "22:00", End = GetStr(qh, "end") ?? "07:00", Timezone = GetStr(qh, "timezone") };
+            m.Heartbeat = hb;
+        }
+
+        if (el.TryGetProperty("fileAccess", out p) && p.ValueKind == JsonValueKind.Object)
+        {
+            var fa = new FileAccessEditModel();
+            if (p.TryGetProperty("allowedReadPaths", out var fap) && fap.ValueKind == JsonValueKind.Array)
+                fa.AllowedReadPaths = fap.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            if (p.TryGetProperty("allowedWritePaths", out fap) && fap.ValueKind == JsonValueKind.Array)
+                fa.AllowedWritePaths = fap.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            if (p.TryGetProperty("deniedPaths", out fap) && fap.ValueKind == JsonValueKind.Array)
+                fa.DeniedPaths = fap.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            m.FileAccess = fa;
+        }
+
+        if (el.TryGetProperty("sessionAccess", out p) && p.ValueKind == JsonValueKind.Object)
+        {
+            var sa = new SessionAccessEditModel { Level = GetStr(p, "level") ?? "own" };
+            if (p.TryGetProperty("allowedAgents", out var sap) && sap.ValueKind == JsonValueKind.Array)
+                sa.AllowedAgents = sap.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            m.SessionAccess = sa;
+        }
+
+        if (el.TryGetProperty("conversationAccess", out p) && p.ValueKind == JsonValueKind.Object)
+        {
+            var ca = new ConversationAccessEditModel { Level = GetStr(p, "level") ?? "own" };
+            if (p.TryGetProperty("allowedAgents", out var cap) && cap.ValueKind == JsonValueKind.Array)
+                ca.AllowedAgents = cap.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            m.ConversationAccess = ca;
+        }
+
+        if (el.TryGetProperty("toolPolicy", out p) && p.ValueKind == JsonValueKind.Object)
+        {
+            var tp2 = new ToolPolicyEditModel();
+            if (p.TryGetProperty("alwaysApprove", out var tpp) && tpp.ValueKind == JsonValueKind.Array)
+                tp2.AlwaysApprove = tpp.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            if (p.TryGetProperty("neverApprove", out tpp) && tpp.ValueKind == JsonValueKind.Array)
+                tp2.NeverApprove = tpp.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            if (p.TryGetProperty("denied", out tpp) && tpp.ValueKind == JsonValueKind.Array)
+                tp2.Denied = tpp.EnumerateArray().Select(x => x.GetString() ?? "").ToList();
+            m.ToolPolicy = tp2;
+        }
+
+        return m;
+    }
+
+    private static string? GetStr(JsonElement el, string key) =>
+        el.TryGetProperty(key, out var p) && p.ValueKind != JsonValueKind.Null ? p.GetString() : null;
+    private static bool GetBool(JsonElement el, string key, bool def) =>
+        el.TryGetProperty(key, out var p) ? p.GetBoolean() : def;
+    private static int GetInt(JsonElement el, string key, int def) =>
+        el.TryGetProperty(key, out var p) && p.ValueKind == JsonValueKind.Number ? p.GetInt32() : def;
+
+    // ── Save / Delete / Nav ───────────────────────────────────────────────
+    private void GoBack() => Nav.NavigateTo("agents");
+
+    private async Task SaveAsync()
+    {
+        if (_model is null) return;
+        _saving = true;
+        StateHasChanged();
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/agents/{Uri.EscapeDataString(AgentId)}";
+            var response = await Http.PutAsJsonAsync(url, _model);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                SetStatus($"Save failed ({(int)response.StatusCode}): {body}", "error");
+                return;
+            }
+            _originalJson = JsonSerializer.Serialize(_model);
+            SetStatus("Agent saved.", "success");
+            await OnSaved.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Save error: {ex.Message}", "error");
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeleteAsync()
+    {
+        _deleting = true;
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + $"/api/agents/{Uri.EscapeDataString(AgentId)}";
+            var response = await Http.DeleteAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                SetStatus($"Delete failed ({(int)response.StatusCode}).", "error");
+                _showDeleteConfirm = false;
+                return;
+            }
+            await OnDeleted.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Delete error: {ex.Message}", "error");
+            _showDeleteConfirm = false;
+        }
+        finally
+        {
+            _deleting = false;
+        }
+    }
+
+    private void SetStatus(string msg, string css)
+    {
+        _statusMessage = msg;
+        _statusClass = css;
+        _statusCts?.Cancel();
+        _statusCts?.Dispose();
+        _statusCts = new CancellationTokenSource();
+        var token = _statusCts.Token;
+        _ = DismissAsync(token);
+    }
+
+    private async Task DismissAsync(CancellationToken token)
+    {
+        try { await Task.Delay(4000, token); _statusMessage = null; _statusClass = ""; await InvokeAsync(StateHasChanged); }
+        catch (TaskCanceledException) { }
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 @inject NavigationManager Nav
+@inject HttpClient Http
 @inject IClientStateStore Store
 @inject IAgentInteractionService Interaction
 @inject IPortalLoadService PortalLoad
@@ -211,6 +212,18 @@
                 }
 
                 <a href="agents" class="sidebar-nav-item @NavClass("agents")" @onclick="OnNavClick">🤖 Agents</a>
+
+                @* Agents sub-nav -- only shown when on the agents page *@
+                @if (IsOnPage("agents"))
+                {
+                    <div class="sidebar-subnav">
+                        @foreach (var agent in _sidebarAgents)
+                        {
+                            <a href="agents/@agent.AgentId" class="sidebar-subnav-item @(IsAgentActive(agent.AgentId) ? "active" : "")" @onclick="CloseSidebar">@agent.DisplayLabel</a>
+                        }
+                        <a href="agents/new" class="sidebar-subnav-item sidebar-subnav-add" @onclick="CloseSidebar">+ Add Agent</a>
+                    </div>
+                }
             </nav>
 
             @* Restart button + build info at bottom *@
@@ -278,7 +291,9 @@
 
 @code {
     private record Announcement(string Id, string Text, string Type = "info");
+    private record SidebarAgentItem(string AgentId, string DisplayLabel);
     private List<Announcement> _announcements = [];
+    private List<SidebarAgentItem> _sidebarAgents = [];
         private bool _restarting;
     private PortalSettingsPanel? _settingsPanel;
     private bool _sidebarOpen = false;
@@ -292,6 +307,7 @@
         PortalLoad.OnReadyChanged += HandleReadyChanged;
         UpdateStatus.StatusChanged += HandleStateChanged;
         ExtensionFeatures.OnChanged += HandleStateChanged;
+        Hub.OnAgentsChanged += HandleSidebarAgentsChanged;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -309,6 +325,7 @@
             if (Store.ActiveAgentId is { Length: > 0 } activeAgentId)
                 await Interaction.RefreshConversationsAsync(activeAgentId);
 
+            await LoadSidebarAgentsAsync();
             StateHasChanged();
         }
     }
@@ -589,6 +606,43 @@
         PortalLoad.OnReadyChanged -= HandleReadyChanged;
         UpdateStatus.StatusChanged -= HandleStateChanged;
         ExtensionFeatures.OnChanged -= HandleStateChanged;
+        Hub.OnAgentsChanged -= HandleSidebarAgentsChanged;
+    }
+
+    private bool IsAgentActive(string agentId)
+    {
+        var uri = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
+        return uri.Equals($"agents/{agentId}", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void HandleSidebarAgentsChanged(AgentsChangedPayload payload)
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadSidebarAgentsAsync();
+            StateHasChanged();
+        });
+    }
+
+    private sealed record SidebarAgentDto(
+        string? AgentId = null,
+        string DisplayName = "",
+        string? Emoji = null);
+
+    private async Task LoadSidebarAgentsAsync()
+    {
+        try
+        {
+            var url = Nav.BaseUri.TrimEnd('/') + "/api/agents";
+            var opts = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var items = await Http.GetFromJsonAsync<List<SidebarAgentDto>>(url, opts);
+            _sidebarAgents = (items ?? [])
+                .Select(a => new SidebarAgentItem(
+                    a.AgentId ?? "",
+                    string.IsNullOrWhiteSpace(a.Emoji) ? a.DisplayName : $"{a.Emoji} {a.DisplayName}"))
+                .ToList();
+        }
+        catch { _sidebarAgents = []; }
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Agents.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Pages/Agents.razor
@@ -1,4 +1,6 @@
 @page "/agents"
+@page "/agents/new"
+@page "/agents/{AgentId}"
 @inject NavigationManager Nav
 @inject HttpClient Http
 @inject GatewayHubConnection Hub
@@ -7,6 +9,13 @@
 <PageTitle>BotNexus — Agents</PageTitle>
 
 <div class="agents-page">
+
+@if (_showDetailPanel && AgentId is not null && AgentId != "new")
+{
+    <AgentDetailPanel AgentId="@AgentId" OnSaved="HandleDetailSaved" OnDeleted="HandleDetailDeleted" />
+}
+else
+{
     <header class="agents-toolbar">
         <h2>🤖 Agents</h2>
         <div class="agents-toolbar-actions">
@@ -197,9 +206,14 @@
             </table>
         }
     }
+}
 </div>
 
 @code {
+    [Parameter] public string? AgentId { get; set; }
+
+    private bool _showDetailPanel;
+
     private record ProviderItem(string Id, string Name);
     private record ModelItem(string ModelId, string Name);
 
@@ -240,6 +254,16 @@
 
     /// <summary>True when the form has been modified from its initial state.</summary>
     private bool IsDirty => _form != _originalForm;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _showDetailPanel = AgentId is not null && AgentId != "new";
+        if (AgentId == "new") ShowAddForm();
+        await base.OnParametersSetAsync();
+    }
+
+    private void HandleDetailSaved() { SetStatus("Agent saved.", "success"); _ = LoadAgentsAsync(); }
+    private void HandleDetailDeleted() { Nav.NavigateTo("agents"); _ = LoadAgentsAsync(); }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -3911,3 +3911,179 @@ h3.conversation-title.editable:hover {
     flex-direction: column;
     height: 100%;
 }
+
+/* ── Agent Detail Panel (Wave 3) ──────────────────────────────────── */
+
+.agent-detail-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding: 0;
+    max-width: 100%;
+}
+
+.agent-detail-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-secondary);
+    flex-shrink: 0;
+}
+
+.agent-detail-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.agent-detail-header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.agent-detail-id {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    padding: 0.15rem 0.45rem;
+    border-radius: var(--radius);
+}
+
+.agent-section {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin: 0.5rem 1rem;
+    background: var(--bg-primary);
+}
+
+.agent-section > summary {
+    padding: 0.6rem 1rem;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    user-select: none;
+}
+
+.agent-section > summary::before {
+    content: '\25B6';
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    transition: transform 0.15s;
+}
+
+.agent-section[open] > summary::before {
+    transform: rotate(90deg);
+}
+
+.agent-section-title {
+    /* alias for summary styling */
+}
+
+.agent-section-body {
+    padding: 0.75rem 1rem 1rem;
+    border-top: 1px solid var(--border);
+}
+
+.agent-tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-bottom: 0.5rem;
+}
+
+.agent-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.agent-tag button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 0;
+    font-size: 0.75rem;
+    line-height: 1;
+}
+
+.agent-tag button:hover {
+    color: var(--text-primary);
+}
+
+.agent-tag-input {
+    max-width: 200px;
+}
+
+.agent-tag-add-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.agent-list-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    margin-bottom: 0.4rem;
+}
+
+.agent-danger-zone {
+    margin: 1rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--danger, #e53e3e);
+    border-radius: var(--radius);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.sidebar-subnav-add {
+    color: var(--text-muted);
+    opacity: 0.75;
+}
+
+.sidebar-subnav-add:hover {
+    opacity: 1;
+    color: var(--accent);
+}
+
+.sidebar-subnav-item.active {
+    color: var(--accent);
+    border-left-color: var(--accent);
+    background: var(--bg-surface);
+}
+
+.world-default-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    padding: 0.1rem 0.4rem;
+    color: var(--text-muted);
+    margin-left: 0.4rem;
+    vertical-align: middle;
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentDetailPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentDetailPanelTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Pages;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class AgentDetailPanelTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly MockHttpMessageHandler _httpHandler = new();
+
+    public AgentDetailPanelTests()
+    {
+        var httpClient = new HttpClient(_httpHandler) { BaseAddress = new Uri("http://localhost/") };
+        _ctx.Services.AddSingleton(httpClient);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private static string AgentJson(string agentId = "test-agent", string displayName = "Test Agent") =>
+        JsonSerializer.Serialize(new
+        {
+            agentId,
+            displayName,
+            description = "A test agent",
+            enabled = true,
+            apiProvider = "openai",
+            modelId = "gpt-4",
+            systemPrompt = "You are helpful"
+        });
+
+    [Fact]
+    public void AgentsPage_NavigatesToDetailPanel_WhenAgentIdRouteProvided()
+    {
+        _httpHandler.SetupResponse("/api/agents/test-agent", AgentJson());
+        _httpHandler.SetupResponse("/api/agents", "[{\"agentId\":\"test-agent\",\"displayName\":\"Test Agent\",\"apiProvider\":\"openai\",\"modelId\":\"gpt-4\"}]");
+        _httpHandler.SetupResponse("/api/providers", "[]");
+        _httpHandler.SetupResponse("/api/models", "[]");
+
+        var hub = new GatewayHubConnection();
+        _ctx.Services.AddSingleton(hub);
+
+        var cut = _ctx.Render<Agents>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        cut.WaitForState(() => cut.HasComponent<AgentDetailPanel>(), TimeSpan.FromSeconds(3));
+        Assert.True(cut.HasComponent<AgentDetailPanel>());
+    }
+
+    [Fact]
+    public void AgentDetailPanel_LoadsAgentData_OnInit()
+    {
+        _httpHandler.SetupResponse("/api/agents/test-agent", AgentJson());
+        _httpHandler.SetupResponse("/api/agents", "[]");
+        _httpHandler.SetupResponse("/api/providers", "[]");
+        _httpHandler.SetupResponse("/api/models", "[]");
+
+        var cut = _ctx.Render<AgentDetailPanel>(p =>
+            p.Add(c => c.AgentId, "test-agent"));
+
+        cut.WaitForState(() => cut.Markup.Contains("Test Agent"), TimeSpan.FromSeconds(3));
+        Assert.Contains("Test Agent", cut.Markup);
+    }
+
+    [Fact]
+    public void AgentDetailPanel_SaveButton_Disabled_WhenNotDirty()
+    {
+        _httpHandler.SetupResponse("/api/agents/test-agent", AgentJson());
+        _httpHandler.SetupResponse("/api/agents", "[]");
+        _httpHandler.SetupResponse("/api/providers", "[]");
+        _httpHandler.SetupResponse("/api/models", "[]");
+
+        var cut = _ctx.Render<AgentDetailPanel>(p =>
+            p.Add(c => c.AgentId, "test-agent"));
+
+        cut.WaitForState(() => !cut.Markup.Contains("Loading agent"), TimeSpan.FromSeconds(3));
+
+        var saveBtn = cut.FindAll("button")
+            .FirstOrDefault(b => b.TextContent.Contains("Save Changes"));
+        Assert.NotNull(saveBtn);
+        Assert.True(saveBtn.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void AgentDetailPanel_ShowsDeleteConfirm_OnDeleteClick()
+    {
+        _httpHandler.SetupResponse("/api/agents/test-agent", AgentJson());
+        _httpHandler.SetupResponse("/api/agents", "[]");
+        _httpHandler.SetupResponse("/api/providers", "[]");
+        _httpHandler.SetupResponse("/api/models", "[]");
+
+        var cut = _ctx.Render<AgentDetailPanel>(p =>
+            p.Add(c => c.AgentId, "test-agent"));
+
+        cut.WaitForState(() => cut.Markup.Contains("Delete Agent"), TimeSpan.FromSeconds(3));
+
+        cut.Find(".toolbar-btn.danger").Click();
+
+        Assert.Contains("Are you sure", cut.Markup);
+        Assert.Contains("Yes, Delete", cut.Markup);
+    }
+
+    /// <summary>Simple mock HTTP handler reused from AgentsPageTests pattern.</summary>
+    internal sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, HttpResponseMessage> _responses = new(StringComparer.OrdinalIgnoreCase);
+
+        public void SetupResponse(string pathSuffix, string jsonContent)
+        {
+            _responses[pathSuffix] = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? "";
+            foreach (var (key, response) in _responses)
+            {
+                if (path.Contains(key, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(response);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}


### PR DESCRIPTION
Closes #407 (Phase 1 + Phase 2)

## What's in this PR

### Sidebar sub-tree (Phase 1)
- `MainLayout.razor`: Agents nav item expands to list all registered agents when on any `/agents/*` route
- Live refresh via `Hub.OnAgentsChanged` — new agents appear immediately
- Clicking an agent navigates to `/agents/{agentId}`
- `+ Add Agent` entry at the bottom navigates to `/agents/new`

### Full agent editor (Phase 2)
- `AgentDetailPanel.razor`: new full-page component covering ALL `AgentDefinitionConfig` fields
- `Agents.razor`: adds `@page "/agents/{AgentId}"` and `@page "/agents/new"` routes
- Sections (collapsible via `<details>`): Identity & Model, System Prompt, Tools & Sub-Agents, Memory, Soul, Heartbeat, File Access, Access Controls, Runtime, Tool Policy
- Dirty tracking via JSON snapshot comparison — Save button disabled when clean
- Save via `PUT /api/agents/{id}`, auto-dismiss success after 4s
- Inline delete confirmation (no overlay)
- World default badges from `GET /api/config/agents/{id}/effective`
- Back to list button

### Tests
- 4 new bUnit tests in `AgentDetailPanelTests.cs`
- 338/339 pass (1 pre-existing flaky mobile JS test `AgentDropdown_NotRendered_WhenIsMobileIsTrue` unrelated to this PR)