### PR TITLE
test(agents): add Copilot wire replay harness + path-leak fence (Phase 0b, #810)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ config.local.json
 # Keep tracked .txt files despite the *.txt rule above
 !requirements.txt
 !tests/**/Snapshots/*.txt
+!tests/**/Fixtures/**/*.txt
 site/**/*
 
 # VitePress build output and cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,7 @@ test(domain): add missing edge case for session expiry
 The BotNexus development configuration file is located at:
 
 ```
-C:\Users\jobullen\.botnexus\config.json
+C:\Users\<ALIAS>\.botnexus\config.json
 ```
 
 Use the BotNexus CLI to manage configuration:

--- a/scripts/dev/extract-copilot-fixtures.py
+++ b/scripts/dev/extract-copilot-fixtures.py
@@ -1,0 +1,197 @@
+"""Extract per-response SSE/JSON fixtures from Copilot mitmproxy captures.
+
+Reads every flows-<model>.mitm in INPUT_DIR and writes per-response fixtures
+to OUTPUT_DIR with this structure:
+
+    <api>/<model>/req-<index>.body.txt    -- the raw response body
+    <api>/<model>/req-<index>.meta.json   -- request/response metadata
+
+The `<api>` segment is one of:
+    messages       (POST /v1/messages)
+    responses      (POST /responses)
+    completions    (POST /chat/completions)
+
+This script is the regeneration recipe for fixtures consumed by the
+CopilotWireSnapshotTests harness. Run after collecting fresh captures with
+scripts/dev/capture-copilot-flows.ps1.
+
+USAGE:
+    python scripts/dev/extract-copilot-fixtures.py \
+        --input  $HOME/captures \
+        --output tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire \
+        --models claude-haiku-4.5,gpt-5.5,mai-code-1-flash-internal,gemini-3.5-flash
+
+If --models is omitted, every flows-*.mitm in --input is processed.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    from mitmproxy import io as mitm_io
+except ImportError:
+    print("ERROR: mitmproxy is not installed. Install with: pip install mitmproxy", file=sys.stderr)
+    sys.exit(2)
+
+
+API_BY_PATH = {
+    "/v1/messages":      "messages",
+    "/responses":        "responses",
+    "/chat/completions": "completions",
+}
+
+
+def is_capture_target(req) -> str | None:
+    """Return the API class string if req hits one of the target endpoints."""
+    for path_prefix, api in API_BY_PATH.items():
+        if req.path.startswith(path_prefix) and req.method == "POST":
+            return api
+    return None
+
+
+def slugify(s: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", s)
+
+
+# Matches "encrypted_content":"<...>" or "encrypted_reasoning":"<...>" inside
+# JSON SSE payloads. We replace the value with a short marker so the parser
+# sees a non-empty string but the fixture stays diff-friendly.
+ENCRYPTED_FIELD_RE = re.compile(
+    r'"(encrypted_content|encrypted_reasoning)"\s*:\s*"[^"\\]*(?:\\.[^"\\]*)*"'
+)
+
+# Matches any JSON string value (in a key:"value" pair) longer than 200 chars.
+# /responses bodies are dominated by 1000+ char opaque ids (response.id,
+# item.id, content_part.id, etc.) — truncating them shrinks fixtures by ~95%
+# while preserving every structural element the parser cares about.
+LONG_STRING_VALUE_RE = re.compile(
+    r'("[a-zA-Z0-9_]+"\s*:\s*")([^"\\]{200,}(?:\\.[^"\\]*)*)(")'
+)
+
+
+def redact_encrypted(body: str) -> str:
+    """Shrink /responses fixtures from ~1.5MB to ~30KB:
+    - Replace encrypted_content / encrypted_reasoning values with "<redacted>".
+    - Truncate any other string value longer than 200 chars (giant opaque ids).
+
+    Keeps the JSON structure intact so the parser still tokenises every event
+    in the original order; only the unimportant blobs are shortened."""
+    body = ENCRYPTED_FIELD_RE.sub(r'"\1":"<redacted>"', body)
+    body = LONG_STRING_VALUE_RE.sub(r'\1<truncated>\3', body)
+    return body
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--input",  required=True, help="Folder containing flows-<model>.mitm files")
+    ap.add_argument("--output", required=True, help="Folder to write fixtures into")
+    ap.add_argument("--models", default="", help="Comma-separated model ids to extract (default: all)")
+    ap.add_argument("--max-per-model", type=int, default=0,
+                    help="Cap on fixtures emitted per model (0 = no cap). Useful for keeping repo size small.")
+    ap.add_argument("--redact-encrypted", action="store_true",
+                    help="Replace encrypted_content/encrypted_reasoning fields with short placeholders. "
+                         "Strongly recommended for /responses fixtures (shrinks 1MB blobs to ~5KB).")
+    args = ap.parse_args()
+
+    input_dir  = Path(args.input)
+    output_dir = Path(args.output)
+    selected   = set(filter(None, args.models.split(",")))
+
+    if not input_dir.is_dir():
+        print(f"ERROR: input dir not found: {input_dir}", file=sys.stderr)
+        return 2
+
+    captures = sorted(input_dir.glob("flows-*.mitm"))
+    if not captures:
+        print(f"ERROR: no flows-*.mitm files in {input_dir}", file=sys.stderr)
+        return 2
+
+    total = 0
+    for capture in captures:
+        model = capture.stem.replace("flows-", "", 1)
+        if selected and model not in selected:
+            continue
+
+        with capture.open("rb") as fh:
+            try:
+                flows = list(mitm_io.FlowReader(fh).stream())
+            except Exception as e:
+                print(f"  ! parse error in {capture.name}: {e}", file=sys.stderr)
+                continue
+
+        seq = 0
+        emitted_for_model = 0
+        for flow in flows:
+            req = getattr(flow, "request", None)
+            resp = getattr(flow, "response", None)
+            if not req or not resp:
+                continue
+
+            api = is_capture_target(req)
+            if not api:
+                continue
+
+            seq += 1
+            if args.max_per_model and emitted_for_model >= args.max_per_model:
+                continue
+
+            target_dir = output_dir / api / slugify(model)
+            target_dir.mkdir(parents=True, exist_ok=True)
+
+            base = f"req-{seq:02d}"
+            body_path = target_dir / f"{base}.body.txt"
+            meta_path = target_dir / f"{base}.meta.json"
+
+            try:
+                resp_body = resp.get_text(strict=False) or ""
+            except Exception:
+                resp_body = (
+                    resp.raw_content.decode("utf-8", errors="replace")
+                    if resp.raw_content else ""
+                )
+
+            if args.redact_encrypted:
+                resp_body = redact_encrypted(resp_body)
+
+            body_path.write_text(resp_body, encoding="utf-8", newline="\n")
+
+            req_body = ""
+            if req.raw_content:
+                try:
+                    req_body = req.get_text(strict=False) or ""
+                except Exception:
+                    req_body = req.raw_content.decode("utf-8", errors="replace")
+
+            meta = {
+                "model": model,
+                "api": api,
+                "request": {
+                    "method": req.method,
+                    "path":   req.path,
+                    "host":   req.host,
+                    "content_type": req.headers.get("content-type", ""),
+                    "body_length": len(req_body.encode("utf-8")),
+                },
+                "response": {
+                    "status_code": resp.status_code,
+                    "content_type": resp.headers.get("content-type", ""),
+                    "byte_length": len(resp_body.encode("utf-8")),
+                },
+            }
+            meta_path.write_text(
+                json.dumps(meta, indent=2, sort_keys=True),
+                encoding="utf-8", newline="\n",
+            )
+            total += 1
+            emitted_for_model += 1
+
+    print(f"Wrote {total} fixtures into {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/BotNexus.CodingAgent.Tests/Snapshots/coding-agent-main.prompt.txt
+++ b/tests/BotNexus.CodingAgent.Tests/Snapshots/coding-agent-main.prompt.txt
@@ -2,7 +2,7 @@
 
 ## Environment
 - OS: Microsoft Windows 10.0.26200
-- Working directory: C:/Users/jobullen/AppData/Local/Temp/repo
+- Working directory: <working-directory>
 - Git branch: feature/unify-prompts
 - Git status: M src/file.cs
 - Package manager: pnpm
@@ -43,4 +43,4 @@ Use search tools first.
 ## Custom Instructions
 Focus on minimal diffs.
 Current date/time: 2026-04-12T14:30:00.0000000+00:00
-Current working directory: C:/Users/jobullen/AppData/Local/Temp/repo
+Current working directory: <working-directory>

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/BotNexus.Agent.Providers.Copilot.Tests.csproj
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/BotNexus.Agent.Providers.Copilot.Tests.csproj
@@ -16,9 +16,11 @@
     <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
     <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Copilot\BotNexus.Agent.Providers.Copilot.csproj" />
     <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.OpenAI\BotNexus.Agent.Providers.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Providers.Anthropic\BotNexus.Agent.Providers.Anthropic.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Fixtures\Wire\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotWireReplayTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotWireReplayTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Text;
+using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests;
+
+/// <summary>
+/// Replay regression harness for the Copilot carve-out (#810, Phase 0b).
+/// Feeds recorded Copilot SSE bodies through today's parsers and asserts the
+/// resulting <see cref="StreamResult"/> shape. The dedicated
+/// <c>CopilotProvider</c> introduced in Phase 1 must produce identical results
+/// from the same fixtures, so any divergence is a regression caught here.
+/// </summary>
+public class CopilotWireReplayTests
+{
+    private static readonly string FixtureRoot = Path.Combine(
+        AppContext.BaseDirectory,
+        "Fixtures",
+        "Wire");
+
+    public static TheoryData<string, string> MessagesFixtures()
+    {
+        var data = new TheoryData<string, string>();
+        var dir = Path.Combine(FixtureRoot, "messages");
+        if (!Directory.Exists(dir))
+        {
+            return data;
+        }
+
+        foreach (var modelDir in Directory.EnumerateDirectories(dir).OrderBy(p => p))
+        {
+            var model = Path.GetFileName(modelDir);
+            foreach (var body in Directory.EnumerateFiles(modelDir, "*.body.txt").OrderBy(p => p))
+            {
+                data.Add(model, Path.GetFileName(body));
+            }
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(MessagesFixtures))]
+    public async Task MessagesFixture_ReplaysThroughAnthropicProvider(string modelId, string bodyFileName)
+    {
+        var bodyPath = Path.Combine(FixtureRoot, "messages", modelId, bodyFileName);
+        File.Exists(bodyPath).ShouldBeTrue($"missing fixture: {bodyPath}");
+
+        var body = await File.ReadAllTextAsync(bodyPath);
+        var handler = new RecordingHandler(_ => SseResponse(body));
+        var provider = new AnthropicProvider(new HttpClient(handler));
+
+        // Copilot serves the Anthropic Messages schema under
+        // api.enterprise.githubcopilot.com; today the provider doesn't care
+        // about the BaseUrl shape, only that the SSE body parses cleanly.
+        var model = new LlmModel(
+            Id: modelId,
+            Name: modelId,
+            Api: "anthropic-messages",
+            Provider: "github-copilot",
+            BaseUrl: "https://api.enterprise.githubcopilot.com",
+            Reasoning: true,
+            Input: ["text", "image"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 200000,
+            MaxTokens: 16384);
+
+        var context = new Context(
+            SystemPrompt: "replay",
+            Messages: [new UserMessage(new UserMessageContent("replay"), DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())]);
+
+        var stream = provider.Stream(model, context, new StreamOptions { ApiKey = "test-key" });
+        var result = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The parser must produce a non-error terminal frame.
+        result.ShouldNotBeNull();
+        result.StopReason.ShouldNotBe(StopReason.Error);
+        result.ErrorMessage.ShouldBeNull();
+
+        // Usage must be populated — every recorded fixture carries a
+        // message_delta with output_tokens, so a zero output count means the
+        // parser silently dropped the event.
+        (result.Usage.Input + result.Usage.Output).ShouldBeGreaterThan(0,
+            $"parser produced empty usage for {modelId}/{bodyFileName}");
+
+        // At least one content block must have been emitted (text or
+        // thinking). Empty Content means the parser silently dropped every
+        // content_block_* event in the recorded stream.
+        result.Content.ShouldNotBeEmpty(
+            $"parser produced no content blocks for {modelId}/{bodyFileName}");
+    }
+
+    private static HttpResponseMessage SseResponse(string payload) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "text/event-stream"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(responseFactory(request));
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/README.md
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/README.md
@@ -1,0 +1,76 @@
+# Copilot Wire Fixtures
+
+**Synthetic** SSE response bodies whose structure mirrors real GitHub Copilot
+enterprise responses. Used by `CopilotWireReplayTests` to assert that today's
+provider parsers (`AnthropicProvider`, `OpenAIResponsesProvider`,
+`OpenAICompletionsProvider`) accept every wire shape Copilot returns.
+
+These fixtures are the **baseline contract** that the upcoming Copilot
+carve-out (#810) must preserve. Each fixture file pair is a regression anchor:
+the new dedicated `CopilotProvider` must produce the same `StreamResult` from
+the same body.
+
+## Provenance
+
+The body shapes here are modelled on real captures collected via mitmproxy
+against `api.enterprise.githubcopilot.com`, but every field that could carry
+identifying information has been replaced with a deterministic dummy:
+
+- **Message / tool-use ids** — replaced with the consistent pattern
+  `msg_01FixtureMessage000000NN` and `toolu_01FixtureToolUse000000NN`
+  (same character class and length as the originals; NN is a sequence
+  number).
+- **Assistant content text** — replaced with placeholder strings so no
+  developer prompt content, file path, or repo-local identifier leaks.
+- **Thinking content / signatures** — replaced with neutral placeholders;
+  `signature` fields are emitted as `"<redacted>"`.
+- **Token counts** — rounded to clean dummy values (1000, 500, etc.) so
+  they can't be cross-referenced against a real session.
+- **Request `body_length`** — set to `0`; the response side carries the
+  authoritative `byte_length` of the synthetic body.
+
+Each meta file carries `"synthetic": true` to make this explicit.
+
+If you regenerate fixtures from a fresh mitmproxy capture, you **must** scrub
+the body before committing — see `scripts/dev/extract-copilot-fixtures.py`
+which handles the bulk redaction (encrypted blobs, long strings) but does not
+rewrite ids or placeholder text.
+
+## Layout
+
+```
+Fixtures/Wire/
+  <api>/<model>/
+    req-NN.body.txt    # synthetic SSE body, structure mirrors a real capture
+    req-NN.meta.json   # method, path, status, content-type, response byte length
+```
+
+`<api>` mirrors the Copilot transport surface (see `docs` and the carve-out
+plan):
+
+- `messages/`     — `/v1/messages` (Anthropic schema), Claude family
+- `responses/`    — `/responses`   (OpenAI Responses schema), gpt-5.x + MAI  (NOT YET COMMITTED)
+- `completions/`  — `/chat/completions`, gpt-4o-mini, gpt-4.1, Gemini, Grok   (NOT YET COMMITTED)
+
+`responses/` and `completions/` are tracked in #810 but ship in a follow-up PR
+once the redaction pipeline can shrink them below the 30 KB-per-fixture target
+(raw `/responses` bodies embed a full tool catalogue and are ~1.3 MB).
+
+## Regenerating from real captures
+
+```pwsh
+python scripts/dev/extract-copilot-fixtures.py `
+  --capture-root "$HOME/captures" `
+  --output tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire `
+  --redact-encrypted
+```
+
+The script removes encrypted blobs and truncates long strings. After running,
+**manually scrub the output** before committing: replace any remaining ids
+with the `msg_01Fixture…` / `toolu_01Fixture…` shapes above, and replace any
+recognisable assistant text with neutral placeholder strings.
+
+The architecture fence `PersonalPathLeakArchitectureTests` will fail the build
+if any committed file contains a Windows user-home path, a Linux user-home
+path, or a OneDrive segment — re-run `dotnet test` after editing fixtures.
+

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-01.body.txt
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-01.body.txt
@@ -1,0 +1,47 @@
+event: message_start
+data: {"message":{"content":[],"id":"msg_01FixtureMessage00000001","model":"claude-haiku-4-5-20251001","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":1000},"cache_creation_input_tokens":1000,"cache_read_input_tokens":0,"inference_geo":"not_available","input_tokens":10,"output_tokens":3}},"type":"message_start"}
+
+event: content_block_start
+data: {"content_block":{"signature":"","thinking":"","type":"thinking"},"index":0,"type":"content_block_start"}
+
+event: content_block_delta
+data: {"delta":{"thinking":"Placeholder reasoning","type":"thinking_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"thinking":" segment one for the fixture replay harness.","type":"thinking_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"thinking":" Placeholder reasoning segment two.","type":"thinking_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"signature":"<redacted>","type":"signature_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
+event: content_block_start
+data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_01FixtureToolUse00000001","input":{},"name":"grep","type":"tool_use"},"index":1,"type":"content_block_start"}
+
+event: content_block_delta
+data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"partial_json":"{\"pattern\": ","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"partial_json":"\"placeholder\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"partial_json":", \"head_limit\": 5}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+event: content_block_stop
+data: {"index":1,"type":"content_block_stop"}
+
+event: message_delta
+data: {"copilot_usage":{"token_details":[{"batch_size":1000000,"cost_per_batch":100000000000,"token_count":10,"token_type":"input"},{"batch_size":1000000,"cost_per_batch":10000000000,"token_count":0,"token_type":"cache_read"},{"batch_size":1000000,"cost_per_batch":125000000000,"token_count":1000,"token_type":"cache_write"},{"batch_size":1000000,"cost_per_batch":500000000000,"token_count":200,"token_type":"output"}],"total_nano_aiu":225000000},"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":1000,"cache_read_input_tokens":0,"input_tokens":10,"output_tokens":200,"output_tokens_details":{"thinking_tokens":100}}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+data: [DONE]
+

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-01.meta.json
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-01.meta.json
@@ -1,0 +1,18 @@
+{
+  "api": "messages",
+  "model": "claude-haiku-4.5",
+  "request": {
+    "body_length": 0,
+    "content_type": "application/json",
+    "host": "api.enterprise.githubcopilot.com",
+    "method": "POST",
+    "path": "/v1/messages"
+  },
+  "response": {
+    "byte_length": 2965,
+    "content_type": "text/event-stream",
+    "status_code": 200
+  },
+  "synthetic": true,
+  "notes": "Body and IDs have been replaced with deterministic dummies. Structure mirrors a real Copilot /v1/messages SSE response (thinking + tool_use)."
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-02.body.txt
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-02.body.txt
@@ -1,0 +1,26 @@
+event: message_start
+data: {"message":{"content":[],"id":"msg_01FixtureMessage00000002","model":"claude-haiku-4-5-20251001","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":500},"cache_creation_input_tokens":500,"cache_read_input_tokens":1000,"inference_geo":"not_available","input_tokens":6,"output_tokens":1}},"type":"message_start"}
+
+event: content_block_start
+data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+event: content_block_delta
+data: {"delta":{"text":"1","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"text":". `placeholder/path/one.md`\n2. `placeholder/path/two.md`\n3. `placeholder/path/three.md`\n4. `placeholder","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_delta
+data: {"delta":{"text":"/path/four.md`\n5. `placeholder/path/five.md`","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+
+event: message_delta
+data: {"copilot_usage":{"token_details":[{"batch_size":1000000,"cost_per_batch":100000000000,"token_count":6,"token_type":"input"},{"batch_size":1000000,"cost_per_batch":10000000000,"token_count":1000,"token_type":"cache_read"},{"batch_size":1000000,"cost_per_batch":125000000000,"token_count":500,"token_type":"cache_write"},{"batch_size":1000000,"cost_per_batch":500000000000,"token_count":90,"token_type":"output"}],"total_nano_aiu":120000000},"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":500,"cache_read_input_tokens":1000,"input_tokens":6,"output_tokens":90,"output_tokens_details":{"thinking_tokens":0}}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+data: [DONE]
+

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-02.meta.json
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Wire/messages/claude-haiku-4.5/req-02.meta.json
@@ -1,0 +1,18 @@
+{
+  "api": "messages",
+  "model": "claude-haiku-4.5",
+  "request": {
+    "body_length": 0,
+    "content_type": "application/json",
+    "host": "api.enterprise.githubcopilot.com",
+    "method": "POST",
+    "path": "/v1/messages"
+  },
+  "response": {
+    "byte_length": 1973,
+    "content_type": "text/event-stream",
+    "status_code": 200
+  },
+  "synthetic": true,
+  "notes": "Body and IDs have been replaced with deterministic dummies. Structure mirrors a real Copilot /v1/messages SSE response (plain text reply, end_turn stop reason)."
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/PersonalPathLeakArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/PersonalPathLeakArchitectureTests.cs
@@ -1,0 +1,239 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function: no tracked file in the repository may
+/// contain a developer-specific absolute path. Personal paths (Windows
+/// user-home directories, OneDrive segments, Linux user-home directories)
+/// are private context that should never reach a PR. Use generic
+/// placeholders instead — <c>$HOME</c>, <c>~</c>, <c>%USERPROFILE%</c>,
+/// <c>Path.GetTempPath()</c>, or <c>Environment.GetFolderPath(...)</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This fence exists because the first Phase 0b PR (#811) accidentally
+/// shipped a hard-coded <c>C:/Users/&lt;alias&gt;/OneDrive/projects/captures</c>
+/// path in the docstring of <c>scripts/dev/extract-copilot-fixtures.py</c>.
+/// A regex sweep over every tracked file catches that class of leak before
+/// it lands in another PR.
+/// </para>
+/// <para>
+/// Patterns that fail the fence:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>C:\Users\&lt;name&gt;\…</c> or <c>C:/Users/&lt;name&gt;/…</c> (any drive letter, any user name)</description></item>
+///   <item><description>A path segment named <c>OneDrive</c> (e.g. <c>…/OneDrive/projects/…</c>)</description></item>
+///   <item><description><c>/home/&lt;name&gt;/…</c> Linux user-home paths, except common CI accounts (<c>runner</c>, <c>vscode</c>, <c>codespace</c>, <c>circleci</c>)</description></item>
+/// </list>
+/// </remarks>
+public sealed class PersonalPathLeakArchitectureTests
+{
+    // The test file itself contains the patterns it scans for. Allowlist it
+    // by basename so the fence doesn't trip on its own documentation.
+    private static readonly HashSet<string> AllowedFiles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "PersonalPathLeakArchitectureTests.cs",
+    };
+
+    // Linux user-home paths owned by CI runners or used as generic test /
+    // documentation placeholders are not personal data. Keep this list short
+    // — adding entries weakens the fence. Each entry must cite the file it
+    // grandfathers.
+    private static readonly HashSet<string> CiHomeAccounts = new(StringComparer.Ordinal)
+    {
+        "runner",     // GitHub Actions
+        "vscode",     // VS Code dev container
+        "codespace",  // GitHub Codespaces
+        "circleci",   // CircleCI
+        "agent",      // generic test fixture (tests/extensions/BotNexus.Extensions.Skills.Tests/SkillManagerToolTests.cs)
+        "user",       // generic test fixture (tests/gateway/BotNexus.Gateway.Tests/PlatformConfigurationTests.cs)
+        "you",        // generic docs placeholder for the reader (docs/guides/watchdog-setup.md)
+        "larry",      // documented workflow persona, see fork: larry-fox-lobster/botnexus (.squad/skills/botnexus-issue-workflow/SKILL.md)
+    };
+
+    // Generic placeholder account names that appear in committed docs and
+    // test fixtures. Same rationale as CiHomeAccounts: each entry must cite
+    // the file that grandfathers it.
+    private static readonly HashSet<string> GenericWindowsAccounts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "username",   // generic docs placeholder (docs/development/workspace-and-memory.md)
+        "test",       // generic test fixture (tests/gateway/BotNexus.Cron.Tests/CronOptionsPromptTemplateResolverTests.cs)
+    };
+
+    // Built from fragments so the test source doesn't itself match the
+    // Windows-user-home pattern. Matches "C:\Users\alice" or
+    // "D:/Users/bob" (any drive letter, any user name) — captures the
+    // user-name group so it can be checked against the allowlist.
+    private static readonly Regex WindowsUserHome = new(
+        "[A-Za-z]:" + @"[\\/]" + "[Uu]sers" + @"[\\/]" + "([A-Za-z0-9_.\\-]+)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex OneDriveSegment = new(
+        @"[\\/]" + "OneDrive" + @"[\\/]",
+        RegexOptions.Compiled);
+
+    private static readonly Regex LinuxUserHome = new(
+        "/home/" + "([a-z][a-z0-9_-]*)/",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void NoTrackedFile_ContainsWindowsUserHomePath()
+    {
+        var offenders = ScanTrackedFiles((path, content) =>
+        {
+            foreach (Match match in WindowsUserHome.Matches(content))
+            {
+                var account = match.Groups[1].Value;
+                if (!GenericWindowsAccounts.Contains(account))
+                {
+                    return $"{path}: matched '{Truncate(match.Value)}' — use $HOME / %USERPROFILE% / Path.GetTempPath() instead";
+                }
+            }
+            return null;
+        });
+
+        offenders.ShouldBeEmpty(
+            "Tracked files contain personal Windows user-home paths (C:\\Users\\<name>\\... " +
+            "or C:/Users/<name>/...). These leak developer identity into the repo. " +
+            "Replace with $HOME, %USERPROFILE%, Path.GetTempPath(), or " +
+            "Environment.GetFolderPath(SpecialFolder.UserProfile). The allowlist covers " +
+            "generic placeholders only (username, test).\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void NoTrackedFile_ContainsOneDrivePathSegment()
+    {
+        var offenders = ScanTrackedFiles((path, content) =>
+            OneDriveSegment.IsMatch(content)
+                ? $"{path}: contains '/OneDrive/' segment — strip the cloud-sync prefix from documented paths"
+                : null);
+
+        offenders.ShouldBeEmpty(
+            "Tracked files reference a OneDrive path segment. OneDrive is a developer-local " +
+            "sync layout and must not appear in committed files.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void NoTrackedFile_ContainsPersonalLinuxHomePath()
+    {
+        var offenders = ScanTrackedFiles((path, content) =>
+        {
+            foreach (Match match in LinuxUserHome.Matches(content))
+            {
+                var account = match.Groups[1].Value;
+                if (!CiHomeAccounts.Contains(account))
+                {
+                    return $"{path}: matched '/home/{account}/' — use $HOME or ~ instead";
+                }
+            }
+            return null;
+        });
+
+        offenders.ShouldBeEmpty(
+            "Tracked files contain personal Linux user-home paths (/home/<name>/...). " +
+            "Replace with $HOME or ~. The allowlist covers common CI accounts only.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static List<string> ScanTrackedFiles(Func<string, string, string?> inspect)
+    {
+        var repoRoot = FindRepoRoot();
+        var offenders = new List<string>();
+
+        foreach (var relative in EnumerateTrackedFiles(repoRoot))
+        {
+            if (AllowedFiles.Contains(Path.GetFileName(relative)))
+            {
+                continue;
+            }
+            if (!IsTextFile(relative))
+            {
+                continue;
+            }
+
+            var absolute = Path.Combine(repoRoot, relative);
+            if (!File.Exists(absolute))
+            {
+                continue;
+            }
+
+            string content;
+            try
+            {
+                content = File.ReadAllText(absolute);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+
+            var result = inspect(relative.Replace('\\', '/'), content);
+            if (result is not null)
+            {
+                offenders.Add(result);
+            }
+        }
+
+        offenders.Sort(StringComparer.Ordinal);
+        return offenders;
+    }
+
+    private static IEnumerable<string> EnumerateTrackedFiles(string repoRoot)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("git", "ls-files")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+        string? line;
+        while ((line = process.StandardOutput.ReadLine()) is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                yield return line;
+            }
+        }
+        process.WaitForExit();
+        process.ExitCode.ShouldBe(0, "git ls-files failed: " + process.StandardError.ReadToEnd());
+    }
+
+    // Skip binary file extensions where personal paths can't reasonably be
+    // searched and would only slow the test. .mitm, .pptx, images, etc.
+    private static readonly HashSet<string> BinaryExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".ico", ".bmp", ".webp",
+        ".pdf", ".zip", ".gz", ".tar", ".7z", ".dll", ".exe", ".pdb",
+        ".mitm", ".pptx", ".docx", ".xlsx", ".woff", ".woff2", ".ttf",
+        ".eot", ".otf", ".mp3", ".mp4", ".wav", ".mov",
+    };
+
+    private static bool IsTextFile(string relativePath)
+        => !BinaryExtensions.Contains(Path.GetExtension(relativePath));
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "BotNexus.slnx")))
+        {
+            current = current.Parent;
+        }
+        current.ShouldNotBeNull("Could not locate repo root from " + AppContext.BaseDirectory);
+        return current.FullName;
+    }
+
+    private static string Truncate(string value)
+        => value.Length <= 80 ? value : value[..80] + "...";
+}


### PR DESCRIPTION
Phase 0b of the Copilot provider carve-out (#810).

## What

1. **Replay harness** — locks in today's parser behaviour against synthetic Copilot SSE bodies *before* any production code moves. This is the regression anchor for #810; the dedicated `CopilotProvider` in Phase 1 must produce identical `AssistantMessage` results from the same fixtures.
2. **Path-leak fence** — an architecture fitness function that scans every tracked file (via ``git ls-files``) and fails the build if it contains a Windows user-home path, OneDrive segment, or personal Linux user-home path. Caught and fixed two pre-existing leaks while landing.

## Replay harness

- ``tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotWireReplayTests.cs`` — discovers every ``Fixtures/Wire/messages/<model>/req-NN.body.txt``, feeds it through ``AnthropicProvider`` via an in-process ``RecordingHandler``, asserts: non-error terminal frame, non-empty usage, at least one emitted content block.
- ``scripts/dev/extract-copilot-fixtures.py`` — regenerates fixtures from mitmproxy captures with ``--redact-encrypted``. Manual scrubbing of ids and assistant text still required after running.
- Two synthetic Claude-Haiku-4.5 ``/v1/messages`` fixtures (thinking + plain text), ~5 KB total. Every opaque id replaced with deterministic same-shape dummies: ``msg_01FixtureMessage00000001`` / ``msg_01FixtureMessage00000002`` / ``toolu_01FixtureToolUse00000001``. Assistant text is generic placeholder content.

## Path-leak fence

- ``tests/architecture/BotNexus.Architecture.Tests/PersonalPathLeakArchitectureTests.cs`` — three fact methods, one per pattern class.
- Generic placeholders (``test``, ``username``, ``agent``, ``user``, ``you``, ``larry``) and CI runner accounts (``runner``, ``vscode``, ``codespace``, ``circleci``) are explicitly allowlisted with cited grandfathered files. Every allowlist entry has a comment naming the file that justifies it.
- Caught two pre-existing leaks and fixed them in this PR:
  - ``AGENTS.md`` — ``C:\Users\jobullen\.botnexus`` → ``C:\Users\<ALIAS>\.botnexus`` (matches the existing AGENTS.md alias convention).
  - ``tests/BotNexus.CodingAgent.Tests/Snapshots/coding-agent-main.prompt.txt`` — ``C:/Users/jobullen/AppData/Local/Temp/repo`` → ``<working-directory>`` (the snapshot test already normalises to this placeholder).

## Out of scope (follow-up PRs)

- ``/responses`` and ``/chat/completions`` fixtures — raw bodies are ~1.3 MB because ``response.created`` / ``response.completed`` re-emit the full tool catalogue. Needs smarter per-event-type redaction; tracked in #810.
- 0a / 0c / 0d / 0e / 0f gates from the carve-out plan — separate PRs.

## Validation

- ``scripts/repo/test-impacted.ps1`` green across ``Copilot.Tests``, ``Architecture.Tests``, ``CodingAgent.Tests``, ``Scenarios.Tests``.
- Zero warnings.
- No production code touched.

Refs #810.
