### PR TITLE
feat(gateway): prepend current datetime to LLM messages when dateTimeInjection is enabled

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -134,6 +134,12 @@ public sealed record AgentDescriptor : ICitizen
     /// <summary>Heartbeat polling configuration for this agent. Null means heartbeat is disabled.</summary>
     public HeartbeatAgentConfig? Heartbeat { get; init; }
 
+    /// <summary>
+    /// Datetime injection configuration for this agent.
+    /// When non-null, overrides the world-level <see cref="GatewaySettingsConfig.DateTimeInjection"/> setting.
+    /// </summary>
+    public DateTimeInjectionConfig? DateTimeInjection { get; init; }
+
     /// <summary>Session access level for this agent's session tool. Defaults to "own".</summary>
     public string SessionAccessLevel { get; init; } = "own";
 

--- a/src/domain/BotNexus.Domain/Gateway/Models/DateTimeInjectionConfig.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/DateTimeInjectionConfig.cs
@@ -1,0 +1,32 @@
+namespace BotNexus.Gateway.Abstractions.Models;
+
+/// <summary>
+/// Datetime injection configuration. When enabled, the current datetime is prepended to every
+/// user message sent to the LLM inside a <c>&lt;currentdatetime&gt;</c> XML tag so the agent
+/// always has reliable temporal context.
+/// </summary>
+/// <remarks>
+/// The world-level default lives on <c>GatewaySettingsConfig.DateTimeInjection</c>. Per-agent
+/// overrides live on <c>AgentDescriptor.DateTimeInjection</c> and take precedence.
+/// </remarks>
+public sealed class DateTimeInjectionConfig
+{
+    /// <summary>
+    /// Whether datetime injection is enabled for this agent/gateway.
+    /// Defaults to <c>false</c> (opt-in). Set to <c>true</c> to activate.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// IANA timezone ID used when formatting the injected datetime.
+    /// Examples: <c>"UTC"</c>, <c>"America/Los_Angeles"</c>, <c>"Europe/London"</c>.
+    /// Falls back to the gateway <c>DefaultTimezone</c> setting, then UTC, when null or empty.
+    /// </summary>
+    public string? Timezone { get; set; }
+
+    /// <summary>
+    /// Output format. Only <c>"iso8601"</c> is supported today; reserved for future extension
+    /// to <c>"rfc2822"</c> or fully custom patterns.
+    /// </summary>
+    public string Format { get; set; } = "iso8601";
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -148,6 +148,13 @@ public sealed class GatewaySettingsConfig
     /// Off by default; enable only for debugging unexpected provider responses.
     /// </summary>
     public bool EnableProviderRequestLogging { get; set; } = false;
+
+    /// <summary>
+    /// Server-wide datetime injection settings. When enabled, the current datetime is prepended
+    /// to every user message sent to the LLM so agents always know the current time.
+    /// Per-agent overrides take precedence over this world default.
+    /// </summary>
+    public DateTimeInjectionConfig? DateTimeInjection { get; set; }
 }
 
 /// <summary>
@@ -450,6 +457,8 @@ public sealed class AgentDefinitionConfig
     public SoulAgentConfig? Soul { get; set; }
     /// <summary>Heartbeat polling configuration.</summary>
     public HeartbeatAgentConfig? Heartbeat { get; set; }
+    /// <summary>Datetime injection configuration override for this agent. Overrides world default when set.</summary>
+    public DateTimeInjectionConfig? DateTimeInjection { get; set; }
     /// <summary>Session access configuration for this agent's session tool.</summary>
     public SessionAccessConfig? SessionAccess { get; set; }
     /// <summary>Conversation access configuration for this agent's conversation tool.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -106,6 +106,7 @@ public sealed class PlatformConfigAgentSource(
                 Memory = CloneMemoryConfig(effectiveConfig.Memory),
                 Soul = CloneSoulConfig(effectiveConfig.Soul),
                 Heartbeat = CloneHeartbeatConfig(effectiveConfig.Heartbeat),
