### PR TITLE
fix(portal): wrap async agent-switch assertion in WaitForAssertion

### DIFF
--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -532,8 +532,11 @@ public sealed class MainLayoutTests : IDisposable
         var dropdown = cut.Find(".agent-dropdown-select");
         dropdown.Change("a-2");
 
-        // Assert: SelectConversationAsync was called for Beta's auto-selected conversation
-        _interaction.Received(1).SelectConversationAsync("a-2", "c-2");
+        // Assert: SelectConversationAsync was called for Beta's auto-selected conversation.
+        // OnAgentSelected is async -- wrap in WaitForAssertion so bUnit waits for the async
+        // event handler to complete before asserting. Without this, the assertion can race
+        // the async continuation on slow CI runners and report a false negative (#828).
+        cut.WaitForAssertion(() => _interaction.Received(1).SelectConversationAsync("a-2", "c-2"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #828

## Problem
`MainLayoutTests.Switching_agent_triggers_history_load_for_active_conversation` failed intermittently on the CI Linux runner with:

`
NSubstitute.Exceptions.ReceivedCallsException: Expected to receive exactly 1 call matching:
    SelectConversationAsync("a-2", "c-2")
Actually received no matching calls.
`

## Root Cause
`OnAgentSelected` is `async Task`. bUnit fires the `@onchange` event synchronously but does not await the async handler before returning. The NSubstitute `Received(1)` assertion ran immediately after `dropdown.Change("a-2")` -- before the async continuation had a chance to execute on a loaded CI Linux runner.

Windows (and fast CI) masks the race because NSubstitute's synchronous tasks complete before the assertion. Linux CI under load does not.

## Fix
Wrapped the assertion in `cut.WaitForAssertion(...)` so bUnit pumps the Blazor render cycle and retries until the async event handler completes (or 1s timeout). This is the correct bUnit pattern for assertions that depend on async event handler completion.

## Changes
- `MainLayoutTests.cs`: wrap `_interaction.Received(1).SelectConversationAsync` in `cut.WaitForAssertion`

## Merge Notes
Safe to merge in any order -- touches one test file only, no overlap with #827 or any other open PR.