### PR TITLE
feat(sessions): write sub-agent session rows to sessions.db on spawn and completion

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/SubAgentInfo.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/SubAgentInfo.cs
@@ -28,6 +28,16 @@ public sealed record SubAgentInfo
     public string? Name { get; init; }
 
     /// <summary>
+    /// Gets the parent agent identifier. Populated at spawn time for session persistence.
+    /// </summary>
+    public string? ParentAgentId { get; init; }
+
+    /// <summary>
+    /// Gets the child agent identifier. Populated at spawn time for session persistence.
+    /// </summary>
+    public string? ChildAgentId { get; init; }
+
+    /// <summary>
     /// Gets the delegated task assigned to the sub-agent.
     /// </summary>
     public required string Task { get; init; }

--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/ISessionStore.cs
@@ -108,4 +108,28 @@ public interface ISessionStore
         AgentId agentId,
         ExistenceQuery query,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists a new sub-agent session row when a sub-agent is spawned.
+    /// Implementations that do not support sub-agent session tracking may no-op.
+    /// </summary>
+    /// <param name="info">The sub-agent runtime info to persist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SaveSubAgentSessionAsync(SubAgentInfo info, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Updates the sub-agent session row when the sub-agent completes, fails, times out, or is killed.
+    /// Implementations that do not support sub-agent session tracking may no-op.
+    /// </summary>
+    /// <param name="subAgentId">The sub-agent ID whose row to update.</param>
+    /// <param name="endedAt">When the sub-agent ended.</param>
+    /// <param name="status">The final status string (Completed, Failed, TimedOut, Killed).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateSubAgentSessionAsync(
+        string subAgentId,
+        DateTimeOffset endedAt,
+        string status,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionStoreBase.cs
@@ -161,6 +161,18 @@ public abstract class SessionStoreBase : ISessionStore
 
     protected abstract Task<IReadOnlyList<GatewaySession>> EnumerateSessionsAsync(CancellationToken cancellationToken);
 
+    /// <inheritdoc />
+    public virtual Task SaveSubAgentSessionAsync(SubAgentInfo info, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public virtual Task UpdateSubAgentSessionAsync(
+        string subAgentId,
+        DateTimeOffset endedAt,
+        string status,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
     private static IEnumerable<GatewaySession> ApplyAgentFilter(IEnumerable<GatewaySession> sessions, AgentId? agentId)
         => agentId is null ? sessions : sessions.Where(session => session.AgentId == agentId);
 }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -1065,4 +1065,50 @@ public sealed class SqliteSessionStore : SessionStoreBase
         return JsonSerializer.Deserialize<Dictionary<string, object?>>(metadataJson, JsonOptions) ?? [];
     }
 
+    /// <inheritdoc />
+    public override async Task SaveSubAgentSessionAsync(SubAgentInfo info, CancellationToken cancellationToken = default)
+    {
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        await using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT OR IGNORE INTO sub_agent_sessions
+                (id, parent_session_id, parent_agent_id, child_agent_id, archetype, started_at, ended_at, status)
+            VALUES
+                (@id, @parentSessionId, @parentAgentId, @childAgentId, @archetype, @startedAt, NULL, 'Active')
+            """;
+        cmd.Parameters.AddWithValue("@id", info.SubAgentId);
+        cmd.Parameters.AddWithValue("@parentSessionId", info.ParentSessionId.Value);
+        cmd.Parameters.AddWithValue("@parentAgentId", info.ParentAgentId ?? string.Empty);
+        cmd.Parameters.AddWithValue("@childAgentId", info.ChildAgentId ?? string.Empty);
+        cmd.Parameters.AddWithValue("@archetype", info.Archetype.ToString());
+        cmd.Parameters.AddWithValue("@startedAt", info.StartedAt.ToString("O"));
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override async Task UpdateSubAgentSessionAsync(
+        string subAgentId,
+        DateTimeOffset endedAt,
+        string status,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        await using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            UPDATE sub_agent_sessions
+            SET ended_at = @endedAt, status = @status
+            WHERE id = @id
+            """;
+        cmd.Parameters.AddWithValue("@id", subAgentId);
+        cmd.Parameters.AddWithValue("@endedAt", endedAt.ToString("O"));
+        cmd.Parameters.AddWithValue("@status", status);
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultSubAgentManager.cs
@@ -201,6 +201,8 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             ParentSessionId = request.ParentSessionId,
             ChildSessionId = childSessionId,
             Name = name,
+            ParentAgentId = request.ParentAgentId.Value,
+            ChildAgentId = childAgentId.Value,
             Task = request.Task,
             Model = modelOverride ?? configuredDefaultModel ?? baseDescriptor.ModelId,
             Archetype = archetype,
@@ -211,6 +213,16 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
 
         if (!_subAgents.TryAdd(subAgentId, info))
             throw new InvalidOperationException($"Sub-agent '{subAgentId}' already exists.");
+
+        // Persist the sub-agent session row to sessions.db (best-effort; non-SQLite stores no-op).
+        if (_sessionStore is not null)
+        {
+            try { await _sessionStore.SaveSubAgentSessionAsync(info, ct).ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to persist sub-agent session row for '{SubAgentId}'.", subAgentId);
+            }
+        }
 
         _parentAgentIds[subAgentId] = request.ParentAgentId;
         _childAgentIds[subAgentId] = childAgentId;
@@ -315,6 +327,23 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
             subAgentId,
             requestingSessionId);
 
