### PR TITLE
fix(gateway): replace blocking DispatchAsync with Post in ConversationTool

### DIFF
--- a/src/gateway/BotNexus.Gateway.Dispatching/DefaultInboundMessageOrchestrator.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/DefaultInboundMessageOrchestrator.cs
@@ -69,6 +69,24 @@ public sealed class DefaultInboundMessageOrchestrator : IInboundMessageOrchestra
         => AcceptAsync(message, cancellationToken);
 
     /// <inheritdoc />
+    public bool Post(InboundMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (!message.Sender.IsValid)
+        {
+            throw new ArgumentException(
+                $"InboundMessage.Sender must be a valid CitizenId; got default(CitizenId). " +
+                $"Channel '{message.ChannelType}' producer must populate it (see #526).",
+                nameof(message));
+        }
+
+        var queueKey = GetQueueKey(message);
+        var queueState = _sessionQueues.GetOrAdd(queueKey, CreateSessionQueueState);
+        var queueItem = new QueuedInboundMessage(message);
+        return queueState.Queue.Writer.TryWrite(queueItem);
+    }
+
+    /// <inheritdoc />
     public async Task<InboundDispatchResult> AcceptAsync(
         InboundMessage message,
         CancellationToken cancellationToken = default)

--- a/src/gateway/BotNexus.Gateway.Dispatching/IInboundMessageOrchestrator.cs
+++ b/src/gateway/BotNexus.Gateway.Dispatching/IInboundMessageOrchestrator.cs
@@ -45,4 +45,18 @@ public interface IInboundMessageOrchestrator
     /// list is populated only for <see cref="InboundDispatchStatus.Accepted"/>.
     /// </returns>
     Task<InboundDispatchResult> AcceptAsync(InboundMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fire-and-forget enqueue: writes the message onto the per-session queue and
+    /// returns immediately without awaiting the processing outcome. Use this when
+    /// the caller must not block on agent execution (e.g. the conversation tool
+    /// seeding a message into another agent's conversation).
+    /// </summary>
+    /// <param name="message">Inbound message from the transport layer.</param>
+    /// <returns>
+    /// <see langword="true"/> if the message was accepted onto the queue;
+    /// <see langword="false"/> if the queue was full (backpressure: caller may
+    /// surface a busy indication and ask the user to retry).
+    /// </returns>
+    bool Post(InboundMessage message);
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -19,6 +19,7 @@ using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Services;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Dispatching;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Agents;
@@ -170,8 +171,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             var conversationId = await ResolveConversationIdAsync(conversationStore, sessionStore, descriptor.AgentId, context.SessionId, cancellationToken)
                 .ConfigureAwait(false);
             var (conversationAccessLevel, conversationAllowedAgents) = ResolveConversationAccess(descriptor);
-            var conversationDispatcher = _serviceProvider.GetService<IChannelDispatcher>();
             var conversationChangeNotifier = _serviceProvider.GetService<IConversationChangeNotifier>();
+            var messageOrchestrator = _serviceProvider.GetService<IInboundMessageOrchestrator>();
             tools.Add(new ConversationTool(
                 conversationStore,
                 descriptor.AgentId,
@@ -179,7 +180,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 conversationAccessLevel,
                 conversationAllowedAgents,
                 sessionStore,
-                conversationDispatcher,
+                messageOrchestrator,
                 conversationChangeNotifier));
         }
 

--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -4,10 +4,10 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
-using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Dispatching;
 
 namespace BotNexus.Gateway.Tools;
 
