### PR TITLE
fix(portal): route TurnEnd event through SignalR to clear streaming state on tool-only turns

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -40,6 +40,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnError += HandleError;
         _hub.OnUserInputRequired += HandleUserInputRequired;
         _hub.OnTurnInterrupted += HandleTurnInterrupted;
+        _hub.OnTurnEnd += HandleTurnEnd;
         _hub.OnSessionReset += HandleSessionReset;
         _hub.OnSubAgentSpawned += HandleSubAgentSpawned;
         _hub.OnSubAgentCompleted += HandleSubAgentCompleted;
@@ -333,6 +334,38 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         }
 
         _store.NotifyChanged();
+    }
+
+    /// <summary>
+    /// Handles a <c>TurnEnd</c> event: the agent turn completed fully.
+    /// For tool-only turns (NO_REPLY or agent runs that only call tools and return nothing),
+    /// no <c>MessageEnd</c> is sent, so IsStreaming may still be true. TurnEnd is the
+    /// reliable signal to clear it (#668).
+    /// </summary>
+    public void HandleTurnEnd(AgentStreamEvent evt)
+    {
+        if (!ResolveAgent(evt.SessionId, out var agentId, out var agent, evt.ConversationId)) return;
+
+        // Only take action if still streaming -- if MessageEnd already cleared it, this is a no-op.
+        if (!agent.IsStreaming) return;
+
+        var convId = ResolveConversationId(agentId!, agent!, evt.SessionId, evt.ConversationId)
+            ?? agent!.ActiveConversationId;
+        if (convId is not null && agent.Conversations.GetValueOrDefault(convId) is { } conv)
+        {
+            // A tool-only turn may have buffered content (e.g. a partial NO_REPLY).
+            // Clear it without adding a message -- the turn produced no user-visible output.
+            conv.StreamState.Buffer = "";
+            conv.StreamState.ThinkingBuffer = "";
+            conv.StreamState.IsStreaming = false;
+        }
+
+        agent.IsStreaming = false;
+        agent.ProcessingStage = null;
+        _store.NotifyChanged();
+
+        // Drain any deferred conversation refreshes (same as MessageEnd path).
+        DrainPendingConversationRefreshes(agentId!);
     }
     public void HandleUserInputRequired(AgentStreamEvent evt)
     {
@@ -868,6 +901,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnError -= HandleError;
         _hub.OnUserInputRequired -= HandleUserInputRequired;
         _hub.OnTurnInterrupted -= HandleTurnInterrupted;
+        _hub.OnTurnEnd -= HandleTurnEnd;
         _hub.OnSessionReset -= HandleSessionReset;
         _hub.OnSubAgentSpawned -= HandleSubAgentSpawned;
         _hub.OnSubAgentCompleted -= HandleSubAgentCompleted;
@@ -881,4 +915,5 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnDisconnected -= HandleDisconnected;
     }
 }
+
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
@@ -46,6 +46,9 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     /// <summary>Raised when the gateway notifies that a previous turn was interrupted by a restart.</summary>
     public event Action<AgentStreamEvent>? OnTurnInterrupted;
 
+    /// <summary>Raised when the agent turn has fully completed (including tool-only turns that produce no MessageEnd).</summary>
+    public event Action<AgentStreamEvent>? OnTurnEnd;
+
     /// <summary>Raised when a sub-agent is spawned.</summary>
     public event Action<SubAgentEventPayload>? OnSubAgentSpawned;
 
@@ -118,6 +121,7 @@ public sealed class GatewayHubConnection : IAsyncDisposable
         _connection.On<AgentStreamEvent>("Error", e => OnError?.Invoke(e));
         _connection.On<AgentStreamEvent>("UserInputRequired", e => OnUserInputRequired?.Invoke(e));
         _connection.On<AgentStreamEvent>("TurnInterrupted", e => OnTurnInterrupted?.Invoke(e));
