### PR TITLE
feat(sessions): add GET /api/sessions/{sessionId}/debug endpoint

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/SessionsController.cs
@@ -185,6 +185,67 @@ public sealed class SessionsController : ControllerBase
     }
 
     /// <summary>
+    /// Gets debug information for a specific session: system prompt, paginated history, and metadata.
+    /// </summary>
+    /// <param name="sessionId">Session identifier.</param>
+    /// <param name="offset">Zero-based history offset (default 0).</param>
+    /// <param name="limit">Maximum number of history entries to return (default 50, max 200).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Debug snapshot: session fields, system prompt, history, metadata.</returns>
+    [HttpGet("{sessionId}/debug")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<object>> GetDebug(
+        string sessionId,
+        [FromQuery] int offset = 0,
+        [FromQuery] int limit = 50,
+        CancellationToken cancellationToken = default)
+    {
+        var session = await _sessions.GetAsync(SessionId.From(sessionId), cancellationToken);
+        if (session is null)
+            return NotFound();
+
+        var boundedLimit = Math.Min(Math.Max(limit, 1), 200);
+        var boundedOffset = Math.Max(offset, 0);
+
+        var totalCount = session.History.Count;
+        var entries = session.GetHistorySnapshot(boundedOffset, boundedLimit);
+
+        // LastRenderedSystemPrompt is stamped by InProcessAgentHandle after BuildSystemPromptAsync
+        // (PR #901 / issue #766). Returns null until that PR merges and the handle has been initialised.
+        // Use reflection-safe property access so this compiles before #901 lands.
+        var promptType = session.GetType().GetProperty("LastRenderedSystemPrompt");
+        var capturedAtType = session.GetType().GetProperty("LastRenderedSystemPromptAt");
+        var systemPrompt = promptType?.GetValue(session) as string;
+        var systemPromptCapturedAt = capturedAtType?.GetValue(session) as DateTimeOffset?;
+
+        var result = new
+        {
+            sessionId = session.SessionId.Value,
+            agentId = session.AgentId.Value,
+            status = session.Status.ToString(),
+            sessionType = session.SessionType.Value,
+            createdAt = session.CreatedAt,
+            updatedAt = session.UpdatedAt,
+            messageCount = session.MessageCount,
+            conversationId = session.ConversationId.IsInitialized() ? session.ConversationId.Value : (string?)null,
+            channelType = session.ChannelType?.Value,
+            systemPrompt = systemPrompt,
+            systemPromptCapturedAt = systemPromptCapturedAt,
+            history = new
+            {
+                totalCount,
+                offset = boundedOffset,
+                limit = boundedLimit,
+                entries
+            },
+            metadata = session.Metadata
+        };
+
+        return Ok(result);
+    }
+
+    /// <summary>
     /// Gets metadata for a specific session.
     /// </summary>
     /// <param name="sessionId">Session identifier.</param>

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionDebugEndpointTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionDebugEndpointTests.cs
@@ -1,0 +1,97 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Sessions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for GET /api/sessions/{sessionId}/debug endpoint (Issue #767, Part of #749).
+/// </summary>
+public sealed class SessionDebugEndpointTests
+{
+    [Fact]
+    public async Task GetDebug_UnknownSession_Returns404()
+    {
+        var store = new InMemorySessionStore();
+        var controller = new SessionsController(store);
+
+        var result = await controller.GetDebug("nonexistent", 0, 50, CancellationToken.None);
+
+        result.Result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetDebug_KnownSession_Returns200WithCorrectShape()
+    {
+        var store = new InMemorySessionStore();
+        var session = await store.GetOrCreateAsync(SessionId.From("s-debug-1"), AgentId.From("agent-a"));
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "Hello" });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "World" });
+        await store.SaveAsync(session);
+
+        var controller = new SessionsController(store);
+
+        var result = await controller.GetDebug("s-debug-1", 0, 50, CancellationToken.None);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var json = System.Text.Json.JsonSerializer.Serialize(ok!.Value);
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("sessionId").GetString().ShouldBe("s-debug-1");
+        root.GetProperty("agentId").GetString().ShouldBe("agent-a");
+        root.GetProperty("messageCount").GetInt32().ShouldBe(2);
+
+        // history shape
+        var history = root.GetProperty("history");
+        history.GetProperty("totalCount").GetInt32().ShouldBe(2);
+        history.GetProperty("offset").GetInt32().ShouldBe(0);
+        history.GetProperty("limit").GetInt32().ShouldBe(50);
+        history.GetProperty("entries").GetArrayLength().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetDebug_HistoryPagination_ReturnsCorrectSlice()
+    {
+        var store = new InMemorySessionStore();
+        var session = await store.GetOrCreateAsync(SessionId.From("s-paged"), AgentId.From("agent-b"));
+        for (var i = 0; i < 10; i++)
+            session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = $"msg-{i}" });
+        await store.SaveAsync(session);
+
+        var controller = new SessionsController(store);
+
+        var result = await controller.GetDebug("s-paged", offset: 3, limit: 4, CancellationToken.None);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var json = System.Text.Json.JsonSerializer.Serialize(ok!.Value);
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        var history = doc.RootElement.GetProperty("history");
+
+        history.GetProperty("totalCount").GetInt32().ShouldBe(10);
+        history.GetProperty("offset").GetInt32().ShouldBe(3);
+        history.GetProperty("limit").GetInt32().ShouldBe(4);
+        history.GetProperty("entries").GetArrayLength().ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task GetDebug_SystemPromptNull_WhenNotCaptured()
+    {
+        var store = new InMemorySessionStore();
+        await store.GetOrCreateAsync(SessionId.From("s-noprompt"), AgentId.From("agent-c"));
+
+        var controller = new SessionsController(store);
+
+        var result = await controller.GetDebug("s-noprompt", 0, 50, CancellationToken.None);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var json = System.Text.Json.JsonSerializer.Serialize(ok!.Value);
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+
+        // systemPrompt should be present as null (or absent) -- not an error
+        doc.RootElement.TryGetProperty("systemPrompt", out var sp);
+        sp.ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Null);
+    }
+}


### PR DESCRIPTION
Closes #767

## Changes

New endpoint on `SessionsController`: `GET /api/sessions/{sessionId}/debug`

Returns a debug snapshot: sessionId, agentId, status, sessionType, createdAt, updatedAt, messageCount,
conversationId, channelType, systemPrompt (null until #901 merges), systemPromptCapturedAt,
paginated history (offset/limit, capped at 200), and metadata key-value map.

Returns 404 if session not found.

4 new unit tests in SessionDebugEndpointTests.cs:
- Unknown session returns 404
- Known session returns 200 with correct shape
- Pagination returns correct slice
- No system prompt returns systemPrompt null (not an error)

## Merge Notes

Depends on #766 (PR #901) for systemPrompt to return non-null. Safe to merge independently.
All other fields are fully functional without #901.