### PR TITLE
feat(conversations): add pin/unpin support with sorted display ordering

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Conversation.cs
@@ -99,6 +99,12 @@ public sealed record Conversation
     /// </remarks>
     public ConversationKind Kind { get; set; } = ConversationKind.HumanAgent;
 
+    /// <summary>Gets or sets whether this conversation is pinned to the top of the list.</summary>
+    public bool IsPinned { get; set; }
+
+    /// <summary>Gets or sets when this conversation was pinned. Null if not pinned. Used for ordering among pinned conversations (most recently pinned first).</summary>
+    public DateTimeOffset? PinnedAt { get; set; }
+
     /// <summary>
     /// Gets or sets the citizens currently participating in this conversation. Populated as
     /// a side effect of inbound message routing and the agent-exchange handshake — see

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -93,7 +93,9 @@ public sealed class ConversationsController : ControllerBase
 
         var summaries = relevant
             .Where(c => c.Status == ConversationStatus.Active)
-            .OrderByDescending(c => c.UpdatedAt)
+            .OrderByDescending(c => c.IsPinned)
+            .ThenByDescending(c => c.PinnedAt)
+            .ThenByDescending(c => c.UpdatedAt)
             .ThenBy(c => c.ConversationId.Value, StringComparer.Ordinal)
             .Select(ToSummary)
             .ToList();
@@ -113,7 +115,9 @@ public sealed class ConversationsController : ControllerBase
             c.CreatedAt,
             c.UpdatedAt,
             c.Purpose,
-            c.Kind.ToString());
+            c.Kind.ToString(),
+            c.IsPinned,
+            c.PinnedAt);
 
     /// <summary>
     /// Gets a specific conversation by ID, including all channel bindings.
@@ -611,6 +615,32 @@ public sealed class ConversationsController : ControllerBase
             return NotFound();
         conversation.CanvasHtml = string.IsNullOrEmpty(html) ? null : html;
         await _conversations.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    /// <summary>Pins a conversation to the top of the list.</summary>
+    [HttpPost("{conversationId}/pin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Pin(string conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null) return NotFound();
+        await _conversations.PinAsync(ConversationId.From(conversationId), true, cancellationToken);
+        await NotifyConversationChangedBestEffortAsync("updated", conversation.AgentId.Value, conversationId, cancellationToken);
+        return NoContent();
+    }
+
+    /// <summary>Unpins a conversation from the top of the list.</summary>
+    [HttpDelete("{conversationId}/pin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Unpin(string conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null) return NotFound();
+        await _conversations.PinAsync(ConversationId.From(conversationId), false, cancellationToken);
+        await NotifyConversationChangedBestEffortAsync("updated", conversation.AgentId.Value, conversationId, cancellationToken);
         return NoContent();
     }
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/ConversationSummary.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/ConversationSummary.cs
@@ -29,4 +29,6 @@ public sealed record ConversationSummary(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt,
     string? Purpose = null,
-    string Kind = "HumanAgent");
+    string Kind = "HumanAgent",
+    bool IsPinned = false,
+    DateTimeOffset? PinnedAt = null);

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationStore.cs
@@ -138,6 +138,13 @@ public interface IConversationStore
     Task TouchAsync(ConversationId conversationId, CancellationToken ct = default);
 
     /// <summary>
+    /// Pins or unpins a conversation. When pinning, stamps PinnedAt to UtcNow.
+    /// When unpinning, clears IsPinned and PinnedAt.
+    /// Silently no-ops when the conversation does not exist.
+    /// </summary>
+    Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns lightweight summaries for all <em>active</em> conversations across the world,
     /// ordered most-recently-updated first.
     /// </summary>

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -174,6 +174,23 @@ public sealed class FileConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public async Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var conversation = await FindByConversationIdAsync(conversationId, ct).ConfigureAwait(false);
+            if (conversation is null)
+                return;
+            conversation.IsPinned = pin;
+            conversation.PinnedAt = pin ? DateTimeOffset.UtcNow : null;
+            conversation.UpdatedAt = DateTimeOffset.UtcNow;
+            await WriteFileAsync(conversation, ct).ConfigureAwait(false);
+        }
+        finally { _lock.Release(); }
+    }
+
+    /// <inheritdoc />
     public async Task AddParticipantsAsync(
         ConversationId conversationId,
         IEnumerable<SessionParticipant> participants,
@@ -246,7 +263,9 @@ public sealed class FileConversationStore : IConversationStore
         var all = await ListAsync(null, ct).ConfigureAwait(false);
         return [.. all
             .Where(c => c.Status != ConversationStatus.Archived)
-            .OrderByDescending(c => c.UpdatedAt)
+            .OrderByDescending(c => c.IsPinned)
+            .ThenByDescending(c => c.PinnedAt)
+            .ThenByDescending(c => c.UpdatedAt)
             .ThenBy(c => c.ConversationId.Value, StringComparer.Ordinal)
             .Select(ToSummary)];
     }
