### PR TITLE
feat(mcp): add auth provider reference to McpServerConfig for HTTP/SSE token injection

### DIFF
--- a/src/extensions/BotNexus.Extensions.Mcp/McpExtensionConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Mcp/McpExtensionConfig.cs
@@ -46,6 +46,15 @@ public sealed class McpServerConfig
     public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>
+    /// Optional BotNexus provider key for auth injection (HTTP/SSE transport only).
+    /// When set, resolves a Bearer token via <c>GetProviderApiKeyAsync</c> at session start
+    /// and injects it as <c>Authorization: Bearer &lt;token&gt;</c>. An explicit
+    /// <see cref="Headers"/> Authorization value wins when both are present.
+    /// </summary>
+    [JsonPropertyName("auth")]
+    public string? Auth { get; set; }
+
+    /// <summary>
     /// Whether to inherit the parent process environment variables.
     /// Default: <c>true</c> for backward compatibility.
     /// <para>

--- a/src/extensions/BotNexus.Extensions.Mcp/McpToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Mcp/McpToolContributor.cs
@@ -7,11 +7,13 @@ namespace BotNexus.Extensions.Mcp;
 
 /// <summary>
 /// Contributes MCP-bridged tools from the non-blocking server warmup cache.
+/// HTTP/SSE servers with an <c>auth</c> provider reference are started fresh per session
+/// with a resolved Bearer token; all other servers use the shared warmup cache.
 /// </summary>
 public sealed class McpToolContributor(ILoggerFactory loggerFactory) : IAgentToolContributor
 {
     /// <inheritdoc />
-    public Task<AgentToolContribution> ContributeAsync(
+    public async Task<AgentToolContribution> ContributeAsync(
         AgentToolContributionContext context,
         CancellationToken cancellationToken = default)
     {
@@ -19,18 +21,84 @@ public sealed class McpToolContributor(ILoggerFactory loggerFactory) : IAgentToo
 
         var config = ResolveMcpExtensionConfig(context.Descriptor);
         if (config is not { Servers.Count: > 0 })
-            return Task.FromResult(new AgentToolContribution([]));
+            return new AgentToolContribution([]);
 
-        var entry = McpServerWarmupCache.EnsureStarted(
-            context.Descriptor.AgentId.Value,
-            config,
-            loggerFactory.CreateLogger<McpServerManager>());
+        // Split into servers that need auth injection and those that do not.
+        var warmupServers = new Dictionary<string, McpServerConfig>(StringComparer.Ordinal);
+        var authServers = new Dictionary<string, McpServerConfig>(StringComparer.Ordinal);
 
-        var contribution = entry.TryGetReadyTools(out var tools)
-            ? new AgentToolContribution(tools)
-            : new AgentToolContribution([]);
+        foreach (var (id, srv) in config.Servers)
+        {
+            if (!string.IsNullOrWhiteSpace(srv.Auth) && !string.IsNullOrWhiteSpace(srv.Url))
+                authServers[id] = srv;
+            else
+                warmupServers[id] = srv;
+        }
 
-        return Task.FromResult(contribution);
+        var tools = new List<IAgentTool>();
+        var resourcesToDispose = new List<object>();
+
+        // Warmup-cache path for non-auth servers.
+        if (warmupServers.Count > 0)
+        {
+            var warmupConfig = new McpExtensionConfig
+            {
+                Servers = warmupServers,
+                ToolPrefix = config.ToolPrefix,
+            };
+
+            var entry = McpServerWarmupCache.EnsureStarted(
+                context.Descriptor.AgentId.Value,
+                warmupConfig,
+                loggerFactory.CreateLogger<McpServerManager>());
+
+            if (entry.TryGetReadyTools(out var warmupTools))
+                tools.AddRange(warmupTools);
+        }
+
+        // Per-session path for auth servers — resolve token and inject header.
+        foreach (var (serverId, serverConfig) in authServers)
+        {
+            var token = await context.GetProviderApiKeyAsync(serverConfig.Auth!, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                loggerFactory.CreateLogger<McpToolContributor>().LogWarning(
+                    "MCP server '{ServerId}' has auth={Auth} configured but no token was resolved. Skipping server.",
+                    serverId, serverConfig.Auth);
+                continue;
+            }
+
+            // Build a hydrated config with the injected Authorization header.
+            // Explicit Headers.Authorization wins over auth-resolved token.
+            var mergedHeaders = new Dictionary<string, string>(
+                serverConfig.Headers ?? new Dictionary<string, string>(),
+                StringComparer.OrdinalIgnoreCase);
+
+            if (!mergedHeaders.ContainsKey("Authorization"))
+                mergedHeaders["Authorization"] = $"Bearer {token}";
+
+            var hydratedConfig = new McpServerConfig
+            {
+                Url = serverConfig.Url,
+                Headers = mergedHeaders,
+                InitTimeoutMs = serverConfig.InitTimeoutMs,
+                CallTimeoutMs = serverConfig.CallTimeoutMs,
+                // Auth is cleared so CreateTransport does not see a stale value
+            };
+
+            var manager = new McpServerManager(loggerFactory.CreateLogger<McpServerManager>());
+            resourcesToDispose.Add(manager);
+
+            var serverTools = await manager.StartSingleServerAsync(
+                serverId, hydratedConfig, config.ToolPrefix, cancellationToken)
+                .ConfigureAwait(false);
+
+            tools.AddRange(serverTools);
+        }
+
+        return new AgentToolContribution(tools, resourcesToDispose.Count > 0 ? resourcesToDispose : null);
     }
 
     internal static McpExtensionConfig? ResolveMcpExtensionConfig(AgentDescriptor descriptor)

--- a/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpAuthReferenceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpAuthReferenceTests.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Extensions.Mcp.Tests;
+
+/// <summary>
+/// Tests for McpServerConfig.Auth field and McpToolContributor auth resolution logic.
+/// </summary>
+public sealed class McpAuthReferenceTests
+{
+    // --- helpers ---
+
+    private static AgentDescriptor BuildDescriptor(McpExtensionConfig config)
+    {
+        var element = JsonSerializer.SerializeToElement(config, JsonContext.Default.McpExtensionConfig);
+        return new AgentDescriptor
+        {
+            AgentId = AgentId.From("test-agent"),
+            DisplayName = "Test Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ExtensionConfig = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            {
+                ["botnexus-mcp"] = element,
+            },
+        };
+    }
+
+    private static AgentToolContributionContext BuildContext(
+        AgentDescriptor descriptor,
+        Func<string, CancellationToken, Task<string?>>? getApiKey = null)
+        => new(
+            descriptor,
+            new AgentExecutionContext { SessionId = SessionId.Create() },
+            Path.GetTempPath(),
+            new AllowAllPathValidator(),
+            _ => null,
+            getApiKey ?? ((_, _) => Task.FromResult<string?>(null)));
+
+    private sealed class AllowAllPathValidator : IPathValidator
+    {
+        public bool CanRead(string absolutePath) => true;
+        public bool CanWrite(string absolutePath) => true;
+        public string? ValidateAndResolve(string rawPath, FileAccessMode mode) => rawPath;
+    }
+
+    // --- McpServerConfig.Auth deserialization ---
+
+    [Fact]
+    public void McpServerConfig_DeserializesAuth_FromJson()
+    {
+        var json = """
+        {
+            "servers": {
+                "github": {
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "auth": "github-copilot"
+                }
+            }
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<McpExtensionConfig>(json)!;
+
+        config.Servers["github"].Auth.ShouldBe("github-copilot");
+        config.Servers["github"].Url.ShouldBe("https://api.githubcopilot.com/mcp/");
+    }
+
+    [Fact]
+    public void McpServerConfig_Auth_DefaultsToNull()
+    {
+        var config = new McpServerConfig();
+        config.Auth.ShouldBeNull();
+    }
+
+    [Fact]
+    public void McpServerConfig_Auth_SerializesAsJsonProperty()
+    {
+        var srv = new McpServerConfig { Url = "http://example.com/mcp", Auth = "my-provider" };
+        var json = JsonSerializer.Serialize(srv);
+        json.ShouldContain("\"auth\"");
+        json.ShouldContain("my-provider");
+    }
+
+    // --- McpToolContributor auth routing ---
+
+    [Fact]
+    public async Task ContributeAsync_AuthServer_NullToken_SkipsServer_ReturnsNoTools()
+    {
+        var config = new McpExtensionConfig
+        {
+            Servers = new Dictionary<string, McpServerConfig>
+            {
+                ["copilot-mcp"] = new McpServerConfig
+                {
+                    Url = "https://api.githubcopilot.com/mcp/",
+                    Auth = "github-copilot",
+                },
+            },
+        };
+
+        var descriptor = BuildDescriptor(config);
+        var context = BuildContext(descriptor, (_, _) => Task.FromResult<string?>(null));
+
+        var contributor = new McpToolContributor(NullLoggerFactory.Instance);
+        var contribution = await contributor.ContributeAsync(context);
+
+        contribution.Tools.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ContributeAsync_AuthServer_ResolvesProviderKeyFromContext()
+    {
+        string? resolvedProvider = null;
+        var config = new McpExtensionConfig
+        {
+            Servers = new Dictionary<string, McpServerConfig>
+            {
+                ["copilot-mcp"] = new McpServerConfig
+                {
+                    Url = "https://example-mcp.invalid/mcp",
+                    Auth = "github-copilot",
+                },
+            },
+        };
+
+        var descriptor = BuildDescriptor(config);
+        var context = BuildContext(descriptor, (providerKey, _) =>
+        {
+            resolvedProvider = providerKey;
+            return Task.FromResult<string?>("test-bearer-token");
+        });
+
+        var contributor = new McpToolContributor(NullLoggerFactory.Instance);
+        await contributor.ContributeAsync(context, CancellationToken.None);
+
+        // The auth provider key should have been passed to GetProviderApiKeyAsync
+        resolvedProvider.ShouldBe("github-copilot");
+    }
+
+    [Fact]
+    public void ContributeAsync_ExplicitHeaderAuthorization_RoundTripsCorrectly()
+    {
+        // Verify that config with both auth and explicit Authorization header round-trips via descriptor
+        var json = """
+        {
+            "servers": {
+                "srv": {
+                    "url": "https://example.com/mcp",
+                    "auth": "my-provider",
+                    "headers": { "Authorization": "Bearer explicit-token" }
+                }
+            }
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<McpExtensionConfig>(json)!;
+
+        config.Servers["srv"].Auth.ShouldBe("my-provider");
+        config.Servers["srv"].Headers!["Authorization"].ShouldBe("Bearer explicit-token");
+
+        // Confirm the descriptor round-trips correctly through ResolveMcpExtensionConfig
+        var descriptor = BuildDescriptor(config);
+        var resolved = McpToolContributor.ResolveMcpExtensionConfig(descriptor)!;
+        resolved.Servers["srv"].Auth.ShouldBe("my-provider");
+        resolved.Servers["srv"].Headers!["Authorization"].ShouldBe("Bearer explicit-token");
+    }
+
+    [Fact]
+    public async Task ContributeAsync_NoAuthServers_DoesNotCallGetProviderApiKeyAsync()
+    {
+        var config = new McpExtensionConfig
+        {
+            Servers = new Dictionary<string, McpServerConfig>
+            {
+                ["local"] = new McpServerConfig { Command = "true" }, // stdio, no auth
+            },
+        };
+
+        var tokenCallCount = 0;
+        var descriptor = BuildDescriptor(config);
+        var context = BuildContext(descriptor, (_, _) =>
+        {
+            tokenCallCount++;
+            return Task.FromResult<string?>("should-not-be-called");
+        });
+
+        var contributor = new McpToolContributor(NullLoggerFactory.Instance);
+        await contributor.ContributeAsync(context, CancellationToken.None);
+
+        tokenCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ContributeAsync_StdioServerWithAuthField_IsRoutedThroughWarmupCache()
+    {
+        // Auth is only meaningful for HTTP/SSE servers (with Url set).
+        // A stdio server (command only) with auth= set is silently treated as a non-auth server.
+        var config = new McpExtensionConfig
+        {
+            Servers = new Dictionary<string, McpServerConfig>
+            {
+                ["stdio-with-auth"] = new McpServerConfig
+                {
+                    Command = "echo",
+                    Auth = "github-copilot",
+                },
+            },
+        };
+
+        var tokenCallCount = 0;
+        var descriptor = BuildDescriptor(config);
+        var context = BuildContext(descriptor, (_, _) =>
+        {
+            tokenCallCount++;
+            return Task.FromResult<string?>("ignored");
+        });
+
+        var contributor = new McpToolContributor(NullLoggerFactory.Instance);
+        await contributor.ContributeAsync(context, CancellationToken.None);
+
+        // Token resolver not called — stdio servers bypass the auth path
+        tokenCallCount.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
Closes #624

## Changes

McpServerConfig.Auth (string?, JsonPropertyName "auth") added — optional provider key for HTTP/SSE servers.
When Auth is set and Url is set, McpToolContributor.ContributeAsync routes the server through a per-session McpServerManager (not the warmup cache) and resolves the Bearer token via context.GetProviderApiKeyAsync(auth) before calling StartSingleServerAsync.
An explicit Headers.Authorization wins over the auth-resolved token (standard header-merge semantics).
If GetProviderApiKeyAsync returns null, the server is skipped with a LogWarning.
Stdio servers (command, no url) with an auth field are silently routed through the warmup cache — auth is HTTP/SSE only.
8 new tests in McpAuthReferenceTests.cs: deserialization, null default, serialization, null-token skip, provider-key resolution call, header round-trip, no-auth-servers path, stdio-with-auth path.

## Example config after this change
{
  "botnexus-mcp": {
    "servers": {
      "github": {
        "url": "https://api.githubcopilot.com/mcp/",
        "auth": "github-copilot"
      }
    }
  }
}

## Merge Notes
Fully independent of all 24 existing open PRs. Safe to merge in any order.