### PR TITLE
test(agents): pin direct-Anthropic request snapshots (Phase 0c, #810)

### DIFF
--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/AnthropicDirectRequestSnapshotTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/AnthropicDirectRequestSnapshotTests.cs
@@ -1,0 +1,176 @@
+using System.Net;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Anthropic.Tests;
+
+/// <summary>
+/// Phase 0c of the Copilot provider carve-out (#810): negative regression.
+///
+/// Pins the outbound /v1/messages envelope <see cref="AnthropicProvider"/>
+/// emits today on the <b>non-Copilot</b> paths (direct Anthropic API key and
+/// OAuth tokens for Claude Code). When Phase 1 deletes the
+/// <c>AuthMode.Copilot</c> branch from <see cref="AnthropicProvider"/>, these
+/// snapshots must stay byte-identical — they are the safety net for direct
+/// Anthropic users who never touch Copilot.
+/// </summary>
+public class AnthropicDirectRequestSnapshotTests
+{
+    private const long FixedTimestamp = 1_700_000_000_000L;
+
+    [Fact]
+    public Task Stream_DirectAnthropic_ApiKeyAuth_MatchesSnapshot()
+        => RunSnapshot(
+            apiKey: "sk-ant-api03-redacted",
+            snapshotPath: "Fixtures/Requests/messages/claude-sonnet-4/apikey-direct.json");
+
+    [Fact]
+    public Task Stream_DirectAnthropic_OAuthAuth_MatchesSnapshot()
+        => RunSnapshot(
+            apiKey: "sk-ant-oat01-redacted",
+            snapshotPath: "Fixtures/Requests/messages/claude-sonnet-4/oauth-direct.json");
+
+    private static async Task RunSnapshot(string apiKey, string snapshotPath)
+    {
+        var handler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var provider = new AnthropicProvider(new HttpClient(handler));
+
+        var model = new LlmModel(
+            Id: "claude-sonnet-4",
+            Name: "claude-sonnet-4",
+            Api: "anthropic-messages",
+            Provider: "anthropic",
+            BaseUrl: "https://api.anthropic.com",
+            Reasoning: true,
+            Input: ["text", "image"],
+            Cost: new ModelCost(3.0m, 15.0m, 0.3m, 3.75m),
+            ContextWindow: 200000,
+            MaxTokens: 12288);
+
+        var toolParams = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "count": { "type": "integer", "minimum": 1, "maximum": 100 }
+              },
+              "required": ["count"]
+            }
+            """).RootElement.Clone();
+
+        var context = new Context(
+            SystemPrompt: "You are a helpful assistant operating inside BotNexus tests. Reply concisely and use tools when asked.",
+            Messages: [new UserMessage(new UserMessageContent("List the first three prime numbers."), FixedTimestamp)],
+            Tools: [new Tool("list_primes", "Returns the first N prime numbers.", toolParams)]);
+
+        var stream = provider.Stream(model, context, new StreamOptions { ApiKey = apiKey });
+        _ = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        handler.RequestBody.ShouldNotBeNull();
+        handler.LastRequestUri.ShouldNotBeNull();
+
+        var actual = BuildEnvelope(handler);
+        var actualJson = SerializeStable(actual);
+
+        var fullPath = Path.Combine(AppContext.BaseDirectory, snapshotPath);
+        if (!File.Exists(fullPath))
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"Snapshot file not found: {snapshotPath}\n" +
+                "Bootstrap by writing the following content into the file:\n\n" +
+                actualJson);
+        }
+
+        var expectedJson = await File.ReadAllTextAsync(fullPath);
+        Normalise(actualJson).ShouldBe(Normalise(expectedJson));
+    }
+
+    private static IDictionary<string, object?> BuildEnvelope(RecordingHandler handler)
+    {
+        var headers = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in HeadersOfInterest)
+        {
+            if (!handler.RequestHeaders.TryGetValue(key, out var value)) continue;
+
+            headers[key] = key switch
+            {
+                _ when string.Equals(key, "Authorization", StringComparison.OrdinalIgnoreCase) => RedactAuthorization(value),
+                _ when string.Equals(key, "x-api-key", StringComparison.OrdinalIgnoreCase) => "<redacted>",
+                _ => value,
+            };
+        }
+
+        using var body = JsonDocument.Parse(handler.RequestBody!);
+        var bodyObject = JsonSerializer.Deserialize<JsonElement>(body.RootElement.GetRawText());
+
+        return new Dictionary<string, object?>
+        {
+            ["method"] = "POST",
+            ["path"] = handler.LastRequestUri!.AbsolutePath,
+            ["headers"] = headers,
+            ["body"] = bodyObject,
+        };
+    }
+
+    private static string RedactAuthorization(string raw)
+    {
+        var space = raw.IndexOf(' ');
+        return space < 0 ? "<redacted>" : $"{raw[..space]} <redacted>";
+    }
+
+    private static readonly string[] HeadersOfInterest =
+    [
+        "Authorization",
+        "x-api-key",
+        "anthropic-version",
+        "anthropic-beta",
+        "user-agent",
+        "x-app",
+    ];
+
+    private static string SerializeStable(object value) => JsonSerializer.Serialize(value, new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    });
+
+    private static string Normalise(string raw) =>
+        raw.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
+
+    private const string MinimalSse = """
+        event: message_start
+        data: {"type":"message_start","message":{"id":"msg_1"}}
+
+        event: message_stop
+        data: {"type":"message_stop"}
+        """;
+
+    private static HttpResponseMessage SseResponse(string payload) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(payload, Encoding.UTF8, "text/event-stream")
+    };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public string? RequestBody { get; private set; }
+        public Uri? LastRequestUri { get; private set; }
+        public Dictionary<string, string> RequestHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            RequestHeaders = request.Headers.ToDictionary(
+                header => header.Key,
+                header => string.Join(",", header.Value),
+                StringComparer.OrdinalIgnoreCase);
+            RequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return responseFactory(request);
+        }
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/BotNexus.Agent.Providers.Anthropic.Tests.csproj
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/BotNexus.Agent.Providers.Anthropic.Tests.csproj
@@ -19,5 +19,6 @@
 
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Fixtures\Requests\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/Fixtures/Requests/README.md
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/Fixtures/Requests/README.md
@@ -1,0 +1,51 @@
+# Direct-Anthropic Outbound Request Snapshots
+
+Canonical outbound-request envelopes produced when BotNexus drives a
+non-Copilot Anthropic model end-to-end. Used by
+`AnthropicDirectRequestSnapshotTests` (Phase 0c of #810) to lock the
+contract for the two **direct Anthropic** auth paths so that the Copilot
+carve-out cannot regress them:
+
+- `apikey-direct.json` — classic `x-api-key` auth
+- `oauth-direct.json` — Claude Code OAuth (`sk-ant-oat...`) tokens
+
+The Copilot envelope is snapshotted separately in
+`tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Requests/`.
+
+## Layout
+
+```
+Fixtures/Requests/
+  <api>/<model>/
+    <scenario>.json    # method, path, selected headers, request body
+```
+
+## Header allowlist
+
+Only headers the carve-out can plausibly change are captured:
+
+- `Authorization` — value replaced with `<scheme> <redacted>`. Scheme is
+  significant: ApiKey path must NOT send Authorization at all; OAuth path
+  must send `Bearer`.
+- `x-api-key` — value redacted. ApiKey path must send it; OAuth path must
+  not.
+- `anthropic-version`
+- `anthropic-beta` — full comma-joined value (OAuth combines
+  claude-code/oauth/fine-grained betas into one header).
+- `user-agent` — OAuth path uses `claude-cli/<ver>`; ApiKey path is unset.
+- `x-app` — OAuth path uses `cli`; ApiKey path is unset.
+
+Other headers (`accept`, `anthropic-dangerous-direct-browser-access`) are
+exercised by `AnthropicProviderAlignmentTests` and not duplicated here.
+
+## Updating
+
+If a request shape changes intentionally:
+
+1. Run the failing test — the failure message includes the captured envelope.
+2. Paste the JSON into the snapshot file.
+3. Justify the diff in the PR description.
+
+If the snapshot drifts unintentionally during the Copilot carve-out, the
+carve-out has leaked across into direct-Anthropic territory — fix the
+provider, not the snapshot.

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/Fixtures/Requests/messages/claude-sonnet-4/apikey-direct.json
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/Fixtures/Requests/messages/claude-sonnet-4/apikey-direct.json
@@ -1,0 +1,56 @@
+{
+  "method": "POST",
+  "path": "/v1/messages",
+  "headers": {
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+    "anthropic-version": "2023-06-01",
+    "x-api-key": "<redacted>"
+  },
+  "body": {
+    "model": "claude-sonnet-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "List the first three prime numbers.",
+            "cache_control": {
+              "type": "ephemeral"
+            }
+          }
+        ]
+      }
+    ],
+    "max_tokens": 4096,
+    "stream": true,
+    "system": [
+      {
+        "type": "text",
+        "text": "You are a helpful assistant operating inside BotNexus tests. Reply concisely and use tools when asked.",
+        "cache_control": {
+          "type": "ephemeral"
+        }
+      }
+    ],
+    "tools": [
+      {
+        "name": "list_primes",
+        "description": "Returns the first N prime numbers.",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          "required": [
+            "count"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/Fixtures/Requests/messages/claude-sonnet-4/oauth-direct.json
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/Fixtures/Requests/messages/claude-sonnet-4/oauth-direct.json
@@ -1,0 +1,65 @@
+{
+  "method": "POST",
+  "path": "/v1/messages",
+  "headers": {
+    "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14",
+    "anthropic-version": "2023-06-01",
+    "Authorization": "Bearer <redacted>",
+    "user-agent": "claude-cli/2.1.75",
+    "x-app": "cli"
+  },
+  "body": {
+    "model": "claude-sonnet-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "List the first three prime numbers.",
+            "cache_control": {
+              "type": "ephemeral"
+            }
+          }
+        ]
+      }
+    ],
+    "max_tokens": 4096,
+    "stream": true,
+    "system": [
+      {
+        "type": "text",
+        "text": "You are Claude Code, Anthropic's official CLI for Claude.",
+        "cache_control": {
+          "type": "ephemeral"
+        }
+      },
+      {
+        "type": "text",
+        "text": "You are a helpful assistant operating inside BotNexus tests. Reply concisely and use tools when asked.",
+        "cache_control": {
+          "type": "ephemeral"
+        }
+      }
+    ],
+    "tools": [
+      {
+        "name": "list_primes",
+        "description": "Returns the first N prime numbers.",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "count": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          "required": [
+            "count"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0c of the Copilot provider carve-out (#810): a **negative-regression**
snapshot harness. Captures the outbound `/v1/messages` envelopes
`AnthropicProvider` emits today on the two **non-Copilot** auth paths so the
Phase 1 surgery on `AnthropicProvider` cannot silently regress direct
Anthropic users.

Sister to:
- #811 — response-side replay harness
- #812 — Phase 0a, Copilot outbound request snapshot

Together these three PRs cover every wire surface the carve-out can touch
before Phase 1 starts moving code.

## What it pins

Two `[Fact]`s drive a fresh `AnthropicProvider` through an in-test
`RecordingHandler` and assert the captured envelope matches a committed
fixture.

### ApiKey direct (`apikey-direct.json`)
- `x-api-key: <redacted>` (no `Authorization` header)
- `anthropic-beta: fine-grained-tool-streaming-2025-05-14`
- No `user-agent` / `x-app`
- Plain system prompt (no Claude Code prefix)

### OAuth direct (`oauth-direct.json`)
- `Authorization: Bearer <redacted>` (no `x-api-key`)
- `anthropic-beta: claude-code-20250219,oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14`
- `user-agent: claude-cli/2.1.75`
- `x-app: cli`
- Claude Code system-prompt prefix injected ahead of the user prompt

Plus the full request body (model, messages with `cache_control`, tools with
`input_schema`, max_tokens, stream).

## Why this PR matters

Phase 1 will remove the `AuthMode.Copilot` branch from
`AnthropicProvider.ConfigureRequestHeaders` and the OAuth-only branch in
`AnthropicRequestBuilder`. Both touch the **same method bodies** that drive
direct-Anthropic users. A careless refactor could leak Copilot-specific
behaviour into the ApiKey/OAuth paths or vice versa. These snapshots make
that diff impossible to miss.

## Verification

- `dotnet test --filter AnthropicDirectRequestSnapshotTests` → **2 passed**
- `scripts/repo/test-impacted.ps1` → **all green**
  - `BotNexus.Agent.Providers.Anthropic.Tests`: 97 / 97
  - `BotNexus.Architecture.Tests`: green (path-leak fence happy)
  - `BotNexus.Scenarios.Tests`: green
- Zero warnings introduced.

## Snapshot layout

```
tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/
  Fixtures/Requests/
    README.md
    messages/claude-sonnet-4/
      apikey-direct.json
      oauth-direct.json
```

Mirrors the Phase 0a layout under
`BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Requests/`.

## Out of scope

Deferred Phase 0 follow-ups (each a separate small PR):
- 0d — gateway-level provider-selection regression
- 0e — `ConfigCompatibilityTests` (pre-carve-out config.json fixture)
- 0f — `OAuthTokenCacheCompatibilityTests` (pre-carve-out token file fixture)
- Same snapshots for `/responses` and `/chat/completions` non-Copilot paths
  (will piggy-back when we add the equivalent Copilot fixtures)

Closes the Phase 0c checkbox on #810.
