### PR TITLE
fix(gateway): add compaction circuit breaker to skip after consecutive LLM failures

### DIFF
--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections.Concurrent;
+using System.Text;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
 using BotNexus.Gateway.Abstractions.Sessions;
@@ -26,6 +27,18 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     private readonly ISecretRedactor? _redactor;
     private readonly IOptionsMonitor<PlatformConfig>? _platformConfig;
 
+    /// <summary>
+    /// Tracks consecutive compaction failures per session for circuit breaker logic.
+    /// After <see cref="MaxConsecutiveFailures"/> consecutive failures, compaction is
+    /// skipped for that session until the gateway restarts.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> _consecutiveFailures = new();
+
+    /// <summary>
+    /// Maximum consecutive compaction failures before the circuit breaker opens.
+    /// </summary>
+    internal const int MaxConsecutiveFailures = 3;
+
     public LlmSessionCompactor(LlmClient llmClient, ILogger<LlmSessionCompactor> logger, ISecretRedactor? redactor = null, IOptionsMonitor<PlatformConfig>? platformConfig = null)
     {
         _llmClient = llmClient;
@@ -47,6 +60,28 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(session);
+
+        // Circuit breaker: skip compaction if this session has failed too many times.
+        var sessionKey = session.SessionId.Value;
+        var failures = _consecutiveFailures.GetValueOrDefault(sessionKey, 0);
+        if (failures >= MaxConsecutiveFailures)
+        {
+            _logger.LogWarning(
+                "Compaction circuit breaker OPEN for session {SessionId}: " +
+                "{Failures} consecutive failures. Skipping until gateway restart.",
+                sessionKey, failures);
+            return new CompactionResult
+            {
+                Summary = string.Empty,
+                Succeeded = false,
+                EntriesSummarized = 0,
+                EntriesPreserved = 0,
+                TokensBefore = 0,
+                TokensAfter = 0,
+                SnapshotDestructiveVersion = 0,
+                SnapshotHistoryCount = 0
+            };
+        }
 
         // Atomic snapshot: history copy + destructive-mutation version + count, all
         // captured under the runtime lock. The compactor operates only on this
@@ -100,11 +135,15 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         // Bug 1 / Bug 5 guard: if the LLM returned nothing, abort — do NOT mutate history.
         if (string.IsNullOrWhiteSpace(summary))
         {
+            _consecutiveFailures.AddOrUpdate(sessionKey, 1, (_, count) => count + 1);
             _logger.LogWarning(
                 "Compaction aborted for session {SessionId}: LLM returned an empty summary. " +
-                "History is unchanged. Summarized {Count} entries would have been marked as historical.",
+                "History is unchanged. Summarized {Count} entries would have been marked as historical. " +
+                "Consecutive failures: {Failures}/{Max}",
                 session.SessionId,
-                toSummarize.Count);
+                toSummarize.Count,
+                _consecutiveFailures.GetValueOrDefault(sessionKey, 1),
+                MaxConsecutiveFailures);
 
             return new CompactionResult
             {
@@ -180,6 +219,9 @@ public sealed class LlmSessionCompactor : ISessionCompactor
             tokensBefore,
             tokensAfter,
             tokensBefore - tokensAfter);
+
+        // Reset circuit breaker on success.
+        _consecutiveFailures.TryRemove(sessionKey, out _);
 
         return new CompactionResult
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -772,4 +772,108 @@ public sealed class LlmSessionCompactorTests
         var llmClient = new LlmClient(providers, models);
         return new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
     }
