### PR TITLE
test(agents): pin gateway-level Copilot routing (Phase 0d, #810)

### DIFF
--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotGatewayRoutingTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotGatewayRoutingTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Text;
+using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.OpenAI;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests;
+
+/// <summary>
+/// Phase 0d of the Copilot provider carve-out (#810): gateway-level
+/// provider-selection regression.
+///
+/// Where Phase 0a/0c pin the wire shape an individual provider emits,
+/// Phase 0d pins the wiring that <i>chooses</i> the provider. It exercises
+/// the full <see cref="ModelRegistry"/> → <see cref="LlmClient"/> →
+/// <see cref="ApiProviderRegistry"/> → HTTP path so a regression in any of
+/// (a) Copilot model registration, (b) provider registration, or
+/// (c) <see cref="LlmClient.ResolveProvider"/> trips a failure here, not in
+/// some downstream integration test.
+///
+/// When Phase 1 retargets Copilot models from <c>anthropic-messages</c> /
+/// <c>openai-responses</c> / <c>openai-completions</c> onto dedicated
+/// <c>github-copilot-*</c> APIs and registers a new <c>CopilotProvider</c>
+/// trio, the assertions in <see cref="LlmClient_RoutesCopilotModel_ToCopilotEndpoint"/>
+/// must keep passing — the user-visible outcome (request hits Copilot host
+/// with Copilot integration headers and the right path) is invariant.
+/// The non-Copilot rows in <see cref="LlmClient_RoutesDirectModel_ToVendorEndpoint"/>
+/// must also stay green: direct Anthropic/OpenAI users cannot be impacted
+/// by the carve-out.
+/// </summary>
+public class CopilotGatewayRoutingTests
+{
+    /// <summary>
+    /// Per Copilot model family: assert (model.Api) registration is what we
+    /// expect today, then drive LlmClient end-to-end and confirm the
+    /// outbound request hit the Copilot host on the expected path with the
+    /// Copilot integration headers attached.
+    /// </summary>
+    [Theory]
+    [InlineData("claude-haiku-4.5", "anthropic-messages", "/v1/messages")]
+    [InlineData("gpt-5.4", "openai-responses", "/responses")]
+    [InlineData("gpt-4.1", "openai-completions", "/chat/completions")]
+    public async Task LlmClient_RoutesCopilotModel_ToCopilotEndpoint(
+        string modelId,
+        string expectedApi,
+        string expectedPath)
+    {
+        var (llmClient, model, handler) = BuildStack("github-copilot", modelId);
+
+        model.Api.ShouldBe(expectedApi);
+        model.BaseUrl.ShouldBe("https://api.individual.githubcopilot.com");
+
+        await DriveStreamAsync(llmClient, model);
+
+        handler.LastRequestUri.ShouldNotBeNull();
+        handler.LastRequestUri!.Host.ShouldBe("api.individual.githubcopilot.com");
+        handler.LastRequestUri.AbsolutePath.ShouldBe(expectedPath);
+        handler.LastRequestUri.Scheme.ShouldBe("https");
+
+        handler.RequestHeaders.ShouldContainKey("User-Agent");
+        handler.RequestHeaders["User-Agent"].ShouldContain("GitHubCopilotChat");
+        handler.RequestHeaders.ShouldContainKey("Editor-Version");
+        handler.RequestHeaders.ShouldContainKey("Editor-Plugin-Version");
+        handler.RequestHeaders.ShouldContainKey("Copilot-Integration-Id");
+        handler.RequestHeaders["Copilot-Integration-Id"].ShouldContain("vscode-chat");
+
+        handler.RequestHeaders.ShouldContainKey("Authorization");
+        handler.RequestHeaders["Authorization"].ShouldStartWith("Bearer ");
+    }
+
+    /// <summary>
+    /// Direct-vendor models (non-Copilot) must continue to route to the
+    /// vendor host with vendor-appropriate auth, untouched by anything the
+    /// Copilot carve-out does.
+    /// </summary>
+    [Theory]
+    [InlineData("anthropic", "claude-sonnet-4-20250514", "anthropic-messages", "api.anthropic.com", "/v1/messages")]
+    [InlineData("openai", "gpt-4.1", "openai-completions", "api.openai.com", "/v1/chat/completions")]
+    [InlineData("openai", "o3", "openai-responses", "api.openai.com", "/v1/responses")]
+    public async Task LlmClient_RoutesDirectModel_ToVendorEndpoint(
+        string providerKey,
+        string modelId,
+        string expectedApi,
+        string expectedHost,
+        string expectedPath)
+    {
+        var (llmClient, model, handler) = BuildStack(providerKey, modelId);
+
+        model.Api.ShouldBe(expectedApi);
+
+        await DriveStreamAsync(llmClient, model);
+
+        handler.LastRequestUri.ShouldNotBeNull();
+        handler.LastRequestUri!.Host.ShouldBe(expectedHost);
+        handler.LastRequestUri.AbsolutePath.ShouldBe(expectedPath);
+
+        handler.RequestHeaders.ShouldNotContainKey("Copilot-Integration-Id");
+    }
+
+    private static (LlmClient Client, LlmModel Model, RecordingHandler Handler) BuildStack(string providerKey, string modelId)
+    {
+        var modelRegistry = new ModelRegistry();
+        new BuiltInModels().RegisterAll(modelRegistry);
+
+        var model = modelRegistry.GetModel(providerKey, modelId);
+        model.ShouldNotBeNull($"BuiltInModels must register {providerKey}/{modelId}");
+
+        var handler = new RecordingHandler(MakeResponseFactory());
+        var httpClient = new HttpClient(handler);
+
+        var apiProviders = new ApiProviderRegistry();
+        apiProviders.Register(new AnthropicProvider(httpClient));
+        apiProviders.Register(new OpenAIResponsesProvider(httpClient, NullLogger<OpenAIResponsesProvider>.Instance));
+        apiProviders.Register(new OpenAICompletionsProvider(httpClient, NullLogger<OpenAICompletionsProvider>.Instance));
+
+        var llmClient = new LlmClient(apiProviders, modelRegistry);
+        return (llmClient, model!, handler);
+    }
+
+    private static async Task DriveStreamAsync(LlmClient client, LlmModel model)
+    {
+        var context = new Context(
+            SystemPrompt: "tests",
+            Messages: [new UserMessage(new UserMessageContent("ping"), 1_700_000_000_000L)]);
+
+        var stream = client.Stream(model, context, new StreamOptions { ApiKey = "test-key" });
+        _ = await stream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private static Func<HttpRequestMessage, HttpResponseMessage> MakeResponseFactory() => request =>
+    {
+        var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+        // Each provider has its own SSE shape. The minimal "happy" stream
+        // for each lets stream.GetResultAsync() complete without errors.
+        if (path.EndsWith("/v1/messages", StringComparison.Ordinal))
+        {
+            return SseResponse("""
+                event: message_start
+                data: {"type":"message_start","message":{"id":"msg_1"}}
+
+                event: message_stop
+                data: {"type":"message_stop"}
+                """);
+        }
+
+        if (path.EndsWith("/responses", StringComparison.Ordinal))
+        {
+            return SseResponse("""
+                data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}
+                data: [DONE]
+                """);
+        }
+
+        // openai-completions
+        return SseResponse("""
+            data: {"id":"cmpl_1","choices":[{"delta":{"content":"ok"}}]}
+            data: {"choices":[{"finish_reason":"stop","delta":{}}]}
+            data: [DONE]
+            """);
+    };
+
+    private static HttpResponseMessage SseResponse(string payload) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(payload, Encoding.UTF8, "text/event-stream")
+    };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+        public Dictionary<string, string> RequestHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            RequestHeaders = request.Headers.ToDictionary(
+                header => header.Key,
+                header => string.Join(",", header.Value),
+                StringComparer.OrdinalIgnoreCase);
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0d of the Copilot provider carve-out (#810): a **gateway-level
provider-selection** regression. Locks the wiring that picks which
`IApiProvider` actually handles a given `LlmModel`.

Where the earlier Phase 0 PRs pin individual surfaces:
- #811 — response-side stream-parser replay
- #812 — Copilot outbound request body
- #860 — direct-Anthropic outbound request body (negative regression)

…this PR pins the **routing decision** that ties them together. Together
the four PRs surround Phase 1 on every wire surface.

## What it pins

Two `[Theory]`s drive `LlmClient` end-to-end through a real
`ModelRegistry` + `ApiProviderRegistry` stack:

### Copilot models (`LlmClient_RoutesCopilotModel_ToCopilotEndpoint`)
| Model | Today's `model.Api` | Expected path |
| --- | --- | --- |
| `claude-haiku-4.5` | `anthropic-messages` | `/v1/messages` |
| `gpt-5.4` | `openai-responses` | `/responses` |
| `gpt-4.1` | `openai-completions` | `/chat/completions` |

For each row, asserts the outbound request:
- hits `api.individual.githubcopilot.com` over HTTPS
- carries all four Copilot integration headers
  (`User-Agent: GitHubCopilotChat*`, `Editor-Version`, `Editor-Plugin-Version`,
  `Copilot-Integration-Id: vscode-chat`)
- uses `Bearer` auth

### Direct vendor models (`LlmClient_RoutesDirectModel_ToVendorEndpoint`)
| Provider | Model | Host | Path |
| --- | --- | --- | --- |
| `anthropic` | `claude-sonnet-4-20250514` | `api.anthropic.com` | `/v1/messages` |
| `openai` | `gpt-4.1` | `api.openai.com` | `/v1/chat/completions` |
| `openai` | `o3` | `api.openai.com` | `/v1/responses` |

Each row asserts the request hits the vendor host and **does not** carry
`Copilot-Integration-Id` — proving carve-out work cannot leak into direct
flows.

## Why this PR matters

Phase 1 will retarget Copilot models from
`anthropic-messages` / `openai-responses` / `openai-completions` onto
dedicated `github-copilot-*` APIs and register a new `CopilotProvider` trio
in `Program.cs`. A misregistration on either side would silently send
Copilot requests to the wrong provider (or the wrong endpoint). These six
rows catch that the moment it happens.

The Copilot rows pin the **outcome** (right host, right path, right
headers) which is invariant across the carve-out. The direct-vendor rows
pin the **separation** — proof that nothing the carve-out does touches
direct-Anthropic or direct-OpenAI users.

## Verification

- `dotnet test --filter CopilotGatewayRoutingTests` → **6 / 6 passed**
- `scripts/repo/test-impacted.ps1` → **all green**
  - `BotNexus.Agent.Providers.Copilot.Tests`: 59 / 59
  - `BotNexus.Architecture.Tests` (path-leak fence): green
  - `BotNexus.Scenarios.Tests`: green
- Zero warnings introduced.

## Out of scope

Deferred Phase 0 follow-ups (each separate small PR):
- 0e — `ConfigCompatibilityTests` (pre-carve-out `config.json` fixture)
- 0f — `OAuthTokenCacheCompatibilityTests` (pre-carve-out token file fixture)
- Phase 1+ — actual carve-out

Closes the Phase 0d checkbox on #810.
