### PR TITLE
fix(gateway): inject CONTEXT COMPACTION guardrail prefix before compaction summary and update structured template to 5-section spec

### DIFF
--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -125,7 +125,7 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         var compactionEntry = new SessionEntry
         {
             Role = MessageRole.System,
-            Content = summary,
+            Content = SummaryPrefix + "\n" + summary,
             IsCompactionSummary = true,
             Timestamp = DateTimeOffset.UtcNow
         };
@@ -226,16 +226,31 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         return (toSummarize, toPreserve);
     }
 
+    /// <summary>
+    /// Guardrail prefix injected before every compaction summary in conversation history.
+    /// Prevents the agent from resuming stale tasks after a context window handoff.
+    /// </summary>
+    internal const string SummaryPrefix =
+        "[CONTEXT COMPACTION -- REFERENCE ONLY] Earlier turns were compacted into the summary below.\n" +
+        "This is a handoff from a previous context window -- treat it as background reference, NOT as active instructions.\n" +
+        "Do NOT answer questions or fulfill requests mentioned in this summary; they were already addressed.\n" +
+        "Respond ONLY to the latest user message that appears AFTER this summary -- that is the single source of truth.\n" +
+        "If the latest user message contradicts, supersedes, or diverges from Active Task / In Progress / Remaining Work,\n" +
+        "the latest message WINS -- discard stale items entirely.\n" +
+        "Reverse signals (stop, undo, roll back, never mind, new topic) must immediately end any in-flight work described in the summary.\n" +
+        "IMPORTANT: Persistent memory (MEMORY.md, USER.md) in the system prompt is ALWAYS authoritative.";
+
     private static string BuildSummarizationPrompt(List<SessionEntry> entries, int maxChars)
     {
         var builder = new StringBuilder();
         builder.AppendLine("Summarize the following conversation history. Preserve critical information in a structured format.");
         builder.AppendLine();
         builder.AppendLine("Required sections:");
-        builder.AppendLine("## Decisions - Key decisions made");
-        builder.AppendLine("## Open TODOs - Incomplete tasks and follow-ups");
-        builder.AppendLine("## Constraints - Rules or constraints established");
-        builder.AppendLine("## Key Identifiers - File paths, UUIDs, URLs, hashes that must be preserved exactly");
+        builder.AppendLine("## Resolved -- completed tasks, decisions made");
+        builder.AppendLine("## Active Task -- what was being worked on at compaction time");
+        builder.AppendLine("## In Progress -- tool calls / sub-tasks mid-flight");
+        builder.AppendLine("## Pending User Asks -- questions waiting for user response");
+        builder.AppendLine("## Remaining Work -- planned but not started");
         builder.AppendLine();
         builder.AppendLine($"Keep the summary under {maxChars} characters.");
         builder.AppendLine();

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SessionCompactionIntegrationTests.cs
@@ -215,8 +215,11 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         session.ReplaceHistory(result.CompactedHistory!);
 
         // Phase 3a (#531): summarised entries preserved as historical; summary at boundary; preserved tail after.
-        session.GetHistorySnapshot().Select(entry => entry.Content)
-            .ShouldBe(new[] { "u1", "a1", "tool-summary", "u2", "a2", "tool-call", "tool-result" }, ignoreOrder: false);
+        var toolSnapshot = session.GetHistorySnapshot();
+        toolSnapshot.Select(e => e.Content).Take(2).ShouldBe(new[] { "u1", "a1" });
+        toolSnapshot[2].IsCompactionSummary.ShouldBeTrue();
+        toolSnapshot[2].Content.ShouldContain("tool-summary");
+        toolSnapshot.Select(e => e.Content).Skip(3).ShouldBe(new[] { "u2", "a2", "tool-call", "tool-result" }, ignoreOrder: false);
     }
 
     [Fact]
@@ -246,8 +249,11 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
         session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "a3" });
 
         // Phase 3a (#531): full transcript including newly-historical entries remains coherent.
-        session.GetHistorySnapshot().Select(entry => entry.Content)
-            .ShouldBe(new[] { "u1", "a1", "coherent-summary", "u2", "a2", "u3", "a3" }, ignoreOrder: false);
+        var coherentSnap = session.GetHistorySnapshot();
+        coherentSnap.Select(e => e.Content).Take(2).ShouldBe(new[] { "u1", "a1" });
+        coherentSnap[2].IsCompactionSummary.ShouldBeTrue();
+        coherentSnap[2].Content.ShouldContain("coherent-summary");
+        coherentSnap.Select(e => e.Content).Skip(3).ShouldBe(new[] { "u2", "a2", "u3", "a3" }, ignoreOrder: false);
     }
 
     [Fact]
