### PR TITLE
feat(tools): add DataStoreTool domain model and DataStoreToolContributor registration

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -6,6 +6,7 @@
     <Project Path="src/extensions/BotNexus.Extensions.McpInvoke/BotNexus.Extensions.McpInvoke.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.WebTools/BotNexus.Extensions.WebTools.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.ProcessTool/BotNexus.Extensions.ProcessTool.csproj" />
+    <Project Path="src/extensions/BotNexus.Extensions.DataStore/BotNexus.Extensions.DataStore.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.ExecTool/BotNexus.Extensions.ExecTool.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/BotNexus.Extensions.Channels.SignalR.BlazorClient.csproj" />
@@ -68,6 +69,7 @@
   </Folder>
   <Folder Name="/tests/extensions/">
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj" />
+    <Project Path="tests/extensions/BotNexus.Extensions.DataStore.Tests/BotNexus.Extensions.DataStore.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.ExecTool.Tests/BotNexus.Extensions.ExecTool.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Mcp.Tests/BotNexus.Extensions.Mcp.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.McpInvoke.Tests/BotNexus.Extensions.McpInvoke.Tests.csproj" />

--- a/src/extensions/BotNexus.Extensions.DataStore/BotNexus.Extensions.DataStore.csproj
+++ b/src/extensions/BotNexus.Extensions.DataStore/BotNexus.Extensions.DataStore.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Extensions.DataStore</RootNamespace>
+    <Description>Per-agent structured SQLite data store tool for BotNexus agents.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Extensions.DataStore.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Core\BotNexus.Agent.Core.csproj" />
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+  </ItemGroup>
+  <!-- Copy extension output + manifest to artifacts/extensions/ for dev-time discovery -->
+  <Target Name="CopyExtensionToArtifacts" AfterTargets="Build">
+    <PropertyGroup>
+      <ExtensionArtifactDir>$(MSBuildThisFileDirectory)..\..\..\artifacts\extensions\botnexus-data-store\</ExtensionArtifactDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(ExtensionArtifactDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ExtensionArtifactDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)botnexus-extension.json" DestinationFolder="$(ExtensionArtifactDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreConfig.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreConfig.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Extensions.DataStore;
+
+/// <summary>
+/// Configuration for the per-agent structured data store tool.
+/// Injected from <c>botnexus-data-store</c> extension config block in agent descriptor.
+/// </summary>
+public sealed class DataStoreConfig
+{
+    /// <summary>Whether the data store tool is enabled for this agent.</summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Maximum size in bytes for the per-agent SQLite data store.
+    /// Default: 50 MB.
+    /// </summary>
+    [JsonPropertyName("maxSizeBytes")]
+    public long MaxSizeBytes { get; init; } = 50 * 1024 * 1024;
+}

--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreTool.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreTool.cs
@@ -1,0 +1,175 @@
+using System.Text;
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Extensions.DataStore;
+
+/// <summary>
+/// Agent-facing tool for managing a per-agent structured SQLite data store.
+/// Supports JSON array ingestion with auto schema inference, SQL SELECT queries,
+/// single-row inserts, row deletions, schema inspection, table listing, and table drops.
+///
+/// Only contributed when <see cref="DataStoreConfig.Enabled"/> is true.
+/// </summary>
+public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
+{
+    // Actions the tool supports.
+    internal static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ingest", "query", "insert", "delete", "schema", "tables", "drop"
+    };
+
+    public string Name => "data_store";
+    public string Label => "Data Store";
+
+    public Tool Definition => new(
+        Name,
+        "Manage a per-agent structured SQLite data store. Ingest JSON arrays, run SELECT queries, insert rows, delete rows, inspect schema, list tables, or drop tables.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": ["ingest", "query", "insert", "delete", "schema", "tables", "drop"],
+                  "description": "Action to perform: 'ingest' - bulk load a JSON array; 'query' - run a SELECT; 'insert' - add a single JSON object row; 'delete' - remove rows matching a WHERE clause; 'schema' - show column names and types; 'tables' - list all tables; 'drop' - drop a table."
+                },
+                "table": {
+                  "type": "string",
+                  "description": "Table name (required for ingest, insert, delete, schema, drop). Lowercase alphanumeric + underscores only."
+                },
+                "data": {
+                  "type": "string",
+                  "description": "JSON array of objects for 'ingest', or single JSON object for 'insert'."
+                },
+                "sql": {
+                  "type": "string",
+                  "description": "SELECT statement for 'query' action. Only SELECT is permitted."
+                },
+                "where": {
+                  "type": "string",
+                  "description": "WHERE clause for 'delete' action (e.g. \"status = 'done'\"). Required for delete to prevent accidental full-table wipe."
+                }
+              },
+              "required": ["action"]
+            }
+            """).RootElement.Clone());
+
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyDictionary<string, object?>>(
+            new Dictionary<string, object?>(arguments, StringComparer.OrdinalIgnoreCase));
+    }
+
+    public async Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        var action = GetString(arguments, "action")?.ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(action) || !ValidActions.Contains(action))
+            return TextResult($"Error: Unknown action '{action}'. Valid actions: {string.Join(", ", ValidActions.Order())}.");
+
+        DataStoreResult result = action switch
+        {
+            "ingest"  => await IngestAsync(arguments, cancellationToken),
+            "query"   => await QueryAsync(arguments, cancellationToken),
+            "insert"  => await InsertAsync(arguments, cancellationToken),
+            "delete"  => await DeleteAsync(arguments, cancellationToken),
+            "schema"  => await SchemaAsync(arguments, cancellationToken),
+            "tables"  => await backend.TablesAsync(cancellationToken),
+            "drop"    => await DropAsync(arguments, cancellationToken),
+            _         => DataStoreResult.Fail($"Unhandled action '{action}'.")
+        };
+
+        return result.Success
+            ? TextResult(result.Payload ?? string.Empty)
+            : TextResult($"Error: {result.Error}");
+    }
+
+    // ── Action helpers ────────────────────────────────────────────────────────
+
+    private async Task<DataStoreResult> IngestAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        var data  = GetString(args, "data");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for ingest.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'. Use lowercase letters, digits, and underscores only.");
+        if (string.IsNullOrWhiteSpace(data))  return DataStoreResult.Fail("'data' (JSON array) is required for ingest.");
+        return await backend.IngestAsync(table, data, ct);
+    }
+
+    private async Task<DataStoreResult> QueryAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var sql = GetString(args, "sql");
+        if (string.IsNullOrWhiteSpace(sql)) return DataStoreResult.Fail("'sql' is required for query.");
+        var trimmed = sql.TrimStart();
+        if (!trimmed.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase))
+            return DataStoreResult.Fail("Only SELECT statements are permitted in 'query'.");
+        return await backend.QueryAsync(sql, ct);
+    }
+
+    private async Task<DataStoreResult> InsertAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        var data  = GetString(args, "data");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for insert.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'. Use lowercase letters, digits, and underscores only.");
+        if (string.IsNullOrWhiteSpace(data))  return DataStoreResult.Fail("'data' (JSON object) is required for insert.");
+        return await backend.InsertAsync(table, data, ct);
+    }
+
+    private async Task<DataStoreResult> DeleteAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        var where = GetString(args, "where");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for delete.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'. Use lowercase letters, digits, and underscores only.");
+        if (string.IsNullOrWhiteSpace(where)) return DataStoreResult.Fail("'where' clause is required for delete to prevent accidental full-table wipe.");
+        return await backend.DeleteAsync(table, where, ct);
+    }
+
+    private async Task<DataStoreResult> SchemaAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for schema.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'.");
+        return await backend.SchemaAsync(table, ct);
+    }
+
+    private async Task<DataStoreResult> DropAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for drop.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'.");
+        return await backend.DropAsync(table, ct);
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────────────────
+
+    internal static string? GetString(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var raw)) return null;
+        return raw switch
+        {
+            string s       => s,
+            JsonElement je => je.ValueKind == JsonValueKind.String ? je.GetString() : je.ToString(),
+            _              => raw?.ToString()
+        };
+    }
+
+    internal static bool IsValidTableName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name) || name.Length > 63) return false;
+        return name.All(c => char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '_');
+    }
+
+    private static AgentToolResult TextResult(string text) =>
+        new([new AgentToolContent(AgentToolContentType.Text, text)]);
+}

--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreToolContributor.cs
@@ -1,0 +1,49 @@
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Extensions.DataStore;
+
+/// <summary>
+/// Contributes the session-scoped <see cref="DataStoreTool"/> when
+/// <see cref="DataStoreConfig.Enabled"/> is <c>true</c> for the agent.
+/// </summary>
+public sealed class DataStoreToolContributor : IAgentToolContributor
+{
+    /// <inheritdoc />
+    public Task<AgentToolContribution> ContributeAsync(
+        AgentToolContributionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var config = ResolveConfig(context.Descriptor);
+
+        if (!config.Enabled)
+            return Task.FromResult(new AgentToolContribution(Array.Empty<IAgentTool>()));
+
+        var storePath = Path.Combine(context.WorkspacePath, ".store", "agent-data.db");
+        var backend   = new SqliteDataStoreBackend(storePath, config.MaxSizeBytes);
+        IReadOnlyList<IAgentTool> tools = [new DataStoreTool(backend)];
+
+        return Task.FromResult(new AgentToolContribution(tools, [backend]));
+    }
+
+    private static DataStoreConfig ResolveConfig(AgentDescriptor descriptor)
+    {
+        if (descriptor.ExtensionConfig.TryGetValue("botnexus-data-store", out var element))
+        {
+            try
+            {
+                return System.Text.Json.JsonSerializer.Deserialize<DataStoreConfig>(element.GetRawText())
+                       ?? new DataStoreConfig();
+            }
+            catch
+            {
+                return new DataStoreConfig();
+            }
+        }
+
+        return new DataStoreConfig();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.DataStore/IDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/IDataStoreBackend.cs
@@ -1,0 +1,57 @@
+namespace BotNexus.Extensions.DataStore;
+
+/// <summary>
+/// Pluggable backend for the data store tool.
+/// The default implementation (provided by <c>BotNexus.Extensions.DataStore</c>) uses SQLite.
+/// Inject a test double in unit tests.
+/// </summary>
+public interface IDataStoreBackend : IDisposable
+{
+    /// <summary>
+    /// Ingest a JSON array of objects, inferring or updating the table schema.
+    /// Non-destructive: new fields are added via ALTER TABLE ADD COLUMN.
+    /// </summary>
+    Task<DataStoreResult> IngestAsync(string table, string json, CancellationToken ct = default);
+
+    /// <summary>Execute a read-only SELECT query.</summary>
+    Task<DataStoreResult> QueryAsync(string sql, CancellationToken ct = default);
+
+    /// <summary>Insert a single JSON object row into the given table.</summary>
+    Task<DataStoreResult> InsertAsync(string table, string json, CancellationToken ct = default);
+
+    /// <summary>Delete rows matching a WHERE clause.</summary>
+    Task<DataStoreResult> DeleteAsync(string table, string where, CancellationToken ct = default);
+
+    /// <summary>Return the schema (column names and types) for a table.</summary>
+    Task<DataStoreResult> SchemaAsync(string table, CancellationToken ct = default);
+
+    /// <summary>List all tables in the data store.</summary>
+    Task<DataStoreResult> TablesAsync(CancellationToken ct = default);
+
+    /// <summary>Drop a table entirely.</summary>
+    Task<DataStoreResult> DropAsync(string table, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result from a <see cref="IDataStoreBackend"/> operation.
+/// </summary>
+public sealed class DataStoreResult
+{
+    /// <summary>Whether the operation succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Human-readable result payload (JSON rows, schema lines, table list, etc.).</summary>
+    public string? Payload { get; init; }
+
+    /// <summary>Error message when <see cref="Success"/> is false.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>Number of rows affected or returned, if applicable.</summary>
+    public int? RowCount { get; init; }
+
+    public static DataStoreResult Ok(string payload, int? rowCount = null) =>
+        new() { Success = true, Payload = payload, RowCount = rowCount };
+
+    public static DataStoreResult Fail(string error) =>
+        new() { Success = false, Error = error };
+}

--- a/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
@@ -1,0 +1,36 @@
+namespace BotNexus.Extensions.DataStore;
+
+/// <summary>
+/// SQLite-backed implementation of <see cref="IDataStoreBackend"/>.
+/// Implementation provided in issue #853 (SQLite storage backend).
+/// This stub satisfies DI requirements and allows <see cref="DataStoreTool"/>
+/// to be tested independently of the SQLite layer.
+/// </summary>
+internal sealed class SqliteDataStoreBackend(string dbPath, long maxSizeBytes) : IDataStoreBackend
+{
+    private readonly string _dbPath       = dbPath;
+    private readonly long   _maxSizeBytes = maxSizeBytes;
+
+    public Task<DataStoreResult> IngestAsync(string table, string json, CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public Task<DataStoreResult> QueryAsync(string sql, CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public Task<DataStoreResult> InsertAsync(string table, string json, CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public Task<DataStoreResult> DeleteAsync(string table, string where, CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public Task<DataStoreResult> SchemaAsync(string table, CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public Task<DataStoreResult> TablesAsync(CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public Task<DataStoreResult> DropAsync(string table, CancellationToken ct = default) =>
+        Task.FromResult(DataStoreResult.Fail("SQLite backend not yet implemented (see #853)."));
+
+    public void Dispose() { /* no-op until SQLite connection added in #853 */ }
+}

--- a/src/extensions/BotNexus.Extensions.DataStore/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.DataStore/botnexus-extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "botnexus-data-store",
+  "name": "BotNexus Data Store",
+  "description": "Per-agent structured SQLite data store with JSON ingestion, SQL SELECT queries, and schema inference.",
+  "version": "1.0.0"
+}

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/BotNexus.Extensions.DataStore.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/BotNexus.Extensions.DataStore.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.DataStore\BotNexus.Extensions.DataStore.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
@@ -1,0 +1,349 @@
+using Shouldly;
+using BotNexus.Domain.Primitives;
+using BotNexus.Extensions.DataStore;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+using System.Text.Json;
+
+namespace BotNexus.Extensions.DataStore.Tests;
+
+public sealed class DataStoreToolTests
+{
+    // ── Fixture helpers ───────────────────────────────────────────────────────
+
+    private static DataStoreTool CreateTool(FakeDataStoreBackend? backend = null) =>
+        new(backend ?? new FakeDataStoreBackend());
+
+    private static IReadOnlyDictionary<string, object?> Args(string action, params (string key, string value)[] extras)
+    {
+        var d = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["action"] = action };
+        foreach (var (k, v) in extras) d[k] = v;
+        return d;
+    }
+
+    private static string TextOf(AgentToolResult r) => r.Content[0].Value;
+    private static bool IsError(AgentToolResult r) => r.Content[0].Value.StartsWith("Error:", StringComparison.OrdinalIgnoreCase);
+
+    // ── ValidActions ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidActions_ContainsAllExpectedActions()
+    {
+        var expected = new[] { "ingest", "query", "insert", "delete", "schema", "tables", "drop" };
+        foreach (var a in expected)
+            DataStoreTool.ValidActions.Contains(a).ShouldBeTrue($"'{a}' missing from ValidActions");
+    }
+
+    // ── Unknown action ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("update")]
+    [InlineData("upsert")]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task ExecuteAsync_UnknownAction_ReturnsError(string? action)
+    {
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["action"] = action };
+        var result = await tool.ExecuteAsync("tc1", args);
+        IsError(result).ShouldBeTrue();
+    }
+
+    // ── Table name validation ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("my_table", true)]
+    [InlineData("table1", true)]
+    [InlineData("MyTable", false)]           // uppercase
+    [InlineData("my-table", false)]          // hyphen
+    [InlineData("", false)]                  // empty
+    [InlineData("SELECT", false)]            // uppercase keyword
+    public void IsValidTableName_ValidatesCorrectly(string name, bool expected) =>
+        DataStoreTool.IsValidTableName(name).ShouldBe(expected);
+
+    // ── ingest ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Ingest_MissingTable_ReturnsError()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("ingest", ("data", "[{\"x\":1}]")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("table");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Ingest_MissingData_ReturnsError()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("ingest", ("table", "my_table")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("data");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Ingest_InvalidTableName_ReturnsError()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("ingest", ("table", "Bad-Table"), ("data", "[{}]")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("Invalid table name");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Ingest_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("ingest", ("table", "events"), ("data", "[{\"id\":1}]")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("ingest");
+        backend.LastTable.ShouldBe("events");
+    }
+
+    // ── query ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Query_MissingSql_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query"));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("sql");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Query_NonSelectStatement_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query", ("sql", "DROP TABLE events")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("SELECT");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Query_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("query", ("sql", "SELECT * FROM events")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("query");
+    }
+
+    // ── insert ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Insert_MissingTable_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("insert", ("data", "{\"x\":1}")));
+        IsError(result).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Insert_MissingData_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("insert", ("table", "events")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("data");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Insert_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("insert", ("table", "events"), ("data", "{\"id\":42}")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("insert");
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Delete_MissingWhere_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("delete", ("table", "events")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("where");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Delete_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("delete", ("table", "events"), ("where", "id = 1")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("delete");
+    }
+
+    // ── schema ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Schema_MissingTable_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("schema"));
+        IsError(result).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Schema_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("schema", ("table", "events")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("schema");
+    }
+
+    // ── tables ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Tables_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("tables"));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("tables");
+    }
+
+    // ── drop ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Drop_MissingTable_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("drop"));
+        IsError(result).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Drop_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("drop", ("table", "events")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("drop");
+    }
+}
+
+// ── Contributor tests ─────────────────────────────────────────────────────────
+
+public sealed class DataStoreToolContributorTests
+{
+    [Fact]
+    public async Task ContributeAsync_WhenDisabled_ReturnsNoTools()
+    {
+        var contributor = new DataStoreToolContributor();
+        var context     = BuildContext(enabled: false);
+        var result      = await contributor.ContributeAsync(context);
+        result.Tools.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ContributeAsync_WhenEnabled_ReturnsDataStoreTool()
+    {
+        var contributor = new DataStoreToolContributor();
+        var context     = BuildContext(enabled: true);
+        var result      = await contributor.ContributeAsync(context);
+        result.Tools.Count.ShouldBe(1);
+        result.Tools[0].Name.ShouldBe("data_store");
+    }
+
+    [Fact]
+    public async Task ContributeAsync_WhenEnabled_ReturnsBackendAsDisposableResource()
+    {
+        var contributor = new DataStoreToolContributor();
+        var context     = BuildContext(enabled: true);
+        var result      = await contributor.ContributeAsync(context);
+        result.ResourcesToDispose.ShouldNotBeNull();
+        result.ResourcesToDispose!.Count.ShouldBe(1);
+        result.ResourcesToDispose[0].ShouldBeOfType<SqliteDataStoreBackend>();
+    }
+
+    [Fact]
+    public async Task ContributeAsync_MissingExtensionConfig_DefaultsToDisabled()
+    {
+        var contributor = new DataStoreToolContributor();
+        var context     = BuildContext(hasConfig: false);
+        var result      = await contributor.ContributeAsync(context);
+        result.Tools.Count.ShouldBe(0);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static AgentToolContributionContext BuildContext(bool enabled = false, bool hasConfig = true)
+    {
+        var configJson = enabled
+            ? """{"enabled":true,"maxSizeBytes":52428800}"""
+            : """{"enabled":false}""";
+
+        var extensionConfig = new Dictionary<string, JsonElement>();
+        if (hasConfig)
+            extensionConfig["botnexus-data-store"] = JsonDocument.Parse(configJson).RootElement;
+
+        var descriptor = new AgentDescriptor
+        {
+            AgentId      = AgentId.From("test-agent"),
+            DisplayName  = "Test Agent",
+            ModelId      = "test-model",
+            ApiProvider  = "test-provider",
+            ExtensionConfig = extensionConfig
+        };
+
+        return new AgentToolContributionContext(
+            descriptor,
+            new AgentExecutionContext { SessionId = SessionId.Create() },
+            Path.Combine(Path.GetTempPath(), "test-workspace"),
+            new AllowAllPathValidator(),
+            _ => null,
+            (_, _) => Task.FromResult<string?>(null));
+    }
+
+    private sealed class AllowAllPathValidator : BotNexus.Gateway.Abstractions.Security.IPathValidator
+    {
+        public bool CanRead(string absolutePath) => true;
+        public bool CanWrite(string absolutePath) => true;
+        public string? ValidateAndResolve(string rawPath, BotNexus.Gateway.Abstractions.Security.FileAccessMode mode) => rawPath;
+    }
+}
+
+// ── Fakes ──────────────────────────────────────────────────────────────────────
+
+internal sealed class FakeDataStoreBackend : IDataStoreBackend
+{
+    public string? LastAction { get; private set; }
+    public string? LastTable  { get; private set; }
+
+    public Task<DataStoreResult> IngestAsync(string table, string json, CancellationToken ct = default)
+    { LastAction = "ingest"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("1 row ingested", 1)); }
+
+    public Task<DataStoreResult> QueryAsync(string sql, CancellationToken ct = default)
+    { LastAction = "query"; return Task.FromResult(DataStoreResult.Ok("[]", 0)); }
+
+    public Task<DataStoreResult> InsertAsync(string table, string json, CancellationToken ct = default)
+    { LastAction = "insert"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("inserted", 1)); }
+
+    public Task<DataStoreResult> DeleteAsync(string table, string where, CancellationToken ct = default)
+    { LastAction = "delete"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("1 deleted", 1)); }
+
+    public Task<DataStoreResult> SchemaAsync(string table, CancellationToken ct = default)
+    { LastAction = "schema"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("id INTEGER", 0)); }
+
+    public Task<DataStoreResult> TablesAsync(CancellationToken ct = default)
+    { LastAction = "tables"; return Task.FromResult(DataStoreResult.Ok("events", 0)); }
+
+    public Task<DataStoreResult> DropAsync(string table, CancellationToken ct = default)
+    { LastAction = "drop"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("dropped", 0)); }
+
+    public void Dispose() { }
+}

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/xunit.runner.json
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0
+}


### PR DESCRIPTION
Closes #856

Part of #831

## Changes

### New project: `BotNexus.Extensions.DataStore`
- `DataStoreConfig.cs` — config model with `Enabled` and `MaxSizeBytes` (default 50 MB); uses `[JsonPropertyName]` for proper camelCase deserialization
- `IDataStoreBackend.cs` — pluggable backend interface with `IngestAsync`, `QueryAsync`, `InsertAsync`, `DeleteAsync`, `SchemaAsync`, `TablesAsync`, `DropAsync`; includes `DataStoreResult` with `Ok`/`Fail` factory methods
- `DataStoreTool.cs` — `IAgentTool` implementation: routes 7 actions (ingest, query, insert, delete, schema, tables, drop), validates table names (lowercase alphanumeric + underscores), enforces SELECT-only for query, requires WHERE for delete
- `DataStoreToolContributor.cs` — `IAgentToolContributor`: contributes tool only when `DataStoreConfig.Enabled = true`; returns backend as disposable resource
- `SqliteDataStoreBackend.cs` — stub implementation returning `not yet implemented (see #853)` until the SQLite layer is added in #853
- `botnexus-extension.json` — extension manifest with ID `botnexus-data-store`

### New test project: `BotNexus.Extensions.DataStore.Tests`
- 32 tests covering all actions (happy + sad + validation paths) and all contributor scenarios

## Tests
- `DataStoreToolTests` — 28 tests: ValidActions set, unknown action, table name validation, all 7 actions (missing args + happy path)
- `DataStoreToolContributorTests` — 4 tests: disabled → 0 tools, enabled → 1 tool (data_store), backend returned as disposable, missing config → disabled

All impacted tests: Architecture ✅ 167, DataStore.Tests ✅ 32, Scenarios ✅ 29

## Merge Notes
Independent of all open PRs — creates new extension project with zero file overlap.
Should merge before #853 (SQLite backend) and #854 (tests) which build on this foundation.