### PR TITLE
fix(portal): style interrupt-steer button to match steer, stop, and send controls

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -355,7 +355,7 @@
                             @onclick="InterruptAndSteer"
                             disabled="@(string.IsNullOrWhiteSpace(_inputText))"
                             title="Abort current turn and redirect with input message">
-                        Interrupt + Redirect
+                        Redirect
                     </button>
                     <button class="abort-btn"
                             @onclick="AbortAgent"

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -1706,6 +1706,28 @@ html, body, #app {
     cursor: not-allowed;
 }
 
+.interrupt-steer-btn {
+    padding: 0.6rem 0.85rem;
+    border: 1px solid var(--warning, #e67e22);
+    border-radius: var(--radius);
+    background: rgba(230, 126, 34, 0.12);
+    color: var(--warning, #e67e22);
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.15s;
+    align-self: flex-end;
+    white-space: nowrap;
+}
+
+.interrupt-steer-btn:hover:not(:disabled) {
+    background: rgba(230, 126, 34, 0.25);
+}
+
+.interrupt-steer-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
 .abort-btn {
     padding: 0.6rem 0.85rem;
     border: 1px solid var(--error);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -662,4 +662,45 @@ public sealed class ChatPanelTests : IDisposable
         Assert.Contains(_store.GetMessages("conv-1"), message => message.Content.Contains("You answered:", StringComparison.Ordinal));
     }
 
+
+    [Fact]
+    public void InterruptSteerButton_HasCorrectCssClass_WhenStreaming()
+    {
+        CreateAndSeedAgent("agent-1", isStreaming: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.SetStreaming("conv-1", true);
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var btn = cut.Find(".interrupt-steer-btn");
+        Assert.NotNull(btn);
+    }
+
+    [Fact]
+    public void InterruptSteerButton_HasAbbreviatedLabel_WhenStreaming()
+    {
+        CreateAndSeedAgent("agent-1", isStreaming: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.SetStreaming("conv-1", true);
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var btn = cut.Find(".interrupt-steer-btn");
+        Assert.Contains("Redirect", btn.TextContent);
+        Assert.DoesNotContain("Interrupt + Redirect", btn.TextContent);
+    }
+
+    [Fact]
+    public void InterruptSteerButton_IsNotRendered_WhenNotStreaming()
+    {
+        CreateAndSeedAgent("agent-1", isStreaming: false);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        Assert.Empty(cut.FindAll(".interrupt-steer-btn"));
+    }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/InterruptSteerButtonCssTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/InterruptSteerButtonCssTests.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using System.Reflection;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Content-level tests verifying interrupt-steer button CSS rules.
+/// Closes #951.
+/// </summary>
+public sealed class InterruptSteerButtonCssTests
+{
+    private static readonly string s_cssPath = Path.Combine(
+        Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+        "wwwroot",
+        "css",
+        "app.css");
+
+    [Fact]
+    public void InterruptSteerBtn_HasCssRule()
+    {
+        var content = File.ReadAllText(s_cssPath);
+
+        var ruleStart = content.IndexOf(".interrupt-steer-btn {", StringComparison.Ordinal);
+        Assert.True(ruleStart >= 0, ".interrupt-steer-btn CSS rule not found in app.css");
+    }
+
+    [Fact]
+    public void InterruptSteerBtn_HasConsistentFontSize()
+    {
+        var content = File.ReadAllText(s_cssPath);
+
+        var ruleStart = content.IndexOf(".interrupt-steer-btn {", StringComparison.Ordinal);
+        var ruleEnd = content.IndexOf('}', ruleStart);
+        var ruleBlock = content.Substring(ruleStart, ruleEnd - ruleStart + 1);
+
+        // Must match steer-btn and abort-btn font-size of 0.85rem
+        Assert.Contains("font-size: 0.85rem", ruleBlock, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InterruptSteerBtn_HasWhiteSpaceNoWrap()
+    {
+        var content = File.ReadAllText(s_cssPath);
+
+        var ruleStart = content.IndexOf(".interrupt-steer-btn {", StringComparison.Ordinal);
+        var ruleEnd = content.IndexOf('}', ruleStart);
+        var ruleBlock = content.Substring(ruleStart, ruleEnd - ruleStart + 1);
+
+        Assert.Contains("white-space: nowrap", ruleBlock, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InterruptSteerBtn_HasDisabledState()
+    {
+        var content = File.ReadAllText(s_cssPath);
+
+        Assert.Contains(".interrupt-steer-btn:disabled", content, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #951

## Changes
- Add `.interrupt-steer-btn` CSS rule with consistent padding (0.6rem 0.85rem), font-size (0.85rem), border-radius, and white-space:nowrap matching `.steer-btn` and `.abort-btn`
- Use warning/orange colour scheme to distinguish from the accent-blue steer button
- Abbreviate label from "Interrupt + Redirect" to "Redirect" to prevent text wrapping at normal viewport widths
- 7 new tests: 3 bUnit (button rendered when streaming, abbreviated label, hidden when not streaming) + 4 CSS content tests (rule exists, font-size, white-space, disabled state)

## Merge Notes
Fully independent — no file overlap with any open PR. Safe to merge in any order.