### PR TITLE
fix(gateway): truncate entry content in compaction prompt to prevent context overflow

### DIFF
--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Text;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Security;
@@ -39,6 +39,19 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     /// </summary>
     internal const int MaxConsecutiveFailures = 3;
 
+    /// <summary>
+    /// Maximum characters per entry content in the summarization prompt.
+    /// Tool results and long assistant messages are truncated to this length
+    /// to prevent the prompt from exceeding model context limits.
+    /// </summary>
+    internal const int MaxEntryContentCharsInPrompt = 500;
+
+    /// <summary>
+    /// Maximum total characters for the summarization prompt.
+    /// If the prompt exceeds this after truncation, older entries are dropped.
+    /// Based on ~80% of a 128K token model's input capacity (chars/4 ≈ tokens).
+    /// </summary>
+    internal const int MaxSummarizationPromptChars = 400_000;
     public LlmSessionCompactor(LlmClient llmClient, ILogger<LlmSessionCompactor> logger, ISecretRedactor? redactor = null, IOptionsMonitor<PlatformConfig>? platformConfig = null)
     {
         _llmClient = llmClient;
@@ -51,7 +64,19 @@ public sealed class LlmSessionCompactor : ISessionCompactor
     {
         var estimatedTokens = EstimateVisibleTokenCount(session);
         var threshold = (int)(options.ContextWindowTokens * options.TokenThresholdRatio);
-        return estimatedTokens > threshold;
+        var shouldCompact = estimatedTokens > threshold;
+
+        _logger.LogDebug(
+            "ShouldCompact check for session {SessionId}: estimated {EstimatedTokens} tokens, " +
+            "threshold {Threshold} (window {Window} * ratio {Ratio}), result: {ShouldCompact}",
+            session.SessionId,
+            estimatedTokens,
+            threshold,
+            options.ContextWindowTokens,
+            options.TokenThresholdRatio,
+            shouldCompact);
+
+        return shouldCompact;
     }
 
     public async Task<CompactionResult> CompactAsync(
@@ -317,10 +342,74 @@ public sealed class LlmSessionCompactor : ISessionCompactor
 
         foreach (var entry in entries)
         {
-            builder.AppendLine($"[{entry.Role}]: {entry.Content}");
+            var content = TruncateForSummarization(entry);
+            builder.AppendLine($"[{entry.Role}]: {content}");
         }
 
-        return builder.ToString();
+        // Guard: if total prompt exceeds max chars, drop oldest entries until it fits.
+        var result = builder.ToString();
+        if (result.Length > MaxSummarizationPromptChars)
+        {
+            builder.Clear();
+            builder.AppendLine("Summarize the following conversation history. Preserve critical information in a structured format.");
+            builder.AppendLine();
+            builder.AppendLine("Required sections:");
+            builder.AppendLine("## Resolved -- completed tasks, decisions made");
+            builder.AppendLine("## Active Task -- what was being worked on at compaction time");
+            builder.AppendLine("## In Progress -- tool calls / sub-tasks mid-flight");
+            builder.AppendLine("## Pending User Asks -- questions waiting for user response");
+            builder.AppendLine("## Remaining Work -- planned but not started");
+            builder.AppendLine();
+            builder.AppendLine($"Keep the summary under {maxChars} characters.");
+            builder.AppendLine();
+            builder.AppendLine("NOTE: This history was truncated to fit the model context window. Focus on the most recent activity.");
+            builder.AppendLine();
+            builder.AppendLine("Conversation:");
+
+            // Re-build with progressively fewer entries (drop oldest first)
+            var remaining = entries;
+            while (remaining.Count > 0)
+            {
+                var candidateBuilder = new StringBuilder(builder.ToString());
+                foreach (var entry in remaining)
+                {
+                    candidateBuilder.AppendLine($"[{entry.Role}]: {TruncateForSummarization(entry)}");
+                }
+
+                if (candidateBuilder.Length <= MaxSummarizationPromptChars)
+                {
+                    return candidateBuilder.ToString();
+                }
+
+                // Drop the oldest quarter of entries
+                var dropCount = Math.Max(1, remaining.Count / 4);
+                remaining = remaining.Skip(dropCount).ToList();
+            }
+
+            // Absolute fallback: just the prompt header
+            return builder.ToString();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Truncates a session entry's content for inclusion in the summarization prompt.
+    /// Tool entries are aggressively truncated since their full output is rarely
+    /// needed for a high-level summary.
+    /// </summary>
+    internal static string TruncateForSummarization(SessionEntry entry)
+    {
+        var content = entry.Content ?? string.Empty;
+        if (content.Length <= MaxEntryContentCharsInPrompt)
+            return content;
+
+        // For tool entries, keep even less — just first 200 chars
+        var limit = entry.Role.Equals(MessageRole.Tool)
+            ? Math.Min(200, MaxEntryContentCharsInPrompt)
+            : MaxEntryContentCharsInPrompt;
+
+        return content[..limit] + $"... [truncated, {content.Length} chars total]";
     }
 
     private async Task<string> CallLlmForSummaryAsync(

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -876,4 +876,79 @@ public sealed class LlmSessionCompactorTests
         var llmClient = new LlmClient(providers, models);
         return new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
     }
+
+    // ── Truncation Tests (Issue #965) ─────────────────────────────────────────
+
+    [Fact]
+    public void TruncateForSummarization_ShortContent_ReturnsUnchanged()
+    {
+        var entry = new SessionEntry { Role = "user", Content = "hello" };
+        var result = LlmSessionCompactor.TruncateForSummarization(entry);
+        result.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void TruncateForSummarization_LongUserContent_TruncatesAt500()
+    {
+        var longContent = new string('x', 1000);
+        var entry = new SessionEntry { Role = "user", Content = longContent };
+        var result = LlmSessionCompactor.TruncateForSummarization(entry);
+        result.ShouldContain("... [truncated, 1000 chars total]");
+        result.Length.ShouldBeLessThan(600);
+    }
+
+    [Fact]
+    public void TruncateForSummarization_LongToolContent_TruncatesAt200()
+    {
+        var longContent = new string('y', 5000);
+        var entry = new SessionEntry { Role = "tool", Content = longContent };
+        var result = LlmSessionCompactor.TruncateForSummarization(entry);
+        result.ShouldContain("... [truncated, 5000 chars total]");
+        // Tool entries are capped at 200 chars + suffix
+        result.Length.ShouldBeLessThan(260);
+    }
+
+    [Fact]
+    public void TruncateForSummarization_EmptyContent_ReturnsEmpty()
+    {
+        var entry = new SessionEntry { Role = "assistant", Content = "" };
+        var result = LlmSessionCompactor.TruncateForSummarization(entry);
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CompactAsync_MassiveToolHistory_DoesNotExceedMaxPromptSize()
+    {
+        // Simulate #965: 500+ tool entries with large content
+        var entries = new List<(string role, string content)>();
+        for (int i = 0; i < 600; i++)
+        {
+            entries.Add(("user", $"Step {i}"));
+            entries.Add(("tool", new string('z', 2000))); // 2000 chars each = 1.2M total raw
+        }
+        entries.Add(("user", "final question"));
+        entries.Add(("assistant", "final answer"));
+
+        var session = CreateSession(entries.ToArray());
+
+        string? capturedPrompt = null;
+        var compactor = CreateCompactorCapturingPrompt(
+            "Summary of large session",
+            prompt => capturedPrompt = prompt);
+
+        var options = new CompactionOptions
+        {
+            ContextWindowTokens = 128_000,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 1,
+            MaxSummaryChars = 5000
+        };
+
+        var result = await compactor.CompactAsync(session, options);
+
+        result.Succeeded.ShouldBeTrue();
+        capturedPrompt.ShouldNotBeNull();
+        // The prompt must stay under the max chars threshold
+        capturedPrompt!.Length.ShouldBeLessThanOrEqualTo(LlmSessionCompactor.MaxSummarizationPromptChars);
+    }
 }


### PR DESCRIPTION
Closes #965

## Problem
Sessions with heavy tool usage (e.g., 1,772 tool entries, 1.18M chars) caused `BuildSummarizationPrompt` to serialize ALL entries verbatim into a single LLM prompt. This exceeded any model's context window, producing empty summaries and leaving session history unbounded.

## Changes
- **Truncate entry content**: User/assistant entries capped at 500 chars, tool entries at 200 chars in summarization prompt. Full content preserved in session history.
- **Max prompt size guard**: If truncated prompt still exceeds 400K chars, progressively drop oldest 25% of entries until it fits.
- **ShouldCompact logging**: Added debug log showing estimated tokens, threshold, and decision on every check.
- **TruncateForSummarization** exposed as `internal static` for direct unit testing.
- 5 new tests: short content passthrough, user truncation at 500, tool truncation at 200, empty content, and full 600-entry session stays under max prompt size.

## Design Decisions
- Truncation in the prompt only — raw session history entries are never mutated.
- Tool entries get aggressive 200-char cap because tool output is verbose (full file contents, stack traces) but summaries only need the gist.
- Progressive dropping removes oldest entries first (most likely already captured in prior summaries).

## Merge Notes
Fully independent — no file overlap with any open PR. Safe to merge in any order.