### PR TITLE
fix(skills): emit LogWarning when SkillDiscovery skips a skill due to invalid frontmatter

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/BotNexus.Extensions.Skills.csproj
+++ b/src/extensions/BotNexus.Extensions.Skills/BotNexus.Extensions.Skills.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 

--- a/src/extensions/BotNexus.Extensions.Skills/SkillDiscovery.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillDiscovery.cs
@@ -1,4 +1,5 @@
 using BotNexus.Extensions.Skills.Security;
+using Microsoft.Extensions.Logging;
 using System.IO.Abstractions;
 
 namespace BotNexus.Extensions.Skills;
@@ -14,23 +15,37 @@ public static class SkillDiscovery
     private const int MaxCompatibilityLength = 500;
     private const long MaxSkillFileBytes = 524_288; // 512 KB
 
+    /// <summary>
+    /// Discovers and merges skills from global, agent, and workspace directories.
+    /// </summary>
+    /// <param name="globalSkillsDir">Optional path to the global skills directory.</param>
+    /// <param name="agentSkillsDir">Optional path to the agent-level skills directory.</param>
+    /// <param name="workspaceSkillsDir">Optional path to the workspace-level skills directory.</param>
+    /// <param name="fileSystem">Optional filesystem abstraction (defaults to real filesystem).</param>
+    /// <param name="logger">Optional logger; when supplied, emits warnings for skipped skills.</param>
     public static IReadOnlyList<SkillDefinition> Discover(
         string? globalSkillsDir,
         string? agentSkillsDir,
         string? workspaceSkillsDir,
-        IFileSystem? fileSystem = null)
+        IFileSystem? fileSystem = null,
+        ILogger? logger = null)
     {
         var fs = fileSystem ?? new FileSystem();
         var skills = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
 
-        ScanDirectory(skills, globalSkillsDir, SkillSource.Global, fs);
-        ScanDirectory(skills, agentSkillsDir, SkillSource.Agent, fs);
-        ScanDirectory(skills, workspaceSkillsDir, SkillSource.Workspace, fs);
+        ScanDirectory(skills, globalSkillsDir, SkillSource.Global, fs, logger);
+        ScanDirectory(skills, agentSkillsDir, SkillSource.Agent, fs, logger);
+        ScanDirectory(skills, workspaceSkillsDir, SkillSource.Workspace, fs, logger);
 
         return skills.Values.ToList();
     }
 
-    private static void ScanDirectory(Dictionary<string, SkillDefinition> skills, string? directory, SkillSource source, IFileSystem fileSystem)
+    private static void ScanDirectory(
+        Dictionary<string, SkillDefinition> skills,
+        string? directory,
+        SkillSource source,
+        IFileSystem fileSystem,
+        ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(directory) || !fileSystem.Directory.Exists(directory))
             return;
@@ -46,50 +61,95 @@ public static class SkillDiscovery
             {
                 var skillFileInfo = fileSystem.FileInfo.New(skillMdPath);
                 if (skillFileInfo.Length > MaxSkillFileBytes)
+                {
+                    logger?.LogWarning(
+                        "Skill at '{SkillDir}' skipped: SKILL.md exceeds the {MaxBytes} byte size limit.",
+                        skillDir, MaxSkillFileBytes);
                     continue;
+                }
 
                 var content = fileSystem.File.ReadAllText(skillMdPath);
                 var skill = SkillParser.Parse(dirName, content, skillDir, source);
 
-                if (!Validate(skill, dirName))
+                if (!TryValidate(skill, dirName, skillDir, logger, out var reason))
+                {
+                    logger?.LogWarning(
+                        "Skill at '{SkillDir}' skipped: {Reason}. Check for UTF-8 BOM or malformed YAML frontmatter.",
+                        skillDir, reason);
                     continue;
+                }
 
                 // Security scan: block skills with critical findings
                 var scanSummary = SkillSecurityScanner.ScanDirectory(skillDir, fileSystem: fileSystem);
                 if (scanSummary.Critical > 0)
+                {
+                    logger?.LogWarning(
+                        "Skill at '{SkillDir}' skipped: security scan found {CriticalCount} critical finding(s).",
+                        skillDir, scanSummary.Critical);
                     continue;
+                }
 
                 skills[skill.Name] = skill;
             }
-            catch
+            catch (Exception ex)
             {
-                // Skip malformed skills
+                logger?.LogWarning(ex,
+                    "Skill at '{SkillDir}' skipped: SKILL.md could not be loaded — {Message}.",
+                    skillDir, ex.Message);
             }
         }
     }
 
