### PR TITLE
fix(gateway): debounce agent config file watcher and filter to definition files only

### DIFF
--- a/src/gateway/BotNexus.Gateway/BotNexus.Gateway.csproj
+++ b/src/gateway/BotNexus.Gateway/BotNexus.Gateway.csproj
@@ -36,4 +36,8 @@
     <EmbeddedResource Include="Templates\*.md" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Gateway.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/FileAgentConfigurationSource.cs
@@ -52,7 +52,7 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
 
         _fileSystem.Directory.CreateDirectory(_directoryPath);
 
-        return new FileConfigurationWatcher(_directoryPath, _fileSystem, onChanged, LoadAsync, _logger);
+        return new FileConfigurationWatcher(_directoryPath, _fileSystem, onChanged, LoadAsync, _logger, reloadDebounceMs: 2000);
     }
 
     private async Task<AgentDescriptor?> TryLoadDescriptorAsync(string configPath, CancellationToken cancellationToken)
@@ -246,7 +246,7 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             _ => element.GetRawText()
         };
 
-    private sealed class FileConfigurationWatcher : IDisposable
+    internal sealed class FileConfigurationWatcher : IDisposable
     {
         private readonly IFileSystemWatcher _watcher;
         private readonly Timer _timer;
@@ -255,6 +255,8 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
         private readonly Func<CancellationToken, Task<IReadOnlyList<AgentDescriptor>>> _loadAsync;
         private readonly ILogger _logger;
         private readonly SemaphoreSlim _reloadGate = new(1, 1);
+        private readonly int _reloadDebounceMs;
+        private int _pendingEventCount;
         private bool _disposed;
 
         public FileConfigurationWatcher(
@@ -262,12 +264,14 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             IFileSystem fileSystem,
             Action<IReadOnlyList<AgentDescriptor>> onChanged,
             Func<CancellationToken, Task<IReadOnlyList<AgentDescriptor>>> loadAsync,
-            ILogger logger)
+            ILogger logger,
+            int reloadDebounceMs = 2000)
         {
             _directoryPath = directoryPath;
             _onChanged = onChanged;
             _loadAsync = loadAsync;
             _logger = logger;
+            _reloadDebounceMs = reloadDebounceMs;
 
             _watcher = fileSystem.FileSystemWatcher.New(directoryPath, "*.*");
             _watcher.IncludeSubdirectories = true;
@@ -300,10 +304,20 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             => _ = ((FileConfigurationWatcher)state!).ReloadAsync();
 
         private void OnChanged(object sender, FileSystemEventArgs args)
-            => QueueReload();
+        {
+            if (!IsAgentDefinitionFile(_directoryPath, args.FullPath))
+                return;
+
+            QueueReload();
+        }
 
         private void OnRenamed(object sender, RenamedEventArgs args)
-            => QueueReload();
+        {
+            if (!IsAgentDefinitionFile(_directoryPath, args.FullPath) && !IsAgentDefinitionFile(_directoryPath, args.OldFullPath))
+                return;
+
+            QueueReload();
+        }
 
         private void OnError(object sender, ErrorEventArgs args)
         {
@@ -311,12 +325,53 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
             QueueReload();
         }
 
+        /// <summary>
+        /// Returns true if the file is an agent definition file (*.json or *.md)
+        /// directly in an agent subdirectory or the root config dir.
+        /// Workspace subdirectory writes (e.g. workspace/, tmp/, memory/) are excluded.
+        /// </summary>
+        internal static bool IsAgentDefinitionFile(string directoryPath, string fullPath)
+        {
+            if (string.IsNullOrEmpty(fullPath))
+                return false;
+
+            var ext = Path.GetExtension(fullPath);
+            if (!ext.Equals(".json", StringComparison.OrdinalIgnoreCase) &&
+                !ext.Equals(".md", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            // Accept files at depth 0 (directly in root config dir) or depth 1
+            // (directly in an agent subdirectory, e.g. agents/farnsworth/config.json)
+            var dir = Path.GetDirectoryName(fullPath);
+            if (dir is null)
+                return false;
+
+            var normalRoot = directoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var normalDir = dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            // Depth 0: file is directly in directoryPath
+            if (string.Equals(normalDir, normalRoot, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Depth 1: file is in an immediate subdirectory of directoryPath
+            var parent = Path.GetDirectoryName(normalDir);
+            return parent is not null &&
+                   string.Equals(parent.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                       normalRoot, StringComparison.OrdinalIgnoreCase);
+        }
+
         private void QueueReload()
         {
             if (_disposed)
                 return;
 
-            _timer.Change(TimeSpan.FromMilliseconds(250), Timeout.InfiniteTimeSpan);
+            var count = Interlocked.Increment(ref _pendingEventCount);
+            if (count > 1)
+            {
+                _logger.LogDebug("Agent config watcher debounced {Count} events into 1 reload.", count);
+            }
+
+            _timer.Change(TimeSpan.FromMilliseconds(_reloadDebounceMs), Timeout.InfiniteTimeSpan);
         }
 
         private async Task ReloadAsync()
@@ -326,6 +381,8 @@ public sealed class FileAgentConfigurationSource(string directoryPath, ILogger<F
 
             if (!await _reloadGate.WaitAsync(0))
                 return;
+
+            Interlocked.Exchange(ref _pendingEventCount, 0);
 
             try
             {

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentConfigWatcherDebounceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentConfigWatcherDebounceTests.cs
@@ -7,10 +7,13 @@ namespace BotNexus.Gateway.Tests;
 /// Tests for the debounced agent config file watcher (#937).
 /// Uses the internal static IsAgentDefinitionFile method directly to avoid
 /// needing MockFileSystem to support FileSystemWatcher.
+///
+/// Paths are built with Path.Combine so tests pass on both Windows and Linux CI.
 /// </summary>
 public sealed class AgentConfigWatcherDebounceTests
 {
-    private const string AgentsRoot = @"C:\agents";
+    // Cross-platform root: e.g. /tmp/agents on Linux, C:\agents on Windows
+    private static readonly string AgentsRoot = Path.Combine(Path.GetTempPath(), "agents");
 
     // Shorthand helper
     private static bool IsDefinitionFile(string fullPath)
@@ -21,7 +24,8 @@ public sealed class AgentConfigWatcherDebounceTests
     [Fact]
     public void IsAgentDefinitionFile_WorkspaceSubdirectoryFile_ReturnsFalse()
     {
-        IsDefinitionFile(@"C:\agents\nova\workspace\memory\2026-01-01.md").ShouldBeFalse();
+        var path = Path.Combine(AgentsRoot, "nova", "workspace", "memory", "2026-01-01.md");
+        IsDefinitionFile(path).ShouldBeFalse();
     }
 
     // ── test 2: config.json at depth 1 triggers reload ───────────────────────
@@ -29,7 +33,8 @@ public sealed class AgentConfigWatcherDebounceTests
     [Fact]
     public void IsAgentDefinitionFile_AgentConfigJson_ReturnsTrue()
     {
-        IsDefinitionFile(@"C:\agents\nova\config.json").ShouldBeTrue();
+        var path = Path.Combine(AgentsRoot, "nova", "config.json");
+        IsDefinitionFile(path).ShouldBeTrue();
     }
 
     // ── test 3: SOUL.md at depth 1 triggers reload ───────────────────────────
@@ -37,7 +42,8 @@ public sealed class AgentConfigWatcherDebounceTests
     [Fact]
     public void IsAgentDefinitionFile_AgentRootMarkdown_ReturnsTrue()
     {
-        IsDefinitionFile(@"C:\agents\nova\SOUL.md").ShouldBeTrue();
+        var path = Path.Combine(AgentsRoot, "nova", "SOUL.md");
+        IsDefinitionFile(path).ShouldBeTrue();
     }
 
     // ── test 4: .txt or .log file does NOT trigger reload ────────────────────
@@ -45,7 +51,8 @@ public sealed class AgentConfigWatcherDebounceTests
     [Fact]
     public void IsAgentDefinitionFile_TxtFile_ReturnsFalse()
     {
-        IsDefinitionFile(@"C:\agents\nova\debug.log").ShouldBeFalse();
+        var path = Path.Combine(AgentsRoot, "nova", "debug.log");
+        IsDefinitionFile(path).ShouldBeFalse();
     }
 
     // ── test 5: tmp file in workspace subdirectory does NOT trigger reload ───
@@ -53,7 +60,8 @@ public sealed class AgentConfigWatcherDebounceTests
     [Fact]
     public void IsAgentDefinitionFile_TmpFileInWorkspace_ReturnsFalse()
     {
-        IsDefinitionFile(@"C:\agents\nova\workspace\tmp\script.ps1").ShouldBeFalse();
+        var path = Path.Combine(AgentsRoot, "nova", "workspace", "tmp", "script.ps1");
+        IsDefinitionFile(path).ShouldBeFalse();
     }
 
     // ── test 6: .md in workspace/playbook subdirectory does NOT trigger ──────
@@ -61,7 +69,8 @@ public sealed class AgentConfigWatcherDebounceTests
     [Fact]
     public void IsAgentDefinitionFile_MdInWorkspaceSubdir_ReturnsFalse()
     {
-        IsDefinitionFile(@"C:\agents\nova\workspace\playbook\ci-pr-monitor.md").ShouldBeFalse();
+        var path = Path.Combine(AgentsRoot, "nova", "workspace", "playbook", "ci-pr-monitor.md");
+        IsDefinitionFile(path).ShouldBeFalse();
     }
 
     // ── test 7: default debounce constant is 2000ms ──────────────────────────

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentConfigWatcherDebounceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentConfigWatcherDebounceTests.cs
@@ -1,0 +1,86 @@
+using BotNexus.Gateway.Configuration;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for the debounced agent config file watcher (#937).
+/// Uses the internal static IsAgentDefinitionFile method directly to avoid
+/// needing MockFileSystem to support FileSystemWatcher.
+/// </summary>
+public sealed class AgentConfigWatcherDebounceTests
+{
+    private const string AgentsRoot = @"C:\agents";
+
+    // Shorthand helper
+    private static bool IsDefinitionFile(string fullPath)
+        => FileAgentConfigurationSource.FileConfigurationWatcher.IsAgentDefinitionFile(AgentsRoot, fullPath);
+
+    // ── test 1: workspace file write does NOT trigger reload ─────────────────
+
+    [Fact]
+    public void IsAgentDefinitionFile_WorkspaceSubdirectoryFile_ReturnsFalse()
+    {
+        IsDefinitionFile(@"C:\agents\nova\workspace\memory\2026-01-01.md").ShouldBeFalse();
+    }
+
+    // ── test 2: config.json at depth 1 triggers reload ───────────────────────
+
+    [Fact]
+    public void IsAgentDefinitionFile_AgentConfigJson_ReturnsTrue()
+    {
+        IsDefinitionFile(@"C:\agents\nova\config.json").ShouldBeTrue();
+    }
+
+    // ── test 3: SOUL.md at depth 1 triggers reload ───────────────────────────
+
+    [Fact]
+    public void IsAgentDefinitionFile_AgentRootMarkdown_ReturnsTrue()
+    {
+        IsDefinitionFile(@"C:\agents\nova\SOUL.md").ShouldBeTrue();
+    }
+
+    // ── test 4: .txt or .log file does NOT trigger reload ────────────────────
+
+    [Fact]
+    public void IsAgentDefinitionFile_TxtFile_ReturnsFalse()
+    {
+        IsDefinitionFile(@"C:\agents\nova\debug.log").ShouldBeFalse();
+    }
+
+    // ── test 5: tmp file in workspace subdirectory does NOT trigger reload ───
+
+    [Fact]
+    public void IsAgentDefinitionFile_TmpFileInWorkspace_ReturnsFalse()
+    {
+        IsDefinitionFile(@"C:\agents\nova\workspace\tmp\script.ps1").ShouldBeFalse();
+    }
+
+    // ── test 6: .md in workspace/playbook subdirectory does NOT trigger ──────
+
+    [Fact]
+    public void IsAgentDefinitionFile_MdInWorkspaceSubdir_ReturnsFalse()
+    {
+        IsDefinitionFile(@"C:\agents\nova\workspace\playbook\ci-pr-monitor.md").ShouldBeFalse();
+    }
+
+    // ── test 7: default debounce constant is 2000ms ──────────────────────────
+
+    [Fact]
+    public void FileConfigurationWatcher_DefaultDebounce_Is2000ms()
+    {
+        // Verify via the ctor's default parameter value
+        var ctor = typeof(FileAgentConfigurationSource.FileConfigurationWatcher)
+            .GetConstructors(
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.Instance)
+            .FirstOrDefault();
+        ctor.ShouldNotBeNull("No constructor found on FileConfigurationWatcher");
+
+        var param = ctor!.GetParameters()
+            .FirstOrDefault(p => p.Name == "reloadDebounceMs");
+        param.ShouldNotBeNull("reloadDebounceMs parameter not found");
+        param!.DefaultValue.ShouldBe(2000);
+    }
+}


### PR DESCRIPTION
Closes #937

## Changes
- `FileConfigurationWatcher` debounce: 250ms → 2000ms (configurable via `reloadDebounceMs` ctor param)
- `IsAgentDefinitionFile` filter: only `*.json` and `*.md` files at depth 0 (config root) or depth 1 (agent subdirectory) trigger reload — workspace subdirectory writes (workspace/, tmp/, memory/, playbook/) are ignored
- Debounce log at `[DBG]` level: `Agent config watcher debounced N events into 1 reload.`
- `FileConfigurationWatcher` changed from `private` to `internal` for testability
- `InternalsVisibleTo BotNexus.Gateway.Tests` added to `BotNexus.Gateway.csproj`
- 7 new tests: workspace subdir writes ignored, config.json and SOUL.md trigger reload, log/txt ignored, default debounce is 2000ms

## Impact
Eliminates the re-registration storm observed on 2026-06-06 where 37 re-registrations of farnsworth occurred in 1 hour due to workspace file writes.

## Merge Notes
Fully independent — no file overlap with any open PR. Safe to merge in any order.