### PR TITLE
feat(platform): introduce BotNexus.Yaml targeted frontmatter parser and migrate SkillParser

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -40,6 +40,7 @@
     <Project Path="src/gateway/BotNexus.Memory/BotNexus.Memory.csproj" />
     <Project Path="src/gateway/BotNexus.Tools/BotNexus.Tools.csproj" />
     <Project Path="src/gateway/BotNexus.Gateway.Webhooks/BotNexus.Gateway.Webhooks.csproj" />
+    <Project Path="src/gateway/BotNexus.Yaml/BotNexus.Yaml.csproj" />
   </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/BotNexus.CodingAgent/BotNexus.CodingAgent.csproj" />
@@ -89,5 +90,6 @@
     <Project Path="tests/gateway/BotNexus.Gateway.Tests/BotNexus.Gateway.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Memory.Tests/BotNexus.Memory.Tests.csproj" />
     <Project Path="tests/gateway/BotNexus.Gateway.Webhooks.Tests/BotNexus.Gateway.Webhooks.Tests.csproj" />
+    <Project Path="tests/gateway/BotNexus.Yaml.Tests/BotNexus.Yaml.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/extensions/BotNexus.Extensions.Skills/BotNexus.Extensions.Skills.csproj
+++ b/src/extensions/BotNexus.Extensions.Skills/BotNexus.Extensions.Skills.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Yaml\BotNexus.Yaml.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />

--- a/src/extensions/BotNexus.Extensions.Skills/SkillParser.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillParser.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using BotNexus.Yaml;
 
 namespace BotNexus.Extensions.Skills;
 
@@ -10,12 +11,18 @@ public static class SkillParser
 {
     private static readonly Regex NameValidation = new(@"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", RegexOptions.Compiled);
 
+    /// <summary>
+    /// The YAML frontmatter parser used for skill file parsing.
+    /// Replace with a custom implementation for testing or extended YAML support.
+    /// </summary>
+    internal static IYamlFrontmatterParser YamlParser { get; set; } = SimpleYamlFrontmatterParser.Instance;
+
     public static SkillDefinition Parse(string directoryName, string markdown, string sourcePath, SkillSource source)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(directoryName);
         ArgumentNullException.ThrowIfNull(markdown);
 
-        // Strip UTF-8 BOM if present — it breaks frontmatter detection
+        // Strip UTF-8 BOM if present - it breaks frontmatter detection
         markdown = markdown.TrimStart('\uFEFF');
 
         var (frontmatter, content) = SplitFrontmatter(markdown);
@@ -29,35 +36,38 @@ public static class SkillParser
 
         if (frontmatter is not null)
         {
-            var fields = ParseFrontmatter(frontmatter);
-            name = fields.GetValueOrDefault("name");
-            description = fields.GetValueOrDefault("description");
-            license = fields.GetValueOrDefault("license");
+            var fields = YamlParser.Parse(frontmatter);
+            name         = fields.GetValueOrDefault("name");
+            description  = fields.GetValueOrDefault("description");
+            license      = fields.GetValueOrDefault("license");
             compatibility = fields.GetValueOrDefault("compatibility");
             allowedTools = fields.GetValueOrDefault("allowed-tools");
-            metadata = ExtractMetadata(frontmatter);
+            metadata     = new Dictionary<string, string>(
+                               YamlParser.ParseNested(frontmatter, "metadata"),
+                               StringComparer.OrdinalIgnoreCase);
         }
 
         var disableModelInvocation = false;
         if (frontmatter is not null)
         {
-            var rawDisable = ParseFrontmatter(frontmatter).GetValueOrDefault("disable-model-invocation");
+            var fields     = YamlParser.Parse(frontmatter);
+            var rawDisable = fields.GetValueOrDefault("disable-model-invocation");
             disableModelInvocation = rawDisable is not null &&
                 bool.TryParse(rawDisable, out var parsed) && parsed;
         }
 
         return new SkillDefinition
         {
-            Name = name ?? directoryName,
-            Description = description ?? string.Empty,
-            License = license,
-            Compatibility = compatibility,
-            AllowedTools = allowedTools,
+            Name                   = name ?? directoryName,
+            Description            = description ?? string.Empty,
+            License                = license,
+            Compatibility          = compatibility,
+            AllowedTools           = allowedTools,
             DisableModelInvocation = disableModelInvocation,
-            Metadata = metadata,
-            Content = content.Trim(),
-            SourcePath = sourcePath,
-            Source = source
+            Metadata               = metadata,
+            Content                = content.Trim(),
+            SourcePath             = sourcePath,
+            Source                 = source
         };
     }
 
