### PR TITLE
fix(gateway): send stall notice when agent returns thinking-only response

### DIFF
--- a/src/gateway/BotNexus.Gateway.Channels/AssistantTextSanitizer.cs
+++ b/src/gateway/BotNexus.Gateway.Channels/AssistantTextSanitizer.cs
@@ -51,4 +51,27 @@ public static class AssistantTextSanitizer
 
         return stripped.Trim();
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="text"/> contains only thinking/reasoning
+    /// block(s) with no user-visible content outside them.
+    /// A response that strips to empty or whitespace-only is considered thinking-only.
+    /// </summary>
+    /// <param name="text">The raw assistant text to inspect.</param>
+    /// <returns>
+    /// <see langword="true"/> when the text is non-empty, contains at least one thinking block,
+    /// and produces no user-visible content after stripping those blocks.
+    /// </returns>
+    public static bool IsThinkingOnlyResponse(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        // Must contain at least one thinking block; otherwise it is simply an empty response.
+        if (!text.Contains("<thinking>", StringComparison.OrdinalIgnoreCase) &&
+            !text.Contains("<thinking>", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return string.IsNullOrWhiteSpace(StripThinkingTags(text));
+    }
 }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -597,13 +597,32 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                     }
                     else if (ResolveChannelAdapter(message.ChannelType) is { } ch)
                     {
+                        // Detect thinking-only responses: when the model returns only a
+                        // reasoning/thinking block with no user-visible content, StripThinkingTags
+                        // produces an empty string. Delivering an empty message would leave the
+                        // user with no reply and the conversation apparently stuck (#849).
+                        // Fall back to a stall notice so the turn completes gracefully.
+                        var outboundContent = ch.SupportsThinkingDisplay
+                            ? response.Content
+                            : AssistantTextSanitizer.StripThinkingTags(response.Content);
+
+                        if (!ch.SupportsThinkingDisplay &&
+                            string.IsNullOrWhiteSpace(outboundContent) &&
+                            AssistantTextSanitizer.IsThinkingOnlyResponse(response.Content))
+                        {
+                            _logger.LogWarning(
+                                "Agent '{AgentId}' session '{SessionId}' returned a thinking-only response " +
+                                "(no user-visible content after stripping reasoning blocks). " +
+                                "Sending stall notice to prevent stuck conversation.",
+                                agentId, sessionId);
+                            outboundContent = "[I wasn't able to generate a response. Please try again.]"; // #849
+                        }
+
                         await ch.SendAsync(new OutboundMessage
                         {
                             ChannelType = message.ChannelType,
                             ChannelAddress = message.ChannelAddress,
-                            Content = ch.SupportsThinkingDisplay
-                                ? response.Content
-                                : AssistantTextSanitizer.StripThinkingTags(response.Content),
+                            Content = outboundContent,
                             SessionId = sessionId,
                             // Binding-aware fields from originating binding fix #126:
                             // ensure replies carry the binding's decoration. Native sub-addresses

--- a/tests/gateway/BotNexus.Gateway.Tests/AssistantTextSanitizerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AssistantTextSanitizerTests.cs
@@ -60,4 +60,58 @@ public sealed class AssistantTextSanitizerTests
         var text = "<thinking>Only reasoning, no actual response.</thinking>";
         AssistantTextSanitizer.StripThinkingTags(text).ShouldBe(string.Empty);
     }
+
+    // --- IsThinkingOnlyResponse ---
+
+    [Fact]
+    public void IsThinkingOnlyResponse_EmptyString_ReturnsFalse()
+    {
+        // Empty string has no thinking block, so it is not a thinking-only response.
+        AssistantTextSanitizer.IsThinkingOnlyResponse(string.Empty).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsThinkingOnlyResponse_NullString_ReturnsFalse()
+    {
+        AssistantTextSanitizer.IsThinkingOnlyResponse(null!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsThinkingOnlyResponse_PlainTextNoThinking_ReturnsFalse()
+    {
+        // Plain response with no thinking tags is not thinking-only.
+        AssistantTextSanitizer.IsThinkingOnlyResponse("Here is the answer.").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsThinkingOnlyResponse_ThinkingBlockWithVisibleText_ReturnsFalse()
+    {
+        // Contains a thinking block but also has visible text outside it.
+        var text = "<thinking>I should reason carefully.</thinking>Here is the answer.";
+        AssistantTextSanitizer.IsThinkingOnlyResponse(text).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsThinkingOnlyResponse_OnlyThinkingBlock_ReturnsTrue()
+    {
+        // Response consists solely of a thinking block with no visible text.
+        var text = "<thinking>Only reasoning, no actual response.</thinking>";
+        AssistantTextSanitizer.IsThinkingOnlyResponse(text).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsThinkingOnlyResponse_AnthropicPrefixedOnlyThinkingBlock_ReturnsTrue()
+    {
+        // Anthropic-prefixed variant with no visible content.
+        var text = "<thinking>Extended reasoning only.</thinking>";
+        AssistantTextSanitizer.IsThinkingOnlyResponse(text).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsThinkingOnlyResponse_ThinkingBlockPlusWhitespace_ReturnsTrue()
+    {
+        // Whitespace around the thinking block is not user-visible content.
+        var text = "  <thinking>Reasoning here.</thinking>  ";
+        AssistantTextSanitizer.IsThinkingOnlyResponse(text).ShouldBeTrue();
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -2147,5 +2147,74 @@ public sealed class GatewayHostTests
             .ShouldBe(["user:hello", "assistant:normal-response"]);
         activity.Activities.Select(a => a.Type).ShouldContain(GatewayActivityType.AgentCompleted);
     }
+
+    // #849 -- thinking-only response stall detection
+
+    [Fact]
+    public async Task DispatchAsync_WhenAgentReturnsThinkingOnlyResponse_SendsStallNotice()
+    {
+        // Arrange: agent returns a response that consists solely of a thinking block.
+        // The channel does NOT support thinking display (most channels).
+        // Expected: stall notice delivered instead of empty message.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+        var thinkingOnlyContent = "<thinking>Only internal reasoning, no visible answer.</thinking>";
+        var handle = CreatePromptHandle("agent-a", "session-1", thinkingOnlyContent);
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        // Explicitly confirm SupportsThinkingDisplay is false.
+        channel.SetupGet(c => c.SupportsThinkingDisplay).Returns(false);
+
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, new InMemorySessionStore(),
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(CreateMessage("hello", sessionId: "session-1"));
+
+        // Assert: channel received the stall notice, NOT the raw thinking block.
+        channel.Verify(c => c.SendAsync(
+            It.Is<OutboundMessage>(m =>
+                m.Content.Contains("wasn't able to generate",
+                    StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenChannelSupportsThinkingDisplay_ThinkingOnlyResponsePassedThrough()
+    {
+        // When the channel supports thinking display, thinking-only responses should pass
+        // through unchanged -- no stall substitution.
+        var router = new Mock<IMessageRouter>();
+        router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["agent-a"]);
+        var thinkingOnlyContent = "<thinking>Only internal reasoning, no visible answer.</thinking>";
+        var handle = CreatePromptHandle("agent-a", "session-1", thinkingOnlyContent);
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(
+                BotNexus.Domain.Primitives.AgentId.From("agent-a"),
+                BotNexus.Domain.Primitives.SessionId.From("session-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+        var channel = CreateChannelAdapter("web", supportsStreaming: false);
+        channel.SetupGet(c => c.SupportsThinkingDisplay).Returns(true);
+
+        await using var host = CreateHost(
+            supervisor.Object, router.Object, new InMemorySessionStore(),
+            new RecordingActivityBroadcaster(), CreateChannelManager(channel.Object));
+
+        await host.DispatchAsync(CreateMessage("hello", sessionId: "session-1"));
+
+        // Assert: raw content passed through -- no stall notice injected.
+        channel.Verify(c => c.SendAsync(
+            It.Is<OutboundMessage>(m => m.Content == thinkingOnlyContent),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
 }
 


### PR DESCRIPTION
Closes #849

## Problem
When a provider (e.g. Claude with extended thinking enabled) returns a response containing only a `<thinking>...</thinking>` reasoning block with no user-visible text, `AssistantTextSanitizer.StripThinkingTags` strips the block and returns an empty string. The gateway then delivers an empty message to the channel, leaving the user with no feedback and the conversation apparently stuck.

## Changes

### `AssistantTextSanitizer.cs`
- Added `IsThinkingOnlyResponse(string text)` — returns `true` when the response contains at least one thinking block and produces no visible text after stripping

### `GatewayHost.cs` (non-streaming path)
- Compute `outboundContent` upfront before calling `SendAsync`
- When `SupportsThinkingDisplay = false` AND `outboundContent` is empty AND `IsThinkingOnlyResponse` is true: substitute `"[I wasn't able to generate a response. Please try again.]"` and log a Warning
- Channels with `SupportsThinkingDisplay = true` receive the raw content unchanged (user explicitly wants to see reasoning)

## Tests
- 7 new `IsThinkingOnlyResponse` unit tests in `AssistantTextSanitizerTests`
- 2 new `GatewayHostTests`: stall notice delivery + thinking-display channel pass-through
- All impacted tests pass (`test-impacted.ps1` ✅)

## Merge Notes
Standalone — only touches `GatewayHost.cs` and `AssistantTextSanitizer.cs`. No file overlap with any open PR. Safe to merge independently.