### PR TITLE
feat(gateway): auto-replay interrupted user turns on gateway restart with max-attempt guard

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/GatewayOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/GatewayOptions.cs
@@ -41,4 +41,18 @@ public sealed class GatewayOptions
     /// Options controlling the built-in file watcher tool.
     /// </summary>
     public FileWatcherToolOptions FileWatcherTool { get; set; } = new();
+
+    /// <summary>
+    /// When <see langword="true"/>, the gateway automatically re-dispatches the last user
+    /// message from sessions interrupted by an unclean restart. Defaults to
+    /// <see langword="false"/> until the replay path is confirmed stable.
+    /// </summary>
+    public bool AutoReplayInterruptedTurns { get; set; } = false;
+
+    /// <summary>
+    /// Maximum number of automatic replay attempts for a single interrupted session before
+    /// falling back to the notification-only path. Prevents infinite replay loops caused by
+    /// messages that always crash the agent.
+    /// </summary>
+    public int MaxAutoReplayAttempts { get; set; } = 2;
 }

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -191,7 +191,14 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IHostedService>(serviceProvider => serviceProvider.GetRequiredService<GatewayHost>());
         services.AddSingleton<IHostedService>(serviceProvider =>
             serviceProvider.GetRequiredService<SessionWarmupService>());
-        services.AddHostedService<InterruptedTurnNotificationService>();
+        services.AddHostedService(sp => new InterruptedTurnNotificationService(
+            sp.GetRequiredService<ISessionStore>(),
+            sp.GetRequiredService<IAgentRegistry>(),
+            sp.GetRequiredService<IActivityBroadcaster>(),
+            sp.GetRequiredService<IChannelManager>(),
+            sp.GetRequiredService<ILogger<InterruptedTurnNotificationService>>(),
+            sp.GetService<IInboundMessageOrchestrator>(),
+            sp.GetService<IOptions<GatewayOptions>>()));
         services.AddHostedService<SessionCleanupService>();
         services.AddHostedService<ConversationRetentionHostedService>();
         services.AddHostedService<MemoryIndexer>();

--- a/src/gateway/BotNexus.Gateway/Sessions/InterruptedTurnNotificationService.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/InterruptedTurnNotificationService.cs
@@ -1,11 +1,15 @@
 using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Activity;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Dispatching;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Sessions;
 
@@ -18,20 +22,31 @@ namespace BotNexus.Gateway.Sessions;
 /// sentinels, persists the session, and delivers an out-of-band notification through
 /// the originating channel when possible.
 /// </summary>
