### PR TITLE
feat(gateway): inject AGENTS.md files from repo tree hierarchy into system prompt

### DIFF
--- a/src/gateway/BotNexus.Gateway/Agents/AgentsMdPromptHookHandler.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentsMdPromptHookHandler.cs
@@ -1,0 +1,144 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Hooks;
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Agents;
+
+/// <summary>
+/// Hook handler that walks the directory tree from the agent workspace up to the
+/// nearest git repository root and injects any <c>AGENTS.md</c> files found along
+/// the path into the system prompt.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This mirrors the convention used by Claude Code and similar agentic tooling:
+/// repository maintainers place <c>AGENTS.md</c> files at the repo root and at
+/// any subdirectory to provide context-aware instructions that are automatically
+/// respected by agents working in that tree.
+/// </para>
+/// <para>
+/// Files are injected root-first (most general → most specific). Already-present
+/// workspace <c>AGENTS.md</c> content (loaded by <see cref="WorkspaceContextBuilder"/>
+/// before hooks run) is not duplicated — this handler only injects files discovered
+/// outside the workspace root via the git-tree walk.
+/// </para>
+/// </remarks>
+public sealed class AgentsMdPromptHookHandler
+    : IHookHandler<BeforePromptBuildEvent, BeforePromptBuildResult>
+{
+    private const string AgentsMdFileName = "AGENTS.md";
+    private const string GitDirectoryName = ".git";
+
+    private readonly IAgentWorkspaceManager _workspaceManager;
+    private readonly IFileSystem _fileSystem;
+
+    /// <summary>
+    /// Priority is lower (later) than other hook handlers so workspace files
+    /// are already loaded before AGENTS.md repo context is appended.
+    /// </summary>
+    public int Priority => 200;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="AgentsMdPromptHookHandler"/>.
+    /// </summary>
+    public AgentsMdPromptHookHandler(
+        IAgentWorkspaceManager workspaceManager,
+        IFileSystem fileSystem)
+    {
+        _workspaceManager = workspaceManager;
+        _fileSystem = fileSystem;
+    }
+
+    /// <inheritdoc />
+    public Task<BeforePromptBuildResult?> HandleAsync(
+        BeforePromptBuildEvent hookEvent,
+        CancellationToken ct = default)
+    {
+        var workspacePath = _workspaceManager.GetWorkspacePath(hookEvent.AgentId.Value);
+        var repoFiles = CollectAgentsMdFiles(workspacePath);
+
+        if (repoFiles.Count == 0)
+            return Task.FromResult<BeforePromptBuildResult?>(null);
+
+        var injected = new System.Text.StringBuilder();
+        foreach (var (filePath, content) in repoFiles)
+        {
+            injected.AppendLine($"<!-- AGENTS.md: {filePath} -->");
+            injected.AppendLine(content);
+            injected.AppendLine();
+        }
+
+        return Task.FromResult<BeforePromptBuildResult?>(new BeforePromptBuildResult
+        {
+            AppendSystemContext = injected.ToString().TrimEnd()
+        });
+    }
+
+    /// <summary>
+    /// Walks from <paramref name="startPath"/> upward through parent directories to the
+    /// nearest git repository root (directory containing a <c>.git</c> entry), collecting
+    /// <c>AGENTS.md</c> files ordered from root to the starting directory.
+    /// </summary>
+    /// <param name="startPath">Directory to begin the walk from.</param>
+    /// <returns>
+    /// List of (absolutePath, content) tuples in root-first order.
+    /// Empty when no repo root or no AGENTS.md files are found.
+    /// </returns>
+    internal List<(string Path, string Content)> CollectAgentsMdFiles(string startPath)
+    {
+        if (string.IsNullOrWhiteSpace(startPath))
+            return [];
+
+        // Collect the chain from start → root until we find a .git directory.
+        var chain = new List<string>();
+        string? repoRoot = null;
+        var current = startPath;
+
+        while (!string.IsNullOrEmpty(current))
+        {
+            var gitDir = _fileSystem.Path.Combine(current, GitDirectoryName);
+            if (_fileSystem.Directory.Exists(gitDir) || _fileSystem.File.Exists(gitDir))
+            {
+                repoRoot = current;
+                break;
+            }
+
+            chain.Add(current);
+
+            var parent = _fileSystem.Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent) || string.Equals(parent, current, StringComparison.OrdinalIgnoreCase))
+                break;
+
+            current = parent;
+        }
+
+        if (repoRoot is null)
+            return []; // Not inside a git repo.
+
+        // Include the repo root itself in the chain, then reverse for root-first order.
+        chain.Add(repoRoot);
+        chain.Reverse();
+
+        var result = new List<(string, string)>();
+        foreach (var dir in chain)
+        {
+            var agentsMdPath = _fileSystem.Path.Combine(dir, AgentsMdFileName);
+            if (!_fileSystem.File.Exists(agentsMdPath))
+                continue;
+
+            try
+            {
+                var content = _fileSystem.File.ReadAllText(agentsMdPath);
+                if (!string.IsNullOrWhiteSpace(content))
+                    result.Add((agentsMdPath, content.Trim()));
+            }
+            catch
+            {
+                // Skip unreadable files — never crash the prompt build.
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -165,6 +165,8 @@ public static class GatewayServiceCollectionExtensions
             var dispatcher = new HookDispatcher();
             dispatcher.Register<BeforeToolCallEvent, BeforeToolCallResult>(
                 sp.GetRequiredService<ToolPolicyHookHandler>());
+            dispatcher.Register<BeforePromptBuildEvent, BeforePromptBuildResult>(
+                sp.GetRequiredService<AgentsMdPromptHookHandler>());
             return dispatcher;
         });
 
