### PR TITLE
fix(tests): make Post_WhenQueueFull_ReturnsFalse deterministic with processorStarted gate

### DIFF
--- a/tests/gateway/BotNexus.Gateway.Tests/Dispatching/DefaultInboundMessageOrchestratorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Dispatching/DefaultInboundMessageOrchestratorTests.cs
@@ -348,15 +348,23 @@ public sealed class DefaultInboundMessageOrchestratorTests
     }
 
     [Fact]
-    public void Post_WhenQueueFull_ReturnsFalse()
+    public async Task Post_WhenQueueFull_ReturnsFalse()
     {
         var processor = Substitute.For<IInboundMessageProcessor>();
-        // Capacity 1 so we can fill it with the first Post
+        // Capacity 1.  Strategy:
+        //   1. Post first message   -> channel buffer has 1 item
+        //   2. Wait until worker dequeues it (enters ProcessAsync) -> buffer empty
+        //   3. Post second message  -> buffer has 1 item again
+        //   4. Post third message   -> buffer full, TryWrite returns false
+        // Without step 2 the worker drains the buffer before step 3, making
+        // the capacity assertion racy.
+        var processorStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var processorGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         processor
             .ProcessAsync(Arg.Any<InboundMessage>(), Arg.Any<CancellationToken>())
             .Returns(async _ =>
             {
+                processorStarted.TrySetResult(true);
                 await processorGate.Task;
                 return new InboundProcessingOutcome(EmptyDispatches, false);
             });
@@ -364,11 +372,20 @@ public sealed class DefaultInboundMessageOrchestratorTests
         var orchestrator = new DefaultInboundMessageOrchestrator(
             processor, NullLogger<DefaultInboundMessageOrchestrator>.Instance, queueCapacity: 1);
 
+        // 1. First Post fills the buffer
         var first = orchestrator.Post(CreateMessage("addr-full"));
-        var second = orchestrator.Post(CreateMessage("addr-full"));
-
         first.ShouldBeTrue();
-        second.ShouldBeFalse(); // queue is full
+
+        // 2. Wait until worker has consumed the first item (buffer now empty, worker in ProcessAsync)
+        await processorStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // 3. Second Post fills the buffer again
+        var second = orchestrator.Post(CreateMessage("addr-full"));
+        second.ShouldBeTrue();
+
+        // 4. Third Post: buffer is at capacity -> TryWrite returns false
+        var third = orchestrator.Post(CreateMessage("addr-full"));
+        third.ShouldBeFalse(); // queue is full
 
         // Unblock the processor to avoid test hang
         processorGate.TrySetResult(true);


### PR DESCRIPTION
Fixes a flaky test introduced in #832.

## Root cause

`Post_WhenQueueFull_ReturnsFalse` assumed that after the first `Post()` to a capacity-1 channel, the channel buffer would remain full when the second `Post()` was called. In practice, the background worker task calls `ReadAllAsync` and dequeues the first item almost immediately - emptying the buffer. The second `TryWrite` then succeeds, making `second.ShouldBeFalse()` fail intermittently on fast CI runners.

## Fix

Changed test to `async Task`. Added `processorStarted` TCS that fires when `ProcessAsync` begins. Test flow:
1. `first = Post(1)` - fills channel buffer
2. `await processorStarted` - confirms worker dequeued item (buffer now empty)
3. `second = Post(2)` - fills buffer again  
4. `third = Post(3)` - buffer at capacity, `TryWrite` returns false

This is deterministic with no wall-clock dependency.

## Verification

All impacted tests pass (Architecture + Gateway.Tests + Scenarios.Tests).

Closes N/A - standalone flaky test fix.