@@ -22,7 +22,7 @@ public sealed class ConversationTool(
     ConversationAccessLevel accessLevel = ConversationAccessLevel.Own,
     IReadOnlyList<string>? allowedAgents = null,
     ISessionStore? sessionStore = null,
-    IChannelDispatcher? channelDispatcher = null,
+    IInboundMessageOrchestrator? messageOrchestrator = null,
     IConversationChangeNotifier? changeNotifier = null) : IAgentTool
 {
     public string Name => "conversation";
@@ -121,8 +121,8 @@ public sealed class ConversationTool(
         if (string.IsNullOrWhiteSpace(message))
             throw new ArgumentException("message must not be empty.");
 
-        if (channelDispatcher is null)
-            throw new InvalidOperationException("Channel dispatcher is required to send a message to a conversation.");
+        if (messageOrchestrator is null)
+            throw new InvalidOperationException("Message orchestrator is required to send a message to a conversation.");
 
         if (sessionStore is null)
             throw new InvalidOperationException("Session store is required to send a message to a conversation.");
@@ -157,7 +157,7 @@ public sealed class ConversationTool(
             await conversationStore.SaveAsync(conversation, ct).ConfigureAwait(false);
         }
 
-        await channelDispatcher.DispatchAsync(
+        messageOrchestrator.Post(
             new InboundMessage
             {
                 ChannelType = ChannelKey.From("internal"),
@@ -174,8 +174,7 @@ public sealed class ConversationTool(
                     ["messageType"] = "message",
                     ["source"] = "conversation-tool-message"
                 }
-            },
-            ct).ConfigureAwait(false);
+            });
 
         return TextResult(JsonSerializer.Serialize(new
         {
@@ -281,9 +280,11 @@ public sealed class ConversationTool(
 
             // Trigger agent turn: dispatch a synthetic inbound message so the agent
             // processes the seeded user message rather than it sitting silently in history.
-            if (channelDispatcher is not null)
+            // Post() is fire-and-forget so the calling agent is not blocked waiting for
+            // the spawned agent turn to complete (fixes #728).
+            if (messageOrchestrator is not null)
             {
-                await channelDispatcher.DispatchAsync(
+                messageOrchestrator.Post(
                     new InboundMessage
                     {
                         ChannelType = ChannelKey.From("internal"),
@@ -300,8 +301,7 @@ public sealed class ConversationTool(
                             ["messageType"] = "message",
                             ["source"] = "conversation-tool-new"
                         }
-                    },
-                    ct).ConfigureAwait(false);
+                    });
             }
         }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
-using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Dispatching;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Conversations;
@@ -152,13 +152,13 @@ public sealed class ConversationToolTests
         // Arrange
         var conversationStore = new InMemoryConversationStore();
         var sessionStore = new InMemorySessionStore();
-        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var orchestrator = Substitute.For<IInboundMessageOrchestrator>();
         var tool = new ConversationTool(
             conversationStore,
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: dispatcher);
+            messageOrchestrator: orchestrator);
 
         // Act
         var result = await tool.ExecuteAsync("call-1", Args(
@@ -172,15 +172,14 @@ public sealed class ConversationToolTests
         var activeSessionId = document.RootElement.GetProperty("activeSessionId").GetString()!;
 
         // Assert: dispatcher was called exactly once with the correct inbound message
-        await dispatcher.Received(1).DispatchAsync(
+        orchestrator.Received(1).Post(
             Arg.Is<InboundMessage>(m =>
                 m.RoutingHints != null &&
                 m.RoutingHints.RequestedAgentId != null && m.RoutingHints.RequestedAgentId.Value.Value == "nova" &&
                 m.Content == "Please investigate issue #285" &&
                 m.RoutingHints.RequestedSessionId != null && m.RoutingHints.RequestedSessionId.Value.Value == activeSessionId &&
                 m.RoutingHints.RequestedConversationId != null && m.RoutingHints.RequestedConversationId.Value.Value == conversationId &&
-                m.ChannelType.Equals(ChannelKey.From("internal"))),
-            Arg.Any<CancellationToken>());
+                m.ChannelType.Equals(ChannelKey.From("internal"))));
     }
 
     [Fact]
@@ -194,7 +193,7 @@ public sealed class ConversationToolTests
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: null);
+            messageOrchestrator: null);
 
         // Act — must not throw
         var result = await tool.ExecuteAsync("call-1", Args(
@@ -219,21 +218,20 @@ public sealed class ConversationToolTests
         // Arrange
         var conversationStore = new InMemoryConversationStore();
         var sessionStore = new InMemorySessionStore();
-        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var orchestrator = Substitute.For<IInboundMessageOrchestrator>();
         var tool = new ConversationTool(
             conversationStore,
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: dispatcher);
+            messageOrchestrator: orchestrator);
 
         // Act
         await tool.ExecuteAsync("call-1", Args("new", agentId: "nova", displayName: "Empty conv"));
 
         // Assert: no dispatch when no message
-        await dispatcher.DidNotReceive().DispatchAsync(
-            Arg.Any<InboundMessage>(),
-            Arg.Any<CancellationToken>());
+        orchestrator.DidNotReceive().Post(
+            Arg.Any<InboundMessage>());
     }
 
     [Fact]
