### PR TITLE
feat(sessions): capture LastRenderedSystemPrompt on GatewaySession at dispatch time

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -161,6 +161,18 @@ public sealed class GatewaySession
     /// <summary>Number of entries in the conversation history.</summary>
     public int MessageCount => Session.MessageCount;
 
+    /// <summary>
+    /// The last system prompt rendered for this session at dispatch time.
+    /// In-memory only — cleared on gateway restart. Set by the isolation
+    /// strategy on handle creation so the debug inspector can retrieve it.
+    /// </summary>
+    public string? LastRenderedSystemPrompt { get; set; }
+
+    /// <summary>
+    /// The timestamp at which <see cref="LastRenderedSystemPrompt"/> was last captured.
+    /// </summary>
+    public DateTimeOffset? LastRenderedSystemPromptAt { get; set; }
+
     /// <summary>Session-level metadata for extensibility.</summary>
     public Dictionary<string, object?> Metadata
     {

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultAgentSupervisor.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultAgentSupervisor.cs
@@ -6,6 +6,7 @@ using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Diagnostics;
+using BotNexus.Gateway.Isolation;
 using Microsoft.Extensions.Logging;
 
 namespace BotNexus.Gateway.Agents;
@@ -234,6 +235,16 @@ public sealed class DefaultAgentSupervisor : IAgentSupervisor, IAgentHandleInspe
             History = priorHistory
         };
         var handle = await strategy.CreateAsync(descriptor, context, cancellationToken);
+
+        // Stamp the last rendered system prompt on the session so the debug inspector
+        // can surface it. InProcessAgentHandle exposes RenderedSystemPrompt as an
+        // internal property; other strategies don't render prompts client-side.
+        if (existingSession is not null && handle is InProcessAgentHandle inProcess
+            && inProcess.RenderedSystemPrompt is { Length: > 0 })
+        {
+            existingSession.LastRenderedSystemPrompt = inProcess.RenderedSystemPrompt;
+            existingSession.LastRenderedSystemPromptAt = DateTimeOffset.UtcNow;
+        }
 
         var instance = new AgentInstance
         {

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -454,13 +454,17 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             ToolTimeout: ResolveToolTimeout(descriptor));
 
         var agent = new BotNexus.Agent.Core.Agent(options);
