### PR TITLE
feat(mobile): add refresh button and auto-reconnect on app resume

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IPortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IPortalLoadService.cs
@@ -14,8 +14,14 @@ public interface IPortalLoadService
     /// <summary>Non-null if startup failed.</summary>
     string? LoadError { get; }
 
+    /// <summary>True when the SignalR hub connection is in the Connected state.</summary>
+    bool IsSignalRConnected { get; }
+
     /// <summary>Raised when <see cref="IsReady"/>, <see cref="IsLoading"/>, or <see cref="LoadError"/> changes.</summary>
     event Action? OnReadyChanged;
+
+    /// <summary>Raised when <see cref="IsSignalRConnected"/> changes.</summary>
+    event Action? OnConnectionStateChanged;
 
     /// <summary>
     /// Executes the portal startup sequence: REST-first, SignalR-second.
@@ -26,4 +32,10 @@ public interface IPortalLoadService
     /// 5. IsReady = true
     /// </summary>
     Task InitializeAsync(string hubUrl, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Re-fetches agent and conversation data and reconnects SignalR if disconnected.
+    /// Intended for mobile app-resume and manual refresh flows.
+    /// </summary>
+    Task RefreshAsync(CancellationToken cancellationToken = default);
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalLoadService.cs
@@ -11,10 +11,14 @@ public sealed class PortalLoadService : IPortalLoadService
     private readonly IGatewayEventHandler _eventHandler;
     private readonly IAgentInteractionService? _agentInteraction;
 
+    private string? _hubUrl;
+
     public bool IsReady { get; private set; }
     public bool IsLoading { get; private set; }
     public string? LoadError { get; private set; }
+    public bool IsSignalRConnected => _hub.IsConnected;
     public event Action? OnReadyChanged;
+    public event Action? OnConnectionStateChanged;
 
     public PortalLoadService(
         IGatewayRestClient restClient,
@@ -35,6 +39,7 @@ public sealed class PortalLoadService : IPortalLoadService
         if (IsReady || IsLoading)
             return;
 
+        _hubUrl = hubUrl;
         IsLoading = true;
         LoadError = null;
         OnReadyChanged?.Invoke();
@@ -100,6 +105,11 @@ public sealed class PortalLoadService : IPortalLoadService
                     concreteHandler.ConversationRefreshDelegate = agentId => agentInteractionRef.RefreshConversationsAsync(agentId);
             }
             await _hub.ConnectAsync(hubUrl);
+
+            // Track SignalR connection state for UI indicators and reconnect flows.
+            _hub.OnReconnecting += () => OnConnectionStateChanged?.Invoke();
+            _hub.OnReconnected += () => OnConnectionStateChanged?.Invoke();
+            _hub.OnDisconnected += () => OnConnectionStateChanged?.Invoke();
 
             var subscribeResult = await _hub.SubscribeAllAsync();
             foreach (var session in subscribeResult.Sessions)
@@ -206,4 +216,50 @@ public sealed class PortalLoadService : IPortalLoadService
         "system" => "System",
         _ => role
     };
+
+    /// <inheritdoc />
+    public async Task RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        if (_hubUrl is null || IsLoading)
+            return;
+
+        try
+        {
+            // Re-fetch agent and conversation lists from REST
+            var agents = await _restClient.GetAgentsAsync(cancellationToken);
+            foreach (var agent in agents)
+            {
+                _store.UpsertAgent(new AgentState
+                {
+                    AgentId = agent.AgentId,
+                    DisplayName = agent.DisplayName,
+                    Emoji = agent.Emoji,
+                    IsConnected = true
+                });
+            }
+
+            var conversationTasks = agents.Select(async agent =>
+            {
+                var conversations = await _restClient.GetConversationsAsync(agent.AgentId, cancellationToken);
+                _store.SeedConversations(agent.AgentId, conversations);
+            });
+            await Task.WhenAll(conversationTasks);
+
+            // Reconnect SignalR if needed
+            if (!_hub.IsConnected)
+            {
+                await _hub.ConnectAsync(_hubUrl);
+                var subscribeResult = await _hub.SubscribeAllAsync();
+                foreach (var session in subscribeResult.Sessions)
+                    _store.RegisterSession(session.AgentId, session.SessionId, session.ChannelType);
+            }
+
+            _store.NotifyChanged();
+            OnConnectionStateChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[PortalLoadService] RefreshAsync failed: {ex.Message}");
+        }
+    }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -32,6 +32,16 @@ else
         .OrderByDescending(c => c.UpdatedAt)
         .ToList() ?? [];
     <div class="mobile-app">
