### PR TITLE
fix(cli): distinguish auth failure from unreachable in gateway status

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
@@ -1,4 +1,4 @@
-using System.CommandLine;
+﻿using System.CommandLine;
 using BotNexus.Cli.Services;
 using BotNexus.Gateway.Configuration;
 using Spectre.Console;
@@ -347,9 +347,38 @@ internal sealed class GatewayCommand
         switch (status.State)
         {
             case GatewayState.Running when status.Pid.HasValue:
+                if (status.ProbeResult == GatewayProbeResult.ReachableNoAuth)
+                {
+                    // Process is alive but gateway is rejecting requests with 401/403.
+                    // Distinguish clearly from healthy -- user needs to fix auth config.
+                    if (interactive)
+                    {
+                        var authContent =
+                            $"[yellow]\u25cf Running (auth error)[/]\n\n" +
+                            $"[dim]PID:[/]    [yellow]{status.Pid.Value}[/]\n" +
+                            (status.Uptime.HasValue ? $"[dim]Uptime:[/] [dim]{FormatUptime(status.Uptime.Value)}[/]\n" : string.Empty) +
+                            "[yellow]Warning:[/] Gateway returned HTTP 401/403 -- API token may be missing or invalid.\n" +
+                            "[dim]Check your config.json apiKey or set BOTNEXUS_API_KEY if required.[/]";
+                        AnsiConsole.Write(new Panel(authContent.TrimEnd())
+                        {
+                            Border = BoxBorder.Rounded,
+                            Padding = new Padding(1, 0)
+                        });
+                    }
+                    else
+                    {
+                        AnsiConsole.MarkupLine($"[yellow]\u25cf[/] Gateway is running (auth error)");
+                        AnsiConsole.MarkupLine($"  PID:    [yellow]{status.Pid.Value}[/]");
+                        if (status.Uptime.HasValue)
+                            AnsiConsole.MarkupLine($"  Uptime: [dim]{FormatUptime(status.Uptime.Value)}[/]");
+                        AnsiConsole.MarkupLine("[yellow]Warning:[/] Gateway returned HTTP 401/403 -- API token may be missing or invalid.");
+                    }
+                    return 2; // distinct exit code: running but not authenticated
+                }
+
                 if (interactive)
                 {
-                    var content = $"[green]● Running[/]\n\n" +
+                    var content = $"[green]\u25cf Running[/]\n\n" +
                         $"[dim]PID:[/]    [yellow]{status.Pid.Value}[/]\n" +
                         (status.Uptime.HasValue ? $"[dim]Uptime:[/] [dim]{FormatUptime(status.Uptime.Value)}[/]" : string.Empty);
                     AnsiConsole.Write(new Panel(content.TrimEnd())
@@ -360,7 +389,7 @@ internal sealed class GatewayCommand
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine($"[green]●[/] Gateway is running");
+                    AnsiConsole.MarkupLine($"[green]\u25cf[/] Gateway is running");
                     AnsiConsole.MarkupLine($"  PID:    [yellow]{status.Pid.Value}[/]");
                     if (status.Uptime.HasValue)
                         AnsiConsole.MarkupLine($"  Uptime: [dim]{FormatUptime(status.Uptime.Value)}[/]");

--- a/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
+++ b/src/gateway/BotNexus.Cli/Services/GatewayProcessManager.cs
@@ -19,17 +19,23 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
     // Allows tests to inject a custom WaitForExit implementation to simulate timeout scenarios
     // without relying on OS-level process termination timing.
     private readonly Func<Process, int, bool>? _waitForExitOverride;
+    // Injectable HttpClient for status probe -- allows tests to mock HTTP responses.
+    private readonly HttpClient _probeClient;
+    // Default health URL used for status probing when no override is provided.
+    internal const string DefaultHealthUrl = "http://localhost:5005/health";
 
     public GatewayProcessManager(
         IHealthChecker healthChecker,
         ILogger<GatewayProcessManager> logger,
         TimeSpan? waitForExitTimeout = null,
-        Func<Process, int, bool>? waitForExitOverride = null)
+        Func<Process, int, bool>? waitForExitOverride = null,
+        HttpClient? probeClient = null)
     {
         _healthChecker = healthChecker;
         _logger = logger;
         _waitForExitTimeout = waitForExitTimeout ?? TimeSpan.FromSeconds(5);
         _waitForExitOverride = waitForExitOverride;
+        _probeClient = probeClient ?? new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
     }
 
     /// <summary>
@@ -362,13 +368,64 @@ public sealed class GatewayProcessManager : IGatewayProcessManager
             _logger.LogDebug("Cannot read start time for PID {Pid}", pid.Value);
         }
 
+        // Probe the gateway HTTP endpoint to distinguish running+authenticated vs
+        // running+no-auth (returns 401/403) vs running+unreachable (wrong port/not bound).
+        var probeResult = await ProbeGatewayAsync(DefaultHealthUrl, CancellationToken.None);
+
+        var message = probeResult switch
+        {
+            GatewayProbeResult.Healthy => uptime.HasValue
+                ? $"Running for {uptime.Value:hh\\:mm\\:ss}"
+                : "Running (uptime unknown)",
+            GatewayProbeResult.ReachableNoAuth =>
+                "Running but authentication is not configured or token is invalid (HTTP 401/403)",
+            GatewayProbeResult.Unreachable =>
+                "Running (process alive) but HTTP endpoint is not reachable at the default port",
+            _ => "Running (probe inconclusive)"
+        };
+
         return new GatewayStatus(
             State: GatewayState.Running,
             Pid: pid.Value,
             Uptime: uptime,
-            Message: uptime.HasValue
-                ? $"Running for {uptime.Value:hh\\:mm\\:ss}"
-                : "Running (uptime unknown)");
+            Message: message,
+            ProbeResult: probeResult);
+    }
+
+    /// <summary>
+    /// Probes the gateway HTTP health endpoint and classifies the response.
+    /// Returns <see cref="GatewayProbeResult.Healthy"/> on 2xx,
+    /// <see cref="GatewayProbeResult.ReachableNoAuth"/> on 401/403,
+    /// and <see cref="GatewayProbeResult.Unreachable"/> on connection failure or timeout.
+    /// </summary>
+    internal async Task<GatewayProbeResult> ProbeGatewayAsync(string healthUrl, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _probeClient.GetAsync(healthUrl, cancellationToken);
+            if (response.IsSuccessStatusCode)
+                return GatewayProbeResult.Healthy;
+
+            var status = (int)response.StatusCode;
+            if (status == 401 || status == 403)
+            {
+                _logger.LogDebug("Gateway health probe returned {StatusCode} -- auth not configured", status);
+                return GatewayProbeResult.ReachableNoAuth;
+            }
+
+            _logger.LogDebug("Gateway health probe returned unexpected status {StatusCode}", status);
+            return GatewayProbeResult.Healthy; // reachable, treat as healthy for status purposes
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug("Gateway health probe connection failed: {Message}", ex.Message);
+            return GatewayProbeResult.Unreachable;
+        }
+        catch (TaskCanceledException)
+        {
+            _logger.LogDebug("Gateway health probe timed out");
+            return GatewayProbeResult.Unreachable;
+        }
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Cli/Services/GatewayProcessTypes.cs
+++ b/src/gateway/BotNexus.Cli/Services/GatewayProcessTypes.cs
@@ -49,15 +49,30 @@ public enum GatewayState
 }
 
 /// <summary>