@@ -312,9 +318,9 @@ public sealed class SessionCompactionIntegrationTests : IDisposable
                 $"original turn '{content}' must survive across compaction cycles");
 
         // Two summaries on disk; older one is historical.
-        snapshot.Single(e => e.Content == "summary-c1").IsHistory.ShouldBeTrue();
-        snapshot.Single(e => e.Content == "summary-c2").IsHistory.ShouldBeFalse();
-        snapshot.Single(e => e.Content == "summary-c2").IsCompactionSummary.ShouldBeTrue();
+        snapshot.Single(e => e.IsCompactionSummary && e.Content.Contains("summary-c1")).IsHistory.ShouldBeTrue();
+        snapshot.Single(e => e.IsCompactionSummary && e.Content.Contains("summary-c2")).IsHistory.ShouldBeFalse();
+        snapshot.Single(e => e.IsCompactionSummary && e.Content.Contains("summary-c2")).IsCompactionSummary.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorRaceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorRaceTests.cs
@@ -65,7 +65,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Applied);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "summary-1", "u2"], ignoreOrder: false);
     }
@@ -93,7 +93,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Rebased);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "summary-1", "u2", "raced-in"], ignoreOrder: false);
     }
@@ -117,7 +117,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Rebased);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "summary-1", "u2", "r1", "r2", "r3"], ignoreOrder: false);
     }
@@ -143,7 +143,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Rebased);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "summary-1", "u2", "batch-1", "batch-2"], ignoreOrder: false);
     }
@@ -189,7 +189,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Aborted);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "u2"], ignoreOrder: false);
         session.GetHistorySnapshot().ShouldNotContain(e => e.IsCrashSentinel);
@@ -216,7 +216,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Applied);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "summary-1", "u2"], ignoreOrder: false);
     }
@@ -248,7 +248,7 @@ public sealed class LlmSessionCompactorRaceTests
         outcome.ShouldBe(HistoryReplaceOutcome.Aborted);
 
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["restored-1", "restored-2"], ignoreOrder: false);
     }
@@ -284,7 +284,7 @@ public sealed class LlmSessionCompactorRaceTests
 
         // First compaction wins; second is stale and discarded.
         session.GetHistorySnapshot()
-            .Select(e => e.Content)
+            .Select(e => e.IsCompactionSummary ? e.Content.Replace(LlmSessionCompactor.SummaryPrefix + "\n", "") : e.Content)
             .ToList()
             .ShouldBe(["u1", "a1", "summary-A", "u2"], ignoreOrder: false);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -72,10 +72,14 @@ public sealed class LlmSessionCompactorTests
 
         // Phase 3a (#531): summarised entries are kept in the session store with IsHistory=true,
         // the summary entry sits at the boundary, then the preserved tail follows.
-        session.GetHistorySnapshot().Select(entry => entry.Content).ToList().ShouldBe(
-            new[] { "u1", "a1", "t1", "summary-u1", "u2", "a2", "t2", "u3", "a3" }, ignoreOrder: false);
-        session.GetHistorySnapshot().Take(3).ShouldAllBe(e => e.IsHistory);
-        session.GetHistorySnapshot().Skip(3).ShouldAllBe(e => !e.IsHistory);
+        // The summary content is the guardrail prefix + raw LLM summary (#669).
+        var snapshot = session.GetHistorySnapshot();
+        snapshot.Select(e => e.Content).Take(3).ShouldBe(new[] { "u1", "a1", "t1" });
+        snapshot[3].Content.ShouldStartWith(LlmSessionCompactor.SummaryPrefix);
+        snapshot[3].Content.ShouldContain("summary-u1");
+        snapshot.Select(e => e.Content).Skip(4).ShouldBe(new[] { "u2", "a2", "t2", "u3", "a3" });
+        snapshot.Take(3).ShouldAllBe(e => e.IsHistory);
+        snapshot.Skip(3).ShouldAllBe(e => !e.IsHistory);
     }
 
     [Fact]
@@ -101,12 +105,15 @@ public sealed class LlmSessionCompactorTests
 
         session.ReplaceHistory(result.CompactedHistory!);
 
