### PR TITLE
feat(gateway): expose CacheRetentionMode in AgentDescriptor and wire into InProcessIsolationStrategy

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -108,6 +108,14 @@ public sealed record AgentDescriptor : ICitizen
     public string IsolationStrategy { get; init; } = "in-process";
 
     /// <summary>
+    /// Prompt caching retention policy for this agent.
+    /// When <see langword="null"/>, the provider default (<c>short</c>) is used.
+    /// Valid values: <c>"none"</c>, <c>"short"</c>, <c>"long"</c>.
+    /// Set to <c>"none"</c> to disable prompt caching for this agent.
+    /// </summary>
+    public string? CacheRetentionMode { get; init; }
+
+    /// <summary>
     /// Maximum concurrent sessions allowed for this agent.
     /// Zero means unlimited.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -443,6 +443,9 @@ public sealed class AgentDefinitionConfig
     public List<string>? SubAgentRoles { get; set; }
     /// <summary>Isolation strategy name (e.g. 'in-process').</summary>
     public string? IsolationStrategy { get; set; }
+    /// <summary>Prompt caching retention policy for this agent. Null means provider default (short) is used.</summary>
+    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<BotNexus.Agent.Providers.Core.Models.CacheRetention>))]
+    public BotNexus.Agent.Providers.Core.Models.CacheRetention? CacheRetention { get; set; }
     /// <summary>Maximum concurrent sessions for this agent.</summary>
     public int? MaxConcurrentSessions { get; set; }
     /// <summary>Agent-level metadata.</summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -100,6 +100,9 @@ public sealed class PlatformConfigAgentSource(
                 IsolationStrategy = string.IsNullOrWhiteSpace(effectiveConfig.IsolationStrategy)
                     ? "in-process"
                     : effectiveConfig.IsolationStrategy,
+                CacheRetentionMode = effectiveConfig.CacheRetention.HasValue
+                    ? effectiveConfig.CacheRetention.Value.ToString().ToLowerInvariant()
+                    : null,
                 MaxConcurrentSessions = effectiveConfig.MaxConcurrentSessions ?? 0,
                 Metadata = metadata,
                 IsolationOptions = ConvertObject(effectiveConfig.IsolationOptions),

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -447,7 +447,15 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             ToolExecutionMode: ToolExecutionMode.Parallel,
             BeforeToolCall: beforeToolCall,
             AfterToolCall: afterToolCall,
-            GenerationSettings: new SimpleStreamOptions(),
+            GenerationSettings: new SimpleStreamOptions
+            {
+                // Parse per-agent cacheRetentionMode string ("none", "short", "long").
+                // Falls back to Short when absent or unrecognised.
+                CacheRetention = Enum.TryParse<BotNexus.Agent.Providers.Core.Models.CacheRetention>(
+                    descriptor.CacheRetentionMode, ignoreCase: true, out var parsedRetention)
+                    ? parsedRetention
+                    : BotNexus.Agent.Providers.Core.Models.CacheRetention.Short
+            },
             SteeringMode: QueueMode.All,
             FollowUpMode: QueueMode.All,
             SessionId: context.SessionId.Value,

--- a/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -575,6 +575,45 @@ public sealed class InProcessIsolationStrategyTests
             AgentToolUpdateCallback? onUpdate = null)
             => Task.FromResult(new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "ok")]));
     }
+
+    // #803 -- CacheRetention forwarding from AgentDescriptor to GenerationSettings
+
+    [Fact]
+    public async Task CreateAsync_WithCacheRetentionNoneInDescriptor_SetsNoneCacheRetentionOnOptions()
+    {
+        var strategy = CreateStrategyWithRegisteredModel();
+        var descriptor = new AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-cr"),
+            DisplayName = "Cache Retention Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            SystemPrompt = "Test.",
+            CacheRetentionMode = "none"
+        };
+
+        var handle = await strategy.CreateAsync(
+            descriptor,
+            new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-cr") });
+
+        var options = GetAgentOptions(handle);
+        options.GenerationSettings.CacheRetention.ShouldBe(CacheRetention.None);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutCacheRetentionInDescriptor_DefaultsToShortCacheRetention()
+    {
+        // When descriptor.CacheRetention is null, the strategy must fall back to Short (provider default).
+        var strategy = CreateStrategyWithRegisteredModel();
+        var descriptor = CreateDescriptor(); // CacheRetention = null
+
+        var handle = await strategy.CreateAsync(
+            descriptor,
+            new AgentExecutionContext { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-cr2") });
+
+        var options = GetAgentOptions(handle);
+        options.GenerationSettings.CacheRetention.ShouldBe(CacheRetention.Short);
+    }
 }
 
 file sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -1090,6 +1090,89 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
         };
     }
 
