### PR TITLE
fix(gateway): write workspace files as BOM-free UTF-8 to prevent YAML parse failures

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/WorkspaceController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/WorkspaceController.cs
@@ -322,7 +322,10 @@ public sealed class WorkspaceController : ControllerBase
         if (!string.IsNullOrEmpty(parentDir) && !_fileSystem.Directory.Exists(parentDir))
             return BadRequest(new { error = "Parent directory does not exist." });
 
-        _fileSystem.File.WriteAllText(resolvedFinalPath, request.Content, Encoding.UTF8);
+        // Use BOM-free UTF-8: Encoding.UTF8 emits a BOM on Windows which breaks YAML
+        // frontmatter parsers (e.g. SkillParser) and agent workspace file consumers.
+        var noBomUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        _fileSystem.File.WriteAllText(resolvedFinalPath, request.Content, noBomUtf8);
         return NoContent();
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/WorkspaceControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/WorkspaceControllerTests.cs
@@ -302,6 +302,61 @@ public sealed class WorkspaceControllerWriteTests
         fileSystem.File.ReadAllText(Path.Combine(WorkspacePath, "notes.md")).ShouldBe("new content");
     }
 
+    [Fact]
+    public void WriteFile_NoBomWritten_RawBytesDoNotStartWithUtf8BomBytes()
+    {
+        // Regression for #869: Encoding.UTF8 emits a UTF-8 BOM on Windows which breaks
+        // YAML frontmatter parsers (SkillParser, YAML loaders). The workspace editor must
+        // write BOM-free UTF-8 so any consumer can parse the file without special handling.
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, ".keep")] = new(string.Empty)
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        controller.WriteFile("agent-a", "skill.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = "---\nname: test\n---\nbody" });
+
+        var bytes = fileSystem.File.ReadAllBytes(Path.Combine(WorkspacePath, "skill.md"));
+        // UTF-8 BOM is 0xEF 0xBB 0xBF
+        bytes.Length.ShouldBeGreaterThan(0);
+        (bytes[0] == 0xEF && bytes.Length > 2 && bytes[1] == 0xBB && bytes[2] == 0xBF).ShouldBeFalse(
+            "WriteFile must not emit a UTF-8 BOM");
+        // Verify content is readable (no invisible prefix)
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
+        text.ShouldStartWith("---");
+    }
+
+    [Fact]
+    public void WriteFile_ContentWithLeadingBom_BomNotDoubled()
+    {
+        // If content arrives already containing a BOM (from a client-side quirk), WriteAllText
+        // with BOM-free encoding must not add a second BOM. The written bytes should contain
+        // exactly one BOM sequence.
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            [Path.Combine(WorkspacePath, ".keep")] = new(string.Empty)
+        });
+        var controller = CreateController(fileSystem, WorkspacePath);
+
+        // Content with an explicit BOM prefix
+        var contentWithBom = "\uFEFF# title";
+        controller.WriteFile("agent-a", "bom-input.md",
+            new BotNexus.Gateway.Api.Models.WorkspaceWriteRequest { Content = contentWithBom });
+
+        var bytes = fileSystem.File.ReadAllBytes(Path.Combine(WorkspacePath, "bom-input.md"));
+        // BOM-free encoding writes the content as-is. If content had a BOM character, it is
+        // preserved as a Unicode code point (3 bytes 0xEF 0xBB 0xBF) but there is exactly one.
+        // Double-BOM would be 6 bytes of BOM at the start, which should never occur.
+        var bomCount = 0;
+        for (var i = 0; i <= bytes.Length - 3; i++)
+        {
+            if (bytes[i] == 0xEF && bytes[i + 1] == 0xBB && bytes[i + 2] == 0xBF)
+                bomCount++;
+        }
+        bomCount.ShouldBeLessThanOrEqualTo(1, "WriteFile must not double-add a BOM");
+    }
+
     // ── sad paths ─────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #869

## Problem

`WorkspaceController.WriteFile` used `Encoding.UTF8` which emits a UTF-8 BOM (bytes `0xEF 0xBB 0xBF`) on Windows. This caused silent failures in:
- **Skills**: `SKILL.md` frontmatter unparseable → skill never loads (name/description blank)
- **YAML consumers**: BOM breaks any parser that doesn't explicitly strip it
- **Agent workspace files**: invisible leading character causes `oldText` mismatches in edit tools

Note: `SkillParser.cs` already strips BOMs at parse time as a defensive measure, but the root cause is the write path.

## Fix

Change `Encoding.UTF8` → `new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)` in the `WriteFile` action.

## Tests

2 new regression tests in `WorkspaceControllerTests.cs`:
- `WriteFile_NoBomWritten_RawBytesDoNotStartWithUtf8BomBytes`: asserts raw bytes do not start with `0xEF 0xBB 0xBF`
- `WriteFile_ContentWithLeadingBom_BomNotDoubled`: asserts at most one BOM sequence when content already contains a BOM character

## Merge Notes

File overlap with PR #843 (`feat/workspace-file-protection`) in `WorkspaceController.cs` — but the changes are in different methods (delete path vs write path). No functional conflict. Safe to merge in any order.

Independent of all other open PRs.