@@ -71,6 +81,8 @@ public static class SkillParser
         return NameValidation.IsMatch(name);
     }
 
+    // ── Frontmatter splitting ─────────────────────────────────────────────────
+
     private static (string? frontmatter, string content) SplitFrontmatter(string markdown)
     {
         var lines = markdown.Split(["\r\n", "\n"], StringSplitOptions.None);
@@ -83,129 +95,7 @@ public static class SkillParser
             return (null, markdown.Trim());
 
         var frontmatter = string.Join("\n", lines[(firstNonEmpty + 1)..closingIndex]);
-        var content = string.Join("\n", lines[(closingIndex + 1)..]);
+        var content     = string.Join("\n", lines[(closingIndex + 1)..]);
         return (frontmatter, content.Trim());
-    }
-
-    private static Dictionary<string, string> ParseFrontmatter(string frontmatter)
-    {
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var lines = frontmatter.Split('\n');
-
-        string? pendingBlockKey = null;     // key waiting for block scalar content
-        bool pendingBlockIsFolded = false;  // true = '>' (fold newlines), false = '|' (preserve)
-        var pendingBlockLines = new List<string>();
-
-        void FlushPendingBlock()
-        {
-            if (pendingBlockKey is null) return;
-            var value = pendingBlockIsFolded
-                ? string.Join(" ", pendingBlockLines).TrimEnd()
-                : string.Join("\n", pendingBlockLines).TrimEnd();
-            if (!string.IsNullOrWhiteSpace(value))
-                result[pendingBlockKey] = value;
-            pendingBlockKey = null;
-            pendingBlockLines.Clear();
-        }
-
-        foreach (var line in lines)
-        {
-            // Collecting indented block scalar content
-            if (pendingBlockKey is not null)
-            {
-                if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
-                {
-                    // Strip one level of leading whitespace (common indentation)
-                    pendingBlockLines.Add(line.TrimStart());
-                    continue;
-                }
-
-                // First non-indented line ends the block
-                FlushPendingBlock();
-            }
-
-            // Skip remaining indented lines that aren't block scalar content
-            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
-                continue;
-
-            var sep = line.IndexOf(':');
-            if (sep <= 0)
-                continue;
-
-            var key = line[..sep].Trim();
-            var rawValue = line[(sep + 1)..].Trim().Trim('"', '\'');
-
-            if (string.IsNullOrWhiteSpace(key))
-                continue;
-
-            // Detect block scalar indicators
-            if (rawValue == "|")
-            {
-                pendingBlockKey = key;
-                pendingBlockIsFolded = false;
-                pendingBlockLines.Clear();
-                continue;
-            }
-
-            if (rawValue == ">")
-            {
-                pendingBlockKey = key;
-                pendingBlockIsFolded = true;
-                pendingBlockLines.Clear();
-                continue;
-            }
-
-            // Skip block-level keys (e.g. metadata:) with no inline value
-            if (!string.IsNullOrWhiteSpace(rawValue))
-                result[key] = rawValue;
-        }
-
-        // Flush any block scalar that ended at EOF
-        FlushPendingBlock();
-
-        return result;
-    }
-
-    private static Dictionary<string, string> ExtractMetadata(string frontmatter)
-    {
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var lines = frontmatter.Split('\n');
-        var inMetadata = false;
-
-        foreach (var line in lines)
-        {
-            var trimmed = line.Trim();
-            if (trimmed.Equals("metadata:", StringComparison.OrdinalIgnoreCase) ||
-                trimmed.StartsWith("metadata:", StringComparison.OrdinalIgnoreCase))
-            {
-                // Check if it's a block start (no value after colon)
-                var afterColon = trimmed["metadata:".Length..].Trim();
-                if (string.IsNullOrEmpty(afterColon))
-                {
-                    inMetadata = true;
-                    continue;
-                }
-            }
-
-            if (inMetadata)
-            {
-                if (line.Length > 0 && line[0] != ' ' && line[0] != '\t')
-                {
-                    inMetadata = false;
-                    continue;
-                }
-
-                var sep = trimmed.IndexOf(':');
-                if (sep > 0)
-                {
-                    var key = trimmed[..sep].Trim();
-                    var value = trimmed[(sep + 1)..].Trim().Trim('"', '\'');
-                    if (!string.IsNullOrEmpty(key))
-                        result[key] = value;
-                }
-            }
-        }
-
-        return result;
     }
 }