+
+    // ── Circuit Breaker Tests ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CompactAsync_EmptySummary_IncrementsFailureCounter()
+    {
+        var session = CreateLargeSession(300);
+        var compactor = CreateCompactor(""); // empty summary → failure
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 2,
+            MaxSummaryChars = 5000
+        };
+
+        var result = await compactor.CompactAsync(session, options);
+
+        result.Succeeded.ShouldBeFalse();
+        // After 1 failure, should still compact next time (threshold is 3)
+        var result2 = await compactor.CompactAsync(session, options);
+        result2.Succeeded.ShouldBeFalse(); // still empty summary but still tries
+    }
+
+    [Fact]
+    public async Task CompactAsync_CircuitBreaker_SkipsAfterMaxFailures()
+    {
+        var session = CreateLargeSession(300);
+        var compactor = CreateCompactor(""); // empty summary → always fails
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 2,
+            MaxSummaryChars = 5000
+        };
+
+        // Exhaust the breaker
+        for (var i = 0; i < LlmSessionCompactor.MaxConsecutiveFailures; i++)
+        {
+            var r = await compactor.CompactAsync(session, options);
+            r.Succeeded.ShouldBeFalse();
+        }
+
+        // Next call should short-circuit without even attempting LLM call
+        var result = await compactor.CompactAsync(session, options);
+        result.Succeeded.ShouldBeFalse();
+        result.EntriesPreserved.ShouldBe(0); // circuit breaker returns zero (didn't snapshot)
+    }
+
+    [Fact]
+    public async Task CompactAsync_SuccessResetsCircuitBreaker()
+    {
+        var session = CreateLargeSession(300);
+        // Use a compactor that returns empty first, then succeeds
+        var callCount = 0;
+        var compactorWithSummary = CreateCompactorWithSequence(
+            () => ++callCount <= 2 ? "" : "Summary text");
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 2,
+            MaxSummaryChars = 5000
+        };
+
+        // Fail twice
+        await compactorWithSummary.CompactAsync(session, options);
+        await compactorWithSummary.CompactAsync(session, options);
+
+        // Succeed on third call → counter resets
+        var result = await compactorWithSummary.CompactAsync(session, options);
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    private static GatewaySession CreateLargeSession(int entryCount)
+    {
+        var entries = new List<(string role, string content)>();
+        for (var i = 0; i < entryCount; i++)
+        {
+            entries.Add((i % 2 == 0 ? "user" : "assistant", $"message {i} " + new string('x', 50)));
+        }
+        return CreateSession(entries.ToArray());
+    }
+
+    private static LlmSessionCompactor CreateCompactorWithSequence(Func<string> summaryFactory)
+    {
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        models.Register(TestModel.Provider, TestModel);
+
+        var provider = new Mock<IApiProvider>();
+        provider.SetupGet(item => item.Api).Returns(TestModel.Api);
+        provider.Setup(item => item.StreamSimple(
+                It.IsAny<LlmModel>(),
+                It.IsAny<Context>(),
+                It.IsAny<SimpleStreamOptions?>()))
+            .Returns(() => CreateStream(summaryFactory()));
+
+        providers.Register(provider.Object);
+
+        var llmClient = new LlmClient(providers, models);
+        return new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
+    }
 }


### PR DESCRIPTION
Closes #960

## Changes
- Added `ConcurrentDictionary<string, int> _consecutiveFailures` to LlmSessionCompactor
- Circuit breaker check at top of `CompactAsync` — skips with warning log after 3 consecutive failures per session
- Failure counter increments on empty-summary abort; resets to 0 on successful compaction
- Enhanced abort log message includes `{Failures}/{Max}` for diagnosability
- `MaxConsecutiveFailures` constant (internal, 3) for testability
- 3 new regression tests: failure increments, circuit opens after threshold, success resets counter

## Root Cause
gpt-4.1 was returning empty Content for compaction on every turn (likely context too large for the model), causing 8+ consecutive failed compaction attempts per session per hour. Each failure wasted an LLM call and the session grew unbounded to 990+ entries.

## Merge Notes
Independent — touches only LlmSessionCompactor.cs (not modified by any open PR). Safe to merge in any order.

Related: PR #963 fixes #959 (the downstream crash caused by unbounded session growth).