+        <!-- DISCONNECTED INDICATOR -->
+        @if (!PortalLoad.IsSignalRConnected)
+        {
+            <div class="disconnected-bar" data-testid="disconnected-bar">
+                &#x26A0; Disconnected
+                <button class="reconnect-inline-btn" @onclick="ManualRefreshAsync" disabled="@_isRefreshing" aria-label="Reconnect">
+                    @(_isRefreshing ? "&#x21BB;" : "Reconnect")
+                </button>
+            </div>
+        }
         <!-- TOP BAR -->
         <div class="top-bar">
             <select class="agent-select" value="@Store.ActiveAgentId" @onchange="OnAgentChanged">
@@ -46,6 +56,9 @@ else
                     <option value="@conv.ConversationId">@conv.Title</option>
                 }
             </select>
+            <button class="refresh-btn" @onclick="ManualRefreshAsync" disabled="@_isRefreshing" aria-label="Refresh" data-testid="refresh-btn" title="Refresh conversations">
+                @(_isRefreshing ? "&#x21BB;" : "&#x21BA;")
+            </button>
             <div class="overflow-menu-wrapper">
                 <button class="overflow-btn" @onclick="ToggleMenu" aria-label="Menu">&#x22EF;</button>
                 @if (_menuOpen)
@@ -161,10 +174,13 @@ else
 
     private string _inputText = "";
     private bool _isSending;
+    private bool _isRefreshing;
     private bool _menuOpen;
     private ElementReference _messageStreamRef;
     private readonly Dictionary<string, string> _markdownCache = new();
     private ChatMessage? _modalToolMessage;
+    private DotNetObjectReference<Chat>? _dotNetRef;
+    private bool _appResumeListenerRegistered;
 
     // Route application guard -- prevents re-applying the same route key twice.
     private string? _appliedRouteKey;
@@ -177,6 +193,7 @@ else
     protected override void OnInitialized()
     {
         PortalLoad.OnReadyChanged += HandleReadyChanged;
+        PortalLoad.OnConnectionStateChanged += HandleConnectionStateChanged;
         Store.OnChanged += HandleStateChanged;
     }
 
@@ -214,6 +231,18 @@ else
                 ? Store.GetMessages(_lastActiveConversationId).Count
                 : 0;
             await ForceScrollToBottomAsync();
+
+            // Register visibilitychange listener for app-resume reconnect (mobile PWA).
+            if (!_appResumeListenerRegistered)
+            {
+                try
+                {
+                    _dotNetRef = DotNetObjectReference.Create(this);
+                    await JS.InvokeVoidAsync("BotNexusAppResume.initialize", _dotNetRef);
+                    _appResumeListenerRegistered = true;
+                }
+                catch { /* JS not ready or not available in test context */ }
+            }
         }
     }
 
@@ -247,6 +276,46 @@ else
             });
         }
         catch (ObjectDisposedException) { }
+    }
+
+    private void HandleConnectionStateChanged() =>
+        _ = InvokeAsync(StateHasChanged);
+
+    /// <summary>
+    /// Called from JavaScript when the Page Visibility API reports the app has returned
+    /// to the foreground (e.g. after being backgrounded in a PWA or mobile browser).
+    /// Re-fetches conversation data and reconnects SignalR if disconnected.
+    /// </summary>
+    [JSInvokable]
+    public async Task OnAppResumed()
+    {
+        await PortalLoad.RefreshAsync();
+        await InvokeAsync(async () =>
+        {
+            StateHasChanged();
+            await ForceScrollToBottomAsync();
+        });
+    }
+
+    /// <summary>
+    /// Handles the manual refresh button tap: re-fetches data and reconnects.
+    /// Shows a brief spinning indicator while in progress.
+    /// </summary>
+    private async Task ManualRefreshAsync()
+    {
+        if (_isRefreshing) return;
+        _isRefreshing = true;
+        StateHasChanged();
+        try
+        {
+            await PortalLoad.RefreshAsync();
+            await ForceScrollToBottomAsync();
+        }
+        finally
+        {
+            _isRefreshing = false;
+            StateHasChanged();
+        }
     }
 
     /// <summary>
@@ -471,5 +540,7 @@ else
     {
         Store.OnChanged -= HandleStateChanged;
         PortalLoad.OnReadyChanged -= HandleReadyChanged;
+        PortalLoad.OnConnectionStateChanged -= HandleConnectionStateChanged;
+        _dotNetRef?.Dispose();
     }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
@@ -456,3 +456,46 @@ body {
     font-size: 13px;
     text-align: center;
 }