--- a/src/gateway/BotNexus.Yaml/BotNexus.Yaml.csproj
+++ b/src/gateway/BotNexus.Yaml/BotNexus.Yaml.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Yaml</RootNamespace>
+    <Description>Minimal targeted YAML frontmatter parser for BotNexus skill files. No third-party dependencies.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Yaml.Tests" />
+    <InternalsVisibleTo Include="BotNexus.Skills.Tests" />
+  </ItemGroup>
+</Project>

--- a/src/gateway/BotNexus.Yaml/IYamlFrontmatterParser.cs
+++ b/src/gateway/BotNexus.Yaml/IYamlFrontmatterParser.cs
@@ -1,0 +1,34 @@
+namespace BotNexus.Yaml;
+
+/// <summary>
+/// Parses YAML frontmatter blocks into key-value string dictionaries.
+/// Implementations must handle the YAML subset used in BotNexus skill files.
+/// </summary>
+public interface IYamlFrontmatterParser
+{
+    /// <summary>
+    /// Parses a YAML frontmatter block (the text between the <c>---</c> delimiters,
+    /// with the delimiters already stripped) into a key-to-value dictionary.
+    /// </summary>
+    /// <param name="frontmatter">
+    /// The raw frontmatter text — multi-line YAML without the surrounding <c>---</c> fences.
+    /// </param>
+    /// <returns>
+    /// A case-insensitive dictionary of top-level key-value pairs.
+    /// Block scalars (<c>|</c> literal, <c>&gt;</c> folded) are supported.
+    /// Quoted strings (single and double) are unquoted.
+    /// Comments (<c>#</c>) are ignored.
+    /// Nested block sections (e.g. <c>metadata:</c>) are NOT included in the returned
+    /// dictionary — callers that need nested values should use <see cref="ParseNested"/>.
+    /// </returns>
+    IReadOnlyDictionary<string, string> Parse(string frontmatter);
+
+    /// <summary>
+    /// Parses the indented child key-value pairs under a named parent key
+    /// (e.g. <c>metadata:</c>) from a frontmatter block.
+    /// </summary>
+    /// <param name="frontmatter">The raw frontmatter text (fences stripped).</param>
+    /// <param name="parentKey">The top-level key whose children to extract.</param>
+    /// <returns>A case-insensitive dictionary of the nested key-value pairs.</returns>
+    IReadOnlyDictionary<string, string> ParseNested(string frontmatter, string parentKey);
+}

