### PR TITLE
feat(copilot): add provider copilot CLI surface (Phase 4, #810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotDiscoveryClient.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotDiscoveryClient.cs
@@ -1,0 +1,99 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.Copilot.Discovery;
+
+/// <summary>
+/// Read-only client for GitHub Copilot's discovery endpoints. Used by CLI
+/// diagnostics (<c>provider copilot whoami|models|quota</c>) and any caller
+/// that needs to inspect the authenticated user's entitlement before invoking
+/// an LLM. The client is intentionally stateless — callers supply the
+/// credentials and (where relevant) the resolved API endpoint per request so
+/// the same instance can serve enterprise and individual users side by side.
+/// </summary>
+public sealed class CopilotDiscoveryClient
+{
+    /// <summary>
+    /// GitHub.com endpoint that returns the authenticated user's Copilot plan,
+    /// entitlement, organization list, regional API endpoints, and current
+    /// per-feature quota snapshots.
+    /// </summary>
+    public const string UserInfoUrl = "https://api.github.com/copilot_internal/user";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+
+    public CopilotDiscoveryClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <summary>
+    /// Fetches the authenticated user's Copilot entitlement and endpoint
+    /// configuration from <see cref="UserInfoUrl"/>. The <paramref name="githubToken"/>
+    /// must be a GitHub OAuth token (gho_* / ghu_*) — Copilot-exchanged session
+    /// tokens are rejected by this endpoint.
+    /// </summary>
+    public async Task<CopilotUserInfo> GetUserAsync(string githubToken, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(githubToken))
+        {
+            throw new ArgumentException("GitHub OAuth token is required.", nameof(githubToken));
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, UserInfoUrl);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {githubToken}");
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        request.Headers.TryAddWithoutValidation("User-Agent", "BotNexus-CLI/1.0");
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var info = await response.Content.ReadFromJsonAsync<CopilotUserInfo>(JsonOptions, cancellationToken).ConfigureAwait(false);
+        return info ?? throw new InvalidOperationException("Copilot user-info response was empty.");
+    }
+
+    /// <summary>
+    /// Lists every model the authenticated user can invoke through GitHub Copilot.
+    /// <paramref name="endpointBase"/> must be the <c>endpoints.api</c> value
+    /// returned by <see cref="GetUserAsync"/> (enterprise vs individual);
+    /// <paramref name="copilotSessionToken"/> must be the short-lived Copilot
+    /// session token returned by <see cref="CopilotOAuth.RefreshAsync"/>.
+    /// </summary>
+    public async Task<CopilotModelsResponse> GetModelsAsync(
+        string endpointBase,
+        string copilotSessionToken,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(endpointBase))
+        {
+            throw new ArgumentException("Copilot API endpoint base URL is required.", nameof(endpointBase));
+        }
+
+        if (string.IsNullOrWhiteSpace(copilotSessionToken))
+        {
+            throw new ArgumentException("Copilot session token is required.", nameof(copilotSessionToken));
+        }
+
+        var url = endpointBase.TrimEnd('/') + "/models";
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {copilotSessionToken}");
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        request.Headers.TryAddWithoutValidation("Content-Type", "application/json");
+        request.Headers.TryAddWithoutValidation("Copilot-Integration-Id", "copilot-developer-cli");
+        request.Headers.TryAddWithoutValidation("Editor-Version", "copilot/1.0.59");
+        request.Headers.TryAddWithoutValidation("User-Agent", "BotNexus-CLI/1.0");
+        request.Headers.TryAddWithoutValidation("X-GitHub-Api-Version", "2026-06-01");
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var models = await response.Content.ReadFromJsonAsync<CopilotModelsResponse>(JsonOptions, cancellationToken).ConfigureAwait(false);
+        return models ?? throw new InvalidOperationException("Copilot models response was empty.");
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotModelInfo.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotModelInfo.cs
@@ -1,0 +1,96 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Agent.Providers.Copilot.Discovery;
+
+/// <summary>
+/// Response shape of <c>GET {endpoints.api}/models</c>. The endpoint enumerates
+/// every model the authenticated user is entitled to invoke through GitHub Copilot.
+/// </summary>
+public sealed class CopilotModelsResponse
+{
+    [JsonPropertyName("data")]
+    public List<CopilotModelInfo>? Data { get; set; }
+
+    [JsonPropertyName("object")]
+    public string? Object { get; set; }
+}
+
+/// <summary>
+/// Metadata for a single Copilot-hosted model. Captures the fields used by the
+/// <c>copilot models</c> CLI command for display; full provider-specific tuning
+/// metadata is intentionally not modelled.
+/// </summary>
+public sealed class CopilotModelInfo
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("vendor")]
+    public string? Vendor { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("model_picker_enabled")]
+    public bool ModelPickerEnabled { get; set; }
+
+    [JsonPropertyName("preview")]
+    public bool Preview { get; set; }
+
+    [JsonPropertyName("capabilities")]
+    public CopilotModelCapabilities? Capabilities { get; set; }
+
+    [JsonPropertyName("billing")]
+    public CopilotModelBilling? Billing { get; set; }
+}
+
+public sealed class CopilotModelCapabilities
+{
+    [JsonPropertyName("family")]
+    public string? Family { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("tokenizer")]
+    public string? Tokenizer { get; set; }
+
+    [JsonPropertyName("supports")]
+    public CopilotModelSupports? Supports { get; set; }
+
+    [JsonPropertyName("limits")]
+    public Dictionary<string, double>? Limits { get; set; }
+}
+
+public sealed class CopilotModelSupports
+{
+    [JsonPropertyName("streaming")]
+    public bool Streaming { get; set; }
+
+    [JsonPropertyName("tool_calls")]
+    public bool ToolCalls { get; set; }
+
+    [JsonPropertyName("parallel_tool_calls")]
+    public bool ParallelToolCalls { get; set; }
+
+    [JsonPropertyName("vision")]
+    public bool Vision { get; set; }
+
+    [JsonPropertyName("structured_outputs")]
+    public bool StructuredOutputs { get; set; }
+}
+
+public sealed class CopilotModelBilling
+{
+    [JsonPropertyName("is_premium")]
+    public bool IsPremium { get; set; }
+
+    [JsonPropertyName("multiplier")]
+    public double Multiplier { get; set; }
+
+    [JsonPropertyName("restricted_to")]
+    public List<string>? RestrictedTo { get; set; }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotUserInfo.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotUserInfo.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Agent.Providers.Copilot.Discovery;
+
+/// <summary>
+/// Response shape of <c>GET https://api.github.com/copilot_internal/user</c>.
+/// Identifies the authenticated user, their Copilot plan, and the API endpoints
+/// (enterprise vs individual) that downstream requests must target. The
+/// <see cref="QuotaSnapshots"/> field carries the per-feature usage allowance
+/// surfaced by the <c>copilot quota</c> CLI command.
+/// </summary>
+public sealed class CopilotUserInfo
+{
+    [JsonPropertyName("login")]
+    public string? Login { get; set; }
+
+    [JsonPropertyName("copilot_plan")]
+    public string? CopilotPlan { get; set; }
+
+    [JsonPropertyName("chat_enabled")]
+    public bool ChatEnabled { get; set; }
+
+    [JsonPropertyName("cli_enabled")]
+    public bool CliEnabled { get; set; }
+
+    [JsonPropertyName("access_type_sku")]
+    public string? AccessTypeSku { get; set; }
+
+    [JsonPropertyName("assigned_date")]
+    public string? AssignedDate { get; set; }
+
+    [JsonPropertyName("organization_login_list")]
+    public List<string>? OrganizationLoginList { get; set; }
+
+    [JsonPropertyName("endpoints")]
+    public CopilotEndpoints? Endpoints { get; set; }
+
+    [JsonPropertyName("quota_reset_date")]
+    public string? QuotaResetDate { get; set; }
+
+    [JsonPropertyName("quota_snapshots")]
+    public Dictionary<string, CopilotQuotaSnapshot>? QuotaSnapshots { get; set; }
+}
+
+/// <summary>
+/// API endpoints returned by the user-info call. <see cref="Api"/> is the base
+/// URL all downstream Copilot LLM requests must be sent to.
+/// </summary>
+public sealed class CopilotEndpoints
+{
+    [JsonPropertyName("api")]
+    public string? Api { get; set; }
+
+    [JsonPropertyName("proxy")]
+    public string? Proxy { get; set; }
+
+    [JsonPropertyName("telemetry")]
+    public string? Telemetry { get; set; }
+
+    [JsonPropertyName("origin-tracker")]
+    public string? OriginTracker { get; set; }
+}
+
+/// <summary>
+/// Per-feature quota snapshot as reported by GitHub Copilot. Common quota IDs
+/// observed in captures: <c>chat</c>, <c>completions</c>,
+/// <c>premium_interactions</c>.
+/// </summary>
+public sealed class CopilotQuotaSnapshot
+{
+    [JsonPropertyName("quota_id")]
+    public string? QuotaId { get; set; }
+
+    [JsonPropertyName("percent_remaining")]
+    public double PercentRemaining { get; set; }
+
+    [JsonPropertyName("quota_remaining")]
+    public double QuotaRemaining { get; set; }
+
+    [JsonPropertyName("entitlement")]
+    public double Entitlement { get; set; }
+
+    [JsonPropertyName("overage_count")]
+    public double OverageCount { get; set; }
+
+    [JsonPropertyName("overage_permitted")]
+    public bool OveragePermitted { get; set; }
+
+    [JsonPropertyName("unlimited")]
+    public bool Unlimited { get; set; }
+}

--- a/src/gateway/BotNexus.Cli/Commands/Provider/CopilotAuthLoader.cs
+++ b/src/gateway/BotNexus.Cli/Commands/Provider/CopilotAuthLoader.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BotNexus.Agent.Providers.Copilot;
+using BotNexus.Cli.Commands;
+
+namespace BotNexus.Cli.Commands.Provider;
+
+/// <summary>
+/// Loads the <c>github-copilot</c> entry from <c>~/.botnexus/auth.json</c> and
+/// turns it into a usable pair of credentials: the long-lived GitHub OAuth
+/// token (required to call <c>/copilot_internal/user</c>) and a short-lived
+/// Copilot session token (required to call the model endpoints). Auto-refreshes
+/// the session token via <see cref="CopilotOAuth.RefreshAsync"/> when it is
+/// missing or near expiry. Reuses <see cref="ProviderCommand.AuthFileEntry"/>
+/// as the on-disk shape so reads and writes match the format the gateway
+/// itself produces.
+/// </summary>
+internal static class CopilotAuthLoader
+{
+    private const string AuthFileName = "auth.json";
+    private const string ProviderKey = "github-copilot";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Resolves Copilot credentials from the BotNexus auth file under
+    /// <paramref name="home"/>. Returns <see langword="null"/> if no entry
+    /// exists for <c>github-copilot</c>. The returned record contains the
+    /// GitHub OAuth token, a fresh Copilot session token, and the resolved API
+    /// endpoint base URL. The auth file is rewritten with refreshed credentials
+    /// when a token exchange occurs so the next CLI invocation reuses them.
+    /// </summary>
+    public static async Task<CopilotResolvedAuth?> LoadAsync(string home, CancellationToken cancellationToken = default)
+    {
+        var authPath = Path.Combine(home, AuthFileName);
+        if (!File.Exists(authPath))
+        {
+            return null;
+        }
+
+        Dictionary<string, ProviderCommand.AuthFileEntry> entries;
+        try
+        {
+            var json = await File.ReadAllTextAsync(authPath, cancellationToken).ConfigureAwait(false);
+            entries = JsonSerializer.Deserialize<Dictionary<string, ProviderCommand.AuthFileEntry>>(json, JsonOptions)
+                ?? new Dictionary<string, ProviderCommand.AuthFileEntry>(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (!entries.TryGetValue(ProviderKey, out var entry))
+        {
+            return null;
+        }
+
+        // The GitHub OAuth token lives in Refresh; if that's empty (older auth.json
+        // shape) Access doubles as the GitHub token until the first refresh.
+        var githubToken = !string.IsNullOrWhiteSpace(entry.Refresh) ? entry.Refresh : entry.Access;
+        if (string.IsNullOrWhiteSpace(githubToken))
+        {
+            return null;
+        }
+
+        // Refresh the Copilot session token when it's missing, near expiry, or
+        // the endpoint hasn't been resolved yet. Mirrors GatewayAuthManager.
+        var needsRefresh = string.IsNullOrWhiteSpace(entry.Access)
+            || string.IsNullOrWhiteSpace(entry.Endpoint)
+            || entry.Expires <= 0
+            || DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() >= entry.Expires - 60_000;
+
+        if (needsRefresh)
+        {
+            var credentials = new OAuthCredentials(
+                AccessToken: entry.Access,
+                RefreshToken: githubToken,
+                ExpiresAt: entry.Expires / 1000,
+                ApiEndpoint: entry.Endpoint);
+
+            var refreshed = await CopilotOAuth.RefreshAsync(credentials, cancellationToken).ConfigureAwait(false);
+
+            entry = new ProviderCommand.AuthFileEntry
+            {
+                Type = entry.Type,
+                Refresh = refreshed.RefreshToken,
+                Access = refreshed.AccessToken,
+                Expires = refreshed.ExpiresAt * 1000,
+                Endpoint = refreshed.ApiEndpoint ?? entry.Endpoint
+            };
+
+            entries[ProviderKey] = entry;
+
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(authPath)!);
+                await File.WriteAllTextAsync(authPath, JsonSerializer.Serialize(entries, JsonOptions), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // Non-fatal: even if we cannot persist, the in-memory tokens
+                // remain usable for the current invocation.
+            }
+
+            githubToken = entry.Refresh;
+        }
+
+        return new CopilotResolvedAuth(
+            GitHubToken: githubToken,
+            CopilotSessionToken: entry.Access,
+            ApiEndpoint: entry.Endpoint,
+            ExpiresAtUnixMs: entry.Expires);
+    }
+}
+
+/// <summary>
+/// Resolved Copilot credentials ready for use by the CLI diagnostic commands.
+/// </summary>
+internal sealed record CopilotResolvedAuth(
+    string GitHubToken,
+    string CopilotSessionToken,
+    string? ApiEndpoint,
+    long ExpiresAtUnixMs);

--- a/src/gateway/BotNexus.Cli/Commands/Provider/CopilotProviderSubcommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/Provider/CopilotProviderSubcommand.cs
@@ -1,0 +1,385 @@
+using System.CommandLine;
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using BotNexus.Agent.Providers.Copilot;
+using BotNexus.Agent.Providers.Copilot.Completions;
+using BotNexus.Agent.Providers.Copilot.Discovery;
+using BotNexus.Agent.Providers.Copilot.Messages;
+using BotNexus.Agent.Providers.Copilot.Responses;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands.Provider;
+
+/// <summary>
+/// Builds the <c>botnexus provider copilot</c> subcommand group:
+/// <c>login</c>, <c>whoami</c>, <c>models</c>, <c>quota</c>, <c>test</c>.
+/// These commands give operators a fast diagnostic surface for the GitHub
+/// Copilot integration without round-tripping through the gateway — useful for
+/// debugging auth, listing entitled models, checking the current quota, and
+/// confirming the carved-out providers can reach the upstream endpoints.
+/// </summary>
+internal static class CopilotProviderSubcommand
+{
+    private const string DefaultTestModel = "gpt-5-mini";
+
+    /// <summary>
+    /// Constructs the <c>copilot</c> command tree. <paramref name="setupAlias"/>
+    /// is invoked by <c>copilot login</c> so the device-code flow stays
+    /// authoritative in <see cref="ProviderCommand.ExecuteSetupAsync(string,string,bool,string?,CancellationToken)"/>
+    /// — this subcommand contributes diagnostics, not new auth code paths.
+    /// </summary>
+    public static Command Build(Option<bool> verboseOption, Func<string, string, bool, CancellationToken, Task<int>> setupAlias)
+    {
+        var copilot = new Command("copilot", "GitHub Copilot diagnostics and auth helpers.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
+        copilot.AddGlobalOption(targetOption);
+
+        copilot.AddCommand(BuildLogin(verboseOption, targetOption, setupAlias));
+        copilot.AddCommand(BuildWhoami(targetOption));
+        copilot.AddCommand(BuildModels(targetOption));
+        copilot.AddCommand(BuildQuota(targetOption));
+        copilot.AddCommand(BuildTest(targetOption));
+
+        return copilot;
+    }
+
+    private static Command BuildLogin(
+        Option<bool> verboseOption,
+        Option<string?> targetOption,
+        Func<string, string, bool, CancellationToken, Task<int>> setupAlias)
+    {
+        var cmd = new Command("login", "Authenticate to GitHub Copilot via device code flow (alias for `provider setup --provider github-copilot`).");
+        cmd.SetHandler(async context =>
+        {
+            var verbose = context.ParseResult.GetValueForOption(verboseOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await setupAlias(configPath, home, verbose, CancellationToken.None);
+        });
+        return cmd;
+    }
+
+    private static Command BuildWhoami(Option<string?> targetOption)
+    {
+        var cmd = new Command("whoami", "Show the authenticated Copilot user, plan, endpoint, and token expiry.");
+        cmd.SetHandler(async context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            context.ExitCode = await ExecuteWhoamiAsync(CliPaths.ResolveTarget(target), CancellationToken.None);
+        });
+        return cmd;
+    }
+
+    private static Command BuildModels(Option<string?> targetOption)
+    {
+        var cmd = new Command("models", "List the GitHub Copilot models the authenticated user is entitled to invoke.");
+        cmd.SetHandler(async context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            context.ExitCode = await ExecuteModelsAsync(CliPaths.ResolveTarget(target), CancellationToken.None);
+        });
+        return cmd;
+    }
+
+    private static Command BuildQuota(Option<string?> targetOption)
+    {
+        var cmd = new Command("quota", "Show the current Copilot quota snapshots (chat, completions, premium interactions).");
+        cmd.SetHandler(async context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            context.ExitCode = await ExecuteQuotaAsync(CliPaths.ResolveTarget(target), CancellationToken.None);
+        });
+        return cmd;
+    }
+
+    private static Command BuildTest(Option<string?> targetOption)
+    {
+        var modelOption = new Option<string>("--model", () => DefaultTestModel, $"Copilot model id to round-trip (default: {DefaultTestModel}).");
+        var promptOption = new Option<string>("--prompt", () => "Respond with the single word: ok.", "Prompt to send.");
+        var cmd = new Command("test", "Round-trip a single request through the carved-out Copilot provider to confirm end-to-end connectivity.");
+        cmd.AddOption(modelOption);
+        cmd.AddOption(promptOption);
+        cmd.SetHandler(async context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var modelId = context.ParseResult.GetValueForOption(modelOption) ?? DefaultTestModel;
+            var prompt = context.ParseResult.GetValueForOption(promptOption) ?? "Respond with the single word: ok.";
+            context.ExitCode = await ExecuteTestAsync(CliPaths.ResolveTarget(target), modelId, prompt, CancellationToken.None);
+        });
+        return cmd;
+    }
+
+    private static async Task<int> ExecuteWhoamiAsync(string home, CancellationToken ct)
+    {
+        var auth = await CopilotAuthLoader.LoadAsync(home, ct);
+        if (auth is null)
+        {
+            AnsiConsole.MarkupLine("[red]Not logged in.[/] Run [green]botnexus provider copilot login[/].");
+            return 1;
+        }
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var client = new CopilotDiscoveryClient(http);
+        CopilotUserInfo info;
+        try
+        {
+            info = await client.GetUserAsync(auth.GitHubToken, ct);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed to fetch Copilot user info:[/] {Markup.Escape(ex.Message)}");
+            return 2;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded).AddColumn("Field").AddColumn("Value");
+        table.AddRow("Login", Markup.Escape(info.Login ?? "—"));
+        table.AddRow("Plan", Markup.Escape(info.CopilotPlan ?? "—"));
+        table.AddRow("SKU", Markup.Escape(info.AccessTypeSku ?? "—"));
+        table.AddRow("Assigned", Markup.Escape(info.AssignedDate ?? "—"));
+        table.AddRow("Chat enabled", info.ChatEnabled ? "[green]yes[/]" : "[red]no[/]");
+        table.AddRow("CLI enabled", info.CliEnabled ? "[green]yes[/]" : "[red]no[/]");
+        table.AddRow("Organizations", Markup.Escape(string.Join(", ", info.OrganizationLoginList ?? new List<string>())));
+        table.AddRow("API endpoint", Markup.Escape(info.Endpoints?.Api ?? "—"));
+        table.AddRow("Cached endpoint", Markup.Escape(auth.ApiEndpoint ?? "—"));
+
+        var expiry = auth.ExpiresAtUnixMs > 0
+            ? DateTimeOffset.FromUnixTimeMilliseconds(auth.ExpiresAtUnixMs).ToString("yyyy-MM-ddTHH:mm:ssK")
+            : "—";
+        table.AddRow("Session token expiry", Markup.Escape(expiry));
+
+        AnsiConsole.Write(table);
+        return 0;
+    }
+
+    private static async Task<int> ExecuteModelsAsync(string home, CancellationToken ct)
+    {
+        var auth = await CopilotAuthLoader.LoadAsync(home, ct);
+        if (auth is null)
+        {
+            AnsiConsole.MarkupLine("[red]Not logged in.[/] Run [green]botnexus provider copilot login[/].");
+            return 1;
+        }
+
+        if (string.IsNullOrWhiteSpace(auth.ApiEndpoint))
+        {
+            AnsiConsole.MarkupLine("[red]No Copilot API endpoint cached.[/] Run [green]botnexus provider copilot whoami[/] first.");
+            return 1;
+        }
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var client = new CopilotDiscoveryClient(http);
+        CopilotModelsResponse models;
+        try
+        {
+            models = await client.GetModelsAsync(auth.ApiEndpoint, auth.CopilotSessionToken, ct);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed to list Copilot models:[/] {Markup.Escape(ex.Message)}");
+            return 2;
+        }
+
+        var entries = models.Data ?? new List<CopilotModelInfo>();
+        if (entries.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No models returned.[/]");
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded)
+            .AddColumn("Id")
+            .AddColumn("Vendor")
+            .AddColumn("Family")
+            .AddColumn("Streaming")
+            .AddColumn("Tools")
+            .AddColumn("Vision")
+            .AddColumn("Premium");
+
+        foreach (var m in entries.OrderBy(m => m.Vendor).ThenBy(m => m.Id))
+        {
+            table.AddRow(
+                Markup.Escape(m.Id ?? "—"),
+                Markup.Escape(m.Vendor ?? "—"),
+                Markup.Escape(m.Capabilities?.Family ?? "—"),
+                Bool(m.Capabilities?.Supports?.Streaming),
+                Bool(m.Capabilities?.Supports?.ToolCalls),
+                Bool(m.Capabilities?.Supports?.Vision),
+                Bool(m.Billing?.IsPremium));
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine($"[dim]{entries.Count} models from {Markup.Escape(auth.ApiEndpoint)}[/]");
+        return 0;
+    }
+
+    private static async Task<int> ExecuteQuotaAsync(string home, CancellationToken ct)
+    {
+        var auth = await CopilotAuthLoader.LoadAsync(home, ct);
+        if (auth is null)
+        {
+            AnsiConsole.MarkupLine("[red]Not logged in.[/] Run [green]botnexus provider copilot login[/].");
+            return 1;
+        }
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var client = new CopilotDiscoveryClient(http);
+        CopilotUserInfo info;
+        try
+        {
+            info = await client.GetUserAsync(auth.GitHubToken, ct);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Failed to fetch Copilot quota:[/] {Markup.Escape(ex.Message)}");
+            return 2;
+        }
+
+        var snapshots = info.QuotaSnapshots ?? new Dictionary<string, CopilotQuotaSnapshot>();
+        if (snapshots.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No quota snapshots reported.[/]");
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded)
+            .AddColumn("Quota")
+            .AddColumn("Remaining %")
+            .AddColumn("Remaining")
+            .AddColumn("Entitlement")
+            .AddColumn("Overage")
+            .AddColumn("Unlimited");
+
+        foreach (var (key, snap) in snapshots.OrderBy(kv => kv.Key))
+        {
+            var pct = snap.PercentRemaining;
+            var colour = pct switch
+            {
+                >= 50 => "green",
+                >= 20 => "yellow",
+                _ => "red"
+            };
+            table.AddRow(
+                Markup.Escape(key),
+                $"[{colour}]{pct:0.0}%[/]",
+                snap.QuotaRemaining.ToString("0.##"),
+                snap.Entitlement.ToString("0.##"),
+                $"{snap.OverageCount:0.##}{(snap.OveragePermitted ? " (permitted)" : "")}",
+                snap.Unlimited ? "[green]yes[/]" : "no");
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine($"[dim]Quota resets: {Markup.Escape(info.QuotaResetDate ?? "—")}[/]");
+        return 0;
+    }
+
+    private static async Task<int> ExecuteTestAsync(string home, string modelId, string prompt, CancellationToken ct)
+    {
+        var auth = await CopilotAuthLoader.LoadAsync(home, ct);
+        if (auth is null)
+        {
+            AnsiConsole.MarkupLine("[red]Not logged in.[/] Run [green]botnexus provider copilot login[/].");
+            return 1;
+        }
+
+        var registry = new ModelRegistry();
+        new BuiltInModels().RegisterAll(registry);
+        var model = registry.GetModel("github-copilot", modelId);
+        if (model is null)
+        {
+            AnsiConsole.MarkupLine($"[red]Unknown Copilot model:[/] {Markup.Escape(modelId)}");
+            AnsiConsole.MarkupLine("Run [green]botnexus provider copilot models[/] to see what your account is entitled to.");
+            return 1;
+        }
+
+        // The carved-out providers read BaseUrl off the model; substitute the
+        // user's actual resolved endpoint (enterprise vs individual) so the
+        // test request lands in the right place.
+        if (!string.IsNullOrWhiteSpace(auth.ApiEndpoint))
+        {
+            model = model with { BaseUrl = auth.ApiEndpoint };
+        }
+
+        var context = new Context(
+            SystemPrompt: null,
+            Messages: new Message[]
+            {
+                new UserMessage(prompt, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+            });
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
+        http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        IApiProvider provider;
+        StreamOptions options;
+        switch (model.Api)
+        {
+            case CopilotMessagesProvider.ApiId:
+                provider = new CopilotMessagesProvider(http);
+                options = new CopilotMessagesOptions { ApiKey = auth.CopilotSessionToken, CancellationToken = ct };
+                break;
+            case "github-copilot-responses":
+                provider = new CopilotResponsesProvider(http, NullLogger<CopilotResponsesProvider>.Instance);
+                options = new CopilotResponsesOptions { ApiKey = auth.CopilotSessionToken, CancellationToken = ct };
+                break;
+            case "github-copilot-completions":
+                provider = new CopilotCompletionsProvider(http, NullLogger<CopilotCompletionsProvider>.Instance);
+                options = new CopilotCompletionsOptions { ApiKey = auth.CopilotSessionToken, CancellationToken = ct };
+                break;
+            default:
+                AnsiConsole.MarkupLine($"[red]Model '{Markup.Escape(modelId)}' is not registered against a Copilot API ({Markup.Escape(model.Api)}).[/]");
+                return 1;
+        }
+
+        AnsiConsole.MarkupLine($"[dim]→ {Markup.Escape(model.Api)} | {Markup.Escape(model.Id)} | {Markup.Escape(model.BaseUrl)}[/]");
+
+        var sw = Stopwatch.StartNew();
+        long? firstTokenMs = null;
+        var collected = new List<string>();
+        try
+        {
+            var stream = provider.Stream(model, context, options);
+            await foreach (var evt in stream.WithCancellation(ct))
+            {
+                switch (evt)
+                {
+                    case TextDeltaEvent delta:
+                        firstTokenMs ??= sw.ElapsedMilliseconds;
+                        collected.Add(delta.Delta);
+                        break;
+                    case ErrorEvent err:
+                        AnsiConsole.MarkupLine($"[red]Stream error:[/] {Markup.Escape(err.Error.ErrorMessage ?? "unknown")}");
+                        return 2;
+                    case DoneEvent:
+                        break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Provider call failed:[/] {Markup.Escape(ex.Message)}");
+            return 2;
+        }
+
+        sw.Stop();
+        var text = string.Concat(collected).Trim();
+        AnsiConsole.MarkupLine($"[green]✓[/] Round-trip succeeded in {sw.ElapsedMilliseconds} ms (first token: {(firstTokenMs?.ToString() ?? "—")} ms).");
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            AnsiConsole.MarkupLine($"[dim]Reply:[/] {Markup.Escape(text)}");
+        }
+        return 0;
+    }
+
+    private static string Bool(bool? value) => value switch
+    {
+        true => "[green]yes[/]",
+        false => "no",
+        _ => "[dim]—[/]"
+    };
+}

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using BotNexus.Agent.Providers.Copilot;
 using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Cli.Commands.Provider;
 using BotNexus.Cli.Wizard;
 using BotNexus.Gateway.Configuration;
 using Spectre.Console;
@@ -63,6 +64,9 @@ internal sealed class ProviderCommand
         command.AddCommand(listCommand);
         command.AddCommand(BuildAddCommand(verboseOption));
         command.AddCommand(BuildRemoveCommand(verboseOption));
+        command.AddCommand(CopilotProviderSubcommand.Build(
+            verboseOption,
+            (configPath, home, verbose, ct) => ExecuteSetupAsync(configPath, home, verbose, "github-copilot", ct)));
 
         // Default to setup when no subcommand given
         var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.") { IsHidden = true };

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/BotNexus.Agent.Providers.Copilot.Tests.csproj
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/BotNexus.Agent.Providers.Copilot.Tests.csproj
@@ -23,5 +23,6 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="Fixtures\Wire\**\*" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="Fixtures\Requests\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Fixtures\Discovery\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Discovery/CopilotDiscoveryClientTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Discovery/CopilotDiscoveryClientTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BotNexus.Agent.Providers.Copilot.Discovery;
+using Shouldly;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Discovery;
+
+/// <summary>
+/// Verifies the discovery DTOs deserialize the real on-wire shape of
+/// <c>/copilot_internal/user</c> and <c>/models</c> as captured from a live
+/// Copilot session. Fixtures are scrubbed: real account login, organization,
+/// analytics IDs, and endpoint hostnames were replaced with generic
+/// placeholders (`octocat`, `example-org`, etc.) before being checked in.
+/// </summary>
+public class CopilotDiscoveryClientTests
+{
+    private static readonly string FixturesDir = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Discovery");
+
+    [Fact]
+    public void UserInfo_deserializes_enterprise_shape()
+    {
+        var path = Path.Combine(FixturesDir, "user-enterprise.json");
+        var json = File.ReadAllText(path);
+
+        var info = JsonSerializer.Deserialize<CopilotUserInfo>(json, JsonOptions);
+
+        info.ShouldNotBeNull();
+        info!.Login.ShouldBe("octocat");
+        info.CopilotPlan.ShouldBe("enterprise");
+        info.AccessTypeSku.ShouldBe("copilot_enterprise_seat_quota");
+        info.ChatEnabled.ShouldBeTrue();
+        info.CliEnabled.ShouldBeTrue();
+        info.OrganizationLoginList.ShouldNotBeNull();
+        info.OrganizationLoginList!.ShouldContain("example-org");
+
+        info.Endpoints.ShouldNotBeNull();
+        info.Endpoints!.Api.ShouldBe("https://api.example.githubcopilot.com");
+        info.Endpoints.Proxy.ShouldBe("https://proxy.example.githubcopilot.com");
+        info.Endpoints.OriginTracker.ShouldBe("https://origin-tracker.example.githubcopilot.com");
+
+        info.QuotaResetDate.ShouldBe("2099-01-01");
+        info.QuotaSnapshots.ShouldNotBeNull();
+        info.QuotaSnapshots!.Count.ShouldBe(3);
+        info.QuotaSnapshots["premium_interactions"].PercentRemaining.ShouldBe(75.5);
+        info.QuotaSnapshots["premium_interactions"].Entitlement.ShouldBe(1000);
+        info.QuotaSnapshots["premium_interactions"].QuotaRemaining.ShouldBe(755.0);
+        info.QuotaSnapshots["chat"].Unlimited.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ModelsResponse_deserializes_three_model_shape()
+    {
+        var path = Path.Combine(FixturesDir, "models-three.json");
+        var json = File.ReadAllText(path);
+
+        var resp = JsonSerializer.Deserialize<CopilotModelsResponse>(json, JsonOptions);
+
+        resp.ShouldNotBeNull();
+        resp!.Object.ShouldBe("list");
+        resp.Data.ShouldNotBeNull();
+        resp.Data!.Count.ShouldBe(3);
+
+        var sonnet = resp.Data.Single(m => m.Id == "claude-sonnet-4.5");
+        sonnet.Vendor.ShouldBe("Anthropic");
+        sonnet.Capabilities!.Family.ShouldBe("claude-sonnet-4.5");
+        sonnet.Capabilities.Supports!.Streaming.ShouldBeTrue();
+        sonnet.Capabilities.Supports.ToolCalls.ShouldBeTrue();
+        sonnet.Capabilities.Supports.Vision.ShouldBeTrue();
+        sonnet.Billing!.IsPremium.ShouldBeTrue();
+        sonnet.Billing.RestrictedTo.ShouldNotBeNull();
+        sonnet.Billing.RestrictedTo!.ShouldContain("enterprise");
+
+        var gpt = resp.Data.Single(m => m.Id == "gpt-5-mini");
+        gpt.Capabilities!.Supports!.StructuredOutputs.ShouldBeTrue();
+        gpt.Billing!.IsPremium.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetUserAsync_sends_bearer_auth_and_accepts_json()
+    {
+        var fixtureJson = await File.ReadAllTextAsync(Path.Combine(FixturesDir, "user-enterprise.json"));
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(fixtureJson, System.Text.Encoding.UTF8, "application/json")
+        });
+        using var http = new HttpClient(handler);
+        var client = new CopilotDiscoveryClient(http);
+
+        var info = await client.GetUserAsync("ghu_test_token_value");
+
+        info.Login.ShouldBe("octocat");
+        var request = handler.LastRequest.ShouldNotBeNull();
+        request!.Method.ShouldBe(HttpMethod.Get);
+        request.RequestUri!.ToString().ShouldBe(CopilotDiscoveryClient.UserInfoUrl);
+        request.Headers.Authorization.ShouldNotBeNull();
+        request.Headers.Authorization!.Scheme.ShouldBe("Bearer");
+        request.Headers.Authorization.Parameter.ShouldBe("ghu_test_token_value");
+        request.Headers.Accept.ShouldContain(h => h.MediaType == "application/json");
+    }
+
+    [Fact]
+    public async Task GetUserAsync_requires_github_token()
+    {
+        using var http = new HttpClient(new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+        var client = new CopilotDiscoveryClient(http);
+
+        await Should.ThrowAsync<ArgumentException>(() => client.GetUserAsync(""));
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_targets_endpoint_models_path_with_copilot_headers()
+    {
+        var fixtureJson = await File.ReadAllTextAsync(Path.Combine(FixturesDir, "models-three.json"));
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(fixtureJson, System.Text.Encoding.UTF8, "application/json")
+        });
+        using var http = new HttpClient(handler);
+        var client = new CopilotDiscoveryClient(http);
+
+        var resp = await client.GetModelsAsync("https://api.example.githubcopilot.com/", "tid=fake_session_token");
+
+        resp.Data!.Count.ShouldBe(3);
+        var request = handler.LastRequest.ShouldNotBeNull();
+        request!.Method.ShouldBe(HttpMethod.Get);
+        request.RequestUri!.ToString().ShouldBe("https://api.example.githubcopilot.com/models");
+        request.Headers.Authorization!.Parameter.ShouldBe("tid=fake_session_token");
+        request.Headers.GetValues("Copilot-Integration-Id").ShouldContain("copilot-developer-cli");
+        request.Headers.GetValues("Editor-Version").Single().ShouldStartWith("copilot/");
+        request.Headers.GetValues("X-GitHub-Api-Version").ShouldContain("2026-06-01");
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_requires_endpoint_and_token()
+    {
+        using var http = new HttpClient(new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+        var client = new CopilotDiscoveryClient(http);
+
+        await Should.ThrowAsync<ArgumentException>(() => client.GetModelsAsync("", "token"));
+        await Should.ThrowAsync<ArgumentException>(() => client.GetModelsAsync("https://x", ""));
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/models-three.json
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/models-three.json
@@ -1,0 +1,94 @@
+{
+  "data": [
+    {
+      "id": "claude-sonnet-4.5",
+      "name": "Claude Sonnet 4.5",
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-4.5",
+      "model_picker_enabled": true,
+      "preview": false,
+      "capabilities": {
+        "family": "claude-sonnet-4.5",
+        "type": "chat",
+        "tokenizer": "o200k_base",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true,
+          "parallel_tool_calls": true,
+          "vision": true,
+          "structured_outputs": false
+        },
+        "limits": {
+          "max_context_window_tokens": 144000,
+          "max_output_tokens": 32000,
+          "max_prompt_tokens": 144000
+        }
+      },
+      "billing": {
+        "is_premium": true,
+        "multiplier": 1.0,
+        "restricted_to": ["pro", "pro_plus", "business", "enterprise", "max"]
+      }
+    },
+    {
+      "id": "gpt-5-mini",
+      "name": "GPT-5 mini",
+      "vendor": "OpenAI",
+      "version": "gpt-5-mini",
+      "model_picker_enabled": true,
+      "preview": false,
+      "capabilities": {
+        "family": "gpt-5",
+        "type": "chat",
+        "tokenizer": "o200k_base",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true,
+          "parallel_tool_calls": true,
+          "vision": true,
+          "structured_outputs": true
+        },
+        "limits": {
+          "max_context_window_tokens": 264000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 264000
+        }
+      },
+      "billing": {
+        "is_premium": false,
+        "multiplier": 0,
+        "restricted_to": []
+      }
+    },
+    {
+      "id": "gemini-2.5-pro",
+      "name": "Gemini 2.5 Pro",
+      "vendor": "Google",
+      "version": "gemini-2.5-pro",
+      "model_picker_enabled": false,
+      "preview": false,
+      "capabilities": {
+        "family": "gemini-2.5",
+        "type": "chat",
+        "tokenizer": "o200k_base",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true,
+          "parallel_tool_calls": false,
+          "vision": true,
+          "structured_outputs": false
+        },
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 64000
+        }
+      },
+      "billing": {
+        "is_premium": true,
+        "multiplier": 1.0,
+        "restricted_to": ["business", "enterprise"]
+      }
+    }
+  ],
+  "object": "list"
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/user-enterprise.json
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/user-enterprise.json
@@ -1,0 +1,65 @@
+{
+  "login": "octocat",
+  "access_type_sku": "copilot_enterprise_seat_quota",
+  "analytics_tracking_id": "00000000000000000000000000000000",
+  "assigned_date": "2024-01-01T00:00:00Z",
+  "can_signup_for_limited": false,
+  "chat_enabled": true,
+  "cli_enabled": true,
+  "copilotignore_enabled": true,
+  "copilot_plan": "enterprise",
+  "editor_preview_features_enabled": true,
+  "is_mcp_enabled": true,
+  "organization_login_list": [
+    "example-org"
+  ],
+  "organization_list": [
+    { "login": "example-org", "name": "Example Org Copilot Access" }
+  ],
+  "restricted_telemetry": false,
+  "cli_remote_control_enabled": true,
+  "cloud_session_storage_enabled": true,
+  "endpoints": {
+    "api": "https://api.example.githubcopilot.com",
+    "origin-tracker": "https://origin-tracker.example.githubcopilot.com",
+    "proxy": "https://proxy.example.githubcopilot.com",
+    "telemetry": "https://telemetry.example.githubcopilot.com"
+  },
+  "can_upgrade_plan": false,
+  "quota_reset_date": "2099-01-01",
+  "quota_snapshots": {
+    "chat": {
+      "entitlement": 0,
+      "overage_count": 0,
+      "overage_permitted": false,
+      "percent_remaining": 100.0,
+      "quota_id": "chat",
+      "quota_remaining": 0.0,
+      "remaining": 0,
+      "unlimited": true,
+      "used": 0
+    },
+    "completions": {
+      "entitlement": 0,
+      "overage_count": 0,
+      "overage_permitted": false,
+      "percent_remaining": 100.0,
+      "quota_id": "completions",
+      "quota_remaining": 0.0,
+      "remaining": 0,
+      "unlimited": true,
+      "used": 0
+    },
+    "premium_interactions": {
+      "entitlement": 1000,
+      "overage_count": 0,
+      "overage_permitted": false,
+      "percent_remaining": 75.5,
+      "quota_id": "premium_interactions",
+      "quota_remaining": 755.0,
+      "remaining": 755,
+      "unlimited": false,
+      "used": 245
+    }
+  }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/Provider/CopilotProviderSubcommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/Provider/CopilotProviderSubcommandTests.cs
@@ -1,0 +1,89 @@
+using System.CommandLine;
+using BotNexus.Cli.Commands;
+using BotNexus.Cli.Commands.Provider;
+using Shouldly;
+
+namespace BotNexus.Cli.Tests.Commands.Provider;
+
+/// <summary>
+/// Wiring tests for the <c>botnexus provider copilot</c> subcommand tree.
+/// These tests don't exercise the network — they confirm the subcommand and
+/// option topology stays stable so renaming a verb or dropping an option is
+/// caught here rather than by users in the field.
+/// </summary>
+public class CopilotProviderSubcommandTests
+{
+    [Fact]
+    public void Build_registers_copilot_command_under_provider()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var providerCmd = new ProviderCommand().Build(verbose);
+
+        var copilot = providerCmd.Subcommands.SingleOrDefault(c => c.Name == "copilot");
+        copilot.ShouldNotBeNull();
+        copilot!.Description.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("login")]
+    [InlineData("whoami")]
+    [InlineData("models")]
+    [InlineData("quota")]
+    [InlineData("test")]
+    public void Build_registers_subcommand(string name)
+    {
+        var verbose = new Option<bool>("--verbose");
+        var providerCmd = new ProviderCommand().Build(verbose);
+        var copilot = providerCmd.Subcommands.Single(c => c.Name == "copilot");
+
+        copilot.Subcommands.ShouldContain(c => c.Name == name);
+    }
+
+    [Fact]
+    public void Test_subcommand_exposes_model_and_prompt_options()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var providerCmd = new ProviderCommand().Build(verbose);
+        var copilot = providerCmd.Subcommands.Single(c => c.Name == "copilot");
+        var test = copilot.Subcommands.Single(c => c.Name == "test");
+
+        test.Options.ShouldContain(o => o.Name == "model");
+        test.Options.ShouldContain(o => o.Name == "prompt");
+    }
+
+    [Fact]
+    public void Copilot_command_exposes_target_global_option()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var providerCmd = new ProviderCommand().Build(verbose);
+        var copilot = providerCmd.Subcommands.Single(c => c.Name == "copilot");
+
+        // --target is added as a global option on the copilot group so every
+        // subcommand inherits it (login/whoami/models/quota/test).
+        copilot.Options.ShouldContain(o => o.Name == "target");
+    }
+
+    [Fact]
+    public async Task Login_subcommand_invokes_setup_alias_with_github_copilot_preselected()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var captured = new List<(string ConfigPath, string Home, bool Verbose)>();
+        Func<string, string, bool, CancellationToken, Task<int>> alias = (configPath, home, v, _) =>
+        {
+            captured.Add((configPath, home, v));
+            return Task.FromResult(0);
+        };
+
+        var copilot = CopilotProviderSubcommand.Build(verbose, alias);
+
+        // Build a root command so System.CommandLine can resolve handlers.
+        var root = new RootCommand();
+        root.AddCommand(copilot);
+        var exit = await root.InvokeAsync(new[] { "copilot", "login" });
+
+        exit.ShouldBe(0);
+        captured.Count.ShouldBe(1);
+        captured[0].ConfigPath.ShouldEndWith("config.json");
+        captured[0].Home.ShouldNotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
## Phase 4 - Copilot provider CLI surface (#810)

Adds `botnexus provider copilot {login | whoami | models | quota | test}` so operators have a fast diagnostic surface for the carved-out GitHub Copilot integration without round-tripping through the gateway.

### New subcommands

| Command | What it does | Endpoint |
|---|---|---|
| `copilot login` | Alias for `provider setup --provider github-copilot` (the device-code flow in `CopilotOAuth.LoginAsync` stays authoritative). | n/a |
| `copilot whoami` | Resolved login, plan, SKU, organisations, API endpoint (enterprise vs individual), session-token expiry. | `GET https://api.github.com/copilot_internal/user` |
| `copilot models` | Table of model id / vendor / family / streaming / tools / vision / premium for every model the user is entitled to. | `GET {endpoints.api}/models` |
| `copilot quota` | Per-feature quota snapshots (`chat`, `completions`, `premium_interactions`) with colour-coded percent-remaining and reset date. | Re-uses `/copilot_internal/user`. |
| `copilot test [--model <id>] [--prompt <text>]` | Round-trips a single request through the carved-out provider matching the model's registered Api (Messages / Responses / Completions) and reports first-token + total latency plus the assistant reply. Defaults to `gpt-5-mini`. | `POST {endpoints.api}/{responses\|chat/completions\|v1/messages}` |

### Supporting infrastructure

- New `BotNexus.Agent.Providers.Copilot.Discovery` namespace:
  - `CopilotDiscoveryClient` — stateless client; credentials and endpoint are passed per-call so one instance serves both enterprise and individual users.
  - DTOs: `CopilotUserInfo`, `CopilotEndpoints`, `CopilotQuotaSnapshot`, `CopilotModelInfo` (+ `CopilotModelCapabilities`, `CopilotModelSupports`, `CopilotModelBilling`).
- New `BotNexus.Cli.Commands.Provider.CopilotAuthLoader`:
  - Reads `~/.botnexus/auth.json`, re-using `ProviderCommand.AuthFileEntry` so on-disk shape stays identical to what the gateway produces.
  - Auto-refreshes the Copilot session token via `CopilotOAuth.RefreshAsync` when it's missing or near expiry, and writes the refreshed entry back to the auth file.

### Tests (15 new, all green)

- **6 discovery tests** (`BotNexus.Agent.Providers.Copilot.Tests`):
  - DTO deserialisation against scrubbed fixtures derived from real captures.
  - Request-shape assertions (`Authorization: Bearer`, `Copilot-Integration-Id`, `X-GitHub-Api-Version`, `Editor-Version`, `/models` URL composition).
  - Argument-validation guards on `GetUserAsync` / `GetModelsAsync`.
- **9 CLI wiring tests** (`BotNexus.Cli.Tests`):
  - Subcommand topology (every verb is registered).
  - Option presence (`test` exposes `--model` and `--prompt`).
  - Global `--target` option on the `copilot` command group.
  - End-to-end `copilot login` invocation reaches the setup-alias callback with `config.json` resolved.

Fixtures are fully scrubbed — real account login, organization, analytics tracking ID, and endpoint hostnames were replaced with `octocat` / `example-org` / `api.example.githubcopilot.com` etc. so no live account data ships in the repo.

### Deployment safety (S1–S6)

- Purely additive — no existing CLI command was modified other than wiring the new subcommand group into `ProviderCommand.Build`.
- No new NuGet dependencies (uses the existing System.CommandLine, Spectre.Console, System.Net.Http stack).
- `copilot test` is purely opt-in — nothing runs unless an operator types the command — so existing deployments are untouched.
- Config-file shape (`auth.json`) is reused; no migration is needed.

### Validation

- `dotnet build BotNexus.slnx --nologo --tl:off` → 0 warnings, 0 errors.
- `scripts/repo/test-impacted.ps1 -NoBuild` — 8 of 9 impacted projects green; `BotNexus.Cli.Tests` reports 139 pass / 1 fail. The 1 failure is the pre-existing `GatewayProcessManagerTests.GetStatusAsync_WhenRunning_ReturnsPidAndUptime` PID-recycling flake — confirmed failing on `main@0739db6f` as well, not introduced here.
- `BotNexus.Agent.Providers.Copilot.Tests`: 84 / 84 (was 78 + 6 new).

Carves out the diagnostic milestone of the GitHub Copilot provider work tracked in #810. Future phases (5+) will address header / body fidelity (`advanced-tool-use` beta, `copilot_usage` parsing, quota response-header surfacing, configurable integration-id).