### PR TITLE
feat(gateway): add log diagnostics ring buffer and REST endpoint for pattern monitoring

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
@@ -1,16 +1,20 @@
+using BotNexus.Gateway.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BotNexus.Gateway.Api.Controllers;
 
 /// <summary>
-/// Lightweight diagnostics endpoint for channel-side error reports.
+/// Lightweight diagnostics endpoint for channel-side error reports and log pattern monitoring.
 /// Authenticated by <see cref="GatewayAuthMiddleware"/> (same as all other /api/* endpoints).
 /// </summary>
 [ApiController]
 [Route("api/diagnostics")]
-public sealed class DiagnosticsController(ILogger<DiagnosticsController> logger) : ControllerBase
+public sealed class DiagnosticsController(
+    ILogger<DiagnosticsController> logger,
+    LogDiagnosticsRingBuffer? logBuffer = null) : ControllerBase
 {
     private readonly ILogger<DiagnosticsController> _logger = logger;
+    private readonly LogDiagnosticsRingBuffer? _logBuffer = logBuffer;
 
     /// <summary>
     /// Accepts an error report from any channel adapter and logs it at Error level.
@@ -37,10 +41,104 @@ public sealed class DiagnosticsController(ILogger<DiagnosticsController> logger)
     }
 
     /// <summary>
+    /// Returns deduplicated Warning/Error log patterns observed within a time window.
+    /// </summary>
+    /// <param name="hours">Time window in hours (default 24, max 168).</param>
+    /// <param name="page">Zero-based page number (default 0).</param>
+    /// <param name="pageSize">Results per page (default 50, max 200).</param>
+    [HttpGet("log-patterns")]
+    public IActionResult GetLogPatterns(
+        [FromQuery] int hours = 24,
+        [FromQuery] int page = 0,
+        [FromQuery] int pageSize = 50)
+    {
+        if (_logBuffer is null)
+            return NotFound("Log diagnostics not enabled.");
+
+        hours = Math.Clamp(hours, 1, 168);
+        page = Math.Max(page, 0);
+        pageSize = Math.Clamp(pageSize, 1, 200);
+
+        var patterns = _logBuffer.GetPatterns(TimeSpan.FromHours(hours));
+        var total = patterns.Count;
+        var paged = patterns
+            .Skip(page * pageSize)
+            .Take(pageSize)
+            .Select(p => new LogPatternDto
+            {
+                Fingerprint = p.Fingerprint,
+                Template = p.Template,
+                Severity = p.Severity.ToString(),
+                Count = p.Count,
+                FirstSeen = p.FirstSeen,
+                LastSeen = p.LastSeen,
+                SampleMessage = p.SampleMessage
+            })
+            .ToList();
+
+        return Ok(new LogPatternsResponse
+        {
+            Patterns = paged,
+            Total = total,
+            Page = page,
+            PageSize = pageSize,
+            Hours = hours
+        });
+    }
+
+    /// <summary>
     /// Strips newline and carriage-return characters from a user-supplied string to prevent
     /// log injection (CodeQL: cs/log-forging). Null-safe.
     /// </summary>
     private static string? Sanitise(string? value) =>
         value?.Replace("\r", string.Empty, StringComparison.Ordinal)
               .Replace("\n", " ", StringComparison.Ordinal);
