### PR TITLE
fix(portal): remove underline from conversation list anchor links

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -3434,6 +3434,7 @@ details[open] > .thinking-summary::before {
     color: var(--text-secondary);
     font-size: 0.82rem;
     text-align: left;
+    text-decoration: none; /* suppress anchor underline when rendered as <a> (#935) */
     cursor: pointer;
     transition: background 0.12s, color 0.12s, border-color 0.12s;
     gap: 0.2rem;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj
@@ -20,4 +20,12 @@
     <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.SignalR.BlazorClient\BotNexus.Extensions.Channels.SignalR.BlazorClient.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Copy app.css to output for CSS content tests (#935) -->
+    <None Include="..\..\..\src\extensions\BotNexus.Extensions.Channels.SignalR.BlazorClient\wwwroot\css\app.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>wwwroot\css\app.css</Link>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationListCssTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationListCssTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Reflection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Content-level tests verifying conversation list item CSS rules are correct.
+/// Closes #935.
+/// </summary>
+public sealed class ConversationListCssTests
+{
+    private static readonly string s_cssPath = Path.Combine(
+        Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+        "wwwroot",
+        "css",
+        "app.css");
+
+    [Fact]
+    public void ConversationListItemBtn_HasNoUnderline()
+    {
+        // #935: <a> elements with class conversation-list-item-btn must not have
+        // browser-default underline.  text-decoration:none is required.
+        var content = File.ReadAllText(s_cssPath);
+
+        // Find the rule block for .conversation-list-item-btn
+        var ruleStart = content.IndexOf(".conversation-list-item-btn {", StringComparison.Ordinal);
+        Assert.True(ruleStart >= 0, ".conversation-list-item-btn rule not found in app.css");
+
+        // Extract to the closing brace
+        var ruleEnd = content.IndexOf('}', ruleStart);
+        Assert.True(ruleEnd > ruleStart, "Could not find closing brace of .conversation-list-item-btn");
+
+        var ruleBlock = content.Substring(ruleStart, ruleEnd - ruleStart + 1);
+
+        Assert.Contains("text-decoration: none", ruleBlock,
+            StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
Closes #935

## Changes
- Added `text-decoration: none` to `.conversation-list-item-btn` in `app.css`
- Added CSS content test `ConversationListCssTests` to verify the rule is present
- Added `<None>` copy entry in test `.csproj` to make `app.css` available at test output path

## Root Cause
PR #858 changed `<button>` elements to `<a>` elements for browser-native right-click / Ctrl+click support. Anchor elements carry a default browser underline that buttons don't — the existing CSS rule didn't include `text-decoration: none`.

## Merge Notes
Portal-only (CSS + test csproj). No file overlap with any open PR. Safe to merge in any order.