-    private static bool Validate(SkillDefinition skill, string directoryName)
+    /// <summary>
+    /// Returns <c>true</c> when the skill passes all validation rules.
+    /// On failure, <paramref name="failureReason"/> is set to a human-readable explanation.
+    /// </summary>
+    private static bool TryValidate(
+        SkillDefinition skill,
+        string directoryName,
+        string skillDir,
+        ILogger? logger,
+        out string failureReason)
     {
         if (!SkillParser.IsValidName(skill.Name))
+        {
+            failureReason = $"name '{skill.Name}' is not a valid skill name (lowercase alphanumeric and hyphens, max 64 chars)";
             return false;
+        }
 
         if (!string.Equals(skill.Name, directoryName, StringComparison.Ordinal))
+        {
+            failureReason = $"name '{skill.Name}' does not match directory name '{directoryName}'";
             return false;
+        }
 
         if (string.IsNullOrWhiteSpace(skill.Description))
+        {
+            failureReason = "description field is missing or empty";
             return false;
+        }
 
         if (skill.Description.Length > MaxDescriptionLength)
+        {
+            failureReason = $"description exceeds the {MaxDescriptionLength}-character limit ({skill.Description.Length} chars)";
             return false;
+        }
 
         // Per spec: compatibility must be 1-500 characters if provided
         if (skill.Compatibility is not null && skill.Compatibility.Length > MaxCompatibilityLength)
+        {
+            failureReason = $"compatibility field exceeds the {MaxCompatibilityLength}-character limit";
             return false;
+        }
 
         // Skills with disable-model-invocation are excluded from model context
         if (skill.DisableModelInvocation)
+        {
+            failureReason = "disable-model-invocation is set — skill is excluded from context injection";
             return false;
+        }
 
+        failureReason = string.Empty;
         return true;
     }
 }

--- a/src/extensions/BotNexus.Extensions.Skills/SkillPromptHookHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillPromptHookHandler.cs
@@ -1,6 +1,8 @@
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Hooks;
 using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions;
 
 namespace BotNexus.Extensions.Skills;
@@ -16,17 +18,20 @@ public sealed class SkillPromptHookHandler
     private readonly IAgentWorkspaceManager _workspaceManager;
     private readonly IAgentRegistry _agentRegistry;
     private readonly IFileSystem _fileSystem;
