### PR TITLE
feat(skills): add slash commands for skill create and delete

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/SkillsCommandContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillsCommandContributor.cs
@@ -34,7 +34,23 @@ public sealed class SkillsCommandContributor : ICommandContributor
                     Description = "Unload a skill from this session.",
                     Arguments = [new CommandArgumentDescriptor { Name = "name", Description = "Skill name.", Required = true }]
                 },
-                new SubCommandDescriptor { Name = "reload", Description = "Re-discover skills from disk." }
+                new SubCommandDescriptor { Name = "reload", Description = "Re-discover skills from disk." },
+                new SubCommandDescriptor
+                {
+                    Name = "create",
+                    Description = "Create a new skill (requires AllowSkillCreation = true).",
+                    Arguments = [new CommandArgumentDescriptor { Name = "name", Description = "Skill name (lowercase, hyphens only).", Required = true }]
+                },
+                new SubCommandDescriptor
+                {
+                    Name = "delete",
+                    Description = "Delete an existing skill (requires AllowSkillDeletion = true). Pass --confirm to execute.",
+                    Arguments =
+                    [
+                        new CommandArgumentDescriptor { Name = "name", Description = "Skill name.", Required = true },
+                        new CommandArgumentDescriptor { Name = "--confirm", Description = "Confirm deletion (required).", Required = false }
+                    ]
+                }
             ]
         }
     ];
@@ -55,18 +71,126 @@ public sealed class SkillsCommandContributor : ICommandContributor
             return Error("Command Not Found", $"Unknown skills command: {commandName}");
         }
 
+        var subCommand = (context.SubCommand ?? "list").ToLowerInvariant();
+
+        // create and delete route through SkillManagerTool, not SkillTool
+        if (subCommand is "create" or "delete")
+            return await ExecuteWriteCommandAsync(subCommand, context, cancellationToken).ConfigureAwait(false);
+
         if (!TryResolveTool(context, out var skillTool, out var errorResult))
             return errorResult!;
 
         var resolvedTool = skillTool;
