### PR TITLE
feat(gateway): auto-generate conversation title from first user+assistant exchange

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -136,6 +136,12 @@ public sealed class GatewaySettingsConfig
     public AutoUpdateConfig? AutoUpdate { get; set; }
 
     /// <summary>
+    /// Auxiliary (cheap/fast) model configuration for background gateway tasks.
+    /// Currently used for: conversation title generation.
+    /// </summary>
+    public AuxiliaryConfig? Auxiliary { get; set; }
+
+    /// <summary>
     /// Server-wide default IANA timezone ID used when an agent has no Soul timezone configured.
     /// Falls back to UTC when null or invalid.
     /// Example: <c>"America/Los_Angeles"</c>.
@@ -582,4 +588,18 @@ public sealed class WorkspacePortalConfig
     /// Defaults to 524288 (512 KB). Set to 0 for no server-side limit.
     /// </summary>
     public int MaxReportFileSizeBytes { get; set; } = 512 * 1024;
+}
+
+/// <summary>
+/// Auxiliary (cheap/fast) model configuration for background gateway tasks.
+/// </summary>
+public sealed class AuxiliaryConfig
+{
+    /// <summary>
+    /// Model ID to use for auto-generating conversation titles after the first user+assistant
+    /// exchange. Supports any registered provider model ID (e.g. "gpt-4o-mini",
+    /// "claude-haiku-3-5", "gemini-2.0-flash-lite").
+    /// When null or empty the primary session model is used as fallback.
+    /// </summary>
+    public string? Titling { get; set; }
 }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -29,6 +29,8 @@ using BotNexus.Gateway.Streaming;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Gateway.Services;
 
 namespace BotNexus.Gateway;
 
@@ -60,6 +62,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
     private readonly IConversationStore? _conversationStore;
     private readonly DefaultInboundMessageOrchestrator _orchestrator;
     private readonly IOptions<PlatformConfig>? _platformConfig;
+    private readonly ConversationAutoTitleService? _autoTitleService;
 
     public GatewayHost(
         IAgentSupervisor supervisor,
@@ -80,7 +83,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         IAgentRegistry? registry = null,
         ISessionCompactionCoordinator? compactionCoordinator = null,
         IConversationStore? conversationStore = null,
-        IOptions<PlatformConfig>? platformConfig = null)
+        IOptions<PlatformConfig>? platformConfig = null,
+        LlmClient? llmClient = null,
+        IConversationChangeNotifier? conversationChangeNotifier = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -99,6 +104,15 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         _registry = registry;
         _conversationStore = conversationStore;
         _platformConfig = platformConfig;
+        // Wire up the auto-title service when the required dependencies are present.
+        if (llmClient is not null && conversationStore is not null)
+        {
+            _autoTitleService = new ConversationAutoTitleService(
+                conversationStore,
+                llmClient,
+                _logger,
+                conversationChangeNotifier);
+        }
         // The coordinator is the single source of truth for compaction (PR #602
         // followup). Tests that construct GatewayHost directly may not provide
         // one; build a fallback from the deps we already have so behaviour
@@ -662,6 +676,10 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                 // surface as turn failures.
                 await TouchConversationAsync(session.ConversationId, cancellationToken).ConfigureAwait(false);
 
+                // Auto-generate conversation title after the first user+assistant exchange
+                // if the title is still the default value (#739). Best-effort fire-and-forget.
+                TryTriggerAutoTitle(session, agentId);
+
                 await _activity.PublishAsync(new GatewayActivity
                 {
                     Type = GatewayActivityType.AgentCompleted,
@@ -1058,12 +1076,39 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         }
     }
 
