### PR TITLE
fix(cron): defer user entry save to after PromptAsync to prevent duplicate message

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -88,20 +88,27 @@ public sealed class CronTrigger(
             await conversations.SaveAsync(conversation, ct).ConfigureAwait(false);
         }
 
+        // Save session metadata before creating the agent handle so the handle picks up
+        // the correct conversation binding and model override — but do NOT add the user
+        // entry yet. Adding it here would cause the handle to load it as prior history
+        // and then receive the same prompt again via PromptAsync, giving the model a
+        // duplicate user message and suppressing tool call execution. (#656)
+        await sessions.SaveAsync(session, ct).ConfigureAwait(false);
+
+        var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);
+        var response = await handle.PromptAsync(prompt, ct).ConfigureAwait(false);
+
         // P9-E (#645): stamp Cron on the user entry. Cron is a proxy for the citizen
         // who scheduled the job — the persisted trigger marks the originating proxy
         // so audit/UI can render the right badge without sniffing SessionType.
+        // Persisted AFTER PromptAsync so session history never contains the user entry
+        // as prior context when the agent handle is created for this run.
         session.AddEntry(new SessionEntry
         {
             Role = MessageRole.User,
             Content = prompt,
             Trigger = TriggerType.Cron
         });
-        await sessions.SaveAsync(session, ct).ConfigureAwait(false);
-
-        var handle = await supervisor.GetOrCreateAsync(agentId, sessionId, ct).ConfigureAwait(false);
-        var response = await handle.PromptAsync(prompt, ct).ConfigureAwait(false);
-
         session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = response.Content });
         await sessions.SaveAsync(session, ct).ConfigureAwait(false);
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -340,6 +340,123 @@ public sealed class CronTriggerTests
         request.ResolvedConversationId.ShouldBe(pinnedConversation.ConversationId);
     }
 