+}
+
+/// <summary>
+/// DTO for a single log pattern returned by the log-patterns endpoint.
+/// </summary>
+public sealed class LogPatternDto
+{
+    /// <summary>Stable fingerprint derived from the message template hash.</summary>
+    public required string Fingerprint { get; init; }
+
+    /// <summary>The original message template (e.g., "Failed for {SessionId}").</summary>
+    public required string Template { get; init; }
+
+    /// <summary>Log severity level (Warning, Error, Critical).</summary>
+    public required string Severity { get; init; }
+
+    /// <summary>Number of times this pattern has been observed in the window.</summary>
+    public required int Count { get; init; }
+
+    /// <summary>Timestamp of the first observation.</summary>
+    public required DateTimeOffset FirstSeen { get; init; }
+
+    /// <summary>Timestamp of the most recent observation.</summary>
+    public required DateTimeOffset LastSeen { get; init; }
+
+    /// <summary>A sample rendered message from the first observation (truncated to 500 chars).</summary>
+    public required string SampleMessage { get; init; }
+}
+
+/// <summary>
+/// Response wrapper for paginated log patterns.
+/// </summary>
+public sealed class LogPatternsResponse
+{
+    /// <summary>The page of patterns matching the query.</summary>
+    public required IReadOnlyList<LogPatternDto> Patterns { get; init; }
+
+    /// <summary>Total number of patterns matching the time window.</summary>
+    public required int Total { get; init; }
+
+    /// <summary>Zero-based page number.</summary>
+    public required int Page { get; init; }
+
+    /// <summary>Results per page.</summary>
+    public required int PageSize { get; init; }
+
+    /// <summary>Time window in hours that was queried.</summary>
+    public required int Hours { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -1,4 +1,4 @@
-﻿using BotNexus.Gateway.Api.Extensions;
+using BotNexus.Gateway.Api.Extensions;
 using BotNexus.Gateway.Api;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Channels;
@@ -329,6 +329,10 @@ using (var bootstrapLoggerFactory = new Serilog.Extensions.Logging.SerilogLogger
             .LogWarning("Some extensions failed to load during startup bootstrap: {FailedExtensions}", failed);
     }
 }
+
+// Log diagnostics: capture Warning+ entries into an in-memory ring buffer for the log-patterns API.
+builder.Services.AddSingleton<BotNexus.Gateway.Diagnostics.LogDiagnosticsRingBuffer>();
+builder.Services.AddSingleton<ILoggerProvider, BotNexus.Gateway.Diagnostics.LogDiagnosticsProvider>();
 
 var app = builder.Build();
 

--- a/src/gateway/BotNexus.Gateway/Diagnostics/LogDiagnosticsProvider.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/LogDiagnosticsProvider.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Custom ILoggerProvider that captures Warning+ log entries into a <see cref="LogDiagnosticsRingBuffer"/>.
+/// </summary>
+[ProviderAlias("LogDiagnostics")]
+public sealed class LogDiagnosticsProvider : ILoggerProvider
+{
+    private readonly LogDiagnosticsRingBuffer _buffer;
+
+    public LogDiagnosticsProvider(LogDiagnosticsRingBuffer buffer)
+    {
+        _buffer = buffer;
+    }
+
+    public ILogger CreateLogger(string categoryName) => new LogDiagnosticsLogger(_buffer);
+
+    public void Dispose()
+    {
+        // No resources to release — ring buffer is managed by DI container.
+    }
+}
+
+internal sealed class LogDiagnosticsLogger : ILogger
+{
+    private readonly LogDiagnosticsRingBuffer _buffer;
+
+    public LogDiagnosticsLogger(LogDiagnosticsRingBuffer buffer)
+    {
+        _buffer = buffer;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+            return;
+
+        var renderedMessage = formatter(state, exception);
+
+        // Try to extract the original format string (message template) from the state.
+        string? messageTemplate = null;
+        if (state is IReadOnlyList<KeyValuePair<string, object?>> logValues)
+        {
+            foreach (var kvp in logValues)
+            {
+                if (kvp.Key == "{OriginalFormat}")
+                {
+                    messageTemplate = kvp.Value?.ToString();
+                    break;
+                }
+            }
+        }
+
+        _buffer.Record(logLevel, messageTemplate, renderedMessage);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/LogDiagnosticsRingBuffer.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/LogDiagnosticsRingBuffer.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Thread-safe in-memory ring buffer that captures Warning+ log entries
+/// and deduplicates them by message template fingerprint.
+/// </summary>
+public sealed class LogDiagnosticsRingBuffer
+{
+    private readonly ConcurrentDictionary<string, LogPatternEntry> _patterns = new();
+    private readonly int _maxPatterns;
+
+    /// <summary>
+    /// Creates a new ring buffer with a maximum pattern capacity.
+    /// </summary>
+    /// <param name="maxPatterns">Maximum number of unique patterns to retain (default 1000).</param>
+    public LogDiagnosticsRingBuffer(int maxPatterns = 1000)
+    {
+        _maxPatterns = maxPatterns;
+    }
+
+    /// <summary>
+    /// Records a log entry. If the template fingerprint already exists, increments count and updates LastSeen.
+    /// </summary>
+    public void Record(LogLevel level, string? messageTemplate, string renderedMessage)
+    {
+        if (level < LogLevel.Warning)
+            return;
+
+        var template = messageTemplate ?? renderedMessage;
+        var fingerprint = ComputeFingerprint(template, level);
+
+        _patterns.AddOrUpdate(
+            fingerprint,
+            _ => new LogPatternEntry
+            {
+                Fingerprint = fingerprint,
+                Template = template,
+                Severity = level,
+                Count = 1,
+                FirstSeen = DateTimeOffset.UtcNow,
+                LastSeen = DateTimeOffset.UtcNow,
+                SampleMessage = Truncate(renderedMessage, 500)
+            },
+            (_, existing) =>
+            {
+                existing.Count++;
+                existing.LastSeen = DateTimeOffset.UtcNow;
+                return existing;
+            });
+
+        // Evict oldest if over capacity
+        if (_patterns.Count > _maxPatterns)
+        {
+            var oldest = _patterns.Values
+                .OrderBy(p => p.LastSeen)
+                .FirstOrDefault();
+
+            if (oldest is not null)
+                _patterns.TryRemove(oldest.Fingerprint, out _);
+        }
+    }
+
+    /// <summary>
+    /// Returns all patterns observed within the specified time window, sorted by LastSeen descending.
+    /// </summary>
+    public IReadOnlyList<LogPatternEntry> GetPatterns(TimeSpan window)
+    {
+        var cutoff = DateTimeOffset.UtcNow - window;
+        return _patterns.Values
+            .Where(p => p.LastSeen >= cutoff)
+            .OrderByDescending(p => p.LastSeen)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Returns the total number of unique patterns currently in the buffer.
+    /// </summary>
+    public int PatternCount => _patterns.Count;
+
+    /// <summary>
+    /// Clears all patterns from the buffer.
+    /// </summary>
+    public void Clear() => _patterns.Clear();
+
+    internal static string ComputeFingerprint(string template, LogLevel level)
+    {
+        var input = $"{level}:{template}";
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(hashBytes)[..16];
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+            return value;
+        return value[..maxLength] + "...";
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/LogPatternEntry.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/LogPatternEntry.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Represents a deduplicated log pattern aggregated by message template fingerprint.
+/// </summary>
+public sealed class LogPatternEntry
+{
+    /// <summary>
+    /// Stable fingerprint derived from the message template (hash).
+    /// </summary>
+    public required string Fingerprint { get; init; }
+
+    /// <summary>
+    /// The original message template (e.g., "Auto-compaction failed for session {SessionId}").
+    /// </summary>
+    public required string Template { get; init; }
+
+    /// <summary>
+    /// Log severity level.
+    /// </summary>
+    public required LogLevel Severity { get; init; }
+
+    /// <summary>
+    /// Number of times this pattern has been observed.
+    /// </summary>
+    public int Count { get; set; } = 1;
+
+    /// <summary>
+    /// Timestamp of the first observation.
+    /// </summary>
+    public required DateTimeOffset FirstSeen { get; init; }
+
+    /// <summary>
+    /// Timestamp of the most recent observation.
+    /// </summary>
+    public DateTimeOffset LastSeen { get; set; }
+
+    /// <summary>
+    /// A sample rendered message from the first observation.
+    /// </summary>
+    public required string SampleMessage { get; init; }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Controllers/DiagnosticsLogPatternsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Controllers/DiagnosticsLogPatternsTests.cs
@@ -1,0 +1,123 @@
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Controllers;
+
+public sealed class DiagnosticsLogPatternsTests
+{
+    private readonly LogDiagnosticsRingBuffer _buffer = new();
+    private readonly DiagnosticsController _controller;
+
+    public DiagnosticsLogPatternsTests()
+    {
+        _controller = new DiagnosticsController(
+            NullLogger<DiagnosticsController>.Instance,
+            _buffer);
+    }
+
+    [Fact]
+    public void GetLogPatterns_ReturnsOkWithEmptyList_WhenNoEntries()
+    {
+        var result = _controller.GetLogPatterns() as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var response = result.Value as LogPatternsResponse;
+        response.ShouldNotBeNull();
+        response.Patterns.Count.ShouldBe(0);
+        response.Total.ShouldBe(0);
+        response.Hours.ShouldBe(24);
+    }
+
+    [Fact]
+    public void GetLogPatterns_ReturnsPatternsWithinWindow()
+    {
+        _buffer.Record(LogLevel.Warning, "Template A", "Template A rendered");
+        _buffer.Record(LogLevel.Error, "Template B {X}", "Template B value");
+
+        var result = _controller.GetLogPatterns(hours: 1) as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var response = result.Value as LogPatternsResponse;
+        response.ShouldNotBeNull();
+        response.Patterns.Count.ShouldBe(2);
+        response.Total.ShouldBe(2);
+        response.Hours.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetLogPatterns_Paginates()
+    {
+        for (int i = 0; i < 5; i++)
+            _buffer.Record(LogLevel.Warning, $"Template {i}", $"Rendered {i}");
+
+        var result = _controller.GetLogPatterns(pageSize: 2, page: 1) as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var response = result.Value as LogPatternsResponse;
+        response.ShouldNotBeNull();
+        response.Total.ShouldBe(5);
+        response.Patterns.Count.ShouldBe(2);
+        response.Page.ShouldBe(1);
+        response.PageSize.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetLogPatterns_ClampsHoursTo168Max()
+    {
+        _buffer.Record(LogLevel.Warning, "Test", "Test");
+
+        var result = _controller.GetLogPatterns(hours: 500) as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var response = result.Value as LogPatternsResponse;
+        response.ShouldNotBeNull();
+        response.Hours.ShouldBe(168);
+    }
+
+    [Fact]
+    public void GetLogPatterns_ClampsPageSizeTo200Max()
+    {
+        _buffer.Record(LogLevel.Warning, "Test", "Test");
+
+        var result = _controller.GetLogPatterns(pageSize: 999) as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var response = result.Value as LogPatternsResponse;
+        response.ShouldNotBeNull();
+        response.PageSize.ShouldBe(200);
+    }
+
+    [Fact]
+    public void GetLogPatterns_ReturnsNotFound_WhenBufferIsNull()
+    {
+        var controller = new DiagnosticsController(
+            NullLogger<DiagnosticsController>.Instance,
+            logBuffer: null);
+
+        var result = controller.GetLogPatterns();
+
+        result.ShouldBeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public void GetLogPatterns_PatternDtoFields_AreCorrect()
+    {
+        _buffer.Record(LogLevel.Error, "Failed for {Id}", "Failed for session_xyz");
+
+        var result = _controller.GetLogPatterns() as OkObjectResult;
+        var response = result!.Value as LogPatternsResponse;
+        var pattern = response!.Patterns[0];
+
+        pattern.Template.ShouldBe("Failed for {Id}");
+        pattern.Severity.ShouldBe("Error");
+        pattern.Count.ShouldBe(1);
+        pattern.SampleMessage.ShouldBe("Failed for session_xyz");
+        pattern.Fingerprint.ShouldNotBeNullOrEmpty();
+        pattern.FirstSeen.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+        pattern.LastSeen.ShouldBeGreaterThanOrEqualTo(pattern.FirstSeen);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/LogDiagnosticsRingBufferTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/LogDiagnosticsRingBufferTests.cs
@@ -1,0 +1,174 @@
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Diagnostics;
+
+public sealed class LogDiagnosticsRingBufferTests
+{
+    [Fact]
+    public void Record_WarningLevel_CapturesEntry()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "Something failed for {SessionId}", "Something failed for abc123");
+
+        buffer.PatternCount.ShouldBe(1);
+        var patterns = buffer.GetPatterns(TimeSpan.FromHours(1));
+        patterns.Count.ShouldBe(1);
+        patterns[0].Template.ShouldBe("Something failed for {SessionId}");
+        patterns[0].Severity.ShouldBe(LogLevel.Warning);
+        patterns[0].Count.ShouldBe(1);
+        patterns[0].SampleMessage.ShouldBe("Something failed for abc123");
+    }
+
+    [Fact]
+    public void Record_BelowWarning_IsIgnored()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Information, "Info message {Id}", "Info message 42");
+        buffer.Record(LogLevel.Debug, "Debug message", "Debug message");
+        buffer.Record(LogLevel.Trace, "Trace message", "Trace message");
+
+        buffer.PatternCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Record_SameTemplate_IncrementsCount()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "Compaction failed for {SessionId}", "Compaction failed for session1");
+        buffer.Record(LogLevel.Warning, "Compaction failed for {SessionId}", "Compaction failed for session2");
+        buffer.Record(LogLevel.Warning, "Compaction failed for {SessionId}", "Compaction failed for session3");
+
+        buffer.PatternCount.ShouldBe(1);
+        var patterns = buffer.GetPatterns(TimeSpan.FromHours(1));
+        patterns[0].Count.ShouldBe(3);
+        // Sample message is from the first observation
+        patterns[0].SampleMessage.ShouldBe("Compaction failed for session1");
+    }
+
+    [Fact]
+    public void Record_DifferentTemplates_CreatesSeparateEntries()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "Template A {Id}", "Template A 1");
+        buffer.Record(LogLevel.Error, "Template B {Name}", "Template B foo");
+
+        buffer.PatternCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Record_SameTemplateButDifferentLevel_CreatesSeparateEntries()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "Something happened", "Something happened");
+        buffer.Record(LogLevel.Error, "Something happened", "Something happened");
+
+        buffer.PatternCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetPatterns_RespectsTimeWindow()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "Recent warning", "Recent warning");
+
+        // With a 1-hour window, should be visible
+        buffer.GetPatterns(TimeSpan.FromHours(1)).Count.ShouldBe(1);
+
+        // With zero window, nothing matches
+        buffer.GetPatterns(TimeSpan.Zero).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetPatterns_SortsByLastSeenDescending()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "First template", "First template");
+        buffer.Record(LogLevel.Error, "Second template", "Second template");
+
+        var patterns = buffer.GetPatterns(TimeSpan.FromHours(1));
+        patterns.Count.ShouldBe(2);
+        // Second template was recorded last, should appear first
+        patterns[0].Template.ShouldBe("Second template");
+        patterns[1].Template.ShouldBe("First template");
+    }
+
+    [Fact]
+    public void Record_EvictsOldestWhenOverCapacity()
+    {
+        var buffer = new LogDiagnosticsRingBuffer(maxPatterns: 3);
+
+        buffer.Record(LogLevel.Warning, "Template 1", "Template 1");
+        buffer.Record(LogLevel.Warning, "Template 2", "Template 2");
+        buffer.Record(LogLevel.Warning, "Template 3", "Template 3");
+        buffer.Record(LogLevel.Warning, "Template 4", "Template 4");
+
+        // Capacity is 3, one should have been evicted
+        buffer.PatternCount.ShouldBeLessThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public void Clear_RemovesAllPatterns()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, "Warning 1", "Warning 1");
+        buffer.Record(LogLevel.Error, "Error 1", "Error 1");
+
+        buffer.Clear();
+
+        buffer.PatternCount.ShouldBe(0);
+        buffer.GetPatterns(TimeSpan.FromHours(24)).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Record_NullTemplate_UsesRenderedMessage()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+
+        buffer.Record(LogLevel.Warning, null, "A rendered message without template");
+
+        var patterns = buffer.GetPatterns(TimeSpan.FromHours(1));
+        patterns.Count.ShouldBe(1);
+        patterns[0].Template.ShouldBe("A rendered message without template");
+    }
+
+    [Fact]
+    public void ComputeFingerprint_SameInput_ProducesSameHash()
+    {
+        var fp1 = LogDiagnosticsRingBuffer.ComputeFingerprint("Template {X}", LogLevel.Warning);
+        var fp2 = LogDiagnosticsRingBuffer.ComputeFingerprint("Template {X}", LogLevel.Warning);
+
+        fp1.ShouldBe(fp2);
+    }
+
+    [Fact]
+    public void ComputeFingerprint_DifferentLevel_ProducesDifferentHash()
+    {
+        var fp1 = LogDiagnosticsRingBuffer.ComputeFingerprint("Template {X}", LogLevel.Warning);
+        var fp2 = LogDiagnosticsRingBuffer.ComputeFingerprint("Template {X}", LogLevel.Error);
+
+        fp1.ShouldNotBe(fp2);
+    }
+
+    [Fact]
+    public void Record_LongMessage_TruncatesTo500Chars()
+    {
+        var buffer = new LogDiagnosticsRingBuffer();
+        var longMessage = new string('x', 1000);
+
+        buffer.Record(LogLevel.Warning, "Long message template", longMessage);
+
+        var patterns = buffer.GetPatterns(TimeSpan.FromHours(1));
+        patterns[0].SampleMessage.Length.ShouldBe(503); // 500 + "..."
+        patterns[0].SampleMessage.ShouldEndWith("...");
+    }
+}


### PR DESCRIPTION
Closes #966

## Changes

- **LogDiagnosticsRingBuffer**: Thread-safe in-memory ring buffer that captures Warning+ log entries and deduplicates them by message template fingerprint (SHA-256 hash of level+template). Bounded capacity with oldest-eviction.
- **LogDiagnosticsProvider/Logger**: Custom `ILoggerProvider` implementation that feeds the ring buffer. Extracts `{OriginalFormat}` from structured log state for template grouping.
- **GET /api/diagnostics/log-patterns**: REST endpoint returning paginated, time-windowed deduplicated patterns sorted by LastSeen descending. Clamped parameters (hours 1-168, pageSize 1-200).
- **DI registration**: `LogDiagnosticsRingBuffer` (singleton) and `LogDiagnosticsProvider` (ILoggerProvider) registered in Program.cs.
- **13 unit tests**: 11 ring buffer tests (record, dedup, eviction, clear, fingerprint, truncation) + 7 controller tests (empty, pagination, clamping, null-buffer 404, field correctness).

## Merge Notes

This PR is fully independent -- no file overlap with any open PR. Safe to merge in any order.