--- a/src/gateway/BotNexus.Yaml/SimpleYamlFrontmatterParser.cs
+++ b/src/gateway/BotNexus.Yaml/SimpleYamlFrontmatterParser.cs
@@ -1,0 +1,185 @@
+namespace BotNexus.Yaml;
+
+/// <summary>
+/// Minimal YAML frontmatter parser for BotNexus skill files.
+/// Handles the strict subset of YAML actually used in skill files:
+/// <list type="bullet">
+///   <item>Plain scalar values: <c>key: value</c></item>
+///   <item>Double-quoted values: <c>key: "quoted string"</c></item>
+///   <item>Single-quoted values: <c>key: 'quoted string'</c></item>
+///   <item>Literal block scalars: <c>key: |</c> (newlines preserved)</item>
+///   <item>Folded block scalars: <c>key: &gt;</c> (newlines converted to spaces)</item>
+///   <item>Nested sections: <c>parentKey:</c> with indented key-value children (via ParseNested)</item>
+///   <item>Comments: lines starting with <c>#</c> are ignored</item>
+/// </list>
+/// Not supported: anchors, aliases, multi-document, YAML sequences.
+/// </summary>
+public sealed class SimpleYamlFrontmatterParser : IYamlFrontmatterParser
+{
+    /// <summary>Singleton instance for use in DI-free contexts.</summary>
+    public static readonly SimpleYamlFrontmatterParser Instance = new();
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string> Parse(string frontmatter)
+    {
+        ArgumentNullException.ThrowIfNull(frontmatter);
+        return ParseTopLevel(frontmatter);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string> ParseNested(string frontmatter, string parentKey)
+    {
+        ArgumentNullException.ThrowIfNull(frontmatter);
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentKey);
+        return ExtractNestedBlock(frontmatter, parentKey);
+    }
+
+    // ── Top-level parsing ────────────────────────────────────────────────────
+
+    private static Dictionary<string, string> ParseTopLevel(string frontmatter)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var lines  = SplitLines(frontmatter);
+
+        string? pendingBlockKey     = null;
+        bool    pendingBlockFolded  = false;
+        var     pendingBlockLines   = new List<string>();
+
+        void FlushPendingBlock()
+        {
+            if (pendingBlockKey is null) return;
+            var value = pendingBlockFolded
+                ? string.Join(" ", pendingBlockLines).TrimEnd()
+                : string.Join("\n", pendingBlockLines).TrimEnd();
+            if (!string.IsNullOrWhiteSpace(value))
+                result[pendingBlockKey] = value;
+            pendingBlockKey = null;
+            pendingBlockLines.Clear();
+        }
+
+        foreach (var line in lines)
+        {
+            // Skip comment-only lines at top level
+            var trimmedLine = line.TrimStart();
+            if (trimmedLine.StartsWith('#'))
+                continue;
+
+            // Collecting indented block scalar content
+            if (pendingBlockKey is not null)
+            {
+                if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
+                {
+                    pendingBlockLines.Add(line.TrimStart());
+                    continue;
+                }
+                // First non-indented, non-empty line ends the block
+                FlushPendingBlock();
+            }
+
+            // Skip lines that are indented (not top-level key-value pairs)
+            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
+                continue;
+
+            var sep = line.IndexOf(':');
+            if (sep <= 0)
+                continue;
+
+            var key      = line[..sep].Trim();
+            var rawValue = line[(sep + 1)..].Trim();
+
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            // Block scalar indicators
+            if (rawValue == "|")
+            {
+                pendingBlockKey    = key;
+                pendingBlockFolded = false;
+                pendingBlockLines.Clear();
+                continue;
+            }
+
+            if (rawValue == ">")
+            {
+                pendingBlockKey    = key;
+                pendingBlockFolded = true;
+                pendingBlockLines.Clear();
+                continue;
+            }
+
+            // Skip block-level parent keys with no inline value (e.g. "metadata:")
+            if (string.IsNullOrWhiteSpace(rawValue))
+                continue;
+
+            result[key] = Unquote(rawValue);
+        }
+
+        FlushPendingBlock();
+        return result;
+    }
+
+    // ── Nested block extraction ───────────────────────────────────────────────
+
+    private static Dictionary<string, string> ExtractNestedBlock(string frontmatter, string parentKey)
+    {
+        var result  = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var lines   = SplitLines(frontmatter);
+        var inBlock = false;
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+
+            // Detect parent key header
+            if (!inBlock)
+            {
+                if (trimmed.Equals($"{parentKey}:", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith($"{parentKey}:", StringComparison.OrdinalIgnoreCase))
+                {
+                    var afterColon = trimmed[(parentKey.Length + 1)..].Trim();
+                    if (string.IsNullOrEmpty(afterColon))
+                    {
+                        inBlock = true;
+                        continue;
+                    }
+                }
+                continue;
+            }
+
+            // Exit when we hit a non-indented line (new top-level key)
+            if (line.Length > 0 && line[0] != ' ' && line[0] != '\t')
+            {
+                inBlock = false;
+                continue;
+            }
+
+            var sep = trimmed.IndexOf(':');
+            if (sep <= 0) continue;
+
+            var key   = trimmed[..sep].Trim();
+            var value = trimmed[(sep + 1)..].Trim();
+
+            if (!string.IsNullOrEmpty(key))
+                result[key] = Unquote(value);
+        }
+
+        return result;
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────────────────
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2)
+        {
+            if ((value[0] == '"'  && value[^1] == '"')  ||
+                (value[0] == '\'' && value[^1] == '\''))
+                return value[1..^1];
+        }
+
+        return value;
+    }
+
+    private static string[] SplitLines(string text) =>
+        text.Split(["\r\n", "\n"], StringSplitOptions.None);
+}

