### PR TITLE
fix(gateway): emit system stall entry when stream completes with thinking only and no visible text

### DIFF
--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -32,6 +32,8 @@ public static class StreamingSessionHelper
         options ??= new StreamingSessionOptions();
         var streamedContent = new StringBuilder();
         var streamedHistory = new List<SessionEntry>();
+        var hadThinkingContent = false;
+        var hadMessageEnd = false;
 
         await foreach (var evt in stream.WithCancellation(cancellationToken))
         {
@@ -39,6 +41,12 @@ public static class StreamingSessionHelper
             {
                 case AgentStreamEventType.ContentDelta when evt.ContentDelta is not null:
                     streamedContent.Append(evt.ContentDelta);
+                    break;
+                case AgentStreamEventType.ThinkingDelta when evt.ThinkingContent is not null:
+                    hadThinkingContent = true;
+                    break;
+                case AgentStreamEventType.MessageEnd:
+                    hadMessageEnd = true;
                     break;
                 case AgentStreamEventType.ToolStart when evt.ToolCallId is not null || evt.ToolName is not null:
                     streamedHistory.Add(new SessionEntry
@@ -108,7 +116,23 @@ public static class StreamingSessionHelper
         // (single-turn runs, or the last partial turn before AgentEnd).
         session.AddEntries(streamedHistory);
         if (streamedContent.Length > 0)
+        {
             session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = streamedContent.ToString() });
+        }
+        else if (streamedHistory.Count == 0 && hadThinkingContent && hadMessageEnd)
+        {
+            // The model produced only reasoning/thinking blocks and no visible text or tool calls.
+            // Without this sentinel the session transcript ends with the user message and no
+            // assistant reply, so the next turn replays the abandoned user prompt, causing
+            // duplicate-message confusion and skipped tool calls (same pattern as #656).
+            // Surface a system entry so the conversation is in a known good state.
+            session.AddEntry(new SessionEntry
+            {
+                Role = MessageRole.System,
+                Content = "Agent produced only reasoning content and could not generate a visible response. Please try again or rephrase your message."
+            });
+        }
+
         // Remove crash sentinel on clean completion (#363).
         session.RemoveCrashSentinels();
         await sessionStore.SaveAsync(session, cancellationToken);

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
@@ -230,6 +230,75 @@ public sealed class StreamingSessionHelperTests
         entry.Content.ShouldBe("the result text");
     }
 
+    [Fact]
+    public async Task ProcessAndSaveAsync_ThinkingOnlyWithMessageEnd_AddsSystemStallEntry()
+    {
+        // Arrange: provider returned only thinking blocks, no visible text, no tools.
+        // MessageEnd signals a clean turn completion — but no user-visible content was produced.
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-think-1"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "Let me think deeply..." },
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "Still thinking." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        // Assert: exactly one system entry with the stall message.
+        session.History.ShouldHaveSingleItem();
+        session.History[0].Role.ShouldBe(MessageRole.System);
+        session.History[0].Content.ShouldContain("only reasoning content");
+        store.Verify(s => s.SaveAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ThinkingThenText_DoesNotAddStallEntry()
+    {
+        // Arrange: provider returned thinking blocks followed by actual text — normal extended-thinking turn.
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-think-2"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "Let me think..." },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Here is my answer." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        // Assert: one assistant entry with the visible content, no system stall entry.
+        session.History.ShouldHaveSingleItem();
+        session.History[0].Role.ShouldBe(MessageRole.Assistant);
+        session.History[0].Content.ShouldBe("Here is my answer.");
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_ThinkingOnlyWithoutMessageEnd_DoesNotAddStallEntry()
+    {
+        // Arrange: stream dropped mid-way (no MessageEnd) — no stall sentinel should be added
+        // because the session may resume and we don't want spurious system entries.
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-think-3"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "Let me think..." }
+                // No MessageEnd — stream dropped
+            ]),
+            session,
+            store.Object);
+
+        // Assert: history is empty — no stall entry for incomplete streams.
+        session.History.ShouldBeEmpty();
+    }
+
     private static async IAsyncEnumerable<AgentStreamEvent> ToAsyncEnumerable(IEnumerable<AgentStreamEvent> events)
     {
         foreach (var evt in events)


### PR DESCRIPTION
Closes #849

## Problem

When a provider returns only reasoning/thinking blocks and no user-visible text or tool calls, `StreamingSessionHelper.ProcessAndSaveAsync` accumulated nothing in `streamedContent` and `streamedHistory`. At the final write:

```csharp
if (streamedContent.Length > 0)
    session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = ... });
```

The condition is false, so the session transcript ends with the user message and no assistant reply. On the next dispatch, the provider sees the abandoned user prompt still at the tail, replays it alongside any residual thinking context, and produces confusing duplicate-message behaviour — the same class of bug as #656.

## Fix

Track two boolean flags during the stream:
- `hadThinkingContent` — set when a `ThinkingDelta` event with non-null `ThinkingContent` is received
- `hadMessageEnd` — set when a `MessageEnd` event is received (clean turn completion)

At the final write, if `streamedContent.Length == 0` AND `streamedHistory.Count == 0` AND `hadThinkingContent` AND `hadMessageEnd`, add a system entry:

```
Agent produced only reasoning content and could not generate a visible response. Please try again or rephrase your message.
```

The sentinel is **not** added when:
- Stream is dropped mid-way (no `MessageEnd`) — incomplete streams may resume
- Thinking blocks are followed by actual text — normal extended-thinking turn
- Thinking blocks precede tool calls — tool-only turn handled separately

## Changes

- `StreamingSessionHelper.cs`: added `hadThinkingContent` and `hadMessageEnd` flags, stall-sentinel guard at final write
- `StreamingSessionHelperTests.cs`: 3 new regression tests

## Tests

| Test | Verifies |
|---|---|
| `ThinkingOnlyWithMessageEnd_AddsSystemStallEntry` | Stall entry emitted when only thinking received + MessageEnd |
| `ThinkingThenText_DoesNotAddStallEntry` | Normal thinking+text turn unaffected |
| `ThinkingOnlyWithoutMessageEnd_DoesNotAddStallEntry` | No sentinel for dropped streams |

2068/2069 `Gateway.Tests` pass (1 pre-existing skip). 167/167 `Architecture.Tests` pass.

## Merge Notes

Touches `StreamingSessionHelper.cs` and `StreamingSessionHelperTests.cs` only. No file overlap with any open PR. Safe to merge in any order.