+
+/* ── Refresh button (mobile header) ─────────────────────────────────────── */
+.refresh-btn {
+    background: none;
+    border: 1px solid rgba(100, 160, 220, 0.25);
+    border-radius: 6px;
+    color: #64a0dc;
+    cursor: pointer;
+    font-size: 18px;
+    padding: 4px 8px;
+    line-height: 1;
+    flex-shrink: 0;
+    min-width: 36px;
+    touch-action: manipulation;
+}
+.refresh-btn:hover:not(:disabled) { background: rgba(100, 160, 220, 0.08); }
+.refresh-btn:disabled { opacity: 0.4; cursor: default; }
+
+/* ── Disconnected bar ────────────────────────────────────────────────────── */
+.disconnected-bar {
+    background: #3b1a1a;
+    border-bottom: 1px solid #7f2e2e;
+    color: #f87171;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    font-size: 13px;
+    padding: 6px 12px;
+}
+
+.reconnect-inline-btn {
+    background: none;
+    border: 1px solid #f87171;
+    border-radius: 4px;
+    color: #f87171;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 2px 8px;
+    touch-action: manipulation;
+}
+.reconnect-inline-btn:hover:not(:disabled) { background: rgba(248, 113, 113, 0.15); }
+.reconnect-inline-btn:disabled { opacity: 0.5; cursor: default; }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
@@ -21,6 +21,7 @@
     <script src="js/purify.min.js"></script>
     <script src="js/markdown.js"></script>
     <script src="js/chatScroll.js"></script>