+/// Result of a health probe against a running gateway HTTP endpoint.
+/// </summary>
+public enum GatewayProbeResult
+{
+    /// <summary>Probe succeeded: gateway is reachable and authenticated.</summary>
+    Healthy,
+    /// <summary>Gateway is reachable but returned an auth error (401/403). Token missing or invalid.</summary>
+    ReachableNoAuth,
+    /// <summary>Gateway process is running but the HTTP endpoint is not reachable (wrong port, not bound yet).</summary>
+    Unreachable,
+}
+
+/// <summary>
 /// Current status of the gateway process.
 /// </summary>
 /// <param name="State">Current lifecycle state.</param>
 /// <param name="Pid">Process ID, if running.</param>
 /// <param name="Uptime">How long the gateway has been running, if known.</param>
 /// <param name="Message">Diagnostic message with additional context.</param>
+/// <param name="ProbeResult">HTTP probe result when process is alive; null when gateway is not running.</param>
 public record GatewayStatus(
     GatewayState State,
     int? Pid,
     TimeSpan? Uptime,
-    string? Message
+    string? Message,
+    GatewayProbeResult? ProbeResult = null
 );

--- a/tests/gateway/BotNexus.Cli.Tests/Services/GatewayProcessManagerProbeTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Services/GatewayProcessManagerProbeTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using BotNexus.Cli.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace BotNexus.Cli.Tests.Services;
+
+/// <summary>
+/// Tests for the HTTP probe logic in GatewayProcessManager that distinguishes
+/// auth failures from unreachable endpoints (#757).
+/// </summary>
+public sealed class GatewayProcessManagerProbeTests
+{
+    private static GatewayProcessManager CreateManagerWithHandler(DelegatingHandler handler) =>
+        new(
+            Substitute.For<IHealthChecker>(),
+            NullLogger<GatewayProcessManager>.Instance,
+            probeClient: new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(3) });
+
+    [Fact]
+    public async Task ProbeGatewayAsync_Returns_Healthy_On_200_Response()
+    {
+        var handler = new FakeHttpHandler(HttpStatusCode.OK);
+        var manager = CreateManagerWithHandler(handler);
+
+        var result = await manager.ProbeGatewayAsync(GatewayProcessManager.DefaultHealthUrl, CancellationToken.None);
+
+        Assert.Equal(GatewayProbeResult.Healthy, result);
+    }
+
+    [Fact]
+    public async Task ProbeGatewayAsync_Returns_ReachableNoAuth_On_401_Response()
+    {
+        var handler = new FakeHttpHandler(HttpStatusCode.Unauthorized);
+        var manager = CreateManagerWithHandler(handler);
+
+        var result = await manager.ProbeGatewayAsync(GatewayProcessManager.DefaultHealthUrl, CancellationToken.None);
+
+        Assert.Equal(GatewayProbeResult.ReachableNoAuth, result);
+    }
+
+    [Fact]
+    public async Task ProbeGatewayAsync_Returns_ReachableNoAuth_On_403_Response()
+    {
+        var handler = new FakeHttpHandler(HttpStatusCode.Forbidden);
+        var manager = CreateManagerWithHandler(handler);
+
+        var result = await manager.ProbeGatewayAsync(GatewayProcessManager.DefaultHealthUrl, CancellationToken.None);
+
+        Assert.Equal(GatewayProbeResult.ReachableNoAuth, result);
+    }
+
+    [Fact]
+    public async Task ProbeGatewayAsync_Returns_Unreachable_On_HttpRequestException()
+    {
+        var handler = new ThrowingHttpHandler(new HttpRequestException("Connection refused"));
+        var manager = CreateManagerWithHandler(handler);
+
+        var result = await manager.ProbeGatewayAsync("http://localhost:9999/health", CancellationToken.None);
+
+        Assert.Equal(GatewayProbeResult.Unreachable, result);
+    }
+
+    [Fact]
+    public async Task ProbeGatewayAsync_Returns_Unreachable_On_Timeout()
+    {
+        var handler = new ThrowingHttpHandler(new TaskCanceledException("timeout"));
+        var manager = CreateManagerWithHandler(handler);
+
+        var result = await manager.ProbeGatewayAsync("http://localhost:9999/health", CancellationToken.None);
+
+        Assert.Equal(GatewayProbeResult.Unreachable, result);
+    }
+
+    [Fact]
+    public async Task ProbeGatewayAsync_Returns_Healthy_On_Non_Auth_Non_2xx_Response()
+    {
+        // Non-2xx responses that are NOT 401/403 (e.g. 503 Service Unavailable) are treated
+        // as Healthy from the auth-distinction perspective -- gateway is reachable, just unhealthy.
+        var handler = new FakeHttpHandler(HttpStatusCode.ServiceUnavailable);
+        var manager = CreateManagerWithHandler(handler);
+
+        var result = await manager.ProbeGatewayAsync(GatewayProcessManager.DefaultHealthUrl, CancellationToken.None);
+
+        Assert.Equal(GatewayProbeResult.Healthy, result);
+    }
+
+    /// <summary>
+    /// A simple delegating handler that returns a fixed HTTP status code.
+    /// </summary>
+    private sealed class FakeHttpHandler(HttpStatusCode statusCode) : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(statusCode));
+    }
+
+    /// <summary>
+    /// A delegating handler that throws a specified exception to simulate connection failures.
+    /// </summary>
+    private sealed class ThrowingHttpHandler(Exception ex) : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromException<HttpResponseMessage>(ex);
+    }
+}