+        // Update the sub-agent session row with Killed status (best-effort).
+        if (_sessionStore is not null && updatedInfo.CompletedAt.HasValue)
+        {
+            try
+            {
+                await _sessionStore.UpdateSubAgentSessionAsync(
+                    subAgentId,
+                    updatedInfo.CompletedAt.Value,
+                    SubAgentStatus.Killed.ToString(),
+                    ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to update sub-agent session row for '{SubAgentId}'.", subAgentId);
+            }
+        }
+
         _parentAgentIds.TryGetValue(subAgentId, out var parentAgentId);
         await PublishLifecycleActivityAsync(
             GatewayActivityType.SubAgentKilled,
@@ -362,6 +391,23 @@ public sealed class DefaultSubAgentManager : ISubAgentManager
                 out var updated))
         {
             return;
+        }
+
+        // Update the sub-agent session row with the final status (best-effort).
+        if (_sessionStore is not null && updated.CompletedAt.HasValue)
+        {
+            try
+            {
+                await _sessionStore.UpdateSubAgentSessionAsync(
+                    subAgentId,
+                    updated.CompletedAt.Value,
+                    updated.Status.ToString(),
+                    ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to update sub-agent session row for '{SubAgentId}'.", subAgentId);
+            }
         }
 
         _parentAgentIds.TryGetValue(subAgentId, out var parentAgentId);

--- a/tests/gateway/BotNexus.Gateway.Tests/SubAgentSessionWriteTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SubAgentSessionWriteTests.cs
@@ -1,0 +1,142 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Verifies that SaveSubAgentSessionAsync and UpdateSubAgentSessionAsync
+/// correctly write and update rows in the sub_agent_sessions table (Issue #808, Part of #785).
+/// </summary>
+public sealed class SubAgentSessionWriteTests : IDisposable
+{
+    private readonly string _directoryPath;
+    private readonly string _sessionDbPath;
+    private readonly string _conversationDbPath;
+
+    public SubAgentSessionWriteTests()
+    {
+        _directoryPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "SubAgentSessionWriteTests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directoryPath);
+        _sessionDbPath = Path.Combine(_directoryPath, "sessions.db");
+        _conversationDbPath = Path.Combine(_directoryPath, "conversations.db");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directoryPath))
+            Directory.Delete(_directoryPath, recursive: true);
+    }
+
+    [Fact]
+    public async Task SaveSubAgentSessionAsync_InsertsRow_WithActiveStatus()
+    {
+        var store = CreateSessionStore();
+        // Initialise DB
+        await store.GetAsync(SessionId.From("init"));
+
+        var info = BuildInfo("sa-1", "parent-s1", "child-s1", SubAgentStatus.Running);
+
+        await store.SaveSubAgentSessionAsync(info);
+
+        var (status, endedAt) = await ReadRow("sa-1");
+        status.ShouldBe("Active");
+        endedAt.ShouldBeNull("ended_at should be NULL when sub-agent is spawned");
+    }
+
+    [Fact]
+    public async Task UpdateSubAgentSessionAsync_SetsEndedAtAndStatus()
+    {
+        var store = CreateSessionStore();
+        await store.GetAsync(SessionId.From("init"));
+
+        var info = BuildInfo("sa-2", "parent-s2", "child-s2", SubAgentStatus.Running);
+        await store.SaveSubAgentSessionAsync(info);
+
+        var endedAt = new DateTimeOffset(2026, 6, 6, 12, 0, 0, TimeSpan.Zero);
+        await store.UpdateSubAgentSessionAsync("sa-2", endedAt, "Completed");
+
+        var (status, endedAtValue) = await ReadRow("sa-2");
+        status.ShouldBe("Completed");
+        endedAtValue.ShouldNotBeNull("ended_at should be set after update");
+        endedAtValue.ShouldContain("2026-06-06");
+    }
+
+    [Fact]
+    public async Task SaveSubAgentSessionAsync_IdempotentOnDuplicate()
+    {
+        var store = CreateSessionStore();
+        await store.GetAsync(SessionId.From("init"));
+
+        var info = BuildInfo("sa-3", "parent-s3", "child-s3", SubAgentStatus.Running);
+        await store.SaveSubAgentSessionAsync(info);
+        // Second call with the same id should be silently ignored (INSERT OR IGNORE).
+        var act = async () => await store.SaveSubAgentSessionAsync(info);
+        await act.ShouldNotThrowAsync();
+    }
+
+    [Fact]
+    public async Task UpdateSubAgentSessionAsync_NoRowForId_DoesNotThrow()
+    {
+        var store = CreateSessionStore();
+        await store.GetAsync(SessionId.From("init"));
+
+        // Updating a non-existent row should be a silent no-op.
+        var act = async () => await store.UpdateSubAgentSessionAsync(
+            "nonexistent-sa", DateTimeOffset.UtcNow, "Completed");
+        await act.ShouldNotThrowAsync();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private SqliteSessionStore CreateSessionStore()
+    {
+        var convStore = new SqliteConversationStore(
+            $"Data Source={_conversationDbPath};Pooling=False",
+            NullLogger<SqliteConversationStore>.Instance);
+        return new SqliteSessionStore(
+            $"Data Source={_sessionDbPath};Pooling=False",
+            NullLogger<SqliteSessionStore>.Instance,
+            convStore);
+    }
+
+    private static SubAgentInfo BuildInfo(
+        string subAgentId,
+        string parentSessionId,
+        string childSessionId,
+        SubAgentStatus status)
+        => new SubAgentInfo
+        {
+            SubAgentId = subAgentId,
+            ParentSessionId = SessionId.From(parentSessionId),
+            ChildSessionId = SessionId.From(childSessionId),
+            Name = null,
+            ParentAgentId = "parent-agent-a",
+            ChildAgentId = "child-agent-a",
+            Task = "test task",
+            Archetype = SubAgentArchetype.General,
+            Status = status,
+            StartedAt = DateTimeOffset.UtcNow
+        };
+
+    private async Task<(string? status, string? endedAt)> ReadRow(string subAgentId)
+    {
+        await using var conn = new SqliteConnection($"Data Source={_sessionDbPath};Pooling=False");
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT status, ended_at FROM sub_agent_sessions WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", subAgentId);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return (null, null);
+        return (
+            reader.IsDBNull(0) ? null : reader.GetString(0),
+            reader.IsDBNull(1) ? null : reader.GetString(1)
+        );
+    }
+}