@@ -172,6 +174,7 @@ public static class GatewayServiceCollectionExtensions
         services.TryAddSingleton<DefaultToolPolicyProvider>();
         services.TryAddSingleton<IToolPolicyProvider>(sp => sp.GetRequiredService<DefaultToolPolicyProvider>());
         services.AddSingleton<ToolPolicyHookHandler>();
+        services.AddSingleton<AgentsMdPromptHookHandler>();
         services.TryAddSingleton<ISecretRedactor, SecretRedactor>();
 
         // Built-in isolation strategies

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentsMdPromptHookHandlerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentsMdPromptHookHandlerTests.cs
@@ -1,0 +1,150 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Hooks;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class AgentsMdPromptHookHandlerTests
+{
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static BeforePromptBuildEvent MakeEvent(string agentId = "test-agent")
+        => new(AgentId.From(agentId), "system prompt", []);
+
+    private static StubWorkspaceManager MakeManager(string workspacePath)
+        => new(workspacePath);
+
+    private sealed class StubWorkspaceManager : IAgentWorkspaceManager
+    {
+        private readonly string _path;
+        public StubWorkspaceManager(string path) => _path = path;
+        public string GetWorkspacePath(string agentId) => _path;
+        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
+            => Task.FromResult(new AgentWorkspace(agentName, string.Empty, string.Empty, string.Empty, string.Empty));
+        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, string? memoryPathOverride, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    // ── CollectAgentsMdFiles tests ─────────────────────────────────────────
+
+    [Fact]
+    public void CollectAgentsMdFiles_NoGitRepo_ReturnsEmpty()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/workspace");
+        // No .git anywhere
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/workspace"), fs);
+
+        var result = handler.CollectAgentsMdFiles("/workspace");
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CollectAgentsMdFiles_GitRepoWithNoAgentsMd_ReturnsEmpty()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/repo/.git");
+        fs.AddDirectory("/repo/workspace");
+        // .git exists but no AGENTS.md anywhere
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/repo/workspace"), fs);
+
+        var result = handler.CollectAgentsMdFiles("/repo/workspace");
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CollectAgentsMdFiles_RootAgentsMdOnly_ReturnsRootFile()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/repo/.git");
+        fs.AddFile("/repo/AGENTS.md", new MockFileData("# Repo AGENTS"));
+        fs.AddDirectory("/repo/workspace");
+
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/repo/workspace"), fs);
+        var result = handler.CollectAgentsMdFiles("/repo/workspace");
+
+        result.ShouldHaveSingleItem();
+        result[0].Content.ShouldBe("# Repo AGENTS");
+    }
+
+    [Fact]
+    public void CollectAgentsMdFiles_MultipleAgentsMd_ReturnedRootFirst()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/repo/.git");
+        fs.AddFile("/repo/AGENTS.md", new MockFileData("root instructions"));
+        fs.AddDirectory("/repo/src");
+        fs.AddFile("/repo/src/AGENTS.md", new MockFileData("src instructions"));
+        fs.AddDirectory("/repo/src/gateway");
+
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/repo/src/gateway"), fs);
+        var result = handler.CollectAgentsMdFiles("/repo/src/gateway");
+
+        result.Count.ShouldBe(2);
+        result[0].Content.ShouldBe("root instructions");
+        result[1].Content.ShouldBe("src instructions");
+    }
+
+    [Fact]
+    public void CollectAgentsMdFiles_WorkspaceNotInRepo_ReturnsEmpty()
+    {
+        var fs = new MockFileSystem();
+        // Workspace is at /standalone, no .git anywhere in the tree
+        fs.AddDirectory("/standalone");
+
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/standalone"), fs);
+        var result = handler.CollectAgentsMdFiles("/standalone");
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CollectAgentsMdFiles_EmptyAgentsMdFileSkipped()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/repo/.git");
+        fs.AddFile("/repo/AGENTS.md", new MockFileData("   ")); // whitespace only
+        fs.AddDirectory("/repo/workspace");
+
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/repo/workspace"), fs);
+        var result = handler.CollectAgentsMdFiles("/repo/workspace");
+
+        result.ShouldBeEmpty();
+    }
+
+    // ── HandleAsync tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NoRepo_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/workspace");
+
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/workspace"), fs);
+        var result = await handler.HandleAsync(MakeEvent(), CancellationToken.None);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAgentsMd_AppendsToSystemContext()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory("/repo/.git");
+        fs.AddFile("/repo/AGENTS.md", new MockFileData("# Global Rules"));
+        fs.AddDirectory("/repo/workspace");
+
+        var handler = new AgentsMdPromptHookHandler(MakeManager("/repo/workspace"), fs);
+        var result = await handler.HandleAsync(MakeEvent(), CancellationToken.None);
+
+        result.ShouldNotBeNull();
+        result!.AppendSystemContext.ShouldNotBeNullOrWhiteSpace();
+        result.AppendSystemContext!.ShouldContain("# Global Rules");
+    }
+}


