### PR TITLE
fix(sessions): retry ReplaceHistoryAsync on phantom rollback errors with fresh connection

### DIFF
--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -145,10 +145,13 @@ public sealed class SqliteSessionStore : SessionStoreBase
         try
         {
             _cache[session.SessionId] = session;
-            await using var connection = CreateConnection();
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-            await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
-            await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
+            await RetryOnTransientAsync(async () =>
+            {
+                await using var connection = CreateConnection();
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
+            }, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         finally { sessionLock.Release(); }
     }
@@ -199,10 +202,13 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 session.Status = SessionStatus.Sealed;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
                 _cache[sessionId] = session;
-                await using var connection = CreateConnection();
-                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-                await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
-                await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                await RetryOnTransientAsync(async () =>
+                {
+                    await using var connection = CreateConnection();
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    await UpsertSessionAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                    await ReplaceHistoryAsync(connection, session, cancellationToken).ConfigureAwait(false);
+                }, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
         finally { sessionLock.Release(); }
@@ -1033,8 +1039,17 @@ public sealed class SqliteSessionStore : SessionStoreBase
     private static readonly int[] TransientSqliteErrorCodes = [5 /* BUSY */, 10 /* IOERR */];
 
     /// <summary>
+    /// Returns true if the exception represents a transient SQLite condition safe to retry.
+    /// Covers BUSY (5), IOERR (10), and the "cannot rollback" phantom transaction error.
+    /// </summary>
+    private static bool IsTransientSqliteException(SqliteException ex)
+        => TransientSqliteErrorCodes.Contains(ex.SqliteErrorCode)
+           || (ex.SqliteErrorCode == 1 && ex.Message.Contains("cannot rollback", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
     /// Executes <paramref name="operation"/> with up to <paramref name="maxAttempts"/> retries
-    /// on transient SQLite errors (BUSY=5, IOERR=10). Waits ~50ms × 2^attempt between retries.
+    /// on transient SQLite errors (BUSY=5, IOERR=10, and phantom rollback errors).
+    /// Waits ~50ms × 2^attempt between retries.
     /// After all retries are exhausted, wraps the last exception in
     /// <see cref="SessionStoreUnavailableException"/>.
     /// </summary>
@@ -1050,7 +1065,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
             {
                 return await operation().ConfigureAwait(false);
             }
-            catch (SqliteException ex) when (TransientSqliteErrorCodes.Contains(ex.SqliteErrorCode))
+            catch (SqliteException ex) when (IsTransientSqliteException(ex))
             {
                 lastEx = ex;
                 var delayMs = 50 * (1 << attempt); // 50ms, 100ms, 200ms

--- a/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreRetryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SqliteSessionStoreRetryTests.cs
@@ -86,6 +86,36 @@ public sealed class SqliteSessionStoreRetryTests
     // ── test 5: SessionsController returns 503 when store unavailable ────────
     //    (via Mock<ISessionStore>; no SqliteException needed)
     // This test lives in SessionsControllerTests.cs
+
+    // ── test 6: "cannot rollback" error is treated as transient ──────────────
+
+    [Fact]
+    public void IsTransientSqliteException_CannotRollback_ReturnsTrue()
+    {
+        var isTransient = SqliteSessionStoreTestHelper.CheckIsTransient(
+            errorCode: 1, message: "SQLite Error 1: cannot rollback - no transaction is active");
+        isTransient.ShouldBeTrue();
+    }
+
+    // ── test 7: unrelated error code 1 is NOT transient ──────────────────────
+
+    [Fact]
+    public void IsTransientSqliteException_OtherError1_ReturnsFalse()
+    {
+        var isTransient = SqliteSessionStoreTestHelper.CheckIsTransient(
+            errorCode: 1, message: "SQLite Error 1: no such table: sessions");
+        isTransient.ShouldBeFalse();
+    }
+
+    // ── test 8: BUSY (5) is transient ────────────────────────────────────────
+
+    [Fact]
+    public void IsTransientSqliteException_Busy_ReturnsTrue()
+    {
+        var isTransient = SqliteSessionStoreTestHelper.CheckIsTransient(
+            errorCode: 5, message: "SQLite Error 5: database is locked");
+        isTransient.ShouldBeTrue();
+    }
 }
 
 /// <summary>
@@ -136,5 +166,28 @@ internal static class SqliteSessionStoreTestHelper
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         fieldInfo.ShouldNotBeNull("TransientSqliteErrorCodes not found on SqliteSessionStore");
         return (int[])fieldInfo!.GetValue(null)!;
+    }
+
+    /// <summary>
+    /// Invokes IsTransientSqliteException via reflection with a fabricated SqliteException.
+    /// </summary>
+    public static bool CheckIsTransient(int errorCode, string message)
+    {
+        var method = typeof(SqliteSessionStore)
+            .GetMethod(
+                "IsTransientSqliteException",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        method.ShouldNotBeNull("IsTransientSqliteException not found on SqliteSessionStore");
+
+        // SqliteException can be instantiated via its (int errorCode, string message) ctor-like path.
+        // Fabricate via reflection since the constructor is internal.
+        var ex = CreateSqliteException(errorCode, message);
+        return (bool)method!.Invoke(null, [ex])!;
+    }
+
+    private static SqliteException CreateSqliteException(int errorCode, string message)
+    {
+        // Microsoft.Data.Sqlite.SqliteException has public ctors: (string, int) and (string, int, int)
+        return new SqliteException(message, errorCode);
     }
 }


### PR DESCRIPTION
Closes #959

## Changes
- Extracted `IsTransientSqliteException` predicate that detects BUSY (5), IOERR (10), AND SQLite error 1 with "cannot rollback" message
- Both `SaveAsync` paths now wrap the connection+upsert+replace sequence in `RetryOnTransientAsync` with a **fresh connection per attempt** — eliminates corrupted connection state on retry
- 3 new regression tests validating the transient detection predicate (cannot-rollback true, unrelated error-1 false, BUSY true)

## Root Cause
With 990+ entries, `ReplaceHistoryAsync` performs DELETE + 990 INSERTs in a single transaction. Under WAL contention (concurrent agent config file watcher writes), SQLite returns error code 1 "cannot rollback - no transaction is active". The old code used one connection for the entire save path — once the connection entered an error state, it could not recover.

## Merge Notes
Independent — no file overlap with any open PR. Safe to merge in any order.