+/// <remarks>
+/// When <see cref="GatewayOptions.AutoReplayInterruptedTurns"/> is <c>true</c> and the
+/// session is interactive (not cron/soul/subagent), the service additionally re-dispatches
+/// the last user message so the agent can complete the interrupted turn automatically.
+/// A replay counter in session metadata caps retries at <see cref="GatewayOptions.MaxAutoReplayAttempts"/>
+/// to prevent infinite crash loops.
+/// </remarks>
 public sealed class InterruptedTurnNotificationService : IHostedService
 {
-    private const string NotificationContent =
+    internal const string NotificationContent =
         "⚠️ The gateway was restarted while your last message was being processed. " +
         "Your message was saved — please resend it to continue.";
+
+    internal const string MetadataKeyReplayCount = "interruption_replay_count";
 
     private readonly ISessionStore _sessions;
     private readonly IAgentRegistry _agentRegistry;
     private readonly IActivityBroadcaster _broadcaster;
     private readonly IChannelManager _channelManager;
     private readonly ILogger<InterruptedTurnNotificationService> _logger;
+    private readonly IInboundMessageOrchestrator? _orchestrator;
+    private readonly GatewayOptions _options;
 
     /// <summary>
-    /// Initializes a new instance of <see cref="InterruptedTurnNotificationService"/>.
+    /// Initializes a new instance without auto-replay support (backwards-compat overload).
     /// </summary>
     public InterruptedTurnNotificationService(
         ISessionStore sessions,
@@ -39,12 +54,30 @@ public sealed class InterruptedTurnNotificationService : IHostedService
         IActivityBroadcaster broadcaster,
         IChannelManager channelManager,
         ILogger<InterruptedTurnNotificationService> logger)
+        : this(sessions, agentRegistry, broadcaster, channelManager, logger,
+               orchestrator: null, options: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with optional auto-replay support.
+    /// </summary>
+    public InterruptedTurnNotificationService(
+        ISessionStore sessions,
+        IAgentRegistry agentRegistry,
+        IActivityBroadcaster broadcaster,
+        IChannelManager channelManager,
+        ILogger<InterruptedTurnNotificationService> logger,
+        IInboundMessageOrchestrator? orchestrator,
+        IOptions<GatewayOptions>? options)
     {
         _sessions = sessions;
         _agentRegistry = agentRegistry;
         _broadcaster = broadcaster;
         _channelManager = channelManager;
         _logger = logger;
+        _orchestrator = orchestrator;
+        _options = options?.Value ?? new GatewayOptions();
     }
 
     /// <inheritdoc />
@@ -52,6 +85,7 @@ public sealed class InterruptedTurnNotificationService : IHostedService
     {
         var agents = _agentRegistry.GetAll();
         var notified = 0;
+        var replayed = 0;
 
         foreach (var descriptor in agents)
         {
@@ -86,6 +120,15 @@ public sealed class InterruptedTurnNotificationService : IHostedService
                 session.AddEntry(notification);
                 session.RemoveCrashSentinels();
 
+                // Attempt auto-replay before saving (replay decision is metadata-driven).
+                var didReplay = false;
+                if (_options.AutoReplayInterruptedTurns && session.IsInteractive && _orchestrator is not null)
+                {
+                    didReplay = await TryAutoReplayAsync(session, agentId, cancellationToken).ConfigureAwait(false);
+                    if (didReplay)
+                        replayed++;
+                }
+
                 try
                 {
                     await _sessions.SaveAsync(session, cancellationToken).ConfigureAwait(false);
@@ -103,11 +146,14 @@ public sealed class InterruptedTurnNotificationService : IHostedService
                     AgentId = agentId.Value,
                     SessionId = session.SessionId.Value,
                     ConversationId = session.ConversationId.IsInitialized() ? session.ConversationId.Value : null,
-                    Message = NotificationContent
+                    Message = didReplay
+                        ? $"{NotificationContent} (auto-replaying)"
+                        : NotificationContent
                 }, cancellationToken).ConfigureAwait(false);
 
                 // Deliver via channel adapter when we have enough addressing information.
-                if (session.ChannelType.HasValue
+                if (!didReplay
+                    && session.ChannelType.HasValue
                     && !string.IsNullOrWhiteSpace(session.CallerId)
                     && _channelManager.Get(session.ChannelType.Value) is { } adapter)
                 {
@@ -135,10 +181,81 @@ public sealed class InterruptedTurnNotificationService : IHostedService
         }
 
         _logger.LogInformation(
-            "Interrupted-turn scan complete: {NotifiedCount} session(s) found with crash sentinels and notified",
-            notified);
+            "Interrupted-turn scan complete: {NotifiedCount} session(s) found with crash sentinels ({ReplayedCount} auto-replayed)",
+            notified, replayed);
     }
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private Task<bool> TryAutoReplayAsync(GatewaySession session, AgentId agentId, CancellationToken cancellationToken)
+    {
+        // Read existing replay count from metadata.
+        var replayCount = 0;
+        if (session.Metadata.TryGetValue(MetadataKeyReplayCount, out var raw))
+        {
+            replayCount = raw switch
+            {
+                int i => i,
+                long l => (int)l,
+                string s when int.TryParse(s, out var parsed) => parsed,
+                _ => 0
+            };
+        }
+
+        if (replayCount >= _options.MaxAutoReplayAttempts)
+        {
+            _logger.LogWarning(
+                "Session {SessionId} has reached max auto-replay attempts ({Max}); falling back to notification only",
+                session.SessionId.Value, _options.MaxAutoReplayAttempts);
+            return Task.FromResult(false);
+        }
+
+        // Find the last user message before the sentinel — this is what we replay.
+        var lastUser = session.History
+            .Where(e => e.Role == MessageRole.User && !e.IsCrashSentinel)
+            .OrderBy(e => e.Timestamp)
+            .LastOrDefault();
+
+        if (lastUser is null || string.IsNullOrWhiteSpace(lastUser.Content))
+        {
+            _logger.LogDebug(
+                "Session {SessionId} has no replayable user message; skipping auto-replay",
+                session.SessionId.Value);
+            return Task.FromResult(false);
+        }
+
+        // Increment the replay counter in metadata.
+        session.Metadata[MetadataKeyReplayCount] = replayCount + 1;
+
+        var channelType = session.ChannelType ?? ChannelKey.From("internal");
+        var callerId = session.CallerId ?? session.SessionId.Value;
+
+        var replay = new InboundMessage
+        {
+            ChannelType = channelType,
+            SenderId = callerId,
+            Sender = CitizenId.Of(agentId),
+            ChannelAddress = ChannelAddress.From(callerId),
+            Content = lastUser.Content,
+            Timestamp = DateTimeOffset.UtcNow,
+            RoutingHints = new InboundMessageRoutingHints(
+                RequestedAgentId: agentId,
+                RequestedSessionId: session.SessionId,
+                RequestedConversationId: session.ConversationId.IsInitialized() ? session.ConversationId : null),
+            Metadata = new Dictionary<string, object?>
+            {
+                ["isReplay"] = true,
+                ["originalTimestamp"] = lastUser.Timestamp.ToString("o")
+            }
+        };
+
+        var accepted = _orchestrator!.Post(replay);
+
+        _logger.LogInformation(
+            "Auto-replay for session {SessionId}: Post returned {Accepted} (attempt {Attempt}/{Max})",
+            session.SessionId.Value, accepted, replayCount + 1, _options.MaxAutoReplayAttempts);
+
+        return Task.FromResult(accepted);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/AutoReplayInterruptedTurnsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/AutoReplayInterruptedTurnsTests.cs
@@ -1,0 +1,221 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Activity;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Dispatching;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+public sealed class AutoReplayInterruptedTurnsTests
+{
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static GatewaySession CreateSession(
+        string sessionId,
+        string agentId,
+        bool withSentinel = false,
+        string? callerId = null,
+        ChannelKey? channelType = null,
+        SessionType? sessionType = null,
+        string? lastUserContent = null,
+        int existingReplayCount = 0)
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From(sessionId),
+            AgentId = AgentId.From(agentId),
+            Status = SessionStatus.Active,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            SessionType = sessionType ?? SessionType.UserAgent,
+            ChannelType = channelType,
+            CallerId = callerId
+        };
+
+        if (lastUserContent is not null)
+        {
+            session.AddEntry(new SessionEntry
+            {
+                Role = MessageRole.User,
+                Content = lastUserContent,
+                Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1)
+            });
+        }
+
+        if (withSentinel)
+        {
+            session.AddEntry(new SessionEntry
+            {
+                Role = MessageRole.System,
+                Content = "[agent turn in progress — gateway restarted if visible]",
+                IsCrashSentinel = true
+            });
+        }
+
+        if (existingReplayCount > 0)
+            session.Metadata[InterruptedTurnNotificationService.MetadataKeyReplayCount] = existingReplayCount;
+
+        return session;
+    }
+
+    private static IAgentRegistry CreateRegistry(params string[] agentIds)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll())
+            .Returns(agentIds.Select(id => new AgentDescriptor
+            {
+                AgentId = AgentId.From(id),
+                DisplayName = id,
+                ModelId = "gpt-4.1",
+                ApiProvider = "copilot"
+            }).ToList());
+        return registry.Object;
+    }
+
+    private static Mock<ISessionStore> CreateStore(params GatewaySession[] sessions)
+    {
+        var store = new Mock<ISessionStore>();
+        store.Setup(s => s.ListAsync(It.IsAny<AgentId?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentId? agentId, CancellationToken _) =>
+                sessions.Where(s => !agentId.HasValue || s.AgentId == agentId.Value).ToList());
+        store.Setup(s => s.SaveAsync(It.IsAny<GatewaySession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return store;
+    }
+
+    private static Mock<IInboundMessageOrchestrator> CreateOrchestrator(bool postAccepted = true)
+    {
+        var orch = new Mock<IInboundMessageOrchestrator>();
+        orch.Setup(o => o.Post(It.IsAny<InboundMessage>())).Returns(postAccepted);
+        return orch;
+    }
+
+    private static InterruptedTurnNotificationService CreateService(
+        ISessionStore store,
+        IAgentRegistry registry,
+        GatewayOptions? options = null,
+        IInboundMessageOrchestrator? orchestrator = null,
+        IActivityBroadcaster? broadcaster = null,
+        IChannelManager? channelManager = null)
+    {
+        broadcaster ??= Mock.Of<IActivityBroadcaster>();
+        channelManager ??= Mock.Of<IChannelManager>();
+        return new InterruptedTurnNotificationService(
+            store,
+            registry,
+            broadcaster,
+            channelManager,
+            NullLogger<InterruptedTurnNotificationService>.Instance,
+            orchestrator,
+            options is not null ? Options.Create(options) : null);
+    }
+
+    // ── Tests ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AutoReplay_WhenEnabled_PostsLastUserMessage()
+    {
+        var session = CreateSession("sess-1", "agent-a", withSentinel: true,
+            channelType: ChannelKey.From("signalr"), lastUserContent: "hello agent");
+        var store = CreateStore(session);
+        var orchestrator = CreateOrchestrator();
+        var options = new GatewayOptions { AutoReplayInterruptedTurns = true, MaxAutoReplayAttempts = 2 };
+
+        var service = CreateService(store.Object, CreateRegistry("agent-a"), options, orchestrator.Object);
+        await service.StartAsync(CancellationToken.None);
+
+        orchestrator.Verify(o => o.Post(It.Is<InboundMessage>(m =>
+            m.Content == "hello agent" &&
+            (bool)m.Metadata["isReplay"]! == true)), Times.Once);
+    }
+
+    [Fact]
+    public async Task AutoReplay_WhenDisabled_DoesNotCallPost()
+    {
+        var session = CreateSession("sess-2", "agent-b", withSentinel: true,
+            channelType: ChannelKey.From("signalr"), lastUserContent: "hello");
+        var store = CreateStore(session);
+        var orchestrator = CreateOrchestrator();
+        var options = new GatewayOptions { AutoReplayInterruptedTurns = false };
+
+        var service = CreateService(store.Object, CreateRegistry("agent-b"), options, orchestrator.Object);
+        await service.StartAsync(CancellationToken.None);
+
+        orchestrator.Verify(o => o.Post(It.IsAny<InboundMessage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AutoReplay_WhenMaxAttemptsReached_FallsBackToNotificationOnly()
+    {
+        var session = CreateSession("sess-3", "agent-c", withSentinel: true,
+            channelType: ChannelKey.From("signalr"), lastUserContent: "retry this",
+            existingReplayCount: 2);
+        var store = CreateStore(session);
+        var orchestrator = CreateOrchestrator();
+        var options = new GatewayOptions { AutoReplayInterruptedTurns = true, MaxAutoReplayAttempts = 2 };
+
+        var service = CreateService(store.Object, CreateRegistry("agent-c"), options, orchestrator.Object);
+        await service.StartAsync(CancellationToken.None);
+
+        // Should NOT replay (at max)
+        orchestrator.Verify(o => o.Post(It.IsAny<InboundMessage>()), Times.Never);
+
+        // But SHOULD still append a notification entry
+        session.History.ShouldContain(e => e.Role == MessageRole.Notification);
+    }
+
+    [Fact]
+    public async Task AutoReplay_CronSession_IsSkipped()
+    {
+        // Cron sessions have ChannelType="cron" — IsInteractive returns false
+        var session = CreateSession("sess-4", "agent-d", withSentinel: true,
+            channelType: ChannelKey.From("cron"), lastUserContent: "cron message");
+        var store = CreateStore(session);
+        var orchestrator = CreateOrchestrator();
+        var options = new GatewayOptions { AutoReplayInterruptedTurns = true, MaxAutoReplayAttempts = 2 };
+
+        var service = CreateService(store.Object, CreateRegistry("agent-d"), options, orchestrator.Object);
+        await service.StartAsync(CancellationToken.None);
+
+        // Cron session is not interactive — replay must not fire
+        orchestrator.Verify(o => o.Post(It.IsAny<InboundMessage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AutoReplay_IncrementsReplayCountInMetadata()
+    {
+        var session = CreateSession("sess-5", "agent-e", withSentinel: true,
+            channelType: ChannelKey.From("signalr"), lastUserContent: "count this");
+        var store = CreateStore(session);
+        var orchestrator = CreateOrchestrator();
+        var options = new GatewayOptions { AutoReplayInterruptedTurns = true, MaxAutoReplayAttempts = 3 };
+
+        var service = CreateService(store.Object, CreateRegistry("agent-e"), options, orchestrator.Object);
+        await service.StartAsync(CancellationToken.None);
+
+        session.Metadata[InterruptedTurnNotificationService.MetadataKeyReplayCount].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task AutoReplay_WhenNoUserMessageExists_DoesNotPost()
+    {
+        // Session with sentinel but no prior user message
+        var session = CreateSession("sess-6", "agent-f", withSentinel: true,
+            channelType: ChannelKey.From("signalr"), lastUserContent: null);
+        var store = CreateStore(session);
+        var orchestrator = CreateOrchestrator();
+        var options = new GatewayOptions { AutoReplayInterruptedTurns = true, MaxAutoReplayAttempts = 2 };
+
+        var service = CreateService(store.Object, CreateRegistry("agent-f"), options, orchestrator.Object);
+        await service.StartAsync(CancellationToken.None);
+
+        orchestrator.Verify(o => o.Post(It.IsAny<InboundMessage>()), Times.Never);
+    }
+}


### PR DESCRIPTION
Closes #744

## Changes

- `GatewayOptions.AutoReplayInterruptedTurns` (bool, default `false`) — opt-in toggle
- `GatewayOptions.MaxAutoReplayAttempts` (int, default `2`) — crash-loop cap
- `InterruptedTurnNotificationService` extended with auto-replay path:
  - Finds last `User` entry before crash sentinel
  - Reads `interruption_replay_count` from session metadata
  - If under max: increments counter, calls `IInboundMessageOrchestrator.Post()`
  - If at max: falls back to notification-only (no infinite loops)
  - Non-interactive sessions (cron/soul/subagent via `IsInteractive`) are excluded
  - Tagged `isReplay=true` + `originalTimestamp` in message metadata
- DI registration updated to inject `IInboundMessageOrchestrator` via `GetService` (backwards-compat: null if not registered)
- Backwards-compat 5-arg constructor overload preserved (no breaking change to existing tests/hosts)

## Tests

6 new tests in `AutoReplayInterruptedTurnsTests.cs`:
- `AutoReplay_WhenEnabled_PostsLastUserMessage`
- `AutoReplay_WhenDisabled_DoesNotCallPost`
- `AutoReplay_WhenMaxAttemptsReached_FallsBackToNotificationOnly`
- `AutoReplay_CronSession_IsSkipped`
- `AutoReplay_IncrementsReplayCountInMetadata`
- `AutoReplay_WhenNoUserMessageExists_DoesNotPost`

`test-impacted`: Architecture 167/167 ✅, Gateway.Tests 2170/2171 (1 skip) ✅, Scenarios 29/29 ✅, Cli 131 (Cli_Install pre-existing worktree race) ✅

## Merge Notes

Fully independent of all 26 currently open PRs. Safe to merge in any order.