-        session.GetHistorySnapshot().Select(entry => entry.Content)
-            .ToList().ShouldBe(new[] { "older", "older-response", "structured summary", "recent", "recent-response" }, ignoreOrder: false);
-        session.GetHistorySnapshot()[0].IsHistory.ShouldBeTrue();
-        session.GetHistorySnapshot()[1].IsHistory.ShouldBeTrue();
-        session.GetHistorySnapshot()[2].IsCompactionSummary.ShouldBeTrue();
-        session.GetHistorySnapshot()[2].IsHistory.ShouldBeFalse();
+        var snap2 = session.GetHistorySnapshot();
+        snap2.Select(e => e.Content).Take(2).ShouldBe(new[] { "older", "older-response" });
+        snap2[2].Content.ShouldStartWith(LlmSessionCompactor.SummaryPrefix);
+        snap2[2].Content.ShouldContain("structured summary");
+        snap2.Select(e => e.Content).Skip(3).ShouldBe(new[] { "recent", "recent-response" });
+        snap2[0].IsHistory.ShouldBeTrue();
+        snap2[1].IsHistory.ShouldBeTrue();
+        snap2[2].IsCompactionSummary.ShouldBeTrue();
+        snap2[2].IsHistory.ShouldBeFalse();
     }
 
     [Fact]
@@ -174,7 +181,8 @@ public sealed class LlmSessionCompactorTests
         summaryEntry.Role.ShouldBe(MessageRole.System);
         summaryEntry.IsCompactionSummary.ShouldBeTrue();
         summaryEntry.IsHistory.ShouldBeFalse();
-        summaryEntry.Content.ShouldBe("compacted");
+        summaryEntry.Content.ShouldStartWith(LlmSessionCompactor.SummaryPrefix);
+        summaryEntry.Content.ShouldContain("compacted");
     }
 
     [Fact]
@@ -198,7 +206,11 @@ public sealed class LlmSessionCompactorTests
         result.Summary.Length.ShouldBe(40);
 
         session.ReplaceHistory(result.CompactedHistory!);
-        session.GetHistorySnapshot().Single(e => e.IsCompactionSummary).Content.Length.ShouldBe(40);
+        var compactEntry = session.GetHistorySnapshot().Single(e => e.IsCompactionSummary);
+        // The prefix is prepended; raw LLM summary is capped at MaxSummaryChars (#669).
+        compactEntry.Content.ShouldStartWith(LlmSessionCompactor.SummaryPrefix);
+        compactEntry.Content.ShouldContain(new string('x', 40));
+        compactEntry.Content.Length.ShouldBeGreaterThan(40);
     }
 
     /// <summary>
@@ -434,8 +446,8 @@ public sealed class LlmSessionCompactorTests
         session.ReplaceHistory(result2.CompactedHistory!);
 
         var snapshot = session.GetHistorySnapshot();
-        snapshot.Where(e => e.Content == "summary-1").Single().IsHistory.ShouldBeTrue();
-        snapshot.Where(e => e.Content == "summary-2").Single().IsHistory.ShouldBeFalse();
+        snapshot.Where(e => e.IsCompactionSummary && e.Content.Contains("summary-1")).Single().IsHistory.ShouldBeTrue();
+        snapshot.Where(e => e.IsCompactionSummary && e.Content.Contains("summary-2")).Single().IsHistory.ShouldBeFalse();
         // u1/a1/u2/a2 all preserved
         snapshot.Select(e => e.Content).ShouldContain("u1");
         snapshot.Select(e => e.Content).ShouldContain("a1");
@@ -640,6 +652,96 @@ public sealed class LlmSessionCompactorTests
             capturedPrompt2.Contains("new-u4") ||
             capturedPrompt2.Contains("new-a4");
         promptContainsNewTurns.ShouldBeTrue("new post-compaction turns must be included in cycle-2 prompt or preserved");
