### PR TITLE
feat(copilot): add CLI-fidelity request headers and response observability (Phase 5, #810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsOptions.cs
@@ -1,3 +1,5 @@
+using BotNexus.Agent.Providers.Core.Utilities;
+
 namespace BotNexus.Agent.Providers.Copilot.Completions;
 
 /// <summary>
@@ -18,4 +20,12 @@ public record class CopilotCompletionsOptions : BotNexus.Agent.Providers.Core.St
     /// Reasoning effort for reasoning-capable models: "low", "medium", "high".
     /// </summary>
     public string? ReasoningEffort { get; set; }
+
+    /// <summary>
+    /// Optional Copilot-CLI-fidelity request headers
+    /// (Copilot-Integration-Id, X-GitHub-Api-Version, Editor-Version,
+    /// X-Interaction-Id, intent override). When null, only the default
+    /// dynamic header set is emitted — preserving wire parity with previous releases.
+    /// </summary>
+    public CopilotHeaderOptions? HeaderOptions { get; set; }
 }

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
@@ -185,12 +185,15 @@ public sealed class CopilotCompletionsProvider(
         // this provider only handles Copilot-routed models, so the runtime check
         // present in the OpenAI parent is unnecessary.
         var copilotHasImages = CopilotHeaders.HasVisionInput(messages);
-        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(messages, copilotHasImages))
+        var copilotHeaderOptions = Headers.CopilotInteractionId.WithResolvedInteractionId(
+            (options as CopilotCompletionsOptions)?.HeaderOptions);
+        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(messages, copilotHasImages, copilotHeaderOptions))
             request.Headers.TryAddWithoutValidation(key, value);
 
         logger.LogDebug("Streaming {Model} from {Url}", model.Id, url);
 
         using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        Headers.CopilotResponseHeaders.EmitToActivity(response, Activity.Current);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Headers/CopilotInteractionId.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Headers/CopilotInteractionId.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Copilot.Headers;
