### PR TITLE
feat(portal): add SessionDebugPanel with Overview and Metadata tabs

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IGatewayRestClient.cs
@@ -118,6 +118,13 @@ public interface IGatewayRestClient
     /// <summary>POST /api/diagnostics/channel-error - report a channel-side error to the gateway log.</summary>
     Task ReportChannelErrorAsync(ChannelErrorReportDto report, CancellationToken cancellationToken = default);
 
+    /// <summary>GET /api/sessions/{sessionId}/debug?offset={offset}&amp;limit={limit}</summary>
+    Task<SessionDebugSnapshotDto?> GetSessionDebugAsync(
+        string sessionId,
+        int offset = 0,
+        int limit = 50,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Current API base URL (set via Configure). Null if not yet configured.</summary>
     string? ApiBaseUrl { get; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayRestClient.cs
@@ -348,4 +348,17 @@ public sealed class GatewayRestClient : IGatewayRestClient, IChannelErrorReporte
     /// <inheritdoc cref="IChannelErrorReporter.ReportAsync" />
     Task IChannelErrorReporter.ReportAsync(ChannelErrorReportDto report, CancellationToken cancellationToken)
         => ReportChannelErrorAsync(report, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<SessionDebugSnapshotDto?> GetSessionDebugAsync(
+        string sessionId,
+        int offset = 0,
+        int limit = 50,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+        return await _http.GetFromJsonAsync<SessionDebugSnapshotDto>(
+            $"{_apiBaseUrl}sessions/{Uri.EscapeDataString(sessionId)}/debug?offset={offset}&limit={limit}",
+            cancellationToken);
+    }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/SessionDebugSnapshotDto.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/SessionDebugSnapshotDto.cs
@@ -1,0 +1,32 @@
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+/// <summary>
+/// Debug snapshot returned by GET /api/sessions/{sessionId}/debug.
+/// </summary>
+public sealed class SessionDebugSnapshotDto
+{
+    public string? SessionId { get; init; }
+    public string? AgentId { get; init; }
+    public string? Status { get; init; }
+    public string? SessionType { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+    public int MessageCount { get; init; }
+    public string? ConversationId { get; init; }
+    public string? ChannelType { get; init; }
+    public string? SystemPrompt { get; init; }
+    public DateTimeOffset? SystemPromptCapturedAt { get; init; }
+    public SessionDebugHistoryDto? History { get; init; }
+    public Dictionary<string, object?>? Metadata { get; init; }
+}
+
+/// <summary>
+/// Paginated history block within a <see cref="SessionDebugSnapshotDto"/>.
+/// </summary>
+public sealed class SessionDebugHistoryDto
+{
+    public int TotalCount { get; init; }
+    public int Offset { get; init; }
+    public int Limit { get; init; }
+    public IReadOnlyList<object?>? Entries { get; init; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SessionDebugPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/SessionDebugPanel.razor
@@ -1,0 +1,113 @@
+@inject IGatewayRestClient GatewayRestClient
+@implements IDisposable
+
+@if (!string.IsNullOrWhiteSpace(SessionId))
+{
+    <div class="session-debug-panel" data-testid="session-debug-panel">
+        <div class="session-debug-header">
+            <h3 class="session-debug-title">Session Debug</h3>
+            <button class="session-debug-close" @onclick="OnClose" title="Close" data-testid="session-debug-close">&#x2715;</button>
+        </div>
+
+        @if (_isLoading)
+        {
+            <div class="session-debug-loading">Loading session…</div>
+        }
+        else if (_loadError is not null)
+        {
+            <div class="session-debug-error" data-testid="session-debug-error">@_loadError</div>
+        }
+        else if (_snapshot is not null)
+        {
+            <div class="session-debug-tabs" data-testid="session-debug-tabs">
+                <button class="session-debug-tab @(_activeTab == "overview" ? "active" : "")"
+                        data-testid="session-debug-tab-overview"
+                        @onclick='() => _activeTab = "overview"'>Overview</button>
+                <button class="session-debug-tab @(_activeTab == "metadata" ? "active" : "")"
+                        data-testid="session-debug-tab-metadata"
+                        @onclick='() => _activeTab = "metadata"'>Metadata</button>
+            </div>
+
+            @if (_activeTab == "overview")
+            {
+                <table class="session-debug-table" data-testid="session-debug-overview">
+                    <tbody>
+                        <tr><th>Session ID</th><td data-testid="session-id">@_snapshot.SessionId</td></tr>
+                        <tr><th>Agent</th><td data-testid="agent-id">@_snapshot.AgentId</td></tr>
+                        <tr><th>Status</th><td data-testid="status">@_snapshot.Status</td></tr>
+                        <tr><th>Type</th><td data-testid="session-type">@_snapshot.SessionType</td></tr>
+                        <tr><th>Created</th><td data-testid="created-at">@_snapshot.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</td></tr>
+                        <tr><th>Updated</th><td data-testid="updated-at">@_snapshot.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</td></tr>
+                        <tr><th>Messages</th><td data-testid="message-count">@_snapshot.MessageCount</td></tr>
+                        <tr><th>Conversation</th><td data-testid="conversation-id">@(_snapshot.ConversationId ?? "—")</td></tr>
+                        <tr><th>Channel</th><td data-testid="channel-type">@(_snapshot.ChannelType ?? "—")</td></tr>
+                    </tbody>
+                </table>
+            }
+            else if (_activeTab == "metadata")
+            {
+                @if (_snapshot.Metadata is null || _snapshot.Metadata.Count == 0)
+                {
+                    <div class="session-debug-empty" data-testid="session-debug-metadata-empty">No metadata entries.</div>
+                }
+                else
+                {
+                    <table class="session-debug-table" data-testid="session-debug-metadata">
+                        <thead>
+                            <tr><th>Key</th><th>Value</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var kv in _snapshot.Metadata)
+                            {
+                                <tr>
+                                    <td class="session-debug-meta-key" data-testid="meta-key">@kv.Key</td>
+                                    <td class="session-debug-meta-value" data-testid="meta-value">@(kv.Value?.ToString() ?? "null")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            }
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public string? SessionId { get; set; }
+
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    private SessionDebugSnapshotDto? _snapshot;
+    private bool _isLoading;
+    private string? _loadError;
+    private string _activeTab = "overview";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SessionId))
+            return;
+
+        _isLoading = true;
+        _loadError = null;
+        _snapshot = null;
+        _activeTab = "overview";
+        StateHasChanged();
+
+        try
+        {
+            _snapshot = await GatewayRestClient.GetSessionDebugAsync(SessionId);
+            if (_snapshot is null)
+                _loadError = "Session not found.";
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"Unable to load session: {ex.Message}";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    public void Dispose() { }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionDebugPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionDebugPanelTests.cs
@@ -1,0 +1,181 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class SessionDebugPanelTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IGatewayRestClient _restClient = Substitute.For<IGatewayRestClient>();
+
+    public SessionDebugPanelTests()
+    {
+        _ctx.Services.AddSingleton(_restClient);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private static SessionDebugSnapshotDto MakeSnapshot(
+        string sessionId = "sess-1",
+        string agentId = "agent-1",
+        string status = "Active",
+        string sessionType = "user-agent",
+        string? conversationId = "conv-1",
+        string? channelType = "signalr",
+        int messageCount = 5,
+        Dictionary<string, object?>? metadata = null) => new()
+    {
+        SessionId = sessionId,
+        AgentId = agentId,
+        Status = status,
+        SessionType = sessionType,
+        CreatedAt = new DateTimeOffset(2026, 6, 1, 10, 0, 0, TimeSpan.Zero),
+        UpdatedAt = new DateTimeOffset(2026, 6, 1, 11, 0, 0, TimeSpan.Zero),
+        MessageCount = messageCount,
+        ConversationId = conversationId,
+        ChannelType = channelType,
+        Metadata = metadata ?? new Dictionary<string, object?> { ["key1"] = "value1", ["key2"] = 42 }
+    };
+
+    [Fact]
+    public void Renders_nothing_when_SessionId_is_null()
+    {
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, (string?)null));
+        cut.Markup.ShouldNotContain("session-debug-panel");
+    }
+
+    [Fact]
+    public void Shows_loading_state_while_fetching()
+    {
+        var tcs = new TaskCompletionSource<SessionDebugSnapshotDto?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ => tcs.Task);
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "sess-1"));
+
+        cut.Markup.ShouldContain("Loading session");
+        tcs.SetResult(null);
+    }
+
+    [Fact]
+    public void Shows_overview_tab_with_session_fields_after_load()
+    {
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionDebugSnapshotDto?>(MakeSnapshot()));
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "sess-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[data-testid='session-id']").TextContent.ShouldBe("sess-1");
+            cut.Find("[data-testid='agent-id']").TextContent.ShouldBe("agent-1");
+            cut.Find("[data-testid='status']").TextContent.ShouldBe("Active");
+            cut.Find("[data-testid='session-type']").TextContent.ShouldBe("user-agent");
+            cut.Find("[data-testid='message-count']").TextContent.ShouldBe("5");
+            cut.Find("[data-testid='conversation-id']").TextContent.ShouldBe("conv-1");
+            cut.Find("[data-testid='channel-type']").TextContent.ShouldBe("signalr");
+        });
+    }
+
+    [Fact]
+    public void Shows_metadata_tab_with_key_value_pairs()
+    {
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionDebugSnapshotDto?>(MakeSnapshot(
+                metadata: new Dictionary<string, object?> { ["myKey"] = "myValue", ["count"] = 99 })));
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "sess-1"));
+
+        cut.WaitForAssertion(() => cut.Find("[data-testid='session-debug-tabs']"));
+
+        // Switch to Metadata tab
+        cut.Find("[data-testid='session-debug-tab-metadata']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var keys = cut.FindAll("[data-testid='meta-key']");
+            keys.Count.ShouldBe(2);
+            keys.Select(k => k.TextContent).ShouldContain("myKey");
+            keys.Select(k => k.TextContent).ShouldContain("count");
+        });
+    }
+
+    [Fact]
+    public void Shows_empty_state_when_metadata_is_empty()
+    {
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionDebugSnapshotDto?>(MakeSnapshot(
+                metadata: new Dictionary<string, object?>())));
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "sess-1"));
+
+        cut.WaitForAssertion(() => cut.Find("[data-testid='session-debug-tabs']"));
+
+        cut.Find("[data-testid='session-debug-tab-metadata']").Click();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("[data-testid='session-debug-metadata-empty']").TextContent.ShouldContain("No metadata"));
+    }
+
+    [Fact]
+    public void Shows_not_found_error_when_api_returns_null()
+    {
+        _restClient.GetSessionDebugAsync("missing", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionDebugSnapshotDto?>(null));
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "missing"));
+
+        cut.WaitForAssertion(() =>
+            cut.Find("[data-testid='session-debug-error']").TextContent.ShouldContain("not found"));
+    }
+
+    [Fact]
+    public void Shows_error_message_on_http_exception()
+    {
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<SessionDebugSnapshotDto?>(new HttpRequestException("timeout")));
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "sess-1"));
+
+        cut.WaitForAssertion(() =>
+            cut.Find("[data-testid='session-debug-error']").TextContent.ShouldContain("Unable to load session"));
+    }
+
+    [Fact]
+    public void Close_button_invokes_OnClose_callback()
+    {
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionDebugSnapshotDto?>(MakeSnapshot()));
+
+        var closeFired = false;
+        var cut = _ctx.Render<SessionDebugPanel>(p => p
+            .Add(x => x.SessionId, "sess-1")
+            .Add(x => x.OnClose, EventCallback.Factory.Create(this, () => closeFired = true)));
+
+        cut.WaitForAssertion(() => cut.Find("[data-testid='session-debug-close']"));
+        cut.Find("[data-testid='session-debug-close']").Click();
+
+        closeFired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Null_conversationId_and_channelType_render_dash_placeholder()
+    {
+        _restClient.GetSessionDebugAsync("sess-1", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionDebugSnapshotDto?>(MakeSnapshot(conversationId: null, channelType: null)));
+
+        var cut = _ctx.Render<SessionDebugPanel>(p => p.Add(x => x.SessionId, "sess-1"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("[data-testid='conversation-id']").TextContent.ShouldBe("—");
+            cut.Find("[data-testid='channel-type']").TextContent.ShouldBe("—");
+        });
+    }
+}


### PR DESCRIPTION
Closes #768

## Changes
New SessionDebugSnapshotDto DTO for the GET /api/sessions/{id}/debug response.
GetSessionDebugAsync added to IGatewayRestClient and GatewayRestClient.
New SessionDebugPanel.razor component:
  Overview tab: session ID, agent, status, type, created/updated, message count, conversation ID, channel
  Metadata tab: raw key/value table of session metadata
  Loading, not-found, and error states
  Close button (OnClose callback)
  Both fields render dash when null
8 new bUnit tests in SessionDebugPanelTests.cs

## Test Results
BlazorClient.Tests: 370/370 pass (8 new)
Architecture.Tests: 167/167 pass
Gateway.Tests: 2164/2165 pass (1 expected skip)
Scenarios.Tests: 29/29 pass

## Merge Notes
This PR should merge after PR #911 (feat/session-debug-endpoint) so the debug API endpoint exists when the panel is used. The panel compiles and renders against the interface -- it will degrade gracefully to a not-found error until the endpoint is live.
Safe to merge in parallel with all other open PRs -- SessionDebugPanel.razor is a new file, no overlap.