### PR TITLE
fix(skills): support YAML block scalars in SkillParser frontmatter

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/SkillParser.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillParser.cs
@@ -90,9 +90,41 @@ public static class SkillParser
     private static Dictionary<string, string> ParseFrontmatter(string frontmatter)
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var line in frontmatter.Split('\n'))
+        var lines = frontmatter.Split('\n');
+
+        string? pendingBlockKey = null;     // key waiting for block scalar content
+        bool pendingBlockIsFolded = false;  // true = '>' (fold newlines), false = '|' (preserve)
+        var pendingBlockLines = new List<string>();
+
+        void FlushPendingBlock()
         {
-            // Skip indented lines (they belong to metadata or list blocks)
+            if (pendingBlockKey is null) return;
+            var value = pendingBlockIsFolded
+                ? string.Join(" ", pendingBlockLines).TrimEnd()
+                : string.Join("\n", pendingBlockLines).TrimEnd();
+            if (!string.IsNullOrWhiteSpace(value))
+                result[pendingBlockKey] = value;
+            pendingBlockKey = null;
+            pendingBlockLines.Clear();
+        }
+
+        foreach (var line in lines)
+        {
+            // Collecting indented block scalar content
+            if (pendingBlockKey is not null)
+            {
+                if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
+                {
+                    // Strip one level of leading whitespace (common indentation)
+                    pendingBlockLines.Add(line.TrimStart());
+                    continue;
+                }
+
+                // First non-indented line ends the block
+                FlushPendingBlock();
+            }
+
+            // Skip remaining indented lines that aren't block scalar content
             if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
                 continue;
 
@@ -101,12 +133,35 @@ public static class SkillParser
                 continue;
 
             var key = line[..sep].Trim();
-            var value = line[(sep + 1)..].Trim().Trim('"', '\'');
+            var rawValue = line[(sep + 1)..].Trim().Trim('"', '\'');
 
-            // Skip block-level keys (metadata:, etc. with no inline value)
-            if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
-                result[key] = value;
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            // Detect block scalar indicators
+            if (rawValue == "|")
+            {
+                pendingBlockKey = key;
+                pendingBlockIsFolded = false;
+                pendingBlockLines.Clear();
+                continue;
+            }
+
+            if (rawValue == ">")
+            {
+                pendingBlockKey = key;
+                pendingBlockIsFolded = true;
+                pendingBlockLines.Clear();
+                continue;
+            }
+
+            // Skip block-level keys (e.g. metadata:) with no inline value
+            if (!string.IsNullOrWhiteSpace(rawValue))
+                result[key] = rawValue;
         }
+
+        // Flush any block scalar that ended at EOF
+        FlushPendingBlock();
 
         return result;
     }

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillParserTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillParserTests.cs
@@ -135,4 +135,87 @@ public sealed class SkillParserTests
         var skill = SkillParser.Parse("actual-dir", markdown, "/s/actual-dir", SkillSource.Global);
         skill.Name.ShouldBe("declared-name");
     }
+
+    // -------------------------------------------------------------------------
+    // Block scalar tests (issue #876)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Parse_LiteralBlockScalar_PreservesNewlines()
+    {
+        var markdown = """
+            ---
+            name: my-skill
+            description: |
+              This skill does something
+              across multiple lines.
+            ---
+            # Content
+            """;
+
+        var skill = SkillParser.Parse("my-skill", markdown, "/s/my-skill", SkillSource.Global);
+
+        skill.Description.ShouldContain("This skill does something");
+        skill.Description.ShouldContain("across multiple lines.");
+        // Literal block: newlines preserved
+        skill.Description.ShouldContain("\n");
+    }
+
+    [Fact]
+    public void Parse_FoldedBlockScalar_CollapsesNewlinesToSpaces()
+    {
+        var markdown = """
+            ---
+            name: my-skill
+            description: >
+              This skill does something
+              across multiple lines.
+            ---
+            # Content
+            """;
+
+        var skill = SkillParser.Parse("my-skill", markdown, "/s/my-skill", SkillSource.Global);
+
+        skill.Description.ShouldContain("This skill does something");
+        skill.Description.ShouldContain("across multiple lines.");
+        // Folded block: newlines collapsed to spaces
+        skill.Description.ShouldNotContain("\n");
+    }
+
+    [Fact]
+    public void Parse_BlockScalar_DoesNotAffectSingleLineValues()
+    {
+        var markdown = """
+            ---
+            name: my-skill
+            description: A simple single-line description
+            ---
+            Content.
+            """;
+
+        var skill = SkillParser.Parse("my-skill", markdown, "/s/my-skill", SkillSource.Global);
+
+        skill.Description.ShouldBe("A simple single-line description");
+    }
+
+    [Fact]
+    public void Parse_BlockScalar_MixedFrontmatter_ParsesAllFields()
+    {
+        var markdown = """
+            ---
+            name: complex-skill
+            description: |
+              First line.
+              Second line.
+            license: MIT
+            ---
+            Content.
+            """;
+
+        var skill = SkillParser.Parse("complex-skill", markdown, "/s/complex-skill", SkillSource.Global);
+
+        skill.Description.ShouldContain("First line.");
+        skill.Description.ShouldContain("Second line.");
+        skill.License.ShouldBe("MIT");
+    }
 }


### PR DESCRIPTION
Closes #876

## Problem
`ParseFrontmatter` stored `description = "|"` or `description = ">"` when a YAML block scalar was used. Subsequent indented lines (the actual content) were silently skipped by the indentation guard.

## Fix
- `ParseFrontmatter` now detects `|` (literal) and `>` (folded) block scalar indicators on a key's value position
- Subsequent indented lines are collected into the block value
- `|` preserves newlines via `string.Join("\n", ...)`
- `>` collapses newlines to spaces via `string.Join(" ", ...)`
- First non-indented line terminates block collection
- Block scalar ending at EOF is flushed correctly
- All existing single-line parsing behaviour is unchanged

## Tests
4 new tests in `SkillParserTests.cs`:
- `Parse_LiteralBlockScalar_PreservesNewlines`
- `Parse_FoldedBlockScalar_CollapsesNewlinesToSpaces`
- `Parse_BlockScalar_DoesNotAffectSingleLineValues` (regression guard)
- `Parse_BlockScalar_MixedFrontmatter_ParsesAllFields`

157/157 BotNexus.Extensions.Skills.Tests + 167/167 Architecture.Tests pass.

## Merge Notes
Touches `SkillParser.cs` and `SkillParserTests.cs` only. No file overlap with any open PR. Safe to merge in any order.
