### PR TITLE
feat(gateway): add archive action to ConversationTool

### DIFF
--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -29,14 +29,14 @@ public sealed class ConversationTool(
 
     public Tool Definition => new(
         Name,
-        "Get, list, create, and annotate persistent conversation context.",
+        "Get, list, create, annotate, and archive persistent conversation context.",
         JsonDocument.Parse("""
             {
               "type": "object",
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["get", "set_title", "set_purpose", "set", "list", "new", "message"],
+                  "enum": ["get", "set_title", "set_purpose", "set", "list", "new", "message", "archive"],
                   "description": "Action to perform."
                 },
                 "conversationId": {
@@ -84,7 +84,8 @@ public sealed class ConversationTool(
             !action.Equals("list", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("new", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("set", StringComparison.OrdinalIgnoreCase) &&
-            !action.Equals("message", StringComparison.OrdinalIgnoreCase))
+            !action.Equals("message", StringComparison.OrdinalIgnoreCase) &&
+            !action.Equals("archive", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException($"Unsupported conversation action '{action}'.");
 
         return Task.FromResult(arguments);
@@ -106,6 +107,7 @@ public sealed class ConversationTool(
             "new" => await NewAsync(arguments, cancellationToken).ConfigureAwait(false),
             "set" => await SetAsync(arguments, cancellationToken).ConfigureAwait(false),
             "message" => await SendMessageAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "archive" => await ArchiveAsync(arguments, cancellationToken).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unsupported conversation action '{action}'.")
         };
     }
@@ -315,6 +317,19 @@ public sealed class ConversationTool(
         }
         await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
         return TextResult("Conversation updated.");
+    }
+
+    private async Task<AgentToolResult> ArchiveAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)
+    {
+        var conversation = await ResolveConversationAsync(arguments, ct).ConfigureAwait(false);
+        EnsureCanAccess(conversation.AgentId);
+        await conversationStore.ArchiveAsync(conversation.ConversationId, ct).ConfigureAwait(false);
+        return TextResult(JsonSerializer.Serialize(new
+        {
+            conversationId = conversation.ConversationId.Value,
+            agentId = conversation.AgentId.Value,
+            status = "archived"
+        }, JsonOptions));
     }
 
     private async Task<Conversation> ResolveConversationAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
@@ -400,6 +400,92 @@ public sealed class ConversationToolTests
         return args;
     }
 
+    // --- Archive action tests (#700) ---
+
+    [Fact]
+    public async Task Archive_SetsConversationStatusToArchived()
+    {
+        var store = new InMemoryConversationStore();
+        var conversation = await store.CreateAsync(CreateConversation("agent-a", "Old Chat", null));
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), conversation.ConversationId);
+
+        var result = await tool.ExecuteAsync("call-1", Args("archive"));
+        var text = ReadText(result);
+
+        text.ShouldContain("archived");
+
+        var updated = await store.GetAsync(conversation.ConversationId);
+        updated.ShouldNotBeNull();
+        updated.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    [Fact]
+    public async Task Archive_WithExplicitConversationId_ArchivesCorrectConversation()
+    {
+        var store = new InMemoryConversationStore();
+        var conv1 = await store.CreateAsync(CreateConversation("agent-a", "Keep", null));
+        var conv2 = await store.CreateAsync(CreateConversation("agent-a", "Remove", null));
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), conv1.ConversationId);
+
+        await tool.ExecuteAsync("call-1", Args("archive", conversationId: conv2.ConversationId.Value));
+
+        var kept = await store.GetAsync(conv1.ConversationId);
+        var removed = await store.GetAsync(conv2.ConversationId);
+        kept.ShouldNotBeNull();
+        kept.Status.ShouldBe(ConversationStatus.Active);
+        removed.ShouldNotBeNull();
+        removed.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    [Fact]
+    public async Task Archive_OwnAccess_DeniesOtherAgentConversation()
+    {
+        var store = new InMemoryConversationStore();
+        var conversation = await store.CreateAsync(CreateConversation("agent-b", "Secret", null));
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.Own);
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("archive", conversationId: conversation.ConversationId.Value));
+
+        await act.ShouldThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task Archive_AllAccess_CanArchiveOtherAgentConversation()
+    {
+        var store = new InMemoryConversationStore();
+        var conversation = await store.CreateAsync(CreateConversation("agent-b", "Old", null));
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.All);
+
+        await tool.ExecuteAsync("call-1", Args("archive", conversationId: conversation.ConversationId.Value));
+
+        var updated = await store.GetAsync(conversation.ConversationId);
+        updated.ShouldNotBeNull();
+        updated.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    [Fact]
+    public async Task Archive_NonExistentConversation_ThrowsKeyNotFoundException()
+    {
+        var store = new InMemoryConversationStore();
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.Own);
+        var fakeId = ConversationId.Create();
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("archive", conversationId: fakeId.Value));
+
+        await act.ShouldThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task PrepareArguments_ArchiveAction_IsAccepted()
+    {
+        var store = new InMemoryConversationStore();
+        var tool = new ConversationTool(store, AgentId.From("agent-a"));
+
+        // Should not throw
+        var result = await tool.PrepareArgumentsAsync(Args("archive"));
+        result.ShouldNotBeNull();
+    }
+
     private static string ReadText(AgentToolResult result)
         => result.Content.Single(c => c.Type == AgentToolContentType.Text).Value;
 }


### PR DESCRIPTION
Closes #700

## Summary

Wires IConversationStore.ArchiveAsync into ConversationTool via a new archive action. All store implementations (InMemoryConversationStore, FileConversationStore, SqliteConversationStore) already implemented ArchiveAsync correctly. The tool was the only missing link.

## Changes

- ConversationTool.cs:
  - Added archive to the Definition JSON schema enum list
  - Added archive to PrepareArgumentsAsync validation
  - Added archive case to ExecuteAsync switch
  - New ArchiveAsync handler: resolves conversation, checks access via EnsureCanAccess, calls conversationStore.ArchiveAsync, returns JSON confirmation
  - Updated tool description to mention archive
- ConversationToolTests.cs: 6 new tests
  - Archive_SetsConversationStatusToArchived
  - Archive_WithExplicitConversationId_ArchivesCorrectConversation
  - Archive_OwnAccess_DeniesOtherAgentConversation
  - Archive_AllAccess_CanArchiveOtherAgentConversation
  - Archive_NonExistentConversation_ThrowsKeyNotFoundException
  - PrepareArguments_ArchiveAction_IsAccepted

## Test Results

- ConversationToolTests: 22/22 pass (16 pre-existing + 6 new)
- Architecture tests: 167/167 pass

## Merge Notes

No file overlap with #816 or #817. Safe to merge in any order.