-        IAgentHandle handle = new InProcessAgentHandle(
+        var inProcessHandle = new InProcessAgentHandle(
             agent,
             descriptor.AgentId,
             context.SessionId,
             _logger,
             tools,
-            extensionResourcesToDispose);
+            extensionResourcesToDispose)
+        {
+            RenderedSystemPrompt = enrichedSystemPrompt
+        };
+        IAgentHandle handle = inProcessHandle;
 
         _logger.LogWarning(
             "Created agent handle for '{AgentId}' session '{SessionId}' with {ToolCount} tools: {ToolNames}",
@@ -660,6 +664,15 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
 
     /// <inheritdoc />
     public AgentId AgentId { get; }
+
+    /// <summary>
+    /// The system prompt that was rendered and injected into the agent at creation time.
+    /// Populated by <see cref="InProcessIsolationStrategy.CreateAsync"/> immediately after
+    /// <see cref="IContextBuilder.BuildSystemPromptAsync"/> returns so that the supervisor
+    /// can stamp <see cref="GatewaySession.LastRenderedSystemPrompt"/> without round-tripping
+    /// through the isolation strategy contract.
+    /// </summary>
+    internal string? RenderedSystemPrompt { get; set; }
 
     /// <inheritdoc />
     public SessionId SessionId { get; }

--- a/tests/gateway/BotNexus.Gateway.Tests/SystemPromptCaptureTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SystemPromptCaptureTests.cs
@@ -1,0 +1,216 @@
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Isolation;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Isolation;
+using BotNexus.Gateway.Tools;
+using BotNexus.Memory;
+using BotNexus.Memory.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for LastRenderedSystemPrompt capture on GatewaySession (Issue #766).
+/// </summary>
+public sealed class SystemPromptCaptureTests
+{
+    // ── GatewaySession property smoke tests ───────────────────────────────
+
+    [Fact]
+    public void GatewaySession_LastRenderedSystemPrompt_DefaultsToNull()
+    {
+        var session = new GatewaySession { SessionId = SessionId.From("s1") };
+        session.LastRenderedSystemPrompt.ShouldBeNull();
+        session.LastRenderedSystemPromptAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GatewaySession_LastRenderedSystemPrompt_CanBeSet()
+    {
+        var session = new GatewaySession { SessionId = SessionId.From("s2") };
+        var before = DateTimeOffset.UtcNow;
+
+        session.LastRenderedSystemPrompt = "## My system prompt";
+        session.LastRenderedSystemPromptAt = DateTimeOffset.UtcNow;
+
+        session.LastRenderedSystemPrompt.ShouldBe("## My system prompt");
+        session.LastRenderedSystemPromptAt.ShouldNotBeNull();
+        session.LastRenderedSystemPromptAt!.Value.ShouldBeGreaterThanOrEqualTo(before);
+    }
+
+    // ── InProcessAgentHandle.RenderedSystemPrompt tests ───────────────────
+
+    [Fact]
+    public async Task InProcessIsolationStrategy_CreateAsync_SetsRenderedSystemPromptOnHandle()
+    {
+        // Arrange
+        const string expectedPrompt = "## Rendered System Prompt for 766";
+        var strategy = CreateStrategy(expectedPrompt);
+
+        // Act
+        var handle = await strategy.CreateAsync(
+            CreateDescriptor(),
+            new AgentExecutionContext { SessionId = SessionId.From("session-766") });
+
+        // Assert – the returned handle is InProcessAgentHandle with RenderedSystemPrompt set
+        var inProcessHandle = handle as InProcessAgentHandle;
+        inProcessHandle.ShouldNotBeNull();
+        inProcessHandle!.RenderedSystemPrompt.ShouldNotBeNullOrWhiteSpace();
+        inProcessHandle.RenderedSystemPrompt!.ShouldContain("Rendered System Prompt for 766");
+    }
+
+    // ── Supervisor stamping tests ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetOrCreateAsync_WhenHandleIsNotInProcessAgentHandle_DoesNotStampSession()
+    {
+        // Arrange – strategy returns a plain Mock<IAgentHandle> (not InProcessAgentHandle)
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        registry.Register(CreateDescriptor());
+
+        var plainHandle = new Mock<IAgentHandle>();
+        plainHandle.SetupGet(h => h.AgentId).Returns(AgentId.From("agent-a"));
+        plainHandle.SetupGet(h => h.SessionId).Returns(SessionId.From("session-plain"));
+        plainHandle.Setup(h => h.IsRunning).Returns(false);
+
+        var strategy = new Mock<IIsolationStrategy>();
+        strategy.SetupGet(s => s.Name).Returns("in-process");
+        strategy.Setup(s => s.CreateAsync(It.IsAny<AgentDescriptor>(), It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plainHandle.Object);
+
+        var gatewaySession = new GatewaySession { SessionId = SessionId.From("session-plain") };
+        var sessionStore = new Mock<ISessionStore>();
+        sessionStore.Setup(s => s.GetAsync(SessionId.From("session-plain"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gatewaySession);
+
+        var supervisor = new DefaultAgentSupervisor(
+            registry, [strategy.Object], sessionStore.Object,
+            NullLogger<DefaultAgentSupervisor>.Instance);
+
+        // Act
+        await supervisor.GetOrCreateAsync(AgentId.From("agent-a"), SessionId.From("session-plain"));
+
+        // Assert – session should NOT be stamped because the handle is not an InProcessAgentHandle
+        gatewaySession.LastRenderedSystemPrompt.ShouldBeNull();
+        gatewaySession.LastRenderedSystemPromptAt.ShouldBeNull();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private static InProcessIsolationStrategy CreateStrategy(string systemPromptContent = "test prompt")
+    {
+        var modelRegistry = new ModelRegistry();
+        modelRegistry.Register("test-provider", new LlmModel(
+            Id: "test-model",
+            Name: "test-model",
+            Api: "test-api",
+            Provider: "test-provider",
+            BaseUrl: "http://localhost",
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 8192,
+            MaxTokens: 1024));
+
+        var llmClient = new LlmClient(new ApiProviderRegistry(), modelRegistry);
+        return new InProcessIsolationStrategy(
+            llmClient,
+            new GatewayAuthManager(
+                new OptionsMonitorStub<PlatformConfig>(new PlatformConfig()),
+                NullLogger<GatewayAuthManager>.Instance,
+                new FileSystem()),
+            new FixedPromptContextBuilder(systemPromptContent),
+            new NoOpAgentToolFactory(),
+            new NoOpWorkspaceManager(),
+            new DefaultToolRegistry(Array.Empty<IAgentTool>()),
+            Array.Empty<IAgentToolContributor>(),
+            new NoOpMemoryStoreFactory(),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLogger<InProcessIsolationStrategy>.Instance);
+    }
+
+    private static AgentDescriptor CreateDescriptor()
+        => new()
+        {
+            AgentId = AgentId.From("agent-a"),
+            DisplayName = "Agent A",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            IsolationStrategy = "in-process",
+            SystemPrompt = "base prompt"
+        };
+
+    // ─── Fakes ───────────────────────────────────────────────────────────
+
+    private sealed class FixedPromptContextBuilder(string prompt) : IContextBuilder
+    {
+        public Task<string> BuildSystemPromptAsync(
+            AgentDescriptor descriptor,
+            AgentExecutionContext? executionContext,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(prompt);
+    }
+
+    private sealed class NoOpAgentToolFactory : IAgentToolFactory
+    {
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+            => Array.Empty<IAgentTool>();
+    }
+
+    private sealed class NoOpWorkspaceManager : IAgentWorkspaceManager
+    {
+        public string GetWorkspacePath(string agentName) => AppContext.BaseDirectory;
+
+        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken cancellationToken = default)
+            => Task.FromResult(new AgentWorkspace(agentName, null, null, null, null));
+
+        public Task SaveMemoryAsync(string agentName, string content, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, string? memoryPathOverride, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class NoOpMemoryStoreFactory : IMemoryStoreFactory
+    {
+        public IMemoryStore Create(string agentId) => new NoOpMemoryStore();
+    }
+
+    private sealed class NoOpMemoryStore : IMemoryStore
+    {
+        public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<MemoryEntry> InsertAsync(MemoryEntry entry, CancellationToken ct = default) => Task.FromResult(entry);
+        public Task<MemoryEntry?> GetByIdAsync(string id, CancellationToken ct = default) => Task.FromResult<MemoryEntry?>(null);
+        public Task<IReadOnlyList<MemoryEntry>> GetBySessionAsync(string sessionId, int limit = 20, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(string query, int topK = 10, MemorySearchFilter? filter = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+        public Task DeleteAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ClearAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}
+
+file sealed class OptionsMonitorStub<T>(T value) : IOptionsMonitor<T>
+{
+    public T CurrentValue => value;
+    public T Get(string? name) => value;
+    public IDisposable? OnChange(Action<T, string?> listener) => null;
+}


### PR DESCRIPTION
Closes #766

Part of #749

## Changes

### `GatewaySession.cs`
- Added `LastRenderedSystemPrompt { get; set; }` (nullable string)
- Added `LastRenderedSystemPromptAt { get; set; }` (nullable DateTimeOffset)
- In-memory only — not persisted, cleared on gateway restart

### `InProcessIsolationStrategy.cs`
- Added `RenderedSystemPrompt { get; set; }` to `InProcessAgentHandle` (internal property)
- After `BuildSystemPromptAsync` returns, the rendered prompt is stamped on the handle

### `DefaultAgentSupervisor.cs`
- After `strategy.CreateAsync`, casts handle to `InProcessAgentHandle` and stamps `existingSession.LastRenderedSystemPrompt` and `LastRenderedSystemPromptAt`
- No-op for null sessions or non-InProcess handles

## Tests (4 new in `SystemPromptCaptureTests.cs`)
- `GatewaySession_LastRenderedSystemPrompt_DefaultsToNull`
- `GatewaySession_LastRenderedSystemPrompt_CanBeSet`
- `InProcessIsolationStrategy_CreateAsync_SetsRenderedSystemPromptOnHandle`
- `GetOrCreateAsync_WhenHandleIsNotInProcessAgentHandle_DoesNotStampSession`

All impacted tests: Architecture ✅ 167, Gateway.Tests ✅ 2168, all other suites pass.

## Merge Notes
Independent — only touches `GatewaySession.cs`, `InProcessIsolationStrategy.cs`, `DefaultAgentSupervisor.cs`. No file overlap with any open PR. Safe to merge in any order.