### PR TITLE
fix(gateway): detect suspicious startup config and recover from most recent valid backup

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigLoader.cs
@@ -203,6 +203,104 @@ public static class PlatformConfigLoader
         fs.Directory.CreateDirectory(configDir);
     }
 
+    /// <summary>
+    /// Returns <c>true</c> when the loaded config looks clobbered or suspiciously minimal.
+    /// Heuristics:
+    /// <list type="bullet">
+    ///   <item>No agents, no providers, no channels, and no gateway settings (empty shell config).</item>
+    ///   <item>The raw JSON is shorter than <see cref="MinHealthyConfigLength"/> characters.</item>
+    /// </list>
+    /// Both heuristics must match to avoid false positives on genuinely empty configs.
+    /// </summary>
+    public static bool IsConfigSuspicious(PlatformConfig config, string rawJson)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(rawJson);
+
+        var hasNoAgents = config.Agents is null || config.Agents.Count == 0;
+        var hasNoProviders = config.Providers is null || config.Providers.Count == 0;
+        var hasNoChannels = config.Channels is null || config.Channels.Count == 0;
+        var hasNoGateway = config.Gateway is null;
+        var hasNoCron = config.Cron is null;
+
+        var structurallyEmpty = hasNoAgents && hasNoProviders && hasNoChannels && hasNoGateway && hasNoCron;
+        var physicallySmall = rawJson.Length < MinHealthyConfigLength;
+
+        return structurallyEmpty && physicallySmall;
+    }
+
+    /// <summary>Minimum character length below which a non-empty config is considered suspiciously small.</summary>
+    public const int MinHealthyConfigLength = 50;
+
+    /// <summary>
+    /// Attempts to find the most recent valid backup of <paramref name="configPath"/> in
+    /// the sibling <c>backups/</c> directory, validate it, and return the recovered config.
+    /// </summary>
+    /// <param name="configPath">Path to the primary config file (used to locate the backups directory).</param>
+    /// <param name="recoveredPath">When recovery succeeds, set to the path of the backup that was restored.</param>
+    /// <param name="fileSystem">Optional file-system abstraction (for testing).</param>
+    /// <returns>The recovered <see cref="PlatformConfig"/>, or <c>null</c> if no valid backup exists.</returns>
+    public static PlatformConfig? TryRecoverFromBackup(
+        string configPath,
+        out string? recoveredPath,
+        IFileSystem? fileSystem = null)
+    {
+        recoveredPath = null;
+        var fs = fileSystem ?? new FileSystem();
+        var configDirectory = Path.GetDirectoryName(configPath);
+        if (string.IsNullOrWhiteSpace(configDirectory))
+            return null;
+
+        var backupsDirectory = Path.Combine(configDirectory, "backups");
+        if (!fs.Directory.Exists(backupsDirectory))
+            return null;
+
+        // Find backup files ordered newest-first.
+        var backupFiles = fs.Directory
+            .GetFiles(backupsDirectory, "config-*.json")
+            .OrderByDescending(f => fs.File.GetLastWriteTimeUtc(f))
+            .ToList();
+
+        foreach (var backup in backupFiles)
+        {
+            try
+            {
+                using var stream = fs.File.OpenRead(backup);
+                using var reader = new StreamReader(stream);
+                var rawJson = reader.ReadToEnd();
+
+                if (rawJson.Length < MinHealthyConfigLength)
+                    continue;
+
+                var config = JsonSerializer.Deserialize<PlatformConfig>(rawJson, JsonOptions)
+                    ?? new PlatformConfig();
+                config = MigrateLegacyGatewaySettings(config, rawJson);
+                ExtractAgentDefaults(config, rawJson);
+
+                if (IsConfigSuspicious(config, rawJson))
+                    continue;
+
+                var errors = new List<string>(PlatformConfigSchema.ValidateObject(config));
+                errors.AddRange(Validate(config));
+                if (errors.Count > 0)
+                    continue;
+
+                recoveredPath = backup;
+                return config;
+            }
+            catch (JsonException)
+            {
+                // Corrupt backup file -- try the next one.
+            }
+            catch (IOException)
+            {
+                // Unreadable backup -- try the next one.
+            }
+        }
+
+        return null;
+    }
+
     private static void ValidatePath(string? path, string fieldName, List<string> errors)
     {
         if (string.IsNullOrWhiteSpace(path))

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigRecoveryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/PlatformConfigRecoveryTests.cs
@@ -1,0 +1,139 @@
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.Json;
+using BotNexus.Gateway.Configuration;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+/// <summary>
+/// Tests for PlatformConfigLoader.IsConfigSuspicious and TryRecoverFromBackup.
+/// </summary>
+public sealed class PlatformConfigRecoveryTests
+{
+    // ── IsConfigSuspicious ─────────────────────────────────────────────────
+
+    [Fact]
+    public void IsConfigSuspicious_EmptyShellJson_ReturnsTrue()
+    {
+        var raw = """{"version":1}""";
+        var config = new PlatformConfig();
+        PlatformConfigLoader.IsConfigSuspicious(config, raw).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsConfigSuspicious_HealthyConfig_ReturnsFalse()
+    {
+        var raw = """
+            {
+              "version": 1,
+              "providers": { "copilot": { "apiKey": "k" } },
+              "agents": { "assistant": { "provider": "copilot", "model": "gpt-4.1" } }
+            }
+            """;
+        var config = new PlatformConfig
+        {
+            Providers = new Dictionary<string, ProviderConfig>
+            {
+                ["copilot"] = new ProviderConfig { ApiKey = "k" }
+            },
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["assistant"] = new AgentDefinitionConfig { Provider = "copilot", Model = "gpt-4.1" }
+            }
+        };
+        PlatformConfigLoader.IsConfigSuspicious(config, raw).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsConfigSuspicious_StructurallyEmptyButLargeJson_ReturnsFalse()
+    {
+        // Large JSON (> MinHealthyConfigLength) with empty structure -- should NOT be suspicious
+        // because physical size guard prevents false positives on intentionally minimal configs.
+        var raw = new string(' ', PlatformConfigLoader.MinHealthyConfigLength + 1) + """{"version":1}""";
+        var config = new PlatformConfig();
+        PlatformConfigLoader.IsConfigSuspicious(config, raw).ShouldBeFalse();
+    }
+
+    // ── TryRecoverFromBackup ───────────────────────────────────────────────
+
+    private static readonly string ValidBackupJson = """
+        {
+          "version": 1,
+          "providers": { "copilot": { "apiKey": "backup-key" } },
+          "agents": { "assistant": { "provider": "copilot", "model": "gpt-4.1" } }
+        }
+        """;
+
+    [Fact]
+    public void TryRecoverFromBackup_ValidBackupExists_ReturnsRecoveredConfig()
+    {
+        var fs = new MockFileSystem();
+        var configPath = "/home/user/.botnexus/config.json";
+        var backupsDir = "/home/user/.botnexus/backups";
+        var backupPath = backupsDir + "/config-20260601-120000-pre-write.json";
+
+        fs.AddDirectory(backupsDir);
+        fs.AddFile(backupPath, new MockFileData(ValidBackupJson));
+
+        var result = PlatformConfigLoader.TryRecoverFromBackup(configPath, out var recovered, fs);
+
+        result.ShouldNotBeNull();
+        recovered.ShouldNotBeNull();
+        Path.GetFileName(recovered!).ShouldBe(Path.GetFileName(backupPath));
+        result.Agents.ShouldNotBeNull();
+        result.Agents.ContainsKey("assistant").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryRecoverFromBackup_NoBackupsDirectory_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        var configPath = "/home/user/.botnexus/config.json";
+
+        var result = PlatformConfigLoader.TryRecoverFromBackup(configPath, out var recovered, fs);
+
+        result.ShouldBeNull();
+        recovered.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryRecoverFromBackup_CorruptBackupOnly_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        var configPath = "/home/user/.botnexus/config.json";
+        var backupsDir = "/home/user/.botnexus/backups";
+
+        fs.AddDirectory(backupsDir);
+        fs.AddFile(backupsDir + "/config-20260601-120000-bad.json", new MockFileData("not-json{{{{"));
+
+        var result = PlatformConfigLoader.TryRecoverFromBackup(configPath, out var recovered, fs);
+
+        result.ShouldBeNull();
+        recovered.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryRecoverFromBackup_MultipleBackups_PicksMostRecent()
+    {
+        var fs = new MockFileSystem();
+        var configPath = "/home/user/.botnexus/config.json";
+        var backupsDir = "/home/user/.botnexus/backups";
+
+        // Older backup — valid but stale
+        var older = backupsDir + "/config-20260101-000000-old.json";
+        fs.AddDirectory(backupsDir);
+        fs.AddFile(older, new MockFileData(ValidBackupJson));
+        fs.GetFile(older).LastWriteTime = new DateTime(2026, 1, 1);
+
+        // Newer backup — also valid
+        var newerJson = ValidBackupJson.Replace("backup-key", "newer-key");
+        var newer = backupsDir + "/config-20260601-120000-recent.json";
+        fs.AddFile(newer, new MockFileData(newerJson));
+        fs.GetFile(newer).LastWriteTime = new DateTime(2026, 6, 1);
+
+        var result = PlatformConfigLoader.TryRecoverFromBackup(configPath, out var recovered, fs);
+
+        result.ShouldNotBeNull();
+        recovered.ShouldNotBeNull();
+        Path.GetFileName(recovered!).ShouldBe(Path.GetFileName(newer));
+    }
+}


### PR DESCRIPTION
Closes #718

## Changes

Adds two new public methods to `PlatformConfigLoader`:

### `IsConfigSuspicious(PlatformConfig, string rawJson) -> bool`
Heuristic check: returns `true` when both conditions are met:
- Config is structurally empty (no agents, providers, channels, gateway, or cron)
- Raw JSON length is below `MinHealthyConfigLength` (50 chars)

Both guards required to avoid false positives on intentionally minimal configs.

### `TryRecoverFromBackup(string configPath, out string? recoveredPath, IFileSystem?) -> PlatformConfig?`
Startup recovery path:
1. Resolves `{configDir}/backups/` (the directory `ConfigBackupService` already maintains)
2. Iterates backup files newest-first
3. Skips corrupt JSON, overly small files, and configs that still fail `IsConfigSuspicious`
4. Returns the first backup that passes full `Validate()` + schema validation

`recoveredPath` is set to the backup path used, so callers can log the recovery event.

### Tests (`PlatformConfigRecoveryTests.cs`) - 7 new tests
- `IsConfigSuspicious_EmptyShellJson_ReturnsTrue`
- `IsConfigSuspicious_HealthyConfig_ReturnsFalse`
- `IsConfigSuspicious_StructurallyEmptyButLargeJson_ReturnsFalse` (false positive guard)
- `TryRecoverFromBackup_ValidBackupExists_ReturnsRecoveredConfig`
- `TryRecoverFromBackup_NoBackupsDirectory_ReturnsNull`
- `TryRecoverFromBackup_CorruptBackupOnly_ReturnsNull`
- `TryRecoverFromBackup_MultipleBackups_PicksMostRecent`

All impacted tests: Architecture ✅ 167, Gateway ✅ 2171, Conversations ✅ 128, Scenarios ✅ 29, Cli ✅ 131, Mcp ✅ 178

## Merge Notes

Standalone fix — no file overlap with any other open PR.
`ConfigBackupService` already creates backups before writes; this adds the read side at startup.

Note: This PR adds the detection + recovery primitives. Callers (e.g. `PlatformConfigPostConfigure` or `Program.cs`) may optionally wire `TryRecoverFromBackup` into startup with a log warning — that call-site integration can be a follow-up PR or can be added here if Jon prefers in one shot.