--- a/tests/gateway/BotNexus.Yaml.Tests/BotNexus.Yaml.Tests.csproj
+++ b/tests/gateway/BotNexus.Yaml.Tests/BotNexus.Yaml.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Yaml\BotNexus.Yaml.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/gateway/BotNexus.Yaml.Tests/SimpleYamlFrontmatterParserTests.cs
+++ b/tests/gateway/BotNexus.Yaml.Tests/SimpleYamlFrontmatterParserTests.cs
@@ -1,0 +1,193 @@
+using Shouldly;
+using BotNexus.Yaml;
+
+namespace BotNexus.Yaml.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SimpleYamlFrontmatterParser"/>.
+/// Covers all supported value forms per the issue #877 acceptance criteria.
+/// </summary>
+public sealed class SimpleYamlFrontmatterParserTests
+{
+    private static SimpleYamlFrontmatterParser Parser => SimpleYamlFrontmatterParser.Instance;
+
+    // ── Plain scalars ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_PlainScalar_ExtractsKeyValue()
+    {
+        var frontmatter = "name: email-triage\ndescription: Triage incoming emails";
+        var result = Parser.Parse(frontmatter);
+        result["name"].ShouldBe("email-triage");
+        result["description"].ShouldBe("Triage incoming emails");
+    }
+
+    [Fact]
+    public void Parse_EmptyFrontmatter_ReturnsEmptyDictionary()
+    {
+        Parser.Parse("").ShouldBeEmpty();
+        Parser.Parse("   ").ShouldBeEmpty();
+    }
+
+    // ── Quoted strings ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_DoubleQuotedValue_UnquotesCorrectly()
+    {
+        var result = Parser.Parse("name: \"my skill\"");
+        result["name"].ShouldBe("my skill");
+    }
+
+    [Fact]
+    public void Parse_SingleQuotedValue_UnquotesCorrectly()
+    {
+        var result = Parser.Parse("name: 'my skill'");
+        result["name"].ShouldBe("my skill");
+    }
+
+    [Fact]
+    public void Parse_MixedQuoteStyles_HandledIndependently()
+    {
+        var frontmatter = "a: \"double\"\nb: 'single'\nc: plain";
+        var result = Parser.Parse(frontmatter);
+        result["a"].ShouldBe("double");
+        result["b"].ShouldBe("single");
+        result["c"].ShouldBe("plain");
+    }
+
+    // ── Block scalars ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_LiteralBlockScalar_PreservesNewlines()
+    {
+        var frontmatter = "description: |\n  Line one.\n  Line two.\n  Line three.";
+        var result = Parser.Parse(frontmatter);
+        result["description"].ShouldBe("Line one.\nLine two.\nLine three.");
+    }
+
+    [Fact]
+    public void Parse_FoldedBlockScalar_JoinsWithSpaces()
+    {
+        var frontmatter = "description: >\n  Line one.\n  Line two.\n  Line three.";
+        var result = Parser.Parse(frontmatter);
+        result["description"].ShouldBe("Line one. Line two. Line three.");
+    }
+
+    [Fact]
+    public void Parse_BlockScalar_FollowedByAnotherKey_BothExtracted()
+    {
+        var frontmatter = "description: |\n  Multi-line content.\n  Second line.\nlicense: MIT";
+        var result = Parser.Parse(frontmatter);
+        result["description"].ShouldBe("Multi-line content.\nSecond line.");
+        result["license"].ShouldBe("MIT");
+    }
+
+    [Fact]
+    public void Parse_BlockScalarAtEndOfFrontmatter_Flushed()
+    {
+        var frontmatter = "description: |\n  Only this.";
+        var result = Parser.Parse(frontmatter);
+        result["description"].ShouldBe("Only this.");
+    }
+
+    // ── Comments ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_CommentLines_AreIgnored()
+    {
+        var frontmatter = "# This is a comment\nname: my-skill\n# Another comment\nversion: 1";
+        var result = Parser.Parse(frontmatter);
+        result.ContainsKey("#").ShouldBeFalse();
+        result["name"].ShouldBe("my-skill");
+        result["version"].ShouldBe("1");
+    }
+
+    // ── Nested metadata (ParseNested) ─────────────────────────────────────────
+
+    [Fact]
+    public void ParseNested_ExtractsChildKeyValuePairs()
+    {
+        var frontmatter = "name: test\nmetadata:\n  author: jon\n  category: productivity\nother: val";
+        var result = Parser.ParseNested(frontmatter, "metadata");
+        result["author"].ShouldBe("jon");
+        result["category"].ShouldBe("productivity");
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ParseNested_MissingParentKey_ReturnsEmptyDictionary()
+    {
+        var frontmatter = "name: test\nauthor: jon";
+        Parser.ParseNested(frontmatter, "metadata").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseNested_QuotedChildValues_UnquotedCorrectly()
+    {
+        var frontmatter = "metadata:\n  author: \"jon bullen\"\n  tag: 'skills'";
+        var result = Parser.ParseNested(frontmatter, "metadata");
+        result["author"].ShouldBe("jon bullen");
+        result["tag"].ShouldBe("skills");
+    }
+
+    // ── Case-insensitivity ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_LookupIsCaseInsensitive()
+    {
+        var result = Parser.Parse("Name: my-skill\nDESCRIPTION: My tool");
+        result["name"].ShouldBe("my-skill");
+        result["description"].ShouldBe("My tool");
+    }
+
+    // ── Hyphenated keys ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_HyphenatedKeys_ExtractedCorrectly()
+    {
+        var result = Parser.Parse("allowed-tools: bash python\ndisable-model-invocation: true");
+        result["allowed-tools"].ShouldBe("bash python");
+        result["disable-model-invocation"].ShouldBe("true");
+    }
+
+    // ── Indented keys not at top level ────────────────────────────────────────
+
+    [Fact]
+    public void Parse_SkipsIndentedLines_NotTopLevelKeys()
+    {
+        var frontmatter = "name: test\nmetadata:\n  author: jon\nname2: other";
+        var result = Parser.Parse(frontmatter);
+        // 'author' is nested, should not appear at top level
+        result.ContainsKey("author").ShouldBeFalse();
+        result["name2"].ShouldBe("other");
+    }
+
+    // ── Null / argument guards ────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_NullFrontmatter_ThrowsArgumentNullException() =>
+        Should.Throw<ArgumentNullException>(() => Parser.Parse(null!));
+
+    [Fact]
+    public void ParseNested_NullFrontmatter_ThrowsArgumentNullException() =>
+        Should.Throw<ArgumentNullException>(() => Parser.ParseNested(null!, "metadata"));
+
+    [Fact]
+    public void ParseNested_NullParentKey_ThrowsArgumentException() =>
+        Should.Throw<ArgumentException>(() => Parser.ParseNested("name: x", null!));
+
+    // ── SkillParser integration ───────────────────────────────────────────────
+
+    [Fact]
+    public void SimpleYamlFrontmatterParser_Instance_IsNotNull()
+    {
+        SimpleYamlFrontmatterParser.Instance.ShouldNotBeNull();
+        SimpleYamlFrontmatterParser.Instance.ShouldBeOfType<SimpleYamlFrontmatterParser>();
+    }
+
+    [Fact]
+    public void Parser_ImplementsIYamlFrontmatterParser()
+    {
+        (SimpleYamlFrontmatterParser.Instance is IYamlFrontmatterParser).ShouldBeTrue();
+    }
+}

--- a/tests/gateway/BotNexus.Yaml.Tests/xunit.runner.json
+++ b/tests/gateway/BotNexus.Yaml.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0
+}


### PR DESCRIPTION
Closes #877

## Changes

### New project: BotNexus.Yaml (src/gateway/BotNexus.Yaml)
Zero dependencies -- pure C# platform library.

- IYamlFrontmatterParser -- interface with Parse(frontmatter) and ParseNested(frontmatter, parentKey)
- SimpleYamlFrontmatterParser -- handles the YAML subset used in skill files:
  - Plain scalars, double-quoted, single-quoted
  - Literal block scalar (newlines preserved) and folded block scalar (newlines to spaces)
  - Nested blocks (metadata:) via ParseNested
  - Comments (#) ignored
- SimpleYamlFrontmatterParser.Instance singleton for DI-free use

### Migrated: SkillParser
- Removed private ParseFrontmatter and ExtractMetadata static methods
- Delegates to IYamlFrontmatterParser.Parse() and ParseNested()
- YamlParser internal property allows test injection
- No behaviour change -- all 162 existing SkillParser tests pass

### New tests: BotNexus.Yaml.Tests (21 tests)
All value forms, block scalars, nested extraction, comment handling, case-insensitivity, hyphenated keys, null/empty guards.

## Tests
- Yaml.Tests: 21/21
- Extensions.Skills.Tests: 162/162 (no regression)
- Architecture: 167/167
- Scenarios: 29/29

## Merge Notes
Independent -- zero file overlap with any open PR. Safe to merge in any order.