### PR TITLE
feat(gateway): wire InterruptAndSteer hub method on GatewayHub

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -395,6 +395,27 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     }
 
     /// <summary>
+    /// Interrupts the active agent turn and redirects it with a new message.
+    /// </summary>
+    /// <param name="agentId">The agent id.</param>
+    /// <param name="sessionId">The session id.</param>
+    /// <param name="message">The new direction message to steer the agent toward.</param>
+    /// <returns><c>true</c> if a running handle was found and interrupted; <c>false</c> if no active handle exists.</returns>
+    public async Task<bool> InterruptAndSteer(AgentId agentId, SessionId sessionId, string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        var typedAgentId = NormalizeAgentId(agentId);
+        var typedSessionId = NormalizeSessionId(sessionId);
+
+        var handle = _supervisor.GetHandle(typedAgentId, typedSessionId);
+        if (handle is null)
+            return false;
+
+        await handle.InterruptAndSteerAsync(message, Context.ConnectionAborted);
+        return true;
+    }
+
+    /// <summary>
     /// Executes follow up.
     /// </summary>
     /// <param name="agentId">The agent id.</param>

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -538,6 +538,49 @@ public sealed class SignalRHubTests
             .Message.ShouldBe("Session 'missing' not found.");
     }
 
+    [Fact]
+    public async Task InterruptAndSteer_WhenHandleExists_CallsInterruptAndSteerAsyncAndReturnsTrue()
+    {
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.InterruptAndSteerAsync("new direction", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetHandle(AgentId.From("agent-a"), SessionId.From("session-1")))
+            .Returns(handle.Object);
+
+        var hub = CreateHub(supervisor: supervisor.Object);
+
+        var result = await hub.InterruptAndSteer(AgentId.From("agent-a"), SessionId.From("session-1"), "new direction");
+
+        result.ShouldBeTrue();
+        handle.Verify(h => h.InterruptAndSteerAsync("new direction", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task InterruptAndSteer_WhenNoHandleExists_ReturnsFalseWithoutThrow()
+    {
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetHandle(It.IsAny<AgentId>(), It.IsAny<SessionId>()))
+            .Returns((IAgentHandle?)null);
+
+        var hub = CreateHub(supervisor: supervisor.Object);
+
+        var result = await hub.InterruptAndSteer(AgentId.From("agent-a"), SessionId.From("missing"), "steer me");
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task InterruptAndSteer_NullOrEmptyMessage_ThrowsArgumentException()
+    {
+        var hub = CreateHub();
+
+        Func<Task> act = () => hub.InterruptAndSteer(AgentId.From("agent-a"), SessionId.From("session-1"), "");
+
+        await act.ShouldThrowAsync<ArgumentException>();
+    }
+
     private static GatewayHub CreateHub(
         IHubCallerClients<IGatewayHubClient>? clients = null,
         IGroupManager? groups = null,


### PR DESCRIPTION
Closes #801

## Changes

Adds `InterruptAndSteer(AgentId, SessionId, string)` hub method to `GatewayHub.cs`.

- Resolves the active agent handle via `_supervisor.GetHandle(agentId, sessionId)`
- Returns `false` immediately if no live handle exists (agent idle or not running)
- Calls `handle.InterruptAndSteerAsync(message, cancellationToken)` which dispatches abort → clear → steer
- Returns `true` on success

## Tests

3 new tests in `SignalRHubTests.cs`:
- `InterruptAndSteer_WhenHandleExists_CallsInterruptAndSteerAsyncAndReturnsTrue`
- `InterruptAndSteer_WhenNoHandleExists_ReturnsFalseWithoutThrow`
- `InterruptAndSteer_NullOrEmptyMessage_ThrowsArgumentException`

All impacted tests: Architecture ✅ 167, Conversations ✅ 128, Gateway ✅ 2167, Scenarios ✅ 29

## Merge Notes

Depends on #888 (IAgentHandle contract) and #893 (InProcessAgentHandle implementation) — both already merged to main.
Part of #704: #799 ✅ → #800 ✅ → **#801 ✅** → next: #802 (portal steer button).
Safe to merge independently — no file overlap with any other open PR.