+
+/// <summary>
+/// Resolves the <c>X-Interaction-Id</c> value a Copilot request should carry.
+/// Captures show the real Copilot CLI sends either a fresh GUID per call or
+/// the current trace context — never a reused id — so this helper deliberately
+/// generates a new value when no explicit override is supplied.
+/// </summary>
+public static class CopilotInteractionId
+{
+    /// <summary>
+    /// Return the explicit override if non-empty; otherwise prefer the
+    /// current <see cref="Activity"/> id (so the Copilot side correlates with
+    /// the local trace), and fall back to a fresh GUID when no Activity is
+    /// active.
+    /// </summary>
+    public static string Resolve(CopilotHeaderOptions? options)
+    {
+        if (!string.IsNullOrEmpty(options?.InteractionId))
+            return options!.InteractionId!;
+
+        var current = Activity.Current;
+        if (current is { Id.Length: > 0 } a)
+            return a.Id!;
+
+        return Guid.NewGuid().ToString("D");
+    }
+
+    /// <summary>
+    /// Return a copy of <paramref name="options"/> with
+    /// <see cref="CopilotHeaderOptions.InteractionId"/> populated. When
+    /// <paramref name="options"/> is null this returns null so the default
+    /// header set is preserved unchanged.
+    /// </summary>
+    public static CopilotHeaderOptions? WithResolvedInteractionId(CopilotHeaderOptions? options)
+    {
+        if (options is null)
+            return null;
+
+        if (!string.IsNullOrEmpty(options.InteractionId))
+            return options;
+
+        return options with { InteractionId = Resolve(options) };
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Headers/CopilotResponseHeaders.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Headers/CopilotResponseHeaders.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Http;
+
+namespace BotNexus.Agent.Providers.Copilot.Headers;
+
+/// <summary>
+/// Reads Copilot-specific response headers off an <see cref="HttpResponseMessage"/>
+/// and surfaces them as structured Activity tags. Designed to be called once
+/// per HTTP request, immediately after <c>SendAsync</c> returns and before any
+/// success-status check — so error responses still expose correlation IDs.
+/// </summary>
+/// <remarks>
+/// Captures of real Copilot CLI traffic show several headers we previously
+/// discarded:
+/// <list type="bullet">
+///   <item><c>x-copilot-service-request-id</c> — Copilot's own correlation GUID</item>
+///   <item><c>x-request-id</c> — front-door request id</item>
+///   <item><c>X-GitHub-Request-Id</c> — GitHub edge request id</item>
+///   <item><c>x-copilot-api-exp-assignment-context</c> — experiment assignments</item>
+///   <item><c>x-quota-snapshot-chat</c> / <c>-completions</c> / <c>-premium_interactions</c>
+///         — URL-encoded per-feature quota snapshot</item>
+/// </list>
+/// All values are emitted as Activity tags under the <c>botnexus.copilot.*</c>
+/// namespace. The quota snapshots are additionally parsed into individual
+/// numeric tags for the six well-known fields
+/// (<c>ent</c>, <c>ov</c>, <c>ovPerm</c>, <c>rem</c>, <c>rst</c>, <c>totRem</c>)
+/// while the raw header value is preserved alongside so future fields are not
+/// lost.
+/// </remarks>
+public static class CopilotResponseHeaders
+{
+    private const string TagPrefix = "botnexus.copilot.";
+
+    private static readonly (string Header, string Tag)[] CorrelationHeaders =
+    [
+        ("x-copilot-service-request-id", TagPrefix + "service_request_id"),
+        ("x-request-id", TagPrefix + "request_id"),
+        ("X-GitHub-Request-Id", TagPrefix + "github_request_id"),
+        ("x-copilot-api-exp-assignment-context", TagPrefix + "exp_assignment_context"),
+    ];
+
+    private static readonly (string Header, string Feature)[] QuotaHeaders =
+    [
+        ("x-quota-snapshot-chat", "chat"),
+        ("x-quota-snapshot-completions", "completions"),
+        ("x-quota-snapshot-premium_interactions", "premium_interactions"),
+    ];
+
+    /// <summary>
+    /// Read the recognised Copilot response headers from <paramref name="response"/>
+    /// and attach them as tags to <paramref name="activity"/>. Silently no-ops
+    /// when either argument is null or the headers are missing.
+    /// </summary>
+    public static void EmitToActivity(HttpResponseMessage response, Activity? activity)
+    {
+        if (response is null || activity is null)
+            return;
+
+        foreach (var (header, tag) in CorrelationHeaders)
+        {
+            if (TryGetSingle(response, header, out var value))
+                activity.SetTag(tag, value);
+        }
+
+        foreach (var (header, feature) in QuotaHeaders)
+        {
+            if (!TryGetSingle(response, header, out var raw))
+                continue;
+
+            // Preserve the raw value so any new fields Copilot adds remain visible.
+            activity.SetTag(TagPrefix + "quota." + feature + ".raw", raw);
+
+            foreach (var (key, parsedValue) in ParseQuotaSnapshot(raw))
+            {
+                activity.SetTag(TagPrefix + "quota." + feature + "." + key, parsedValue);
+            }
+        }
+    }
+
+    private static bool TryGetSingle(HttpResponseMessage response, string name, out string value)
+    {
+        if (response.Headers.TryGetValues(name, out var values))
+        {
+            value = string.Join(",", values);
+            return !string.IsNullOrEmpty(value);
+        }
+
+        if (response.Content?.Headers is not null
+            && response.Content.Headers.TryGetValues(name, out var contentValues))
+        {
+            value = string.Join(",", contentValues);
+            return !string.IsNullOrEmpty(value);
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Parse a URL-encoded quota snapshot value, e.g.
+    /// <c>ent=-1&amp;ov=0.0&amp;ovPerm=false&amp;rem=100.0&amp;rst=2026-07-01T00:00:00Z&amp;totRem=-1</c>,
+    /// into a sequence of (key, typed value) pairs. Numbers are returned as
+    /// <see cref="double"/>, booleans as <see cref="bool"/>, everything else as
+    /// the decoded <see cref="string"/>.
+    /// </summary>
+    internal static IEnumerable<KeyValuePair<string, object>> ParseQuotaSnapshot(string raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+            yield break;
+
+        foreach (var pair in raw.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq <= 0)
+                continue;
+
+            var key = pair.Substring(0, eq);
+            var rawValue = Uri.UnescapeDataString(pair.Substring(eq + 1));
+            yield return new KeyValuePair<string, object>(key, Coerce(rawValue));
+        }
+    }
+
+    private static object Coerce(string value)
+    {
+        if (bool.TryParse(value, out var b))
+            return b;
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d))
+            return d;
+        return value;
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesOptions.cs
@@ -1,3 +1,5 @@
+using BotNexus.Agent.Providers.Core.Utilities;
+
 namespace BotNexus.Agent.Providers.Copilot.Messages;
 
 /// <summary>
@@ -26,4 +28,13 @@ public record class CopilotMessagesOptions : Core.StreamOptions
     /// or an Anthropic-shaped tool_choice object.
     /// </summary>
     public object? ToolChoice { get; set; }
+
+    /// <summary>
+    /// Optional Copilot-CLI-fidelity request headers
+    /// (Copilot-Integration-Id, X-GitHub-Api-Version, Editor-Version,
+    /// X-Interaction-Id, intent override). When null, only the default
+    /// dynamic header set (X-Initiator, Openai-Intent, Copilot-Vision-Request)
+    /// is emitted — preserving wire parity with previous releases.
+    /// </summary>
+    public CopilotHeaderOptions? HeaderOptions { get; set; }
 }

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
@@ -179,7 +179,8 @@ public sealed partial class CopilotMessagesProvider(HttpClient httpClient) : IAp
 
         // Copilot transport always applies the dynamic vision/intent headers.
         var hasImages = CopilotHeaders.HasVisionInput(context.Messages);
-        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(context.Messages, hasImages))
+        var headerOptions = Headers.CopilotInteractionId.WithResolvedInteractionId(copilotOpts?.HeaderOptions);
+        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(context.Messages, hasImages, headerOptions))
             httpRequest.Headers.TryAddWithoutValidation(key, value);
 
         var setupTimeoutMs = options?.StreamSetupTimeoutMs ?? 0;