+    }
+
+    // ─── Issue #669: compaction guardrail prefix + structured template ────────
+
+    /// <summary>Compaction summary entry must start with the guardrail prefix to prevent
+    /// the agent from resuming stale tasks after a context window handoff.</summary>
+    [Fact]
+    public async Task CompactAsync_SummaryEntry_BeginsWithGuardrailPrefix()
+    {
+        var session = CreateSession(
+            ("user", "do something"),
+            ("assistant", "done"),
+            ("user", "keep me"));
+        var compactor = CreateCompactor("raw-llm-output");
+
+        var result = await compactor.CompactAsync(session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeTrue();
+        var summaryEntry = result.CompactedHistory!.Single(e => e.IsCompactionSummary);
+        summaryEntry.Content.ShouldStartWith(LlmSessionCompactor.SummaryPrefix);
+        summaryEntry.Content.ShouldContain("raw-llm-output");
+        // The raw LLM output (result.Summary) is NOT prefixed -- prefix lives in history only.
+        result.Summary.ShouldBe("raw-llm-output");
+    }
+
+    /// <summary>The summarization prompt must request the 5 structured sections from the spec.</summary>
+    [Fact]
+    public async Task CompactAsync_SummarizationPrompt_HasFiveStructuredSections()
+    {
+        var session = CreateSession(
+            ("user", "build it"),
+            ("assistant", "building"),
+            ("user", "recent"));
+        string? capturedPrompt = null;
+        var compactor = CreateCompactorCapturingPrompt("summary", p => capturedPrompt = p);
+
+        await compactor.CompactAsync(session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        capturedPrompt.ShouldNotBeNull();
+        capturedPrompt!.ShouldContain("## Resolved");
+        capturedPrompt.ShouldContain("## Active Task");
+        capturedPrompt.ShouldContain("## In Progress");
+        capturedPrompt.ShouldContain("## Pending User Asks");
+        capturedPrompt.ShouldContain("## Remaining Work");
+    }
+
+    /// <summary>Guardrail prefix must be visible in the LLM message list when the session is projected.
+    /// On the NEXT compaction cycle the prefix appears in the summarization prompt,
+    /// proving it will be LLM-visible during normal operation.</summary>
+    [Fact]
+    public async Task CompactAsync_GuardrailPrefix_IsVisibleInSubsequentCompactionPrompt()
+    {
+        var session = CreateSession(
+            ("user", "old-task"),
+            ("assistant", "old-result"),
+            ("user", "mid"));
+        // Cycle 1
+        var cycle1 = await CreateCompactor("cycle1-summary").CompactAsync(session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+        session.ReplaceHistory(cycle1.CompactedHistory!);
+        session.AddEntries(new[]
+        {
+            new SessionEntry { Role = MessageRole.User, Content = "new-u" },
+            new SessionEntry { Role = MessageRole.Assistant, Content = "new-a" },
+            new SessionEntry { Role = MessageRole.User, Content = "preserve" }
+        });
+
+        // Cycle 2 -- capture prompt sent to LLM
+        string? prompt2 = null;
+        await CreateCompactorCapturingPrompt("cycle2-summary", p => prompt2 = p).CompactAsync(session, new CompactionOptions
+        {
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        });
+
+        prompt2.ShouldNotBeNull();
+        // The guardrail prefix from cycle 1 must be present in the cycle 2 summarization prompt
+        // (it travels with the compaction entry content into the LLM context).
+        prompt2!.ShouldContain("[CONTEXT COMPACTION -- REFERENCE ONLY]");
     }
 
     private static LlmSessionCompactor CreateCompactorCapturingPrompt(


### PR DESCRIPTION
Closes #669

## Changes

Every compaction summary entry in session history now begins with a SUMMARY_PREFIX guardrail block that prevents the agent from resuming stale tasks after a context window handoff.

Updated BuildSummarizationPrompt to use the 5-section spec from #669 (Resolved / Active Task / In Progress / Pending User Asks / Remaining Work) instead of the old 4-section template.

result.Summary continues to return the raw LLM output without the prefix. The prefix lives in the session history Content field only.

## Tests

3 new regression tests in LlmSessionCompactorTests:
- CompactAsync_SummaryEntry_BeginsWithGuardrailPrefix
- CompactAsync_SummarizationPrompt_HasFiveStructuredSections
- CompactAsync_GuardrailPrefix_IsVisibleInSubsequentCompactionPrompt

Updated 10+ existing tests in LlmSessionCompactorTests, LlmSessionCompactorRaceTests, and SessionCompactionIntegrationTests to account for the prefixed Content field (using ShouldStartWith / ShouldContain / prefix-stripping helper). All 33 compaction tests pass; Architecture 167/167 pass; Scenarios 29/29 pass.

## Merge Notes

Fully independent -- no file overlap with any other open PR. Safe to merge in any order.