+    <script src="js/appResume.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/js/appResume.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/js/appResume.js
@@ -1,0 +1,19 @@
+// appResume.js -- Page Visibility API integration for BotNexus mobile app.
+// Detects when the app returns to foreground after being backgrounded (e.g. PWA home screen mode).
+
+window.BotNexusAppResume = {
+    /**
+     * Registers a visibility change listener that calls OnAppResumed on the
+     * provided Blazor .NET object reference when the page becomes visible.
+     * @param {DotNetObjectReference} dotNetRef - Reference to the Blazor component.
+     */
+    initialize: function (dotNetRef) {
+        document.addEventListener('visibilitychange', function () {
+            if (document.visibilityState === 'visible') {
+                dotNetRef.invokeMethodAsync('OnAppResumed').catch(function (err) {
+                    console.warn('[BotNexus] OnAppResumed failed:', err);
+                });
+            }
+        });
+    }
+};

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileRefreshReconnectTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileRefreshReconnectTests.cs
@@ -1,0 +1,130 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Pages;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for issue #825: mobile refresh button and auto-reconnect on app resume.
+/// </summary>
+public sealed class MobileRefreshReconnectTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store;
+    private readonly IPortalLoadService _portalLoad;
+    private readonly IAgentInteractionService _interaction;
+
+    public MobileRefreshReconnectTests()
+    {
+        _store = Substitute.For<IClientStateStore>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+        _interaction = Substitute.For<IAgentInteractionService>();
+
+        _portalLoad.IsReady.Returns(true);
+        _portalLoad.IsLoading.Returns(false);
+        _portalLoad.IsSignalRConnected.Returns(true);
+        _portalLoad.LoadError.Returns((string?)null);
+        _portalLoad.InitializeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        _portalLoad.RefreshAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        _store.Agents.Returns(new Dictionary<string, AgentState>().AsReadOnly());
+        _store.ActiveAgentId.Returns((string?)null);
+        _store.GetStreamState(Arg.Any<string>()).Returns(new ConversationStreamState());
+        _store.GetMessages(Arg.Any<string>()).Returns(new List<ChatMessage>().AsReadOnly());
+
+        _ctx.Services.AddSingleton(_store);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    // ── Refresh button presence ──────────────────────────────────────────────
+
+    [Fact]
+    public void Refresh_button_is_rendered_in_top_bar_when_portal_is_ready()
+    {
+        var cut = _ctx.Render<Chat>();
+        var btn = cut.Find("[data-testid='refresh-btn']");
+        Assert.NotNull(btn);
+    }
+
+    [Fact]
+    public void Refresh_button_is_enabled_when_not_refreshing()
+    {
+        var cut = _ctx.Render<Chat>();
+        var btn = cut.Find("[data-testid='refresh-btn']");
+        Assert.Null(btn.GetAttribute("disabled"));
+    }
+
+    // ── Disconnected indicator ───────────────────────────────────────────────
+
+    [Fact]
+    public void Disconnected_bar_is_hidden_when_SignalR_is_connected()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<Chat>();
+        Assert.Empty(cut.FindAll("[data-testid='disconnected-bar']"));
+    }
+
+    [Fact]
+    public void Disconnected_bar_is_shown_when_SignalR_is_disconnected()
+    {
+        _portalLoad.IsSignalRConnected.Returns(false);
+        var cut = _ctx.Render<Chat>();
+        Assert.NotEmpty(cut.FindAll("[data-testid='disconnected-bar']"));
+    }
+
+    [Fact]
+    public void Disconnected_bar_appears_when_connection_state_changes_to_disconnected()
+    {
+        _portalLoad.IsSignalRConnected.Returns(true);
+        var cut = _ctx.Render<Chat>();
+
+        // Verify no bar initially
+        Assert.Empty(cut.FindAll("[data-testid='disconnected-bar']"));
+
+        // Simulate connection drop
+        _portalLoad.IsSignalRConnected.Returns(false);
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+
+        cut.WaitForAssertion(() =>
+            Assert.NotEmpty(cut.FindAll("[data-testid='disconnected-bar']")));
+    }
+
+    // ── Manual refresh invokes PortalLoad.RefreshAsync ───────────────────────
+
+    [Fact]
+    public void Clicking_refresh_button_calls_PortalLoad_RefreshAsync()
+    {
+        var cut = _ctx.Render<Chat>();
+        cut.Find("[data-testid='refresh-btn']").Click();
+
+        _portalLoad.Received(1).RefreshAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ── OnAppResumed invokes RefreshAsync ─────────────────────────────────────
+
+    [Fact]
+    public async Task OnAppResumed_calls_PortalLoad_RefreshAsync()
+    {
+        var cut = _ctx.Render<Chat>();
+        await cut.Instance.OnAppResumed();
+
+        await _portalLoad.Received(1).RefreshAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ── IPortalLoadService.OnConnectionStateChanged subscription ────────────
+
+    [Fact]
+    public void Dispose_unsubscribes_from_OnConnectionStateChanged()
+    {
+        var cut = _ctx.Render<Chat>();
+        cut.Instance.Dispose();
+
+        // Raising after dispose should not throw or cause re-render
+        _portalLoad.OnConnectionStateChanged += Raise.Event<Action>();
+    }
+}


### PR DESCRIPTION
Closes #825

## Changes

### IPortalLoadService (Core)
- IsSignalRConnected property -- delegates to GatewayHubConnection.IsConnected
- OnConnectionStateChanged event -- raised on hub Reconnecting / Reconnected / Disconnected
- RefreshAsync() -- re-fetches agents and conversations; reconnects SignalR if disconnected
- RefreshAsync is a no-op guard if _hubUrl is null (not yet initialized) or already loading

### PortalLoadService (Core)
- Stores _hubUrl on InitializeAsync for use in RefreshAsync
- Wires OnReconnecting / OnReconnected / OnDisconnected hub events to OnConnectionStateChanged

### Chat.razor (Mobile)
- **Refresh button** (circular arrow) in top bar -- always visible, calls ManualRefreshAsync
- **Disconnected bar** shown when !IsSignalRConnected -- red banner with inline Reconnect button
- **visibilitychange listener** via BotNexusAppResume.initialize(dotNetRef) in OnAfterRenderAsync
- [JSInvokable] OnAppResumed() -- called by JS on page-visible event, invokes RefreshAsync
- ManualRefreshAsync() -- spins _isRefreshing flag, calls RefreshAsync, force-scrolls on completion
- HandleConnectionStateChanged() -- triggers StateHasChanged on hub state events
- Dispose() unsubscribes OnConnectionStateChanged and disposes DotNetObjectReference

### appResume.js (new)
- BotNexusAppResume.initialize(dotNetRef) -- registers isibilitychange listener
- Invokes OnAppResumed on .NET side when document.visibilityState === 'visible'

### mobile.css
- .refresh-btn -- top-bar button styling, matches existing button aesthetic
- .disconnected-bar -- red warning banner
- .reconnect-inline-btn -- inline reconnect button in disconnected bar

## Test Results
- 19/19 Mobile.Tests PASS (7 new in MobileRefreshReconnectTests.cs)
- 361/361 BlazorClient.Tests PASS (no regression)
- 128/128 Conversations.Tests PASS
- 2164/2165 Gateway.Tests PASS (1 skip: pre-existing SignalR integration)
- 29/29 Scenarios.Tests PASS
- 167/167 Architecture.Tests PASS

## Merge Notes

Fully independent. Files changed:
- IPortalLoadService.cs -- no open PR touches this
- PortalLoadService.cs -- no open PR touches this
- Chat.razor (mobile) -- no open PR touches this
- ppResume.js (new file)
- index.html (mobile)
- mobile.css -- no open PR touches this

Safe to merge in any order with all 32 open PRs.