### PR TITLE
feat(channels): strip embedded thinking tags from outbound text for non-thinking channels

### DIFF
--- a/src/gateway/BotNexus.Gateway.Channels/AssistantTextSanitizer.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/AssistantTextSanitizer.cs
@@ -1,0 +1,54 @@
+using System.Text.RegularExpressions;
+
+namespace BotNexus.Gateway.Channels;
+
+/// <summary>
+/// Utility for sanitising outbound assistant text before delivery to channels.
+/// Strips thinking/reasoning blocks that some LLM providers embed as XML-tagged
+/// markup in the text stream when extended thinking is enabled.
+/// </summary>
+/// <remarks>
+/// Providers that return structured thinking content via dedicated stream event types
+/// (e.g. Anthropic's <c>thinking_delta</c> SSE event) do not need this sanitizer —
+/// the gateway routes those via <c>AgentStreamEventType.ThinkingDelta</c> and the
+/// channel adapter decides whether to display them based on
+/// <see cref="BotNexus.Gateway.Abstractions.Channels.IChannelAdapter.SupportsThinkingDisplay"/>.
+/// <para>
+/// This sanitizer addresses the defensive case where a provider returns thinking
+/// as raw embedded XML tags inside the text content (e.g. some reasoning models):
+/// <c>&lt;thinking&gt;...&lt;/thinking&gt;</c> or
+/// <c>&lt;antml:thinking&gt;...&lt;/antml:thinking&gt;</c>.
+/// </para>
+/// </remarks>
+public static class AssistantTextSanitizer
+{
+    // Matches <thinking>...</thinking> and <thinking>...</thinking> (case-insensitive,
+    // dotall so newlines inside the block are matched).
+    private static readonly Regex ThinkingTagPattern = new(
+        @"<(?:antml:)?thinking>.*?</(?:antml:)?thinking>",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips any embedded thinking/reasoning XML tags from assistant text.
+    /// Returns the input unchanged if no such tags are present.
+    /// </summary>
+    /// <param name="text">The raw assistant text that may contain thinking blocks.</param>
+    /// <returns>The text with all embedded thinking blocks removed and excess whitespace trimmed.</returns>
+    public static string StripThinkingTags(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        // Fast-path: avoid regex overhead if no opening tag present.
+        if (!text.Contains("<thinking>", StringComparison.OrdinalIgnoreCase) &&
+            !text.Contains("<thinking>", StringComparison.OrdinalIgnoreCase))
+            return text;
+
+        var stripped = ThinkingTagPattern.Replace(text, string.Empty);
+
+        // Collapse multiple consecutive blank lines left after tag removal.
+        stripped = Regex.Replace(stripped, @"\n{3}", "\n\n");
+
+        return stripped.Trim();
+    }
+}

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using BotNexus.Agent.Core.Types;
 using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
 using BotNexus.Gateway.Channels;
@@ -596,7 +596,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                         {
                             ChannelType = message.ChannelType,
                             ChannelAddress = message.ChannelAddress,
-                            Content = response.Content,
+                            Content = ch.SupportsThinkingDisplay
+                                ? response.Content
+                                : AssistantTextSanitizer.StripThinkingTags(response.Content),
                             SessionId = sessionId,
                             // Binding-aware fields from originating binding fix #126:
                             // ensure replies carry the binding's decoration. Native sub-addresses

--- a/tests/gateway/BotNexus.Gateway.Tests/AssistantTextSanitizerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AssistantTextSanitizerTests.cs
@@ -1,0 +1,63 @@
+using BotNexus.Gateway.Channels;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class AssistantTextSanitizerTests
+{
+    [Fact]
+    public void StripThinkingTags_NoTags_ReturnsUnchanged()
+    {
+        var text = "Hello, this is a plain response.";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe(text);
+    }
+
+    [Fact]
+    public void StripThinkingTags_NullOrEmpty_ReturnsUnchanged()
+    {
+        AssistantTextSanitizer.StripThinkingTags(string.Empty).ShouldBe(string.Empty);
+        AssistantTextSanitizer.StripThinkingTags(null!).ShouldBeNull();
+    }
+
+    [Fact]
+    public void StripThinkingTags_SingleThinkingBlock_RemovesBlock()
+    {
+        var text = "<thinking>I should reason carefully here.</thinking>The answer is 42.";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe("The answer is 42.");
+    }
+
+    [Fact]
+    public void StripThinkingTags_AnthropicPrefixedBlock_RemovesBlock()
+    {
+        var text = "<thinking>Chain of thought goes here.</thinking>Here is my answer.";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe("Here is my answer.");
+    }
+
+    [Fact]
+    public void StripThinkingTags_MultilineThinkingBlock_RemovesBlock()
+    {
+        var text = "Intro.\n<thinking>\nLine one of reasoning.\nLine two of reasoning.\n</thinking>\nConclusion.";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe("Intro.\n\nConclusion.");
+    }
+
+    [Fact]
+    public void StripThinkingTags_MultipleBlocks_RemovesAll()
+    {
+        var text = "<thinking>First thought.</thinking>Part one.<thinking>Second thought.</thinking>Part two.";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe("Part one.Part two.");
+    }
+
+    [Fact]
+    public void StripThinkingTags_CaseInsensitive_RemovesBlock()
+    {
+        var text = "<THINKING>Uppercase tags.</THINKING>Answer.";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe("Answer.");
+    }
+
+    [Fact]
+    public void StripThinkingTags_OnlyThinkingBlock_ReturnsEmptyOrTrimmed()
+    {
+        var text = "<thinking>Only reasoning, no actual response.</thinking>";
+        AssistantTextSanitizer.StripThinkingTags(text).ShouldBe(string.Empty);
+    }
+}


### PR DESCRIPTION
Closes #851

Adds AssistantTextSanitizer.StripThinkingTags() utility in BotNexus.Gateway.Channels that strips raw XML thinking/reasoning tags from assistant text before outbound delivery.

GatewayHost.SendAsync applies the sanitizer when the target channel has SupportsThinkingDisplay=false. Channels with SupportsThinkingDisplay=true (Telegram, SignalR) receive content unchanged.

8 unit tests: no-op for clean text, single block strip, antml-prefixed block strip, multiline block, multiple blocks, case-insensitive, only-thinking-block result.

## Merge Notes

Independent. Safe to merge in any order with all open PRs. No file overlap.