### PR TITLE
fix(portal): remove broken Restart Gateway button

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -226,11 +226,9 @@
                 }
             </nav>
 
-            @* Restart button + build info at bottom *@
+            @* Build info at bottom *@
             <div class="sidebar-footer">
-                <button class="restart-btn" @onclick="RestartGateway" disabled="@_restarting">
-                    @(_restarting ? "Restarting…" : "🔄 Restart Gateway")
-                </button>
+                @* Restart Gateway button removed -- no process supervisor present; button killed the gateway with no recovery (#794) *@
                 @if (GatewayInfo.Info is not null)
                 {
                     <div class="gateway-info">
@@ -294,7 +292,6 @@
     private record SidebarAgentItem(string AgentId, string DisplayLabel);
     private List<Announcement> _announcements = [];
     private List<SidebarAgentItem> _sidebarAgents = [];
-        private bool _restarting;
     private PortalSettingsPanel? _settingsPanel;
     private bool _sidebarOpen = false;
     private bool _isMobile = false;
@@ -587,18 +584,6 @@
         _showUpdateConfirm = false;
         await UpdateStatus.StartUpdateAsync();
         await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task RestartGateway()
-    {
-        _restarting = true;
-        try
-        {
-            using var http = new HttpClient { BaseAddress = new Uri(Nav.BaseUri) };
-            await http.PostAsync("/api/gateway/shutdown", null);
-        }
-        catch { /* Expected — gateway drops */ }
-        _restarting = false;
     }
 
     public void Dispose()

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/GatewayController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/GatewayController.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Hosting;
 
 namespace BotNexus.Gateway.Api.Controllers;
 
@@ -8,7 +7,7 @@ namespace BotNexus.Gateway.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/gateway")]
-public sealed class GatewayController(IHostApplicationLifetime lifetime) : ControllerBase
+public sealed class GatewayController : ControllerBase
 {
     /// <summary>Returns runtime and build information about the running gateway.</summary>
     [HttpGet("info")]
@@ -20,15 +19,4 @@ public sealed class GatewayController(IHostApplicationLifetime lifetime) : Contr
         commitShort   = GatewayBuildInfo.CommitShort,
         version       = GatewayBuildInfo.Version
     });
-
-    /// <summary>
-    /// Initiates a graceful shutdown so the process supervisor can restart the gateway cleanly.
-    /// </summary>
-    /// <returns>A shutdown acknowledgement payload.</returns>
-    [HttpPost("shutdown")]
-    public IActionResult Shutdown()
-    {
-        lifetime.StopApplication();
-        return Ok(new { status = "shutting_down" });
-    }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.AspNetCore.Components;
@@ -604,5 +604,25 @@ public sealed class MainLayoutTests : IDisposable
 
         // Dropdown should be visible on desktop
         cut.Find(".agent-dropdown-select");
+    }
+
+    [Fact]
+    public void Restart_Gateway_button_is_not_rendered()
+    {
+        // #794: the Restart Gateway button was removed because it killed the gateway
+        // with no automatic recovery -- no process supervisor is present.
+        var cut = RenderLayout();
+
+        Assert.Empty(cut.FindAll(".restart-btn"));
+        Assert.DoesNotContain("Restart Gateway", cut.Markup);
+    }
+
+    [Fact]
+    public void Sidebar_footer_is_still_rendered_without_restart_button()
+    {
+        // The sidebar footer (build info, update badge) must survive the button removal.
+        var cut = RenderLayout();
+
+        cut.Find(".sidebar-footer");
     }
 }


### PR DESCRIPTION
Closes #794
Closes #791

## Changes

- Removed the **Restart Gateway** button and `RestartGateway()` method from `MainLayout.razor`
- Removed the now-dead `POST /api/gateway/shutdown` endpoint from `GatewayController` (no callers remain)
- Added 2 tests to `MainLayoutTests`: `Restart_Gateway_button_is_not_rendered` and `Sidebar_footer_is_still_rendered_without_restart_button`

## Why

The button called `POST /api/gateway/shutdown` which calls `IHostApplicationLifetime.StopApplication()`. Without a process supervisor to restart the gateway, clicking it terminates the service with no recovery path. The watchdog that was expected to auto-restart no longer exists.

Option B (proper restart via OS service integration, #120) is the right long-term solution and is tracked in #791.

## Merge Notes

This PR touches only `MainLayout.razor`, `GatewayController.cs`, and `MainLayoutTests.cs`. No overlap with any other known open PR. Safe to merge at any time.