@@ -377,5 +396,7 @@ public sealed class FileConversationStore : IConversationStore
             c.CreatedAt,
             c.UpdatedAt,
             c.Purpose,
-            c.Kind.ToString());
+            c.Kind.ToString(),
+            c.IsPinned,
+            c.PinnedAt);
 }

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -117,6 +117,21 @@ public sealed class InMemoryConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default)
+    {
+        if (_conversations.TryGetValue(conversationId.Value, out var existing))
+        {
+            _conversations[conversationId.Value] = existing with
+            {
+                IsPinned = pin,
+                PinnedAt = pin ? DateTimeOffset.UtcNow : null,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     public async Task AddParticipantsAsync(
         ConversationId conversationId,
         IEnumerable<SessionParticipant> participants,
@@ -185,7 +200,9 @@ public sealed class InMemoryConversationStore : IConversationStore
         // Archived conversations are excluded from the active list.
         IReadOnlyList<ConversationSummary> summaries = [.. _conversations.Values
             .Where(c => c.Status != ConversationStatus.Archived)
-            .OrderByDescending(c => c.UpdatedAt)
+            .OrderByDescending(c => c.IsPinned)
+            .ThenByDescending(c => c.PinnedAt)
+            .ThenByDescending(c => c.UpdatedAt)
             .ThenBy(c => c.ConversationId.Value, StringComparer.Ordinal)
             .Select(ToSummary)];
         return Task.FromResult(summaries);
@@ -225,6 +242,8 @@ public sealed class InMemoryConversationStore : IConversationStore
             c.CreatedAt,
             c.UpdatedAt,
             c.Purpose,
-            c.Kind.ToString());
+            c.Kind.ToString(),
+            c.IsPinned,
+            c.PinnedAt);
 }
 

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -406,6 +406,53 @@ public sealed class SqliteConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public async Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default)
+    {
+        using var activity = ActivitySource.StartActivity("conversation.pin", ActivityKind.Internal);
+        activity?.SetTag("botnexus.conversation.id", conversationId.Value);
+        activity?.SetTag("botnexus.conversation.pin", pin);
+
+        await EnsureCreatedAsync(ct).ConfigureAwait(false);
+        var conversationLock = GetConversationLock(conversationId.Value);
+        await conversationLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var pinnedAt = pin ? now : (DateTimeOffset?)null;
+
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE conversations
+                SET is_pinned = $pin,
+                    pinned_at = $pinnedAt,
+                    updated_at = $now
+                WHERE id = $id
+                """;
+            command.Parameters.AddWithValue("$pin", pin ? 1 : 0);
+            command.Parameters.AddWithValue("$pinnedAt", pinnedAt.HasValue ? (object)pinnedAt.Value.ToString("O") : DBNull.Value);
+            command.Parameters.AddWithValue("$now", now.ToString("O"));
+            command.Parameters.AddWithValue("$id", conversationId.Value);
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            if (_cache.TryGetValue(conversationId.Value, out var cached))
+            {
+                var updated = CloneConversation(cached);
+                updated.IsPinned = pin;
+                updated.PinnedAt = pinnedAt;
+                updated.UpdatedAt = now;
+                _cache[conversationId.Value] = updated;
+            }
+        }
+        finally
+        {
+            conversationLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<Conversation?> ResolveByBindingAsync(
         AgentId agentId,
         ChannelKey channelType,
@@ -469,12 +516,14 @@ public sealed class SqliteConversationStore : IConversationStore
                 c.updated_at,
                 COUNT(b.binding_id),
                 c.instructions,
-                c.kind
+                c.kind,
+                c.is_pinned,
+                c.pinned_at
             FROM conversations c
             LEFT JOIN conversation_bindings b ON b.conversation_id = c.id
             WHERE c.status = 'Active'
-            GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions, c.kind
-            ORDER BY c.updated_at DESC
+            GROUP BY c.id, c.agent_id, c.title, c.purpose, c.is_default, c.status, c.active_session_id, c.created_at, c.updated_at, c.instructions, c.kind, c.is_pinned, c.pinned_at
+            ORDER BY c.is_pinned DESC, c.pinned_at DESC, c.updated_at DESC
             """;
 
         var summaries = new List<ConversationSummary>();
@@ -494,7 +543,9 @@ public sealed class SqliteConversationStore : IConversationStore
                 reader.IsDBNull(3) ? null : reader.GetString(3),
                 reader.FieldCount > 11 && !reader.IsDBNull(11)
                     ? reader.GetString(11)
-                    : ConversationKind.HumanAgent.ToString()));
+                    : ConversationKind.HumanAgent.ToString(),
+                reader.FieldCount > 12 && !reader.IsDBNull(12) && reader.GetInt64(12) != 0,
+                reader.FieldCount > 13 && !reader.IsDBNull(13) ? ParseTimestamp(reader.GetString(13)) : null));
         }
 
         return summaries;