@@ -242,7 +240,7 @@ public sealed class ConversationToolTests
         // Arrange
         var conversationStore = new InMemoryConversationStore();
         var sessionStore = new InMemorySessionStore();
-        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var orchestrator = Substitute.For<IInboundMessageOrchestrator>();
         var conversation = await conversationStore.CreateAsync(CreateConversation("nova", "Planning", null));
 
         var tool = new ConversationTool(
@@ -250,7 +248,7 @@ public sealed class ConversationToolTests
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: dispatcher);
+            messageOrchestrator: orchestrator);
 
         // Act
         var result = await tool.ExecuteAsync("call-1", Args(
@@ -259,13 +257,12 @@ public sealed class ConversationToolTests
             message: "Hello Nova!"));
 
         // Assert: dispatcher called with the user message
-        await dispatcher.Received(1).DispatchAsync(
+        orchestrator.Received(1).Post(
             Arg.Is<InboundMessage>(m =>
                 m.Content == "Hello Nova!" &&
                 m.RoutingHints != null &&
                 m.RoutingHints.RequestedAgentId != null && m.RoutingHints.RequestedAgentId.Value.Value == "nova" &&
-                m.ChannelType == ChannelKey.From("internal")),
-            Arg.Any<CancellationToken>());
+                m.ChannelType == ChannelKey.From("internal")));
 
         // Result includes conversation and session IDs
         using var document = JsonDocument.Parse(ReadText(result));
@@ -285,7 +282,7 @@ public sealed class ConversationToolTests
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: null);
+            messageOrchestrator: null);
 
         Func<Task> act = () => tool.ExecuteAsync("call-1", Args(
             "message",
@@ -306,7 +303,7 @@ public sealed class ConversationToolTests
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: null);
+            messageOrchestrator: null);
 
         Func<Task> act = () => tool.ExecuteAsync("call-1", Args(
             "message",
@@ -321,7 +318,7 @@ public sealed class ConversationToolTests
     {
         var conversationStore = new InMemoryConversationStore();
         var sessionStore = new InMemorySessionStore();
-        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var orchestrator = Substitute.For<IInboundMessageOrchestrator>();
         var conversation = await conversationStore.CreateAsync(CreateConversation("nova", "Planning", null));
 
         // agent-a with Own access cannot message nova's conversation
@@ -330,7 +327,7 @@ public sealed class ConversationToolTests
             AgentId.From("agent-a"),
             accessLevel: ConversationAccessLevel.Own,
             sessionStore: sessionStore,
-            channelDispatcher: dispatcher);
+            messageOrchestrator: orchestrator);
 
         Func<Task> act = () => tool.ExecuteAsync("call-1", Args(
             "message",
@@ -345,7 +342,7 @@ public sealed class ConversationToolTests
     {
         var conversationStore = new InMemoryConversationStore();
         var sessionStore = new InMemorySessionStore();
-        var dispatcher = Substitute.For<IChannelDispatcher>();
+        var orchestrator = Substitute.For<IInboundMessageOrchestrator>();
 
         var session = await sessionStore.GetOrCreateAsync(SessionId.Create(), AgentId.From("nova"), default);
         var conversation = await conversationStore.CreateAsync(
@@ -361,7 +358,7 @@ public sealed class ConversationToolTests
             AgentId.From("orchestrator"),
             accessLevel: ConversationAccessLevel.All,
             sessionStore: sessionStore,
-            channelDispatcher: dispatcher);
+            messageOrchestrator: orchestrator);
 
         var result = await tool.ExecuteAsync("call-1", Args(
             "message",
@@ -502,8 +499,7 @@ public sealed class ConversationToolTests
         await notifier.Received(1).NotifyConversationChangedAsync(
             "updated",
             "agent-a",
-            conversation.ConversationId.Value,
-            Arg.Any<CancellationToken>());
+            conversation.ConversationId.Value);
     }
 
     [Fact]
@@ -519,8 +515,7 @@ public sealed class ConversationToolTests
         await notifier.Received(1).NotifyConversationChangedAsync(
             "updated",
             "agent-a",
-            conversation.ConversationId.Value,
-            Arg.Any<CancellationToken>());
+            conversation.ConversationId.Value);
     }
 
     [Fact]
@@ -536,8 +531,7 @@ public sealed class ConversationToolTests
         await notifier.Received(1).NotifyConversationChangedAsync(
             "updated",
             "agent-a",
-            conversation.ConversationId.Value,
-            Arg.Any<CancellationToken>());
+            conversation.ConversationId.Value);
     }
 
     [Fact]
