### PR TITLE
refactor(domain): remove redundant normalisation at domain primitive call sites

### DIFF
--- a/src/domain/BotNexus.Domain/AgentExchange/CrossWorldAgentReference.cs
+++ b/src/domain/BotNexus.Domain/AgentExchange/CrossWorldAgentReference.cs
@@ -33,7 +33,7 @@ public sealed record CrossWorldAgentReference
         }
 
         var worldId = value[..separatorIndex].Trim();
-        var agentId = value[(separatorIndex + 1)..].Trim();
+        var agentId = value[(separatorIndex + 1)..];
         if (string.IsNullOrWhiteSpace(worldId) || string.IsNullOrWhiteSpace(agentId))
         {
             reference = null;

--- a/src/domain/BotNexus.Domain/Primitives/AgentSessionKey.cs
+++ b/src/domain/BotNexus.Domain/Primitives/AgentSessionKey.cs
@@ -33,7 +33,7 @@ public readonly record struct AgentSessionKey(AgentId AgentId, SessionId Session
 
         return new AgentSessionKey(
             AgentId.From(parts[0]),
-            SessionId.From(string.Join("::", parts.Skip(1)).Trim()));
+            SessionId.From(string.Join("::", parts.Skip(1))));
     }
 
     /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -148,7 +148,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
 
         var normalizedConversationId = string.IsNullOrWhiteSpace(conversationId)
             ? null
-            : conversationId.Trim();
+            : conversationId;
 
         // Resolve the (sessionId, conversationId) the inbound message will land on so the
         // caller is in the conversation group before the orchestrator's worker emits stream
@@ -194,7 +194,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         if (string.IsNullOrWhiteSpace(requestId))
             throw new HubException("Request ID is required.");
 
-        var normalizedConversationId = ConversationId.From(conversationId.Trim());
+        var normalizedConversationId = ConversationId.From(conversationId);
         var conversation = await _conversationStore.GetAsync(normalizedConversationId, Context.ConnectionAborted);
         if (conversation is null)
             throw new HubException($"Conversation '{normalizedConversationId.Value}' not found.");
@@ -366,7 +366,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         await SubscribeInternalAsync(typedSessionId);
 
         var connectionId = Context.ConnectionId;
