### PR TITLE
fix(mobile): preserve active conversation on refresh, render Unicode icons, add error boundary

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -55,7 +55,20 @@ public sealed class ClientStateStore : IClientStateStore
     /// <inheritdoc />
     public void UpsertAgent(AgentState agent)
     {
-        _agents[agent.AgentId] = agent;
+        if (_agents.TryGetValue(agent.AgentId, out var existing))
+        {
+            // Merge metadata without destroying local-only state (Conversations,
+            // ActiveConversationId, SessionId, Messages, StreamState, etc.).
+            existing.DisplayName = agent.DisplayName;
+            existing.Emoji = agent.Emoji;
+            existing.Description = agent.Description;
+            existing.IsConnected = agent.IsConnected;
+        }
+        else
+        {
+            _agents[agent.AgentId] = agent;
+        }
+
         NotifyChanged();
     }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/GlobalErrorBoundary.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/GlobalErrorBoundary.razor
@@ -1,0 +1,95 @@
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
+@inject IJSRuntime JS
+@inject IChannelErrorReporter ErrorReporter
+@inject IClientStateStore Store
+@inherits ErrorBoundaryBase
+
+@if (CurrentException is null)
+{
+    @ChildContent
+}
+else
+{
+    <div class="global-error-boundary" data-testid="error-boundary">
+        <div class="error-boundary-banner">
+            <span class="error-boundary-icon" aria-hidden="true">&#x26A0;&#xFE0F;</span>
+            <span class="error-boundary-message">Something went wrong.</span>
+            <button class="error-boundary-toggle" @onclick="ToggleDetail" aria-expanded="@_showDetail">
+                @(_showDetail ? "Hide" : "Details")
+            </button>
+            <button class="error-boundary-dismiss" @onclick="RecoverFromError" title="Dismiss">&#x2715;</button>
+        </div>
+
+        @if (_showDetail)
+        {
+            <div class="error-boundary-detail">
+                <pre class="error-boundary-stack" data-testid="error-detail">@FormatException(CurrentException)</pre>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private bool _showDetail;
+    private bool _reported;
+
+    protected override async Task OnErrorAsync(Exception exception)
+    {
+        if (_reported)
+            return;
+
+        _reported = true;
+
+        string? url = null;
+        string? ua = null;
+        try
+        {
+            url = await JS.InvokeAsync<string>("eval", "window.location.href");
+            ua = await JS.InvokeAsync<string>("eval", "navigator.userAgent");
+        }
+        catch
+        {
+            // JS interop may not be available in all error scenarios.
+        }
+
+        var report = new ChannelErrorReportDto
+        {
+            Message = exception.Message,
+            StackTrace = exception.StackTrace,
+            Timestamp = DateTimeOffset.UtcNow,
+            AgentId = Store.ActiveAgentId,
+            Url = url,
+            UserAgent = ua,
+        };
+
+        await ErrorReporter.ReportAsync(report);
+    }
+
+    private void ToggleDetail() => _showDetail = !_showDetail;
+
+    private void RecoverFromError()
+    {
+        _reported = false;
+        _showDetail = false;
+        Recover();
+    }
+
+    private static string FormatException(Exception? ex)
+    {
+        if (ex is null)
+            return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine(ex.GetType().FullName);
+        sb.AppendLine(ex.Message);
+        if (ex.StackTrace is not null)
+            sb.AppendLine(ex.StackTrace);
+        if (ex.InnerException is not null)
+        {
+            sb.AppendLine("--- Inner Exception ---");
+            sb.AppendLine(FormatException(ex.InnerException));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Layout/MobileLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Layout/MobileLayout.razor
@@ -1,3 +1,6 @@
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Components
 @inherits LayoutComponentBase
 
-@Body
+<GlobalErrorBoundary>
+    @Body
+</GlobalErrorBoundary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -17,7 +17,7 @@
         }
         else
         {
-            <div class="portal-load-spinner">Connecting&#x2026;</div>
+            <div class="portal-load-spinner">Connecting…</div>
         }
     </div>
 }
@@ -38,7 +38,7 @@ else
             <div class="disconnected-bar" data-testid="disconnected-bar">
                 &#x26A0; Disconnected
                 <button class="reconnect-inline-btn" @onclick="ManualRefreshAsync" disabled="@_isRefreshing" aria-label="Reconnect">
-                    @(_isRefreshing ? "&#x21BB;" : "Reconnect")
+                    @(_isRefreshing ? "↻" : "Reconnect")
                 </button>
             </div>
         }
@@ -57,7 +57,7 @@ else
                 }
             </select>
             <button class="refresh-btn" @onclick="ManualRefreshAsync" disabled="@_isRefreshing" aria-label="Refresh" data-testid="refresh-btn" title="Refresh conversations">
-                @(_isRefreshing ? "&#x21BB;" : "&#x21BA;")
+                @(_isRefreshing ? "↻" : "↺")
             </button>
             <div class="overflow-menu-wrapper">
                 <button class="overflow-btn" @onclick="ToggleMenu" aria-label="Menu">&#x22EF;</button>
@@ -122,7 +122,7 @@ else
         <div class="bottom-bar">
             <textarea
                 class="input-textarea"