@@ -553,8 +547,7 @@ public sealed class ConversationToolTests
         await notifier.Received(1).NotifyConversationChangedAsync(
             "archived",
             "agent-a",
-            conversation.ConversationId.Value,
-            Arg.Any<CancellationToken>());
+            conversation.ConversationId.Value);
     }
 
     [Fact]
@@ -573,7 +566,7 @@ public sealed class ConversationToolTests
     {
         var store = new InMemoryConversationStore();
         var notifier = Substitute.For<IConversationChangeNotifier>();
-        notifier.NotifyConversationChangedAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        notifier.NotifyConversationChangedAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
             .Returns(Task.FromException(new InvalidOperationException("SignalR hub unavailable")));
         var conversation = await store.CreateAsync(CreateConversation("agent-a", "Chat", null));
         var tool = new ConversationTool(store, AgentId.From("agent-a"), conversation.ConversationId, changeNotifier: notifier);
@@ -591,3 +584,4 @@ public sealed class ConversationToolTests
     private static string ReadText(AgentToolResult result)
         => result.Content.Single(c => c.Type == AgentToolContentType.Text).Value;
 }
+

--- a/tests/gateway/BotNexus.Gateway.Tests/Dispatching/CapturingInboundMessageOrchestrator.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Dispatching/CapturingInboundMessageOrchestrator.cs
@@ -66,4 +66,15 @@ public sealed class CapturingInboundMessageOrchestrator : IInboundMessageOrchest
     {
         await AcceptAsync(message, cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Fire-and-forget enqueue: records the message and returns <see langword="true"/>
+    /// (always succeeds in the test fake — no capacity limit).
+    /// </summary>
+    public bool Post(InboundMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        _captured.Enqueue(message);
+        return true;
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Dispatching/DefaultInboundMessageOrchestratorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Dispatching/DefaultInboundMessageOrchestratorTests.cs
@@ -297,4 +297,80 @@ public sealed class DefaultInboundMessageOrchestratorTests
             DisplayPrefix: null);
         return new DispatchResult(context, source, resolution);
     }
+
+    [Fact]
+    public void Post_ValidMessage_ReturnsTrueAndQueuesWithoutBlocking()
+    {
+        // Post must return synchronously (not await processor completion).
+        // We verify only the return value here; the processor contract is tested
+        // via AcceptAsync tests which confirm the queue worker runs ProcessAsync.
+        var processor = Substitute.For<IInboundMessageProcessor>();
+        processor
+            .ProcessAsync(Arg.Any<InboundMessage>(), Arg.Any<CancellationToken>())
+            .Returns(new InboundProcessingOutcome(EmptyDispatches, false));
+
+        var orchestrator = new DefaultInboundMessageOrchestrator(
+            processor, NullLogger<DefaultInboundMessageOrchestrator>.Instance);
+
+        var result = orchestrator.Post(CreateMessage("addr-post"));
+
+        // Post returns true = message was accepted onto the queue.
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Post_NullMessage_Throws()
+    {
+        var processor = Substitute.For<IInboundMessageProcessor>();
+        var orchestrator = new DefaultInboundMessageOrchestrator(
+            processor, NullLogger<DefaultInboundMessageOrchestrator>.Instance);
+
+        Should.Throw<ArgumentNullException>(() => orchestrator.Post(null!));
+    }
+
+    [Fact]
+    public void Post_InvalidSender_Throws()
+    {
+        var processor = Substitute.For<IInboundMessageProcessor>();
+        var orchestrator = new DefaultInboundMessageOrchestrator(
+            processor, NullLogger<DefaultInboundMessageOrchestrator>.Instance);
+
+        var message = new InboundMessage
+        {
+            ChannelType = ChannelKey.From("test"),
+            ChannelAddress = ChannelAddress.From("addr-1"),
+            SenderId = "sender-1",
+            Sender = default, // invalid
+            Content = "hi"
+        };
+
+        Should.Throw<ArgumentException>(() => orchestrator.Post(message));
+    }
+
+    [Fact]
+    public void Post_WhenQueueFull_ReturnsFalse()
+    {
+        var processor = Substitute.For<IInboundMessageProcessor>();
+        // Capacity 1 so we can fill it with the first Post
+        var processorGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        processor
+            .ProcessAsync(Arg.Any<InboundMessage>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                await processorGate.Task;
+                return new InboundProcessingOutcome(EmptyDispatches, false);
+            });
+
+        var orchestrator = new DefaultInboundMessageOrchestrator(
+            processor, NullLogger<DefaultInboundMessageOrchestrator>.Instance, queueCapacity: 1);
+
+        var first = orchestrator.Post(CreateMessage("addr-full"));
+        var second = orchestrator.Post(CreateMessage("addr-full"));
+
+        first.ShouldBeTrue();
+        second.ShouldBeFalse(); // queue is full
+
+        // Unblock the processor to avoid test hang
+        processorGate.TrySetResult(true);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRConversationRoutingTests.cs
@@ -267,5 +267,12 @@ public sealed class SignalRConversationRoutingTests : IAsyncDisposable
             Messages.Add(message);
             return Task.FromResult(InboundDispatchResult.Accepted(Array.Empty<DispatchResult>()));
         }
+
+        public bool Post(InboundMessage message)
+        {
+            Messages.Add(message);
+            return true;
+        }
     }
 }
