### PR TITLE
fix(gateway): bump conversation UpdatedAt on every completed message turn

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
@@ -124,6 +124,20 @@ public interface IConversationStore
         CancellationToken ct = default);
 
     /// <summary>
+    /// Updates the <see cref="Conversation.UpdatedAt"/> timestamp to <see cref="DateTimeOffset.UtcNow"/>
+    /// without loading or rewriting the full conversation state.
+    /// <para>
+    /// Intended for high-frequency call sites such as the message processing loop where
+    /// bumping a timestamp is appropriate but a full <see cref="SaveAsync"/> round-trip
+    /// (which reloads the cache and rewrites all columns) is unnecessary overhead.
+    /// </para>
+    /// <para>Silently no-ops when the conversation does not exist.</para>
+    /// </summary>
+    /// <param name="conversationId">The conversation to touch.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task TouchAsync(ConversationId conversationId, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns lightweight summaries for all <em>active</em> conversations across the world,
     /// ordered most-recently-updated first.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -160,6 +160,20 @@ public sealed class FileConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public async Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var conversation = await FindByConversationIdAsync(conversationId, ct).ConfigureAwait(false);
+            if (conversation is null)
+                return;
+            await WriteFileAsync(conversation with { UpdatedAt = DateTimeOffset.UtcNow }, ct).ConfigureAwait(false);
+        }
+        finally { _lock.Release(); }
+    }
+
+    /// <inheritdoc />
     public async Task AddParticipantsAsync(
         ConversationId conversationId,
         IEnumerable<SessionParticipant> participants,

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -109,6 +109,14 @@ public sealed class InMemoryConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
+    {
+        if (_conversations.TryGetValue(conversationId.Value, out var existing))
+            _conversations[conversationId.Value] = existing with { UpdatedAt = DateTimeOffset.UtcNow };
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     public async Task AddParticipantsAsync(
         ConversationId conversationId,
         IEnumerable<SessionParticipant> participants,

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -366,6 +366,46 @@ public sealed class SqliteConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public async Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
+    {
+        using var activity = ActivitySource.StartActivity("conversation.touch", ActivityKind.Internal);
+        activity?.SetTag("botnexus.conversation.id", conversationId.Value);
+
+        await EnsureCreatedAsync(ct).ConfigureAwait(false);
+        var conversationLock = GetConversationLock(conversationId.Value);
+        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var updatedAt = DateTimeOffset.UtcNow;
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE conversations
+                SET updated_at = $updatedAt
+                WHERE id = $id
+                """;
+            command.Parameters.AddWithValue("$updatedAt", updatedAt.ToString("O"));
+            command.Parameters.AddWithValue("$id", conversationId.Value);
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            // Keep the in-memory cache consistent so subsequent GetAsync / ListAsync
+            // calls return the updated timestamp without a disk round-trip.
+            if (_cache.TryGetValue(conversationId.Value, out var cached))
+            {
+                var touched = CloneConversation(cached);
+                touched.UpdatedAt = updatedAt;
+                _cache[conversationId.Value] = touched;
+            }
+        }
+        finally
+        {
+            conversationLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<Conversation?> ResolveByBindingAsync(
         AgentId agentId,
         ChannelKey channelType,

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -654,6 +654,12 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                 // Outbound fan-out: deliver response to other bindings in the conversation
                 await FanOutResponseAsync(message, sessionId, cancellationToken);
 
+                // Bump UpdatedAt on the conversation so the portal list ordering and
+                // retention thresholds reflect the time of the last message, not the
+                // last explicit metadata edit (#890). Best-effort: failures must not
+                // surface as turn failures.
+                await TouchConversationAsync(session.ConversationId, cancellationToken).ConfigureAwait(false);
+
                 await _activity.PublishAsync(new GatewayActivity
                 {
                     Type = GatewayActivityType.AgentCompleted,
@@ -1026,6 +1032,28 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
             session.ConversationId,
             [new SessionParticipant { CitizenId = callerCitizenId }],
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Best-effort bump of <see cref="Conversation.UpdatedAt"/> after a completed turn.
+    /// Failures are logged at debug level and swallowed so turn delivery is never impacted (#890).
+    /// No-ops when no conversation store is wired (legacy test compositions).
+    /// </summary>
+    private async Task TouchConversationAsync(ConversationId conversationId, CancellationToken cancellationToken)
+    {
+        if (!conversationId.IsInitialized() || _conversationStore is null)
+            return;
+        try
+        {
+            await _conversationStore.TouchAsync(conversationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Failed to touch conversation UpdatedAt for {ConversationId}; portal list ordering may be stale.",
+                conversationId);
+        }
     }
 
     private SessionType ResolveSessionType(GatewaySession session, InboundMessage message, bool isNewSession)

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreTests.cs
@@ -638,6 +638,55 @@ public sealed class SqliteConversationStoreTests
         numericAgain!.ChannelBindings[0].ChannelAddress.ShouldBe(ChannelAddress.From("12345/topic:67"));
     }
 
+    // ── TouchAsync ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TouchAsync_UpdatesUpdatedAtAndCacheEntry()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = CreateConversation(Agent("agent-a"), "title");
+        var before = DateTimeOffset.UtcNow.AddSeconds(-10);
+        conversation.UpdatedAt = before;
+        await store.CreateAsync(conversation);
+
+        await store.TouchAsync(conversation.ConversationId);
+
+        var loaded = await fixture.CreateStore().GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.UpdatedAt.ShouldBeGreaterThan(before);
+    }
+
+    [Fact]
+    public async Task TouchAsync_IsIdempotentAndDoesNotThrowForMissingConversation()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        // Touch a conversation that does not exist -- must not throw
+        var fakeId = ConversationId.From("conv-nonexistent");
+        await store.TouchAsync(fakeId); // no exception expected
+    }
+
+    [Fact]
+    public async Task TouchAsync_CacheReflectsUpdatedAt_AfterTouchWithoutFullReload()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = CreateConversation(Agent("agent-a"), "title");
+        await store.CreateAsync(conversation);
+
+        // Load into cache
+        _ = await store.GetAsync(conversation.ConversationId);
+        var before = (await store.GetAsync(conversation.ConversationId))!.UpdatedAt;
+
+        await Task.Delay(5); // ensure clock advances at least 1ms
+        await store.TouchAsync(conversation.ConversationId);
+
+        // GetAsync must return the updated timestamp from cache without a disk reload
+        var after = (await store.GetAsync(conversation.ConversationId))!.UpdatedAt;
+        after.ShouldBeGreaterThan(before);
+    }
+
     private static string TempDb()
         => Path.Combine(Path.GetTempPath(), $"bn-conv-test-{Guid.NewGuid():N}.db");
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -577,6 +577,8 @@ public sealed class AgentExchangeArchiveTests
         }
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
+        public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
+            => _inner.TouchAsync(conversationId, ct);
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => _inner.GetSummariesAsync(ct);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -298,6 +298,9 @@ public sealed class ConversationsControllerHistoryTests
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => throw new NotSupportedException();
 
+        public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
+            => Task.CompletedTask;
+
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => throw new NotSupportedException();
 

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1916,6 +1916,8 @@ file sealed class ThrowingArchiveConversationStore : IConversationStore
     }
     public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
         => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
+    public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
+        => _inner.TouchAsync(conversationId, ct);
     public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
         => _inner.GetSummariesAsync(ct);
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
@@ -799,6 +799,7 @@ public sealed class LegacyConversationBackfillTests
         public Task ArchiveAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.ArchiveAsync(conversationId, ct);
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => Inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
+        public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.TouchAsync(conversationId, ct);
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => Inner.GetSummariesAsync(ct);
     }


### PR DESCRIPTION
Closes #890

## Problem

`GatewayHost` called `_sessions.SaveAsync()` after each turn but never called `_conversationStore.SaveAsync()`. This meant `Conversation.UpdatedAt` only advanced when:
- A user explicitly edited the conversation title/settings
- A session was reset via `DefaultConversationResetService`
- A conversation was archived

As a result, the portal conversation list was ordered by creation time (not last message), and `ConversationRetentionHostedService` measured inactivity from creation rather than last message.

## Changes

**`IConversationStore` (Contracts):** Added `TouchAsync(ConversationId, CancellationToken)` — lightweight timestamp-only update. No full row reload or cache invalidation.

**`SqliteConversationStore`:** `UPDATE conversations SET updated_at = ? WHERE id = ?` plus in-memory cache patch via `CloneConversation` — no disk round-trip on subsequent `GetAsync`.

**`InMemoryConversationStore`:** `record with { UpdatedAt = UtcNow }` update.

**`FileConversationStore`:** `FindByConversationIdAsync` + `WriteFileAsync` with updated timestamp.

**`GatewayHost`:** Added `TouchConversationAsync` helper (best-effort, swallows at Debug). Called after `FanOutResponseAsync` on each clean turn completion.

**4 test fakes updated** (`ThrowingArchiveStore`, `DelayableConversationStore`, `StubConversationStore`, `ThrowingArchiveConversationStore`) to implement `TouchAsync`.

## Tests

3 new regression tests in `SqliteConversationStoreTests`:
- `TouchAsync_UpdatesUpdatedAtAndCacheEntry` — disk and cache both updated
- `TouchAsync_IsIdempotentAndDoesNotThrowForMissingConversation` — safe no-op
- `TouchAsync_CacheReflectsUpdatedAt_AfterTouchWithoutFullReload` — cache patch verified

## Merge Notes

Independent — no file overlap with any open PR. Safe to merge in any order.
