### PR TITLE
feat(cli): scaffold heartbeat config by default in init and agent add

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
@@ -1,6 +1,7 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using BotNexus.Cli.Wizard;
 using BotNexus.Gateway.Abstractions.Configuration;
+using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
 using Spectre.Console;
 using ValidationResult = Spectre.Console.ValidationResult;
@@ -230,7 +231,13 @@ internal sealed class AgentCommands
             Description = string.IsNullOrWhiteSpace(description) ? null : description,
             Provider = provider,
             Model = model,
-            Enabled = enabled
+            Enabled = enabled,
+            Heartbeat = new HeartbeatAgentConfig
+            {
+                Enabled = true,
+                IntervalMinutes = 30,
+                QuietHours = new QuietHoursConfig { Enabled = true, Start = "23:00", End = "07:00" }
+            }
         };
 
         var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);
@@ -277,7 +284,13 @@ internal sealed class AgentCommands
             Emoji = string.IsNullOrWhiteSpace(emoji) ? null : emoji,
             Provider = provider,
             Model = model,
-            Enabled = enabled
+            Enabled = enabled,
+            Heartbeat = new HeartbeatAgentConfig
+            {
+                Enabled = true,
+                IntervalMinutes = 30,
+                QuietHours = new QuietHoursConfig { Enabled = true, Start = "23:00", End = "07:00" }
+            }
         };
 
         var saveCode = await SaveAndValidateAsync(config, configPath, verbose, cancellationToken);

