### PR TITLE
test(gateway): pin pre-carve-out config.json compatibility (Phase 0e, #810)

### DIFF
--- a/tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj
+++ b/tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj
@@ -47,5 +47,6 @@
 
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Fixtures\Configs\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/ConfigCompatibilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/ConfigCompatibilityTests.cs
@@ -1,0 +1,153 @@
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Gateway.Configuration;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+/// <summary>
+/// Phase 0e of the Copilot provider carve-out (#810): deployment-safety
+/// regression. Loads a representative pre-carve-out <c>config.json</c>
+/// fixture and asserts that everything a user currently has in their config
+/// continues to deserialize and resolve.
+///
+/// Compatibility surfaces this test guards against the carve-out:
+/// - S1: Model ids in <c>providers.*.defaultModel</c> and <c>providers.*.models</c>
+///   keep resolving through <see cref="ModelRegistry.GetModel"/>.
+/// - S2: Both provider keys users may have typed (<c>"copilot"</c> alias
+///   and <c>"github-copilot"</c> canonical) keep loading and keep resolving
+///   to Copilot built-in models.
+/// - S4: <see cref="ProviderConfig"/> deserialization is additive only —
+///   <c>apiKey</c>, <c>baseUrl</c>, <c>defaultModel</c>, <c>models</c>,
+///   and <c>enabled</c> all round-trip from a v1 config.
+/// - S5: Schema <c>Version</c> stays at 1 — no implicit migration.
+///
+/// When Phase 1 introduces dedicated <c>github-copilot-*</c> APIs and
+/// (optionally) a <c>CopilotProvider</c>, this test must keep passing
+/// unchanged — proving prior configs continue to work without user-side
+/// edits.
+/// </summary>
+public sealed class ConfigCompatibilityTests
+{
+    private static readonly string FixturePath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Fixtures",
+        "Configs",
+        "precarveout-config.json");
+
+    [Fact]
+    public void PreCarveOutConfig_Loads_WithoutErrors()
+    {
+        var config = PlatformConfigLoader.Load(FixturePath);
+
+        config.ShouldNotBeNull();
+        config.Version.ShouldBe(1);
+        config.Schema.ShouldBe("https://botnexus.dev/schemas/config.json");
+        config.Gateway.ShouldNotBeNull();
+        config.Gateway!.ListenUrl.ShouldBe("http://localhost:18790");
+    }
+
+    [Fact]
+    public void PreCarveOutConfig_PreservesAllProviderEntries()
+    {
+        var config = PlatformConfigLoader.Load(FixturePath);
+        config.Providers.ShouldNotBeNull();
+        var providers = config.Providers!;
+
+        providers.ShouldContainKey("copilot");
+        providers.ShouldContainKey("github-copilot");
+        providers.ShouldContainKey("anthropic");
+        providers.ShouldContainKey("openai");
+    }
+
+    [Fact]
+    public void PreCarveOutConfig_CopilotAliasEntry_RoundTripsAllProviderFields()
+    {
+        var providers = PlatformConfigLoader.Load(FixturePath).Providers!;
+        var copilot = providers["copilot"];
+
+        copilot.Enabled.ShouldBeTrue();
+        copilot.ApiKey.ShouldBe("ghu_REDACTED_COPILOT_TOKEN");
+        copilot.BaseUrl.ShouldBe("https://api.individual.githubcopilot.com");
+        copilot.DefaultModel.ShouldBe("claude-sonnet-4");
+        copilot.Models.ShouldNotBeNull();
+        copilot.Models!.ShouldBe(["claude-haiku-4.5", "claude-sonnet-4", "claude-sonnet-4.5", "gpt-4.1", "gpt-5.4"]);
+    }
+
+    [Fact]
+    public void PreCarveOutConfig_GitHubCopilotCanonicalEntry_RoundTripsAllProviderFields()
+    {
+        var providers = PlatformConfigLoader.Load(FixturePath).Providers!;
+        var copilot = providers["github-copilot"];
+
+        copilot.Enabled.ShouldBeTrue();
+        copilot.ApiKey.ShouldBe("ghu_REDACTED_ENTERPRISE_TOKEN");
+        copilot.BaseUrl.ShouldBe("https://api.enterprise.githubcopilot.com");
+        copilot.DefaultModel.ShouldBe("claude-opus-4.6");
+        copilot.Models.ShouldNotBeNull();
+        copilot.Models!.ShouldBe(["claude-opus-4.6", "gpt-5.2"]);
+    }
+
+    [Fact]
+    public void PreCarveOutConfig_EveryConfiguredCopilotModel_ResolvesThroughAliasAndCanonicalKeys()
+    {
+        var providers = PlatformConfigLoader.Load(FixturePath).Providers!;
+        var modelRegistry = new ModelRegistry();
+        new BuiltInModels().RegisterAll(modelRegistry);
+
+        // S2 invariant: the "copilot" alias must keep resolving to Copilot built-ins.
+        foreach (var modelId in CollectModelIds(providers["copilot"]))
+        {
+            modelRegistry.GetModel("copilot", modelId)
+                .ShouldNotBeNull($"alias 'copilot' must resolve model '{modelId}'");
+        }
+
+        // The canonical "github-copilot" key must of course also resolve.
+        foreach (var modelId in CollectModelIds(providers["github-copilot"]))
+        {
+            modelRegistry.GetModel("github-copilot", modelId)
+                .ShouldNotBeNull($"'github-copilot' must resolve model '{modelId}'");
+        }
+    }
+
+    [Fact]
+    public void PreCarveOutConfig_AliasAndCanonical_ResolveToTheSameModel()
+    {
+        var modelRegistry = new ModelRegistry();
+        new BuiltInModels().RegisterAll(modelRegistry);
+
+        var viaAlias = modelRegistry.GetModel("copilot", "claude-sonnet-4");
+        var viaCanonical = modelRegistry.GetModel("github-copilot", "claude-sonnet-4");
+
+        viaAlias.ShouldNotBeNull();
+        viaCanonical.ShouldNotBeNull();
+        ModelRegistry.ModelsAreEqual(viaAlias!, viaCanonical!).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PreCarveOutConfig_DirectVendorModels_ResolveUnaffected()
+    {
+        var providers = PlatformConfigLoader.Load(FixturePath).Providers!;
+        var modelRegistry = new ModelRegistry();
+        new BuiltInModels().RegisterAll(modelRegistry);
+
+        foreach (var modelId in CollectModelIds(providers["anthropic"]))
+        {
+            modelRegistry.GetModel("anthropic", modelId)
+                .ShouldNotBeNull($"direct anthropic must resolve '{modelId}'");
+        }
+
+        foreach (var modelId in CollectModelIds(providers["openai"]))
+        {
+            modelRegistry.GetModel("openai", modelId)
+                .ShouldNotBeNull($"direct openai must resolve '{modelId}'");
+        }
+    }
+
+    private static IEnumerable<string> CollectModelIds(ProviderConfig provider)
+    {
+        if (!string.IsNullOrWhiteSpace(provider.DefaultModel))
+            yield return provider.DefaultModel!;
+        if (provider.Models is null) yield break;
+        foreach (var id in provider.Models)
+            yield return id;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Fixtures/Configs/precarveout-config.json
+++ b/tests/gateway/BotNexus.Gateway.Tests/Fixtures/Configs/precarveout-config.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://botnexus.dev/schemas/config.json",
+  "version": 1,
+  "gateway": {
+    "listenUrl": "http://localhost:18790",
+    "defaultAgentId": "default-agent",
+    "logLevel": "Information"
+  },
+  "providers": {
+    "copilot": {
+      "enabled": true,
+      "apiKey": "ghu_REDACTED_COPILOT_TOKEN",
+      "baseUrl": "https://api.individual.githubcopilot.com",
+      "defaultModel": "claude-sonnet-4",
+      "models": [
+        "claude-haiku-4.5",
+        "claude-sonnet-4",
+        "claude-sonnet-4.5",
+        "gpt-4.1",
+        "gpt-5.4"
+      ]
+    },
+    "github-copilot": {
+      "enabled": true,
+      "apiKey": "ghu_REDACTED_ENTERPRISE_TOKEN",
+      "baseUrl": "https://api.enterprise.githubcopilot.com",
+      "defaultModel": "claude-opus-4.6",
+      "models": [
+        "claude-opus-4.6",
+        "gpt-5.2"
+      ]
+    },
+    "anthropic": {
+      "enabled": true,
+      "apiKey": "sk-ant-api03-REDACTED",
+      "baseUrl": "https://api.anthropic.com",
+      "defaultModel": "claude-sonnet-4-20250514"
+    },
+    "openai": {
+      "enabled": true,
+      "apiKey": "sk-REDACTED",
+      "defaultModel": "gpt-4.1",
+      "models": [
+        "gpt-4.1",
+        "o3"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0e of the Copilot provider carve-out (#810): **deployment-safety**
regression. Loads a representative pre-carve-out `config.json` fixture and
asserts every field a user currently has continues to deserialize and
resolve.

This is the safety net for compatibility surface S1/S2/S4/S5 listed in the
carve-out deployment-safety plan: **no existing install should require a
config edit after Phase 1 ships.**

Joins the surrounding Phase 0 PRs (#811, #812, #860, #863) — between them
they fence the carve-out on every observable surface.

## What it pins

Fixture: `tests/gateway/BotNexus.Gateway.Tests/Fixtures/Configs/precarveout-config.json`
covers four provider entries:

- `copilot` — the alias key (individual host)
- `github-copilot` — the canonical key (enterprise host)
- `anthropic` — direct vendor
- `openai` — direct vendor

…each populated with realistic fields: `enabled`, `apiKey`, `baseUrl`,
`defaultModel`, `models`.

Seven `[Fact]`s in `ConfigCompatibilityTests`:

1. `PreCarveOutConfig_Loads_WithoutErrors` — version 1, schema URL, gateway
   section all parse.
2. `PreCarveOutConfig_PreservesAllProviderEntries` — all four provider
   dictionary keys survive deserialization.
3. `PreCarveOutConfig_CopilotAliasEntry_RoundTripsAllProviderFields` —
   ProviderConfig field round trip for the `copilot` alias path.
4. `PreCarveOutConfig_GitHubCopilotCanonicalEntry_RoundTripsAllProviderFields`
   — same, for the canonical key.
5. `PreCarveOutConfig_EveryConfiguredCopilotModel_ResolvesThroughAliasAndCanonicalKeys`
   — every model id named in `providers.copilot.models` and
   `providers["github-copilot"].models` resolves via `ModelRegistry` +
   `BuiltInModels`.
6. `PreCarveOutConfig_AliasAndCanonical_ResolveToTheSameModel` — proves the
   alias map is intact (`"copilot"` ↔ `"github-copilot"`); they return the
   same `LlmModel` for `"claude-sonnet-4"`.
7. `PreCarveOutConfig_DirectVendorModels_ResolveUnaffected` — every model
   in the `anthropic` and `openai` entries resolves; carve-out work cannot
   bleed into direct flows.

## Why this PR matters

Phase 1 will retarget Copilot models from `anthropic-messages` /
`openai-responses` / `openai-completions` onto dedicated `github-copilot-*`
APIs, register a new `CopilotProvider` trio, and trim `AnthropicProvider`'s
auth-mode switch. None of those changes should require users to edit their
config — and this test makes any regression on that promise loud and
specific.

In particular, **the alias map (`"copilot"` → `"github-copilot"`) is now
fenced**: removing or renaming it will fail Fact #5 and #6.

## Verification

- `dotnet test --filter ConfigCompatibilityTests` → **7 / 7 passed**
- `scripts/repo/test-impacted.ps1` → **all green**
  - `BotNexus.Gateway.Tests`: 2093 / 2094 (1 pre-existing skip)
  - `BotNexus.Architecture.Tests` (path-leak fence): green
  - `BotNexus.Scenarios.Tests`: green
- Zero warnings introduced.

## Out of scope

Final Phase 0 sub-phase, then carve-out begins:
- 0f — `OAuthTokenCacheCompatibilityTests` (pre-carve-out token file fixture)
- Phase 1+ — actual carve-out

Closes the Phase 0e checkbox on #810.