+    // #803 — CacheRetention per-agent config
+
+    [Fact]
+    public async Task LoadAsync_WithCacheRetentionNone_DescriptorHasCacheRetentionNone()
+    {
+        var config = JsonSerializer.Deserialize<PlatformConfig>(
+            """
+            {
+              "Agents": {
+                "assistant": {
+                  "Provider": "copilot",
+                  "Model": "gpt-4.1",
+                  "Enabled": true,
+                  "CacheRetention": "none"
+                }
+              }
+            }
+            """)!;
+
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.CacheRetentionMode.ShouldBe("none");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithCacheRetentionLong_DescriptorHasCacheRetentionLong()
+    {
+        var config = JsonSerializer.Deserialize<PlatformConfig>(
+            """
+            {
+              "Agents": {
+                "assistant": {
+                  "Provider": "copilot",
+                  "Model": "gpt-4.1",
+                  "Enabled": true,
+                  "CacheRetention": "long"
+                }
+              }
+            }
+            """)!;
+
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.CacheRetentionMode.ShouldBe("long");
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithoutCacheRetention_DescriptorCacheRetentionIsNull()
+    {
+        // When cacheRetention is omitted, descriptor should be null (caller uses provider default).
+        var config = JsonSerializer.Deserialize<PlatformConfig>(
+            """
+            {
+              "Agents": {
+                "assistant": {
+                  "Provider": "copilot",
+                  "Model": "gpt-4.1",
+                  "Enabled": true
+                }
+              }
+            }
+            """)!;
+
+        var source = new PlatformConfigAgentSource(
+            new TestOptionsMonitor<PlatformConfig>(config),
+            _configDirectory,
+            new ListLogger<PlatformConfigAgentSource>());
+
+        var descriptor = (await source.LoadAsync()).ShouldHaveSingleItem();
+
+        descriptor.CacheRetentionMode.ShouldBeNull();
+    }
+
     private sealed class StubLocationResolver(IReadOnlyDictionary<string, string> paths) : ILocationResolver
     {
         private readonly IReadOnlyDictionary<string, string> _paths = paths;


### PR DESCRIPTION
Closes #803
Part of #702

## Problem
Prompt-caching behaviour was hardcoded to `CacheRetention.Short` in `InProcessIsolationStrategy.CreateAsync` via `new SimpleStreamOptions()`. Operators had no way to disable caching or switch to long-term caching per agent.

## Changes

### `AgentDescriptor.cs`
- Added `CacheRetentionMode` (`string?`) — accepted values: `"none"`, `"short"`, `"long"`
- String representation preserves the Domain leaf-node architecture rule (`DomainArchitectureTests.Domain_HasNoProjectReferences`)

### `PlatformConfig.cs` (`AgentDefinitionConfig`)
- Added `CacheRetention` (`CacheRetention?`) with `JsonStringEnumConverter` so config JSON uses lowercase strings

### `PlatformConfigAgentSource.cs`
- Maps `effectiveConfig.CacheRetention` enum value to lowercase string on `descriptor.CacheRetentionMode`

### `InProcessIsolationStrategy.cs`
- `Enum.TryParse<CacheRetention>(descriptor.CacheRetentionMode, ignoreCase: true)` — falls back to `Short` when absent or unrecognised

## Tests (5 new in `BotNexus.Gateway.Tests`)
- `PlatformConfigAgentSourceTests`: 3 deserialization tests (`none`, `long`, null/absent)
- `InProcessIsolationStrategyTests`: 2 forwarding tests (`none` sets `None`, null defaults to `Short`)
- All impacted tests pass (`test-impacted.ps1` ✅)

## Merge Notes
Independent — touches `AgentDescriptor.cs`, `PlatformConfig.cs`, `PlatformConfigAgentSource.cs`, `InProcessIsolationStrategy.cs`. No file overlap with any other open PR. Safe to merge in any order with #899.