### PR TITLE
fix(gateway): seal session when CloseAfterResponse forces archive in CrossWorldFederationController

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -240,8 +240,24 @@ public sealed class CrossWorldFederationController(
             // final turn via CloseAfterResponse (single-shot / max-turns) — archive the
             // receiver-side conversation. Otherwise just clear ActiveSessionId so the portal
             // stops rendering it as "in flight" while the sender pauses between turns.
+            //
+            // Seal-when-archived rule (#626): whenever ArchiveOnExchangeEndAsync fires (for
+            // either reason) we also seal the session so the state machine is consistent.
+            // An Archived conversation with an Active session allows a follow-up sender relay
+            // to resurrect ActiveSessionId on an Archived conversation, which is structurally
+            // inconsistent and portal-visible. The exchangeFinished branch already seals above;
+            // we seal here for the CloseAfterResponse-only path.
             if (exchangeFinished || request.CloseAfterResponse)
             {
+                if (!exchangeFinished)
+                {
+                    // CloseAfterResponse forced archive but the target did not invoke
+                    // finish_agent_exchange. Seal the session now so the receiver-side
+                    // state machine matches: Archived conversation  +  Sealed session.
+                    session.Status = GatewaySessionStatus.Sealed;
+                    session.Metadata["conversationStatus"] = "sealed";
+                    await sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
+                }
                 await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
             }
             else
@@ -254,7 +270,8 @@ public sealed class CrossWorldFederationController(
                 Response = response.Content ?? string.Empty,
                 // Surface the finish state on the wire so the sender's loop sees a non-"active"
                 // status when the target has explicitly closed the exchange.
-                Status = exchangeFinished ? "sealed" : "active",
+                // After #626 fix: CloseAfterResponse also seals, so surface "sealed" for that path too.
+                Status = (exchangeFinished || request.CloseAfterResponse) ? "sealed" : "active",
                 SessionId = sessionId.Value,
                 ExchangeFinished = exchangeFinished,
                 FinishReason = exchangeFinished ? finishReason : null,

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1,4 +1,4 @@
-using BotNexus.Domain;
+﻿using BotNexus.Domain;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -1273,6 +1273,73 @@ public sealed class CrossWorldFederationControllerTests
         var session = await sessions.GetAsync(existence[0].SessionId);
         session.ShouldNotBeNull();
         session!.Status.ShouldBe(GatewaySessionStatus.Sealed);
+    }
+
+
+    // #626 seal-when-archived behaviour pins
+    //
+    // Issue #626: When CloseAfterResponse=true && exchangeFinished=false the receiver archives
+    // the conversation but previously left the session Active. A follow-up relay could then
+    // resurrect ActiveSessionId on an Archived conversation, which is structurally inconsistent
+    // and portal-visible. Fix: apply the "seal-when-archived" rule - whenever
+    // ArchiveOnExchangeEndAsync fires, also seal the session.
+
+    /// <summary>
+    /// Behaviour pin for #626: when CloseAfterResponse=true and the target agent did NOT invoke
+    /// finish_agent_exchange, the receiver must seal the session (not just archive the conversation).
+    /// The combination Archived+Active is a state-machine inconsistency.
+    /// </summary>
+    [Fact]
+    public async Task RelayAsync_CloseAfterResponse_WithoutFinishTool_SealsSession()
+    {
+        // Arrange: single-shot relay (closeAfterResponse=true); target does NOT invoke finish_agent_exchange.
+        var (controller, sessions, conversations, _) = BuildController(replyContent: "ack");
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        // Act
+        var response = await controller.RelayAsync(
+            BuildRequest(closeAfterResponse: true), CancellationToken.None);
+
+        // Assert: conversation is Archived (P9-C, already tested elsewhere)
+        var convs = await conversations.ListAsync();
+        convs[0].Status.ShouldBe(ConversationStatus.Archived,
+            "P9-C prerequisite: conversation must be archived on CloseAfterResponse=true.");
+
+        // Assert: session must also be Sealed (#626)
+        var existence = await sessions.GetExistenceAsync(AgentId.From(TargetAgentId), new ExistenceQuery());
+        existence.Count.ShouldBe(1);
+        var session = await sessions.GetAsync(existence[0].SessionId);
+        session.ShouldNotBeNull();
+        session!.Status.ShouldBe(GatewaySessionStatus.Sealed,
+            "#626: CloseAfterResponse forces archive; the session must also be Sealed so the state " +
+            "machine is consistent. An Archived conversation with an Active session would allow " +
+            "a follow-up sender relay to resurrect ActiveSessionId on an Archived conversation.");
+    }
+
+    /// <summary>
+    /// Behaviour pin for #626: the response Status field must be "sealed" when CloseAfterResponse
+    /// forces archive (even though the target did not invoke finish_agent_exchange).
+    /// The sender loop uses this field to decide whether to stop or retry.
+    /// </summary>
+    [Fact]
+    public async Task RelayAsync_CloseAfterResponse_WithoutFinishTool_ResponseStatusIsSealed()
+    {
+        var (controller, _, _, _) = BuildController(replyContent: "done");
+        SetApiKeyHeader(controller, SharedApiKey);
+
+        var response = await controller.RelayAsync(
+            BuildRequest(closeAfterResponse: true), CancellationToken.None);
+
+        var ok = response.Result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<CrossWorldRelayResponse>();
+
+        payload.Status.ShouldBe("sealed",
+            "#626: when CloseAfterResponse forces a terminal archive, the wire Status must be " +
+            """\"sealed\"" so the sender loop does not spin on a false \"active\" result. """ +
+            "ExchangeFinished remains false (the target never called finish_agent_exchange).");
+        payload.ExchangeFinished.ShouldBeFalse(
+            "ExchangeFinished must remain false even when CloseAfterResponse seals the session - " +
+            "the target did not invoke finish_agent_exchange.");
     }
 
     // ─── end P9-C receiver pins ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #626

## Problem

In `CrossWorldFederationController.ExecuteRelayAsync`, when `CloseAfterResponse=true && exchangeFinished=false` (sender forced final turn, target never invoked `finish_agent_exchange`), the code archived the receiver-side conversation via `ArchiveOnExchangeEndAsync` but left the session `Active`.

This hybrid state (`Archived` conversation + `Active` session) is structurally inconsistent: a follow-up sender relay with the same `RemoteSessionId` would call `ResolveSessionAsync` which finds an Active session and resurrects `ActiveSessionId` on an already-Archived conversation. The portal renders this as a ghost active conversation.

## Fix

Apply the **seal-when-archived rule** (#626): whenever `ArchiveOnExchangeEndAsync` fires, also seal the session. The `exchangeFinished` path already sealed (existing behaviour). Added the seal for the `CloseAfterResponse && !exchangeFinished` path:

1. `CrossWorldFederationController.cs`: In the `if (exchangeFinished || request.CloseAfterResponse)` block, when `!exchangeFinished`, seal the session before calling `ArchiveOnExchangeEndAsync`.
2. Response `Status` field: updated from `exchangeFinished ? "sealed" : "active"` to `(exchangeFinished || request.CloseAfterResponse) ? "sealed" : "active"` so the sender loop sees the correct terminal status.

## Tests

2 new behaviour pins in `CrossWorldFederationControllerTests.cs`:
- `RelayAsync_CloseAfterResponse_WithoutFinishTool_SealsSession` — asserts session is `Sealed` after a `CloseAfterResponse=true` relay without `finish_agent_exchange`
- `RelayAsync_CloseAfterResponse_WithoutFinishTool_ResponseStatusIsSealed` — asserts response `Status = "sealed"` and `ExchangeFinished = false` on the same path

`test-impacted.ps1`: 167 Architecture + 2077 Gateway.Tests + 125 Conversations.Tests + 29 Scenarios = all pass.

## Merge Notes

Independent of all open PRs — only touches `CrossWorldFederationController.cs` and `CrossWorldFederationControllerTests.cs`. Safe to merge in any order.