### PR TITLE
fix(cron): guard ActiveSessionId so cron sessions never evict a human session (#867)

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Triggers/CronTrigger.cs
@@ -81,7 +81,16 @@ public sealed class CronTrigger(
         else
             session.Metadata["cronJobId"] = request.CronJobId.Value.Value;
 
-        if (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId)
+        // Only claim ActiveSessionId if no human (SignalR) session currently holds it.
+        // A cron session must never evict a human session from the portal-facing pointer.
+        // If a user has intentionally pinned a cron job to their conversation, the cron
+        // messages still appear live (SignalR routes by ConversationId group, not session),
+        // but the portal stays connected to the human session. (#867)
+        var existingIsHumanSession = conversation.ActiveSessionId is { } existingId
+            && !existingId.Value.StartsWith("cron:", StringComparison.Ordinal);
+
+        if (!existingIsHumanSession &&
+            (conversation.ActiveSessionId is null || conversation.ActiveSessionId != sessionId))
         {
             conversation.ActiveSessionId = sessionId;
             conversation.UpdatedAt = DateTimeOffset.UtcNow;

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -478,32 +478,10 @@ public sealed class CronTriggerTests
             ActiveSessionId = humanSessionId,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
-=======
-    // ── #864 reactivation notify tests ─────────────────────────────────────
-
-    /// <summary>
-    /// Regression test for #864: when CronTrigger reactivates an archived pinned conversation,
-    /// it must fire a SignalR notification via IConversationChangeNotifier so the portal
-    /// sidebar reflects the conversation status change without a page reload.
-    /// </summary>
-    [Fact]
-    public async Task CreateSessionAsync_PinnedArchivedConversation_FiresReactivationNotify()
-    {
-        var archivedConversation = new Conversation
-        {
-            ConversationId = ConversationId.From("conv:archived-notify-test"),
-            AgentId = AgentId.From("agent-n"),
-            Title = "Archived Job",
-            IsDefault = false,
-            Status = ConversationStatus.Archived,
-            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
-            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-7)
->>>>>>> origin/main
         };
 
         var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
         conversationStore
-<<<<<<< HEAD
             .Setup(s => s.GetAsync(pinnedConversation.ConversationId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(pinnedConversation);
 
@@ -546,69 +524,10 @@ public sealed class CronTriggerTests
             ActiveSessionId = null,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
-=======
-            .Setup(s => s.GetAsync(archivedConversation.ConversationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(archivedConversation);
-
-        var notifier = new Mock<IConversationChangeNotifier>();
-        notifier
-            .Setup(n => n.NotifyConversationChangedAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        var trigger = new CronTrigger(
-            supervisor.Object,
-            conversationStore.Object,
-            sessionStore.Object,
-            NullLogger<CronTrigger>.Instance,
-            notifier.Object);
-
-        await trigger.CreateSessionAsync(
-            AgentId.From("agent-n"),
-            "Run archived job",
-            request: new InternalTriggerRequest
-            {
-                CronJobId = JobId.From("job-archived"),
-                ConversationId = archivedConversation.ConversationId
-            });
-
-        // The archived conversation must be reactivated to Active
-        archivedConversation.Status.ShouldBe(ConversationStatus.Active,
-            "CronTrigger must reactivate an archived pinned conversation (#864)");
-
-        // The notifier must fire exactly once with the correct parameters
-        notifier.Verify(
-            n => n.NotifyConversationChangedAsync(
-                "updated",
-                "agent-n",
-                archivedConversation.ConversationId.Value,
-                It.IsAny<CancellationToken>()),
-            Times.Once,
-            "IConversationChangeNotifier must be called once when an archived conversation is reactivated (#864)");
-    }
-
-    /// <summary>
-    /// When no IConversationChangeNotifier is injected (null), reactivating an archived
-    /// conversation must not throw -- the notifier is optional for backward compatibility.
-    /// </summary>
-    [Fact]
-    public async Task CreateSessionAsync_PinnedArchivedConversation_NoNotifier_DoesNotThrow()
-    {
-        var archivedConversation = new Conversation
-        {
-            ConversationId = ConversationId.From("conv:archived-no-notifier"),
-            AgentId = AgentId.From("agent-nn"),
-            Title = "Archived Job No Notifier",
-            IsDefault = false,
-            Status = ConversationStatus.Archived,
-            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
-            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-7)
->>>>>>> origin/main
         };
 
         var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
         conversationStore
-<<<<<<< HEAD
             .Setup(s => s.GetAsync(cronConversation.ConversationId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(cronConversation);
 
@@ -667,7 +586,91 @@ public sealed class CronTriggerTests
         humanConversation.ActiveSessionId.ShouldNotBeNull(
             "Cron should claim ActiveSessionId when it is null — no human session to protect");
         humanConversation.ActiveSessionId!.Value.Value.ShouldStartWith("cron:");
-=======
+    }
+
+    // ── #864 reactivation notify tests ───────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for #864: when CronTrigger reactivates an archived pinned conversation,
+    /// it must fire a SignalR notification via IConversationChangeNotifier so the portal
+    /// sidebar reflects the conversation status change without a page reload.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_PinnedArchivedConversation_FiresReactivationNotify()
+    {
+        var archivedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:archived-notify-test"),
+            AgentId = AgentId.From("agent-n"),
+            Title = "Archived Job",
+            IsDefault = false,
+            Status = ConversationStatus.Archived,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-7)
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .Setup(s => s.GetAsync(archivedConversation.ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archivedConversation);
+
+        var notifier = new Mock<IConversationChangeNotifier>();
+        notifier
+            .Setup(n => n.NotifyConversationChangedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var trigger = new CronTrigger(
+            supervisor.Object,
+            conversationStore.Object,
+            sessionStore.Object,
+            NullLogger<CronTrigger>.Instance,
+            notifier.Object);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-n"),
+            "Run archived job",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = JobId.From("job-archived"),
+                ConversationId = archivedConversation.ConversationId
+            });
+
+        // The archived conversation must be reactivated to Active
+        archivedConversation.Status.ShouldBe(ConversationStatus.Active,
+            "CronTrigger must reactivate an archived pinned conversation (#864)");
+
+        // The notifier must fire exactly once with the correct parameters
+        notifier.Verify(
+            n => n.NotifyConversationChangedAsync(
+                "updated",
+                "agent-n",
+                archivedConversation.ConversationId.Value,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "IConversationChangeNotifier must be called once when an archived conversation is reactivated (#864)");
+    }
+
+    /// <summary>
+    /// When no IConversationChangeNotifier is injected (null), reactivating an archived
+    /// conversation must not throw -- the notifier is optional for backward compatibility.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_PinnedArchivedConversation_NoNotifier_DoesNotThrow()
+    {
+        var archivedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:archived-no-notifier"),
+            AgentId = AgentId.From("agent-nn"),
+            Title = "Archived Job No Notifier",
+            IsDefault = false,
+            Status = ConversationStatus.Archived,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-7)
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
             .Setup(s => s.GetAsync(archivedConversation.ConversationId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(archivedConversation);
 
@@ -690,7 +693,6 @@ public sealed class CronTriggerTests
 
         archivedConversation.Status.ShouldBe(ConversationStatus.Active,
             "Conversation must still be reactivated even when notifier is absent");
->>>>>>> origin/main
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -545,7 +545,7 @@ public sealed class CronTriggerTests
         // ActiveSessionId should now be set to the cron session
         cronConversation.ActiveSessionId.ShouldNotBeNull(
             "Cron session should stamp ActiveSessionId when no human session holds it");
-        cronConversation.ActiveSessionId!.Value.ShouldStartWith("cron:");
+        cronConversation.ActiveSessionId!.Value.Value.ShouldStartWith("cron:");
     }
 
     /// <summary>
@@ -585,7 +585,7 @@ public sealed class CronTriggerTests
 
         humanConversation.ActiveSessionId.ShouldNotBeNull(
             "Cron should claim ActiveSessionId when it is null — no human session to protect");
-        humanConversation.ActiveSessionId!.Value.ShouldStartWith("cron:");
+        humanConversation.ActiveSessionId!.Value.Value.ShouldStartWith("cron:");
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Api/CronTriggerTests.cs
@@ -457,6 +457,137 @@ public sealed class CronTriggerTests
         assistantEntry!.Content.ShouldBe("model-answer");
     }
 
+    // ── #867 session ownership tests ────────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for #867: cron session must NOT overwrite ActiveSessionId when
+    /// a human (SignalR) session already holds it. The cron messages still flow to the
+    /// portal via the ConversationId group — the pointer just stays on the human session.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_HumanSessionHoldsActiveSessionId_DoesNotOverwrite()
+    {
+        var humanSessionId = SessionId.From("signalr:abc123");
+        var pinnedConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:human-conv"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "Human conversation",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            ActiveSessionId = humanSessionId,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .Setup(s => s.GetAsync(pinnedConversation.ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pinnedConversation);
+
+        var savedConversations = new List<Conversation>();
+        conversationStore
+            .Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()))
+            .Callback<Conversation, CancellationToken>((c, _) => savedConversations.Add(c))
+            .Returns(Task.CompletedTask);
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "Cron task",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = JobId.From("job-x"),
+                ConversationId = pinnedConversation.ConversationId
+            });
+
+        // ActiveSessionId must remain pointing at the human session — never the cron session
+        pinnedConversation.ActiveSessionId.ShouldBe(humanSessionId,
+            "Cron session must not overwrite ActiveSessionId when a human session holds it (#867)");
+    }
+
+    /// <summary>
+    /// #867: cron fires on its own cronconv: conversation — ActiveSessionId MUST be stamped
+    /// (no human session is being displaced).
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_CronOwnsConversation_StampsActiveSessionId()
+    {
+        var cronConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("cronconv:farnsworth:job-heartbeat"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "Heartbeat",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            ActiveSessionId = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .Setup(s => s.GetAsync(cronConversation.ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cronConversation);
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "heartbeat",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = JobId.From("job-heartbeat"),
+                ConversationId = cronConversation.ConversationId
+            });
+
+        // ActiveSessionId should now be set to the cron session
+        cronConversation.ActiveSessionId.ShouldNotBeNull(
+            "Cron session should stamp ActiveSessionId when no human session holds it");
+        cronConversation.ActiveSessionId!.Value.ShouldStartWith("cron:");
+    }
+
+    /// <summary>
+    /// #867: cron fires on a human conversation whose ActiveSessionId is NULL
+    /// (no human session is connected) — cron SHOULD claim it.
+    /// </summary>
+    [Fact]
+    public async Task CreateSessionAsync_NullActiveSessionId_CronClaimsIt()
+    {
+        var humanConversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:unattended-conv"),
+            AgentId = AgentId.From("agent-a"),
+            Title = "Unattended conversation",
+            IsDefault = false,
+            Status = ConversationStatus.Active,
+            ActiveSessionId = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var (sessionStore, conversationStore, supervisor) = BuildStandardMocks();
+        conversationStore
+            .Setup(s => s.GetAsync(humanConversation.ConversationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(humanConversation);
+
+        var trigger = new CronTrigger(supervisor.Object, conversationStore.Object, sessionStore.Object, NullLogger<CronTrigger>.Instance);
+
+        await trigger.CreateSessionAsync(
+            AgentId.From("agent-a"),
+            "post summary",
+            request: new InternalTriggerRequest
+            {
+                CronJobId = JobId.From("job-summary"),
+                ConversationId = humanConversation.ConversationId
+            });
+
+        humanConversation.ActiveSessionId.ShouldNotBeNull(
+            "Cron should claim ActiveSessionId when it is null — no human session to protect");
+        humanConversation.ActiveSessionId!.Value.ShouldStartWith("cron:");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static (Mock<ISessionStore>, Mock<IConversationStore>, Mock<IAgentSupervisor>) BuildStandardMocks()


### PR DESCRIPTION
Closes #867. Guards ActiveSessionId in CronTrigger so cron sessions never evict a human SignalR session. 3 new regression tests.