+        _connection.On<AgentStreamEvent>("TurnEnd", e => OnTurnEnd?.Invoke(e));
         _connection.On<SubAgentEventPayload>("SubAgentSpawned", p => OnSubAgentSpawned?.Invoke(p));
         _connection.On<SubAgentEventPayload>("SubAgentCompleted", p => OnSubAgentCompleted?.Invoke(p));
         _connection.On<SubAgentEventPayload>("SubAgentFailed", p => OnSubAgentFailed?.Invoke(p));

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
@@ -30,4 +30,7 @@ public interface IGatewayHubClient
 
     /// <summary>Server notifies the client that a gateway restart interrupted its active agent turn.</summary>
     Task TurnInterrupted(AgentStreamEvent evt);
+
+    /// <summary>Server signals that the agent turn has fully completed (all tool calls done, no more events).</summary>
+    Task TurnEnd(AgentStreamEvent evt);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRChannelAdapter.cs
@@ -112,6 +112,10 @@ public sealed class SignalRChannelAdapter(ILogger<SignalRChannelAdapter> logger,
             AgentStreamEventType.Error => client.Error(enrichedEvent),
             AgentStreamEventType.UserInputRequired => client.UserInputRequired(enrichedEvent),
             AgentStreamEventType.TurnInterrupted => client.TurnInterrupted(enrichedEvent),
+            // TurnEnd is emitted when the agent's full turn completes (including tool-only turns
+            // where no MessageEnd is sent). Without this, the portal never clears IsStreaming
+            // for tool-only cron or background turns, leaving a permanent spinner (#668).
+            AgentStreamEventType.TurnEnd => client.TurnEnd(enrichedEvent),
             _ => Task.CompletedTask
         };
     }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -775,4 +775,64 @@ public sealed class GatewayEventHandlerTests
         Assert.Equal(originalUpdatedAt, conv.UpdatedAt);
     }
 
+
+    // #668 - TurnEnd: portal should clear IsStreaming on tool-only turns
+    // that emit no MessageEnd.
+
+    [Fact]
+    public void HandleTurnEnd_WhenStillStreaming_ClearsStreamingState()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+
+        // Simulate a tool-only turn in progress.
+        agent.IsStreaming = true;
+        agent.ProcessingStage = "Running tools";
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "partial";
+        conv.StreamState.ThinkingBuffer = "thinking";
+
+        _handler.HandleTurnEnd(new AgentStreamEvent { SessionId = "sess-1", ConversationId = "conv-1" });
+
+        Assert.False(agent.IsStreaming);
+        Assert.Null(agent.ProcessingStage);
+        Assert.False(conv.StreamState.IsStreaming);
+        Assert.Equal("", conv.StreamState.Buffer);
+        Assert.Equal("", conv.StreamState.ThinkingBuffer);
+    }
+
+    [Fact]
+    public void HandleTurnEnd_WhenNotStreaming_IsNoOp()
+    {
+        // If MessageEnd already cleared IsStreaming, HandleTurnEnd should be a no-op.
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = false;
+        conv.StreamState.IsStreaming = false;
+        var msgCountBefore = conv.Messages.Count;
+
+        _handler.HandleTurnEnd(new AgentStreamEvent { SessionId = "sess-1", ConversationId = "conv-1" });
+
+        Assert.False(agent.IsStreaming);
+        Assert.Equal(msgCountBefore, conv.Messages.Count); // no phantom message added
+    }
+
+    [Fact]
+    public void HandleTurnEnd_ToolOnlyTurn_DoesNotAddVisibleMessage()
+    {
+        // Tool-only turns (e.g. cron NO_REPLY) should NOT add any user-visible message.
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "NO_REPLY";
+        var msgCountBefore = conv.Messages.Count;
+
+        _handler.HandleTurnEnd(new AgentStreamEvent { SessionId = "sess-1", ConversationId = "conv-1" });
+
+        // Streaming cleared, no new message added.
+        Assert.False(agent.IsStreaming);
+        Assert.Equal(msgCountBefore, conv.Messages.Count);
+    }
+
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRChannelAdapterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRChannelAdapterTests.cs
@@ -82,4 +82,37 @@ public sealed class SignalRChannelAdapterTests
                 It.Is<AgentStreamEvent>(evt => evt.Type == AgentStreamEventType.UserInputRequired)),
             Times.Once);
     }