@@ -193,6 +194,10 @@ public sealed partial class CopilotMessagesProvider(HttpClient httpClient) : IAp
 
         using var response = await _httpClient.SendAsync(
             httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveCt);
+
+        // Surface Copilot response correlation IDs + quota snapshots before the
+        // success check so error responses are still observable.
+        Headers.CopilotResponseHeaders.EmitToActivity(response, Activity.Current);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesOptions.cs
@@ -1,3 +1,5 @@
+using BotNexus.Agent.Providers.Core.Utilities;
+
 namespace BotNexus.Agent.Providers.Copilot.Responses;
 
 /// <summary>
@@ -13,4 +15,12 @@ public record class CopilotResponsesOptions : BotNexus.Agent.Providers.Core.Stre
     public string? ReasoningSummary { get; set; }
     public string? PreviousResponseId { get; set; }
     public string? ServiceTier { get; set; }
+
+    /// <summary>
+    /// Optional Copilot-CLI-fidelity request headers
+    /// (Copilot-Integration-Id, X-GitHub-Api-Version, Editor-Version,
+    /// X-Interaction-Id, intent override). When null, only the default
+    /// dynamic header set is emitted — preserving wire parity with previous releases.
+    /// </summary>
+    public CopilotHeaderOptions? HeaderOptions { get; set; }
 }

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
@@ -122,7 +122,9 @@ public sealed class CopilotResponsesProvider(
         // this provider only handles Copilot-routed models, so the runtime check
         // present in the OpenAI parent is unnecessary.
         var copilotHasImages = CopilotHeaders.HasVisionInput(context.Messages);
-        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(context.Messages, copilotHasImages))
+        var copilotHeaderOptions = Headers.CopilotInteractionId.WithResolvedInteractionId(
+            (options as CopilotResponsesOptions)?.HeaderOptions);
+        foreach (var (key, value) in CopilotHeaders.BuildDynamicHeaders(context.Messages, copilotHasImages, copilotHeaderOptions))
             request.Headers.TryAddWithoutValidation(key, value);
 
         if (options?.Headers is not null)
