### PR TITLE
feat(gateway): add InterruptAndSteerAsync contract to IAgentHandle

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentHandle.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentHandle.cs
@@ -97,4 +97,18 @@ public interface IAgentHandle : IAsyncDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that completes when the message is queued.</returns>
     Task FollowUpAsync(AgentMessage message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically aborts the current agent run (if any) and injects a new steering direction.
+    /// The new direction is queued immediately after abort completes so the agent resumes
+    /// with the redirected goal rather than continuing the abandoned turn.
+    /// </summary>
+    /// <param name="message">The new direction to inject after aborting the current run.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the abort is issued and the steer is queued.</returns>
+    /// <remarks>
+    /// This is the Phase 1a contract definition (Issue #799, Part of #704).
+    /// Implementation is wired in Issue #800.
+    /// </remarks>
+    Task InterruptAndSteerAsync(string message, CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -976,6 +976,15 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Phase 1a stub: contract defined in Issue #799 (Part of #704).
+    /// Full implementation wired in Issue #800.
+    /// </remarks>
+    public Task InterruptAndSteerAsync(string message, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException(
+            "InterruptAndSteerAsync is not yet implemented. See Issue #800 (feat/interrupt-steer-agent-core).");
+
+    /// <inheritdoc />
     public Task FollowUpAsync(string message, CancellationToken cancellationToken = default)
     {
         _agent.FollowUp(new AgentCoreUserMessage(message));

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/CopilotIntegrationTests.cs
@@ -384,6 +384,7 @@ public sealed class CopilotIntegrationTests
             => StreamAsync(message.Content, cancellationToken);
 
         public Task AbortAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InterruptAndSteerAsync(string message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task SteerAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(AgentMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/MultiAgentConcurrencyTests.cs
@@ -457,6 +457,7 @@ public sealed class MultiAgentConcurrencyTests : IAsyncDisposable
             => StreamAsync(message.Content, ct);
 
         public Task AbortAsync(CancellationToken ct) { IsRunning = false; return Task.CompletedTask; }
+        public Task InterruptAndSteerAsync(string message, CancellationToken ct = default) => throw new NotImplementedException();
         public Task SteerAsync(string message, CancellationToken ct) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken ct) => Task.CompletedTask;
         public Task FollowUpAsync(AgentMessage message, CancellationToken ct) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/Phase5IntegrationTests.cs
@@ -326,6 +326,7 @@ public sealed class Phase5IntegrationTests
             => StreamAsync(message.Content, cancellationToken);
 
         public Task AbortAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InterruptAndSteerAsync(string message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task SteerAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(AgentMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -845,6 +845,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
             return Task.CompletedTask;
         }
 
+        public Task InterruptAndSteerAsync(string message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task SteerAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(string message, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task FollowUpAsync(AgentMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/gateway/BotNexus.Gateway.Tests/InterruptAndSteerContractTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InterruptAndSteerContractTests.cs
@@ -1,0 +1,127 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Agent.Core;
+using BotNexus.Agent.Core.Configuration;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Isolation;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Verifies the domain contract for InterruptAndSteerAsync (#799, Part of #704).
+/// Phase 1a: contract definition only. Implementation wired in #800.
+/// </summary>
+public sealed class InterruptAndSteerContractTests
+{
+    [Fact]
+    public void IAgentHandle_HasInterruptAndSteerAsync_Method()
+    {
+        // Verify the method exists on the interface with the correct signature.
+        var method = typeof(IAgentHandle).GetMethod(
+            "InterruptAndSteerAsync",
+            [typeof(string), typeof(CancellationToken)]);
+
+        method.ShouldNotBeNull("IAgentHandle must declare InterruptAndSteerAsync(string, CancellationToken)");
+        method!.ReturnType.ShouldBe(typeof(Task));
+    }
+
+    [Fact]
+    public void IAgentHandle_InterruptAndSteerAsync_HasOptionalCancellationToken()
+    {
+        var method = typeof(IAgentHandle).GetMethod(
+            "InterruptAndSteerAsync",
+            [typeof(string), typeof(CancellationToken)]);
+
+        method.ShouldNotBeNull();
+        var ctParam = method!.GetParameters()[1];
+        ctParam.ParameterType.ShouldBe(typeof(CancellationToken));
+        ctParam.HasDefaultValue.ShouldBeTrue("CancellationToken parameter should be optional (default = default)");
+    }
+
+    [Fact]
+    public async Task InProcessAgentHandle_InterruptAndSteerAsync_ThrowsNotImplementedException()
+    {
+        // Phase 1a stub: implementation not yet wired. #800 will replace this with real logic.
+        var (_, handle) = CreateHandle();
+
+        await Should.ThrowAsync<NotImplementedException>(
+            () => handle.InterruptAndSteerAsync("steer me elsewhere"));
+    }
+
+    // ── factory ─────────────────────────────────────────────────────────────────
+
+    private static (BotNexus.Agent.Core.Agent Agent, InProcessAgentHandle Handle) CreateHandle()
+    {
+        var modelRegistry = new ModelRegistry();
+        modelRegistry.Register("test-provider", new LlmModel(
+            Id: "test-model",
+            Name: "test-model",
+            Api: "test-api",
+            Provider: "test-provider",
+            BaseUrl: "http://localhost",
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 8192,
+            MaxTokens: 1024));
+
+        var providers = new ApiProviderRegistry();
+        providers.Register(new StubStreamingProvider());
+        var llmClient = new LlmClient(providers, modelRegistry);
+        var model = modelRegistry.GetModel("test-provider", "test-model")!;
+        var options = new AgentOptions(
+            InitialState: new AgentInitialState(SystemPrompt: "test", Model: model),
+            Model: model,
+            LlmClient: llmClient,
+            ConvertToLlm: null,
+            TransformContext: null,
+            GetApiKey: (_, _) => Task.FromResult<string?>(null),
+            GetSteeringMessages: null,
+            GetFollowUpMessages: null,
+            ToolExecutionMode: ToolExecutionMode.Parallel,
+            BeforeToolCall: null,
+            AfterToolCall: null,
+            GenerationSettings: new SimpleStreamOptions(),
+            SteeringMode: QueueMode.All,
+            FollowUpMode: QueueMode.All,
+            SessionId: "session-1");
+
+        var agent = new BotNexus.Agent.Core.Agent(options);
+        var handle = new InProcessAgentHandle(agent, AgentId.From("agent-a"), SessionId.From("session-1"), NullLogger.Instance);
+        return (agent, handle);
+    }
+
+    private sealed class StubStreamingProvider : IApiProvider
+    {
+        public string Api => "test-api";
+
+        public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+            => StreamSimple(model, context, null);
+
+        public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+        {
+            var stream = new LlmStream();
+            var partial = new AssistantMessage(
+                Content: [],
+                Api: model.Api,
+                Provider: model.Provider,
+                ModelId: model.Id,
+                Usage: Usage.Empty(),
+                StopReason: StopReason.Stop,
+                ErrorMessage: null,
+                ResponseId: null,
+                Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            var withText = partial with { Content = [new TextContent("ok")] };
+            stream.Push(new StartEvent(partial));
+            stream.Push(new TextDeltaEvent(0, "ok", withText));
+            stream.Push(new DoneEvent(StopReason.Stop, withText));
+            return stream;
+        }
+    }
+}


### PR DESCRIPTION
Closes #799

## Changes
- Added `InterruptAndSteerAsync(string message, CancellationToken ct)` to `IAgentHandle` interface with full XML documentation
- Added `NotImplementedException` stub in `InProcessAgentHandle` (Phase 1a per issue spec — implementation wired in #800)
- Updated all 4 test-fake `IAgentHandle` implementations (`CopilotIntegrationTests`, `Phase5IntegrationTests`, `MultiAgentConcurrencyTests`, `SignalRIntegrationTests`) with matching stubs to satisfy compiler
- Added `InterruptAndSteerContractTests.cs` with 3 tests:
  - Interface has the method with correct signature
  - `CancellationToken` parameter is optional (default)
  - `InProcessAgentHandle` stub throws `NotImplementedException` (Phase 1a guard)

## Test results
All impacted projects: 167/167 Architecture, 2136/2137 Gateway.Tests (1 expected integration skip), plus Cli, Cron, Conversations, Sessions, Scenarios, Skills, Mcp, WebTools, ServiceBus, McpInvoke — all pass.

## Merge Notes
This PR can merge independently of all 7 currently open PRs (#881, #883, #884, #885, #886 + 2 new). No file overlap with any open PR.

`#800 feat(interrupt-steer): implement atomic abort+steer in agent run loop` can merge after this PR lands (it depends on the contract defined here).