### PR TITLE
fix(gateway): isolate session transcript save from channel send delivery

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -614,10 +614,36 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
 
                 if (!sessionSaved)
                 {
+                    // Isolate transcript write from delivery success: a SaveAsync failure
+                    // must not propagate as a delivery failure — the channel send already
+                    // succeeded and retrying the outer operation would duplicate the reply
+                    // to the user. Log a warning and continue (#756).
                     using var saveActivity = GatewayDiagnostics.Source.StartActivity("session.save", ActivityKind.Internal);
                     saveActivity?.SetTag("botnexus.session.id", session.SessionId);
                     saveActivity?.SetTag("botnexus.agent.id", session.AgentId);
-                    await _sessions.SaveAsync(session, cancellationToken);
+                    try
+                    {
+                        await _sessions.SaveAsync(session, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        // Suppress: session is shutting down. Transcript loss is acceptable
+                        // on clean cancellation; no retry, no duplicate send.
+                        _logger.LogDebug(
+                            "Session transcript save skipped (cancellation) for session '{SessionId}'",
+                            sessionId);
+                    }
+                    catch (Exception saveEx)
+                    {
+                        // Delivery succeeded; log the transcript failure as a warning only.
+                        // The caller must NOT retry the outer operation — the channel send
+                        // already reached the user.
+                        _logger.LogWarning(
+                            saveEx,
+                            "Session transcript save failed after successful channel send for session '{SessionId}'. " +
+                            "Delivery was successful; transcript may be missing the last assistant turn.",
+                            sessionId);
+                    }
                 }
 
                 // Outbound fan-out: deliver response to other bindings in the conversation

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -2000,5 +2000,152 @@ public sealed class GatewayHostTests
                 It.IsAny<CancellationToken>()),
             Times.Once); // exactly once as the primary channel, not doubled via observer fan-out
     }
+
+    // #756 — transcript mirror isolation: SaveAsync failures after a successful channel send
+    // must NOT propagate as delivery failures (which could trigger duplicate retries).
+
+    [Fact]
+    public async Task DispatchAsync_WhenSaveAsyncThrows_DoesNotPropagateException_AndChannelSendSucceeded()
+    {
+        // Arrange: agent responds, channel send succeeds, but SaveAsync (transcript write) throws.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+        var handle = CreatePromptHandle("agent-a", "session-1", "agent-response");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-1"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-a")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        var saveCallCount = 0;
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns<GatewaySession, CancellationToken>((_, _) =>
+            {
+                saveCallCount++;
+                // First two saves succeed (write-ahead user message + crash sentinel);
+                // the transcript save after channel send throws.
+                if (saveCallCount >= 3)
+                    throw new InvalidOperationException("Simulated transcript write failure");
+                return Task.CompletedTask;
+            });
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        var activity = new RecordingActivityBroadcaster();
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object, activity,
+            CreateChannelManager(channel.Object));
+
+        // Act: should NOT throw even though SaveAsync threw on the 3rd call.
+        await host.DispatchAsync(CreateMessage("hello", sessionId: "session-1"));
+
+        // Assert: channel send was called (delivery happened).
+        channel.Verify(c => c.SendAsync(
+            It.Is<OutboundMessage>(m => m.Content == "agent-response"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        // AgentCompleted activity published (turn completed despite transcript failure).
+        activity.Activities.Select(a => a.Type).ShouldContain(GatewayActivityType.AgentCompleted);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenSaveAsyncThrowsException_ChannelSendCalledExactlyOnce()
+    {
+        // Verify no duplicate send occurs when SaveAsync fails: the channel must see exactly
+        // one SendAsync call, proving the transcript failure did not trigger a retry path.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-b"]);
+        var handle = CreatePromptHandle("agent-b", "session-2", "only-once");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-b"),
+                BotNexus.Domain.Primitives.SessionId.From("session-2"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-2"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-b")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-2"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-b"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        var saveCallCount = 0;
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns<GatewaySession, CancellationToken>((_, _) =>
+            {
+                saveCallCount++;
+                if (saveCallCount >= 3)
+                    throw new IOException("Disk full - transcript write failed");
+                return Task.CompletedTask;
+            });
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object,
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(CreateMessage("hello", sessionId: "session-2"));
+
+        // Channel send must be called exactly once — no duplicate.
+        channel.Verify(c => c.SendAsync(
+            It.IsAny<OutboundMessage>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenSaveAsyncSucceeds_NormalBehaviourUnchanged()
+    {
+        // Regression guard: ensure the happy path still records history and completes normally.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-c"]);
+        var handle = CreatePromptHandle("agent-c", "session-3", "normal-response");
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-c"),
+                BotNexus.Domain.Primitives.SessionId.From("session-3"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        var session = new GatewaySession
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("session-3"),
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-c")
+        };
+        var sessions = new Mock<ISessionStore>();
+        sessions.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.SessionId.From("session-3"),
+                BotNexus.Domain.Primitives.AgentId.From("agent-c"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        sessions.Setup(s => s.SaveAsync(session, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        var activity = new RecordingActivityBroadcaster();
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, sessions.Object, activity,
+            CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(CreateMessage("hello", sessionId: "session-3"));
+
+        channel.Verify(c => c.SendAsync(
+            It.Is<OutboundMessage>(m => m.Content == "normal-response"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        session.History.Select(e => $"{e.Role}:{e.Content}").ToList()
+            .ShouldBe(["user:hello", "assistant:normal-response"]);
+        activity.Activities.Select(a => a.Type).ShouldContain(GatewayActivityType.AgentCompleted);
+    }
 }
 


### PR DESCRIPTION
Closes #756

## Problem
In the non-streaming agent turn path, SaveAsync is called after channel.SendAsync to persist the session transcript. If SaveAsync throws, the exception propagates to the outer catch handler which logs an error and sends an error reply to the user. This means:

- The original response was already delivered successfully.
- The error reply creates a confusing second message.
- Any retry mechanism would send the full agent response a second time.

## Fix
Wrap the post-send SaveAsync in its own try/catch:
- OperationCanceledException (clean shutdown): log at Debug, continue.
- Any other exception: log at Warning noting delivery succeeded, continue.

The streaming path (sessionSaved = true) is unaffected.

## Tests
3 new unit tests in GatewayHostTests.cs:
- DispatchAsync_WhenSaveAsyncThrows_DoesNotPropagateException_AndChannelSendSucceeded
- DispatchAsync_WhenSaveAsyncThrowsException_ChannelSendCalledExactlyOnce
- DispatchAsync_WhenSaveAsyncSucceeds_NormalBehaviourUnchanged

44/44 GatewayHostTests pass.

## Merge Notes
Independent -- touches only GatewayHost.cs and GatewayHostTests.cs. Safe to merge in any order with other open PRs.
