### PR TITLE
fix(portal): suppress NO_REPLY cron turns from conversation history

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -256,14 +256,20 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         agent.IsStreaming = false;
         agent.ProcessingStage = null;
 
-        // Update timestamp client-side so sort order reflects recent activity (issue #382).
-        conv.UpdatedAt = DateTimeOffset.UtcNow;
+        if (!isNoReply)
+        {
+            // Update timestamp client-side so sort order reflects recent activity (issue #382).
+            // NO_REPLY turns must not bump the timestamp -- they produce no user-facing activity
+            // and bumping UpdatedAt would cause the conversation to appear at the top of the list
+            // with a recent timestamp, creating noise for cron wakeups that had nothing to say (#773).
+            conv.UpdatedAt = DateTimeOffset.UtcNow;
 
-        if (agent.AgentId != _store.ActiveAgentId)
-            agent.UnreadCount++;
+            if (agent.AgentId != _store.ActiveAgentId)
+                agent.UnreadCount++;
 
-        if (convId != agent.ActiveConversationId)
-            conv.UnreadCount++;
+            if (convId != agent.ActiveConversationId)
+                conv.UnreadCount++;
+        }
 
         _store.ClearPendingAskUser(convId);
         _store.NotifyChanged();

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -692,4 +692,87 @@ public sealed class GatewayEventHandlerTests
         Assert.True(refreshCalled, "refresh must fire immediately when not streaming");
     }
 
+
+    // ---- NO_REPLY sentinel tests (issue #773) ----
+
+    [Fact]
+    public void HandleMessageEnd_noReply_does_not_add_message_to_conversation()
+    {
+        // NO_REPLY turns must leave conversation.Messages untouched.
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "NO_REPLY";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.Empty(conv.Messages);
+    }
+
+    [Fact]
+    public void HandleMessageEnd_noReply_does_not_update_conversation_timestamp()
+    {
+        // NO_REPLY turns must not bump UpdatedAt -- bumping it surfaces the conversation
+        // as recently-active in the sidebar and creates noise for cron no-ops (#773).
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        var originalUpdatedAt = conv.UpdatedAt;
+        conv.StreamState.Buffer = "NO_REPLY";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.Equal(originalUpdatedAt, conv.UpdatedAt);
+    }
+
+    [Fact]
+    public void HandleMessageEnd_noReply_does_not_increment_unread_counts()
+    {
+        // NO_REPLY turns must not increment agent or conversation unread counts.
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        var agentUnreadBefore = agent.UnreadCount;
+        var convUnreadBefore = conv.UnreadCount;
+        conv.StreamState.Buffer = "NO_REPLY";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.Equal(agentUnreadBefore, agent.UnreadCount);
+        Assert.Equal(convUnreadBefore, conv.UnreadCount);
+    }
+
+    [Fact]
+    public void HandleMessageEnd_noReply_still_clears_streaming_state()
+    {
+        // Even for NO_REPLY, streaming flags must be cleared so the UI does not
+        // show a perpetual "Agent is responding..." indicator.
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "NO_REPLY";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.False(agent.IsStreaming);
+        Assert.False(conv.StreamState.IsStreaming);
+        Assert.Equal(string.Empty, conv.StreamState.Buffer);
+        Assert.Null(agent.ProcessingStage);
+    }
+
+    [Fact]
+    public void HandleMessageEnd_noReply_with_leading_trailing_whitespace_is_suppressed()
+    {
+        // The sentinel check uses .Trim() so whitespace around NO_REPLY is tolerated.
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        var originalUpdatedAt = conv.UpdatedAt;
+        conv.StreamState.Buffer = "  NO_REPLY  ";
+
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        Assert.Empty(conv.Messages);
+        Assert.Equal(originalUpdatedAt, conv.UpdatedAt);
+    }
+
 }


### PR DESCRIPTION
Closes #773

## Changes

- In `GatewayEventHandler.HandleMessageEnd`: when the response is the `NO_REPLY` sentinel, skip updating `conv.UpdatedAt` and skip incrementing `agent.UnreadCount` / `conv.UnreadCount`
- Streaming state cleanup (`IsStreaming = false`, buffer clear, `ProcessingStage = null`) still runs for NO_REPLY — the UI must exit its responding indicator even for silent turns
- Added 5 unit tests in `GatewayEventHandlerTests`:
  - `HandleMessageEnd_noReply_does_not_add_message_to_conversation`
  - `HandleMessageEnd_noReply_does_not_update_conversation_timestamp`
  - `HandleMessageEnd_noReply_does_not_increment_unread_counts`
  - `HandleMessageEnd_noReply_still_clears_streaming_state`
  - `HandleMessageEnd_noReply_with_leading_trailing_whitespace_is_suppressed`

## Root Cause

The NO_REPLY message check correctly prevented adding a chat message to `conv.Messages`. But `conv.UpdatedAt = DateTimeOffset.UtcNow` was unconditional — so every cron no-op wakeup bumped the conversation's last-activity timestamp. With hourly cron jobs, this produced dozens of empty "recent activity" entries in the sidebar conversation list.

## Merge Notes

This PR touches only `GatewayEventHandler.cs` and `GatewayEventHandlerTests.cs`. No overlap with any other open PR. Safe to merge at any time — can merge before or after #816 without conflict.
