### PR TITLE
feat(copilot): route Copilot Claude models via CopilotMessagesProvider (Phase 1b, #810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/Registry/BuiltInModels.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Registry/BuiltInModels.cs
@@ -39,12 +39,12 @@ public sealed class BuiltInModels
 
     private static void RegisterCopilotModels(ModelRegistry modelRegistry)
     {
-        Register(modelRegistry, "github-copilot", "claude-haiku-4.5", "Claude Haiku 4.5", "anthropic-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "claude-opus-4.5", "Claude Opus 4.5", "anthropic-messages", CopilotBaseUrl, true, ["text", "image"], 160000, 32000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "claude-opus-4.6", "Claude Opus 4.6", "anthropic-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 64000, supportsExtraHighThinking: true, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "claude-sonnet-4", "Claude Sonnet 4", "anthropic-messages", CopilotBaseUrl, true, ["text", "image"], 216000, 16000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "claude-sonnet-4.5", "Claude Sonnet 4.5", "anthropic-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "claude-sonnet-4.6", "Claude Sonnet 4.6", "anthropic-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 32000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-haiku-4.5", "Claude Haiku 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-opus-4.5", "Claude Opus 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 160000, 32000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-opus-4.6", "Claude Opus 4.6", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 64000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-sonnet-4", "Claude Sonnet 4", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 216000, 16000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-sonnet-4.5", "Claude Sonnet 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-sonnet-4.6", "Claude Sonnet 4.6", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 32000, headers: CopilotHeaders);
 
         Register(modelRegistry, "github-copilot", "gemini-2.5-pro", "Gemini 2.5 Pro", "openai-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
         Register(modelRegistry, "github-copilot", "gemini-3-flash-preview", "Gemini 3 Flash", "openai-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotGatewayRoutingTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotGatewayRoutingTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Copilot.Messages;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
@@ -40,7 +41,7 @@ public class CopilotGatewayRoutingTests
     /// Copilot integration headers attached.
     /// </summary>
     [Theory]
-    [InlineData("claude-haiku-4.5", "anthropic-messages", "/v1/messages")]
+    [InlineData("claude-haiku-4.5", "github-copilot-messages", "/v1/messages")]
     [InlineData("gpt-5.4", "openai-responses", "/responses")]
     [InlineData("gpt-4.1", "openai-completions", "/chat/completions")]
     public async Task LlmClient_RoutesCopilotModel_ToCopilotEndpoint(
@@ -113,6 +114,7 @@ public class CopilotGatewayRoutingTests
 
         var apiProviders = new ApiProviderRegistry();
         apiProviders.Register(new AnthropicProvider(httpClient));
+        apiProviders.Register(new CopilotMessagesProvider(httpClient));
         apiProviders.Register(new OpenAIResponsesProvider(httpClient, NullLogger<OpenAIResponsesProvider>.Instance));
         apiProviders.Register(new OpenAICompletionsProvider(httpClient, NullLogger<OpenAICompletionsProvider>.Instance));
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
@@ -262,14 +262,13 @@ public sealed class GatewayStartupAndConfigurationTests
     }
 
     [Fact]
-    public void GatewayConfiguration_CopilotMessagesProvider_IsRegisteredAndAdditiveToAnthropicMessages()
+    public void GatewayConfiguration_CopilotMessagesProvider_IsRoutedFromBuiltInClaudeModels()
     {
-        // Phase 1a (#810): The carved-out CopilotMessagesProvider exists alongside
-        // AnthropicProvider. It is reachable under Api="github-copilot-messages" but
-        // BuiltInModels does NOT yet route any model to it — that is Phase 1b.
-        // This test pins the additive deployment contract: existing Claude-on-Copilot
-        // requests continue to route through AnthropicProvider (anthropic-messages),
-        // and the new provider is available for the upcoming routing flip.
+        // Phase 1b (#810): BuiltInModels now routes the Copilot Claude entries through the
+        // carved-out CopilotMessagesProvider (Api="github-copilot-messages"). Both providers
+        // remain registered so direct-Anthropic users are unaffected; the user-visible wire
+        // contract for Copilot Claude requests is pinned by Phase 0a + the Phase 1a parity
+        // tests, which both stayed green across this flip.
         using var httpClient = new HttpClient();
 
         var apiProviders = new ApiProviderRegistry();
@@ -289,14 +288,17 @@ public sealed class GatewayStartupAndConfigurationTests
         registeredApis.ShouldContain("anthropic-messages",
             "AnthropicProvider must remain registered — direct-Anthropic users depend on it.");
         registeredApis.ShouldContain("github-copilot-messages",
-            "Phase 1a registers CopilotMessagesProvider so Phase 1b can flip Claude models without code change.");
+            "CopilotMessagesProvider must remain registered so the Copilot Claude entries resolve.");
 
-        // BuiltInModels still routes Claude entries via anthropic-messages in Phase 1a.
-        // Phase 1b will flip these to github-copilot-messages.
-        var haiku = llmClient.Models.GetModel("github-copilot", "claude-haiku-4.5");
-        haiku.ShouldNotBeNull();
-        haiku!.Api.ShouldBe("anthropic-messages",
-            "Phase 1a is additive — model routing must not change yet.");
+        // After the Phase 1b flip, every Claude entry under github-copilot routes via
+        // github-copilot-messages. Spot-check one of each family.
+        foreach (var modelId in new[] { "claude-haiku-4.5", "claude-opus-4.6", "claude-sonnet-4.6" })
+        {
+            var model = llmClient.Models.GetModel("github-copilot", modelId);
+            model.ShouldNotBeNull($"BuiltInModels must register github-copilot/{modelId}");
+            model!.Api.ShouldBe("github-copilot-messages",
+                $"Phase 1b — github-copilot/{modelId} must route via the carved-out provider.");
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Phase 1b — route Copilot Claude models via `CopilotMessagesProvider`

Tiny follow-up to #886 (Phase 1a). Flips the routing flag so the six Copilot Claude entries in `BuiltInModels` resolve to the carved-out `CopilotMessagesProvider` (`Api = ""github-copilot-messages""`) instead of `AnthropicProvider` (`Api = ""anthropic-messages""`).

### Diff
- `BuiltInModels.RegisterCopilotModels`: 6 `Register` calls — Haiku 4.5, Opus 4.5, Opus 4.6, Sonnet 4, Sonnet 4.5, Sonnet 4.6 — change one string each.
- Tests updated:
  - `CopilotGatewayRoutingTests` (Phase 0d) — InlineData expects `github-copilot-messages`; `BuildStack` registers the new provider so resolution succeeds.
  - `GatewayStartupAndConfigurationTests` — the Phase 1a additive test is now `..._IsRoutedFromBuiltInClaudeModels` and asserts the flipped routing across Haiku/Opus/Sonnet families.

### Why this is the smallest possible PR
Phase 1a (#886) added the new provider behind the routing flag. This PR is the flag flip. The byte-identical safety net it relies on (request body + headers) was built across Phase 0a + Phase 1a; both stayed green here, confirming the swap is wire-compatible.

### Deployment safety
- `AnthropicProvider` and its `AuthMode.Copilot` branch stay in place — direct-Anthropic users unaffected; any user with an explicit `Api: ""anthropic-messages""` override in config.json continues to resolve.
- Removal of the dead Copilot branch in `AnthropicProvider` is deferred to a later phase after this flip has soaked.

### Validation
`scripts/repo/test-impacted.ps1` — **25 affected suites all green**, including:
- `Copilot.Tests` 70 passed (Phase 0a snapshot + Phase 1a parity tests + flipped Phase 0d routing all match)
- `Architecture.Tests`, `Gateway.Tests` (2134), `Scenarios.Tests`, `Conformance.Tests`, all provider tests

### Next
- **Phase 2** — carve Responses + Completions for the OpenAI-on-Copilot transport (gpt-5.x and gemini/grok via Copilot).
- **Phase 3** (later, cleanup) — dead-code-eliminate `AuthMode.Copilot` from `AnthropicProvider` once 1b has soaked.

Refs #810.