@@ -570,6 +621,7 @@ public sealed class SqliteConversationStore : IConversationStore
             await EnsureInitiatorColumnAsync(connection, ct).ConfigureAwait(false);
             await EnsureKindColumnAsync(connection, ct).ConfigureAwait(false);
             await EnsureWorldIdColumnAsync(connection, ct).ConfigureAwait(false);
+            await EnsurePinColumnsAsync(connection, ct).ConfigureAwait(false);
             await MigrateThreadIdIntoChannelAddressAsync(connection, ct).ConfigureAwait(false);
 
             // One-time migration: archive stale signalr:connection-id conversations created
@@ -784,6 +836,40 @@ public sealed class SqliteConversationStore : IConversationStore
         }
     }
 
+    private static async Task EnsurePinColumnsAsync(SqliteConnection connection, CancellationToken ct)
+    {
+        await using var tableInfoCommand = connection.CreateCommand();
+        tableInfoCommand.CommandText = "PRAGMA table_info(conversations);";
+
+        var hasIsPinned = false;
+        var hasPinnedAt = false;
+        await using (var reader = await tableInfoCommand.ExecuteReaderAsync(ct).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                var name = reader.GetString(1);
+                if (string.Equals(name, "is_pinned", StringComparison.OrdinalIgnoreCase))
+                    hasIsPinned = true;
+                else if (string.Equals(name, "pinned_at", StringComparison.OrdinalIgnoreCase))
+                    hasPinnedAt = true;
+            }
+        }
+
+        if (!hasIsPinned)
+        {
+            await using var alterCommand = connection.CreateCommand();
+            alterCommand.CommandText = "ALTER TABLE conversations ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0";
+            await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        if (!hasPinnedAt)
+        {
+            await using var alterCommand = connection.CreateCommand();
+            alterCommand.CommandText = "ALTER TABLE conversations ADD COLUMN pinned_at TEXT";
+            await alterCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+    }
+
     // Migrates legacy conversation_bindings rows with a thread_id column into the composite
     // channel_address scheme adopted in PR #512 (refactor: drop ThreadId from core contracts).
     // Idempotent: if the thread_id column has already been dropped, the method is a no-op.
@@ -914,7 +1000,7 @@ public sealed class SqliteConversationStore : IConversationStore
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id
+            SELECT id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id, is_pinned, pinned_at
             FROM conversations
             WHERE id = $id
             """;
@@ -939,7 +1025,9 @@ public sealed class SqliteConversationStore : IConversationStore
             CanvasHtml = reader.FieldCount > 11 && !reader.IsDBNull(11) ? reader.GetString(11) : null,
             Initiator = reader.FieldCount > 12 ? DeserializeInitiator(reader.IsDBNull(12) ? null : reader.GetString(12)) : null,
             Kind = reader.FieldCount > 13 ? ParseConversationKind(reader.IsDBNull(13) ? null : reader.GetString(13)) : ConversationKind.HumanAgent,
-            WorldId = reader.FieldCount > 14 && !reader.IsDBNull(14) ? reader.GetString(14) : string.Empty
+            WorldId = reader.FieldCount > 14 && !reader.IsDBNull(14) ? reader.GetString(14) : string.Empty,
+            IsPinned = reader.FieldCount > 15 && !reader.IsDBNull(15) && reader.GetInt64(15) != 0,
+            PinnedAt = reader.FieldCount > 16 && !reader.IsDBNull(16) ? ParseTimestamp(reader.GetString(16)) : null
         };
         if (!reader.IsDBNull(6))
             conversation.ActiveSessionId = SessionId.From(reader.GetString(6));
@@ -1038,8 +1126,8 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Transaction = transaction;
         conversationCommand.CommandText = upsert
             ? """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind, $worldId)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id, is_pinned, pinned_at)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind, $worldId, $isPinned, $pinnedAt)
                 ON CONFLICT(id) DO UPDATE SET
                     agent_id = excluded.agent_id,
                     title = excluded.title,
