### PR TITLE
feat(copilot): add CopilotResponsesProvider + CopilotCompletionsProvider (Phase 2a, #810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsOptions.cs
@@ -1,0 +1,21 @@
+namespace BotNexus.Agent.Providers.Copilot.Completions;
+
+/// <summary>
+/// Provider-specific options for the GitHub Copilot Chat Completions API.
+/// Carved out of <c>OpenAICompletionsOptions</c> so the Copilot transport has
+/// no cross-provider dependency on the OpenAI project. Field shape matches
+/// <c>OpenAICompletionsOptions</c> intentionally — the carve-out preserves the
+/// wire contract while removing the cross-provider coupling.
+/// </summary>
+public record class CopilotCompletionsOptions : BotNexus.Agent.Providers.Core.StreamOptions
+{
+    /// <summary>
+    /// Tool choice mode: "auto", "none", "required".
+    /// </summary>
+    public string? ToolChoice { get; set; }
+
+    /// <summary>
+    /// Reasoning effort for reasoning-capable models: "low", "medium", "high".
+    /// </summary>
+    public string? ReasoningEffort { get; set; }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
@@ -1,0 +1,960 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Compatibility;
+using BotNexus.Agent.Providers.Core.Diagnostics;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Agent.Providers.Core.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Agent.Providers.Copilot.Completions;
+
+/// <summary>
+/// GitHub Copilot Chat Completions API provider. Carved out of <see cref="BotNexus.Agent.Providers.OpenAI.OpenAICompletionsProvider"/> so the Copilot transport has no cross-provider dependency on the OpenAI project. Always applies Copilot dynamic headers.
+/// See <c>tests/.../CopilotCompletionsProviderParityTests</c> for the byte-identical-body proof against the legacy OpenAI-with-Copilot-auth path.
+/// Uses raw HttpClient for SSE streaming — full control over headers, compat, and streaming.
+/// </summary>
+public sealed class CopilotCompletionsProvider(
+    HttpClient httpClient,
+    ILogger<CopilotCompletionsProvider> logger) : IApiProvider
+{
+    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private static readonly OpenAIStreamProcessor StreamProcessor = new();
+    private static readonly IReadOnlyDictionary<string, Action<CompatFlags>> CompatProfiles = new Dictionary<string, Action<CompatFlags>>
+    {
+        ["cerebras"] = flags =>
+        {
+            flags.SupportsStore = false;
+            flags.SupportsStoreParam = false;
+            flags.SupportsDeveloperRole = false;
+            flags.SupportsMetadata = false;
+        },
+        ["xai"] = flags =>
+        {
+            flags.SupportsStore = false;
+            flags.SupportsStoreParam = false;
+            flags.SupportsDeveloperRole = false;
+            flags.SupportsMetadata = false;
+            flags.SupportsReasoningEffort = false;
+        },
+        ["zai"] = flags =>
+        {
+            flags.SupportsStore = false;
+            flags.SupportsStoreParam = false;
+            flags.SupportsDeveloperRole = false;
+            flags.SupportsMetadata = false;
+            flags.SupportsReasoningEffort = false;
+            flags.ThinkingFormat = "zai";
+        },
+        ["deepseek"] = flags =>
+        {
+            flags.SupportsStore = false;
+            flags.SupportsStoreParam = false;
+            flags.SupportsDeveloperRole = false;
+            flags.SupportsMetadata = false;
+        },
+        ["chutes"] = flags =>
+        {
+            flags.SupportsStore = false;
+            flags.SupportsStoreParam = false;
+            flags.SupportsDeveloperRole = false;
+            flags.SupportsMetadata = false;
+            flags.MaxTokensField = "max_tokens";
+        },
+        ["groq"] = flags =>
+        {
+            flags.SupportsStore = false;
+            flags.SupportsStoreParam = false;
+            flags.SupportsDeveloperRole = false;
+            flags.SupportsMetadata = false;
+        },
+        ["openrouter"] = flags => flags.ThinkingFormat = "openrouter"
+    };
+
+    public string Api => "github-copilot-completions";
+
+    public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+    {
+        var stream = new LlmStream();
+        var ct = options?.CancellationToken ?? CancellationToken.None;
+
+        _ = Task.Run(async () =>
+        {
+            using var activity = ProviderDiagnostics.Source.StartActivity("provider.copilot-completions.stream", ActivityKind.Client);
+            activity?.SetTag("botnexus.provider.name", model.Provider);
+            activity?.SetTag("botnexus.model", model.Id);
+            activity?.SetTag("botnexus.model.api", model.Api);
+
+            try
+            {
+                await StreamCoreAsync(stream, model, context, options, ct);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+            }
+            catch (OperationCanceledException)
+            {
+                EmitAborted(stream, model);
+                activity?.SetStatus(ActivityStatusCode.Error, "Operation canceled");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Copilot completions stream failed for model {Model}", model.Id);
+                EmitError(stream, model, ex.Message);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            }
+        }, ct);
+
+        return stream;
+    }
+
+    public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+    {
+        var apiKey = options?.ApiKey ?? EnvironmentApiKeys.GetApiKey(model.Provider) ?? "";
+
+        var completionsOptions = new CopilotCompletionsOptions
+        {
+            ApiKey = apiKey,
+            Temperature = options?.Temperature,
+            MaxTokens = options?.MaxTokens,
+            CancellationToken = options?.CancellationToken ?? CancellationToken.None,
+            Transport = options?.Transport ?? Transport.Sse,
+            CacheRetention = options?.CacheRetention ?? CacheRetention.Short,
+            SessionId = options?.SessionId,
+            OnPayload = options?.OnPayload,
+            Headers = options?.Headers,
+            MaxRetryDelayMs = options?.MaxRetryDelayMs ?? 60000,
+            Metadata = options?.Metadata,
+        };
+
+        if (options?.Reasoning is not null && model.Reasoning)
+            completionsOptions.ReasoningEffort = MapThinkingLevel(options.Reasoning.Value, GetCompat(model));
+
+        return Stream(model, context, completionsOptions);
+    }
+
+    private async Task StreamCoreAsync(
+        LlmStream stream,
+        LlmModel model,
+        Context context,
+        StreamOptions? options,
+        CancellationToken ct)
+    {
+        var compat = GetCompat(model);
+        var apiKey = options?.ApiKey ?? EnvironmentApiKeys.GetApiKey(model.Provider) ?? "";
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException(
+                $"No API key for {model.Provider}. Set credentials before using model '{model.Id}'.");
+        }
+
+        var messages = MessageTransformer.TransformMessages(context.Messages, model);
+
+        var payload = BuildRequestPayload(model, context.SystemPrompt, messages, context.Tools, options, compat);
+
+        if (options?.OnPayload is not null)
+        {
+            var modified = await options.OnPayload(payload, model);
+            if (modified is JsonObject obj)
+                payload = obj;
+        }
+
+        var url = $"{model.BaseUrl.TrimEnd('/')}/chat/completions";
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        if (model.Headers is not null)
+        {
+            foreach (var (key, value) in model.Headers)
+                request.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        if (options?.Headers is not null)
+        {
+            foreach (var (key, value) in options.Headers)
+                request.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        // Copilot transport always applies the dynamic vision/intent headers —
+        // this provider only handles Copilot-routed models, so the runtime check
+        // present in the OpenAI parent is unnecessary.
+        var copilotHasImages = CopilotHeaders.HasVisionInput(messages);
+        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(messages, copilotHasImages))
+            request.Headers.TryAddWithoutValidation(key, value);
+
+        logger.LogDebug("Streaming {Model} from {Url}", model.Id, url);
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            var providerError = ExtractProviderErrorMessage(errorBody, model);
+            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {providerError}");
+        }
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(responseStream, Encoding.UTF8);
+
+        await StreamProcessor.ParseOpenAiCompletionsAsync(
+            stream,
+            reader,
+            model,
+            Api,
+            ParseUsage,
+            MapStopReason,
+            ExtractProviderErrorMessage,
+            EmitError,
+            () => logger.LogDebug("Skipping malformed SSE chunk"),
+            ct);
+    }
+
+    #region Payload Building
+
+    private static JsonObject BuildRequestPayload(
+        LlmModel model,
+        string? systemPrompt,
+        IReadOnlyList<Message> messages,
+        IReadOnlyList<Tool>? tools,
+        StreamOptions? options,
+        OpenAICompletionsCompat compat)
+    {
+        var payload = new JsonObject
+        {
+            ["model"] = model.Id,
+            ["stream"] = true,
+        };
+
+        if (options?.MaxTokens is not null)
+            payload[compat.MaxTokensField] = options.MaxTokens.Value;
+
+        if (compat.SupportsTemperature != false && options?.Temperature is not null)
+            payload["temperature"] = options.Temperature.Value;
+
+        if (compat.SupportsStore == true && compat.SupportsStoreParam != false)
+            payload["store"] = false;
+
+        if (compat.SupportsMetadata != false && options?.Metadata is { Count: > 0 })
+            payload["metadata"] = JsonSerializer.SerializeToNode(options.Metadata);
+
+        if (compat.SupportsUsageInStreaming != false)
+            payload["stream_options"] = new JsonObject { ["include_usage"] = true };
+
+        // Reasoning / thinking support
+        if (options is CopilotCompletionsOptions { ReasoningEffort: not null } compOptions && model.Reasoning)
+        {
+            if (compat.ThinkingFormat is "openai" && compat.SupportsReasoningEffort != false)
+            {
+                payload["reasoning_effort"] = compOptions.ReasoningEffort;
+            }
+            else if (compat.ThinkingFormat is "qwen")
+            {
+                payload["enable_thinking"] = true;
+            }
+            else if (compat.ThinkingFormat is "qwen-chat-template")
+            {
+                payload["chat_template_kwargs"] = new JsonObject { ["enable_thinking"] = true };
+            }
+            else if (compat.ThinkingFormat is "openrouter")
+            {
+                payload["reasoning"] = new JsonObject
+                {
+                    ["effort"] = compOptions.ReasoningEffort
+                };
+            }
+            else
+            {
+                payload["enable_thinking"] = true;
+                payload["thinking_format"] = compat.ThinkingFormat;
+            }
+        }
+        else if (compat.ThinkingFormat is "openrouter" && model.Reasoning)
+        {
+            payload["reasoning"] = new JsonObject
+            {
+                ["effort"] = "none"
+            };
+        }
+
+        if (options is CopilotCompletionsOptions { ToolChoice: not null } tcOptions)
+            payload["tool_choice"] = tcOptions.ToolChoice;
+
+        payload["messages"] = ConvertMessages(systemPrompt, model, messages, compat);
+
+        if (tools is { Count: > 0 } && compat.SupportsTools != false)
+        {
+            payload["tools"] = ConvertTools(tools, compat);
+            if (compat.ZaiToolStream == true)
+                payload["tool_stream"] = true;
+        }
+        else if (HasToolHistory(messages) && compat.SupportsTools != false)
+        {
+            payload["tools"] = new JsonArray();
+        }
+
+        if (model.BaseUrl.Contains("openrouter.ai", StringComparison.OrdinalIgnoreCase) &&
+            compat.OpenRouterRouting is { } openRouterRouting &&
+            (openRouterRouting.Only is { Count: > 0 } || openRouterRouting.Order is { Count: > 0 }))
+        {
+            payload["provider"] = JsonSerializer.SerializeToNode(openRouterRouting);
+        }
+
+        if (model.BaseUrl.Contains("ai-gateway.vercel.sh", StringComparison.OrdinalIgnoreCase) &&
+            compat.VercelGatewayRouting is { } routing &&
+            (routing.Only is { Count: > 0 } || routing.Order is { Count: > 0 }))
+        {
+            var gateway = new JsonObject();
+            if (routing.Only is { Count: > 0 })
+                gateway["only"] = JsonSerializer.SerializeToNode(routing.Only);
+            if (routing.Order is { Count: > 0 })
+                gateway["order"] = JsonSerializer.SerializeToNode(routing.Order);
+            payload["providerOptions"] = new JsonObject
+            {
+                ["gateway"] = gateway
+            };
+        }
+
+        MaybeAddOpenRouterAnthropicCacheControl(model, payload);
+
+        return payload;
+    }
+
+    #endregion
+
+    #region Message Conversion
+
+    private static bool HasToolHistory(IReadOnlyList<Message> messages)
+    {
+        foreach (var message in messages)
+        {
+            if (message is ToolResultMessage)
+                return true;
+
+            if (message is AssistantMessage assistant &&
+                assistant.Content.Any(block => block is ToolCallContent))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string NormalizeToolCallId(string id, LlmModel sourceModel, string targetProviderId)
+    {
+        if (id.Contains('|'))
+        {
+            var callId = id.Split('|', 2)[0];
+            return callId.NormalizeToolCallId(40);
+        }
+
+        if (string.Equals(targetProviderId, "openai", StringComparison.OrdinalIgnoreCase) && id.Length > 40)
+            return id[..40];
+
+        return id;
+    }
+
+    private static void MaybeAddOpenRouterAnthropicCacheControl(LlmModel model, JsonObject payload)
+    {
+        if (!string.Equals(model.Provider, "openrouter", StringComparison.OrdinalIgnoreCase) ||
+            !model.Id.StartsWith("anthropic/", StringComparison.OrdinalIgnoreCase) ||
+            payload["messages"] is not JsonArray messages)
+        {
+            return;
+        }
+
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            if (messages[i] is not JsonObject message)
+                continue;
+
+            var role = message["role"]?.GetValue<string>();
+            if (role is not ("user" or "assistant"))
+                continue;
+
+            var content = message["content"];
+            if (content is JsonValue stringContent)
+            {
+                message["content"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["type"] = "text",
+                        ["text"] = stringContent.ToString(),
+                        ["cache_control"] = new JsonObject { ["type"] = "ephemeral" }
+                    }
+                };
+                return;
+            }
+
+            if (content is not JsonArray contentParts)
+                continue;
+
+            for (var j = contentParts.Count - 1; j >= 0; j--)
+            {
+                if (contentParts[j] is JsonObject part &&
+                    string.Equals(part["type"]?.GetValue<string>(), "text", StringComparison.OrdinalIgnoreCase))
+                {
+                    part["cache_control"] = new JsonObject { ["type"] = "ephemeral" };
+                    return;
+                }
+            }
+        }
+    }
+
+    private static JsonArray ConvertMessages(
+        string? systemPrompt,
+        LlmModel model,
+        IReadOnlyList<Message> messages,
+        OpenAICompletionsCompat compat)
+    {
+        var result = new JsonArray();
+        var transformedMessages = MessageTransformer.TransformMessages(
+            messages,
+            model,
+            (id, sourceModel, targetProviderId) => NormalizeToolCallId(id, sourceModel, targetProviderId));
+        string? lastRole = null;
+
+        if (systemPrompt is not null)
+        {
+            var role = model.Reasoning && compat.SupportsDeveloperRole != false ? "developer" : "system";
+            result.Add(new JsonObject { ["role"] = role, ["content"] = UnicodeSanitizer.SanitizeSurrogates(systemPrompt) });
+        }
+
+        for (var i = 0; i < transformedMessages.Count; i++)
+        {
+            var message = transformedMessages[i];
+            if (compat.RequiresAssistantAfterToolResult == true &&
+                lastRole == "toolResult" &&
+                message is UserMessage)
+            {
+                result.Add(new JsonObject { ["role"] = "assistant", ["content"] = "I have processed the tool results." });
+            }
+
+            switch (message)
+            {
+                case UserMessage user:
+                {
+                    var userMessage = ConvertUserMessage(user, model.Input.Contains("image"));
+                    if (userMessage is not null)
+                        result.Add(userMessage);
+                    lastRole = "user";
+                    break;
+                }
+
+                case AssistantMessage assistant:
+                    var assistantMessage = ConvertAssistantMessage(assistant, compat, model);
+                    if (assistantMessage is not null)
+                    {
+                        result.Add(assistantMessage);
+                        lastRole = "assistant";
+                    }
+                    break;
+
+                case ToolResultMessage toolResult:
+                {
+                    var imageBlocks = new JsonArray();
+                    var j = i;
+                    for (; j < transformedMessages.Count && transformedMessages[j] is ToolResultMessage; j++)
+                    {
+                        var tr = (ToolResultMessage)transformedMessages[j];
+                        result.Add(ConvertToolResultMessage(tr, compat));
+
+                        var hasImages = tr.Content.Any(c => c is ImageContent);
+                        if (hasImages && model.Input.Contains("image"))
+                        {
+                            foreach (var image in tr.Content.OfType<ImageContent>())
+                            {
+                                imageBlocks.Add(new JsonObject
+                                {
+                                    ["type"] = "image_url",
+                                    ["image_url"] = new JsonObject
+                                    {
+                                        ["url"] = $"data:{image.MimeType};base64,{image.Data}"
+                                    }
+                                });
+                            }
+                        }
+                    }
+
+                    i = j - 1;
+                    if (imageBlocks.Count > 0)
+                    {
+                        if (compat.RequiresAssistantAfterToolResult == true)
+                        {
+                            result.Add(new JsonObject
+                            {
+                                ["role"] = "assistant",
+                                ["content"] = "I have processed the tool results."
+                            });
+                        }
+
+                        var userContent = new JsonArray
+                        {
+                            new JsonObject { ["type"] = "text", ["text"] = "Attached image(s) from tool result:" }
+                        };
+                        foreach (var image in imageBlocks)
+                            userContent.Add(image?.DeepClone());
+
+                        result.Add(new JsonObject
+                        {
+                            ["role"] = "user",
+                            ["content"] = userContent
+                        });
+                        lastRole = "user";
+                    }
+                    else
+                    {
+                        lastRole = "toolResult";
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static JsonObject? ConvertUserMessage(UserMessage user, bool supportsImages)
+    {
+        if (user.Content.IsText)
+            return new JsonObject
+            {
+                ["role"] = "user",
+                ["content"] = UnicodeSanitizer.SanitizeSurrogates(user.Content.Text ?? string.Empty)
+            };
+
+        var contentArray = new JsonArray();
+        foreach (var block in user.Content.Blocks!)
+        {
+            switch (block)
+            {
+                case TextContent text:
+                    contentArray.Add(new JsonObject
+                    {
+                        ["type"] = "text",
+                        ["text"] = UnicodeSanitizer.SanitizeSurrogates(text.Text)
+                    });
+                    break;
+
+                case ImageContent image when supportsImages:
+                    contentArray.Add(new JsonObject
+                    {
+                        ["type"] = "image_url",
+                        ["image_url"] = new JsonObject
+                        {
+                            ["url"] = $"data:{image.MimeType};base64,{image.Data}"
+                        }
+                    });
+                    break;
+            }
+        }
+
+        if (contentArray.Count == 0)
+            return null;
+
+        return new JsonObject { ["role"] = "user", ["content"] = contentArray };
+    }
+
+    private static JsonObject? ConvertAssistantMessage(AssistantMessage assistant, OpenAICompletionsCompat compat, LlmModel model)
+    {
+        var msg = new JsonObject { ["role"] = "assistant" };
+        var textParts = new List<string>();
+        var thinkingParts = new List<string>();
+        var toolCalls = new JsonArray();
+        var reasoningDetails = new JsonArray();
+
+        foreach (var block in assistant.Content)
+        {
+            switch (block)
+            {
+                case TextContent text:
+                    if (!string.IsNullOrWhiteSpace(text.Text))
+                        textParts.Add(UnicodeSanitizer.SanitizeSurrogates(text.Text));
+                    break;
+
+                case ThinkingContent thinking:
+                    if (string.IsNullOrWhiteSpace(thinking.Thinking))
+                        break;
+
+                    if (compat.RequiresThinkingAsText == true)
+                    {
+                        thinkingParts.Add(UnicodeSanitizer.SanitizeSurrogates(thinking.Thinking));
+                    }
+                    else if (!string.IsNullOrWhiteSpace(thinking.ThinkingSignature))
+                    {
+                        var signature = thinking.ThinkingSignature;
+                        msg[signature] = string.Join("\n", assistant.Content.OfType<ThinkingContent>()
+                            .Where(t => !string.IsNullOrWhiteSpace(t.Thinking))
+                            .Select(t => UnicodeSanitizer.SanitizeSurrogates(t.Thinking)));
+                    }
+                    break;
+
+                case ToolCallContent tc:
+                    if (!string.IsNullOrWhiteSpace(tc.ThoughtSignature))
+                    {
+                        try
+                        {
+                            var parsed = JsonNode.Parse(tc.ThoughtSignature);
+                            if (parsed is not null)
+                                reasoningDetails.Add(parsed);
+                        }
+                        catch (JsonException)
+                        {
+                        }
+                    }
+                    toolCalls.Add(new JsonObject
+                    {
+                        ["id"] = NormalizeToolCallId(tc.Id, model, model.Provider),
+                        ["type"] = "function",
+                        ["function"] = new JsonObject
+                        {
+                            ["name"] = tc.Name,
+                            ["arguments"] = JsonSerializer.Serialize(tc.Arguments)
+                        }
+                    });
+                    break;
+            }
+        }
+
+        if (thinkingParts.Count > 0)
+            textParts.Insert(0, string.Join("\n\n", thinkingParts));
+
+        var textContent = textParts.Count > 0 ? string.Join("", textParts) : null;
+        if (string.IsNullOrWhiteSpace(textContent) && toolCalls.Count == 0)
+            return null;
+
+        msg["content"] = string.IsNullOrWhiteSpace(textContent) ? null : JsonValue.Create(textContent);
+
+        if (toolCalls.Count > 0)
+            msg["tool_calls"] = toolCalls;
+        if (reasoningDetails.Count > 0)
+            msg["reasoning_details"] = reasoningDetails;
+
+        return msg;
+    }
+
+    private static JsonObject ConvertToolResultMessage(ToolResultMessage toolResult, OpenAICompletionsCompat compat)
+    {
+        var content = string.Join("\n", toolResult.Content
+            .OfType<TextContent>()
+            .Select(t => UnicodeSanitizer.SanitizeSurrogates(t.Text)));
+
+        var msg = new JsonObject
+        {
+            ["role"] = "tool",
+            ["tool_call_id"] = toolResult.ToolCallId,
+            ["content"] = string.IsNullOrWhiteSpace(content) ? "(see attached image)" : content
+        };
+
+        if (compat.RequiresToolResultName == true)
+            msg["name"] = toolResult.ToolName;
+
+        return msg;
+    }
+
+    #endregion
+
+    #region Tool Conversion
+
+    private static JsonArray ConvertTools(IReadOnlyList<Tool> tools, OpenAICompletionsCompat compat)
+    {
+        var result = new JsonArray();
+
+        foreach (var tool in tools)
+        {
+            var fn = new JsonObject
+            {
+                ["name"] = tool.Name,
+                ["description"] = tool.Description,
+                ["parameters"] = JsonNode.Parse(tool.Parameters.GetRawText())
+            };
+
+            if (compat.SupportsStrictMode != false)
+                fn["strict"] = false;
+
+            result.Add(new JsonObject
+            {
+                ["type"] = "function",
+                ["function"] = fn
+            });
+        }
+
+        return result;
+    }
+
+    #endregion
+
+    #region Usage & Mapping
+
+    private static Usage ParseUsage(JsonElement usageElement, Usage usage, LlmModel model)
+    {
+        var promptTokens = usage.Input + usage.CacheRead + usage.CacheWrite;
+        var completionTokens = usage.Output;
+        var reportedCachedTokens = usage.CacheRead;
+        var cacheWriteTokens = usage.CacheWrite;
+        var reasoningTokens = 0;
+
+        if (usageElement.TryGetProperty("prompt_tokens", out var pt))
+            promptTokens = pt.GetInt32();
+
+        if (usageElement.TryGetProperty("completion_tokens", out var ct))
+            completionTokens = ct.GetInt32();
+
+        if (usageElement.TryGetProperty("prompt_tokens_details", out var ptDetails) &&
+            ptDetails.TryGetProperty("cached_tokens", out var cached))
+        {
+            reportedCachedTokens = cached.GetInt32();
+        }
+
+        if (usageElement.TryGetProperty("prompt_tokens_details", out ptDetails) &&
+            ptDetails.TryGetProperty("cache_write_tokens", out var cacheWrite))
+        {
+            cacheWriteTokens = cacheWrite.GetInt32();
+        }
+
+        if (usageElement.TryGetProperty("completion_tokens_details", out var completionDetails) &&
+            completionDetails.TryGetProperty("reasoning_tokens", out var reasoning))
+        {
+            reasoningTokens = reasoning.GetInt32();
+        }
+
+        var cacheReadTokens = cacheWriteTokens > 0
+            ? Math.Max(0, reportedCachedTokens - cacheWriteTokens)
+            : reportedCachedTokens;
+
+        var inputTokens = Math.Max(0, promptTokens - cacheReadTokens - cacheWriteTokens);
+        var outputTokens = completionTokens + reasoningTokens;
+
+        var updated = usage with
+        {
+            Input = inputTokens,
+            Output = outputTokens,
+            CacheRead = cacheReadTokens,
+            CacheWrite = cacheWriteTokens,
+            TotalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens
+        };
+        updated = updated with { Cost = ModelRegistry.CalculateCost(model, updated) };
+        return updated;
+    }
+
+    private static (StopReason StopReason, string? ErrorMessage) MapStopReason(string? reason) => reason switch
+    {
+        "stop" => (StopReason.Stop, null),
+        "end" => (StopReason.Stop, null),
+        "length" => (StopReason.Length, null),
+        "function_call" => (StopReason.ToolUse, null),
+        "tool_calls" => (StopReason.ToolUse, null),
+        "content_filter" => (StopReason.Error, "Content filtered by provider"),
+        "refusal" => (StopReason.Refusal, null),
+        "network_error" => (StopReason.Error, "Provider finish_reason: network_error"),
+        null => (StopReason.Stop, null),
+        _ => (StopReason.Error, $"Provider finish_reason: {reason}")
+    };
+
+    private static string MapThinkingLevel(ThinkingLevel level, OpenAICompletionsCompat? compat)
+    {
+        if (compat?.ReasoningEffortMap is not null &&
+            compat.ReasoningEffortMap.TryGetValue(level, out var mapped))
+            return mapped;
+
+        return level switch
+        {
+            ThinkingLevel.Minimal => "low",
+            ThinkingLevel.Low => "low",
+            ThinkingLevel.Medium => "medium",
+            ThinkingLevel.High => "high",
+            ThinkingLevel.ExtraHigh => "xhigh",
+            _ => "medium"
+        };
+    }
+
+    private static OpenAICompletionsCompat GetCompat(LlmModel model)
+    {
+        var detected = DetectCompat(model);
+        var configured = model.Compat;
+        if (configured is null)
+            return detected;
+
+        return detected with
+        {
+            SupportsStoreParam = configured.SupportsStoreParam ?? detected.SupportsStoreParam,
+            SupportsStore = configured.SupportsStore ?? detected.SupportsStore,
+            SupportsDeveloperRole = configured.SupportsDeveloperRole ?? detected.SupportsDeveloperRole,
+            SupportsTemperature = configured.SupportsTemperature ?? detected.SupportsTemperature,
+            SupportsMetadata = configured.SupportsMetadata ?? detected.SupportsMetadata,
+            SupportsReasoningEffort = configured.SupportsReasoningEffort ?? detected.SupportsReasoningEffort,
+            ReasoningEffortMap = configured.ReasoningEffortMap ?? detected.ReasoningEffortMap,
+            SupportsUsageInStreaming = configured.SupportsUsageInStreaming ?? detected.SupportsUsageInStreaming,
+            MaxTokensField = configured.MaxTokensField,
+            RequiresToolResultName = configured.RequiresToolResultName ?? detected.RequiresToolResultName,
+            RequiresAssistantAfterToolResult = configured.RequiresAssistantAfterToolResult ?? detected.RequiresAssistantAfterToolResult,
+            RequiresThinkingAsText = configured.RequiresThinkingAsText ?? detected.RequiresThinkingAsText,
+            ThinkingFormat = configured.ThinkingFormat,
+            OpenRouterRouting = configured.OpenRouterRouting ?? detected.OpenRouterRouting,
+            VercelGatewayRouting = configured.VercelGatewayRouting ?? detected.VercelGatewayRouting,
+            ZaiToolStream = configured.ZaiToolStream ?? detected.ZaiToolStream,
+            SupportsStrictMode = configured.SupportsStrictMode ?? detected.SupportsStrictMode
+        };
+    }
+
+    private static OpenAICompletionsCompat DetectCompat(LlmModel model)
+    {
+        var provider = model.Provider.ToLowerInvariant();
+        var baseUrl = model.BaseUrl.ToLowerInvariant();
+        var flags = new CompatFlags();
+
+        var matches = new Dictionary<string, bool>
+        {
+            ["cerebras"] = provider == "cerebras" || baseUrl.Contains("cerebras.ai"),
+            ["xai"] = provider == "xai" || baseUrl.Contains("api.x.ai"),
+            ["zai"] = provider == "zai" || baseUrl.Contains("api.z.ai"),
+            ["deepseek"] = provider == "deepseek" || baseUrl.Contains("deepseek.com"),
+            ["chutes"] = baseUrl.Contains("chutes.ai"),
+            ["groq"] = provider == "groq" || baseUrl.Contains("groq.com"),
+            ["openrouter"] = provider == "openrouter" || baseUrl.Contains("openrouter.ai")
+        };
+
+        foreach (var (key, isMatch) in matches)
+        {
+            if (!isMatch) continue;
+            CompatProfiles[key](flags);
+        }
+
+        if (matches["groq"] && string.Equals(model.Id, "qwen/qwen3-32b", StringComparison.Ordinal))
+        {
+            flags.ReasoningEffortMap = new Dictionary<ThinkingLevel, string>
+            {
+                [ThinkingLevel.Minimal] = "default",
+                [ThinkingLevel.Low] = "default",
+                [ThinkingLevel.Medium] = "default",
+                [ThinkingLevel.High] = "default",
+                [ThinkingLevel.ExtraHigh] = "default"
+            };
+        }
+
+        if (model.Id.Contains("qwen-chat-template", StringComparison.OrdinalIgnoreCase))
+            flags.ThinkingFormat = "qwen-chat-template";
+        else if (model.Id.StartsWith("qwen/", StringComparison.OrdinalIgnoreCase))
+            flags.ThinkingFormat = "qwen";
+
+        return new OpenAICompletionsCompat
+        {
+            SupportsStoreParam = flags.SupportsStoreParam,
+            SupportsStore = flags.SupportsStore,
+            SupportsDeveloperRole = flags.SupportsDeveloperRole,
+            SupportsTemperature = flags.SupportsTemperature,
+            SupportsMetadata = flags.SupportsMetadata,
+            SupportsReasoningEffort = flags.SupportsReasoningEffort,
+            ReasoningEffortMap = flags.ReasoningEffortMap,
+            SupportsUsageInStreaming = true,
+            MaxTokensField = flags.MaxTokensField,
+            RequiresToolResultName = false,
+            RequiresAssistantAfterToolResult = false,
+            RequiresThinkingAsText = false,
+            ThinkingFormat = flags.ThinkingFormat,
+            OpenRouterRouting = new(),
+            VercelGatewayRouting = new(),
+            ZaiToolStream = false,
+            SupportsStrictMode = true
+        };
+    }
+
+    private sealed class CompatFlags
+    {
+        public bool SupportsStoreParam { get; set; } = true;
+        public bool SupportsStore { get; set; } = true;
+        public bool SupportsDeveloperRole { get; set; } = true;
+        public bool SupportsTemperature { get; set; } = true;
+        public bool SupportsMetadata { get; set; } = true;
+        public bool SupportsReasoningEffort { get; set; } = true;
+        public string MaxTokensField { get; set; } = "max_completion_tokens";
+        public string ThinkingFormat { get; set; } = "openai";
+        public Dictionary<ThinkingLevel, string>? ReasoningEffortMap { get; set; }
+    }
+
+    private static string ExtractProviderErrorMessage(string rawError, LlmModel model)
+    {
+        if (string.IsNullOrWhiteSpace(rawError))
+            return "Unknown API error";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(rawError);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("error", out var error))
+            {
+                var message = error.TryGetProperty("message", out var messageEl)
+                    ? messageEl.GetString()
+                    : null;
+
+                if (string.Equals(model.Provider, "openrouter", StringComparison.OrdinalIgnoreCase) &&
+                    error.TryGetProperty("metadata", out var metadata) &&
+                    metadata.ValueKind == JsonValueKind.Object)
+                {
+                    var code = metadata.TryGetProperty("code", out var codeEl) ? codeEl.GetString() : null;
+                    var providerName = metadata.TryGetProperty("provider_name", out var providerEl) ? providerEl.GetString() : null;
+                    var suffix = string.Join(", ", new[] { code, providerName }.Where(v => !string.IsNullOrWhiteSpace(v)));
+                    if (!string.IsNullOrWhiteSpace(suffix))
+                        return $"{message ?? "OpenRouter error"} ({suffix})";
+                }
+
+                return message ?? rawError;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return rawError;
+    }
+
+    #endregion
+
+    #region Error Helpers
+
+    private void EmitError(LlmStream stream, LlmModel model, string errorMessage,
+        List<ContentBlock>? partialContent = null)
+    {
+        var message = new AssistantMessage(
+            Content: partialContent ?? [],
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Error,
+            ErrorMessage: errorMessage,
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new ErrorEvent(StopReason.Error, message));
+        stream.End(message);
+    }
+
+    private void EmitAborted(LlmStream stream, LlmModel model)
+    {
+        var message = new AssistantMessage(
+            Content: [],
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Aborted,
+            ErrorMessage: "Request was cancelled",
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new DoneEvent(StopReason.Aborted, message));
+        stream.End(message);
+    }
+
+    #endregion
+
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesOptions.cs
@@ -1,0 +1,16 @@
+namespace BotNexus.Agent.Providers.Copilot.Responses;
+
+/// <summary>
+/// Provider-specific options for the GitHub Copilot Responses API.
+/// Carved out of <c>OpenAIResponsesOptions</c> so the Copilot transport has no
+/// cross-provider dependency on the OpenAI project. Field shape matches
+/// <c>OpenAIResponsesOptions</c> intentionally — the carve-out preserves the
+/// wire contract while removing the cross-provider coupling.
+/// </summary>
+public record class CopilotResponsesOptions : BotNexus.Agent.Providers.Core.StreamOptions
+{
+    public string? ReasoningEffort { get; set; }
+    public string? ReasoningSummary { get; set; }
+    public string? PreviousResponseId { get; set; }
+    public string? ServiceTier { get; set; }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
@@ -1,0 +1,1005 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Diagnostics;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Agent.Providers.Core.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Agent.Providers.Copilot.Responses;
+
+/// <summary>
+/// GitHub Copilot Responses API provider. Carved out of <see cref="BotNexus.Agent.Providers.OpenAI.OpenAIResponsesProvider"/> so the Copilot transport has no cross-provider dependency on the OpenAI project. Always applies Copilot dynamic headers and omits the non-Copilot reasoning fallback.
+/// See <c>tests/.../CopilotResponsesProviderParityTests</c> for the byte-identical-body proof against the legacy OpenAI-with-Copilot-auth path.
+/// </summary>
+public sealed class CopilotResponsesProvider(
+    HttpClient httpClient,
+    ILogger<CopilotResponsesProvider> logger) : IApiProvider
+{
+    public string Api => "github-copilot-responses";
+
+    public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null)
+    {
+        var stream = new LlmStream();
+        var ct = options?.CancellationToken ?? CancellationToken.None;
+
+        _ = Task.Run(async () =>
+        {
+            using var activity = ProviderDiagnostics.Source.StartActivity("provider.copilot-responses.stream", ActivityKind.Client);
+            activity?.SetTag("botnexus.provider.name", model.Provider);
+            activity?.SetTag("botnexus.model", model.Id);
+            activity?.SetTag("botnexus.model.api", model.Api);
+
+            try
+            {
+                await StreamCoreAsync(stream, model, context, options, ct);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+            }
+            catch (OperationCanceledException)
+            {
+                EmitAborted(stream, model);
+                activity?.SetStatus(ActivityStatusCode.Error, "Operation canceled");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Copilot responses stream failed for model {Model}", model.Id);
+                EmitError(stream, model, ex.Message);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            }
+        }, ct);
+
+        return stream;
+    }
+
+    public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null)
+    {
+        var apiKey = options?.ApiKey ?? EnvironmentApiKeys.GetApiKey(model.Provider) ?? "";
+        var reasoning = ModelRegistry.SupportsExtraHigh(model) ? options?.Reasoning : SimpleOptionsHelper.ClampReasoning(options?.Reasoning);
+        var responsesOptions = new CopilotResponsesOptions
+        {
+            ApiKey = apiKey,
+            Temperature = options?.Temperature,
+            MaxTokens = options?.MaxTokens,
+            CancellationToken = options?.CancellationToken ?? CancellationToken.None,
+            Transport = options?.Transport ?? Transport.Sse,
+            CacheRetention = options?.CacheRetention ?? CacheRetention.Short,
+            SessionId = options?.SessionId,
+            OnPayload = options?.OnPayload,
+            Headers = options?.Headers,
+            MaxRetryDelayMs = options?.MaxRetryDelayMs ?? 60000,
+            Metadata = options?.Metadata
+        };
+
+        if (reasoning is not null && model.Reasoning)
+            responsesOptions.ReasoningEffort = MapThinkingLevel(reasoning.Value);
+
+        return Stream(model, context, responsesOptions);
+    }
+
+    private async Task StreamCoreAsync(
+        LlmStream stream,
+        LlmModel model,
+        Context context,
+        StreamOptions? options,
+        CancellationToken ct)
+    {
+        var apiKey = options?.ApiKey ?? EnvironmentApiKeys.GetApiKey(model.Provider) ?? "";
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException(
+                $"No API key for {model.Provider}. Set credentials before using model '{model.Id}'.");
+        }
+
+        var messages = MessageTransformer.TransformMessages(context.Messages, model);
+        var payload = BuildRequestPayload(model, context.SystemPrompt, messages, context.Tools, options);
+
+        if (options?.OnPayload is not null)
+        {
+            var modified = await options.OnPayload(payload, model);
+            if (modified is JsonObject obj)
+                payload = obj;
+        }
+
+        var url = $"{model.BaseUrl.TrimEnd('/')}/responses";
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        if (model.Headers is not null)
+        {
+            foreach (var (key, value) in model.Headers)
+                request.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        // Copilot transport always applies the dynamic vision/intent headers —
+        // this provider only handles Copilot-routed models, so the runtime check
+        // present in the OpenAI parent is unnecessary.
+        var copilotHasImages = CopilotHeaders.HasVisionInput(context.Messages);
+        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(context.Messages, copilotHasImages))
+            request.Headers.TryAddWithoutValidation(key, value);
+
+        if (options?.Headers is not null)
+        {
+            foreach (var (key, value) in options.Headers)
+                request.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {errorBody}");
+        }
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(responseStream, Encoding.UTF8);
+        await ParseSseStream(stream, reader, model, options, ct);
+    }
+
+    private static JsonObject BuildRequestPayload(
+        LlmModel model,
+        string? systemPrompt,
+        IReadOnlyList<Message> messages,
+        IReadOnlyList<Tool>? tools,
+        StreamOptions? options)
+    {
+        var input = ConvertMessages(messages, model);
+        if (!string.IsNullOrWhiteSpace(systemPrompt))
+        {
+            input.Insert(0, new JsonObject
+            {
+                ["role"] = model.Reasoning ? "developer" : "system",
+                ["content"] = UnicodeSanitizer.SanitizeSurrogates(systemPrompt)
+            });
+        }
+
+        var payload = new JsonObject
+        {
+            ["model"] = model.Id,
+            ["stream"] = true,
+            ["store"] = false,
+            ["input"] = input
+        };
+
+        if (options?.MaxTokens is not null)
+            payload["max_output_tokens"] = options.MaxTokens.Value;
+
+        if (options?.Temperature is not null)
+            payload["temperature"] = options.Temperature.Value;
+
+        if (options is CopilotResponsesOptions { ServiceTier: not null } responsesOptions)
+            payload["service_tier"] = responsesOptions.ServiceTier;
+
+        if (options?.CacheRetention != CacheRetention.None && !string.IsNullOrWhiteSpace(options?.SessionId))
+            payload["prompt_cache_key"] = options.SessionId;
+        var promptCacheRetention = GetPromptCacheRetention(model.BaseUrl, options?.CacheRetention ?? CacheRetention.Short);
+        if (!string.IsNullOrWhiteSpace(promptCacheRetention))
+            payload["prompt_cache_retention"] = promptCacheRetention;
+
+        if (tools is { Count: > 0 })
+            payload["tools"] = ConvertTools(tools);
+
+        if (model.Reasoning)
+        {
+            var effort = options is CopilotResponsesOptions { ReasoningEffort: not null } ro ? ro.ReasoningEffort : null;
+            var summary = options is CopilotResponsesOptions { ReasoningSummary: not null } rs ? rs.ReasoningSummary : null;
+            if (effort is not null || summary is not null)
+            {
+                payload["reasoning"] = new JsonObject
+                {
+                    ["effort"] = effort ?? "medium",
+                    ["summary"] = summary ?? "auto"
+                };
+                payload["include"] = new JsonArray { "reasoning.encrypted_content" };
+            }
+            // The legacy OpenAI provider falls back to {effort:"none"} when the caller
+            // does not request reasoning for a reasoning-capable model. Copilot has
+            // never emitted that fallback, so the carve-out drops it.
+        }
+
+        return payload;
+    }
+
+    private static JsonArray ConvertMessages(IReadOnlyList<Message> messages, LlmModel model)
+    {
+        var result = new JsonArray();
+
+        foreach (var message in messages)
+        {
+            switch (message)
+            {
+                case UserMessage user:
+                    result.Add(ConvertUserMessage(user, model));
+                    break;
+
+                case AssistantMessage assistant:
+                    foreach (var item in ConvertAssistantMessage(assistant, model))
+                        result.Add(item);
+                    break;
+
+                case ToolResultMessage toolResult:
+                    result.Add(ConvertToolResultMessage(toolResult, model));
+                    break;
+            }
+        }
+
+        return result;
+    }
+
+    private static JsonObject ConvertUserMessage(UserMessage user, LlmModel model)
+    {
+        if (user.Content.IsText)
+        {
+            return new JsonObject
+            {
+                ["type"] = "message",
+                ["role"] = "user",
+                ["content"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["type"] = "input_text",
+                        ["text"] = UnicodeSanitizer.SanitizeSurrogates(user.Content.Text ?? "")
+                    }
+                }
+            };
+        }
+
+        var contentArray = new JsonArray();
+        foreach (var block in user.Content.Blocks ?? [])
+        {
+            switch (block)
+            {
+                case TextContent text:
+                    contentArray.Add(new JsonObject
+                    {
+                        ["type"] = "input_text",
+                        ["text"] = UnicodeSanitizer.SanitizeSurrogates(text.Text)
+                    });
+                    break;
+
+                case ImageContent image when model.Input.Contains("image"):
+                    contentArray.Add(new JsonObject
+                    {
+                        ["type"] = "input_image",
+                        ["detail"] = "auto",
+                        ["image_url"] = $"data:{image.MimeType};base64,{image.Data}"
+                    });
+                    break;
+            }
+        }
+
+        return new JsonObject
+        {
+            ["type"] = "message",
+            ["role"] = "user",
+            ["content"] = contentArray
+        };
+    }
+
+    private static IReadOnlyList<JsonObject> ConvertAssistantMessage(AssistantMessage assistant, LlmModel model)
+    {
+        var items = new List<JsonObject>();
+        var isDifferentModel = !string.Equals(assistant.ModelId, model.Id, StringComparison.Ordinal) &&
+                               string.Equals(assistant.Provider, model.Provider, StringComparison.Ordinal) &&
+                               string.Equals(assistant.Api, model.Api, StringComparison.Ordinal);
+        var msgIndex = 0;
+
+        foreach (var block in assistant.Content)
+        {
+            switch (block)
+            {
+                case TextContent textBlock:
+                    var parsedSignature = ParseTextSignature(textBlock.TextSignature);
+                    var msgId = parsedSignature?.Id;
+                    if (string.IsNullOrWhiteSpace(msgId))
+                    {
+                        msgId = $"msg_{msgIndex}";
+                    }
+                    else if (msgId.Length > 64)
+                    {
+                        msgId = $"msg_{ShortHash(msgId)}";
+                    }
+
+                    var textItem = new JsonObject
+                    {
+                        ["type"] = "message",
+                        ["role"] = "assistant",
+                        ["content"] = new JsonArray
+                        {
+                            new JsonObject
+                            {
+                                ["type"] = "output_text",
+                                ["text"] = UnicodeSanitizer.SanitizeSurrogates(textBlock.Text),
+                                ["annotations"] = new JsonArray()
+                            }
+                        },
+                        ["status"] = "completed",
+                        ["id"] = msgId
+                    };
+                    if (parsedSignature?.Phase is not null)
+                        textItem["phase"] = parsedSignature.Phase;
+                    items.Add(textItem);
+                    msgIndex++;
+                    break;
+
+                case ThinkingContent thinking:
+                    if (!string.IsNullOrWhiteSpace(thinking.ThinkingSignature))
+                    {
+                        try
+                        {
+                            var parsed = JsonNode.Parse(thinking.ThinkingSignature);
+                            if (parsed is JsonObject reasoningItem)
+                                items.Add(reasoningItem);
+                        }
+                        catch (JsonException)
+                        {
+                        }
+                    }
+                    break;
+
+                case ToolCallContent toolCall:
+                    var (callId, itemId) = SplitToolCallId(toolCall.Id);
+                    if (isDifferentModel && itemId?.StartsWith("fc_", StringComparison.Ordinal) == true)
+                        itemId = null;
+                    items.Add(new JsonObject
+                    {
+                        ["type"] = "function_call",
+                        ["call_id"] = callId,
+                        ["id"] = itemId,
+                        ["name"] = toolCall.Name,
+                        ["arguments"] = JsonSerializer.Serialize(toolCall.Arguments)
+                    });
+                    break;
+            }
+        }
+
+        return items;
+    }
+
+    private static JsonObject ConvertToolResultMessage(ToolResultMessage toolResult, LlmModel model)
+    {
+        var (callId, _) = SplitToolCallId(toolResult.ToolCallId);
+        var textResult = string.Join("\n", toolResult.Content.OfType<TextContent>().Select(t => t.Text));
+        var hasImages = toolResult.Content.Any(c => c is ImageContent) && model.Input.Contains("image");
+        JsonNode output;
+
+        if (hasImages)
+        {
+            var outputParts = new JsonArray();
+            if (!string.IsNullOrWhiteSpace(textResult))
+            {
+                outputParts.Add(new JsonObject
+                {
+                    ["type"] = "input_text",
+                    ["text"] = UnicodeSanitizer.SanitizeSurrogates(textResult)
+                });
+            }
+
+            foreach (var image in toolResult.Content.OfType<ImageContent>())
+            {
+                outputParts.Add(new JsonObject
+                {
+                    ["type"] = "input_image",
+                    ["detail"] = "auto",
+                    ["image_url"] = $"data:{image.MimeType};base64,{image.Data}"
+                });
+            }
+
+            output = outputParts;
+        }
+        else
+        {
+            output = JsonValue.Create(UnicodeSanitizer.SanitizeSurrogates(
+                string.IsNullOrWhiteSpace(textResult) ? "(see attached image)" : textResult))!;
+        }
+
+        return new JsonObject
+        {
+            ["type"] = "function_call_output",
+            ["call_id"] = callId,
+            ["output"] = output
+        };
+    }
+
+    private static JsonArray ConvertTools(IReadOnlyList<Tool> tools)
+    {
+        var result = new JsonArray();
+        foreach (var tool in tools)
+        {
+            result.Add(new JsonObject
+            {
+                ["type"] = "function",
+                ["name"] = tool.Name,
+                ["description"] = tool.Description,
+                ["parameters"] = JsonNode.Parse(tool.Parameters.GetRawText()),
+                ["strict"] = false
+            });
+        }
+
+        return result;
+    }
+
+    private async Task ParseSseStream(
+        LlmStream stream,
+        StreamReader reader,
+        LlmModel model,
+        StreamOptions? options,
+        CancellationToken ct)
+    {
+        var contentBlocks = new List<ContentBlock>();
+        var usage = Usage.Empty();
+        string? responseId = null;
+        var started = false;
+        var stopReason = StopReason.Stop;
+        var sawRefusal = false;
+
+        var textStates = new Dictionary<string, (int ContentIndex, StringBuilder Text)>(StringComparer.Ordinal);
+        var thinkingStates = new Dictionary<string, (int ContentIndex, StringBuilder Text)>(StringComparer.Ordinal);
+        var toolStates = new Dictionary<string, ToolState>(StringComparer.Ordinal);
+
+        AssistantMessage BuildPartial() => new(
+            Content: contentBlocks.ToList(),
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: usage,
+            StopReason: stopReason,
+            ErrorMessage: null,
+            ResponseId: responseId,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        void EnsureStart()
+        {
+            if (started) return;
+            stream.Push(new StartEvent(BuildPartial()));
+            started = true;
+        }
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var evt = await ReadSseEventAsync(reader, ct);
+            if (evt is null) break;
+
+            if (string.Equals(evt.Event, "error", StringComparison.Ordinal))
+            {
+                EmitError(stream, model, evt.Data);
+                return;
+            }
+
+            JsonDocument? doc;
+            try
+            {
+                doc = JsonDocument.Parse(evt.Data);
+            }
+            catch (JsonException)
+            {
+                logger.LogDebug("Skipping malformed responses SSE event {Event}", evt.Event);
+                continue;
+            }
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+
+                if (evt.Event is "response.created")
+                {
+                    if (root.TryGetProperty("response", out var responseEl))
+                        responseId = GetString(responseEl, "id") ?? responseId;
+                    continue;
+                }
+
+                if (evt.Event is "response.output_item.added")
+                {
+                    EnsureStart();
+                    if (!root.TryGetProperty("item", out var item)) continue;
+                    var itemType = GetString(item, "type");
+                    var itemId = GetString(item, "id");
+
+                    switch (itemType)
+                    {
+                        case "reasoning":
+                        {
+                            var index = contentBlocks.Count;
+                            contentBlocks.Add(new ThinkingContent(""));
+                            if (!string.IsNullOrWhiteSpace(itemId))
+                                thinkingStates[itemId] = (index, new StringBuilder());
+                            stream.Push(new ThinkingStartEvent(index, BuildPartial()));
+                            break;
+                        }
+                        case "message":
+                        {
+                            var index = contentBlocks.Count;
+                            contentBlocks.Add(new TextContent(""));
+                            if (!string.IsNullOrWhiteSpace(itemId))
+                                textStates[itemId] = (index, new StringBuilder());
+                            stream.Push(new TextStartEvent(index, BuildPartial()));
+                            break;
+                        }
+                        case "function_call":
+                        {
+                            var callId = GetString(item, "call_id") ?? "";
+                            var name = GetString(item, "name") ?? "";
+                            var arguments = GetString(item, "arguments") ?? "";
+                            var index = contentBlocks.Count;
+                            var parsed = StreamingJsonParser.Parse(arguments);
+                            contentBlocks.Add(new ToolCallContent(ComposeToolCallId(callId, itemId), name, parsed));
+                            stream.Push(new ToolCallStartEvent(index, BuildPartial()));
+
+                            var state = new ToolState(callId, itemId, name, index);
+                            state.Arguments.Append(arguments);
+                            toolStates[callId] = state;
+
+                            if (arguments.Length > 0)
+                                stream.Push(new ToolCallDeltaEvent(index, arguments, BuildPartial()));
+                            break;
+                        }
+                    }
+
+                    continue;
+                }
+
+                if (evt.Event is "response.reasoning_summary_text.delta")
+                {
+                    EnsureStart();
+                    var itemId = GetString(root, "item_id");
+                    if (itemId is null || !thinkingStates.TryGetValue(itemId, out var state)) continue;
+                    var delta = GetString(root, "delta") ?? "";
+                    if (delta.Length == 0) continue;
+                    state.Text.Append(delta);
+                    contentBlocks[state.ContentIndex] = new ThinkingContent(state.Text.ToString());
+                    stream.Push(new ThinkingDeltaEvent(state.ContentIndex, delta, BuildPartial()));
+                    thinkingStates[itemId] = state;
+                    continue;
+                }
+
+                if (evt.Event is "response.reasoning_summary_part.done")
+                {
+                    var itemId = GetString(root, "item_id");
+                    if (itemId is null || !thinkingStates.TryGetValue(itemId, out var state)) continue;
+                    state.Text.Append("\n\n");
+                    contentBlocks[state.ContentIndex] = new ThinkingContent(state.Text.ToString());
+                    stream.Push(new ThinkingDeltaEvent(state.ContentIndex, "\n\n", BuildPartial()));
+                    thinkingStates[itemId] = state;
+                    continue;
+                }
+
+                if (evt.Event is "response.output_text.delta" or "response.refusal.delta")
+                {
+                    EnsureStart();
+                    if (evt.Event is "response.refusal.delta")
+                    {
+                        sawRefusal = true;
+                        stopReason = StopReason.Refusal;
+                    }
+                    var itemId = GetString(root, "item_id");
+                    var delta = GetString(root, "delta") ?? "";
+                    if (delta.Length == 0) continue;
+
+                    if (itemId is null || !textStates.TryGetValue(itemId, out var state))
+                    {
+                        var index = contentBlocks.Count;
+                        contentBlocks.Add(new TextContent(""));
+                        state = (index, new StringBuilder());
+                        textStates[itemId ?? Guid.NewGuid().ToString("N")] = state;
+                        stream.Push(new TextStartEvent(index, BuildPartial()));
+                    }
+
+                    state.Text.Append(delta);
+                    contentBlocks[state.ContentIndex] = new TextContent(state.Text.ToString());
+                    stream.Push(new TextDeltaEvent(state.ContentIndex, delta, BuildPartial()));
+                    if (itemId is not null)
+                        textStates[itemId] = state;
+                    continue;
+                }
+
+                if (evt.Event is "response.function_call_arguments.delta")
+                {
+                    EnsureStart();
+                    var callId = GetString(root, "call_id");
+                    var delta = GetString(root, "delta") ?? "";
+                    if (callId is null || delta.Length == 0 || !toolStates.TryGetValue(callId, out var state)) continue;
+
+                    state.Arguments.Append(delta);
+                    contentBlocks[state.ContentIndex] = new ToolCallContent(
+                        ComposeToolCallId(state.CallId, state.ItemId),
+                        state.Name,
+                        StreamingJsonParser.Parse(state.Arguments.ToString()));
+                    stream.Push(new ToolCallDeltaEvent(state.ContentIndex, delta, BuildPartial()));
+                    continue;
+                }
+
+                if (evt.Event is "response.function_call_arguments.done")
+                {
+                    var callId = GetString(root, "call_id");
+                    var finalArgs = GetString(root, "arguments") ?? "";
+                    if (callId is null || !toolStates.TryGetValue(callId, out var state)) continue;
+                    var before = state.Arguments.ToString();
+                    state.Arguments.Clear();
+                    state.Arguments.Append(finalArgs);
+                    contentBlocks[state.ContentIndex] = new ToolCallContent(
+                        ComposeToolCallId(state.CallId, state.ItemId),
+                        state.Name,
+                        StreamingJsonParser.Parse(finalArgs));
+                    if (finalArgs.StartsWith(before, StringComparison.Ordinal))
+                    {
+                        var delta = finalArgs[before.Length..];
+                        if (delta.Length > 0)
+                            stream.Push(new ToolCallDeltaEvent(state.ContentIndex, delta, BuildPartial()));
+                    }
+                    continue;
+                }
+
+                if (evt.Event is "response.output_item.done")
+                {
+                    if (!root.TryGetProperty("item", out var item)) continue;
+                    var itemType = GetString(item, "type");
+                    var itemId = GetString(item, "id");
+
+                    switch (itemType)
+                    {
+                        case "reasoning" when itemId is not null && thinkingStates.TryGetValue(itemId, out var thinkingState):
+                            contentBlocks[thinkingState.ContentIndex] = new ThinkingContent(
+                                thinkingState.Text.ToString(),
+                                JsonSerializer.Serialize(item));
+                            stream.Push(new ThinkingEndEvent(thinkingState.ContentIndex, thinkingState.Text.ToString(), BuildPartial()));
+                            thinkingStates.Remove(itemId);
+                            break;
+
+                        case "message" when itemId is not null && textStates.TryGetValue(itemId, out var textState):
+                            var phase = GetString(item, "phase");
+                            contentBlocks[textState.ContentIndex] = new TextContent(
+                                textState.Text.ToString(),
+                                EncodeTextSignatureV1(itemId, phase));
+                            stream.Push(new TextEndEvent(textState.ContentIndex, textState.Text.ToString(), BuildPartial()));
+                            textStates.Remove(itemId);
+                            break;
+
+                        case "function_call":
+                        {
+                            var callId = GetString(item, "call_id");
+                            var name = GetString(item, "name") ?? "";
+                            var args = GetString(item, "arguments") ?? "";
+                            if (callId is null || !toolStates.TryGetValue(callId, out var state)) break;
+                            if (args.Length > 0)
+                            {
+                                state.Arguments.Clear();
+                                state.Arguments.Append(args);
+                            }
+
+                            var toolCall = new ToolCallContent(
+                                ComposeToolCallId(callId, state.ItemId),
+                                name.Length > 0 ? name : state.Name,
+                                StreamingJsonParser.Parse(state.Arguments.ToString()));
+                            contentBlocks[state.ContentIndex] = toolCall;
+                            stream.Push(new ToolCallEndEvent(state.ContentIndex, toolCall, BuildPartial()));
+                            toolStates.Remove(callId);
+                            break;
+                        }
+                    }
+
+                    continue;
+                }
+
+                if (evt.Event is "response.completed" or "response.done")
+                {
+                    var responseEl = root.TryGetProperty("response", out var resp) ? resp : root;
+                    responseId = GetString(responseEl, "id") ?? responseId;
+                    stopReason = MapStopReason(GetString(responseEl, "status"));
+
+                    if (responseEl.TryGetProperty("incomplete_details", out var incompleteDetails) &&
+                        incompleteDetails.ValueKind == JsonValueKind.Object &&
+                        string.Equals(GetString(incompleteDetails, "reason"), "content_filter", StringComparison.OrdinalIgnoreCase))
+                    {
+                        stopReason = StopReason.Sensitive;
+                    }
+                    else if (sawRefusal && stopReason == StopReason.Stop)
+                    {
+                        stopReason = StopReason.Refusal;
+                    }
+
+                    if (responseEl.TryGetProperty("usage", out var usageEl) &&
+                        usageEl.ValueKind == JsonValueKind.Object)
+                    {
+                        usage = ParseUsage(usageEl, model);
+                        var configuredTier = options is CopilotResponsesOptions ro ? ro.ServiceTier : null;
+                        var responseTier = GetString(responseEl, "service_tier");
+                        usage = ApplyServiceTierPricing(usage, responseTier ?? configuredTier);
+                    }
+
+                    if (contentBlocks.OfType<ToolCallContent>().Any() && stopReason == StopReason.Stop)
+                        stopReason = StopReason.ToolUse;
+
+                    break;
+                }
+
+                if (evt.Event is "response.failed")
+                {
+                    var message = GetErrorMessage(root);
+                    EmitError(stream, model, message, contentBlocks);
+                    return;
+                }
+            }
+        }
+
+        var final = BuildPartial() with { StopReason = stopReason };
+        stream.Push(new DoneEvent(stopReason, final));
+        stream.End(final);
+    }
+
+    private static async Task<SseEvent?> ReadSseEventAsync(StreamReader reader, CancellationToken ct)
+    {
+        string? eventType = null;
+        var data = new StringBuilder();
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var line = await reader.ReadLineAsync(ct);
+            if (line is null)
+            {
+                if (eventType is null && data.Length == 0) return null;
+                break;
+            }
+
+            if (line.Length == 0)
+            {
+                if (eventType is not null || data.Length > 0) break;
+                continue;
+            }
+
+            if (line.StartsWith("event: ", StringComparison.Ordinal))
+            {
+                eventType = line[7..];
+                continue;
+            }
+
+            if (line.StartsWith("data: ", StringComparison.Ordinal))
+            {
+                if (data.Length > 0) data.Append('\n');
+                data.Append(line[6..]);
+            }
+        }
+
+        if (data.Length == 0 || data.ToString() == "[DONE]") return null;
+        return new SseEvent(eventType ?? "message", data.ToString());
+    }
+
+    private static Usage ParseUsage(JsonElement usageElement, LlmModel model)
+    {
+        var inputTokens = usageElement.TryGetProperty("input_tokens", out var input) ? input.GetInt32() : 0;
+        var outputTokens = usageElement.TryGetProperty("output_tokens", out var output) ? output.GetInt32() : 0;
+        var total = usageElement.TryGetProperty("total_tokens", out var totalEl) ? totalEl.GetInt32() : inputTokens + outputTokens;
+        var cacheRead = 0;
+        var cacheWrite = 0;
+
+        if (usageElement.TryGetProperty("input_tokens_details", out var details))
+        {
+            if (details.TryGetProperty("cached_tokens", out var cached))
+                cacheRead = cached.GetInt32();
+            if (details.TryGetProperty("cache_write_tokens", out var write))
+                cacheWrite = write.GetInt32();
+        }
+
+        var usage = new Usage
+        {
+            Input = Math.Max(0, inputTokens - cacheRead - cacheWrite),
+            Output = outputTokens,
+            CacheRead = cacheRead,
+            CacheWrite = cacheWrite,
+            TotalTokens = total
+        };
+
+        return usage with { Cost = ModelRegistry.CalculateCost(model, usage) };
+    }
+
+    private static string GetErrorMessage(JsonElement root)
+    {
+        if (root.TryGetProperty("response", out var response) &&
+            response.TryGetProperty("error", out var error) &&
+            error.ValueKind == JsonValueKind.Object)
+        {
+            var code = GetString(error, "code");
+            var message = GetString(error, "message");
+            return $"{code ?? "unknown"}: {message ?? "no message"}";
+        }
+
+        if (root.TryGetProperty("response", out response) &&
+            response.TryGetProperty("incomplete_details", out var details) &&
+            details.TryGetProperty("reason", out var reason))
+        {
+            return $"incomplete: {reason.GetString()}";
+        }
+
+        if (root.TryGetProperty("message", out var messageEl))
+            return messageEl.GetString() ?? "Unknown error";
+
+        return "Unknown error";
+    }
+
+    private static StopReason MapStopReason(string? status) => status switch
+    {
+        "completed" => StopReason.Stop,
+        "incomplete" => StopReason.Length,
+        "refusal" => StopReason.Refusal,
+        "content_filter" => StopReason.Sensitive,
+        "failed" => StopReason.Error,
+        "cancelled" => StopReason.Error,
+        "in_progress" => StopReason.Stop,
+        "queued" => StopReason.Stop,
+        _ => StopReason.Stop
+    };
+
+    private static string MapThinkingLevel(ThinkingLevel level) => level switch
+    {
+        ThinkingLevel.Minimal => "minimal",
+        ThinkingLevel.Low => "low",
+        ThinkingLevel.Medium => "medium",
+        ThinkingLevel.High => "high",
+        ThinkingLevel.ExtraHigh => "xhigh",
+        _ => "medium"
+    };
+
+    private static string EncodeTextSignatureV1(string id, string? phase)
+    {
+        var payload = new JsonObject
+        {
+            ["v"] = 1,
+            ["id"] = id
+        };
+        if (phase is "commentary" or "final_answer")
+            payload["phase"] = phase;
+        return payload.ToJsonString();
+    }
+
+    private sealed record ParsedTextSignature(string Id, string? Phase);
+
+    private static ParsedTextSignature? ParseTextSignature(string? signature)
+    {
+        if (string.IsNullOrWhiteSpace(signature))
+            return null;
+
+        if (signature.StartsWith("{", StringComparison.Ordinal))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(signature);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("v", out var version) &&
+                    version.ValueKind == JsonValueKind.Number &&
+                    version.GetInt32() == 1 &&
+                    root.TryGetProperty("id", out var idProp) &&
+                    idProp.ValueKind == JsonValueKind.String)
+                {
+                    var id = idProp.GetString()!;
+                    var phase = root.TryGetProperty("phase", out var phaseProp) &&
+                                phaseProp.ValueKind == JsonValueKind.String
+                        ? phaseProp.GetString()
+                        : null;
+                    if (phase is not ("commentary" or "final_answer"))
+                        phase = null;
+                    return new ParsedTextSignature(id, phase);
+                }
+            }
+            catch (JsonException)
+            {
+            }
+        }
+
+        return new ParsedTextSignature(signature, null);
+    }
+
+    private static string ShortHash(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes)[..8].ToLowerInvariant();
+    }
+
+    private static Usage ApplyServiceTierPricing(Usage usage, string? serviceTier)
+    {
+        var multiplier = serviceTier switch
+        {
+            "flex" => 0.5m,
+            "priority" => 2m,
+            _ => 1m
+        };
+        if (multiplier == 1m)
+            return usage;
+
+        var cost = usage.Cost with
+        {
+            Input = usage.Cost.Input * multiplier,
+            Output = usage.Cost.Output * multiplier,
+            CacheRead = usage.Cost.CacheRead * multiplier,
+            CacheWrite = usage.Cost.CacheWrite * multiplier
+        };
+        cost = cost with
+        {
+            Total = cost.Input + cost.Output + cost.CacheRead + cost.CacheWrite
+        };
+
+        return usage with { Cost = cost };
+    }
+
+    private static string? GetPromptCacheRetention(string baseUrl, CacheRetention retention)
+    {
+        if (retention != CacheRetention.Long)
+            return null;
+
+        return baseUrl.Contains("api.openai.com", StringComparison.OrdinalIgnoreCase) ? "24h" : null;
+    }
+
+    private static string? GetString(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String)
+            return value.GetString();
+        return null;
+    }
+
+    private static (string CallId, string? ItemId) SplitToolCallId(string id)
+    {
+        if (!id.Contains('|')) return (id, null);
+        var parts = id.Split('|', 2);
+        return (parts[0], parts[1]);
+    }
+
+    private static string ComposeToolCallId(string callId, string? itemId)
+        => string.IsNullOrWhiteSpace(itemId) ? callId : $"{callId}|{itemId}";
+
+    private void EmitError(
+        LlmStream stream,
+        LlmModel model,
+        string errorMessage,
+        IReadOnlyList<ContentBlock>? partialContent = null)
+    {
+        var message = new AssistantMessage(
+            Content: partialContent?.ToList() ?? [],
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Error,
+            ErrorMessage: errorMessage,
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new ErrorEvent(StopReason.Error, message));
+        stream.End(message);
+    }
+
+    private void EmitAborted(LlmStream stream, LlmModel model)
+    {
+        var message = new AssistantMessage(
+            Content: [],
+            Api: Api,
+            Provider: model.Provider,
+            ModelId: model.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Aborted,
+            ErrorMessage: "Request was cancelled",
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        stream.Push(new DoneEvent(StopReason.Aborted, message));
+        stream.End(message);
+    }
+
+    private sealed record SseEvent(string Event, string Data);
+
+    private sealed class ToolState(string callId, string? itemId, string name, int contentIndex)
+    {
+        public string CallId { get; } = callId;
+        public string? ItemId { get; } = itemId;
+        public string Name { get; } = name;
+        public int ContentIndex { get; } = contentIndex;
+        public StringBuilder Arguments { get; } = new();
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -8,6 +8,8 @@ using BotNexus.Gateway.Extensions;
 using BotNexus.Agent.Providers.Core.Logging;
 using BotNexus.Agent.Providers.Anthropic;
 using BotNexus.Agent.Providers.Copilot.Messages;
+using BotNexus.Agent.Providers.Copilot.Responses;
+using BotNexus.Agent.Providers.Copilot.Completions;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
@@ -235,6 +237,8 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
     apiProviders.Register(new CopilotMessagesProvider(httpClient));
     apiProviders.Register(new OpenAICompletionsProvider(httpClient, loggerFactory.CreateLogger<OpenAICompletionsProvider>()));
     apiProviders.Register(new OpenAIResponsesProvider(httpClient, loggerFactory.CreateLogger<OpenAIResponsesProvider>()));
+    apiProviders.Register(new CopilotCompletionsProvider(httpClient, loggerFactory.CreateLogger<CopilotCompletionsProvider>()));
+    apiProviders.Register(new CopilotResponsesProvider(httpClient, loggerFactory.CreateLogger<CopilotResponsesProvider>()));
     apiProviders.Register(new OpenAICompatProvider(httpClient));
     apiProviders.Register(new IntegrationMockProvider());
 

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Completions/CopilotCompletionsProviderParityTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Completions/CopilotCompletionsProviderParityTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using BotNexus.Agent.Providers.Copilot.Completions;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.OpenAI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Completions;
+
+/// <summary>
+/// Phase 2a — proves that the carved-out <see cref="CopilotCompletionsProvider"/>
+/// emits a byte-identical outbound request to the legacy path
+/// (<see cref="OpenAICompletionsProvider"/> driven against a github-copilot
+/// model with Bearer auth). This is the deployment-safety pivot for Phase 2b:
+/// when the model registry flips gemini/grok/gpt-4.x entries from
+/// <c>openai-completions</c> to <c>github-copilot-completions</c>, the wire
+/// contract must not change.
+/// </summary>
+public class CopilotCompletionsProviderParityTests
+{
+    [Fact]
+    public void Api_IsGitHubCopilotCompletions()
+    {
+        var provider = new CopilotCompletionsProvider(
+            new HttpClient(new NoOpHandler()),
+            NullLogger<CopilotCompletionsProvider>.Instance);
+        provider.Api.ShouldBe("github-copilot-completions");
+    }
+
+    [Fact]
+    public async Task Stream_GeminiWithToolCatalogue_MatchesOpenAICopilotModeBody()
+    {
+        var (copilotHandler, openAiHandler) = await DriveBothProvidersAsync();
+
+        var copilotBody = Normalise(copilotHandler.RequestBody!);
+        var openAiBody = Normalise(openAiHandler.RequestBody!);
+
+        copilotBody.ShouldBe(
+            openAiBody,
+            "CopilotCompletionsProvider must emit a request body that is byte-identical to " +
+            "OpenAICompletionsProvider's Copilot-mode output. A diff here will become a user-visible " +
+            "behaviour change the moment BuiltInModels flips Copilot-flavour completions entries to github-copilot-completions.");
+    }
+
+    [Fact]
+    public async Task Stream_AppliesBearerAuth_AndCopilotDynamicHeaders()
+    {
+        var (handler, _) = await DriveBothProvidersAsync();
+
+        handler.RequestHeaders.TryGetValue("Authorization", out var auth).ShouldBeTrue();
+        auth.ShouldStartWith("Bearer ");
+
+        handler.RequestHeaders.ShouldContainKey("X-Initiator");
+        handler.RequestHeaders.ShouldContainKey("Openai-Intent");
+    }
+
+    [Fact]
+    public async Task Stream_PostsToChatCompletionsEndpoint()
+    {
+        var (handler, _) = await DriveBothProvidersAsync();
+        handler.RequestUri!.AbsoluteUri.ShouldBe(
+            "https://api.enterprise.githubcopilot.com/chat/completions");
+        handler.RequestMethod.ShouldBe("POST");
+    }
+
+    private static async Task<(RecordingHandler CopilotHandler, RecordingHandler OpenAIHandler)> DriveBothProvidersAsync()
+    {
+        var copilotHandler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var copilotProvider = new CopilotCompletionsProvider(
+            new HttpClient(copilotHandler),
+            NullLogger<CopilotCompletionsProvider>.Instance);
+
+        var openAiHandler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var openAiProvider = new OpenAICompletionsProvider(
+            new HttpClient(openAiHandler),
+            NullLogger<OpenAICompletionsProvider>.Instance);
+
+        var model = BuildModel();
+        var context = BuildContext();
+
+        var copilotOpts = new CopilotCompletionsOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+        var openAiOpts = new OpenAICompletionsOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+
+        var copilotStream = copilotProvider.Stream(model, context, copilotOpts);
+        _ = await copilotStream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var openAiStream = openAiProvider.Stream(model, context, openAiOpts);
+        _ = await openAiStream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        return (copilotHandler, openAiHandler);
+    }
+
+    // NB: Api stays "openai-completions" intentionally — Phase 2a is additive and the
+    // built-in routing has not flipped yet. The parity proof pins the wire contract
+    // *as it exists today* so Phase 2b can change BuiltInModels without drift.
+    private static LlmModel BuildModel() => new(
+        Id: "gemini-2.5-pro",
+        Name: "gemini-2.5-pro",
+        Api: "openai-completions",
+        Provider: "github-copilot",
+        BaseUrl: "https://api.enterprise.githubcopilot.com",
+        Reasoning: false,
+        Input: ["text", "image"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 200000,
+        MaxTokens: 16384);
+
+    private static Context BuildContext()
+    {
+        const long fixedTimestamp = 1_700_000_000_000L;
+        return new Context(
+            SystemPrompt: "You are a helpful assistant operating inside BotNexus tests. " +
+                          "Reply concisely and use tools when asked.",
+            Messages:
+            [
+                new UserMessage(new UserMessageContent("List the first three prime numbers."), fixedTimestamp),
+            ],
+            Tools:
+            [
+                new Tool(
+                    Name: "list_primes",
+                    Description: "Returns the first N prime numbers.",
+                    Parameters: JsonDocument.Parse("""
+                        {
+                          "type": "object",
+                          "properties": {
+                            "count": { "type": "integer", "minimum": 1, "maximum": 100 }
+                          },
+                          "required": ["count"]
+                        }
+                        """).RootElement.Clone()),
+            ]);
+    }
+
+    private const string MinimalSse =
+        "data: {\"id\":\"chatcmpl_fixture\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n" +
+        "\n" +
+        "data: {\"id\":\"chatcmpl_fixture\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n" +
+        "\n" +
+        "data: [DONE]\n" +
+        "\n";
+
+    private static string Normalise(string text)
+        => text.Replace("\r\n", "\n").TrimEnd();
+
+    private static HttpResponseMessage SseResponse(string payload) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "text/event-stream"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public string? RequestMethod { get; private set; }
+        public string? RequestBody { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public Dictionary<string, string> RequestHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestMethod = request.Method.Method;
+            RequestUri = request.RequestUri;
+            RequestHeaders = request.Headers.ToDictionary(
+                header => header.Key,
+                header => string.Join(",", header.Value),
+                StringComparer.OrdinalIgnoreCase);
+            RequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responseFactory(request);
+        }
+    }
+
+    private sealed class NoOpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Responses/CopilotResponsesProviderParityTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Responses/CopilotResponsesProviderParityTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using BotNexus.Agent.Providers.Copilot.Responses;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.OpenAI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Responses;
+
+/// <summary>
+/// Phase 2a — proves that the carved-out <see cref="CopilotResponsesProvider"/>
+/// emits a byte-identical outbound request to the legacy path
+/// (<see cref="OpenAIResponsesProvider"/> driven against a github-copilot model
+/// with Bearer auth). This is the deployment-safety pivot for Phase 2b: when
+/// the model registry flips gpt-5.x entries from <c>openai-responses</c> to
+/// <c>github-copilot-responses</c>, the wire contract must not change.
+/// </summary>
+public class CopilotResponsesProviderParityTests
+{
+    [Fact]
+    public void Api_IsGitHubCopilotResponses()
+    {
+        var provider = new CopilotResponsesProvider(
+            new HttpClient(new NoOpHandler()),
+            NullLogger<CopilotResponsesProvider>.Instance);
+        provider.Api.ShouldBe("github-copilot-responses");
+    }
+
+    [Fact]
+    public async Task Stream_Gpt55WithToolCatalogue_MatchesOpenAICopilotModeBody()
+    {
+        var (copilotHandler, openAiHandler) = await DriveBothProvidersAsync();
+
+        var copilotBody = Normalise(copilotHandler.RequestBody!);
+        var openAiBody = Normalise(openAiHandler.RequestBody!);
+
+        copilotBody.ShouldBe(
+            openAiBody,
+            "CopilotResponsesProvider must emit a request body that is byte-identical to " +
+            "OpenAIResponsesProvider's Copilot-mode output. A diff here will become a user-visible " +
+            "behaviour change the moment BuiltInModels flips Copilot-flavour gpt-5.x entries to github-copilot-responses.");
+    }
+
+    [Fact]
+    public async Task Stream_AppliesBearerAuth_AndCopilotDynamicHeaders()
+    {
+        var (handler, _) = await DriveBothProvidersAsync();
+
+        handler.RequestHeaders.TryGetValue("Authorization", out var auth).ShouldBeTrue();
+        auth.ShouldStartWith("Bearer ");
+
+        // Two of the Copilot dynamic headers that are unconditionally applied to every
+        // Copilot request (Copilot-Vision-Request is only set when images are present).
+        handler.RequestHeaders.ShouldContainKey("X-Initiator");
+        handler.RequestHeaders.ShouldContainKey("Openai-Intent");
+    }
+
+    [Fact]
+    public async Task Stream_PostsToResponsesEndpoint()
+    {
+        var (handler, _) = await DriveBothProvidersAsync();
+        handler.RequestUri!.AbsoluteUri.ShouldBe(
+            "https://api.enterprise.githubcopilot.com/responses");
+        handler.RequestMethod.ShouldBe("POST");
+    }
+
+    private static async Task<(RecordingHandler CopilotHandler, RecordingHandler OpenAIHandler)> DriveBothProvidersAsync()
+    {
+        var copilotHandler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var copilotProvider = new CopilotResponsesProvider(
+            new HttpClient(copilotHandler),
+            NullLogger<CopilotResponsesProvider>.Instance);
+
+        var openAiHandler = new RecordingHandler(_ => SseResponse(MinimalSse));
+        var openAiProvider = new OpenAIResponsesProvider(
+            new HttpClient(openAiHandler),
+            NullLogger<OpenAIResponsesProvider>.Instance);
+
+        var model = BuildModel();
+        var context = BuildContext();
+
+        var copilotOpts = new CopilotResponsesOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+        var openAiOpts = new OpenAIResponsesOptions
+        {
+            ApiKey = "test-copilot-token",
+            MaxTokens = 4096,
+            CacheRetention = CacheRetention.Short,
+        };
+
+        var copilotStream = copilotProvider.Stream(model, context, copilotOpts);
+        _ = await copilotStream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var openAiStream = openAiProvider.Stream(model, context, openAiOpts);
+        _ = await openAiStream.GetResultAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        return (copilotHandler, openAiHandler);
+    }
+
+    // NB: Api stays "openai-responses" intentionally — Phase 2a is additive and the
+    // built-in routing has not flipped yet. The parity proof pins the wire contract
+    // *as it exists today* so Phase 2b can change BuiltInModels without drift.
+    private static LlmModel BuildModel() => new(
+        Id: "gpt-5.5",
+        Name: "gpt-5.5",
+        Api: "openai-responses",
+        Provider: "github-copilot",
+        BaseUrl: "https://api.enterprise.githubcopilot.com",
+        Reasoning: true,
+        Input: ["text", "image"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 200000,
+        MaxTokens: 16384);
+
+    private static Context BuildContext()
+    {
+        const long fixedTimestamp = 1_700_000_000_000L;
+        return new Context(
+            SystemPrompt: "You are a helpful assistant operating inside BotNexus tests. " +
+                          "Reply concisely and use tools when asked.",
+            Messages:
+            [
+                new UserMessage(new UserMessageContent("List the first three prime numbers."), fixedTimestamp),
+            ],
+            Tools:
+            [
+                new Tool(
+                    Name: "list_primes",
+                    Description: "Returns the first N prime numbers.",
+                    Parameters: JsonDocument.Parse("""
+                        {
+                          "type": "object",
+                          "properties": {
+                            "count": { "type": "integer", "minimum": 1, "maximum": 100 }
+                          },
+                          "required": ["count"]
+                        }
+                        """).RootElement.Clone()),
+            ]);
+    }
+
+    private const string MinimalSse =
+        "event: response.created\n" +
+        "data: {\"response\":{\"id\":\"resp_fixture000000000001\"}}\n" +
+        "\n" +
+        "event: response.completed\n" +
+        "data: {\"response\":{\"id\":\"resp_fixture000000000001\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"total_tokens\":15}}}\n" +
+        "\n";
+
+    private static string Normalise(string text)
+        => text.Replace("\r\n", "\n").TrimEnd();
+
+    private static HttpResponseMessage SseResponse(string payload) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "text/event-stream"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public string? RequestMethod { get; private set; }
+        public string? RequestBody { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public Dictionary<string, string> RequestHeaders { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestMethod = request.Method.Method;
+            RequestUri = request.RequestUri;
+            RequestHeaders = request.Headers.ToDictionary(
+                header => header.Key,
+                header => string.Join(",", header.Value),
+                StringComparer.OrdinalIgnoreCase);
+            RequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return responseFactory(request);
+        }
+    }
+
+    private sealed class NoOpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}


### PR DESCRIPTION
## Phase 2a — additive Copilot Responses + Completions providers

Carves the OpenAI-on-Copilot transport into its own first-class provider pair, mirroring Phase 1a (#886) for the Messages API. **This PR is additive only — no routing change.** `BuiltInModels` still routes Copilot-flavour gpt-5.x / gemini / grok / gpt-4.x entries through the existing `OpenAIResponsesProvider` / `OpenAICompletionsProvider` exactly as today. Phase 2b will flip `BuiltInModels` once this soaks.

### What ships
| Path | Api id | Purpose |
| --- | --- | --- |
| `src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs` | `github-copilot-responses` | Carved out of `OpenAIResponsesProvider` |
| `src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs` | `github-copilot-completions` | Carved out of `OpenAICompletionsProvider` |
| `+ matching Options DTOs` | | Duplicated so the Copilot project depends only on Providers.Core |

Both providers are registered in `Gateway.Api/Program.cs` alongside the existing OpenAI providers.

### How the carve-out differs from the OpenAI parents
- Copilot dynamic vision/intent headers are applied **unconditionally**; the runtime `if (model.Provider == \"github-copilot\")` check is removed because this provider only handles Copilot-routed models.
- The non-Copilot `{reasoning:{effort:\"none\"}}` fallback in the Responses payload is **dropped** — Copilot has never emitted that fallback.
- **No cross-provider dependency** on the OpenAI project; Options DTOs are duplicated.

### Deployment safety (S1–S6)
- ✅ Existing `config.json` keeps working — `openai-responses` and `openai-completions` remain registered, so any user override resolves exactly as before.
- ✅ No changes to `BuiltInModels` — Phase 2b owns the routing flip.
- ✅ Both `CopilotMessagesProvider` (Phase 1) and `AnthropicProvider.AuthMode.Copilot` paths remain untouched.

### Parity tests pin the wire contract
Two new test files prove the carved-out providers emit a **byte-identical** request body to the legacy OpenAI-with-Copilot-auth path. This is the deployment-safety pivot for Phase 2b:

- `Responses/CopilotResponsesProviderParityTests` — 4 tests, gpt-5.5 + tool catalogue, asserts URL, body parity, Bearer auth, Copilot dynamic headers
- `Completions/CopilotCompletionsProviderParityTests` — 4 tests, gemini-2.5-pro + tool catalogue, same shape

### Verification
- `dotnet test BotNexus.Agent.Providers.Copilot.Tests` → **78/78** (was 70/70)
- `scripts/repo/test-impacted.ps1` → **9/9 suites green**

Refs #810