+                DateTimeInjection = effectiveConfig.DateTimeInjection,
                 SessionAccessLevel = effectiveConfig.SessionAccess?.Level ?? "own",
                 SessionAllowedAgents = effectiveConfig.SessionAccess?.AllowedAgents?.ToArray() ?? [],
                 ConversationAccessLevel = effectiveConfig.ConversationAccess?.Level ?? effectiveConfig.SessionAccess?.Level ?? "own",

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -10,6 +10,7 @@ using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Routing;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Dispatching;
 using AgentId = BotNexus.Domain.Primitives.AgentId;
@@ -58,6 +59,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
     private readonly ISessionCompactionCoordinator _compactionCoordinator;
     private readonly IConversationStore? _conversationStore;
     private readonly DefaultInboundMessageOrchestrator _orchestrator;
+    private readonly IOptions<PlatformConfig>? _platformConfig;
 
     public GatewayHost(
         IAgentSupervisor supervisor,
@@ -77,7 +79,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         IPreCompactionMemoryFlusher? memoryFlusher = null,
         IAgentRegistry? registry = null,
         ISessionCompactionCoordinator? compactionCoordinator = null,
-        IConversationStore? conversationStore = null)
+        IConversationStore? conversationStore = null,
+        IOptions<PlatformConfig>? platformConfig = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -95,6 +98,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         _memoryFlusher = memoryFlusher;
         _registry = registry;
         _conversationStore = conversationStore;
+        _platformConfig = platformConfig;
         // The coordinator is the single source of truth for compaction (PR #602
         // followup). Tests that construct GatewayHost directly may not provide
         // one; build a fallback from the deps we already have so behaviour
@@ -463,6 +467,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                 }, cancellationToken);
 
                 var sessionSaved = false;
+                var agentDescriptor = _registry?.Get(AgentId.From(agentId));
                 var resolvedChannel = ResolveChannelAdapter(message.ChannelType);
                 _logger.LogInformation("Channel resolution: type='{ChannelType}' found={Found} streaming={Streaming} streamEvents={StreamEvents}",
                     message.ChannelType,
@@ -512,7 +517,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                         }
                     }
 
