### PR TITLE
fix(gateway): add RuntimePinnedTools to DefaultToolPolicyProvider that bypass all deny-list checks

### DIFF
--- a/src/gateway/BotNexus.Gateway/Security/DefaultToolPolicyProvider.cs
+++ b/src/gateway/BotNexus.Gateway/Security/DefaultToolPolicyProvider.cs
@@ -30,10 +30,35 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
 
     private static readonly HashSet<string> HttpDeniedLookup = new(HttpDeniedTools, StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Gateway-internal tools that are always required for basic agent function and must
+    /// never be silently dropped by a deny-list. These bypass <see cref="IsDenied"/> checks
+    /// regardless of per-agent or sub-agent deny-list configuration.
+    /// </summary>
+    internal static readonly HashSet<string> RuntimePinnedTools = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Interactive flow control
+        "ask_user",
+        // Canvas publishing
+        "canvas",
+        // Memory lifecycle (required when memory is enabled)
+        "memory_save",
+        "memory_search",
+        "memory_get",
+        // Cron schedule management (required when cron extension is active)
+        "cron",
+        // Session and conversation access (required by gateway routing)
+        "session",
+        "conversation",
+    };
+
     private readonly ConcurrentDictionary<string, byte> _mcpServerIds = new(StringComparer.OrdinalIgnoreCase);
 
     // Dynamic deny-lists for ephemeral sub-agents that have no PlatformConfig entry.
     private readonly ConcurrentDictionary<string, IReadOnlyList<string>> _dynamicDenyLists = new(StringComparer.OrdinalIgnoreCase);
+
+    // Runtime-pinned tools registered by extensions at startup or session creation time.
+    private readonly ConcurrentDictionary<string, byte> _dynamicPinnedTools = new(StringComparer.OrdinalIgnoreCase);
 
     private readonly IOptionsMonitor<PlatformConfig> _config;
     private readonly ILogger<DefaultToolPolicyProvider> _logger;
@@ -56,6 +81,26 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
         _mcpServerIds.TryAdd(serverId, 0);
         _logger.LogDebug("Registered MCP server ID '{ServerId}' for tool policy", serverId);
     }