### PR DESCRIPTION
Closes #757

## Problem
`botnexus gateway status` only checks if the gateway process is alive (via PID file). If the process is running but the gateway is returning 401/403 (API token not configured), the command prints "Running" in green -- misleading operators into thinking the gateway is healthy when auth is broken.

## Fix
Added an HTTP probe to `GetStatusAsync` after confirming the process is alive:

- **200 / 2xx** → `Healthy` -- running and authenticated  
- **401 / 403** → `ReachableNoAuth` -- process running, but API token missing or invalid
- **Connection failure / timeout** → `Unreachable` -- process running but endpoint not reachable (wrong port or not bound yet)

The `status` command now:
- Shows a **yellow warning panel** for `ReachableNoAuth` with "Check your config.json apiKey..."
- Returns **exit code 2** (running but not authenticated) vs 0 (healthy) vs 1 (not running) -- scripts can now detect the auth-error state

## Changes
- `GatewayProcessTypes.cs`: add `GatewayProbeResult` enum (`Healthy`, `ReachableNoAuth`, `Unreachable`) + nullable `ProbeResult` field on `GatewayStatus`
- `GatewayProcessManager.cs`: inject optional `HttpClient` (injectable for tests), add `ProbeGatewayAsync(url)` helper, call it from `GetStatusAsync`
- `GatewayCommand.cs`: add yellow-warning branch for `ReachableNoAuth`, return exit code 2
- `GatewayProcessManagerProbeTests.cs`: 6 unit tests (200, 401, 403, connection-refused, timeout, non-2xx-non-auth)

## Merge Notes
Touches CLI only (`BotNexus.Cli.*` + `BotNexus.Cli.Tests`). No overlap with PR #827, #829, or any other open PR. Safe to merge in any order.

## Prior art
OpenClaw reference SHA: `d48b9274d819a369ed936bdcbee1ecdb42416703`