+

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -774,6 +774,12 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
             Messages.Add(message);
             return Task.FromResult(InboundDispatchResult.Accepted(Array.Empty<DispatchResult>()));
         }
+
+        public bool Post(InboundMessage message)
+        {
+            Messages.Add(message);
+            return true;
+        }
     }
 
     private sealed class AbortAwareSupervisor(string agentId, string sessionId) : IAgentSupervisor

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
@@ -715,6 +715,12 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
             Messages.Add(message);
             return Task.FromResult(InboundDispatchResult.Accepted(Array.Empty<DispatchResult>()));
         }
+
+        public bool Post(InboundMessage message)
+        {
+            Messages.Add(message);
+            return true;
+        }
     }
 
     private sealed record MuteByAddressCall(AgentId? AgentId, ChannelKey ChannelType, ChannelAddress ChannelAddress);
@@ -766,3 +772,4 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
         }
     }
 }
+

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRThreadRoutingTests.cs
@@ -271,5 +271,11 @@ public sealed class SignalRThreadRoutingTests : IAsyncDisposable
             lock (_messages) { _messages.Add(message); }
             return Task.FromResult(InboundDispatchResult.Accepted(Array.Empty<DispatchResult>()));
         }
+
+        public bool Post(InboundMessage message)
+        {
+            lock (_messages) { _messages.Add(message); }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
fix(gateway): replace blocking DispatchAsync with Post in ConversationTool

Closes #728

## Problem
`ConversationTool` used `IChannelDispatcher.DispatchAsync` to trigger agent turns from `action=new` and `action=message`. `DispatchAsync` delegates to `AcceptAsync` which **awaits the queued agent turn to completion** — meaning the calling agent was blocked for the full duration of the spawned turn (all LLM round trips, tool calls, etc.).

Observed: session `57196a684c224752aae3bcb4a9121e92` (aurum) timed out while the spawned conversation `c_348b418d03d8481ca59c515d91d3629d` completed successfully.

## Fix

Added `IInboundMessageOrchestrator.Post(InboundMessage)` — a synchronous fire-and-forget enqueue that writes the message onto the per-session `Channel<T>` and returns `true/false` (queued/busy) without awaiting completion.

- `IInboundMessageOrchestrator.cs`: added `bool Post(InboundMessage)` to interface
- `DefaultInboundMessageOrchestrator.cs`: implemented `Post` using `TryWrite` on the session queue
- `ConversationTool.cs`: replaced `IChannelDispatcher` parameter with `IInboundMessageOrchestrator`; call `Post()` in both `NewAsync` and `SendMessageAsync` dispatch paths
- `InProcessIsolationStrategy.cs`: resolve `IInboundMessageOrchestrator` from DI instead of `IChannelDispatcher`

Also updated all test implementations (`CapturingInboundMessageOrchestrator` + 4 `RecordingDispatcher` fakes) and added 4 new unit tests for `Post`.

## Merge Notes
Touches `BotNexus.Gateway.Dispatching`, `BotNexus.Gateway`, and their tests. No file overlap with PR #827, #829, or #830. Safe to merge in any order.