-        var normalizedConversationId = string.IsNullOrWhiteSpace(conversationId) ? null : conversationId.Trim();
+        var normalizedConversationId = string.IsNullOrWhiteSpace(conversationId) ? null : conversationId;
 
         _ = SafeDispatchAsync(
             () => _orchestrator.AcceptAsync(

--- a/tests/architecture/BotNexus.Architecture.Tests/DomainPrimitiveNormalisationArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/DomainPrimitiveNormalisationArchitectureTests.cs
@@ -1,0 +1,133 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Prevents redundant normalisation of domain primitive IDs at call sites.
+/// <para>
+/// Domain primitives (<c>AgentId</c>, <c>SessionId</c>, <c>ConversationId</c>) implement
+/// <c>NormalizeInput</c> which already trims whitespace. Callers must not manually call
+/// <c>.Trim()</c> before <c>From()</c> — it's redundant and masks the primitive's contract.
+/// </para>
+/// </summary>
+public sealed partial class DomainPrimitiveNormalisationArchitectureTests
+{
+    /// <summary>
+    /// Patterns that represent a redundant <c>.Trim()</c> immediately before a domain primitive
+    /// <c>From()</c> call. These are caught at the architecture level to prevent regression.
+    /// </summary>
+    private static readonly Regex[] RedundantTrimBeforeFromPatterns =
+    [
+        TrimBeforeAgentIdFrom(),
+        TrimBeforeSessionIdFrom(),
+        TrimBeforeConversationIdFrom(),
+    ];
+
+    /// <summary>
+    /// Source files excluded from this check (e.g., the NormalizeInput implementation itself,
+    /// or test files that explicitly test normalisation behaviour).
+    /// </summary>
+    private static readonly string[] ExcludedFilePatterns =
+    [
+        "AgentId.cs",
+        "SessionId.cs",
+        "ConversationId.cs",
+        "DomainPrimitiveNormalisationArchitectureTests.cs",
+    ];
+
+    [Fact]
+    public void No_Redundant_Trim_Before_DomainPrimitive_From()
+    {
+        var srcRoot = FindSrcRoot();
+        var violations = new List<string>();
+
+        var csFiles = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !ExcludedFilePatterns.Any(ex => f.EndsWith(ex, StringComparison.OrdinalIgnoreCase)))
+            .Where(f => !f.Contains("obj", StringComparison.OrdinalIgnoreCase))
+            .Where(f => !f.Contains("bin", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var file in csFiles)
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                foreach (var pattern in RedundantTrimBeforeFromPatterns)
+                {
+                    if (pattern.IsMatch(line))
+                    {
+                        var relativePath = Path.GetRelativePath(srcRoot, file);
+                        violations.Add($"{relativePath}:{i + 1} — {line.Trim()}");
+                    }
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            $"Found {violations.Count} redundant .Trim() calls before domain primitive .From():\n" +
+            string.Join("\n", violations));
+    }
+
+    [Fact]
+    public void No_ToLower_On_DomainPrimitive_Value()
+    {
+        var srcRoot = FindSrcRoot();
+        var violations = new List<string>();
+        var pattern = ToLowerOnPrimitiveValue();
+
+        var csFiles = Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !ExcludedFilePatterns.Any(ex => f.EndsWith(ex, StringComparison.OrdinalIgnoreCase)))
+            .Where(f => !f.Contains("obj", StringComparison.OrdinalIgnoreCase))
+            .Where(f => !f.Contains("bin", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var file in csFiles)
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (pattern.IsMatch(lines[i]))
+                {
+                    var relativePath = Path.GetRelativePath(srcRoot, file);
+                    violations.Add($"{relativePath}:{i + 1} — {lines[i].Trim()}");
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            $"Found {violations.Count} .ToLower() / .ToLowerInvariant() calls on .Value of domain primitives:\n" +
+            string.Join("\n", violations));
+    }
+
+    private static string FindSrcRoot()
+    {
+        // Walk up from the test assembly location to find the repo src/ directory.
+        var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        while (dir is not null)
+        {
+            var srcCandidate = Path.Combine(dir, "src");
+            if (Directory.Exists(srcCandidate) && File.Exists(Path.Combine(dir, "BotNexus.slnx")))
+                return srcCandidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not locate repository src/ root from test assembly location.");
+    }
+
+    // Matches: .Trim()) where .From( precedes it on the same line, covering patterns like:
+    //   AgentId.From(value.Trim())
+    //   AgentId.From(parts[0].Trim())
+    //   ConversationId.From(conversationId.Trim())
+    [GeneratedRegex(@"AgentId\.From\([^)]*\.Trim\(\)", RegexOptions.Compiled)]
+    private static partial Regex TrimBeforeAgentIdFrom();
+
+    [GeneratedRegex(@"SessionId\.From\([^)]*\.Trim\(\)", RegexOptions.Compiled)]
+    private static partial Regex TrimBeforeSessionIdFrom();
+
+    [GeneratedRegex(@"ConversationId\.From\([^)]*\.Trim\(\)", RegexOptions.Compiled)]
+    private static partial Regex TrimBeforeConversationIdFrom();
+
+    // Matches: .Value.ToLower() or .Value.ToLowerInvariant() on agentId/sessionId/conversationId
+    [GeneratedRegex(@"\.(AgentId|SessionId|ConversationId)\.Value\.(ToLower|ToLowerInvariant)\(\)", RegexOptions.Compiled)]
+    private static partial Regex ToLowerOnPrimitiveValue();
+}


### PR DESCRIPTION
Closes #940

## Changes

- Remove redundant `.Trim()` calls before `AgentId.From()`, `SessionId.From()`, `ConversationId.From()` at 5 call sites
- `GatewayHub.cs` lines 151, 197, 369: conversation ID trim removed (NormalizeInput handles it)
- `CrossWorldAgentReference.cs` line 36: agent ID trim removed
- `AgentSessionKey.cs` line 36: session ID trim removed
- Add `DomainPrimitiveNormalisationArchitectureTests.cs` with 2 enforcement rules:
  - No `.Trim()` inside `From()` calls for domain primitives
  - No `.ToLower()`/`.ToLowerInvariant()` on `.Value` of domain primitives

## Merge Notes

Fully independent of all open PRs. Safe to merge in any order.