--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -164,6 +164,17 @@ internal sealed class InitCommand
                 {
                     ["enabled"] = true,
                     ["indexing"] = "auto"
+                },
+                ["heartbeat"] = new System.Text.Json.Nodes.JsonObject
+                {
+                    ["enabled"] = true,
+                    ["intervalMinutes"] = 30,
+                    ["quietHours"] = new System.Text.Json.Nodes.JsonObject
+                    {
+                        ["enabled"] = true,
+                        ["start"] = "23:00",
+                        ["end"] = "07:00"
+                    }
                 }
             };
             // Insert defaults as the first key

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/HeartbeatDefaultsTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/HeartbeatDefaultsTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using BotNexus.Cli.Commands;
+using Shouldly;
+
+namespace BotNexus.Cli.Tests.Commands;
+
+/// <summary>
+/// Tests for heartbeat default config scaffolding in InitCommand and AgentCommands.
+/// Covers acceptance criteria for issue #823.
+/// </summary>
+public sealed class HeartbeatDefaultsTests
+{
+    // -------------------------------------------------------------------------
+    // InitCommand — agents.defaults must include heartbeat block
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Init_DefaultConfig_IncludesHeartbeatInAgentDefaults()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), $"botnexus-hb-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+
+        try
+        {
+            var cmd = new InitCommand();
+
+            // Act
+            await cmd.ExecuteAsync(tempHome, force: false, verbose: false, CancellationToken.None);
+
+            // Assert — agents.defaults.heartbeat must be present
+            var configPath = Path.Combine(tempHome, "config.json");
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            root.TryGetProperty("agents", out var agents).ShouldBeTrue("agents section missing");
+            agents.TryGetProperty("defaults", out var defaults).ShouldBeTrue("agents.defaults missing");
+            defaults.TryGetProperty("heartbeat", out var heartbeat).ShouldBeTrue("agents.defaults.heartbeat missing");
+            heartbeat.TryGetProperty("enabled", out var enabled).ShouldBeTrue("heartbeat.enabled missing");
+            enabled.GetBoolean().ShouldBeTrue("heartbeat.enabled should be true");
+            heartbeat.TryGetProperty("intervalMinutes", out var interval).ShouldBeTrue("heartbeat.intervalMinutes missing");
+            interval.GetInt32().ShouldBe(30);
+            heartbeat.TryGetProperty("quietHours", out var quietHours).ShouldBeTrue("heartbeat.quietHours missing");
+            quietHours.TryGetProperty("enabled", out var qhEnabled).ShouldBeTrue();
+            qhEnabled.GetBoolean().ShouldBeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+                Directory.Delete(tempHome, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Init_DefaultConfig_HeartbeatDefaults_HasExpectedQuietHoursBoundaries()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), $"botnexus-hb-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+
+        try
+        {
+            var cmd = new InitCommand();
+
+            // Act
+            await cmd.ExecuteAsync(tempHome, force: false, verbose: false, CancellationToken.None);
+
+            // Assert — quiet hours default 23:00–07:00
+            var configPath = Path.Combine(tempHome, "config.json");
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var quietHours = doc.RootElement
+                .GetProperty("agents")
+                .GetProperty("defaults")
+                .GetProperty("heartbeat")
+                .GetProperty("quietHours");
+
+            quietHours.GetProperty("start").GetString().ShouldBe("23:00");
+            quietHours.GetProperty("end").GetString().ShouldBe("07:00");
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+                Directory.Delete(tempHome, recursive: true);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // AgentCommands.ExecuteAddAsync — new agent should include heartbeat block
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task AgentAdd_NewAgent_IncludesHeartbeatBlock()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), $"botnexus-hb-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+
+        try
+        {
+            // Write a minimal config.json
+            var configPath = Path.Combine(tempHome, "config.json");
+            var minimalConfig = """
+                {
+                  "version": 1,
+                  "agents": {}
+                }
+                """;
+            await File.WriteAllTextAsync(configPath, minimalConfig);
+
+            var cmds = new AgentCommands();
+
+            // Act
+            var result = await cmds.ExecuteAddAsync(
+                id: "test-agent",
+                provider: "github-copilot",
+                model: "gpt-4.1",
+                enabled: true,
+                configPath: configPath,
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            result.ShouldBe(0, "ExecuteAddAsync should succeed");
+
+            var updatedJson = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(updatedJson);
+            var agentElem = doc.RootElement.GetProperty("agents").GetProperty("test-agent");
+
+            agentElem.TryGetProperty("heartbeat", out var heartbeat).ShouldBeTrue("heartbeat block missing from new agent");
+            heartbeat.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+            heartbeat.GetProperty("intervalMinutes").GetInt32().ShouldBe(30);
+            heartbeat.GetProperty("quietHours").GetProperty("start").GetString().ShouldBe("23:00");
+            heartbeat.GetProperty("quietHours").GetProperty("end").GetString().ShouldBe("07:00");
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+                Directory.Delete(tempHome, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AgentAdd_NewAgent_HeartbeatEnabled_IsTrue()
+    {
+        // Arrange — heartbeat enabled should be true even without explicit defaults block
+        var tempHome = Path.Combine(Path.GetTempPath(), $"botnexus-hb-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+
+        try
+        {
+            var configPath = Path.Combine(tempHome, "config.json");
+            await File.WriteAllTextAsync(configPath, """{"version":1,"agents":{}}""");
+
+            var cmds = new AgentCommands();
+
+            await cmds.ExecuteAddAsync(
+                id: "alpha",
+                provider: "openai",
+                model: "gpt-4o",
+                enabled: true,
+                configPath: configPath,
+                verbose: false,
+                cancellationToken: CancellationToken.None);
+
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            var heartbeat = doc.RootElement.GetProperty("agents").GetProperty("alpha").GetProperty("heartbeat");
+            heartbeat.GetProperty("enabled").GetBoolean().ShouldBeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+                Directory.Delete(tempHome, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`botnexus init` generates a `config.json` with no `heartbeat` block in `agents.defaults`. `botnexus agent add` creates new agents with no heartbeat config. Since heartbeat is a core feature (#822), all scaffolding paths should include it out of the box.

## Changes

**`InitCommand.cs`** — `SerializeWithAgentDefaults` now injects a `heartbeat` block into `agents.defaults` alongside the existing `memory` block:
```json
"defaults": {
  "memory": { "enabled": true, "indexing": "auto" },
  "heartbeat": {
    "enabled": true,
    "intervalMinutes": 30,
    "quietHours": { "enabled": true, "start": "23:00", "end": "07:00" }
  }
}
```

**`AgentCommands.cs`** — `ExecuteAddAsync` (both wizard and non-wizard paths) now includes a `Heartbeat` block on the new `AgentDefinitionConfig`, matching the defaults above.

**Tests** — 4 new tests in `HeartbeatDefaultsTests`:
- `Init_DefaultConfig_IncludesHeartbeatInAgentDefaults`
- `Init_DefaultConfig_HeartbeatDefaults_HasExpectedQuietHoursBoundaries`
- `AgentAdd_NewAgent_IncludesHeartbeatBlock`
- `AgentAdd_NewAgent_HeartbeatEnabled_IsTrue`

## Acceptance Criteria Met
- [x] `botnexus init` generated config includes heartbeat in `agents.defaults`
- [x] `botnexus agent add` includes heartbeat block in new agent config
- [x] Unit tests updated for `InitCommand` and agent add scaffolding

## Merge Notes
Touches `BotNexus.Cli` + `BotNexus.Cli.Tests` only. No file overlap with any open PR. Safe to merge in any order with #834 (gateway heartbeat defaults).

Closes #823
