### PR TITLE
feat(skills): seed example-skill when global skills directory is first created

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/SkillsSeeder.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillsSeeder.cs
@@ -1,0 +1,118 @@
+using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Skills;
+
+/// <summary>
+/// Seeds a well-commented <c>example-skill</c> into the global skills directory
+/// the first time the Skills extension is used on a machine.
+/// <para>
+/// The seed is a one-time bootstrap: it runs only when the global skills directory
+/// is newly created (did not previously exist) or exists but contains no skills.
+/// Existing skills are never modified or removed.
+/// </para>
+/// </summary>
+public static class SkillsSeeder
+{
+    private const string ExampleSkillName = "example-skill";
+    private const string SkillFileName = "SKILL.md";
+
+    /// <summary>
+    /// Ensures the global skills directory exists and, if it contains no existing
+    /// skills, writes the <c>example-skill</c> seed.
+    /// </summary>
+    /// <param name="globalSkillsDir">Path to <c>~/.botnexus/skills</c>.</param>
+    /// <param name="fileSystem">Optional filesystem abstraction; defaults to real filesystem.</param>
+    /// <param name="logger">Optional logger; emits info when the seed is written.</param>
+    public static void EnsureGlobalSkillsSeed(
+        string? globalSkillsDir,
+        IFileSystem? fileSystem = null,
+        ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(globalSkillsDir))
+            return;
+
+        var fs = fileSystem ?? new FileSystem();
+
+        // Create the global skills directory if it doesn't exist yet.
+        var directoryCreated = false;
+        if (!fs.Directory.Exists(globalSkillsDir))
+        {
+            fs.Directory.CreateDirectory(globalSkillsDir);
+            directoryCreated = true;
+        }
+
+        // Only seed when no skills exist yet (directory was just created or is empty of skill subdirs).
+        // "Has skills" = at least one subdirectory containing a SKILL.md file.
+        if (!directoryCreated && HasExistingSkills(fs, globalSkillsDir))
+            return;
+
+        var exampleDir = Path.Combine(globalSkillsDir, ExampleSkillName);
+        var skillFilePath = Path.Combine(exampleDir, SkillFileName);
+
+        // Idempotent: don't overwrite an existing example skill.
+        if (fs.File.Exists(skillFilePath))
+            return;
+
+        fs.Directory.CreateDirectory(exampleDir);
+        fs.File.WriteAllText(skillFilePath, BuildExampleSkillContent());
+
+        logger?.LogInformation(
+            "Skills: created example skill at '{SkillPath}'. " +
+            "Use this as a template to create your own skills.",
+            skillFilePath);
+    }
+
+    private static bool HasExistingSkills(IFileSystem fs, string skillsDir)
+    {
+        foreach (var subDir in fs.Directory.GetDirectories(skillsDir))
+        {
+            var skillFile = Path.Combine(subDir, SkillFileName);
+            if (fs.File.Exists(skillFile))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string BuildExampleSkillContent() =>
+        """
+        ---
+        name: example-skill
+        description: A simple example skill to demonstrate the BotNexus skill format.
+        tags: [example]
+        ---
+        # Example Skill
+
+        This is an example skill. Copy this directory and edit `SKILL.md` to create your own skills.
+
+        ## What is a Skill?
+
+        Skills are reusable markdown files that inject domain-specific knowledge and instructions
+        into an agent's context when loaded. They let you package expertise once and share it
+        across sessions or agents.
+
+        ## Instructions
+
+        When the user asks you to greet them, respond with a friendly greeting that includes:
+        - Their name if known
+        - The current time of day
+        - A helpful tip about BotNexus skills
+
+        ## Example
+
+        User: "Give me a greeting"
+
+        Assistant: "Good morning! Welcome back. Did you know you can create your own skills by
+        adding markdown files to your `~/.botnexus/skills/` directory? Each skill lives in its
+        own subdirectory with a `SKILL.md` file — just like this one."
+
+        ## How to Create Your Own Skill
+
+        1. Copy this directory: `cp -r ~/.botnexus/skills/example-skill ~/.botnexus/skills/my-skill`
+        2. Rename to match your skill name (lowercase, hyphens only)
+        3. Edit the frontmatter: set `name` to match the directory name
+        4. Replace the content with your domain knowledge or instructions
+        5. Load it in a session: `/skills load my-skill`
+        """;
+}

--- a/src/extensions/BotNexus.Extensions.Skills/SkillsToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillsToolContributor.cs
@@ -22,6 +22,9 @@ public sealed class SkillsToolContributor : IAgentToolContributor
         var workspaceSkillsDir = Path.Combine(context.WorkspacePath, "skills");
         var config = ResolveExtensionConfig<SkillsConfig>(context.Descriptor, "botnexus-skills");
 
+        // Seed the global skills directory with an example skill on first use.
+        SkillsSeeder.EnsureGlobalSkillsSeed(globalSkillsDir);
+
         IReadOnlyList<IAgentTool> tools =
         [
             new SkillTool(globalSkillsDir, agentSkillsDir, workspaceSkillsDir, config)

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillsSeederTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillsSeederTests.cs
@@ -1,0 +1,81 @@
+using BotNexus.Extensions.Skills;
+using Shouldly;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace BotNexus.Extensions.Skills.Tests;
+
+public sealed class SkillsSeederTests
+{
+    [Fact]
+    public void EnsureGlobalSkillsSeed_CreatesDirectoryAndExampleSkillWhenMissing()
+    {
+        var fs = new MockFileSystem();
+        var globalDir = "/skills";
+
+        SkillsSeeder.EnsureGlobalSkillsSeed(globalDir, fs);
+
+        fs.Directory.Exists(globalDir).ShouldBeTrue();
+        var skillFile = Path.Combine(globalDir, "example-skill", "SKILL.md");
+        fs.File.Exists(skillFile).ShouldBeTrue();
+        var content = fs.File.ReadAllText(skillFile);
+        content.ShouldContain("name: example-skill");
+        content.ShouldContain("description:");
+    }
+
+    [Fact]
+    public void EnsureGlobalSkillsSeed_SeedsWhenDirectoryExistsButHasNoSkills()
+    {
+        var fs = new MockFileSystem();
+        var globalDir = "/skills";
+        fs.Directory.CreateDirectory(globalDir);
+        // Empty directory, no subdirs
+
+        SkillsSeeder.EnsureGlobalSkillsSeed(globalDir, fs);
+
+        var skillFile = Path.Combine(globalDir, "example-skill", "SKILL.md");
+        fs.File.Exists(skillFile).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EnsureGlobalSkillsSeed_IsIdempotentWhenExampleAlreadyExists()
+    {
+        var fs = new MockFileSystem();
+        var globalDir = "/skills";
+        var exampleDir = Path.Combine(globalDir, "example-skill");
+        var skillFile = Path.Combine(exampleDir, "SKILL.md");
+        fs.Directory.CreateDirectory(exampleDir);
+        fs.File.WriteAllText(skillFile, "original content");
+
+        SkillsSeeder.EnsureGlobalSkillsSeed(globalDir, fs);
+
+        // Must not overwrite
+        fs.File.ReadAllText(skillFile).ShouldBe("original content");
+    }
+
+    [Fact]
+    public void EnsureGlobalSkillsSeed_DoesNotSeedWhenExistingSkillsPresent()
+    {
+        var fs = new MockFileSystem();
+        var globalDir = "/skills";
+        // Existing skill (not example-skill)
+        var existingDir = Path.Combine(globalDir, "my-existing-skill");
+        fs.Directory.CreateDirectory(existingDir);
+        fs.File.WriteAllText(Path.Combine(existingDir, "SKILL.md"), "---\nname: my-existing-skill\ndescription: existing\n---\n");
+
+        SkillsSeeder.EnsureGlobalSkillsSeed(globalDir, fs);
+
+        // example-skill should NOT have been created
+        var exampleFile = Path.Combine(globalDir, "example-skill", "SKILL.md");
+        fs.File.Exists(exampleFile).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EnsureGlobalSkillsSeed_NoOpsOnNullOrEmptyPath()
+    {
+        var fs = new MockFileSystem();
+        // Must not throw
+        SkillsSeeder.EnsureGlobalSkillsSeed(null, fs);
+        SkillsSeeder.EnsureGlobalSkillsSeed(string.Empty, fs);
+        SkillsSeeder.EnsureGlobalSkillsSeed("   ", fs);
+    }
+}


### PR DESCRIPTION
Closes #783

## Changes

Adds `SkillsSeeder.EnsureGlobalSkillsSeed(globalSkillsDir, fileSystem?, logger?)` — a lightweight, idempotent bootstrap:

1. Creates `~/.botnexus/skills/` if it does not exist
2. If the directory has **no existing skills** (no subdirectory containing a `SKILL.md`), writes `example-skill/SKILL.md`
3. If any skills already exist, does nothing
4. If `example-skill/SKILL.md` already exists, does nothing (idempotent)

`SkillsToolContributor.ContributeAsync` calls `EnsureGlobalSkillsSeed` before creating the `SkillTool`, so the seed runs the first time any session uses the Skills extension.

The example skill is a well-commented template that explains:
- What skills are
- The frontmatter format (`name`, `description`, `tags`)
- How to create a new skill from the template

## Tests

5 new tests in `SkillsSeederTests`:
- `EnsureGlobalSkillsSeed_CreatesDirectoryAndExampleSkillWhenMissing`
- `EnsureGlobalSkillsSeed_SeedsWhenDirectoryExistsButHasNoSkills`
- `EnsureGlobalSkillsSeed_IsIdempotentWhenExampleAlreadyExists`
- `EnsureGlobalSkillsSeed_DoesNotSeedWhenExistingSkillsPresent`
- `EnsureGlobalSkillsSeed_NoOpsOnNullOrEmptyPath`

All 162 `BotNexus.Extensions.Skills.Tests` pass.

## Merge Notes

Independent — touches only `BotNexus.Extensions.Skills` project. No file overlap with any open PR. Safe to merge in any order.