### PR DESCRIPTION
Closes #808

## Changes

Wires sub-agent lifecycle events into `sessions.db` using the `sub_agent_sessions` table added in #807.

### ISessionStore (interface)
Added two default no-op methods so all implementations compile without changes:
- `SaveSubAgentSessionAsync(SubAgentInfo, CancellationToken)` — INSERT OR IGNORE on spawn
- `UpdateSubAgentSessionAsync(string, DateTimeOffset, string, CancellationToken)` — UPDATE on end

### SessionStoreBase
Exposes both as `virtual` no-ops so `SqliteSessionStore` can override without breaking `InMemorySessionStore` / `FileSessionStore`.

### SqliteSessionStore
Overrides both methods:
- `SaveSubAgentSessionAsync` — INSERT OR IGNORE into `sub_agent_sessions` with id, parent_session_id, parent_agent_id, child_agent_id, archetype, started_at; status = 'Active'
- `UpdateSubAgentSessionAsync` — UPDATE ended_at and status WHERE id = subAgentId

### SubAgentInfo (domain model)
Added `ParentAgentId?` and `ChildAgentId?` properties, populated at spawn time in `DefaultSubAgentManager.SpawnAsync`.

### DefaultSubAgentManager
- Calls `SaveSubAgentSessionAsync` on spawn (best-effort, catches+logs exceptions)
- Calls `UpdateSubAgentSessionAsync` on completion, failure, timeout, and kill (best-effort)

### Tests
4 new unit tests in `SubAgentSessionWriteTests.cs`:
- Insert with Active status
- Update sets ended_at and status
- Save is idempotent (INSERT OR IGNORE)
- Update for non-existent id is a silent no-op

## Merge Notes
Depends on #807 (sub_agent_sessions schema) — already merged to main.
Safe to merge independently of all other open PRs (no file overlap).
Part of #785: #807 ✅ → #808 ✅ → next: #809 (API endpoint).