### PR TITLE
fix(mobile): bypass service worker cache for top-level navigate requests

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/service-worker.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/service-worker.js
@@ -30,6 +30,14 @@ self.addEventListener('fetch', event => {
     // Only handle GET requests
     if (event.request.method !== 'GET') return;
 
+    // Pass through top-level navigations directly to the network.
+    // HTTP auth challenges (Basic, NTLM, Negotiate) only trigger the browser's
+    // native credentials dialog when the response comes directly from the network.
+    // A cached response from the service worker suppresses the WWW-Authenticate
+    // header, leaving reverse-proxy deployments broken after the browser's auth
+    // cache expires. See: https://fetch.spec.whatwg.org/#concept-request-mode
+    if (event.request.mode === 'navigate') return;
+
     // Pass through SignalR/API requests
     const url = new URL(event.request.url);
     if (url.pathname.startsWith('/hub/') || url.pathname.startsWith('/api/')) return;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
-
   <ItemGroup>
     <PackageReference Include="bunit" />
     <PackageReference Include="coverlet.collector">
@@ -11,15 +10,19 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Bunit" />
     <Using Include="NSubstitute" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile\BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.csproj" />
   </ItemGroup>
-
+  <ItemGroup>
+    <!-- Copy service worker to output for ServiceWorkerTests (#688) -->
+    <Content Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile\wwwroot\service-worker.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>wwwroot\service-worker.js</Link>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/ServiceWorkerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/ServiceWorkerTests.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using System.Reflection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Content-level tests verifying the service worker respects HTTP auth challenge
+/// semantics by bypassing the cache for top-level navigations (#688).
+/// </summary>
+public sealed class ServiceWorkerTests
+{
+    private static readonly string s_serviceWorkerPath = Path.Combine(
+        Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+        "wwwroot",
+        "service-worker.js");
+
+    [Fact]
+    public void ServiceWorker_HasNavigateBypass_BeforeApiBypass()
+    {
+        // Arrange
+        var content = File.ReadAllText(s_serviceWorkerPath);
+
+        // Act
+        var navigateIdx = content.IndexOf("event.request.mode === 'navigate'", StringComparison.Ordinal);
+        var apiIdx = content.IndexOf("url.pathname.startsWith('/api/')", StringComparison.Ordinal);
+
+        // Assert: both guards are present
+        Assert.True(navigateIdx >= 0, "service-worker.js must contain the navigate-mode bypass guard");
+        Assert.True(apiIdx >= 0, "service-worker.js must contain the /api/ pass-through guard");
+
+        // Navigate bypass should appear before the URL-based guards so top-level
+        // navigations are short-circuited before URL parsing.
+        Assert.True(navigateIdx < apiIdx,
+            "navigate-mode bypass must appear before the /api/ URL guard to short-circuit navigate requests early");
+    }
+
+    [Fact]
+    public void ServiceWorker_NavigateBypass_IsInsideFetchHandler()
+    {
+        var content = File.ReadAllText(s_serviceWorkerPath);
+
+        // The fetch listener body must contain the navigate guard
+        var fetchListenerStart = content.IndexOf("addEventListener('fetch'", StringComparison.Ordinal);
+        var navigateIdx = content.IndexOf("event.request.mode === 'navigate'", StringComparison.Ordinal);
+
+        Assert.True(fetchListenerStart >= 0, "service-worker.js must have a fetch event listener");
+        Assert.True(navigateIdx > fetchListenerStart,
+            "navigate-mode bypass must be inside the fetch event listener body");
+    }
+
+    [Fact]
+    public void ServiceWorker_NavigateBypass_Returns_WhenModeIsNavigate()
+    {
+        var content = File.ReadAllText(s_serviceWorkerPath);
+
+        // The guard must return (not just log or continue)
+        // Pattern: if (event.request.mode === 'navigate') return;
+        Assert.Contains("if (event.request.mode === 'navigate') return;", content,
+            StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #688

## Changes

Adds a single guard to the mobile service worker's fetch event handler:

    if (event.request.mode === 'navigate') return;

HTTP auth challenges (Basic, NTLM, Negotiate) only trigger the browser's native credentials dialog when the response comes directly from the network. A cached service worker response suppresses WWW-Authenticate, leaving reverse-proxy deployments broken after browser auth cache expires.

Fix: early return for navigate mode so top-level navigations always go to the network.

**Tests (3 new -- ServiceWorkerTests.cs):**
- ServiceWorker_HasNavigateBypass_BeforeApiBypass
- ServiceWorker_NavigateBypass_IsInsideFetchHandler
- ServiceWorker_NavigateBypass_Returns_WhenModeIsNavigate

## Merge Notes
Standalone -- only touches service-worker.js and mobile test project. No file overlap with any other open PR.