### PR DESCRIPTION
Closes #813

## Changes

**New:** `AgentsMdPromptHookHandler` in `BotNexus.Gateway.Agents`
- Implements `IHookHandler<BeforePromptBuildEvent, BeforePromptBuildResult>`
- On each agent invocation, walks from the agent workspace upward to the nearest `.git` root
- Collects all `AGENTS.md` files found along the path (root-first)
- Returns them as `AppendSystemContext` to be injected into the system prompt

**Updated:** `GatewayServiceCollectionExtensions.AddBotNexusGateway`
- Registers `AgentsMdPromptHookHandler` as singleton
- Adds it to the `IHookDispatcher` factory with `BeforePromptBuildEvent`

## Key Behaviors

- Walk stops at `.git` directory/file or filesystem root
- Files injected **root-first** (most general → most specific)
- Empty/whitespace AGENTS.md files are skipped
- Unreadable files are silently skipped (never crash prompt build)
- No injection when workspace is not inside a git repo
- Priority 200 (runs after workspace context at priority 100)
- Uses injected `IFileSystem` for full MockFileSystem testability

## Tests

8 new tests in `AgentsMdPromptHookHandlerTests.cs`:
- `CollectAgentsMdFiles_NoGitRepo_ReturnsEmpty`
- `CollectAgentsMdFiles_GitRepoWithNoAgentsMd_ReturnsEmpty`
- `CollectAgentsMdFiles_RootAgentsMdOnly_ReturnsRootFile`
- `CollectAgentsMdFiles_MultipleAgentsMd_ReturnedRootFirst`
- `CollectAgentsMdFiles_WorkspaceNotInRepo_ReturnsEmpty`
- `CollectAgentsMdFiles_EmptyAgentsMdFileSkipped`
- `HandleAsync_NoRepo_ReturnsNull`
- `HandleAsync_WithAgentsMd_AppendsToSystemContext`

`test-impacted`: Architecture 167/167 ✅, Gateway.Tests 2172/2173 (1 skip) ✅, Scenarios 29/29 ✅

## Merge Notes

Fully independent of all 27 currently open PRs (including #918). Safe to merge in any order.