### PR TITLE
feat(agents): add optional Order field to AgentDescriptor for consistent agent list sort

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -46,6 +46,12 @@ public sealed record AgentDescriptor : ICitizen
     public string? Description { get; init; }
 
     /// <summary>
+    /// Optional display order. Lower values sort first. When null the agent sorts
+    /// alphabetically after all agents that have an explicit order value.
+    /// </summary>
+    public int? Order { get; init; }
+
+    /// <summary>
     /// The LLM model identifier this agent uses by default (e.g., "claude-sonnet-4-20250514").
     /// Can be overridden per-session.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultAgentRegistry.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultAgentRegistry.cs
@@ -87,7 +87,15 @@ public sealed class DefaultAgentRegistry : IAgentRegistry
     /// <inheritdoc />
     public IReadOnlyList<AgentDescriptor> GetAll()
     {
-        lock (_sync) return [.. _agents.Values];
+        lock (_sync)
+        {
+            // Sort rule: agents with Order set come first (ascending Order, then DisplayName).
+            // Agents with no Order set follow (sorted by DisplayName).
+            return [.. _agents.Values
+                .OrderBy(a => a.Order.HasValue ? 0 : 1)
+                .ThenBy(a => a.Order ?? int.MaxValue)
+                .ThenBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)];
+        }
     }
 
     /// <inheritdoc />

--- a/tests/gateway/BotNexus.Gateway.Tests/DefaultAgentRegistryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DefaultAgentRegistryTests.cs
@@ -1,4 +1,4 @@
-using BotNexus.Gateway.Abstractions.Activity;
+﻿using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Agents;
@@ -208,4 +208,89 @@ public sealed class DefaultAgentRegistryTests
             yield break;
         }
     }
+}
+
+public sealed class DefaultAgentRegistryOrderTests
+{
+    [Fact]
+    public void GetAll_WithNoOrderSet_ReturnsSortedAlphabetically()
+    {
+        var registry = CreateRegistry();
+        registry.Register(CreateDescriptor("b-agent", "Bravo"));
+        registry.Register(CreateDescriptor("a-agent", "Alpha"));
+        registry.Register(CreateDescriptor("c-agent", "Charlie"));
+
+        var result = registry.GetAll();
+
+        result.Select(a => a.DisplayName).ShouldBe(new[] { "Alpha", "Bravo", "Charlie" });
+    }
+
+    [Fact]
+    public void GetAll_WithOrderSet_PutsOrderedAgentsFirst()
+    {
+        var registry = CreateRegistry();
+        registry.Register(CreateDescriptor("unordered-agent", "Zulu", order: null));
+        registry.Register(CreateDescriptor("second-agent", "Beta", order: 2));
+        registry.Register(CreateDescriptor("first-agent", "Alpha", order: 1));
+
+        var result = registry.GetAll();
+
+        result[0].DisplayName.ShouldBe("Alpha"); // order 1
+        result[1].DisplayName.ShouldBe("Beta");  // order 2
+        result[2].DisplayName.ShouldBe("Zulu");  // no order -> alphabetical after
+    }
+
+    [Fact]
+    public void GetAll_WithSameOrder_SortsAlphabeticallyAsSecondary()
+    {
+        var registry = CreateRegistry();
+        registry.Register(CreateDescriptor("b-agent", "Bravo", order: 1));
+        registry.Register(CreateDescriptor("a-agent", "Alpha", order: 1));
+
+        var result = registry.GetAll();
+
+        result[0].DisplayName.ShouldBe("Alpha");
+        result[1].DisplayName.ShouldBe("Bravo");
+    }
+
+    [Fact]
+    public void GetAll_WithNegativeOrder_SortsBeforePositiveOrder()
+    {
+        var registry = CreateRegistry();
+        registry.Register(CreateDescriptor("positive-agent", "Positive", order: 5));
+        registry.Register(CreateDescriptor("negative-agent", "Negative", order: -1));
+
+        var result = registry.GetAll();
+
+        result[0].DisplayName.ShouldBe("Negative"); // order -1
+        result[1].DisplayName.ShouldBe("Positive"); // order 5
+    }
+
+    [Fact]
+    public void GetAll_WithAllUnordered_ReturnsCaseInsensitiveAlphabetical()
+    {
+        var registry = CreateRegistry();
+        registry.Register(CreateDescriptor("z-agent", "zebra"));
+        registry.Register(CreateDescriptor("a-agent", "Alpha"));
+        registry.Register(CreateDescriptor("m-agent", "mango"));
+
+        var result = registry.GetAll();
+
+        result.Select(a => a.DisplayName).ShouldBe(
+            new[] { "Alpha", "mango", "zebra" },
+            ignoreOrder: false);
+    }
+
+    private static DefaultAgentRegistry CreateRegistry()
+        => new(Microsoft.Extensions.Logging.Abstractions.NullLogger<DefaultAgentRegistry>.Instance);
+
+    private static AgentDescriptor CreateDescriptor(string agentId, string displayName, int? order = null)
+        => new()
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From(agentId),
+            DisplayName = displayName,
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            Order = order
+        };
 }


### PR DESCRIPTION
Closes #815

## Changes

### `AgentDescriptor.cs`
- Added `int? Order` property — nullable, optional, defaults to null (unordered)

### `DefaultAgentRegistry.cs`
- `GetAll()` now returns agents sorted: ordered agents first (ascending Order, then DisplayName), unordered agents last (alphabetical DisplayName)
- Negative Order values are supported for pinning above positive-ordered agents

## Sort Rule

```
[Agents with Order set]     → sorted by Order asc, then DisplayName asc
[Agents with no Order set]  → sorted by DisplayName asc
```

## Tests
5 new tests in `DefaultAgentRegistryOrderTests`:
- Alphabetical sort when no Order set
- Ordered agents appear before unordered agents
- Same-Order tie broken by DisplayName
- Negative Order values sort before positive
- Case-insensitive alphabetical for unordered

## Notes
- All API consumers (`GET /api/agents`, `list_agents` tool, portal sidebar) receive sorted output automatically via `GetAll()` — no caller changes required
- Scope intentionally excludes the world-default-agent pin (no such concept in config yet) — can be added as a follow-up when the gateway.defaultAgent config concept is introduced

## Merge Notes
Standalone — touches `AgentDescriptor.cs`, `DefaultAgentRegistry.cs`, and `DefaultAgentRegistryTests.cs` only. Zero file overlap with all current open PRs.