+    // ── #656 ordering tests ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for #656: user entry must NOT be in session history when the
+    /// agent handle is created. Adding it before GetOrCreateAsync causes the model to
+    /// receive a duplicate user message, which suppresses tool call execution.
+    /// The test verifies ordering: metadata-only save → handle creation → transcript save.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_AgentHandleCreated_WithNoUserEntryInHistory()
+    {
+        var sessionStore = new Mock<ISessionStore>(MockBehavior.Strict);
+        var conversationStore = new Mock<IConversationStore>();
+        var supervisor = new Mock<IAgentSupervisor>();
+        var handle = new Mock<IAgentHandle>();
+
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "assistant-response" });
+
+        // Track calls in order: [0] = GetOrCreate, [1] = first Save (metadata), [2] = GetOrCreate via supervisor, [3] = second Save (transcript)
+        var callLog = new List<string>();
+        GatewaySession? capturedSession = null;
+
+        sessionStore
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<SessionId>(), It.IsAny<AgentId>(), It.IsAny<CancellationToken>()))
+            .Returns<SessionId, AgentId, CancellationToken>((sid, aid, _) =>
+            {
+                capturedSession = new GatewaySession { SessionId = sid, AgentId = aid };
+                callLog.Add("GetOrCreate");
+                return Task.FromResult(capturedSession);
+            });
+        sessionStore
+            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Callback<GatewaySession, CancellationToken>((s, _) =>
+                callLog.Add($"Save:history={s.History.Count}"))
+            .Returns(Task.CompletedTask);
+
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Returns<Conversation, CancellationToken>((c, _) => Task.FromResult(c));
+        conversationStore.Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callLog.Add("Supervisor.GetOrCreate"))
+            .ReturnsAsync(handle.Object);
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Scheduled prompt",
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-x"), JobName = "Test job" });
+
+        // Expected order: GetOrCreate (session store), Save (metadata only, 0 entries),
+        //                 Supervisor.GetOrCreate (handle creation), Save (transcript, 2 entries)
+        callLog.ShouldBe(
+            ["GetOrCreate", "Save:history=0", "Supervisor.GetOrCreate", "Save:history=2"],
+            "User entry must not exist in session at handle-creation time — duplicate user message suppresses tool calls (#656)");
+    }
+
+    /// <summary>
+    /// Regression test for #656: both user and assistant entries must appear in the final
+    /// session save, with the user entry stamped Trigger = Cron.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_FinalSessionSave_ContainsBothUserAndAssistantEntries()
+    {
+        var sessionStore = new Mock<ISessionStore>();
+        var conversationStore = new Mock<IConversationStore>();
+        var supervisor = new Mock<IAgentSupervisor>();
+        var handle = new Mock<IAgentHandle>();
+
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "model-answer" });
+
+        GatewaySession? lastSavedSession = null;
+
+        sessionStore
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<SessionId>(), It.IsAny<AgentId>(), It.IsAny<CancellationToken>()))
+            .Returns<SessionId, AgentId, CancellationToken>((sid, aid, _) =>
+                Task.FromResult(new GatewaySession { SessionId = sid, AgentId = aid }));
+        sessionStore
+            .Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Callback<GatewaySession, CancellationToken>((s, _) => lastSavedSession = s)
+            .Returns(Task.CompletedTask);
+
+        conversationStore
+            .Setup(s => s.CreateAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Returns<Conversation, CancellationToken>((c, _) => Task.FromResult(c));
+        conversationStore.Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        supervisor
+            .Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-b"),
+            "Do the thing",
+            request: new InternalTriggerRequest { CronJobId = JobId.From("job-y"), JobName = "Nightly task" });
+
+        lastSavedSession.ShouldNotBeNull();
+        lastSavedSession!.History.Count.ShouldBe(2, "Final save must contain exactly user + assistant entries");
+
+        var userEntry = lastSavedSession.History.FirstOrDefault(e => e.Role == MessageRole.User);
+        var assistantEntry = lastSavedSession.History.FirstOrDefault(e => e.Role == MessageRole.Assistant);
+
+        userEntry.ShouldNotBeNull();
+        userEntry!.Content.ShouldBe("Do the thing");
+        userEntry.Trigger.ShouldBe(TriggerType.Cron, "User entry must carry Cron trigger stamp (P9-E)");
+
+        assistantEntry.ShouldNotBeNull();
+        assistantEntry!.Content.ShouldBe("model-answer");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static (Mock<ISessionStore>, Mock<IConversationStore>, Mock<IAgentSupervisor>) BuildStandardMocks()


### PR DESCRIPTION
Closes #656

## Root Cause

`CronTrigger.CreateSessionAsync` added the user `SessionEntry` to the session and
persisted it **before** calling `supervisor.GetOrCreateAsync`. The supervisor loads
session history from the store when creating the agent handle — so the handle's
initial context already contained the user message. Immediately calling
`PromptAsync(prompt)` sent the same prompt again, giving the LLM a **duplicated
user message**. Most provider models respond to a doubled user message by producing
a text reply only, skipping the tool-use planning step entirely. This is why cron
sessions had exactly 2 history entries (user + hallucinated assistant) and no tool
calls, while the same prompt in a SignalR session worked correctly.

## Changes

**`CronTrigger.cs`**
- Remove the `AddEntry(user)` + `SaveAsync` calls from before `GetOrCreateAsync`
- Save session metadata only (channel, model override, cronJobId) before handle creation
- Add both user and assistant entries to history in a single `SaveAsync` after `PromptAsync` returns
- This matches `GatewayHost`'s pattern for SignalR sessions

**`CronTriggerTests.cs`** — 2 new regression tests:
- `CreateSessionAsync_AgentHandleCreated_WithNoUserEntryInHistory` — verifies call ordering:
  `GetOrCreate` → `Save:history=0` → `Supervisor.GetOrCreate` → `Save:history=2`
- `CreateSessionAsync_FinalSessionSave_ContainsBothUserAndAssistantEntries` — verifies both
  entries appear with correct content and Cron trigger stamp (P9-E)

## Merge Notes
Touches `CronTrigger.cs` and `CronTriggerTests.cs` only. No file overlap with any open PR.
Safe to merge in any order with all current open PRs.