+    private readonly ILogger<SkillPromptHookHandler> _logger;
 
     /// <summary>Skills load after other hooks.</summary>
     public int Priority => 100;
 
     public SkillPromptHookHandler(
         IAgentWorkspaceManager workspaceManager,
-        IAgentRegistry agentRegistry)
+        IAgentRegistry agentRegistry,
+        ILogger<SkillPromptHookHandler>? logger = null)
     {
         _workspaceManager = workspaceManager;
         _agentRegistry = agentRegistry;
         _fileSystem = new FileSystem();
+        _logger = logger ?? NullLogger<SkillPromptHookHandler>.Instance;
     }
 
     public Task<BeforePromptBuildResult?> HandleAsync(
@@ -45,7 +50,7 @@ public sealed class SkillPromptHookHandler
         var agentSkillsDir = Path.Combine(botnexusHome, "agents", hookEvent.AgentId.Value, "skills");
         var workspaceSkillsDir = Path.Combine(workspacePath, "skills");
 
-        var allSkills = SkillDiscovery.Discover(globalSkillsDir, agentSkillsDir, workspaceSkillsDir, _fileSystem);
+        var allSkills = SkillDiscovery.Discover(globalSkillsDir, agentSkillsDir, workspaceSkillsDir, _fileSystem, _logger);
         if (allSkills.Count == 0)
             return Task.FromResult<BeforePromptBuildResult?>(null);
 

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/BotNexus.Extensions.Skills.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/BotNexus.Extensions.Skills.Tests.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillDiscoveryTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillDiscoveryTests.cs
@@ -1,4 +1,7 @@
 using BotNexus.Extensions.Skills;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
 using System.IO.Abstractions.TestingHelpers;
 
 namespace BotNexus.Extensions.Skills.Tests;
@@ -168,4 +171,86 @@ public sealed class SkillDiscoveryTests
             """);
     }
 
+    // ── warning-log tests (issue #870) ───────────────────────────────────────
+
+    [Fact]
+    public void Discover_SkillWithMissingDescription_EmitsWarning()
+    {
+        // A SKILL.md with a name but no description should be skipped with a LogWarning.
+        var dir = Path.Combine(TempDir, "warn-no-desc");
+        var skillDir = Path.Combine(dir, "my-skill");
+        _fileSystem.Directory.CreateDirectory(skillDir);
+        _fileSystem.File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+            "---\nname: my-skill\n---\nBody without description.");
+
+        var logger = new CapturingLogger();
+        var skills = SkillDiscovery.Discover(dir, null, null, _fileSystem, logger);
+
+        skills.ShouldBeEmpty();
+        logger.Warnings.ShouldContain(w => w.Contains("my-skill") && w.Contains("description"));
+    }
+
+    [Fact]
+    public void Discover_SkillWithInvalidName_EmitsWarning()
+    {
+        // Directory name "bad name" (space) should fail SkillParser.IsValidName.
+        var dir = Path.Combine(TempDir, "warn-bad-name");
+        var skillDir = Path.Combine(dir, "bad name");
+        _fileSystem.Directory.CreateDirectory(skillDir);
+        _fileSystem.File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+            "---\nname: bad name\ndescription: desc\n---\nBody.");
+
+        var logger = new CapturingLogger();
+        var skills = SkillDiscovery.Discover(dir, null, null, _fileSystem, logger);
+
+        skills.ShouldBeEmpty();
+        logger.Warnings.ShouldNotBeEmpty("Expected a warning for invalid skill name");
+    }
+
+    [Fact]
+    public void Discover_ValidSkill_EmitsNoWarning()
+    {
+        // A well-formed skill must never emit any warnings.
+        var dir = Path.Combine(TempDir, "warn-valid");
+        CreateSkill(dir, "my-skill", "A valid description");
+
+        var logger = new CapturingLogger();
+        var skills = SkillDiscovery.Discover(dir, null, null, _fileSystem, logger);
+
+        skills.ShouldHaveSingleItem();
+        logger.Warnings.ShouldBeEmpty("No warnings expected for a valid skill");
+    }
+
+    [Fact]
+    public void Discover_SkillWithNullLogger_DoesNotThrow()
+    {
+        // Passing null for logger must be safe (backward compat with all existing call sites).
+        var dir = Path.Combine(TempDir, "warn-null-logger");
+        var skillDir = Path.Combine(dir, "my-skill");
+        _fileSystem.Directory.CreateDirectory(skillDir);
+        // Malformed SKILL.md so a warning would normally fire if logger were wired
+        _fileSystem.File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+            "---\nname: my-skill\n---\nNo description.");
+
+        // Should not throw even though skill is invalid and logger is null
+        Should.NotThrow(() => SkillDiscovery.Discover(dir, null, null, _fileSystem, logger: null));
+    }
+
+}
+
+/// <summary>
+/// Minimal logger that captures Warning-level messages for test assertions.
+/// </summary>
+public sealed class CapturingLogger : ILogger
+{
+    public List<string> Warnings { get; } = new();
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullLogger.Instance.BeginScope(state);
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel >= LogLevel.Warning)
+            Warnings.Add(formatter(state, exception));
+    }
 }


### PR DESCRIPTION
Closes #870

## Problem

`SkillDiscovery.ScanDirectory` silently skipped invalid skills with bare `continue` or an empty `catch {}`. Users had no diagnostic path when a skill failed to load — it simply wasn't present in the list.

Common triggers:
- UTF-8 BOM in `SKILL.md` (related: #869 workspace editor BOM fix)
- Missing or empty `description` field (description drives skill triggering)
- Directory name / skill `name` mismatch
- Invalid skill name characters
- `disable-model-invocation: true` (excluded by design)

## Changes

1. **`SkillDiscovery.Discover`**: adds optional `ILogger? logger = null` parameter — backward compatible, all existing call sites compile without change.
2. **`SkillDiscovery.ScanDirectory`**: replaced silent skips with `logger?.LogWarning(...)` for:
   - File exceeds 512 KB limit
   - Validation failures (invalid name, name/dir mismatch, missing/blank description, overlong description or compatibility, disable-model-invocation)
   - Security scan critical findings
   - I/O or parse exception
3. **`SkillDiscovery.TryValidate`**: extracted private helper that returns the failure reason string, keeping all validation logic in one place.
4. **`SkillPromptHookHandler`**: injects `ILogger<SkillPromptHookHandler>` (optional, defaults to `NullLogger`) and passes it to `Discover`.
5. **`BotNexus.Extensions.Skills.csproj`**: explicit `Microsoft.Extensions.Logging.Abstractions` reference.

## Tests (4 new)

- `Discover_SkillWithMissingDescription_EmitsWarning`: warning contains skill path and `description`
- `Discover_SkillWithInvalidName_EmitsWarning`: warning emitted for spaces in directory name
- `Discover_ValidSkill_EmitsNoWarning`: no spurious warnings for a good skill
- `Discover_SkillWithNullLogger_DoesNotThrow`: null logger is safe (backward compat)

## Merge Notes

Independent of all open PRs — only touches `BotNexus.Extensions.Skills` and its test project. Safe to merge in any order.