@@ -132,6 +134,7 @@ public sealed class CopilotResponsesProvider(
         }
 
         using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        Headers.CopilotResponseHeaders.EmitToActivity(response, Activity.Current);
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(ct);

--- a/src/agent/BotNexus.Agent.Providers.Core/Utilities/CopilotHeaderOptions.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Utilities/CopilotHeaderOptions.cs
@@ -1,0 +1,40 @@
+namespace BotNexus.Agent.Providers.Core.Utilities;
+
+/// <summary>
+/// Optional extra Copilot request headers a caller can supply alongside the
+/// always-on dynamic headers (X-Initiator, Openai-Intent, Copilot-Vision-Request).
+/// </summary>
+/// <remarks>
+/// All properties are nullable. A null value means "do not emit this header,"
+/// preserving the current wire shape for callers that do not opt in. This
+/// keeps the existing parity tests green while letting newer call sites
+/// surface higher-fidelity headers captured from the real Copilot CLI.
+/// </remarks>
+/// <param name="IntegrationId">
+/// Value for <c>Copilot-Integration-Id</c>. Real Copilot CLI traffic uses
+/// <c>copilot-developer-cli</c>; the VS Code chat client uses <c>vscode-chat</c>.
+/// Empty/null = not sent.
+/// </param>
+/// <param name="ApiVersion">
+/// Value for <c>X-GitHub-Api-Version</c>, e.g. <c>2026-06-01</c>. Empty/null = not sent.
+/// </param>
+/// <param name="EditorVersion">
+/// Value for <c>Editor-Version</c>, e.g. <c>BotNexus/0.1.0</c>. Empty/null = not sent.
+/// </param>
+/// <param name="InteractionId">
+/// Value for <c>X-Interaction-Id</c>. When null and any of the other extra
+/// headers are emitted, callers should generate a per-call correlation id
+/// rather than re-using a single value across requests.
+/// </param>
+/// <param name="IntentOverride">
+/// Overrides the default <c>Openai-Intent</c> value. Captures show the
+/// Copilot CLI varies this per call (e.g. <c>conversation-agent</c>,
+/// <c>conversation-background</c>). When null, the default <c>conversation-edits</c>
+/// is preserved for backward compatibility.
+/// </param>
+public sealed record CopilotHeaderOptions(
+    string? IntegrationId = null,
+    string? ApiVersion = null,
+    string? EditorVersion = null,
+    string? InteractionId = null,
+    string? IntentOverride = null);

--- a/src/agent/BotNexus.Agent.Providers.Core/Utilities/CopilotHeaders.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Utilities/CopilotHeaders.cs
@@ -48,17 +48,44 @@ public static class CopilotHeaders
     /// </summary>
     public static Dictionary<string, string> BuildDynamicHeaders(
         IReadOnlyList<Message> messages, bool hasImages)