+
+    [Fact]
+    public async Task SendStreamEventAsync_TurnEnd_RoutesToConversationGroupAndCallsTurnEnd()
+    {
+        // #668: TurnEnd must be forwarded to the SignalR group so the portal clears
+        // IsStreaming on tool-only turns that produce no MessageEnd.
+        var clientProxy = new Mock<IGatewayHubClient>();
+        clientProxy.Setup(proxy => proxy.TurnEnd(It.IsAny<AgentStreamEvent>()))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubClients<IGatewayHubClient>>();
+        clients.Setup(value => value.Group("conversation:conv-2")).Returns(clientProxy.Object);
+
+        var hubContext = new Mock<IHubContext<GatewayHub, IGatewayHubClient>>();
+        hubContext.SetupGet(value => value.Clients).Returns(clients.Object);
+
+        var adapter = new SignalRChannelAdapter(NullLogger<SignalRChannelAdapter>.Instance, hubContext.Object);
+        var target = new ChannelStreamTarget(
+            ConversationId.From("conv-2"),
+            SessionId.From("sess-2"),
+            ChannelAddress.From("addr-2"),
+            null);
+
+        var streamEvent = new AgentStreamEvent { Type = AgentStreamEventType.TurnEnd };
+        await adapter.SendStreamEventAsync(target, streamEvent);
+
+        // TurnEnd must route to the conversation group and call TurnEnd on the client.
+        clientProxy.Verify(proxy => proxy.TurnEnd(It.Is<AgentStreamEvent>(evt =>
+            evt.Type == AgentStreamEventType.TurnEnd &&
+            evt.ConversationId == ConversationId.From("conv-2") &&
+            evt.SessionId == SessionId.From("sess-2"))), Times.Once);
+    }
+
 }


### PR DESCRIPTION
Closes #668

## Problem
`TurnEnd` events were silently dropped in `SignalRChannelAdapter.SendStreamEventAsync` (fell to the `_ => Task.CompletedTask` default). For tool-only cron or background turns — where the agent calls tools, returns NO_REPLY, and never emits `MessageEnd` — the portal never received a signal to clear `IsStreaming`. Result: a permanent spinning indicator in the UI until the user refreshed.

## Changes

- `IGatewayHubClient`: add `TurnEnd(AgentStreamEvent)` method
- `SignalRChannelAdapter.SendStreamEventAsync`: route `AgentStreamEventType.TurnEnd` to `client.TurnEnd()`
- `GatewayHubConnection`: add `OnTurnEnd` event + `.On<AgentStreamEvent>("TurnEnd", ...)` registration
- `GatewayEventHandler`: subscribe `OnTurnEnd`, implement `HandleTurnEnd` to clear `IsStreaming`/`ProcessingStage` when still streaming (no-op when already clear); unsubscribe in `Dispose`

## Tests
4 new tests:
- `HandleTurnEnd_WhenStillStreaming_ClearsStreamingState` -- clears buffer, stream state, agent state
- `HandleTurnEnd_WhenNotStreaming_IsNoOp` -- no phantom message added when already clear
- `HandleTurnEnd_ToolOnlyTurn_DoesNotAddVisibleMessage` -- NO_REPLY buffer not emitted as a message
- `SendStreamEventAsync_TurnEnd_RoutesToConversationGroupAndCallsTurnEnd` -- adapter routes to correct group

38/38 GatewayEventHandlerTests pass. 3/3 SignalRChannelAdapterTests pass.

## Merge Notes
Independent -- touches SignalR extension and BlazorClient.Core only.
No file overlap with any open PR. Safe to merge in any order with #826.
