### PR TITLE
fix(portal): re-apply tab deep-link after agent data loads via store change

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/AgentPanel.razor
@@ -66,6 +66,9 @@
     public string AgentId { get; set; } = default!;
 
     private AgentPanelTab _activeTab = AgentPanelTab.Conversation;
+    // Track whether the agent was a sub-agent last time we checked, so we can
+    // re-apply tab suppression when agent data arrives after the URL tab was set.
+    private bool? _lastIsSubAgent;
 
     private AgentState? Agent => Store.GetAgent(AgentId);
     private string DisplayName => Agent?.DisplayName ?? AgentId;
@@ -88,7 +91,9 @@
     protected override void OnInitialized()
     {
         Nav.LocationChanged += HandleLocationChanged;
+        Store.OnChanged += HandleStoreChanged;
         ApplyTabFromUri(Nav.Uri);
+        _lastIsSubAgent = CurrentAgent is not null ? IsSubAgent : null;
     }
 
     protected override void OnParametersSet()
@@ -99,12 +104,32 @@
     public void Dispose()
     {
         Nav.LocationChanged -= HandleLocationChanged;
+        Store.OnChanged -= HandleStoreChanged;
     }
 
     private void HandleLocationChanged(object? sender, LocationChangedEventArgs e)
     {
         var previous = _activeTab;
         ApplyTabFromUri(e.Location);
+        if (previous != _activeTab)
+            _ = InvokeAsync(StateHasChanged);
+    }
+
+    // Re-apply tab when agent data first arrives (or changes) so sub-agent
+    // suppression is applied correctly even if agent was null at URL parse time.
+    // Store.OnChanged is Action (not Func<Task>) so this must be void.
+    private void HandleStoreChanged()
+    {
+        var currentIsSubAgent = CurrentAgent is not null ? IsSubAgent : (bool?)null;
+        if (currentIsSubAgent == _lastIsSubAgent)
+    
+
+        _lastIsSubAgent = currentIsSubAgent;
+
+        // If agent data just arrived, re-apply tab from URL so the correct
+        // tab is shown without waiting for a navigation event.
+        var previous = _activeTab;
+        ApplyTabFromUri(Nav.Uri);
         if (previous != _activeTab)
             _ = InvokeAsync(StateHasChanged);
     }
@@ -135,11 +160,18 @@
 
         if (TryParseTab(tabValue, out var parsed))
         {
-            // Suppress Workspace/Reports tabs for sub-agents
-            if (IsSubAgent && (parsed == AgentPanelTab.Workspace || parsed == AgentPanelTab.Reports))
+            // Only suppress Workspace/Reports for sub-agents when agent data is already
+            // available. If the agent hasn't loaded yet, preserve the requested tab;
+            // HandleStoreChanged will re-apply suppression once data arrives.
+            if (CurrentAgent is not null && IsSubAgent &&
+                (parsed == AgentPanelTab.Workspace || parsed == AgentPanelTab.Reports))
+            {
                 _activeTab = AgentPanelTab.Conversation;
+            }
             else
+            {
                 _activeTab = parsed;
+            }
         }
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentPanelVerticalSliceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentPanelVerticalSliceTests.cs
@@ -114,6 +114,73 @@ public sealed class AgentPanelVerticalSliceTests : IDisposable
         Assert.NotNull(cut.Find("[data-testid='agent-panel-conversation'] .chat-panel"));
     }
 
+    // #637 — AgentPanel tab URL deep-link fixes
+
+    [Fact]
+    public void Workspace_query_parameter_activates_workspace_tab_for_regular_agent()
+    {
+        _ctx.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("http://localhost/chat/agent-1/conv-1?tab=workspace");
+
+        var cut = RenderHomeForAgentConversation();
+
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find(".agent-panel-tab.active[data-tab='workspace']")));
+    }
+
+    [Fact]
+    public void SubAgent_workspace_tab_url_is_suppressed_to_conversation()
+    {
+        // Register agent-1 as a sub-agent
+        _store.RegisterSession("agent-1", "session-sub-1", "signalr", "agent-subagent");
+
+        _ctx.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("http://localhost/chat/agent-1/conv-1?tab=workspace");
+
+        var cut = RenderHomeForAgentConversation();
+
+        // Sub-agent should not show workspace; fall back to conversation
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find(".agent-panel-tab.active[data-tab='conversation']")));
+    }
+
+    [Fact]
+    public void Tab_is_reapplied_when_store_changes_after_initial_render()
+    {
+        // Start with agent-1 as a regular agent and canvas tab in URL
+        _ctx.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("http://localhost/chat/agent-1/conv-1?tab=canvas");
+
+        var cut = RenderHomeForAgentConversation();
+
+        // Canvas tab should be active for regular agent
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find(".agent-panel-tab.active[data-tab='canvas']")));
+
+        // Simulate agent becoming a sub-agent after data arrives (store change)
+        _store.RegisterSession("agent-1", "session-sub-1", "signalr", "agent-subagent");
+        _store.NotifyChanged();
+
+        // Sub-agent canvas IS allowed (only workspace/reports suppressed), so canvas remains
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find(".agent-panel-tab.active[data-tab='canvas']")));
+    }
+
+    [Fact]
+    public void SubAgent_reports_tab_url_is_suppressed_to_conversation()
+    {
+        // Register agent-1 as a sub-agent
+        _store.RegisterSession("agent-1", "session-sub-1", "signalr", "agent-subagent");
+
+        _ctx.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("http://localhost/chat/agent-1/conv-1?tab=reports");
+
+        var cut = RenderHomeForAgentConversation();
+
+        cut.WaitForAssertion(() =>
+            Assert.NotNull(cut.Find(".agent-panel-tab.active[data-tab='conversation']")));
+    }
+
     [Fact]
     public void App_css_contains_agent_panel_mobile_responsive_hooks()
     {


### PR DESCRIPTION
Closes #637

## Changes

- `AgentPanel.razor`: subscribe to `Store.OnChanged` and unsubscribe in `Dispose` to react when agent data arrives after initial render
- `ApplyTabFromUri`: only applies sub-agent suppression when `CurrentAgent` is non-null; preserves requested tab until data arrives
- `HandleStoreChanged`: re-applies the URL tab when the agent's `IsReadOnly`/`SessionType` changes, ensuring correct sub-agent tab suppression without a navigation event
- Tracks `_lastIsSubAgent` to avoid unnecessary re-renders on unrelated store changes
- 4 new tests: workspace/canvas URL param round-trip, sub-agent workspace and reports suppression, store-change re-apply

## Merge Notes

This PR only touches `AgentPanel.razor` and `AgentPanelVerticalSliceTests.cs`.
Independent of all other open PRs — safe to merge in any order.
