### PR TITLE
feat(copilot): route Copilot OpenAI-flavour models via carved-out providers (Phase 2b, #810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/Registry/BuiltInModels.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Registry/BuiltInModels.cs
@@ -46,27 +46,27 @@ public sealed class BuiltInModels
         Register(modelRegistry, "github-copilot", "claude-sonnet-4.5", "Claude Sonnet 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
         Register(modelRegistry, "github-copilot", "claude-sonnet-4.6", "Claude Sonnet 4.6", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 32000, headers: CopilotHeaders);
 
-        Register(modelRegistry, "github-copilot", "gemini-2.5-pro", "Gemini 2.5 Pro", "openai-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
-        Register(modelRegistry, "github-copilot", "gemini-3-flash-preview", "Gemini 3 Flash", "openai-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
-        Register(modelRegistry, "github-copilot", "gemini-3-pro-preview", "Gemini 3 Pro Preview", "openai-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
-        Register(modelRegistry, "github-copilot", "gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", "openai-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "gemini-2.5-pro", "Gemini 2.5 Pro", "github-copilot-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "gemini-3-flash-preview", "Gemini 3 Flash", "github-copilot-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "gemini-3-pro-preview", "Gemini 3 Pro Preview", "github-copilot-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", "github-copilot-completions", CopilotBaseUrl, true, ["text", "image"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
 
-        Register(modelRegistry, "github-copilot", "gpt-4.1", "GPT-4.1", "openai-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 16384, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
-        Register(modelRegistry, "github-copilot", "gpt-4o", "GPT-4o", "openai-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 4096, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "gpt-4.1", "GPT-4.1", "github-copilot-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 16384, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "gpt-4o", "GPT-4o", "github-copilot-completions", CopilotBaseUrl, false, ["text", "image"], 128000, 4096, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
 
-        Register(modelRegistry, "github-copilot", "gpt-5", "GPT-5", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 128000, 128000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5-mini", "GPT-5-mini", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 264000, 64000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.1", "GPT-5.1", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 264000, 64000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.1-codex", "GPT-5.1-Codex", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.1-codex-max", "GPT-5.1-Codex-max", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.1-codex-mini", "GPT-5.1-Codex-mini", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.2", "GPT-5.2", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 264000, 64000, supportsExtraHighThinking: true, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.2-codex", "GPT-5.2-Codex", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.3-codex", "GPT-5.3-Codex", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.4", "GPT-5.4", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
-        Register(modelRegistry, "github-copilot", "gpt-5.4-mini", "GPT-5.4 mini", "openai-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5", "GPT-5", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 128000, 128000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5-mini", "GPT-5-mini", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 264000, 64000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.1", "GPT-5.1", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 264000, 64000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.1-codex", "GPT-5.1-Codex", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.1-codex-max", "GPT-5.1-Codex-max", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.1-codex-mini", "GPT-5.1-Codex-mini", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.2", "GPT-5.2", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 264000, 64000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.2-codex", "GPT-5.2-Codex", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.3-codex", "GPT-5.3-Codex", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.4", "GPT-5.4", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "gpt-5.4-mini", "GPT-5.4 mini", "github-copilot-responses", CopilotBaseUrl, true, ["text", "image"], 400000, 128000, supportsExtraHighThinking: true, headers: CopilotHeaders);
 
-        Register(modelRegistry, "github-copilot", "grok-code-fast-1", "Grok Code Fast 1", "openai-completions", CopilotBaseUrl, true, ["text"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
+        Register(modelRegistry, "github-copilot", "grok-code-fast-1", "Grok Code Fast 1", "github-copilot-completions", CopilotBaseUrl, true, ["text"], 128000, 64000, headers: CopilotHeaders, compat: CopilotCompletionsCompat);
     }
 
     private static void RegisterAnthropicModels(ModelRegistry modelRegistry)

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotGatewayRoutingTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/CopilotGatewayRoutingTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Text;
 using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Copilot.Completions;
 using BotNexus.Agent.Providers.Copilot.Messages;
+using BotNexus.Agent.Providers.Copilot.Responses;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
@@ -42,8 +44,8 @@ public class CopilotGatewayRoutingTests
     /// </summary>
     [Theory]
     [InlineData("claude-haiku-4.5", "github-copilot-messages", "/v1/messages")]
-    [InlineData("gpt-5.4", "openai-responses", "/responses")]
-    [InlineData("gpt-4.1", "openai-completions", "/chat/completions")]
+    [InlineData("gpt-5.4", "github-copilot-responses", "/responses")]
+    [InlineData("gpt-4.1", "github-copilot-completions", "/chat/completions")]
     public async Task LlmClient_RoutesCopilotModel_ToCopilotEndpoint(
         string modelId,
         string expectedApi,
@@ -117,6 +119,8 @@ public class CopilotGatewayRoutingTests
         apiProviders.Register(new CopilotMessagesProvider(httpClient));
         apiProviders.Register(new OpenAIResponsesProvider(httpClient, NullLogger<OpenAIResponsesProvider>.Instance));
         apiProviders.Register(new OpenAICompletionsProvider(httpClient, NullLogger<OpenAICompletionsProvider>.Instance));
+        apiProviders.Register(new CopilotResponsesProvider(httpClient, NullLogger<CopilotResponsesProvider>.Instance));
+        apiProviders.Register(new CopilotCompletionsProvider(httpClient, NullLogger<CopilotCompletionsProvider>.Instance));
 
         var llmClient = new LlmClient(apiProviders, modelRegistry);
         return (llmClient, model!, handler);

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/GatewayStartupAndConfigurationTests.cs
@@ -5,7 +5,9 @@ using BotNexus.Gateway;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Agent.Providers.Anthropic;
+using BotNexus.Agent.Providers.Copilot.Completions;
 using BotNexus.Agent.Providers.Copilot.Messages;
+using BotNexus.Agent.Providers.Copilot.Responses;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Registry;
 using BotNexus.Agent.Providers.OpenAI;
@@ -243,6 +245,9 @@ public sealed class GatewayStartupAndConfigurationTests
         apiProviders.Register(new AnthropicProvider(httpClient));
         apiProviders.Register(new OpenAICompletionsProvider(httpClient, NullLogger<OpenAICompletionsProvider>.Instance));
         apiProviders.Register(new OpenAIResponsesProvider(httpClient, NullLogger<OpenAIResponsesProvider>.Instance));
+        apiProviders.Register(new CopilotMessagesProvider(httpClient));
+        apiProviders.Register(new CopilotResponsesProvider(httpClient, NullLogger<CopilotResponsesProvider>.Instance));
+        apiProviders.Register(new CopilotCompletionsProvider(httpClient, NullLogger<CopilotCompletionsProvider>.Instance));
         apiProviders.Register(new OpenAICompatProvider(httpClient));
 
         new BuiltInModels().RegisterAll(models);
@@ -299,6 +304,70 @@ public sealed class GatewayStartupAndConfigurationTests
             model!.Api.ShouldBe("github-copilot-messages",
                 $"Phase 1b — github-copilot/{modelId} must route via the carved-out provider.");
         }
+    }
+
+    [Fact]
+    public void GatewayConfiguration_CopilotResponsesAndCompletionsProviders_AreRoutedFromBuiltInOpenAIModels()
+    {
+        // Phase 2b (#810): BuiltInModels now routes the Copilot gpt-5.x entries through the
+        // carved-out CopilotResponsesProvider (Api="github-copilot-responses") and the Copilot
+        // gemini/grok/gpt-4.x entries through CopilotCompletionsProvider
+        // (Api="github-copilot-completions"). The legacy openai-responses /
+        // openai-completions providers remain registered so direct-OpenAI users are unaffected;
+        // the user-visible wire contract for Copilot OpenAI-flavour requests is pinned by the
+        // Phase 2a parity tests, which both stayed green across this flip.
+        using var httpClient = new HttpClient();
+
+        var apiProviders = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+
+        apiProviders.Register(new AnthropicProvider(httpClient));
+        apiProviders.Register(new CopilotMessagesProvider(httpClient));
+        apiProviders.Register(new OpenAICompletionsProvider(httpClient, NullLogger<OpenAICompletionsProvider>.Instance));
+        apiProviders.Register(new OpenAIResponsesProvider(httpClient, NullLogger<OpenAIResponsesProvider>.Instance));
+        apiProviders.Register(new CopilotResponsesProvider(httpClient, NullLogger<CopilotResponsesProvider>.Instance));
+        apiProviders.Register(new CopilotCompletionsProvider(httpClient, NullLogger<CopilotCompletionsProvider>.Instance));
+        apiProviders.Register(new OpenAICompatProvider(httpClient));
+
+        new BuiltInModels().RegisterAll(models);
+
+        var llmClient = new LlmClient(apiProviders, models);
+        var registeredApis = llmClient.ApiProviders.GetAll().Select(provider => provider.Api).ToArray();
+
+        registeredApis.ShouldContain("openai-responses",
+            "OpenAIResponsesProvider must remain registered — direct-OpenAI users depend on it.");
+        registeredApis.ShouldContain("openai-completions",
+            "OpenAICompletionsProvider must remain registered — direct-OpenAI users depend on it.");
+        registeredApis.ShouldContain("github-copilot-responses",
+            "CopilotResponsesProvider must remain registered so the Copilot gpt-5.x entries resolve.");
+        registeredApis.ShouldContain("github-copilot-completions",
+            "CopilotCompletionsProvider must remain registered so the Copilot gemini/grok/gpt-4.x entries resolve.");
+
+        // After the Phase 2b flip, every gpt-5.x entry under github-copilot routes via
+        // github-copilot-responses. Spot-check across the family.
+        foreach (var modelId in new[] { "gpt-5", "gpt-5.1-codex", "gpt-5.4" })
+        {
+            var model = llmClient.Models.GetModel("github-copilot", modelId);
+            model.ShouldNotBeNull($"BuiltInModels must register github-copilot/{modelId}");
+            model!.Api.ShouldBe("github-copilot-responses",
+                $"Phase 2b — github-copilot/{modelId} must route via the carved-out Responses provider.");
+        }
+
+        // And every gemini/grok/gpt-4.x entry under github-copilot routes via
+        // github-copilot-completions. Spot-check across the family.
+        foreach (var modelId in new[] { "gemini-2.5-pro", "gpt-4.1", "gpt-4o", "grok-code-fast-1" })
+        {
+            var model = llmClient.Models.GetModel("github-copilot", modelId);
+            model.ShouldNotBeNull($"BuiltInModels must register github-copilot/{modelId}");
+            model!.Api.ShouldBe("github-copilot-completions",
+                $"Phase 2b — github-copilot/{modelId} must route via the carved-out Completions provider.");
+        }
+
+        // Direct-OpenAI users must not be impacted by the Copilot routing flip.
+        var directOpenAi = llmClient.Models.GetModel("openai", "o3");
+        directOpenAi.ShouldNotBeNull();
+        directOpenAi!.Api.ShouldBe("openai-responses",
+            "Direct-OpenAI o3 must still route via openai-responses — Copilot carve-out is namespace-scoped.");
     }
 
     [Fact]


### PR DESCRIPTION
## Phase 2b — flip BuiltInModels routing for Copilot OpenAI-flavour models

Completes the additive Phase 2a (#944) by retargeting the 14 Copilot OpenAI-flavour entries in `BuiltInModels` from the legacy OpenAI providers onto the carved-out `CopilotResponsesProvider` / `CopilotCompletionsProvider`.

### Routing flip

| Family | Count | Was | Is |
| --- | --- | --- | --- |
| gpt-5.x (gpt-5, gpt-5-mini, gpt-5.1/.1-codex/.1-codex-max/.1-codex-mini, gpt-5.2/.2-codex, gpt-5.3-codex, gpt-5.4/.4-mini) | 11 | `openai-responses` | `github-copilot-responses` |
| gemini-{2.5-pro,3-flash-preview,3-pro-preview,3.1-pro-preview} | 4 | `openai-completions` | `github-copilot-completions` |
| gpt-4.1 / gpt-4o (Copilot-flavoured) | 2 | `openai-completions` | `github-copilot-completions` |
| grok-code-fast-1 | 1 | `openai-completions` | `github-copilot-completions` |

Direct-OpenAI BuiltInModels entries (provider `openai`: gpt-4.1, gpt-4.1-mini, gpt-4o, o3, o4-mini) are **unchanged**.

### Deployment safety (S1–S6)
- ✅ `OpenAIResponsesProvider` and `OpenAICompletionsProvider` remain registered alongside the new providers — any config.json with an explicit `Api: \"openai-*\"` override still resolves.
- ✅ No `config.json` migration required.
- ✅ Phase 2a parity tests (byte-identical bodies between carved-out providers and the legacy path) stayed green across this flip — wire contract preserved.

### Test updates
- `CopilotGatewayRoutingTests` — InlineData for `gpt-5.4` / `gpt-4.1` now expects the new Apis; `BuildStack` registers the new providers.
- `GatewayStartupAndConfigurationTests`:
  - `GithubCopilotModelsMapToRegisteredApiProviders` now also registers the new providers so the `gpt-4.1` spot-check resolves post-flip.
  - **New** `CopilotResponsesAndCompletionsProviders_AreRoutedFromBuiltInOpenAIModels` asserts post-2b routing across gpt-5 / gpt-5.1-codex / gpt-5.4 + gemini-2.5-pro / gpt-4.1 / gpt-4o / grok-code-fast-1, and that direct-OpenAI `o3` remains on `openai-responses`.

### Verification
- `dotnet test BotNexus.Agent.Providers.Copilot.Tests` → **78/78**
- `scripts/repo/test-impacted.ps1` → **26/26 suites green**

Refs #810