+
+    /// <summary>
+    /// Pins a tool name so it cannot be silently dropped by any deny-list, including
+    /// sub-agent propagated deny-lists and per-agent config overrides.
+    /// Use this for runtime-injected tools that are required for basic agent function.
+    /// </summary>
+    public void PinTool(string toolName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+        _dynamicPinnedTools.TryAdd(toolName, 0);
+        _logger.LogDebug("Pinned tool '{ToolName}' -- exempt from all deny-list checks", toolName);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the tool is pinned (either statically in
+    /// <see cref="RuntimePinnedTools"/> or dynamically via <see cref="PinTool"/>).
+    /// Pinned tools are never denied regardless of deny-list configuration.
+    /// </summary>
+    internal bool IsPinned(string toolName) =>
+        RuntimePinnedTools.Contains(toolName) || _dynamicPinnedTools.ContainsKey(toolName);
 
     /// <summary>
     /// Sets the effective deny-list for an ephemeral sub-agent session.
@@ -155,10 +200,16 @@ public sealed class DefaultToolPolicyProvider : IToolPolicyProvider
     /// Checks whether a tool is completely blocked for a specific agent.
     /// Checks both static config deny-lists and runtime dynamic deny-lists (for sub-agents).
     /// Supports MCP wildcard deny via <c>serverId_*</c> patterns in the denied list.
+    /// Pinned tools (either statically in <see cref="RuntimePinnedTools"/> or dynamically
+    /// via <see cref="PinTool"/>) are never blocked regardless of deny-list entries.
     /// </summary>
     internal bool IsDenied(string toolName, string? agentId)
     {
         if (agentId is null)
+            return false;
+
+        // Pinned tools bypass all deny-list checks -- they are runtime-required (#667).
+        if (IsPinned(toolName))
             return false;
 
         return IsInDenyList(toolName, GetEffectiveDenyList(agentId));

--- a/tests/gateway/BotNexus.Gateway.Tests/ToolPolicyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ToolPolicyTests.cs
@@ -238,4 +238,102 @@ public sealed class ToolPolicyTests
 
         handler.Priority.ShouldBeLessThan(0, "policy handler should run before other handlers");
     }
+
+    // ─── Issue #667: runtime-pinned tools bypass deny-list ──────────────────────
+
+    /// <summary>Static RuntimePinnedTools cannot be denied by per-agent deny-list config.</summary>
+    [Theory]
+    [InlineData("ask_user")]
+    [InlineData("canvas")]
+    [InlineData("memory_save")]
+    [InlineData("memory_search")]
+    [InlineData("memory_get")]
+    [InlineData("session")]
+    [InlineData("conversation")]
+    public void IsDenied_RuntimePinnedTool_ReturnsFalse_EvenWhenInDenyList(string toolName)
+    {
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["test-agent"] = new AgentDefinitionConfig
+                {
+                    ToolPolicy = new ToolPolicyConfig { Denied = [toolName] }
+                }
+            }
+        };
+        var provider = CreateProvider(config);
+
+        // Tool in deny-list but also in RuntimePinnedTools -- must not be denied.
+        provider.IsDenied(toolName, "test-agent").ShouldBeFalse(
+            $"runtime-pinned tool '{toolName}' must never be denied");
+    }
+
+    /// <summary>PinTool registers a dynamic pin; the pinned tool bypasses deny-list.</summary>
+    [Fact]
+    public void IsDenied_DynamicallyPinnedTool_ReturnsFalse_EvenWhenInDenyList()
+    {
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["a"] = new AgentDefinitionConfig
+                {
+                    ToolPolicy = new ToolPolicyConfig { Denied = ["my_custom_tool"] }
+                }
+            }
+        };
+        var provider = CreateProvider(config);
+        provider.PinTool("my_custom_tool");
+
+        provider.IsDenied("my_custom_tool", "a").ShouldBeFalse(
+            "dynamically-pinned tool must bypass deny-list");
+    }
+
+    /// <summary>Non-pinned tools in the deny-list are still denied normally.</summary>
+    [Fact]
+    public void IsDenied_NonPinnedDeniedTool_ReturnsTrueAsNormal()
+    {
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["a"] = new AgentDefinitionConfig
+                {
+                    ToolPolicy = new ToolPolicyConfig { Denied = ["some_blocked_tool"] }
+                }
+            }
+        };
+        var provider = CreateProvider(config);
+
+        provider.IsDenied("some_blocked_tool", "a").ShouldBeTrue();
+    }
+
+    /// <summary>ToolPolicyHookHandler does not deny runtime-pinned tools
+    /// even when they appear in the agent's deny-list.</summary>
+    [Fact]
+    public async Task HookHandler_RuntimePinnedTool_NotDenied_EvenWhenInDenyList()
+    {
+        var config = new PlatformConfig
+        {
+            Agents = new Dictionary<string, AgentDefinitionConfig>
+            {
+                ["test-agent-pinned"] = new AgentDefinitionConfig
+                {
+                    ToolPolicy = new ToolPolicyConfig { Denied = ["ask_user"] }
+                }
+            }
+        };
+        var provider = CreateProvider(config);
+        var handler = new ToolPolicyHookHandler(
+            provider,
+            NullLogger<ToolPolicyHookHandler>.Instance);
+
+        var evt = new BeforeToolCallEvent(
+            AgentId.From("test-agent-pinned"), "ask_user", "tc-pinned",
+            new Dictionary<string, object?> { ["prompt"] = "Are you sure?" });
+
+        var result = await handler.HandleAsync(evt);
+        result.ShouldBeNull("runtime-pinned ask_user must not be denied even when in deny-list");
+    }
 }


### PR DESCRIPTION
Closes #667

## Changes

Added a RuntimePinnedTools static set and PinTool(string) dynamic method to DefaultToolPolicyProvider. Pinned tools bypass IsDenied checks regardless of per-agent config deny-lists, sub-agent dynamic deny-lists, or wildcard patterns.

**Static RuntimePinnedTools** (hardcoded gateway internals that must never be denied):
- ask_user, canvas
- memory_save, memory_search, memory_get
- cron, session, conversation

**PinTool(string)** allows callers (e.g. extensions at startup, InProcessIsolationStrategy) to dynamically pin additional runtime-required tools.

**IsPinned(string)** internal helper checks both sets.

## Tests

10 new tests in ToolPolicyTests.cs:
- Theory: IsDenied_RuntimePinnedTool_ReturnsFalse_EvenWhenInDenyList (7 inline values)
- IsDenied_DynamicallyPinnedTool_ReturnsFalse_EvenWhenInDenyList
- IsDenied_NonPinnedDeniedTool_ReturnsTrueAsNormal
- HookHandler_RuntimePinnedTool_NotDenied_EvenWhenInDenyList

34/34 ToolPolicyTests pass; Architecture 167/167; Gateway.Tests 2174/2174; Scenarios 29/29.

## Merge Notes

Fully independent -- touches DefaultToolPolicyProvider.cs and ToolPolicyTests.cs only. No file overlap with any open PR. Safe to merge in any order.