### PR TITLE
test(agents): add Copilot request-body snapshot harness (Phase 0a, #810)

### DIFF
--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/BotNexus.Agent.Providers.Copilot.Tests.csproj
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/BotNexus.Agent.Providers.Copilot.Tests.csproj
@@ -22,5 +22,6 @@
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="Fixtures\Wire\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Fixtures\Requests\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotRequestSnapshotTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotRequestSnapshotTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests;
+
+/// <summary>
+/// Outbound request-shape regression for the Copilot carve-out (#810,
+/// Phase 0a). Drives <see cref="AnthropicProvider"/> with a representative
+/// Copilot-flavoured <see cref="LlmModel"/> + <see cref="Context"/>, captures
+/// the request body and Copilot-specific headers, and compares against a
+/// committed snapshot.
+///
+/// The dedicated <c>CopilotProvider</c> introduced in Phase 1 must produce
+/// the same on-the-wire request from the same inputs; a snapshot diff is the
+/// canonical signal that the carve-out has accidentally changed the contract.
+/// </summary>
+public class CopilotRequestSnapshotTests
+{
+    private static readonly string SnapshotRoot = Path.Combine(
+        AppContext.BaseDirectory,
+        "Fixtures",
+        "Requests");
+
+    // Headers we assert on. The full set Copilot adds is larger but most are
+    // either invariant or computed from BaseUrl — these three are the ones
+    // the carve-out has the most opportunity to silently change.
+    private static readonly string[] InterestingHeaders =
+    {
+        "Authorization",
+        "anthropic-version",
+        "anthropic-beta",
+    };
+
+    [Fact]
+    public async Task Stream_CopilotMessages_HaikuWithThinkingAndToolCatalogue_MatchesSnapshot()
+    {
+        var handler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var provider = new AnthropicProvider(new HttpClient(handler));
+
+        var model = new LlmModel(
+            Id: "claude-haiku-4.5",
+            Name: "claude-haiku-4.5",
+            Api: "anthropic-messages",
+            Provider: "github-copilot",
+            BaseUrl: "https://api.enterprise.githubcopilot.com",
+            Reasoning: true,
+            Input: ["text", "image"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 200000,
+            MaxTokens: 16384);
+
+        const long fixedTimestamp = 1_700_000_000_000L;
+        var context = new Context(
+            SystemPrompt: "You are a helpful assistant operating inside BotNexus tests. " +
+                          "Reply concisely and use tools when asked.",
+            Messages:
+            [
+                new UserMessage(new UserMessageContent("List the first three prime numbers."), fixedTimestamp),
+            ],
+            Tools:
+            [
+                new Tool(
+                    Name: "list_primes",
+                    Description: "Returns the first N prime numbers.",
+                    Parameters: JsonDocument.Parse("""
+                        {
+                          "type": "object",
+                          "properties": {
+                            "count": { "type": "integer", "minimum": 1, "maximum": 100 }
+                          },
+                          "required": ["count"]
+                        }
+                        """).RootElement.Clone()),
+            ]);
+
+        var options = new AnthropicOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+
+        var stream = provider.Stream(model, context, options);
+        _ = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        handler.RequestBody.ShouldNotBeNullOrWhiteSpace();
+        handler.RequestUri.ShouldNotBeNull();
+        handler.RequestUri!.AbsoluteUri.ShouldBe("https://api.enterprise.githubcopilot.com/v1/messages");
+
+        var actual = BuildEnvelope(handler);
+        var actualJson = SerializeStable(actual);
+
+        var snapshotPath = Path.Combine(SnapshotRoot, "messages", "claude-haiku-4.5", "haiku-thinking-tool.json");
+        File.Exists(snapshotPath).ShouldBeTrue(
+            $"missing snapshot: {snapshotPath}\n" +
+            "If this is the first run, write the snapshot manually from the captured envelope:\n" +
+            actualJson);
+
+        var expectedJson = await File.ReadAllTextAsync(snapshotPath);
+        Normalise(actualJson).ShouldBe(Normalise(expectedJson),
+            "Outbound Copilot request shape diverged from snapshot. " +
+            "If this is an intentional change, update the snapshot file:\n" + snapshotPath);
+    }
+
+    private const string MinimalSse =
+        "event: message_start\n" +
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01FixtureMessage00000001\"}}\n" +
+        "\n" +
+        "event: message_stop\n" +
+        "data: {\"type\":\"message_stop\"}\n" +
+        "\n";
+
+    private static JsonObject BuildEnvelope(RecordingHandler handler)
+    {
+        var body = JsonNode.Parse(handler.RequestBody!)!.AsObject();
+
+        var headers = new JsonObject();
+        foreach (var name in InterestingHeaders.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            if (handler.RequestHeaders.TryGetValue(name, out var value))
+            {
+                // Authorization carries the (fake) bearer token; we redact
+                // its value but keep the scheme so the snapshot proves Copilot
+                // uses Bearer auth (not x-api-key).
+                if (string.Equals(name, "Authorization", StringComparison.OrdinalIgnoreCase))
+                {
+                    var scheme = value.Split(' ', 2)[0];
+                    headers[name] = $"{scheme} <redacted>";
+                }
+                else
+                {
+                    headers[name] = value;
+                }
+            }
+        }
+
+        return new JsonObject
+        {
+            ["method"] = handler.RequestMethod ?? "POST",
+            ["path"] = handler.RequestUri!.AbsolutePath,
+            ["headers"] = headers,
+            ["body"] = body,
+        };
+    }
+
+    private static string SerializeStable(JsonNode node)
+        => JsonSerializer.Serialize(node, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            // Keep angle brackets etc. unescaped so the snapshot is
+            // human-readable when reviewers diff it. The payload only
+            // contains our own placeholder text — never untrusted input.
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        });
+
+    // Strip line-ending differences so snapshots survive CRLF/LF normalisation.
+    private static string Normalise(string text)
+        => text.Replace("\r\n", "\n").TrimEnd();
+
+    private static HttpResponseMessage SseResponse(string payload) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "text/event-stream"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public string? RequestMethod { get; private set; }
+        public string? RequestBody { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public Dictionary<string, string> RequestHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestMethod = request.Method.Method;
+            RequestUri = request.RequestUri;
+            RequestHeaders = request.Headers.ToDictionary(
+                header => header.Key,
+                header => string.Join(",", header.Value),
+                StringComparer.OrdinalIgnoreCase);
+            RequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responseFactory(request);
+        }
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Requests/README.md
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Requests/README.md
@@ -1,0 +1,57 @@
+# Copilot Outbound Request Snapshots
+
+Canonical outbound-request envelopes produced when BotNexus drives a Copilot
+model end-to-end. Used by `CopilotRequestSnapshotTests` to lock in the wire
+contract on the **request** side, complementing the response-side fixtures
+under `../Wire/`.
+
+The dedicated `CopilotProvider` introduced in Phase 1 of the carve-out (#810)
+must produce identical envelopes from identical inputs; a snapshot diff is the
+canonical signal that the carve-out has changed the contract.
+
+## Layout
+
+```
+Fixtures/Requests/
+  <api>/<model>/
+    <scenario>.json    # method, path, selected headers, request body
+```
+
+Each snapshot is a single JSON document with shape:
+
+```json
+{
+  "method": "POST",
+  "path": "/v1/messages",
+  "headers": {
+    "Authorization": "Bearer <redacted>",
+    "anthropic-version": "2023-06-01",
+    "anthropic-beta": "..."
+  },
+  "body": { ... }
+}
+```
+
+## Header set
+
+Only headers the carve-out can plausibly change are captured. The current
+allowlist is:
+
+- `Authorization` — value is replaced with `<scheme> <redacted>`. The
+  scheme itself is meaningful (Copilot must use `Bearer`, not `x-api-key`).
+- `anthropic-version`
+- `anthropic-beta`
+
+Other headers (`accept`, `anthropic-dangerous-direct-browser-access`, etc.)
+are exercised by `AnthropicProviderAlignmentTests` and not duplicated here.
+
+## Updating
+
+If a request shape changes intentionally:
+
+1. Run the failing test — its failure message includes the captured envelope.
+2. Paste the captured JSON into the snapshot file.
+3. Justify the diff in the PR description.
+
+If the snapshot drifts unintentionally, the carve-out has introduced a wire
+regression — fix the provider, not the snapshot.

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Requests/messages/claude-haiku-4.5/haiku-thinking-tool.json
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Requests/messages/claude-haiku-4.5/haiku-thinking-tool.json
@@ -1,0 +1,56 @@
+{
+  "method": "POST",
+  "path": "/v1/messages",
+  "headers": {
+    "Authorization": "Bearer <redacted>",
+    "anthropic-beta": "interleaved-thinking-2025-05-14",
+    "anthropic-version": "2023-06-01"
+  },
+  "body": {
+    "model": "claude-haiku-4.5",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "List the first three prime numbers.",
+            "cache_control": {
+              "type": "ephemeral"
+            }
+          }
+        ]
+      }
+    ],
+    "max_tokens": 4096,
+    "stream": true,
+    "system": [
+      {
+        "type": "text",
+        "text": "You are a helpful assistant operating inside BotNexus tests. Reply concisely and use tools when asked.",
+        "cache_control": {
+          "type": "ephemeral"
+        }
+      }
+    ],
+    "tools": [
+      {
+        "name": "list_primes",
+        "description": "Returns the first N prime numbers.",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          "required": [
+            "count"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0a of the Copilot provider carve-out (#810): a request-side snapshot
harness that locks in the outbound `/v1/messages` envelope BotNexus produces
today when driving a Copilot-authenticated model through `AnthropicProvider`.
Complements the response-side replay harness landed in #811.

## What it pins

For `claude-haiku-4.5` on `https://api.enterprise.githubcopilot.com`:

- `POST /v1/messages` with **Bearer** auth (not `x-api-key`)
- `anthropic-version: 2023-06-01`
- `anthropic-beta: interleaved-thinking-2025-05-14`
- `system` block with `cache_control: ephemeral`
- last user-content block carries `cache_control: ephemeral`
- `tools[]` `input_schema` shape (object + properties + required)
- `max_tokens` / `stream: true`

The snapshot lives at:

```
tests/agent/BotNexus.Agent.Providers.Copilot.Tests/
  Fixtures/Requests/messages/claude-haiku-4.5/haiku-thinking-tool.json
```

A `Fixtures/Requests/README.md` documents the layout, header allowlist
(Authorization, anthropic-version, anthropic-beta), and the update workflow.

## Why this exists

Phase 1 will introduce a dedicated `CopilotProvider` that no longer piggy-backs
on `AnthropicProvider`. To prove the carve-out hasn't silently changed the
wire contract, we need a byte-level baseline of what `AnthropicProvider` emits
on the Copilot path today. This PR is that baseline.

## How the test works

`CopilotRequestSnapshotTests` drives `AnthropicProvider.Stream(...)` through
an in-test `RecordingHandler` that:

1. Captures the actual outbound `HttpRequestMessage` (method, path, headers,
   body) before short-circuiting with a minimal valid SSE stream so `Stream`
   completes deterministically.
2. Builds a stable JSON envelope (filtered header set; `Authorization` value
   redacted but scheme preserved so the snapshot proves Bearer auth).
3. Compares against the committed snapshot file.

If the snapshot file is missing, the failure message includes the captured
envelope verbatim — paste it into the snapshot to bootstrap.

## Verification

- `dotnet test ... --filter CopilotRequestSnapshot` → **1 passed**
- `scripts/repo/test-impacted.ps1` → **all green** (Copilot.Tests +
  Architecture.Tests including the personal-path-leak fence + Scenarios.Tests)
- Zero warnings introduced.

## Out of scope

Deferred to follow-up small PRs:

- 0b extension to `/responses` and `/chat/completions` request shapes
- 0c direct-provider negative regression
- 0d gateway-level provider selection
- 0e `ConfigCompatibilityTests`
- 0f `OAuthTokenCacheCompatibilityTests`
- Phase 1+ — the actual carve-out

Closes the Phase 0a checkbox on #810.