+        => BuildDynamicHeaders(messages, hasImages, options: null);
+
+    /// <summary>
+    /// Build dynamic headers for Copilot requests, optionally including the
+    /// higher-fidelity Copilot CLI headers (Copilot-Integration-Id,
+    /// X-GitHub-Api-Version, X-Interaction-Id, Editor-Version) when
+    /// <paramref name="options"/> populates them. Passing <c>null</c>
+    /// preserves the original three-header behaviour byte-for-byte.
+    /// </summary>
+    public static Dictionary<string, string> BuildDynamicHeaders(
+        IReadOnlyList<Message> messages,
+        bool hasImages,
+        CopilotHeaderOptions? options)
     {
-        var headers = new Dictionary<string, string>
+        var headers = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["X-Initiator"] = InferInitiator(messages),
-            ["Openai-Intent"] = "conversation-edits"
+            ["Openai-Intent"] = !string.IsNullOrEmpty(options?.IntentOverride)
+                ? options!.IntentOverride!
+                : "conversation-edits"
         };
 
         if (hasImages)
         {
             headers["Copilot-Vision-Request"] = "true";
         }
+
+        if (options is null)
+            return headers;
+
+        if (!string.IsNullOrEmpty(options.IntegrationId))
+            headers["Copilot-Integration-Id"] = options.IntegrationId!;
+        if (!string.IsNullOrEmpty(options.ApiVersion))
+            headers["X-GitHub-Api-Version"] = options.ApiVersion!;
+        if (!string.IsNullOrEmpty(options.EditorVersion))
+            headers["Editor-Version"] = options.EditorVersion!;
+        if (!string.IsNullOrEmpty(options.InteractionId))
+            headers["X-Interaction-Id"] = options.InteractionId!;
 
         return headers;
     }

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Headers/CopilotHeaderOptionsTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Headers/CopilotHeaderOptionsTests.cs
@@ -1,0 +1,84 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Headers;
+
+/// <summary>
+/// Pins the behaviour of <see cref="CopilotHeaders.BuildDynamicHeaders(System.Collections.Generic.IReadOnlyList{Message}, bool, CopilotHeaderOptions?)"/>
+/// — both the wire-parity-preserving default path and the opt-in
+/// Copilot-CLI-fidelity overload (Phase 5 of the carve-out, #810).
+/// </summary>
+public class CopilotHeaderOptionsTests
+{
+    private static IReadOnlyList<Message> UserMessage() =>
+        [new UserMessage("hi", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())];
+
+    [Fact]
+    public void NullOptions_EmitsOnlyLegacyHeaderSet()
+    {
+        var headers = CopilotHeaders.BuildDynamicHeaders(UserMessage(), hasImages: false, options: null);
+
+        headers.Keys.OrderBy(k => k, StringComparer.Ordinal).ShouldBe(
+            ["Openai-Intent", "X-Initiator"]);
+        headers["Openai-Intent"].ShouldBe("conversation-edits");
+        headers["X-Initiator"].ShouldBe("user");
+    }
+
+    [Fact]
+    public void NullOptions_AndImages_AddsCopilotVisionRequest()
+    {
+        var headers = CopilotHeaders.BuildDynamicHeaders(UserMessage(), hasImages: true, options: null);
+
+        headers["Copilot-Vision-Request"].ShouldBe("true");
+        headers.ShouldNotContainKey("Copilot-Integration-Id");
+    }
+
+    [Fact]
+    public void OptionsPopulated_EmitsExtraCopilotCliHeaders()
+    {
+        var options = new CopilotHeaderOptions(
+            IntegrationId: "copilot-developer-cli",
+            ApiVersion: "2026-06-01",
+            EditorVersion: "BotNexus/0.1.0",
+            InteractionId: "00000000-0000-0000-0000-000000000001");
+
+        var headers = CopilotHeaders.BuildDynamicHeaders(UserMessage(), hasImages: false, options);
+
+        headers["Copilot-Integration-Id"].ShouldBe("copilot-developer-cli");
+        headers["X-GitHub-Api-Version"].ShouldBe("2026-06-01");
+        headers["Editor-Version"].ShouldBe("BotNexus/0.1.0");
+        headers["X-Interaction-Id"].ShouldBe("00000000-0000-0000-0000-000000000001");
+        // Legacy header set still present.
+        headers["X-Initiator"].ShouldBe("user");
+        headers["Openai-Intent"].ShouldBe("conversation-edits");
+    }
+
+    [Fact]
+    public void IntentOverride_ReplacesDefaultOpenaiIntent()
+    {
+        var options = new CopilotHeaderOptions(IntentOverride: "conversation-agent");
+
+        var headers = CopilotHeaders.BuildDynamicHeaders(UserMessage(), hasImages: false, options);
+
+        headers["Openai-Intent"].ShouldBe("conversation-agent");
+    }
+
+    [Fact]
+    public void EmptyStringFields_AreNotEmitted()
+    {
+        var options = new CopilotHeaderOptions(
+            IntegrationId: "",
+            ApiVersion: "",
+            EditorVersion: "",
+            InteractionId: "",
+            IntentOverride: "");
+
+        var headers = CopilotHeaders.BuildDynamicHeaders(UserMessage(), hasImages: false, options);
+
+        headers.ShouldNotContainKey("Copilot-Integration-Id");
+        headers.ShouldNotContainKey("X-GitHub-Api-Version");
+        headers.ShouldNotContainKey("Editor-Version");
+        headers.ShouldNotContainKey("X-Interaction-Id");
+        headers["Openai-Intent"].ShouldBe("conversation-edits"); // empty override → default
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Headers/CopilotInteractionIdTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Headers/CopilotInteractionIdTests.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics;
+using BotNexus.Agent.Providers.Copilot.Headers;
+using BotNexus.Agent.Providers.Core.Utilities;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Headers;
+
+/// <summary>
+/// Pins <see cref="CopilotInteractionId"/>'s precedence rules:
+/// explicit override &gt; current trace id &gt; fresh GUID. The "never reuse"
+/// invariant — captures show the real Copilot CLI never sends the same
+/// X-Interaction-Id twice — is verified by issuing two resolves without a
+/// trace context and asserting the values differ.
+/// </summary>
+public class CopilotInteractionIdTests
+{
+    [Fact]
+    public void Resolve_NullOptions_AndNoActivity_ReturnsFreshGuidEachCall()
+    {
+        var previous = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            var a = CopilotInteractionId.Resolve(options: null);
+            var b = CopilotInteractionId.Resolve(options: null);
+
+            Guid.TryParseExact(a, "D", out _).ShouldBeTrue();
+            Guid.TryParseExact(b, "D", out _).ShouldBeTrue();
+            a.ShouldNotBe(b);
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    [Fact]
+    public void Resolve_PrefersExplicitOverride()
+    {
+        var options = new CopilotHeaderOptions(InteractionId: "00000000-0000-0000-0000-00000000ffff");
+
+        var resolved = CopilotInteractionId.Resolve(options);
+
+        resolved.ShouldBe("00000000-0000-0000-0000-00000000ffff");
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToActivityIdWhenAvailable()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var source = new ActivitySource("BotNexus.Test.InteractionId");
+        using var activity = source.StartActivity("test", ActivityKind.Client)!;
+        activity.ShouldNotBeNull();
+
+        var resolved = CopilotInteractionId.Resolve(options: null);
+
+        resolved.ShouldBe(activity.Id);
+    }
+
+    [Fact]
+    public void WithResolvedInteractionId_NullOptions_ReturnsNull()
+    {
+        CopilotInteractionId.WithResolvedInteractionId(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void WithResolvedInteractionId_PopulatesInteractionIdOnExistingOptions()
+    {
+        var previous = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            var options = new CopilotHeaderOptions(IntegrationId: "copilot-developer-cli");
+
+            var updated = CopilotInteractionId.WithResolvedInteractionId(options);
+
+            updated.ShouldNotBeNull();
+            updated!.IntegrationId.ShouldBe("copilot-developer-cli");
+            updated.InteractionId.ShouldNotBeNullOrEmpty();
+            Guid.TryParseExact(updated.InteractionId!, "D", out _).ShouldBeTrue();
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Headers/CopilotResponseHeadersTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Headers/CopilotResponseHeadersTests.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using BotNexus.Agent.Providers.Copilot.Headers;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Headers;
+
+/// <summary>
+/// Pins <see cref="CopilotResponseHeaders.EmitToActivity"/> against the
+/// header shape observed in real Copilot CLI captures (mitm flows captured
+/// against both Anthropic-flavour and OpenAI-flavour endpoints, Phase 5 / #810).
+/// </summary>
+public class CopilotResponseHeadersTests
+{
+    [Fact]
+    public void EmitToActivity_PopulatesCorrelationAndQuotaTags()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource("BotNexus.Test.CopilotResponseHeaders");
+        using var activity = source.StartActivity("test", ActivityKind.Client)!;
+        activity.ShouldNotBeNull();
+
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("")
+        };
+        response.Headers.TryAddWithoutValidation("x-copilot-service-request-id", "00000000-0000-0000-0000-0000000000aa");
+        response.Headers.TryAddWithoutValidation("x-request-id", "00000-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        response.Headers.TryAddWithoutValidation("X-GitHub-Request-Id", "AAAA:BBBB:CCCCCCC:DDDDDDD:11111111");
+        response.Headers.TryAddWithoutValidation("x-copilot-api-exp-assignment-context",
+            "e1aaaa1234:1100000;c_x1bbb2345:1200000;");
+        response.Headers.TryAddWithoutValidation("x-quota-snapshot-chat",
+            "ent=-1&ov=0.0&ovPerm=false&rem=100.0&rst=2099-01-01T00%3A00%3A00Z&totRem=-1");
+        response.Headers.TryAddWithoutValidation("x-quota-snapshot-completions",
+            "ent=-1&ov=0.0&ovPerm=false&rem=95.5&rst=2099-01-01T00%3A00%3A00Z&totRem=-1");
+        response.Headers.TryAddWithoutValidation("x-quota-snapshot-premium_interactions",
+            "ent=-1&ov=0.0&ovPerm=true&rem=100.0&rst=2099-01-01T00%3A00%3A00Z&totRem=-1");
+
+        CopilotResponseHeaders.EmitToActivity(response, activity);
+
+        var tags = activity.TagObjects.ToDictionary(t => t.Key, t => t.Value!);
+        tags["botnexus.copilot.service_request_id"].ShouldBe("00000000-0000-0000-0000-0000000000aa");
+        tags["botnexus.copilot.request_id"].ShouldBe("00000-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        tags["botnexus.copilot.github_request_id"].ShouldBe("AAAA:BBBB:CCCCCCC:DDDDDDD:11111111");
+        tags["botnexus.copilot.exp_assignment_context"].ShouldBe("e1aaaa1234:1100000;c_x1bbb2345:1200000;");
+
+        tags["botnexus.copilot.quota.chat.raw"].ShouldNotBeNull();
+        tags["botnexus.copilot.quota.chat.rem"].ShouldBe(100.0);
+        tags["botnexus.copilot.quota.chat.ovPerm"].ShouldBe(false);
+        tags["botnexus.copilot.quota.chat.ent"].ShouldBe(-1.0);
+        tags["botnexus.copilot.quota.chat.totRem"].ShouldBe(-1.0);
+        tags["botnexus.copilot.quota.chat.rst"].ShouldBe("2099-01-01T00:00:00Z");
+        tags["botnexus.copilot.quota.completions.rem"].ShouldBe(95.5);
+        tags["botnexus.copilot.quota.premium_interactions.ovPerm"].ShouldBe(true);
+    }
+
+    [Fact]
+    public void EmitToActivity_NullActivity_DoesNotThrow()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("")
+        };
+        response.Headers.TryAddWithoutValidation("x-request-id", "x");
+
+        Should.NotThrow(() => CopilotResponseHeaders.EmitToActivity(response, null));
+    }
+
+    [Fact]
+    public void EmitToActivity_MissingHeaders_LeavesActivityUntouched()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var source = new ActivitySource("BotNexus.Test.CopilotResponseHeaders.Empty");
+        using var activity = source.StartActivity("test", ActivityKind.Client)!;
+        activity.ShouldNotBeNull();
+
+        using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("") };
+
+        CopilotResponseHeaders.EmitToActivity(response, activity);
+
+        activity.TagObjects.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Phase 5 — Copilot CLI-fidelity request headers + response observability (#810)

Adds two **opt-in** observability surfaces without breaking wire parity for existing callers.

### What this adds

#### Request headers
- New `CopilotHeaderOptions` record (in `Providers.Core.Utilities`, next to `CopilotHeaders`) carries the higher-fidelity headers captured from real Copilot CLI traffic:
  - `Copilot-Integration-Id` (e.g. `copilot-developer-cli`)
  - `X-GitHub-Api-Version` (e.g. `2026-06-01`)
  - `Editor-Version` (e.g. `BotNexus/0.1.0`)
  - `X-Interaction-Id` (per-call correlation id)
  - `IntentOverride` (overrides default `Openai-Intent: conversation-edits`)
- `BuildDynamicHeaders` gains an overload that consumes the record; passing `null` keeps the existing three-header output byte-for-byte.
- New `CopilotInteractionId` resolver picks an explicit override -> the current `Activity` id -> a fresh GUID, so callers never reuse the same `X-Interaction-Id` across requests (matches CLI capture behaviour).

#### Response observability
- New `CopilotResponseHeaders.EmitToActivity` reads Copilot-specific response headers and attaches them as `botnexus.copilot.*` Activity tags:
  - `x-copilot-service-request-id`, `x-request-id`, `X-GitHub-Request-Id`, `x-copilot-api-exp-assignment-context`
  - `x-quota-snapshot-chat` / `-completions` / `-premium_interactions` (URL-encoded per-feature quota snapshots)
- Quota snapshots are parsed into typed fields (`ent`, `ov`, `ovPerm`, `rem`, `rst`, `totRem`) and the **raw** header value is preserved alongside so future Copilot-added fields are not lost.

#### Wiring
- All three carved-out providers (`Messages`, `Responses`, `Completions`) thread `HeaderOptions` through their options record.
- Each provider calls `EmitToActivity` immediately after `SendAsync` **and before the success check**, so error responses still expose correlation IDs.

### Deployment safety (S2)

When callers do not populate `HeaderOptions`, only the legacy `X-Initiator` + `Openai-Intent` + `Copilot-Vision-Request` set is emitted. The wire-parity tests from #886 / #944 stay green untouched.

### Tests

14 new tests, all passing:
- `CopilotHeaderOptionsTests` — null/empty/populated/intent-override paths against the new overload (5 tests).
- `CopilotResponseHeadersTests` — populates correlation + quota tags, null-activity no-op, missing-headers no-op (3 tests).
- `CopilotInteractionIdTests` — fresh GUID per call, explicit override, Activity.Current fallback, WithResolvedInteractionId behaviour (5 tests).
- Plus 1 baseline from the existing `CopilotHeadersIntegrationTests` (unchanged).

### Validation

- `dotnet build BotNexus.slnx --nologo --tl:off`: **0 warnings, 0 errors**
- `scripts/repo/test-impacted.ps1 -NoBuild`: **all green** except the pre-existing `GatewayProcessManagerTests.GetStatusAsync_WhenRunning_ReturnsPidAndUptime` PID-recycle flake (confirmed on `main`, unrelated to this change).
- Parity tests (`CopilotMessages/Responses/CompletionsProviderParityTests` + `CopilotRequestSnapshotTests` + `CopilotGatewayRoutingTests`): all 19 still pass.

### Deferred to Phase 5B

- `copilot_usage` body parsing (`total_nano_aiu` + token_details by type). Needs a hook in `Providers.Core.OpenAIStreamProcessor` for the Completions path and deserves its own design review.
- Flipping defaults to emit the new headers always (a follow-up after this lands).

Refs #810