-                    var userMessage = BuildUserMessage(message, processedParts ?? originalParts);
+                    var userMessage = BuildUserMessage(message, processedParts ?? originalParts, agentDescriptor);
                     await StreamingSessionHelper.ProcessAndSaveAsync(
                         handle.StreamAsync(userMessage, cancellationToken),
                         session,
@@ -584,7 +589,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                 }
                 else
                 {
-                    var userMessage = BuildUserMessage(message, processedParts ?? originalParts);
+                    var userMessage = BuildUserMessage(message, processedParts ?? originalParts, agentDescriptor);
                     var response = await handle.PromptAsync(userMessage, cancellationToken);
                     if (IsHeartbeatAck(response.Content))
                     {
@@ -1156,15 +1161,62 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
     /// Builds a <see cref="AgentUserMessage"/> from an inbound message, attaching any image
     /// content parts as <see cref="AgentImageContent"/> so vision-capable models receive them.
     /// Falls back to a plain text <see cref="AgentUserMessage"/> when no image parts are present.
+    /// When datetime injection is configured, prepends the current datetime to the message content
+    /// inside a <c>&lt;currentdatetime&gt;</c> XML tag before sending to the provider.
+    /// The raw session-store entry is NOT modified.
     /// </summary>
-    private static AgentUserMessage BuildUserMessage(
+    private AgentUserMessage BuildUserMessage(
         InboundMessage message,
-        IReadOnlyList<MessageContentPart>? contentParts)
+        IReadOnlyList<MessageContentPart>? contentParts,
+        AgentDescriptor? descriptor = null)
     {
+        var content = InjectDateTimeIfEnabled(message.Content, descriptor);
         var images = BuildImageContent(contentParts);
         return images is { Count: > 0 }
-            ? new AgentUserMessage(message.Content, images)
-            : new AgentUserMessage(message.Content);
+            ? new AgentUserMessage(content, images)
+            : new AgentUserMessage(content);
+    }
+
+    /// <summary>
+    /// Resolves the effective datetime injection config for the given agent descriptor,
+    /// applies it to the raw user content, and returns the (possibly prefixed) result.
+    /// When injection is disabled or not configured, returns the original content unchanged.
+    /// </summary>
+    internal string InjectDateTimeIfEnabled(string content, AgentDescriptor? descriptor)
+    {
+        var worldInjection = _platformConfig?.Value.Gateway?.DateTimeInjection;
+        var agentInjection = descriptor?.DateTimeInjection;
+
+        // Per-agent override supersedes world default when present.
+        // An agent with Enabled=false explicitly disables injection even if world default is on.
+        var effective = agentInjection ?? worldInjection;
+        if (effective is null || !effective.Enabled)
+            return content;
+
+        // Resolve timezone: agent override > world DateTimeInjection timezone > world DefaultTimezone > UTC.
+        var tzId = agentInjection?.Timezone
+            ?? worldInjection?.Timezone
+            ?? _platformConfig?.Value.Gateway?.DefaultTimezone
+            ?? "UTC";
+
+        TimeZoneInfo tz;
+        try
+        {
+            tz = TimeZoneInfo.FindSystemTimeZoneById(tzId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            tz = TimeZoneInfo.Utc;
+        }
+
+        var now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz);
+        var offset = tz.GetUtcOffset(now);
+        var offsetStr = offset >= TimeSpan.Zero
+            ? $"+{offset:hh\\:mm}"
+            : $"-{offset.Negate():hh\\:mm}";
+        var dateTimeStr = $"{now:yyyy-MM-ddTHH:mm:ss}{offsetStr} ({tzId})";
+
+        return $"<currentdatetime>{dateTimeStr}</currentdatetime>\n{content}";
     }
 
     private static IReadOnlyList<AgentImageContent>? BuildImageContent(

--- a/tests/gateway/BotNexus.Gateway.Tests/DateTimeInjectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DateTimeInjectionTests.cs
@@ -1,0 +1,173 @@
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Routing;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the datetime injection feature in GatewayHost.InjectDateTimeIfEnabled.
+/// </summary>
+public sealed class DateTimeInjectionTests
+{
+    // ── Helper: build a minimal GatewayHost with optional PlatformConfig ──
+
+    private static GatewayHost CreateHostWithConfig(PlatformConfig? config)
+    {
+        var platformOptions = config is null ? null : Options.Create(config);
+        return new GatewayHost(
+            Mock.Of<IAgentSupervisor>(),
+            Mock.Of<IMessageRouter>(),
+            Mock.Of<ISessionStore>(),
+            Mock.Of<IActivityBroadcaster>(),
+            Mock.Of<IChannelManager>(),
+            Mock.Of<ISessionCompactor>(),
+            new TestOptionsMonitor<CompactionOptions>(new CompactionOptions()),
+            NullLogger<GatewayHost>.Instance,
+            platformConfig: platformOptions);
+    }
+
+    // ── Test 1: injection disabled by default ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenNotConfigured_ReturnsContentUnchanged()
+    {
+        var host = CreateHostWithConfig(null);
+        var result = host.InjectDateTimeIfEnabled("Hello world", descriptor: null);
+        result.ShouldBe("Hello world");
+    }
+
+    // ── Test 2: world-level injection enabled ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenWorldEnabled_PrependsDatetimeTag()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                DateTimeInjection = new DateTimeInjectionConfig { Enabled = true, Timezone = "UTC" }
+            }
+        };
+        var host = CreateHostWithConfig(config);
+        var result = host.InjectDateTimeIfEnabled("Hello", descriptor: null);
+        result.ShouldStartWith("<currentdatetime>");
+        result.ShouldContain("</currentdatetime>\nHello");
+        result.ShouldContain("UTC");
+    }
+
+    // ── Test 3: per-agent disabled overrides world enabled ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenAgentDisabled_ReturnsContentUnchanged()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                DateTimeInjection = new DateTimeInjectionConfig { Enabled = true, Timezone = "UTC" }
+            }
+        };
+        var host = CreateHostWithConfig(config);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = Domain.Primitives.AgentId.From("agent-1"),
+            DisplayName = "Agent 1",
+            ModelId = "gpt-4o",
+            ApiProvider = "openai",
+            DateTimeInjection = new DateTimeInjectionConfig { Enabled = false }
+        };
+        var result = host.InjectDateTimeIfEnabled("Hello", descriptor);
+        result.ShouldBe("Hello");
+    }
+
+    // ── Test 4: per-agent timezone overrides world ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenAgentTimezoneSet_UsesAgentTimezone()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                DateTimeInjection = new DateTimeInjectionConfig { Enabled = true, Timezone = "UTC" }
+            }
+        };
+        var host = CreateHostWithConfig(config);
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = Domain.Primitives.AgentId.From("agent-2"),
+            DisplayName = "Agent 2",
+            ModelId = "gpt-4o",
+            ApiProvider = "openai",
+            DateTimeInjection = new DateTimeInjectionConfig { Enabled = true, Timezone = "America/New_York" }
+        };
+        var result = host.InjectDateTimeIfEnabled("Hello", descriptor);
+        result.ShouldContain("America/New_York");
+    }
+
+    // ── Test 5: invalid timezone falls back to UTC ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenInvalidTimezone_FallsBackToUtc()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                DateTimeInjection = new DateTimeInjectionConfig { Enabled = true, Timezone = "Not/A/Valid/Zone" }
+            }
+        };
+        var host = CreateHostWithConfig(config);
+        var result = host.InjectDateTimeIfEnabled("Hello", descriptor: null);
+        result.ShouldStartWith("<currentdatetime>");
+        // Should still produce a valid ISO8601-like tag (fallen back to UTC)
+        result.ShouldContain("</currentdatetime>\nHello");
+    }
+
+    // ── Test 6: world default timezone fallback ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenNoTimezoneSet_FallsBackToDefaultTimezone()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                DefaultTimezone = "Europe/London",
+                DateTimeInjection = new DateTimeInjectionConfig { Enabled = true }
+                // Timezone not set on injection config — should fall back to DefaultTimezone
+            }
+        };
+        var host = CreateHostWithConfig(config);
+        var result = host.InjectDateTimeIfEnabled("Hello", descriptor: null);
+        result.ShouldContain("Europe/London");
+    }
+
+    // ── Test 7: injection format — well-formed XML tag ──
+
+    [Fact]
+    public void InjectDateTimeIfEnabled_WhenEnabled_ProducesWellFormedXmlTag()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                DateTimeInjection = new DateTimeInjectionConfig { Enabled = true, Timezone = "UTC" }
+            }
+        };
+        var host = CreateHostWithConfig(config);
+        var result = host.InjectDateTimeIfEnabled("My message", descriptor: null);
+        // Format: <currentdatetime>2026-06-05T14:32:00+00:00 (UTC)</currentdatetime>\nMy message
+        result.ShouldStartWith("<currentdatetime>");
+        result.ShouldContain("</currentdatetime>\nMy message");
+        // The datetime tag should contain the timezone in parentheses
+        result.ShouldContain("(UTC)");
+    }
+}


