### PR TITLE
fix(signalr): classify pre-handshake WebSocket close as benign in GatewayHub

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -577,7 +577,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     /// <param name="exception">The disconnect exception, if any.</param>
     public override async Task OnDisconnectedAsync(Exception? exception)
     {
-        _logger.LogInformation("Hub OnDisconnected: connection={ConnectionId}", Context.ConnectionId);
+        if (exception is not null && IsBenignConnectionException(exception))
+            _logger.LogDebug(exception, "Hub OnDisconnected: benign pre-handshake close for connection {ConnectionId}", Context.ConnectionId);
+        else if (exception is not null)
+            _logger.LogWarning(exception, "Hub OnDisconnected: unexpected exception for connection {ConnectionId}", Context.ConnectionId);
+        else
+            _logger.LogInformation("Hub OnDisconnected: connection={ConnectionId}", Context.ConnectionId);
 
         // Best-effort: mute any Interactive/NotifyOnly bindings keyed to this connection ID.
         // If the store lookup fails, fan-out self-healing via StaleChannelConnectionException
@@ -736,5 +741,29 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         ConversationId ConversationId,
         AgentId AgentId,
         ChannelKey ChannelType);
+
+    /// <summary>
+    /// Returns <see langword="true"/> for exceptions that are expected side-effects of a
+    /// WebSocket client disconnecting before (or during) the SignalR handshake — e.g.
+    /// the browser navigating away, a network blip, or a rapid reconnect cycle. These
+    /// are logged at Debug level instead of Warning to avoid Application Insights noise.
+    /// </summary>
+    public static bool IsBenignConnectionException(Exception ex)
+    {
+        // Unwrap IOException wrappers (ASP.NET Kestrel sometimes wraps WebSocketException
+        // in an IOException when the underlying stream is torn down).
+        var inner = ex is System.IO.IOException ioEx ? ioEx.InnerException ?? ioEx : ex;
+
+        if (inner is OperationCanceledException)
+            return true;
+
+        if (inner is System.Net.WebSockets.WebSocketException wse)
+        {
+            return wse.WebSocketErrorCode == System.Net.WebSockets.WebSocketError.ConnectionClosedPrematurely
+                || wse.Message.Contains("closed before the connection was established", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
 }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -611,4 +611,52 @@ public sealed class SignalRHubTests
         public override CancellationToken ConnectionAborted { get; } = CancellationToken.None;
         public override void Abort() { }
     }
+
+    // IsBenignConnectionException classification tests
+    [Fact]
+    public void IsBenignConnectionException_WithPreHandshakeMessageString_ReturnsTrue()
+    {
+        var ex = new System.Net.WebSockets.WebSocketException("WebSocket was closed before the connection was established");
+        GatewayHub.IsBenignConnectionException(ex).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsBenignConnectionException_WithConnectionClosedPrematurely_ReturnsTrue()
+    {
+        var ex = new System.Net.WebSockets.WebSocketException(
+            System.Net.WebSockets.WebSocketError.ConnectionClosedPrematurely,
+            "Connection closed prematurely");
+        GatewayHub.IsBenignConnectionException(ex).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsBenignConnectionException_WithOperationCanceledException_ReturnsTrue()
+    {
+        var ex = new OperationCanceledException("Request was cancelled");
+        GatewayHub.IsBenignConnectionException(ex).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsBenignConnectionException_WithIoWrappedWebSocketException_ReturnsTrue()
+    {
+        var inner = new System.Net.WebSockets.WebSocketException("WebSocket was closed before the connection was established");
+        var ex = new System.IO.IOException("An existing connection was forcibly closed", inner);
+        GatewayHub.IsBenignConnectionException(ex).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsBenignConnectionException_WithGenericException_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException("Something went wrong");
+        GatewayHub.IsBenignConnectionException(ex).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsBenignConnectionException_WithUnrelatedWebSocketException_ReturnsFalse()
+    {
+        var ex = new System.Net.WebSockets.WebSocketException(
+            System.Net.WebSockets.WebSocketError.InvalidMessageType,
+            "Unexpected message type");
+        GatewayHub.IsBenignConnectionException(ex).ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
Closes #652

## Changes

- Added public static IsBenignConnectionException(Exception ex) helper to GatewayHub
- OnDisconnectedAsync now classifies disconnect exceptions: benign pre-handshake closes log at Debug level; unexpected exceptions log at Warning; clean disconnects log at Information
- Covered patterns: WebSocketException with ConnectionClosedPrematurely error code, WebSocketException with "closed before the connection was established" message, OperationCanceledException, IOException wrapping WebSocketException
- 6 unit tests covering all benign and non-benign classification paths

## Merge Notes

Only touches GatewayHub.cs in BotNexus.Extensions.Channels.SignalR and SignalRHubTests.cs. Zero overlap with CronController.cs or any Portal files. Safe to merge in any order with other open PRs.