@@ -1054,11 +1142,13 @@ public sealed class SqliteConversationStore : IConversationStore
                     canvas_html = excluded.canvas_html,
                     initiator = excluded.initiator,
                     kind = excluded.kind,
-                    world_id = excluded.world_id
+                    world_id = excluded.world_id,
+                    is_pinned = excluded.is_pinned,
+                    pinned_at = excluded.pinned_at
                 """
             : """
-                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id)
-                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind, $worldId)
+                INSERT INTO conversations (id, agent_id, title, purpose, is_default, status, active_session_id, metadata, created_at, updated_at, instructions, canvas_html, initiator, kind, world_id, is_pinned, pinned_at)
+                VALUES ($id, $agentId, $title, $purpose, $isDefault, $status, $activeSessionId, $metadata, $createdAt, $updatedAt, $instructions, $canvasHtml, $initiator, $kind, $worldId, $isPinned, $pinnedAt)
                 """;
         conversationCommand.Parameters.AddWithValue("$id", conversation.ConversationId.Value);
         conversationCommand.Parameters.AddWithValue("$agentId", conversation.AgentId.Value);
@@ -1075,6 +1165,8 @@ public sealed class SqliteConversationStore : IConversationStore
         conversationCommand.Parameters.AddWithValue("$initiator", (object?)SerializeInitiator(conversation.Initiator) ?? DBNull.Value);
         conversationCommand.Parameters.AddWithValue("$kind", conversation.Kind.ToString());
         conversationCommand.Parameters.AddWithValue("$worldId", conversation.WorldId ?? string.Empty);
+        conversationCommand.Parameters.AddWithValue("$isPinned", conversation.IsPinned ? 1 : 0);
+        conversationCommand.Parameters.AddWithValue("$pinnedAt", conversation.PinnedAt.HasValue ? (object)conversation.PinnedAt.Value.ToString("O") : DBNull.Value);
         await conversationCommand.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
 
         await using var deleteBindingsCommand = connection.CreateCommand();
@@ -1154,6 +1246,8 @@ public sealed class SqliteConversationStore : IConversationStore
             Initiator = conversation.Initiator,
             Kind = conversation.Kind,
             WorldId = conversation.WorldId,
+            IsPinned = conversation.IsPinned,
+            PinnedAt = conversation.PinnedAt,
             IsDefault = conversation.IsDefault,
             Status = conversation.Status,
             CreatedAt = conversation.CreatedAt,

--- a/src/gateway/BotNexus.Gateway/Conversations/ConversationRetentionHostedService.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/ConversationRetentionHostedService.cs
@@ -17,7 +17,7 @@ namespace BotNexus.Gateway.Conversations;
 /// must be <c>true</c> before any archiving occurs. Per-agent overrides can extend or
 /// reduce the window, or disable auto-archive entirely for a specific agent.
 /// </para>
-/// <para>Pinned conversations (once #780 is implemented) are always excluded.</para>
+/// <para>Pinned conversations are always excluded from auto-archive.</para>
 /// </summary>
 public sealed class ConversationRetentionHostedService(
     IConversationStore conversationStore,
@@ -143,12 +143,10 @@ public sealed class ConversationRetentionHostedService(
     }
 
     /// <summary>
-    /// Forward-compatible pin check. Always returns <c>false</c> until issue #780
-    /// (pin conversations) adds an <c>IsPinned</c> field to <see cref="Conversation"/>.
+    /// Returns <c>true</c> when the conversation is pinned and should be excluded from retention.
     /// </summary>
     private static bool IsConversationPinned(Conversation conversation) =>
-        // TODO(#780): return conversation.IsPinned once the field is added.
-        false;
+        conversation.IsPinned;
 
     private async Task NotifyBestEffortAsync(Conversation conv, CancellationToken cancellationToken)
     {

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationPinTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationPinTests.cs
@@ -1,0 +1,124 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Tests for conversation pinning behaviour in <see cref="SqliteConversationStore"/>.
+/// </summary>
+public sealed class ConversationPinTests
+{
+    private static AgentId Agent(string id) => AgentId.From(id);
+
+    private static Conversation CreateConversation(AgentId agentId, string title)
+        => new()
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = agentId,
+            Title = title,
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public async Task PinAsync_Sets_IsPinned_And_PinnedAt()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = CreateConversation(Agent("agent-a"), "Pin me");
+        await store.CreateAsync(conversation);
+
+        await store.PinAsync(conversation.ConversationId, true);
+
+        var loaded = await store.GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.IsPinned.ShouldBeTrue();
+        loaded.PinnedAt.ShouldNotBeNull();
+        loaded.PinnedAt!.Value.ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddMinutes(-1));
+    }
+
+    [Fact]
+    public async Task PinAsync_Unpin_Clears_IsPinned_And_PinnedAt()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var conversation = CreateConversation(Agent("agent-a"), "Unpin me");
+        await store.CreateAsync(conversation);
+
+        await store.PinAsync(conversation.ConversationId, true);
+        await store.PinAsync(conversation.ConversationId, false);
+
+        var loaded = await store.GetAsync(conversation.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.IsPinned.ShouldBeFalse();
+        loaded.PinnedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PinAsync_Nonexistent_Conversation_Noops()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        // Should not throw
+        await store.PinAsync(ConversationId.From("nonexistent-id"), true);
+    }
+
+    [Fact]
+    public async Task GetSummariesAsync_Orders_Pinned_First()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+
+        var unpinned = CreateConversation(Agent("agent-a"), "Unpinned");
+        unpinned.UpdatedAt = DateTimeOffset.UtcNow;
+        await store.CreateAsync(unpinned);
+
+        // Small delay to ensure ordering by updated_at is deterministic
+        await Task.Delay(50);
+
+        var pinned = CreateConversation(Agent("agent-a"), "Pinned");
+        pinned.UpdatedAt = DateTimeOffset.UtcNow.AddDays(-1); // older updated_at, but pinned
+        await store.CreateAsync(pinned);
+        await store.PinAsync(pinned.ConversationId, true);
+
+        var summaries = await store.GetSummariesAsync();
+        summaries.Count.ShouldBeGreaterThanOrEqualTo(2);
+
+        var pinnedSummary = summaries.First(s => s.ConversationId == pinned.ConversationId.Value);
+        var unpinnedSummary = summaries.First(s => s.ConversationId == unpinned.ConversationId.Value);
+
+        pinnedSummary.IsPinned.ShouldBeTrue();
+        pinnedSummary.PinnedAt.ShouldNotBeNull();
+        unpinnedSummary.IsPinned.ShouldBeFalse();
+
+        // Pinned should come first regardless of UpdatedAt
+        var pinnedIndex = summaries.ToList().IndexOf(pinnedSummary);
+        var unpinnedIndex = summaries.ToList().IndexOf(unpinnedSummary);
+        pinnedIndex.ShouldBeLessThan(unpinnedIndex);
+    }
+
+    [Fact]
+    public async Task ListForCitizenAsync_Includes_Pin_State()
+    {
+        using var fixture = new StoreFixture();
+        var store = fixture.CreateStore();
+        var agentId = Agent("agent-pin-list");
+        var conversation = CreateConversation(agentId, "Pinned citizen conv");
+        await store.CreateAsync(conversation);
+        await store.PinAsync(conversation.ConversationId, true);
+
+        var citizen = CitizenId.Of(agentId);
+        var results = await store.ListForCitizenAsync(citizen);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(1);
+        var loaded = results.First(c => c.ConversationId == conversation.ConversationId);
+        loaded.IsPinned.ShouldBeTrue();
+        loaded.PinnedAt.ShouldNotBeNull();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeArchiveTests.cs
@@ -579,6 +579,8 @@ public sealed class AgentExchangeArchiveTests
             => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
         public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
             => _inner.TouchAsync(conversationId, ct);
+        public Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default)
+            => _inner.PinAsync(conversationId, pin, ct);
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => _inner.GetSummariesAsync(ct);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Controllers/ConversationPinControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Controllers/ConversationPinControllerTests.cs
@@ -1,0 +1,121 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Tests.Controllers;
+
+/// <summary>
+/// Tests for conversation pin/unpin endpoints in <see cref="ConversationsController"/>.
+/// </summary>
+public sealed class ConversationPinControllerTests
+{
+    private static readonly AgentId TestAgent = AgentId.From("agent-pin-test");
+
+    private static Conversation CreateConversation(string id)
+        => new()
+        {
+            ConversationId = ConversationId.From(id),
+            AgentId = TestAgent,
+            Title = "Test",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+    private static ConversationsController CreateController(IConversationStore store)
+        => new(store, new InMemorySessionStore());
+
+    [Fact]
+    public async Task Pin_Returns_NoContent_And_Updates_Store()
+    {
+        var store = new InMemoryConversationStore();
+        var conversation = CreateConversation("conv-pin-1");
+        await store.CreateAsync(conversation);
+
+        var controller = CreateController(store);
+        var result = await controller.Pin("conv-pin-1", CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+
+        var loaded = await store.GetAsync(ConversationId.From("conv-pin-1"));
+        loaded.ShouldNotBeNull();
+        loaded!.IsPinned.ShouldBeTrue();
+        loaded.PinnedAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Pin_Nonexistent_Returns_NotFound()
+    {
+        var store = new InMemoryConversationStore();
+        var controller = CreateController(store);
+
+        var result = await controller.Pin("nonexistent", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Unpin_Returns_NoContent_And_Clears_Pin()
+    {
+        var store = new InMemoryConversationStore();
+        var conversation = CreateConversation("conv-unpin-1");
+        await store.CreateAsync(conversation);
+        await store.PinAsync(ConversationId.From("conv-unpin-1"), true);
+
+        var controller = CreateController(store);
+        var result = await controller.Unpin("conv-unpin-1", CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+
+        var loaded = await store.GetAsync(ConversationId.From("conv-unpin-1"));
+        loaded.ShouldNotBeNull();
+        loaded!.IsPinned.ShouldBeFalse();
+        loaded.PinnedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task List_Orders_Pinned_First()
+    {
+        var store = new InMemoryConversationStore();
+
+        var older = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-older"),
+            AgentId = TestAgent,
+            Title = "Older pinned",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-10),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-10)
+        };
+        await store.CreateAsync(older);
+        await store.PinAsync(ConversationId.From("conv-older"), true);
+
+        var newer = new Conversation
+        {
+            ConversationId = ConversationId.From("conv-newer"),
+            AgentId = TestAgent,
+            Title = "Newer unpinned",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        await store.CreateAsync(newer);
+
+        var controller = CreateController(store);
+        var result = await controller.List(TestAgent.Value, CancellationToken.None);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        var summaries = okResult.Value.ShouldBeAssignableTo<List<ConversationSummary>>();
+        summaries.ShouldNotBeNull();
+        summaries!.Count.ShouldBe(2);
+        summaries[0].ConversationId.ShouldBe("conv-older");
+        summaries[0].IsPinned.ShouldBeTrue();
+        summaries[1].ConversationId.ShouldBe("conv-newer");
+        summaries[1].IsPinned.ShouldBeFalse();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -301,6 +301,9 @@ public sealed class ConversationsControllerHistoryTests
         public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
             => Task.CompletedTask;
 
+        public Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default)
+            => Task.CompletedTask;
+
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => throw new NotSupportedException();
 

--- a/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CrossWorldFederationControllerTests.cs
@@ -1918,6 +1918,8 @@ file sealed class ThrowingArchiveConversationStore : IConversationStore
         => _inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
     public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default)
         => _inner.TouchAsync(conversationId, ct);
+    public Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default)
+        => _inner.PinAsync(conversationId, pin, ct);
     public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
         => _inner.GetSummariesAsync(ct);
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LegacyConversationBackfillTests.cs
@@ -800,6 +800,7 @@ public sealed class LegacyConversationBackfillTests
         public Task<Conversation?> ResolveByBindingAsync(AgentId agentId, ChannelKey channelType, ChannelAddress channelAddress, CancellationToken ct = default)
             => Inner.ResolveByBindingAsync(agentId, channelType, channelAddress, ct);
         public Task TouchAsync(ConversationId conversationId, CancellationToken ct = default) => Inner.TouchAsync(conversationId, ct);
+        public Task PinAsync(ConversationId conversationId, bool pin, CancellationToken ct = default) => Inner.PinAsync(conversationId, pin, ct);
         public Task<IReadOnlyList<ConversationSummary>> GetSummariesAsync(CancellationToken ct = default)
             => Inner.GetSummariesAsync(ct);
     }


### PR DESCRIPTION
Closes #780

## Changes

- Domain model: Added IsPinned (bool) and PinnedAt (DateTimeOffset?) to Conversation
- ConversationSummary: Extended with IsPinned and PinnedAt fields for portal consumption
- IConversationStore: Added PinAsync(ConversationId, bool, CancellationToken) contract
- SqliteConversationStore: Schema migration (ALTER TABLE ADD COLUMN), full read/write/pin implementation
- InMemoryConversationStore: Pin implementation
- FileConversationStore: Pin implementation
- ConversationsController: POST /api/conversations/{id}/pin and DELETE /api/conversations/{id}/pin endpoints; list ordering updated to pinned-first (PinnedAt desc), then unpinned (UpdatedAt desc)
- ConversationRetentionHostedService: Pinned conversations excluded from auto-archive
- Tests: 5 store-level pin tests + 4 controller-level pin tests

## Merge Notes

This PR is fully independent -- no file overlap with any open PR. Safe to merge in any order.

Portal UI (pin icon on hover, right-click context menu) is a follow-up -- this PR provides the data model + API surface.