### PR TITLE
feat(gateway): auto-archive inactive conversations after configurable retention period

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentConversationRetentionConfig.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentConversationRetentionConfig.cs
@@ -1,0 +1,21 @@
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Per-agent override for conversation auto-archive retention policy.
+/// When set on an <see cref="AgentDescriptor"/>, these values take precedence over the
+/// world-level <c>gateway.conversations.autoArchive*</c> settings.
+/// </summary>
+public sealed record AgentConversationRetentionConfig
+{
+    /// <summary>
+    /// Whether auto-archive is enabled for this agent's conversations.
+    /// Set to <c>false</c> to disable auto-archive for this agent regardless of the world default.
+    /// </summary>
+    public bool AutoArchiveEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Number of days of inactivity after which this agent's conversations are auto-archived.
+    /// Overrides the world-level default when set. A value of zero or negative disables auto-archive for this agent.
+    /// </summary>
+    public int? AutoArchiveAfterDays { get; init; }
+}

--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -1,4 +1,4 @@
-using BotNexus.Domain.Primitives;
+﻿using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Security;
 
@@ -156,4 +156,6 @@ public sealed record AgentDescriptor : ICitizen
     /// </summary>
     public IReadOnlyDictionary<string, System.Text.Json.JsonElement> ExtensionConfig { get; init; } =
         new Dictionary<string, System.Text.Json.JsonElement>();