### PR DESCRIPTION
Closes #879

## Changes
- `DateTimeInjectionConfig` domain model: `Enabled`, `Timezone` (IANA), `Format`
- `GatewaySettingsConfig.DateTimeInjection` — world-level default (opt-in, `Enabled=false`)
- `AgentDefinitionConfig.DateTimeInjection` — per-agent override; `Enabled=false` disables even when world default is on
- `AgentDescriptor.DateTimeInjection` — exposed on domain descriptor for runtime resolution
- `PlatformConfigAgentSource` wires per-agent config to descriptor
- `GatewayHost.InjectDateTimeIfEnabled` — resolves effective config, formats datetime, prepends XML tag
- `GatewayHost.BuildUserMessage` — passes `agentDescriptor` through to inject datetime before provider call
- Raw session-store entries are NOT modified — only the provider-bound payload is prefixed

## Injection format
```
<currentdatetime>2026-06-05T14:32:00-07:00 (America/Los_Angeles)</currentdatetime>
{original user message}
```

## Tests
7 new tests in `DateTimeInjectionTests.cs`:
1. Not configured → content unchanged
2. World enabled → tag prepended
3. Per-agent disabled overrides world enabled
4. Per-agent timezone overrides world timezone
5. Invalid timezone falls back to UTC
6. `DefaultTimezone` fallback when injection has no explicit timezone
7. Tag is well-formed XML with timezone in parentheses

## Merge Notes
Independent — no file overlap with any open PR. Safe to merge in any order.