+    /// <summary>
+    /// Fires auto-title generation if this is the first user+assistant exchange in the session
+    /// and the conversation title is still at its default value. No-op when auto-title is not
+    /// wired or the conversation is not initialised.
+    /// </summary>
+    private void TryTriggerAutoTitle(GatewaySession session, string agentIdValue)
+    {
+        if (_autoTitleService is null || !session.ConversationId.IsInitialized())
+            return;
+
+        // Only fire on the first exchange: exactly 1 user entry + at least 1 assistant entry.
+        var userEntries = session.History.Count(e => e.Role == MessageRole.User);
+        var assistantEntries = session.History.Count(e => e.Role == MessageRole.Assistant);
+        if (userEntries != 1 || assistantEntries < 1)
+            return;
+
+        var userText = session.History
+            .FirstOrDefault(e => e.Role == MessageRole.User)?.Content ?? string.Empty;
+        var assistantText = session.History
+            .LastOrDefault(e => e.Role == MessageRole.Assistant)?.Content ?? string.Empty;
+
+        var titlingModel = _platformConfig?.Value?.Gateway?.Auxiliary?.Titling;
+
+        _autoTitleService.TriggerBestEffort(
+            session.ConversationId,
+            Domain.Primitives.AgentId.From(agentIdValue),
+            userText,
+            assistantText,
+            titlingModel);
+    }
+
     private SessionType ResolveSessionType(GatewaySession session, InboundMessage message, bool isNewSession)
     {
-        // Phase 5 / F-6 step 2 (#554): sub-agent classification is driven by the
-        // typed AgentDescriptor.Kind signal sourced from IAgentRegistry rather than
-        // the legacy SessionId.IsSubAgent substring check. The substring path is
-        // deleted from this method — pinned by AgentKindArchitectureTests.
         var descriptor = _registry?.Get(session.AgentId);
         if (descriptor is { Kind: AgentKind.SubAgent })
             return SessionType.AgentSubAgent;

--- a/src/gateway/BotNexus.Gateway/Services/ConversationAutoTitleService.cs
+++ b/src/gateway/BotNexus.Gateway/Services/ConversationAutoTitleService.cs
@@ -1,0 +1,228 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Services;
+
+/// <summary>
+/// Generates a short descriptive title for a conversation after the first user+assistant
+/// exchange, if the title is still at the default value "New conversation".
+/// </summary>
+/// <remarks>
+/// This is a best-effort background service. Title generation failures are logged at
+/// Warning level and do not surface as turn failures.
+/// </remarks>
+public sealed class ConversationAutoTitleService
+{
+    /// <summary>The default title assigned to new conversations before a user-generated title exists.</summary>
+    public const string DefaultTitle = "New conversation";
+
+    private readonly IConversationStore _store;
+    private readonly IConversationChangeNotifier? _notifier;
+    private readonly LlmClient _llmClient;
+    private readonly ILogger _logger;
+
+    public ConversationAutoTitleService(
+        IConversationStore store,
+        LlmClient llmClient,
+        ILogger logger,
+        IConversationChangeNotifier? notifier = null)
+    {
+        _store = store;
+        _llmClient = llmClient;
+        _logger = logger;
+        _notifier = notifier;
+    }
+
+    /// <summary>
+    /// Attempts to auto-generate and persist a conversation title, best-effort.
+    /// The method returns immediately without waiting for the background work to complete.
+    /// </summary>
+    /// <param name="conversationId">Conversation to title.</param>
+    /// <param name="agentId">Agent that owns the conversation.</param>
+    /// <param name="userText">The first user message text.</param>
+    /// <param name="assistantText">The first assistant response text.</param>
+    /// <param name="preferredModelId">Optional model ID from auxiliary.titling config.</param>
+    public void TriggerBestEffort(
+        ConversationId conversationId,
+        AgentId agentId,
+        string userText,
+        string assistantText,
+        string? preferredModelId)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await GenerateAndSaveAsync(
+                    conversationId, agentId, userText, assistantText, preferredModelId,
+                    CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Auto-title generation failed for conversation '{ConversationId}' (best-effort, ignoring)",
+                    conversationId);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Generates and saves the conversation title. Returns the generated title, or null when
+    /// the conversation already has a custom title or the LLM returned an empty result.
+    /// </summary>
+    internal async Task<string?> GenerateAndSaveAsync(
+        ConversationId conversationId,
+        AgentId agentId,
+        string userText,
+        string assistantText,
+        string? preferredModelId,
+        CancellationToken ct)
+    {
+        // Load conversation and check that it still has the default title.
+        var conversation = await _store.GetAsync(conversationId, ct).ConfigureAwait(false);
+        if (conversation is null || !IsDefaultTitle(conversation.Title))
+            return null;
+
+        // Resolve model (preferred titling model, then any registered fallback).
+        LlmModel? model;
+        try
+        {
+            model = ResolveModel(preferredModelId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Auto-title: no model available for conversation '{ConversationId}'",
+                conversationId);
+            return null;
+        }
+
+        // Call LLM.
+        var prompt = BuildPrompt(userText, assistantText);
+        var context = new Context(
+            SystemPrompt: null,
+            Messages: [new UserMessage(new UserMessageContent(prompt), DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())]);
+
+        AssistantMessage completion;
+        try
+        {
+            completion = await _llmClient
+                .CompleteSimpleAsync(model, context)
+                .WaitAsync(TimeSpan.FromSeconds(30), ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Auto-title: LLM call failed for conversation '{ConversationId}'",
+                conversationId);
+            return null;
+        }
+
+        var rawTitle = string.Join(
+            " ",
+            completion.Content
+                .OfType<TextContent>()
+                .Select(t => t.Text)
+                .Where(t => !string.IsNullOrWhiteSpace(t)));
+
+        var title = SanitizeTitle(rawTitle);
+        if (string.IsNullOrWhiteSpace(title))
+            return null;
+
+        // Re-read and guard again in case another path already set a custom title.
+        conversation = await _store.GetAsync(conversationId, ct).ConfigureAwait(false);
+        if (conversation is null || !IsDefaultTitle(conversation.Title))
+            return null;
+
+        conversation.Title = title;
+        await _store.SaveAsync(conversation, ct).ConfigureAwait(false);
+
+        if (_notifier is not null)
+        {
+            try
+            {
+                await _notifier.NotifyConversationChangedAsync(
+                    "updated", agentId.Value, conversationId.Value, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Notification failure must not fail the title save.
+                _logger.LogWarning(
+                    ex,
+                    "Auto-title: SignalR notification failed for conversation '{ConversationId}'",
+                    conversationId);
+            }
+        }
+
+        _logger.LogInformation(
+            "Auto-title set to '{Title}' for conversation '{ConversationId}' (model {ModelId})",
+            title, conversationId, model.Id);
+
+        return title;
+    }
+
+    /// <summary>Returns true when the title is still at the default "New conversation" value.</summary>
+    public static bool IsDefaultTitle(string? title)
+        => string.IsNullOrWhiteSpace(title) ||
+           string.Equals(title, DefaultTitle, StringComparison.OrdinalIgnoreCase);
+
+    internal static string BuildPrompt(string userText, string assistantText)
+        => $"In 5 words or fewer, give a descriptive title for this conversation based on the " +
+           $"first user message and assistant response. Return only the title, no punctuation, " +
+           $"no quotes.\n\nUser: {userText}\n\nAssistant: {assistantText}";
+
+    internal static string SanitizeTitle(string raw)
+    {
+        var sanitised = raw
+            .Replace("\"", "")
+            .Replace("'", "")
+            .Trim();
+        // Limit to 80 chars defensively.
+        return sanitised.Length > 80 ? sanitised[..80].TrimEnd() : sanitised;
+    }
+
+    private LlmModel ResolveModel(string? preferredModelId)
+    {
+        if (!string.IsNullOrWhiteSpace(preferredModelId))
+        {
+            var preferred = FindModel(preferredModelId);
+            if (preferred is not null)
+                return preferred;
+
+            _logger.LogWarning(
+                "Auto-title: configured titling model '{ModelId}' not found; falling back to first available",
+                preferredModelId);
+        }
+
+        // Fall back to first available model.
+        var fallback = _llmClient.Models
+            .GetProviders()
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .SelectMany(p => _llmClient.Models.GetModels(p))
+            .FirstOrDefault();
+
+        return fallback
+               ?? throw new InvalidOperationException("No models are registered for auto-title generation.");
+    }
+
+    private LlmModel? FindModel(string modelId)
+    {
+        foreach (var provider in _llmClient.Models.GetProviders())
+        {
+            var m = _llmClient.Models.GetModels(provider)
+                .FirstOrDefault(candidate => string.Equals(candidate.Id, modelId, StringComparison.OrdinalIgnoreCase));
+            if (m is not null)
+                return m;
+        }
+        return null;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationAutoTitleServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationAutoTitleServiceTests.cs
@@ -1,0 +1,257 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class ConversationAutoTitleServiceTests
+{
+    private static readonly AgentId AgentId = Domain.Primitives.AgentId.From("agent-a");
+    private static readonly ConversationId ConvId = Domain.Primitives.ConversationId.From("conv-1");
+
+    // -----------------------------------------------------------------------
+    // Unit helpers for static methods
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void IsDefaultTitle_NullOrEmpty_ReturnsTrue()
+    {
+        ConversationAutoTitleService.IsDefaultTitle(null).ShouldBeTrue();
+        ConversationAutoTitleService.IsDefaultTitle("").ShouldBeTrue();
+        ConversationAutoTitleService.IsDefaultTitle("   ").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsDefaultTitle_DefaultValue_ReturnsTrue()
+    {
+        ConversationAutoTitleService.IsDefaultTitle("New conversation").ShouldBeTrue();
+        ConversationAutoTitleService.IsDefaultTitle("new conversation").ShouldBeTrue(); // case-insensitive
+    }
+
+    [Fact]
+    public void IsDefaultTitle_CustomTitle_ReturnsFalse()
+    {
+        ConversationAutoTitleService.IsDefaultTitle("My custom title").ShouldBeFalse();
+        ConversationAutoTitleService.IsDefaultTitle("Discussion about something").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void BuildPrompt_ContainsUserAndAssistantText()
+    {
+        var prompt = ConversationAutoTitleService.BuildPrompt("hello world", "hi there");
+
+        prompt.ShouldContain("hello world");
+        prompt.ShouldContain("hi there");
+        prompt.ShouldContain("5 words or fewer");
+    }
+
+    [Theory]
+    [InlineData("\"Hello World\"", "Hello World")]
+    [InlineData("'Chat About Cats'", "Chat About Cats")]
+    [InlineData("  Some Title  ", "Some Title")]
+    public void SanitizeTitle_RemovesQuotesAndTrims(string raw, string expected)
+    {
+        ConversationAutoTitleService.SanitizeTitle(raw).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void SanitizeTitle_LongTitle_TruncatesAt80()
+    {
+        var longTitle = new string('A', 100);
+        var result = ConversationAutoTitleService.SanitizeTitle(longTitle);
+        result.Length.ShouldBeLessThanOrEqualTo(80);
+    }
+
+    // -----------------------------------------------------------------------
+    // GenerateAndSaveAsync -- integration tests with mocks
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_CustomTitle_SkipsGeneration()
+    {
+        var store = new Mock<IConversationStore>();
+        var conv = new Conversation
+        {
+            ConversationId = ConvId,
+            AgentId = AgentId,
+            Title = "My Custom Title"
+        };
+        store.Setup(s => s.GetAsync(ConvId, It.IsAny<CancellationToken>())).ReturnsAsync(conv);
+
+        var svc = new ConversationAutoTitleService(
+            store.Object,
+            CreateFakeLlmClient("Generated Title"),
+            NullLogger.Instance);
+
+        var result = await svc.GenerateAndSaveAsync(
+            ConvId, AgentId, "user text", "assistant text", null, CancellationToken.None);
+
+        result.ShouldBeNull();
+        store.Verify(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_NullConversation_ReturnsNull()
+    {
+        var store = new Mock<IConversationStore>();
+        store.Setup(s => s.GetAsync(ConvId, It.IsAny<CancellationToken>())).ReturnsAsync((Conversation?)null);
+
+        var svc = new ConversationAutoTitleService(
+            store.Object,
+            CreateFakeLlmClient("Generated Title"),
+            NullLogger.Instance);
+
+        var result = await svc.GenerateAndSaveAsync(
+            ConvId, AgentId, "user", "assistant", null, CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_DefaultTitle_GeneratesAndSaves()
+    {
+        var conv = new Conversation
+        {
+            ConversationId = ConvId,
+            AgentId = AgentId,
+            Title = ConversationAutoTitleService.DefaultTitle
+        };
+        var store = new Mock<IConversationStore>();
+        // Return same conversation on both GetAsync calls.
+        store.Setup(s => s.GetAsync(ConvId, It.IsAny<CancellationToken>())).ReturnsAsync(conv);
+        store.Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var svc = new ConversationAutoTitleService(
+            store.Object,
+            CreateFakeLlmClient("Chat About Cats"),
+            NullLogger.Instance);
+
+        var result = await svc.GenerateAndSaveAsync(
+            ConvId, AgentId, "What do cats eat?", "Cats eat...", null, CancellationToken.None);
+
+        result.ShouldNotBeNull();
+        result.ShouldBe("Chat About Cats");
+        store.Verify(s => s.SaveAsync(It.Is<Conversation>(c => c.Title == "Chat About Cats"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_PushesSignalRNotification()
+    {
+        var conv = new Conversation
+        {
+            ConversationId = ConvId,
+            AgentId = AgentId,
+            Title = ConversationAutoTitleService.DefaultTitle
+        };
+        var store = new Mock<IConversationStore>();
+        store.Setup(s => s.GetAsync(ConvId, It.IsAny<CancellationToken>())).ReturnsAsync(conv);
+        store.Setup(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var notifier = new Mock<IConversationChangeNotifier>();
+        notifier.Setup(n => n.NotifyConversationChangedAsync("updated", AgentId.Value, ConvId.Value, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var svc = new ConversationAutoTitleService(
+            store.Object,
+            CreateFakeLlmClient("Notification Test"),
+            NullLogger.Instance,
+            notifier.Object);
+
+        await svc.GenerateAndSaveAsync(ConvId, AgentId, "user", "assistant", null, CancellationToken.None);
+
+        notifier.Verify(n => n.NotifyConversationChangedAsync("updated", AgentId.Value, ConvId.Value,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_TitleChangedBeforeSecondRead_SkipsSave()
+    {
+        // First read: default title. Second read (guard): custom title already set by another path.
+        var conv1 = new Conversation { ConversationId = ConvId, AgentId = AgentId, Title = ConversationAutoTitleService.DefaultTitle };
+        var conv2 = new Conversation { ConversationId = ConvId, AgentId = AgentId, Title = "Already Set" };
+
+        var call = 0;
+        var store = new Mock<IConversationStore>();
+        store.Setup(s => s.GetAsync(ConvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++call == 1 ? conv1 : conv2);
+
+        var svc = new ConversationAutoTitleService(
+            store.Object,
+            CreateFakeLlmClient("Race Condition Title"),
+            NullLogger.Instance);
+
+        var result = await svc.GenerateAndSaveAsync(ConvId, AgentId, "user", "assistant", null, CancellationToken.None);
+
+        result.ShouldBeNull();
+        store.Verify(s => s.SaveAsync(It.IsAny<Conversation>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates a minimal LlmClient backed by a fake provider that returns the given title text.
+    /// </summary>
+    private static LlmClient CreateFakeLlmClient(string responseText)
+    {
+        var modelRegistry = new ModelRegistry();
+        var fakeModel = new LlmModel(
+            Id: "fake-model",
+            Name: "fake-model",
+            Api: "fake-api",
+            Provider: "fake",
+            BaseUrl: "https://fake.example.com",
+            Reasoning: false,
+            Input: ["text"],
+            Cost: new ModelCost(0, 0, 0, 0),
+            ContextWindow: 4096,
+            MaxTokens: 512);
+
+        modelRegistry.Register("fake", fakeModel);
+
+        var providerRegistry = new ApiProviderRegistry();
+        providerRegistry.Register(new FakeApiProvider(responseText));
+
+        return new LlmClient(providerRegistry, modelRegistry);
+    }
+
+    private sealed class FakeApiProvider : IApiProvider
+    {
+        private readonly string _responseText;
+
+        public FakeApiProvider(string responseText) => _responseText = responseText;
+
+        public string Api => "fake-api";
+
+        public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+        {
+            throw new NotImplementedException("FakeApiProvider only supports StreamSimple/CompleteSimple");
+        }
+
+        public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+        {
+            var msg = new AssistantMessage(
+                Content: [new TextContent(_responseText)],
+                Api: "fake-api",
+                Provider: "fake",
+                ModelId: "fake-model",
+                Usage: new Usage(),
+                StopReason: StopReason.Stop,
+                ErrorMessage: null,
+                ResponseId: null,
+                Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            var stream = new LlmStream();
+            stream.Push(new DoneEvent(StopReason.Stop, msg));
+            return stream;
+        }
+    }
+}


### PR DESCRIPTION
Closes #739

## Changes

### PlatformConfig.cs
- Added `AuxiliaryConfig` class with `Titling` property (model ID string)
- Added `GatewaySettingsConfig.Auxiliary` property to configure cheap models for background tasks

### ConversationAutoTitleService.cs (new)
- `ConversationAutoTitleService` in `BotNexus.Gateway.Services` namespace
- `IsDefaultTitle(string?)` -- checks if title is still "New conversation" (static, testable)
- `BuildPrompt(userText, assistantText)` -- builds 5-word title prompt (static, testable)
- `SanitizeTitle(raw)` -- removes quotes, trims, caps at 80 chars (static, testable)
- `GenerateAndSaveAsync(...)` -- loads conversation, checks default title, calls LLM, re-checks, saves, notifies
- `TriggerBestEffort(...)` -- fire-and-forget wrapper; failures logged at Warning and swallowed
- `ResolveModel(preferredModelId?)` -- uses gateway.auxiliary.titling if configured, falls back to first registered model

### GatewayHost.cs
- Added optional `LlmClient? llmClient` and `IConversationChangeNotifier? conversationChangeNotifier` constructor params (backwards-compatible, no test breakage)
- `ConversationAutoTitleService` wired when both deps are present
- `TryTriggerAutoTitle(session, agentId)` -- called after TouchConversationAsync; fires only when History has exactly 1 user entry + at least 1 assistant entry

### ConversationAutoTitleServiceTests.cs (new)
13 new tests: IsDefaultTitle (null/default/custom), BuildPrompt contains user+assistant text, SanitizeTitle removes quotes and truncates, GenerateAndSaveAsync skips on custom title, skips on null conversation, saves when default, notifies SignalR, skips on race condition (title changed between reads).

## Tests
- Gateway.Tests: 2177/2178 pass (13 new, 1 expected skip)
- Architecture.Tests: 167/167 pass
- All impacted tests passing

## Config
Operators can set a cheap titling model via:
```json
{
  "gateway": {
    "auxiliary": {
      "titling": "gpt-4o-mini"
    }
  }
}
```

## Merge Notes
Independent -- no file overlap with any open PR. Safe to merge in any order.
