### PR TITLE
fix(cron): fire SignalR notify when CronTrigger reactivates an archived pinned conversation

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -27,7 +27,8 @@ public sealed class CronTrigger(
     IAgentSupervisor supervisor,
     IConversationStore conversations,
     ISessionStore sessions,
-    ILogger<CronTrigger> logger) : IInternalTrigger
+    ILogger<CronTrigger> logger,
+    IConversationChangeNotifier? changeNotifier = null) : IInternalTrigger
 {
     /// <summary>
     /// Gets the trigger type identifier.
@@ -139,6 +140,25 @@ public sealed class CronTrigger(
                     pinned.Status = ConversationStatus.Active;
                     pinned.UpdatedAt = DateTimeOffset.UtcNow;
                     await conversations.SaveAsync(pinned, ct).ConfigureAwait(false);
+
+                    // Notify the portal so the conversation reappears in the sidebar without
+                    // requiring a page reload. Best-effort: failure here must not block the
+                    // cron turn. (#864)
+                    if (changeNotifier is not null)
+                    {
+                        try
+                        {
+                            await changeNotifier.NotifyConversationChangedAsync(
+                                "updated", agentId.Value, pinned.ConversationId.Value, ct)
+                                .ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex,
+                                "CronTrigger: non-fatal failure sending reactivation notification for conversation {ConversationId}",
+                                pinned.ConversationId);
+                        }
+                    }
                 }
                 return pinned;
             }

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -457,6 +457,113 @@ public sealed class CronTriggerTests
         assistantEntry!.Content.ShouldBe("model-answer");
     }
 
+    // ── #864 reactivation notify tests ─────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for #864: when CronTrigger reactivates an archived pinned conversation,
+    /// it must fire a SignalR notification via IConversationChangeNotifier so the portal
+    /// sidebar reflects the conversation status change without a page reload.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_PinnedArchivedConversation_FiresReactivationNotify()
+    {
+        var archivedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:archived-notify-test"),
+            AgentId = AgentId.From("agent-n"),
+            Title = "Archived Job",
+            IsDefault = false,
+            Status = ConversationStatus.Archived,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-7)
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .Setup(s => s.GetAsync(archivedConversation.ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archivedConversation);
+
+        var notifier = new Mock<IConversationChangeNotifier>();
+        notifier
+            .Setup(n => n.NotifyConversationChangedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var trigger = new CronTrigger(
+            supervisor.Object,
+            conversationStore.Object,
+            sessionStore.Object,
+            NullLogger<CronTrigger>.Instance,
+            notifier.Object);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-n"),
+            "Run archived job",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = JobId.From("job-archived"),
+                ConversationId = archivedConversation.ConversationId
+            });
+
+        // The archived conversation must be reactivated to Active
+        archivedConversation.Status.ShouldBe(ConversationStatus.Active,
+            "CronTrigger must reactivate an archived pinned conversation (#864)");
+
+        // The notifier must fire exactly once with the correct parameters
+        notifier.Verify(
+            n => n.NotifyConversationChangedAsync(
+                "updated",
+                "agent-n",
+                archivedConversation.ConversationId.Value,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "IConversationChangeNotifier must be called once when an archived conversation is reactivated (#864)");
+    }
+
+    /// <summary>
+    /// When no IConversationChangeNotifier is injected (null), reactivating an archived
+    /// conversation must not throw -- the notifier is optional for backward compatibility.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_PinnedArchivedConversation_NoNotifier_DoesNotThrow()
+    {
+        var archivedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:archived-no-notifier"),
+            AgentId = AgentId.From("agent-nn"),
+            Title = "Archived Job No Notifier",
+            IsDefault = false,
+            Status = ConversationStatus.Archived,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-7)
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .Setup(s => s.GetAsync(archivedConversation.ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archivedConversation);
+
+        // No changeNotifier -- constructor omits it (null by default)
+        var trigger = new CronTrigger(
+            supervisor.Object,
+            conversationStore.Object,
+            sessionStore.Object,
+            NullLogger<CronTrigger>.Instance);
+
+        // Must not throw even without a notifier
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-nn"),
+            "Run archived job without notifier",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = JobId.From("job-no-notifier"),
+                ConversationId = archivedConversation.ConversationId
+            });
+
+        archivedConversation.Status.ShouldBe(ConversationStatus.Active,
+            "Conversation must still be reactivated even when notifier is absent");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static (Mock<ISessionStore>, Mock<IConversationStore>, Mock<IAgentSupervisor>) BuildStandardMocks()


### PR DESCRIPTION
Closes #864

## Problem

When a cron job fires against a pinned conversation that has been archived, `CronTrigger.ResolveOrCreateConversationAsync` correctly reactivated the status and saved the conversation — but did not fire a `IConversationChangeNotifier` notification. The portal sidebar would therefore show the conversation as archived until the next page load.

## Changes

- `CronTrigger.cs`: added optional `IConversationChangeNotifier?` parameter (backward-compat default = `null`). After reactivation, calls `NotifyConversationChangedAsync("updated", ...)` best-effort (exceptions are caught and logged as Warning, never propagated to the cron turn).
- `CronTriggerTests.cs`: 2 new regression tests
  - `CreateSessionAsync_PinnedArchivedConversation_FiresReactivationNotify` — verifies notify fires exactly once with correct parameters
  - `CreateSessionAsync_PinnedArchivedConversation_NoNotifier_DoesNotThrow` — verifies backward compat when no notifier is wired

## Test Results

`test-impacted.ps1`: 167 Architecture + 2077 Gateway.Tests + 125 Conversations.Tests + 29 Scenarios = all pass.

## Merge Notes

Independent of all open PRs — only touches `CronTrigger.cs` and `CronTriggerTests.cs`. Safe to merge in any order.