-        return (context.SubCommand ?? "list").ToLowerInvariant() switch
+        return subCommand switch
         {
             "list" => BuildListResult(resolvedTool, context.AgentId),
             "info" => BuildInfoResult(resolvedTool, context.Arguments),
             "add" => await AddSkillAsync(resolvedTool, context.Arguments, cancellationToken).ConfigureAwait(false),
             "remove" => RemoveSkill(resolvedTool, context.Arguments),
             "reload" => ReloadSkills(resolvedTool),
-            _ => Error("Invalid Sub-command", "Usage: /skills [list|info <name>|add <name>|remove <name>|reload]")
+            _ => Error("Invalid Sub-command", "Usage: /skills [list|info <name>|add <name>|remove <name>|reload|create <name>|delete <name> --confirm]")
+        };
+    }
+
+    // ── create / delete (SkillManagerTool path) ────────────────────────────
+
+    private static async Task<CommandResult> ExecuteWriteCommandAsync(
+        string subCommand,
+        CommandExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (context.ResolveSessionTool is null)
+            return Error("Skills Unavailable", "No active session tool resolver. Open an agent session and try again.");
+
+        var managerTool = context.ResolveSessionTool("skill_manage") as SkillManagerTool;
+
+        if (subCommand == "create")
+            return await ExecuteCreateAsync(managerTool, context.Arguments, cancellationToken).ConfigureAwait(false);
+
+        return await ExecuteDeleteAsync(managerTool, context.Arguments, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task<CommandResult> ExecuteCreateAsync(
+        SkillManagerTool? managerTool,
+        IReadOnlyList<string> args,
+        CancellationToken cancellationToken)
+    {
+        if (managerTool is null)
+        {
+            return Task.FromResult(Error(
+                "Skill Creation Disabled",
+                "Skill creation is not enabled for this agent. Set AllowSkillCreation = true in the agent's botnexus-skills extension config to enable it."));
+        }
+
+        var skillName = args.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(skillName))
+            return Task.FromResult(Error("Missing Argument", "Usage: /skills create <name>"));
+
+        // Prompt the agent to supply the SKILL.md content via skill_manage tool call
+        return Task.FromResult(new CommandResult
+        {
+            Title = $"Create Skill: {skillName}",
+            Body = $"""
+                    To create skill '{skillName}', call the skill_manage tool with:
+                      action: "create"
+                      name: "{skillName}"
+                      content: "<full SKILL.md content including YAML frontmatter>"
+
+                    The SKILL.md must include at minimum:
+                      ---
+                      name: {skillName}
+                      description: <short description>
+                      ---
+
+                      <skill body>
+
+                    The skill will be validated and security-scanned before being written.
+                    """,
+            IsError = false
+        });
+    }
+
+    private static async Task<CommandResult> ExecuteDeleteAsync(
+        SkillManagerTool? managerTool,
+        IReadOnlyList<string> args,
+        CancellationToken cancellationToken)
+    {
+        if (managerTool is null)
+        {
+            return Error(
+                "Skill Deletion Disabled",
+                "Skill deletion is not enabled for this agent. Set AllowSkillDeletion = true in the agent's botnexus-skills extension config to enable it.");
+        }
+
+        var skillName = args.FirstOrDefault(a => !a.StartsWith("--", StringComparison.Ordinal));
+        if (string.IsNullOrWhiteSpace(skillName))
+            return Error("Missing Argument", "Usage: /skills delete <name> [--confirm]");
+
+        var confirmed = args.Any(a => string.Equals(a, "--confirm", StringComparison.OrdinalIgnoreCase));
+        if (!confirmed)
+        {
+            return new CommandResult
+            {
+                Title = $"Confirm Delete: {skillName}",
+                Body = $"Are you sure you want to permanently delete skill '{skillName}'? This cannot be undone.\nRun: /skills delete {skillName} --confirm",
+                IsError = false
+            };
+        }
+
+        var toolArgs = new Dictionary<string, object?> { ["action"] = "delete", ["name"] = skillName };
+        var toolResult = await managerTool.ExecuteAsync(
+            toolCallId: "skills-command-delete",
+            arguments: toolArgs,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var content = toolResult.Content?.FirstOrDefault()?.Value ?? string.Empty;
+        var isError = content.StartsWith("Error: ", StringComparison.Ordinal);
+
+        return new CommandResult
+        {
+            Title = isError ? "Delete Failed" : $"Skill Deleted: {skillName}",
+            Body = content,
+            IsError = isError
         };
     }
 

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillsCommandContributorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillsCommandContributorTests.cs
@@ -16,7 +16,7 @@ public sealed class SkillsCommandContributorTests
 
         var command = contributor.GetCommands().Single(value => value.Name == "/skills");
 
-        command.SubCommands!.Select(value => value.Name).ShouldBe(new[] { "list", "info", "add", "remove", "reload" });
+        command.SubCommands!.Select(value => value.Name).ShouldBe(new[] { "list", "info", "add", "remove", "reload", "create", "delete" });
     }
 
     [Fact]
@@ -256,5 +256,169 @@ public sealed class SkillsCommandContributorTests
         if (skillName is not null)
             dict["skillName"] = skillName;
         return dict;
+    }
+
+    // ── create / delete tests ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_WhenManagerToolNotAvailable_ReturnsDisabledError()
+    {
+        var contributor = CreateContributor();
+        // No skill_manage tool registered
+        var context = new CommandExecutionContext
+        {
+            RawInput = "/skills create my-skill",
+            SubCommand = "create",
+            Arguments = ["my-skill"],
+            AgentId = "test-agent",
+            SessionId = "session-1",
+            HomeDirectory = @"Q:\repos\botnexus",
+            ResolveSessionTool = _ => null
+        };
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeTrue();
+        result.Body.ShouldContain("AllowSkillCreation");
+    }
+
+    [Fact]
+    public async Task Create_MissingName_ReturnsError()
+    {
+        var (contributor, _, managerTool) = CreateContributorWithBothTools();
+        var context = BuildWriteContext("create", [], managerTool);
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeTrue();
+        result.Body.ShouldContain("name");
+    }
+
+    [Fact]
+    public async Task Create_WithName_ReturnsInstructionMessage()
+    {
+        var (contributor, _, managerTool) = CreateContributorWithBothTools();
+        var context = BuildWriteContext("create", ["my-skill"], managerTool);
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeFalse();
+        result.Body.ShouldContain("my-skill");
+        result.Body.ShouldContain("skill_manage");
+    }
+
+    [Fact]
+    public async Task Delete_WhenManagerToolNotAvailable_ReturnsDisabledError()
+    {
+        var contributor = CreateContributor();
+        var context = new CommandExecutionContext
+        {
+            RawInput = "/skills delete my-skill --confirm",
+            SubCommand = "delete",
+            Arguments = ["my-skill", "--confirm"],
+            AgentId = "test-agent",
+            SessionId = "session-1",
+            HomeDirectory = @"Q:\repos\botnexus",
+            ResolveSessionTool = _ => null
+        };
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeTrue();
+        result.Body.ShouldContain("AllowSkillDeletion");
+    }
+
+    [Fact]
+    public async Task Delete_MissingName_ReturnsError()
+    {
+        var (contributor, _, managerTool) = CreateContributorWithBothTools();
+        var context = BuildWriteContext("delete", [], managerTool);
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Delete_WithoutConfirm_ReturnsConfirmationPrompt()
+    {
+        var (contributor, _, managerTool) = CreateContributorWithBothTools();
+        var context = BuildWriteContext("delete", ["my-skill"], managerTool);
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeFalse();
+        result.Body.ShouldContain("--confirm");
+    }
+
+    [Fact]
+    public async Task Delete_WithConfirm_AndSkillExists_ExecutesDelete()
+    {
+        // Arrange: create a real skill directory in a mock filesystem
+        var fs = new System.IO.Abstractions.TestingHelpers.MockFileSystem();
+        const string agentSkillsDir = @"C:\agent-skills";
+        const string skillName = "test-skill";
+        var skillDir = Path.Combine(agentSkillsDir, skillName);
+        fs.AddDirectory(skillDir);
+        fs.AddFile(Path.Combine(skillDir, "SKILL.md"), new System.IO.Abstractions.TestingHelpers.MockFileData("""
+            ---
+            name: test-skill
+            description: A test skill
+            ---
+            Body.
+            """));
+
+        var config = new SkillsConfig { AllowSkillCreation = true, AllowSkillDeletion = true };
+        var managerTool = new SkillManagerTool(agentSkillsDir, null, config, fs);
+        var contributor = CreateContributor();
+        var context = BuildWriteContext("delete", [skillName, "--confirm"], managerTool);
+
+        var result = await contributor.ExecuteAsync("/skills", context, CancellationToken.None);
+
+        result.IsError.ShouldBeFalse();
+        result.Title.ShouldContain(skillName);
+        fs.Directory.Exists(skillDir).ShouldBeFalse();
+    }
+
+    private static (ICommandContributor Contributor, SkillTool SkillTool, SkillManagerTool ManagerTool) CreateContributorWithBothTools()
+    {
+        var skills = new[]
+        {
+            MakeSkill("loaded-skill"),
+            MakeSkill("available-skill"),
+            MakeSkill("denied-skill")
+        };
+        var config = new SkillsConfig
+        {
+            AutoLoad = ["loaded-skill"],
+            Disabled = ["denied-skill"],
+            MaxLoadedSkills = 20,
+            MaxSkillContentChars = 100_000,
+            AllowSkillCreation = true,
+            AllowSkillDeletion = true
+        };
+        var skillTool = new SkillTool(skills, config);
+        var managerTool = new SkillManagerTool(null, null, config);
+
+        return (CreateContributor(), skillTool, managerTool);
+    }
+
+    private static CommandExecutionContext BuildWriteContext(
+        string subCommand,
+        string[] arguments,
+        SkillManagerTool managerTool)
+    {
+        return new CommandExecutionContext
+        {
+            RawInput = $"/skills {subCommand} {string.Join(" ", arguments)}".Trim(),
+            SubCommand = subCommand,
+            Arguments = arguments,
+            AgentId = "test-agent",
+            SessionId = "session-1",
+            HomeDirectory = @"Q:\repos\botnexus",
+            ResolveSessionTool = name => string.Equals(name, "skill_manage", StringComparison.OrdinalIgnoreCase)
+                ? managerTool
+                : null
+        };
     }
 }


### PR DESCRIPTION
Adds `/skills create <name>` and `/skills delete <name> [--confirm]` sub-commands to SkillsCommandContributor.

## Changes
- **`/skills create <name>`**: when `skill_manage` tool is contributed (AllowSkillCreation = true), returns structured instructions prompting the agent to call `skill_manage` with action=create. Returns a gate-disabled error otherwise.
- **`/skills delete <name> [--confirm]`**: when `skill_manage` is contributed (AllowSkillDeletion = true), shows a confirmation prompt; with `--confirm` delegates to `SkillManagerTool.delete` and surfaces the result. Returns a gate-disabled error otherwise.
- `GetCommands` descriptor updated to include `create` and `delete` sub-commands.
- 7 new unit tests covering all paths (gate-disabled, missing-name, instruction message, confirmation prompt, actual delete with MockFileSystem).

Closes #710

## Merge Notes
Independent PR — zero file overlap with any current open PRs. Safe to merge in any order.