-                placeholder="Message&#x2026;"
+                placeholder="Message…"
                 rows="1"
                 @bind="_inputText"
                 @bind:event="oninput"

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileRefreshReconnectTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileRefreshReconnectTests.cs
@@ -105,6 +105,18 @@ public sealed class MobileRefreshReconnectTests : IDisposable
         _portalLoad.Received(1).RefreshAsync(Arg.Any<CancellationToken>());
     }
 
+    // ── Refresh button renders Unicode not HTML entities ─────────────────────
+
+    [Fact]
+    public void Refresh_button_shows_unicode_arrow_not_html_entity()
+    {
+        var cut = _ctx.Render<Chat>();
+        var btn = cut.Find("[data-testid='refresh-btn']");
+        // Should render the actual Unicode character ↺ not the entity string
+        Assert.DoesNotContain("&#x21BA;", btn.InnerHtml);
+        Assert.Contains("\u21ba", btn.TextContent);
+    }
+
     // ── OnAppResumed invokes RefreshAsync ─────────────────────────────────────
 
     [Fact]

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ClientStateStoreTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ClientStateStoreTests.cs
@@ -42,13 +42,47 @@ public sealed class ClientStateStoreTests
     }
 
     [Fact]
-    public void UpsertAgent_replaces_or_adds_agent()
+    public void UpsertAgent_adds_new_agent()
     {
         var store = new ClientStateStore();
 
         store.UpsertAgent(new AgentState { AgentId = "a-1", DisplayName = "Agent", IsConnected = true });
 
         Assert.True(store.GetAgent("a-1")?.IsConnected);
+        Assert.Equal("Agent", store.GetAgent("a-1")?.DisplayName);
+    }
+
+    [Fact]
+    public void UpsertAgent_merges_metadata_without_destroying_conversations()
+    {
+        var store = new ClientStateStore();
+        store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        store.SeedConversations("a-1", [CreateConversation("c-1", "a-1", "General")]);
+        store.SetActiveConversation("a-1", "c-1");
+
+        // Simulate a refresh that upserts with updated metadata
+        store.UpsertAgent(new AgentState { AgentId = "a-1", DisplayName = "Alpha Updated", Emoji = "\ud83d\ude80", IsConnected = true });
+
+        var agent = store.GetAgent("a-1");
+        Assert.NotNull(agent);
+        Assert.Equal("Alpha Updated", agent.DisplayName);
+        Assert.Equal("\ud83d\ude80", agent.Emoji);
+        Assert.True(agent.IsConnected);
+        // Critical: conversations and active selection must be preserved
+        Assert.Single(agent.Conversations);
+        Assert.Equal("c-1", agent.ActiveConversationId);
+    }
+
+    [Fact]
+    public void UpsertAgent_preserves_session_id_on_existing_agent()
+    {
+        var store = new ClientStateStore();
+        store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        store.GetAgent("a-1")!.SessionId = "session-123";
+
+        store.UpsertAgent(new AgentState { AgentId = "a-1", DisplayName = "Alpha", IsConnected = true });
+
+        Assert.Equal("session-123", store.GetAgent("a-1")?.SessionId);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes three mobile UI issues reported by Jon:

## 1. Refresh button changes active conversation

**Root cause:** `ClientStateStore.UpsertAgent` replaced the entire `AgentState` object (including `Conversations`, `ActiveConversationId`, `SessionId`, etc.) with a fresh instance. When `RefreshAsync()` ran, it created blank `AgentState` objects and called `UpsertAgent` -- nuking all local state. Then `SeedConversations` hit the auto-select branch (because `ActiveConversationId` was now null) and picked whatever conversation was newest.

**Fix:** `UpsertAgent` now merges metadata fields (DisplayName, Emoji, Description, IsConnected) onto the existing `AgentState` without replacing the object. New agents are still inserted wholesale.

## 2. HTML entities rendered as text (&#x21BA; / &#x2026;)

**Root cause:** In Blazor, HTML entities inside C# `@()` expressions are treated as literal strings, not interpreted as HTML. So `@(_isRefreshing ? "&#x21BB;" : "&#x21BA;")` renders the text "&#x21BA;" instead of the arrow.

**Fix:** Replaced all HTML entity references with actual Unicode characters in C# string literals and Razor attributes.

## 3. Errors not caught/reported on mobile

**Root cause:** Desktop wraps `@Body` in `<GlobalErrorBoundary>` which catches unhandled render exceptions and reports them to the gateway via `IChannelErrorReporter`. Mobile had no error boundary at all -- exceptions just crashed the renderer silently.

**Fix:** Added `GlobalErrorBoundary.razor` to the Mobile project (same pattern as desktop but mobile-tailored copy text). Wrapped `MobileLayout.razor` in `<GlobalErrorBoundary>`. All error reports now flow to the gateway logs via the existing `POST /api/diagnostics/channel-error` endpoint.

## Tests

- 3 new `ClientStateStoreTests` (adds, merge-preserves, session-preserves)
- 1 new `MobileRefreshReconnectTests` (Unicode rendering assertion)
- All 390 BlazorClient + 23 Mobile + 167 Architecture + Gateway + Scenarios pass
