### PR TITLE
fix(gateway): filter NO_REPLY assistant entries from conversation history API

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -384,10 +384,17 @@ public sealed class ConversationsController : ControllerBase
                 });
             }
 
-            // Append all history entries from this session
+            // Append all history entries from this session.
+            // Skip assistant entries whose content is exactly "NO_REPLY" (optionally padded with whitespace).
+            // These are deliberate cron no-ops that produced no user-facing output; including them in
+            // history would show blank turns in the portal for every cron wakeup that had nothing to say (#773).
             var snapshot = session.GetHistorySnapshot();
             foreach (var entry in snapshot)
             {
+                if (entry.Role == MessageRole.Assistant &&
+                    string.Equals(entry.Content?.Trim(), "NO_REPLY", StringComparison.Ordinal))
+                    continue;
+
                 allEntries.Add(new ConversationHistoryEntry
                 {
                     Kind = "message",

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -307,4 +307,89 @@ public sealed class ConversationsControllerHistoryTests
         public Task<IReadOnlyList<Conversation>> ListForCitizenAsync(BotNexus.Domain.World.CitizenId citizen, CancellationToken ct = default)
             => throw new NotSupportedException();
     }
+
+    /// <summary>
+    /// Regression tests for #773: NO_REPLY assistant entries must be stripped from conversation history
+    /// so cron wakeups that had nothing to say don't appear as blank turns in the portal.
+    /// </summary>
+    [Fact]
+    public async Task GetHistory_FiltersOutNoReplyAssistantEntries()
+    {
+        var conversationId = ConversationId.From("c_noreply_filter");
+        var sessions = new InMemorySessionStore();
+        var conversationStore = new StubConversationStore(CreateConversation(conversationId, "quill"));
+        var session = await sessions.GetOrCreateAsync(SessionId.From("s-noreply-1"), AgentId.From("quill"));
+        session.Session.ConversationId = conversationId;
+
+        // Interleave real messages with NO_REPLY turns
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "real question", Timestamp = DateTimeOffset.UtcNow.AddMinutes(1) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "real answer", Timestamp = DateTimeOffset.UtcNow.AddMinutes(2) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "another question", Timestamp = DateTimeOffset.UtcNow.AddMinutes(3) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "NO_REPLY", Timestamp = DateTimeOffset.UtcNow.AddMinutes(4) }); // cron NO_REPLY -- must be filtered
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "yet another", Timestamp = DateTimeOffset.UtcNow.AddMinutes(5) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "second real answer", Timestamp = DateTimeOffset.UtcNow.AddMinutes(6) });
+
+        await sessions.SaveAsync(session);
+        var controller = new ConversationsController(conversationStore, sessions);
+
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 200, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+        // 5 visible entries (1 NO_REPLY filtered out)
+        response!.TotalCount.ShouldBe(5);
+        response.Entries.ShouldNotContain(e => e.Content == "NO_REPLY");
+        response.Entries.ShouldContain(e => e.Content == "real answer");
+        response.Entries.ShouldContain(e => e.Content == "second real answer");
+    }
+
+    [Fact]
+    public async Task GetHistory_FiltersNoReplyWithWhitespace()
+    {
+        // NO_REPLY with surrounding whitespace/newlines should also be filtered (matches client-side Trim() behaviour)
+        var conversationId = ConversationId.From("c_noreply_whitespace");
+        var sessions = new InMemorySessionStore();
+        var conversationStore = new StubConversationStore(CreateConversation(conversationId, "quill"));
+        var session = await sessions.GetOrCreateAsync(SessionId.From("s-noreply-2"), AgentId.From("quill"));
+        session.Session.ConversationId = conversationId;
+
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "hello", Timestamp = DateTimeOffset.UtcNow.AddMinutes(1) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "  NO_REPLY  ", Timestamp = DateTimeOffset.UtcNow.AddMinutes(2) }); // padded
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "NO_REPLY\n", Timestamp = DateTimeOffset.UtcNow.AddMinutes(3) }); // trailing newline
+
+        await sessions.SaveAsync(session);
+        var controller = new ConversationsController(conversationStore, sessions);
+
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 200, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+        response!.TotalCount.ShouldBe(1); // only the user message
+        response.Entries[0].Content.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task GetHistory_DoesNotFilterUserEntriesNamedNoReply()
+    {
+        // A user message literally saying "NO_REPLY" should NOT be filtered (only assistant entries)
+        var conversationId = ConversationId.From("c_noreply_user_safe");
+        var sessions = new InMemorySessionStore();
+        var conversationStore = new StubConversationStore(CreateConversation(conversationId, "quill"));
+        var session = await sessions.GetOrCreateAsync(SessionId.From("s-noreply-3"), AgentId.From("quill"));
+        session.Session.ConversationId = conversationId;
+
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "NO_REPLY", Timestamp = DateTimeOffset.UtcNow.AddMinutes(1) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "I understand you typed NO_REPLY", Timestamp = DateTimeOffset.UtcNow.AddMinutes(2) });
+
+        await sessions.SaveAsync(session);
+        var controller = new ConversationsController(conversationStore, sessions);
+
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 200, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+        response!.TotalCount.ShouldBe(2); // both entries preserved
+        response.Entries.ShouldContain(e => e.Content == "NO_REPLY" && e.Role == "user");
+        response.Entries.ShouldContain(e => e.Content == "I understand you typed NO_REPLY");
+    }
 }


### PR DESCRIPTION
Closes #773

## Problem
The conversation history API returns all assistant session entries without filtering. Cron jobs that respond with NO_REPLY wrote an Assistant entry with content "NO_REPLY" to the session store. When the portal loaded history, these appeared as blank/empty turns.

## Fix
Added a server-side filter in ConversationsController.GetHistory that skips assistant entries whose trimmed content is exactly "NO_REPLY". Mirrors the existing client-side filter in GatewayEventHandler.HandleMessageEnd -- which suppressed live streaming but not history reload.

- entry.Role == MessageRole.Assistant && entry.Content?.Trim() == "NO_REPLY" -- skip
- User entries with NO_REPLY content are NOT filtered
- Applies to both indexed path and ActiveSessionId fallback path

## Tests
3 new regression tests in ConversationsControllerHistoryTests:
- GetHistory_FiltersOutNoReplyAssistantEntries -- mixed real + NO_REPLY entries; only real survive
- GetHistory_FiltersNoReplyWithWhitespace -- padded/newline variants also filtered
- GetHistory_DoesNotFilterUserEntriesNamedNoReply -- user NO_REPLY content preserved

## Merge Notes
Independent of all 21 other open PRs. No file overlap.