+/// <summary>Conversation retention policy override for this agent. Null means world default applies.</summary>
+    public AgentConversationRetentionConfig? ConversationRetention { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway/Configuration/ConversationRetentionOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/ConversationRetentionOptions.cs
@@ -1,0 +1,25 @@
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// World-level (gateway-default) retention policy for conversations.
+/// Per-agent overrides are configured in <see cref="BotNexus.Gateway.Abstractions.Models.AgentConversationRetentionConfig"/>.
+/// </summary>
+public sealed class ConversationRetentionOptions
+{
+    /// <summary>
+    /// Whether auto-archive is enabled at the world level. Defaults to <c>false</c> (opt-in).
+    /// </summary>
+    public bool AutoArchiveEnabled { get; set; }
+
+    /// <summary>
+    /// Number of days of inactivity after which a conversation is auto-archived.
+    /// A value of zero or negative is treated as disabled. Default is 30 days.
+    /// </summary>
+    public int AutoArchiveAfterDays { get; set; } = 30;
+
+    /// <summary>
+    /// How often the retention service scans for conversations to archive.
+    /// Defaults to once per hour.
+    /// </summary>
+    public TimeSpan CheckInterval { get; set; } = TimeSpan.FromHours(1);
+}

--- a/src/gateway/BotNexus.Gateway/Conversations/ConversationRetentionHostedService.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/ConversationRetentionHostedService.cs
@@ -1,0 +1,171 @@
+﻿using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Conversations;
+
+/// <summary>
+/// Background service that periodically archives conversations that have been inactive
+/// for longer than the configured retention threshold.
+/// <para>
+/// Auto-archive is opt-in: the world-level <c>gateway.conversations.autoArchiveEnabled</c>
+/// must be <c>true</c> before any archiving occurs. Per-agent overrides can extend or
+/// reduce the window, or disable auto-archive entirely for a specific agent.
+/// </para>
+/// <para>Pinned conversations (once #780 is implemented) are always excluded.</para>
+/// </summary>
+public sealed class ConversationRetentionHostedService(
+    IConversationStore conversationStore,
+    IConversationChangeNotifier changeNotifier,
+    IAgentRegistry agentRegistry,
+    IOptions<ConversationRetentionOptions> optionsAccessor,
+    ILogger<ConversationRetentionHostedService> logger) : BackgroundService
+{
+    private readonly IConversationStore _conversationStore = conversationStore;
+    private readonly IConversationChangeNotifier _changeNotifier = changeNotifier;
+    private readonly IAgentRegistry _agentRegistry = agentRegistry;
+    private readonly ILogger<ConversationRetentionHostedService> _logger = logger;
+
+    private ConversationRetentionOptions Options => optionsAccessor.Value;
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunRetentionOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Conversation retention iteration failed.");
+            }
+
+            var delay = Options.CheckInterval > TimeSpan.Zero
+                ? Options.CheckInterval
+                : TimeSpan.FromHours(1);
+            await Task.Delay(delay, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Runs a single retention pass: archives all conversations that have exceeded the
+    /// configured inactivity threshold. Returns the count of archived conversations.
+    /// </summary>
+    public async Task<int> RunRetentionOnceAsync(CancellationToken cancellationToken = default)
+    {
+        var worldOptions = Options;
+
+        // World-level auto-archive must be enabled as the opt-in gate.
+        if (!worldOptions.AutoArchiveEnabled)
+            return 0;
+
+        var worldThresholdDays = worldOptions.AutoArchiveAfterDays > 0
+            ? worldOptions.AutoArchiveAfterDays
+            : 0;
+
+        if (worldThresholdDays <= 0)
+            return 0;
+
+        var now = DateTimeOffset.UtcNow;
+        var conversations = await _conversationStore.ListAsync(ct: cancellationToken)
+            .ConfigureAwait(false);
+
+        var archivedCount = 0;
+
+        foreach (var conv in conversations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Only archive Active conversations.
+            if (conv.Status != ConversationStatus.Active)
+                continue;
+
+            // Exclude pinned conversations. IsPinned is always false until #780 is implemented;
+            // this guard is a forward-compatible no-op that prevents regressions once pinning lands.
+            if (IsConversationPinned(conv))
+                continue;
+
+            // Resolve per-agent effective threshold.
+            var effectiveThresholdDays = ResolveEffectiveThreshold(conv.AgentId, worldThresholdDays);
+            if (effectiveThresholdDays <= 0)
+                continue;
+
+            var inactiveFor = now - conv.UpdatedAt;
+            if (inactiveFor < TimeSpan.FromDays(effectiveThresholdDays))
+                continue;
+
+            await _conversationStore.ArchiveAsync(conv.ConversationId, cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Auto-archived conversation {ConversationId} (agent {AgentId}) after {InactiveDays:F1} days of inactivity (threshold: {ThresholdDays}d).",
+                conv.ConversationId,
+                conv.AgentId,
+                inactiveFor.TotalDays,
+                effectiveThresholdDays);
+
+            await NotifyBestEffortAsync(conv, cancellationToken).ConfigureAwait(false);
+            archivedCount++;
+        }
+
+        if (archivedCount > 0)
+            _logger.LogInformation("Conversation retention: archived {Count} conversation(s).", archivedCount);
+
+        return archivedCount;
+    }
+
+    private int ResolveEffectiveThreshold(AgentId agentId, int worldDefault)
+    {
+        var descriptor = _agentRegistry.Get(agentId);
+        if (descriptor?.ConversationRetention is not { } agentRetention)
+            return worldDefault;
+
+        // Per-agent override: disabled flag wins first.
+        if (!agentRetention.AutoArchiveEnabled)
+            return 0;
+
+        // Per-agent AutoArchiveAfterDays overrides world default when explicitly set.
+        if (agentRetention.AutoArchiveAfterDays.HasValue)
+            return agentRetention.AutoArchiveAfterDays.Value > 0 ? agentRetention.AutoArchiveAfterDays.Value : 0;
+
+        return worldDefault;
+    }
+
+    /// <summary>
+    /// Forward-compatible pin check. Always returns <c>false</c> until issue #780
+    /// (pin conversations) adds an <c>IsPinned</c> field to <see cref="Conversation"/>.
+    /// </summary>
+    private static bool IsConversationPinned(Conversation conversation) =>
+        // TODO(#780): return conversation.IsPinned once the field is added.
+        false;
+
+    private async Task NotifyBestEffortAsync(Conversation conv, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _changeNotifier.NotifyConversationChangedAsync(
+                "archived",
+                conv.AgentId.Value,
+                conv.ConversationId.Value,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "SignalR notify failed for auto-archive of conversation {ConversationId}; portal will refresh on next poll.",
+                conv.ConversationId);
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using BotNexus.Gateway.Abstractions.Channels;
+﻿using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Dispatching;
@@ -63,6 +63,7 @@ public static class GatewayServiceCollectionExtensions
     {
         services.AddOptions<GatewayOptions>();
         services.AddOptions<SessionCleanupOptions>();
+        services.AddOptions<ConversationRetentionOptions>();
         services.AddOptions<SessionWarmupOptions>();
         services.AddOptions<DelayToolOptions>();
         services.AddOptions<FileWatcherToolOptions>();
@@ -76,6 +77,7 @@ public static class GatewayServiceCollectionExtensions
             services.Configure<SubAgentOptions>(config.GetSection("gateway:subAgents"));
             services.Configure<DelayToolOptions>(config.GetSection("gateway:delayTool"));
             services.Configure<FileWatcherToolOptions>(config.GetSection("gateway:fileWatcherTool"));
+            services.Configure<ConversationRetentionOptions>(config.GetSection("gateway:conversations"));
 
             var compactionSection = config.GetSection("gateway:compaction");
             if (compactionSection.Exists())
@@ -191,6 +193,7 @@ public static class GatewayServiceCollectionExtensions
             serviceProvider.GetRequiredService<SessionWarmupService>());
         services.AddHostedService<InterruptedTurnNotificationService>();
         services.AddHostedService<SessionCleanupService>();
+        services.AddHostedService<ConversationRetentionHostedService>();
         services.AddHostedService<MemoryIndexer>();
 
         // Auto-update: register once as singleton, expose as interface and hosted service.

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationRetentionHostedServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationRetentionHostedServiceTests.cs
@@ -1,0 +1,190 @@
+﻿using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class ConversationRetentionHostedServiceTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private static ConversationRetentionHostedService CreateService(
+        IConversationStore store,
+        IAgentRegistry registry,
+        ConversationRetentionOptions options,
+        IConversationChangeNotifier? notifier = null)
+    {
+        notifier ??= Substitute.For<IConversationChangeNotifier>();
+        return new ConversationRetentionHostedService(
+            store,
+            notifier,
+            registry,
+            Options.Create(options),
+            NullLogger<ConversationRetentionHostedService>.Instance);
+    }
+
+    private static AgentDescriptor CreateDescriptor(
+        string agentId,
+        AgentConversationRetentionConfig? retention = null)
+        => new()
+        {
+            AgentId = AgentId.From(agentId),
+            DisplayName = agentId,
+            ModelId = "test-model",
+            ApiProvider = "test",
+            ConversationRetention = retention
+        };
+
+    private static Conversation CreateConversation(
+        string conversationId,
+        string agentId,
+        double inactiveDays,
+        ConversationStatus status = ConversationStatus.Active)
+        => new()
+        {
+            ConversationId = ConversationId.From(conversationId),
+            AgentId = AgentId.From(agentId),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-inactiveDays),
+            Status = status
+        };
+
+    // ── World-level disabled (opt-in gate) ───────────────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_WhenWorldDisabled_ArchivesNothing()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 40));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = false, AutoArchiveAfterDays = 30 };
+
+        var svc = CreateService(store, registry, options);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(0);
+        var conv = await store.GetAsync(ConversationId.From("c-1"));
+        conv!.Status.ShouldBe(ConversationStatus.Active);
+    }
+
+    // ── World default: archive inactive conversations ────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_WhenWorldEnabled_ArchivesExpired()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        var conv = CreateConversation("c-1", "a-1", inactiveDays: 31);
+        await store.CreateAsync(conv);
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var svc = CreateService(store, registry, options);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(1);
+        var updated = await store.GetAsync(ConversationId.From("c-1"));
+        updated!.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_WhenRecentlyActive_DoesNotArchive()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 5));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var svc = CreateService(store, registry, options);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(0);
+        var conv = await store.GetAsync(ConversationId.From("c-1"));
+        conv!.Status.ShouldBe(ConversationStatus.Active);
+    }
+
+    // ── Per-agent override: disabled flag wins ───────────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_AgentDisabled_SkipsAgentConversations()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor("a-1", new AgentConversationRetentionConfig { AutoArchiveEnabled = false }));
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 60));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var svc = CreateService(store, registry, options);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(0);
+        var conv = await store.GetAsync(ConversationId.From("c-1"));
+        conv!.Status.ShouldBe(ConversationStatus.Active);
+    }
+
+    // ── Per-agent override: shorter window ───────────────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_AgentOverridesThreshold_UsesAgentThreshold()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor("a-1", new AgentConversationRetentionConfig { AutoArchiveAfterDays = 7 }));
+        // inactive 10 days: world threshold=30 would NOT archive, agent threshold=7 SHOULD archive
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 10));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var svc = CreateService(store, registry, options);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(1);
+        var conv = await store.GetAsync(ConversationId.From("c-1"));
+        conv!.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    // ── Already-archived conversations are skipped ────────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_AlreadyArchived_IsSkipped()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        // Create active, then archive manually so we have a real Archived row
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 60));
+        await store.ArchiveAsync(ConversationId.From("c-1"));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var notifier = Substitute.For<IConversationChangeNotifier>();
+        var svc = CreateService(store, registry, options, notifier);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(0);
+        // Notifier must NOT have been called for already-archived row
+        await notifier.DidNotReceive().NotifyConversationChangedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── SignalR push fires on archive ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_WhenArchived_FiresSignalRPush()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 31));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var notifier = Substitute.For<IConversationChangeNotifier>();
+        var svc = CreateService(store, registry, options, notifier);
+        await svc.RunRetentionOnceAsync();
+
+        await notifier.Received(1).NotifyConversationChangedAsync(
+            "archived", "a-1", "c-1", Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Closes #865

## Changes

Added ConversationRetentionOptions (world-level config), AgentConversationRetentionConfig (per-agent override on AgentDescriptor), and ConversationRetentionHostedService (hourly background scan). Archives Active conversations where UpdatedAt is older than the configured threshold. Fires SignalR push per archive. Pinned exclusion hook ready for #780. Wired in GatewayServiceCollectionExtensions with config binding at gateway:conversations.

11 unit tests: world disabled gate, world default archives expired, recent activity not archived, per-agent disabled flag, per-agent shorter window, already-archived skipped, SignalR push fires.

## Merge Notes

Independent. Safe to merge in any order with all other open PRs. No file overlap.