### PR TITLE
feat(copilot): add CopilotMessagesProvider for Phase 1a carve-out (#810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesMessageConverter.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesMessageConverter.cs
@@ -1,0 +1,366 @@
+using System.Text.Json;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Copilot.Messages;
+
+/// <summary>
+/// Converts BotNexus messages to GitHub Copilot's Anthropic-Messages-compatible
+/// message format and handles cache control and tool-call ID normalization.
+/// Owned by the Copilot provider so the carve-out has no cross-provider
+/// dependency on the Anthropic project. Behaviour is byte-identical to the
+/// Anthropic converter for the Copilot transport (which never used the
+/// claude-cli OAuth tool-name remapping).
+/// </summary>
+internal static class CopilotMessagesMessageConverter
+{
+    internal static object NormalizeToolSchema(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            return new Dictionary<string, object?>
+            {
+                ["type"] = "object",
+                ["properties"] = new Dictionary<string, object?>(),
+                ["required"] = Array.Empty<string>()
+            };
+        }
+
+        if (schema.TryGetProperty("type", out var typeElement) &&
+            string.Equals(typeElement.GetString(), "object", StringComparison.OrdinalIgnoreCase))
+        {
+            return schema;
+        }
+
+        var properties = schema.TryGetProperty("properties", out var propertiesElement)
+            ? JsonSerializer.Deserialize<object>(propertiesElement.GetRawText())
+            : new Dictionary<string, object?>();
+        var required = schema.TryGetProperty("required", out var requiredElement) &&
+                       requiredElement.ValueKind == JsonValueKind.Array
+            ? JsonSerializer.Deserialize<object>(requiredElement.GetRawText())
+            : Array.Empty<string>();
+
+        return new Dictionary<string, object?>
+        {
+            ["type"] = "object",
+            ["properties"] = properties,
+            ["required"] = required
+        };
+    }
+
+    internal static List<Dictionary<string, object?>> ConvertMessages(
+        IReadOnlyList<Message> messages, LlmModel model)
+    {
+        var transformed = MessageTransformer.TransformMessages(messages, model, NormalizeToolCallId);
+        var result = new List<Dictionary<string, object?>>();
+        var isLastToolResult = false;
+
+        foreach (var msg in transformed)
+        {
+            switch (msg)
+            {
+                case UserMessage user:
+                    isLastToolResult = false;
+                    var userMessage = ConvertUserMessage(user, model);
+                    if (userMessage is not null)
+                        result.Add(userMessage);
+                    break;
+
+                case AssistantMessage assistant:
+                    isLastToolResult = false;
+                    var assistantMessage = ConvertAssistantMessage(assistant);
+                    if (assistantMessage is not null)
+                        result.Add(assistantMessage);
+                    break;
+
+                case ToolResultMessage toolResult:
+                    var block = MakeToolResultBlock(toolResult);
+                    if (isLastToolResult && result.Count > 0 &&
+                        result[^1]["content"] is List<object> existingBlocks)
+                    {
+                        existingBlocks.Add(block);
+                    }
+                    else
+                    {
+                        result.Add(new Dictionary<string, object?>
+                        {
+                            ["role"] = "user",
+                            ["content"] = new List<object> { block }
+                        });
+                        isLastToolResult = true;
+                    }
+                    break;
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, object?>? ConvertUserMessage(UserMessage msg, LlmModel model)
+    {
+        object content;
+
+        if (msg.Content.IsText)
+        {
+            if (string.IsNullOrWhiteSpace(msg.Content.Text))
+                return null;
+
+            content = UnicodeSanitizer.SanitizeSurrogates(msg.Content.Text);
+        }
+        else
+        {
+            var blocks = new List<object>();
+            foreach (var block in msg.Content.Blocks!)
+            {
+                switch (block)
+                {
+                    case TextContent text:
+                        if (string.IsNullOrWhiteSpace(text.Text))
+                            break;
+
+                        blocks.Add(new Dictionary<string, object?>
+                        {
+                            ["type"] = "text",
+                            ["text"] = UnicodeSanitizer.SanitizeSurrogates(text.Text)
+                        });
+                        break;
+                    case ImageContent image:
+                        if (!model.Input.Contains("image"))
+                            break;
+                        blocks.Add(new Dictionary<string, object?>
+                        {
+                            ["type"] = "image",
+                            ["source"] = new Dictionary<string, object?>
+                            {
+                                ["type"] = "base64",
+                                ["media_type"] = image.MimeType,
+                                ["data"] = image.Data
+                            }
+                        });
+                        break;
+                }
+            }
+            if (blocks.Count == 0)
+                return null;
+
+            content = blocks;
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["role"] = "user",
+            ["content"] = content
+        };
+    }
+
+    private static Dictionary<string, object?>? ConvertAssistantMessage(AssistantMessage msg)
+    {
+        var blocks = new List<object>();
+
+        foreach (var block in msg.Content)
+        {
+            switch (block)
+            {
+                case TextContent text:
+                    if (string.IsNullOrWhiteSpace(text.Text))
+                        break;
+
+                    var textBlock = new Dictionary<string, object?>
+                    {
+                        ["type"] = "text",
+                        ["text"] = UnicodeSanitizer.SanitizeSurrogates(text.Text)
+                    };
+                    if (text.TextSignature is not null)
+                        textBlock["signature"] = text.TextSignature;
+                    blocks.Add(textBlock);
+                    break;
+
+                case ThinkingContent thinking:
+                    if (thinking.Redacted == true)
+                    {
+                        if (string.IsNullOrWhiteSpace(thinking.ThinkingSignature))
+                            break;
+
+                        blocks.Add(new Dictionary<string, object?>
+                        {
+                            ["type"] = "redacted_thinking",
+                            ["data"] = thinking.ThinkingSignature
+                        });
+                    }
+                    else
+                    {
+                        if (string.IsNullOrWhiteSpace(thinking.Thinking))
+                            break;
+
+                        if (string.IsNullOrWhiteSpace(thinking.ThinkingSignature))
+                        {
+                            blocks.Add(new Dictionary<string, object?>
+                            {
+                                ["type"] = "text",
+                                ["text"] = UnicodeSanitizer.SanitizeSurrogates(thinking.Thinking)
+                            });
+                            break;
+                        }
+
+                        blocks.Add(new Dictionary<string, object?>
+                        {
+                            ["type"] = "thinking",
+                            ["thinking"] = UnicodeSanitizer.SanitizeSurrogates(thinking.Thinking),
+                            ["signature"] = thinking.ThinkingSignature
+                        });
+                    }
+                    break;
+
+                case ToolCallContent toolCall:
+                    var toolUseBlock = new Dictionary<string, object?>
+                    {
+                        ["type"] = "tool_use",
+                        ["id"] = toolCall.Id,
+                        ["name"] = toolCall.Name,
+                        ["input"] = toolCall.Arguments
+                    };
+                    if (toolCall.ThoughtSignature is not null)
+                        toolUseBlock["signature"] = toolCall.ThoughtSignature;
+                    blocks.Add(toolUseBlock);
+                    break;
+            }
+        }
+
+        if (blocks.Count == 0)
+            return null;
+
+        return new Dictionary<string, object?>
+        {
+            ["role"] = "assistant",
+            ["content"] = blocks
+        };
+    }
+
+    private static Dictionary<string, object?> MakeToolResultBlock(ToolResultMessage toolResult)
+    {
+        object content;
+        var textBlocks = toolResult.Content.OfType<TextContent>()
+            .Select(t => UnicodeSanitizer.SanitizeSurrogates(t.Text))
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+        var hasImages = toolResult.Content.Any(c => c is ImageContent);
+
+        if (!hasImages && textBlocks.Count == 1)
+        {
+            content = textBlocks[0];
+        }
+        else
+        {
+            var blocks = new List<object>();
+            if (textBlocks.Count > 0)
+            {
+                blocks.Add(new Dictionary<string, object?>
+                {
+                    ["type"] = "text",
+                    ["text"] = string.Join("\n", textBlocks)
+                });
+            }
+            else if (hasImages)
+            {
+                blocks.Add(new Dictionary<string, object?>
+                {
+                    ["type"] = "text",
+                    ["text"] = "(see attached image)"
+                });
+            }
+
+            foreach (var image in toolResult.Content.OfType<ImageContent>())
+            {
+                blocks.Add(new Dictionary<string, object?>
+                {
+                    ["type"] = "image",
+                    ["source"] = new Dictionary<string, object?>
+                    {
+                        ["type"] = "base64",
+                        ["media_type"] = image.MimeType,
+                        ["data"] = image.Data
+                    }
+                });
+            }
+
+            content = blocks;
+        }
+
+        var result = new Dictionary<string, object?>
+        {
+            ["type"] = "tool_result",
+            ["tool_use_id"] = toolResult.ToolCallId,
+            ["content"] = content
+        };
+
+        if (toolResult.IsError)
+        {
+            result["is_error"] = true;
+        }
+
+        return result;
+    }
+
+    internal static Dictionary<string, object?>? BuildCacheControl(
+        CacheRetention retention, string baseUrl)
+    {
+        if (retention == CacheRetention.None)
+            return null;
+
+        var cacheControl = new Dictionary<string, object?> { ["type"] = "ephemeral" };
+
+        // 1h TTL is an Anthropic-direct feature; Copilot's base URL never matches so
+        // the branch below is effectively dead today. Retained verbatim from the
+        // Anthropic converter so behaviour is byte-identical if a user ever points a
+        // Copilot model at the Anthropic edge.
+        if (retention == CacheRetention.Long &&
+            baseUrl.Contains("api.anthropic.com", StringComparison.OrdinalIgnoreCase))
+        {
+            cacheControl["ttl"] = "1h";
+        }
+
+        return cacheControl;
+    }
+
+    internal static void ApplyLastUserMessageCacheControl(
+        List<Dictionary<string, object?>> messages, CacheRetention retention, string baseUrl)
+    {
+        if (retention == CacheRetention.None) return;
+
+        var cacheControl = BuildCacheControl(retention, baseUrl);
+        if (cacheControl is null) return;
+
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            if (messages[i].TryGetValue("role", out var role) && role?.ToString() == "user")
+            {
+                var content = messages[i]["content"];
+
+                if (content is string textContent)
+                {
+                    messages[i]["content"] = new List<object>
+                    {
+                        new Dictionary<string, object?>
+                        {
+                            ["type"] = "text",
+                            ["text"] = textContent,
+                            ["cache_control"] = cacheControl
+                        }
+                    };
+                }
+                else if (content is List<object> blocks && blocks.Count > 0)
+                {
+                    if (blocks[^1] is Dictionary<string, object?> lastBlock)
+                        lastBlock["cache_control"] = cacheControl;
+                }
+
+                break;
+            }
+        }
+    }
+
+    internal static string NormalizeToolCallId(string id, LlmModel sourceModel, string targetProviderId)
+    {
+        return id.NormalizeToolCallId(64);
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesOptions.cs
@@ -1,0 +1,29 @@
+namespace BotNexus.Agent.Providers.Copilot.Messages;
+
+/// <summary>
+/// Copilot-Messages streaming options. Mirrors the Anthropic Messages options
+/// but is owned by the Copilot provider so the Copilot carve-out has no
+/// dependency on the Anthropic project.
+/// </summary>
+public record class CopilotMessagesOptions : Core.StreamOptions
+{
+    public bool? ThinkingEnabled { get; set; }
+    public int? ThinkingBudgetTokens { get; set; }
+
+    /// <summary>
+    /// Adaptive thinking effort level: "low", "medium", "high", "max".
+    /// Used with Opus 4.6 and Sonnet 4.6 models served via GitHub Copilot.
+    /// </summary>
+    public string? Effort { get; set; }
+
+    /// <summary>
+    /// Enable interleaved thinking (thinking blocks between text/tool blocks).
+    /// </summary>
+    public bool InterleavedThinking { get; set; } = true;
+
+    /// <summary>
+    /// Tool choice: "auto", "any", "none", a specific tool name,
+    /// or an Anthropic-shaped tool_choice object.
+    /// </summary>
+    public object? ToolChoice { get; set; }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
@@ -1,0 +1,309 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Diagnostics;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Copilot.Messages;
+
+/// <summary>
+/// GitHub Copilot Anthropic-Messages-compatible provider. Carved out of
+/// <c>AnthropicProvider</c>'s <c>AuthMode.Copilot</c> branch so the Copilot
+/// transport has no cross-provider dependency on the Anthropic project.
+/// Always uses Bearer auth with the Copilot OAuth access token and applies
+/// Copilot dynamic headers on every request.
+/// </summary>
+public sealed partial class CopilotMessagesProvider(HttpClient httpClient) : IApiProvider
+{
+    private const string ApiVersion = "2023-06-01";
+    public const string ApiId = "github-copilot-messages";
+
+    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+
+    public string Api => ApiId;
+
+    public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+    {
+        var stream = new LlmStream();
+        var ct = options?.CancellationToken ?? CancellationToken.None;
+
+        _ = Task.Run(async () =>
+        {
+            var usage = Usage.Empty();
+            string? responseId = null;
+            var stopReason = StopReason.Stop;
+            var contentBlocks = new List<ContentBlock>();
+            using var activity = ProviderDiagnostics.Source.StartActivity("provider.copilot-messages.stream", ActivityKind.Client);
+            activity?.SetTag("botnexus.provider.name", model.Provider);
+            activity?.SetTag("botnexus.model", model.Id);
+            activity?.SetTag("botnexus.model.api", model.Api);
+
+            try
+            {
+                await StreamCoreAsync(model, context, options, stream,
+                    contentBlocks, usage,
+                    updatedUsage => usage = updatedUsage,
+                    id => responseId = id,
+                    reason => stopReason = reason, ct);
+
+                var final = BuildMessage(model, contentBlocks, usage, stopReason, null, responseId);
+                stream.Push(new DoneEvent(stopReason, final));
+                stream.End(final);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                var msg = BuildMessage(model, contentBlocks, usage, StopReason.Aborted, null, responseId);
+                stream.Push(new ErrorEvent(StopReason.Aborted, msg));
+                stream.End(msg);
+                activity?.SetStatus(ActivityStatusCode.Error, "Operation canceled");
+            }
+            catch (Exception ex)
+            {
+                var msg = BuildMessage(model, contentBlocks, usage, StopReason.Error, ex.Message, responseId);
+                stream.Push(new ErrorEvent(StopReason.Error, msg));
+                stream.End(msg);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            }
+        }, ct);
+
+        return stream;
+    }
+
+    public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+    {
+        var apiKey = options?.ApiKey ?? EnvironmentApiKeys.GetApiKey(model.Provider) ?? "";
+        var baseOptions = SimpleOptionsHelper.BuildBaseOptions(model, options, apiKey);
+
+        var copilotOpts = new CopilotMessagesOptions
+        {
+            Temperature = baseOptions.Temperature,
+            MaxTokens = baseOptions.MaxTokens,
+            CancellationToken = baseOptions.CancellationToken,
+            ApiKey = baseOptions.ApiKey,
+            Transport = baseOptions.Transport,
+            CacheRetention = baseOptions.CacheRetention,
+            SessionId = baseOptions.SessionId,
+            OnPayload = baseOptions.OnPayload,
+            Headers = baseOptions.Headers,
+            MaxRetryDelayMs = baseOptions.MaxRetryDelayMs,
+            Metadata = baseOptions.Metadata,
+            StreamSetupTimeoutMs = baseOptions.StreamSetupTimeoutMs,
+        };
+
+        if (options?.Reasoning is { } reasoning)
+        {
+            var clamped = SimpleOptionsHelper.ClampReasoning(reasoning);
+
+            if (IsAdaptiveThinkingModel(model.Id))
+            {
+                copilotOpts.ThinkingEnabled = true;
+                copilotOpts.Effort = reasoning switch
+                {
+                    ThinkingLevel.Minimal => "low",
+                    ThinkingLevel.Low => "low",
+                    ThinkingLevel.Medium => "medium",
+                    ThinkingLevel.High => "high",
+                    ThinkingLevel.ExtraHigh => IsOpus46Model(model.Id) ? "max" : "high",
+                    _ => "high"
+                };
+            }
+            else if (model.Reasoning)
+            {
+                var budgetLevel = SimpleOptionsHelper.GetBudgetForLevel(
+                    clamped ?? ThinkingLevel.Medium, options?.ThinkingBudgets);
+
+                var maxTokens = copilotOpts.MaxTokens;
+                var budgetTokens = budgetLevel ?? SimpleOptionsHelper.GetDefaultThinkingBudget(clamped ?? ThinkingLevel.Medium);
+
+                var (adjustedMax, adjustedBudget) = SimpleOptionsHelper.AdjustMaxTokensForThinking(
+                    model, maxTokens, budgetTokens);
+
+                copilotOpts = copilotOpts with
+                {
+                    ThinkingEnabled = true,
+                    ThinkingBudgetTokens = adjustedBudget,
+                    MaxTokens = adjustedMax
+                };
+            }
+        }
+        else if (model.Reasoning)
+        {
+            copilotOpts.ThinkingEnabled = false;
+        }
+
+        return Stream(model, context, copilotOpts);
+    }
+
+    private async Task StreamCoreAsync(
+        LlmModel model, Context context, StreamOptions? options,
+        LlmStream stream, List<ContentBlock> contentBlocks, Usage initialUsage,
+        Action<Usage> setUsage,
+        Action<string?> setResponseId, Action<StopReason> setStopReason,
+        CancellationToken ct)
+    {
+        var copilotOpts = options as CopilotMessagesOptions;
+        var apiKey = options?.ApiKey ?? EnvironmentApiKeys.GetApiKey(model.Provider) ?? "";
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException(
+                $"No API key for {model.Provider}. Set credentials before using model '{model.Id}'.");
+        }
+
+        var baseUrl = model.BaseUrl.TrimEnd('/');
+
+        var requestBody = CopilotMessagesRequestBuilder.BuildRequestBody(
+            model,
+            context,
+            options,
+            copilotOpts,
+            IsAdaptiveThinkingModel);
+
+        if (options?.OnPayload is { } onPayload)
+        {
+            var modified = await onPayload(requestBody, model);
+            if (modified is JsonObject modifiedObject)
+                requestBody = modifiedObject;
+        }
+
+        var json = requestBody.ToJsonString();
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/v1/messages");
+        httpRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        ConfigureRequestHeaders(httpRequest, apiKey, copilotOpts, model);
+
+        // Copilot transport always applies the dynamic vision/intent headers.
+        var hasImages = CopilotHeaders.HasVisionInput(context.Messages);
+        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(context.Messages, hasImages))
+            httpRequest.Headers.TryAddWithoutValidation(key, value);
+
+        var setupTimeoutMs = options?.StreamSetupTimeoutMs ?? 0;
+        using var setupTimeoutCts = setupTimeoutMs > 0
+            ? new CancellationTokenSource(setupTimeoutMs)
+            : null;
+        using var linkedCts = setupTimeoutCts is not null
+            ? CancellationTokenSource.CreateLinkedTokenSource(ct, setupTimeoutCts.Token)
+            : null;
+        var effectiveCt = linkedCts?.Token ?? ct;
+
+        using var response = await _httpClient.SendAsync(
+            httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveCt);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(effectiveCt);
+            throw new HttpRequestException(
+                $"Copilot Messages API returned {(int)response.StatusCode}: {errorBody}");
+        }
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(effectiveCt);
+        using var reader = new StreamReader(responseStream, Encoding.UTF8);
+
+        Action? onFirstToken = setupTimeoutCts is not null
+            ? () =>
+            {
+                try { setupTimeoutCts.Cancel(); }
+                catch (ObjectDisposedException) { }
+            }
+            : null;
+
+        var (usage, responseId, stopReason) = await CopilotMessagesStreamParser.ProcessStreamAsync(
+            reader,
+            model,
+            stream,
+            contentBlocks,
+            initialUsage,
+            BuildMessage,
+            MapStopReason,
+            ct,
+            onFirstToken);
+
+        setUsage(usage);
+        setResponseId(responseId);
+        setStopReason(stopReason);
+    }
+
+    private static void ConfigureRequestHeaders(
+        HttpRequestMessage request, string apiKey,
+        CopilotMessagesOptions? opts, LlmModel model)
+    {
+        request.Headers.Add("anthropic-version", ApiVersion);
+        request.Headers.TryAddWithoutValidation("accept", "application/json");
+        request.Headers.TryAddWithoutValidation("anthropic-dangerous-direct-browser-access", "true");
+
+        if (model.Headers is not null)
+        {
+            foreach (var (key, value) in model.Headers)
+                request.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        if (opts?.Headers is not null)
+        {
+            foreach (var (key, value) in opts.Headers)
+                request.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        var betaFeatures = new List<string>();
+        if (opts?.InterleavedThinking == true && !IsAdaptiveThinkingModel(model.Id))
+            betaFeatures.Add("interleaved-thinking-2025-05-14");
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        if (betaFeatures.Count > 0)
+            request.Headers.TryAddWithoutValidation("anthropic-beta", string.Join(",", betaFeatures));
+    }
+
+    internal static AssistantMessage BuildMessage(
+        LlmModel model, List<ContentBlock> content,
+        Usage usage, StopReason stopReason, string? errorMessage, string? responseId)
+    {
+        var usageWithTotals = usage with
+        {
+            TotalTokens = usage.Input + usage.Output + usage.CacheRead + usage.CacheWrite
+        };
+        usageWithTotals = usageWithTotals with
+        {
+            Cost = ModelRegistry.CalculateCost(model, usageWithTotals)
+        };
+
+        return new AssistantMessage(
+            Content: [.. content],
+            Api: ApiId,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: usageWithTotals,
+            StopReason: stopReason,
+            ErrorMessage: errorMessage,
+            ResponseId: responseId,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+    }
+
+    private static StopReason MapStopReason(string? reason) => reason switch
+    {
+        "end_turn" => StopReason.Stop,
+        "max_tokens" => StopReason.Length,
+        "tool_use" => StopReason.ToolUse,
+        "refusal" => StopReason.Refusal,
+        "pause_turn" => StopReason.Stop,
+        "stop_sequence" => StopReason.Stop,
+        "content_policy" => StopReason.Sensitive,
+        "safety" => StopReason.Sensitive,
+        "sensitive" => StopReason.Sensitive,
+        _ => throw new InvalidOperationException($"Unhandled Copilot Messages stop reason: {reason}")
+    };
+
+    internal static bool IsAdaptiveThinkingModel(string modelId) =>
+        modelId.Contains("opus-4-6", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("opus-4.6", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("sonnet-4-6", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("sonnet-4.6", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsOpus46Model(string modelId) =>
+        modelId.Contains("opus-4-6", StringComparison.OrdinalIgnoreCase) ||
+        modelId.Contains("opus-4.6", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesRequestBuilder.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesRequestBuilder.cs
@@ -1,0 +1,154 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Utilities;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace BotNexus.Agent.Providers.Copilot.Messages;
+
+/// <summary>
+/// Builds the JSON request body for the GitHub Copilot Anthropic-Messages-compatible
+/// API from a <see cref="Context"/> and <see cref="StreamOptions"/>. Owned by the
+/// Copilot provider; behaviour is byte-identical to the Anthropic builder for the
+/// Copilot transport (no claude-cli OAuth system-prompt prefix).
+/// </summary>
+internal static class CopilotMessagesRequestBuilder
+{
+    internal static JsonObject BuildRequestBody(
+        LlmModel model,
+        Context context,
+        StreamOptions? options,
+        CopilotMessagesOptions? copilotOpts,
+        Func<string, bool> isAdaptiveThinkingModel)
+    {
+        var messages = CopilotMessagesMessageConverter.ConvertMessages(context.Messages, model);
+        CopilotMessagesMessageConverter.ApplyLastUserMessageCacheControl(
+            messages,
+            options?.CacheRetention ?? CacheRetention.Short,
+            model.BaseUrl);
+
+        var body = new JsonObject
+        {
+            ["model"] = model.Id,
+            ["messages"] = ToNode(messages),
+            ["max_tokens"] = options?.MaxTokens ?? (model.MaxTokens / 3),
+            ["stream"] = true
+        };
+
+        if (context.SystemPrompt is { } systemPrompt)
+        {
+            var cacheControl = CopilotMessagesMessageConverter.BuildCacheControl(
+                options?.CacheRetention ?? CacheRetention.Short,
+                model.BaseUrl);
+
+            body["system"] = ToNode(new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["type"] = "text",
+                    ["text"] = UnicodeSanitizer.SanitizeSurrogates(systemPrompt),
+                    ["cache_control"] = cacheControl
+                }
+            });
+        }
+
+        if (context.Tools is { Count: > 0 } tools)
+        {
+            body["tools"] = ToNode(tools.Select(t => new Dictionary<string, object?>
+            {
+                ["name"] = t.Name,
+                ["description"] = t.Description,
+                ["input_schema"] = CopilotMessagesMessageConverter.NormalizeToolSchema(t.Parameters)
+            }).ToList());
+        }
+
+        if (options?.Metadata is { } metadata &&
+            metadata.TryGetValue("user_id", out var rawUserId) &&
+            rawUserId is string userId &&
+            !string.IsNullOrWhiteSpace(userId))
+        {
+            body["metadata"] = ToNode(new Dictionary<string, object?>
+            {
+                ["user_id"] = userId
+            });
+        }
+
+        if (copilotOpts?.ToolChoice is { } toolChoice)
+        {
+            body["tool_choice"] = BuildToolChoiceNode(toolChoice);
+        }
+
+        if (model.Reasoning && copilotOpts?.ThinkingEnabled == true)
+        {
+            if (isAdaptiveThinkingModel(model.Id))
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "adaptive" });
+                if (copilotOpts.Effort is not null)
+                    body["output_config"] = ToNode(new Dictionary<string, object?> { ["effort"] = copilotOpts.Effort });
+            }
+            else if (copilotOpts.ThinkingBudgetTokens is { } budget)
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?>
+                {
+                    ["type"] = "enabled",
+                    ["budget_tokens"] = budget
+                });
+            }
+            else
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?>
+                {
+                    ["type"] = "enabled",
+                    ["budget_tokens"] = 1024
+                });
+            }
+        }
+        else if (model.Reasoning && copilotOpts?.ThinkingEnabled == false)
+        {
+            body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "disabled" });
+        }
+
+        if (options?.Temperature.HasValue == true && copilotOpts?.ThinkingEnabled != true)
+            body["temperature"] = options.Temperature.Value;
+
+        return body;
+    }
+
+    private static JsonNode? ToNode<T>(T value)
+    {
+        var element = JsonSerializer.SerializeToElement(value);
+        return JsonNode.Parse(element.GetRawText());
+    }
+
+    private static JsonNode? BuildToolChoiceNode(object toolChoice)
+    {
+        if (toolChoice is JsonNode node)
+        {
+            return node.DeepClone();
+        }
+
+        if (toolChoice is JsonElement element)
+        {
+            return JsonNode.Parse(element.GetRawText());
+        }
+
+        if (toolChoice is IDictionary<string, object?> dictionary)
+        {
+            return ToNode(dictionary);
+        }
+
+        if (toolChoice is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return ToNode(readOnlyDictionary);
+        }
+
+        var choice = toolChoice as string ?? toolChoice.ToString() ?? string.Empty;
+        return ToNode(choice switch
+        {
+            "auto" => new Dictionary<string, object?> { ["type"] = "auto" },
+            "any" => new Dictionary<string, object?> { ["type"] = "any" },
+            "none" => new Dictionary<string, object?> { ["type"] = "none" },
+            _ => new Dictionary<string, object?> { ["type"] = "tool", ["name"] = choice }
+        });
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesStreamParser.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesStreamParser.cs
@@ -1,0 +1,324 @@
+using System.Text;
+using System.Text.Json;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Copilot.Messages;
+
+/// <summary>
+/// Parses GitHub Copilot Anthropic-Messages SSE streams into content blocks and
+/// streaming events. Owned by the Copilot provider; behaviour is byte-identical
+/// to the Anthropic parser for the Copilot transport (which never used the
+/// claude-cli OAuth tool-name reverse-lookup).
+/// </summary>
+internal static class CopilotMessagesStreamParser
+{
+    internal static async Task<(Usage Usage, string? ResponseId, StopReason StopReason)> ProcessStreamAsync(
+        StreamReader reader,
+        LlmModel model,
+        LlmStream stream,
+        List<ContentBlock> contentBlocks,
+        Usage initialUsage,
+        Func<LlmModel, List<ContentBlock>, Usage, StopReason, string?, string?, AssistantMessage> buildMessage,
+        Func<string?, StopReason> mapStopReason,
+        CancellationToken ct,
+        Action? onFirstToken = null)
+    {
+        var usage = initialUsage;
+        var blockTypes = new Dictionary<int, string>();
+        var textAccumulators = new Dictionary<int, StringBuilder>();
+        var signatureAccumulators = new Dictionary<int, StringBuilder>();
+        var toolCallIds = new Dictionary<int, string>();
+        var toolCallNames = new Dictionary<int, string>();
+        string? responseId = null;
+        var stopReason = StopReason.Stop;
+        string? currentEvent = null;
+        var firstTokenFired = false;
+
+        while (!ct.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(ct);
+            if (line is null) break;
+
+            if (line.StartsWith("event:", StringComparison.Ordinal))
+            {
+                currentEvent = line[6..].TrimStart();
+                continue;
+            }
+
+            if (!line.StartsWith("data:", StringComparison.Ordinal))
+                continue;
+
+            var data = line[5..].TrimStart();
+            if (string.IsNullOrWhiteSpace(data))
+                continue;
+
+            JsonDocument? doc = null;
+            try { doc = JsonDocument.Parse(data); }
+            catch { continue; }
+
+            if (!firstTokenFired)
+            {
+                firstTokenFired = true;
+                onFirstToken?.Invoke();
+            }
+
+            using (doc)
+            {
+                ProcessSseEvent(
+                    currentEvent,
+                    doc.RootElement,
+                    model,
+                    stream,
+                    contentBlocks,
+                    blockTypes,
+                    textAccumulators,
+                    signatureAccumulators,
+                    toolCallIds,
+                    toolCallNames,
+                    usage,
+                    buildMessage,
+                    mapStopReason,
+                    ref responseId,
+                    ref stopReason,
+                    out usage);
+            }
+
+            currentEvent = null;
+        }
+
+        return (usage, responseId, stopReason);
+    }
+
+    private static void ProcessSseEvent(
+        string? eventType,
+        JsonElement data,
+        LlmModel model,
+        LlmStream stream,
+        List<ContentBlock> contentBlocks,
+        Dictionary<int, string> blockTypes,
+        Dictionary<int, StringBuilder> textAccumulators,
+        Dictionary<int, StringBuilder> signatureAccumulators,
+        Dictionary<int, string> toolCallIds,
+        Dictionary<int, string> toolCallNames,
+        Usage usage,
+        Func<LlmModel, List<ContentBlock>, Usage, StopReason, string?, string?, AssistantMessage> buildMessage,
+        Func<string?, StopReason> mapStopReason,
+        ref string? responseId,
+        ref StopReason stopReason,
+        out Usage updatedUsage)
+    {
+        updatedUsage = usage;
+        var type = data.TryGetProperty("type", out var typeProp)
+            ? typeProp.GetString()
+            : eventType;
+
+        switch (type)
+        {
+            case "message_start":
+                if (data.TryGetProperty("message", out var msg))
+                {
+                    if (msg.TryGetProperty("id", out var id))
+                        responseId = id.GetString();
+                    if (msg.TryGetProperty("usage", out var msgUsage))
+                        updatedUsage = UpdateUsage(updatedUsage, msgUsage);
+                }
+                stream.Push(new StartEvent(
+                    buildMessage(model, contentBlocks, updatedUsage, StopReason.Stop, null, responseId)));
+                break;
+
+            case "content_block_start":
+                HandleContentBlockStart(data, model, stream, contentBlocks, blockTypes,
+                    textAccumulators, signatureAccumulators, toolCallIds, toolCallNames, usage, responseId,
+                    buildMessage);
+                break;
+
+            case "content_block_delta":
+                HandleContentBlockDelta(data, model, stream, contentBlocks, blockTypes,
+                    textAccumulators, signatureAccumulators, usage, responseId, buildMessage);
+                break;
+
+            case "content_block_stop":
+                HandleContentBlockStop(data, model, stream, contentBlocks, blockTypes,
+                    textAccumulators, signatureAccumulators, toolCallIds, toolCallNames, usage, responseId, buildMessage);
+                break;
+
+            case "message_delta":
+                if (data.TryGetProperty("delta", out var delta) &&
+                    delta.TryGetProperty("stop_reason", out var sr))
+                {
+                    stopReason = mapStopReason(sr.GetString());
+                }
+                if (data.TryGetProperty("usage", out var deltaUsage))
+                    updatedUsage = UpdateUsage(updatedUsage, deltaUsage);
+                break;
+
+            case "message_stop":
+                break;
+
+            case "error":
+                var errorMsg = data.TryGetProperty("error", out var err)
+                    ? err.TryGetProperty("message", out var m) ? m.GetString() : "Unknown error"
+                    : "Unknown error";
+                throw new InvalidOperationException($"Copilot streaming error: {errorMsg}");
+        }
+    }
+
+    private static void HandleContentBlockStart(
+        JsonElement data,
+        LlmModel model,
+        LlmStream stream,
+        List<ContentBlock> contentBlocks,
+        Dictionary<int, string> blockTypes,
+        Dictionary<int, StringBuilder> textAccumulators,
+        Dictionary<int, StringBuilder> signatureAccumulators,
+        Dictionary<int, string> toolCallIds,
+        Dictionary<int, string> toolCallNames,
+        Usage usage,
+        string? responseId,
+        Func<LlmModel, List<ContentBlock>, Usage, StopReason, string?, string?, AssistantMessage> buildMessage)
+    {
+        var index = data.GetProperty("index").GetInt32();
+        if (!data.TryGetProperty("content_block", out var block)) return;
+
+        var blockType = block.GetProperty("type").GetString() ?? "text";
+        blockTypes[index] = blockType;
+        textAccumulators[index] = new StringBuilder();
+        signatureAccumulators[index] = new StringBuilder();
+
+        var partial = buildMessage(model, contentBlocks, usage, StopReason.Stop, null, responseId);
+
+        switch (blockType)
+        {
+            case "text":
+                stream.Push(new TextStartEvent(index, partial));
+                break;
+            case "thinking":
+                stream.Push(new ThinkingStartEvent(index, partial));
+                break;
+            case "redacted_thinking":
+                if (block.TryGetProperty("data", out var redactedData))
+                    signatureAccumulators[index].Append(redactedData.GetString());
+                textAccumulators[index].Append("[Reasoning redacted]");
+                stream.Push(new ThinkingStartEvent(index, partial));
+                break;
+            case "tool_use":
+                if (block.TryGetProperty("id", out var tcId))
+                    toolCallIds[index] = tcId.GetString() ?? "";
+                if (block.TryGetProperty("name", out var tcName))
+                    toolCallNames[index] = tcName.GetString() ?? "";
+                stream.Push(new ToolCallStartEvent(index, partial));
+                break;
+        }
+    }
+
+    private static void HandleContentBlockDelta(
+        JsonElement data,
+        LlmModel model,
+        LlmStream stream,
+        List<ContentBlock> contentBlocks,
+        Dictionary<int, string> blockTypes,
+        Dictionary<int, StringBuilder> textAccumulators,
+        Dictionary<int, StringBuilder> signatureAccumulators,
+        Usage usage,
+        string? responseId,
+        Func<LlmModel, List<ContentBlock>, Usage, StopReason, string?, string?, AssistantMessage> buildMessage)
+    {
+        var index = data.GetProperty("index").GetInt32();
+        if (!data.TryGetProperty("delta", out var delta)) return;
+
+        var deltaType = delta.GetProperty("type").GetString();
+        var partial = buildMessage(model, contentBlocks, usage, StopReason.Stop, null, responseId);
+
+        switch (deltaType)
+        {
+            case "text_delta":
+                var text = delta.GetProperty("text").GetString() ?? "";
+                textAccumulators[index].Append(text);
+                stream.Push(new TextDeltaEvent(index, text, partial));
+                break;
+            case "thinking_delta":
+                var thinking = delta.GetProperty("thinking").GetString() ?? "";
+                textAccumulators[index].Append(thinking);
+                stream.Push(new ThinkingDeltaEvent(index, thinking, partial));
+                break;
+            case "input_json_delta":
+                var jsonFrag = delta.GetProperty("partial_json").GetString() ?? "";
+                textAccumulators[index].Append(jsonFrag);
+                stream.Push(new ToolCallDeltaEvent(index, jsonFrag, partial));
+                break;
+            case "signature_delta":
+                var sig = delta.GetProperty("signature").GetString() ?? "";
+                signatureAccumulators[index].Append(sig);
+                break;
+        }
+    }
+
+    private static void HandleContentBlockStop(
+        JsonElement data,
+        LlmModel model,
+        LlmStream stream,
+        List<ContentBlock> contentBlocks,
+        Dictionary<int, string> blockTypes,
+        Dictionary<int, StringBuilder> textAccumulators,
+        Dictionary<int, StringBuilder> signatureAccumulators,
+        Dictionary<int, string> toolCallIds,
+        Dictionary<int, string> toolCallNames,
+        Usage usage,
+        string? responseId,
+        Func<LlmModel, List<ContentBlock>, Usage, StopReason, string?, string?, AssistantMessage> buildMessage)
+    {
+        var index = data.GetProperty("index").GetInt32();
+        if (!blockTypes.TryGetValue(index, out var blockType)) return;
+
+        var accumulated = textAccumulators.GetValueOrDefault(index)?.ToString() ?? "";
+        var signature = signatureAccumulators.GetValueOrDefault(index)?.ToString();
+        if (string.IsNullOrEmpty(signature)) signature = null;
+
+        switch (blockType)
+        {
+            case "text":
+                contentBlocks.Add(new TextContent(accumulated, signature));
+                var textPartial = buildMessage(model, contentBlocks, usage, StopReason.Stop, null, responseId);
+                stream.Push(new TextEndEvent(index, accumulated, textPartial));
+                break;
+
+            case "thinking":
+                contentBlocks.Add(new ThinkingContent(accumulated, signature));
+                var thinkPartial = buildMessage(model, contentBlocks, usage, StopReason.Stop, null, responseId);
+                stream.Push(new ThinkingEndEvent(index, accumulated, thinkPartial));
+                break;
+
+            case "redacted_thinking":
+                contentBlocks.Add(new ThinkingContent(accumulated, signature, Redacted: true));
+                var redactPartial = buildMessage(model, contentBlocks, usage, StopReason.Stop, null, responseId);
+                stream.Push(new ThinkingEndEvent(index, accumulated, redactPartial));
+                break;
+
+            case "tool_use":
+                var toolId = toolCallIds.GetValueOrDefault(index, "");
+                var toolName = toolCallNames.GetValueOrDefault(index, "");
+                var args = StreamingJsonParser.Parse(accumulated);
+                var toolCall = new ToolCallContent(toolId, toolName, args, signature);
+                contentBlocks.Add(toolCall);
+                var toolPartial = buildMessage(model, contentBlocks, usage, StopReason.Stop, null, responseId);
+                stream.Push(new ToolCallEndEvent(index, toolCall, toolPartial));
+                break;
+        }
+    }
+
+    private static Usage UpdateUsage(Usage usage, JsonElement usageElement)
+    {
+        var updated = usage;
+        if (usageElement.TryGetProperty("input_tokens", out var it))
+            updated = updated with { Input = it.GetInt32() };
+        if (usageElement.TryGetProperty("output_tokens", out var ot))
+            updated = updated with { Output = ot.GetInt32() };
+        if (usageElement.TryGetProperty("cache_read_input_tokens", out var cr))
+            updated = updated with { CacheRead = cr.GetInt32() };
+        if (usageElement.TryGetProperty("cache_creation_input_tokens", out var cw))
+            updated = updated with { CacheWrite = cw.GetInt32() };
+        return updated;
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
+++ b/src/gateway/BotNexus.Gateway.Api/BotNexus.Gateway.Api.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
     <ProjectReference Include="..\BotNexus.Gateway.Webhooks\BotNexus.Gateway.Webhooks.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Anthropic\BotNexus.Agent.Providers.Anthropic.csproj" />
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Copilot\BotNexus.Agent.Providers.Copilot.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.OpenAI\BotNexus.Agent.Providers.OpenAI.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.OpenAICompat\BotNexus.Agent.Providers.OpenAICompat.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.IntegrationMock\BotNexus.Agent.Providers.IntegrationMock.csproj" />

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -7,6 +7,7 @@ using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Extensions;
 using BotNexus.Agent.Providers.Core.Logging;
 using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Copilot.Messages;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
@@ -231,6 +232,7 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
     apiProviders.Register(new AnthropicProvider(httpClient));
+    apiProviders.Register(new CopilotMessagesProvider(httpClient));
     apiProviders.Register(new OpenAICompletionsProvider(httpClient, loggerFactory.CreateLogger<OpenAICompletionsProvider>()));
     apiProviders.Register(new OpenAIResponsesProvider(httpClient, loggerFactory.CreateLogger<OpenAIResponsesProvider>()));
     apiProviders.Register(new OpenAICompatProvider(httpClient));

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Messages/CopilotMessagesProviderParityTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Messages/CopilotMessagesProviderParityTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Copilot.Messages;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Messages;
+
+/// <summary>
+/// Phase 1a — proves that the carved-out <see cref="CopilotMessagesProvider"/>
+/// emits a byte-identical outbound request to the legacy path
+/// (<see cref="AnthropicProvider"/> driven against a github-copilot model with
+/// Bearer auth). This is the deployment-safety pivot for Phase 1b: when the
+/// model registry flips the Claude entries from <c>anthropic-messages</c> to
+/// <c>github-copilot-messages</c>, the wire contract must not change.
+///
+/// The test purposefully reuses the Phase 0a snapshot
+/// (<c>Fixtures/Requests/messages/claude-haiku-4.5/haiku-thinking-tool.json</c>)
+/// so any drift between the two providers, or between either provider and the
+/// committed contract, surfaces here.
+/// </summary>
+public class CopilotMessagesProviderParityTests
+{
+    private static readonly string SnapshotRoot = Path.Combine(
+        AppContext.BaseDirectory,
+        "Fixtures",
+        "Requests");
+
+    private static readonly string[] InterestingHeaders =
+    {
+        "Authorization",
+        "anthropic-version",
+        "anthropic-beta",
+    };
+
+    [Fact]
+    public void Api_IsGitHubCopilotMessages()
+    {
+        var provider = new CopilotMessagesProvider(new HttpClient(new NoOpHandler()));
+        provider.Api.ShouldBe("github-copilot-messages");
+    }
+
+    [Fact]
+    public async Task Stream_HaikuWithToolCatalogue_MatchesAnthropicCopilotModeBody()
+    {
+        var (copilotHandler, anthropicHandler) = await DriveBothProvidersAsync();
+
+        var copilotBody = Normalise(copilotHandler.RequestBody!);
+        var anthropicBody = Normalise(anthropicHandler.RequestBody!);
+
+        copilotBody.ShouldBe(
+            anthropicBody,
+            "CopilotMessagesProvider must emit a request body that is byte-identical to " +
+            "AnthropicProvider's Copilot-mode output. A diff here will become a user-visible " +
+            "behaviour change the moment BuiltInModels flips Claude entries to github-copilot-messages.");
+    }
+
+    [Fact]
+    public async Task Stream_HaikuWithToolCatalogue_MatchesPhase0aSnapshot()
+    {
+        var (copilotHandler, _) = await DriveBothProvidersAsync();
+
+        copilotHandler.RequestUri!.AbsoluteUri.ShouldBe(
+            "https://api.enterprise.githubcopilot.com/v1/messages");
+
+        var envelope = BuildEnvelope(copilotHandler);
+        var actualJson = SerializeStable(envelope);
+
+        var snapshotPath = Path.Combine(SnapshotRoot, "messages", "claude-haiku-4.5", "haiku-thinking-tool.json");
+        File.Exists(snapshotPath).ShouldBeTrue($"missing Phase 0a snapshot: {snapshotPath}");
+
+        var expectedJson = await File.ReadAllTextAsync(snapshotPath);
+        Normalise(actualJson).ShouldBe(
+            Normalise(expectedJson),
+            "CopilotMessagesProvider diverged from the Phase 0a snapshot. The carved-out " +
+            "provider must produce the same wire request as the legacy Anthropic-with-Copilot-auth path.");
+    }
+
+    [Fact]
+    public async Task Stream_AppliesBearerAuth_AndCopilotDynamicHeaders()
+    {
+        var (handler, _) = await DriveBothProvidersAsync();
+
+        handler.RequestHeaders.TryGetValue("Authorization", out var auth).ShouldBeTrue();
+        auth.ShouldStartWith("Bearer ");
+
+        // Two of the Copilot dynamic headers that are unconditionally applied to every
+        // Copilot request (Copilot-Vision-Request is only set when images are present).
+        handler.RequestHeaders.ShouldContainKey("X-Initiator");
+        handler.RequestHeaders.ShouldContainKey("Openai-Intent");
+    }
+
+    private static async Task<(RecordingHandler CopilotHandler, RecordingHandler AnthropicHandler)> DriveBothProvidersAsync()
+    {
+        var copilotHandler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var copilotProvider = new CopilotMessagesProvider(new HttpClient(copilotHandler));
+
+        var anthropicHandler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var anthropicProvider = new AnthropicProvider(new HttpClient(anthropicHandler));
+
+        var model = BuildModel();
+        var context = BuildContext();
+
+        var copilotOpts = new CopilotMessagesOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+        var anthropicOpts = new AnthropicOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+
+        var copilotStream = copilotProvider.Stream(model, context, copilotOpts);
+        _ = await copilotStream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var anthropicStream = anthropicProvider.Stream(model, context, anthropicOpts);
+        _ = await anthropicStream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        return (copilotHandler, anthropicHandler);
+    }
+
+    private static LlmModel BuildModel() => new(
+        Id: "claude-haiku-4.5",
+        Name: "claude-haiku-4.5",
+        Api: "anthropic-messages",
+        Provider: "github-copilot",
+        BaseUrl: "https://api.enterprise.githubcopilot.com",
+        Reasoning: true,
+        Input: ["text", "image"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 200000,
+        MaxTokens: 16384);
+
+    private static Context BuildContext()
+    {
+        const long fixedTimestamp = 1_700_000_000_000L;
+        return new Context(
+            SystemPrompt: "You are a helpful assistant operating inside BotNexus tests. " +
+                          "Reply concisely and use tools when asked.",
+            Messages:
+            [
+                new UserMessage(new UserMessageContent("List the first three prime numbers."), fixedTimestamp),
+            ],
+            Tools:
+            [
+                new Tool(
+                    Name: "list_primes",
+                    Description: "Returns the first N prime numbers.",
+                    Parameters: JsonDocument.Parse("""
+                        {
+                          "type": "object",
+                          "properties": {
+                            "count": { "type": "integer", "minimum": 1, "maximum": 100 }
+                          },
+                          "required": ["count"]
+                        }
+                        """).RootElement.Clone()),
+            ]);
+    }
+
+    private const string MinimalSse =
+        "event: message_start\n" +
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01FixtureMessage00000001\"}}\n" +
+        "\n" +
+        "event: message_stop\n" +
+        "data: {\"type\":\"message_stop\"}\n" +
+        "\n";
+
+    private static JsonObject BuildEnvelope(RecordingHandler handler)
+    {
+        var body = JsonNode.Parse(handler.RequestBody!)!.AsObject();
+
+        var headers = new JsonObject();
+        foreach (var name in InterestingHeaders.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            if (handler.RequestHeaders.TryGetValue(name, out var value))
+            {
+                if (string.Equals(name, "Authorization", StringComparison.OrdinalIgnoreCase))
+                {
+                    var scheme = value.Split(' ', 2)[0];
+                    headers[name] = $"{scheme} <redacted>";
+                }
+                else
+                {
+                    headers[name] = value;
+                }
+            }
+        }
+
+        return new JsonObject
+        {
+            ["method"] = handler.RequestMethod ?? "POST",
+            ["path"] = handler.RequestUri!.AbsolutePath,
+            ["headers"] = headers,
+            ["body"] = body,
+        };
+    }
+
+    private static string SerializeStable(JsonNode node)
+        => JsonSerializer.Serialize(node, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        });
+
+    private static string Normalise(string text)
+        => text.Replace("\r\n", "\n").TrimEnd();
+
+    private static HttpResponseMessage SseResponse(string payload) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "text/event-stream"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public string? RequestMethod { get; private set; }
+        public string? RequestBody { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public Dictionary<string, string> RequestHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestMethod = request.Method.Method;
+            RequestUri = request.RequestUri;
+            RequestHeaders = request.Headers.ToDictionary(
+                header => header.Key,
+                header => string.Join(",", header.Value),
+                StringComparer.OrdinalIgnoreCase);
+            RequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responseFactory(request);
+        }
+    }
+
+    private sealed class NoOpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
@@ -5,6 +5,7 @@ using BotNexus.Gateway;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Copilot.Messages;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Registry;
 using BotNexus.Agent.Providers.OpenAI;
@@ -258,6 +259,44 @@ public sealed class GatewayStartupAndConfigurationTests
         var copilotModel = llmClient.Models.GetModel("github-copilot", "gpt-4.1");
         copilotModel.ShouldNotBeNull();
         registeredApis.ShouldContain(copilotModel!.Api);
+    }
+
+    [Fact]
+    public void GatewayConfiguration_CopilotMessagesProvider_IsRegisteredAndAdditiveToAnthropicMessages()
+    {
+        // Phase 1a (#810): The carved-out CopilotMessagesProvider exists alongside
+        // AnthropicProvider. It is reachable under Api="github-copilot-messages" but
+        // BuiltInModels does NOT yet route any model to it — that is Phase 1b.
+        // This test pins the additive deployment contract: existing Claude-on-Copilot
+        // requests continue to route through AnthropicProvider (anthropic-messages),
+        // and the new provider is available for the upcoming routing flip.
+        using var httpClient = new HttpClient();
+
+        var apiProviders = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+
+        apiProviders.Register(new AnthropicProvider(httpClient));
+        apiProviders.Register(new CopilotMessagesProvider(httpClient));
+        apiProviders.Register(new OpenAICompletionsProvider(httpClient, NullLogger<OpenAICompletionsProvider>.Instance));
+        apiProviders.Register(new OpenAIResponsesProvider(httpClient, NullLogger<OpenAIResponsesProvider>.Instance));
+        apiProviders.Register(new OpenAICompatProvider(httpClient));
+
+        new BuiltInModels().RegisterAll(models);
+
+        var llmClient = new LlmClient(apiProviders, models);
+        var registeredApis = llmClient.ApiProviders.GetAll().Select(provider => provider.Api).ToArray();
+
+        registeredApis.ShouldContain("anthropic-messages",
+            "AnthropicProvider must remain registered — direct-Anthropic users depend on it.");
+        registeredApis.ShouldContain("github-copilot-messages",
+            "Phase 1a registers CopilotMessagesProvider so Phase 1b can flip Claude models without code change.");
+
+        // BuiltInModels still routes Claude entries via anthropic-messages in Phase 1a.
+        // Phase 1b will flip these to github-copilot-messages.
+        var haiku = llmClient.Models.GetModel("github-copilot", "claude-haiku-4.5");
+        haiku.ShouldNotBeNull();
+        haiku!.Api.ShouldBe("anthropic-messages",
+            "Phase 1a is additive — model routing must not change yet.");
     }
 
     [Fact]


### PR DESCRIPTION
## Phase 1a — `CopilotMessagesProvider` carve-out (additive, no routing change)

First implementation step of the Copilot provider carve-out (#810). All six Phase 0 regression PRs have merged (#811, #812, #860, #863, #875, #878); this PR is the first to add new provider code.

### What this is
- New provider: `CopilotMessagesProvider` (`Api = ""github-copilot-messages""`), carved out of `AnthropicProvider`'s `AuthMode.Copilot` branch.
- Lives under `src/agent/BotNexus.Agent.Providers.Copilot/Messages/` with its own `RequestBuilder`, `MessageConverter`, `StreamParser`, and `Options` types. **No cross-provider dependency on the Anthropic project.**
- Always uses Bearer auth with the Copilot OAuth access token and always applies the Copilot dynamic headers (`X-Initiator`, `Openai-Intent`, `Copilot-Vision-Request` when images present).
- Registered in `Gateway.Api` `Program.cs` alongside `AnthropicProvider`.

### What this is **not**
- **No model routing change.** `BuiltInModels.RegisterCopilotModels` still maps the 6 Claude entries to `Api = ""anthropic-messages""`. Existing deployments are byte-for-byte unaffected. Phase 1b will flip the routing in a tiny follow-up PR.

### Why two PRs
- Phase 1a is additive only — easy to ship, trivially safe.
- Phase 1b becomes a one-line registry change guarded by the Phase 0a snapshot + the new parity test in this PR. A regression in 1b can be rolled back without touching provider code.

### Deployment safety
The user's deployment-safety rules (S1–S6) require every PR to ship standalone without coordinated user changes. This PR satisfies that by leaving routing unchanged and adding a provider class behind it.

### Tests (4 facts in `CopilotMessagesProviderParityTests` + 1 in gateway integration)
1. `Api` id is `""github-copilot-messages""`.
2. **Byte-identical request body** vs `AnthropicProvider` Copilot-mode for the Phase 0a haiku scenario — this is the deployment-safety pivot for Phase 1b.
3. **Matches the committed Phase 0a snapshot** (`Fixtures/Requests/messages/claude-haiku-4.5/haiku-thinking-tool.json`) — proves the new provider is wire-compatible with the existing contract.
4. Applies Bearer auth + Copilot dynamic headers (`X-Initiator`, `Openai-Intent`) on every request.
5. `GatewayConfiguration_CopilotMessagesProvider_IsRegisteredAndAdditiveToAnthropicMessages` — pins that the new provider is reachable in the gateway AND that Claude routing is still `anthropic-messages` in Phase 1a.

### Validation
`scripts/repo/test-impacted.ps1` — 9 affected test projects all green:
- `Copilot.Tests` 70 passed (4 new parity facts)
- `Architecture.Tests` all green
- `Gateway.Tests` 2134 passed
- `Scenarios.Tests` all green
- `CodingAgent`, `Cli`, `Mcp`, `Conversations` all green

### Next
- **Phase 1b**: flip `BuiltInModels` Claude entries from `anthropic-messages` → `github-copilot-messages` (one-line PR).
- **Phase 1c** (later): once the routing flip has soaked, dead-code-eliminate `AuthMode.Copilot` from `AnthropicProvider` and `CopilotProvider.cs` static helper.
- **Phase 2**: carve Responses + Completions for the OpenAI-on-Copilot transport.

Refs #810.
