### PR TITLE
test(conversations): add abstract parity test base for IConversationStore with all 3 implementations

### DIFF
--- a/tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj
+++ b/tests/architecture/BotNexus.Architecture.Tests/BotNexus.Architecture.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Sessions\BotNexus.Gateway.Sessions.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Conversations\BotNexus.Gateway.Conversations.csproj" />
     <ProjectReference Include="..\..\scenarios\BotNexus.Scenarios.Harness\BotNexus.Scenarios.Harness.csproj" />
     <ProjectReference Include="..\..\scenarios\BotNexus.Scenarios.Tests\BotNexus.Scenarios.Tests.csproj" />
   </ItemGroup>

--- a/tests/architecture/BotNexus.Architecture.Tests/ConversationStoreParityArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ConversationStoreParityArchitectureTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Conversations;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Ensures that every concrete <see cref="IConversationStore"/> implementation in the
+/// Conversations assembly exists and is not abstract. This is the compile-time half of
+/// the parity enforcement — the test-time half is the abstract
+/// <c>ConversationStoreContractTests</c> base class in the Conversations.Tests project.
+/// </summary>
+public sealed class ConversationStoreParityArchitectureTests
+{
+    private static readonly Assembly StoreAssembly = typeof(InMemoryConversationStore).Assembly;
+
+    [Fact]
+    public void All_IConversationStore_Implementations_Are_Concrete_And_Not_Abstract()
+    {
+        var implementations = StoreAssembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract)
+            .Where(t => typeof(IConversationStore).IsAssignableFrom(t))
+            .ToList();
+
+        implementations.ShouldNotBeEmpty(
+            "Expected at least one concrete IConversationStore implementation in BotNexus.Gateway.Conversations");
+
+        // Verify known implementations exist — this fails at compile time if renamed/removed
+        implementations.ShouldContain(t => t == typeof(InMemoryConversationStore));
+        implementations.ShouldContain(t => t == typeof(SqliteConversationStore));
+    }
+
+    [Fact]
+    public void IConversationStore_Has_At_Least_Three_Implementations()
+    {
+        // File, InMemory, Sqlite — if one is removed, this catches it
+        var count = StoreAssembly.GetTypes()
+            .Count(t => t.IsClass && !t.IsAbstract && typeof(IConversationStore).IsAssignableFrom(t));
+
+        count.ShouldBeGreaterThanOrEqualTo(3,
+            "Expected at least 3 IConversationStore implementations (InMemory, File, Sqlite)");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreContractTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreContractTests.cs
@@ -1,0 +1,209 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using Shouldly;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Abstract contract test base for <see cref="IConversationStore"/>. Each concrete subclass
+/// provides a real implementation via <see cref="CreateStore"/>. All tests run identically
+/// against every implementation to enforce parity.
+/// </summary>
+public abstract class ConversationStoreContractTests
+{
+    /// <summary>Creates a fresh store instance for a single test.</summary>
+    protected abstract IConversationStore CreateStore();
+
+    /// <summary>Disposes any resources used by the store fixture (e.g. temp DB).</summary>
+    protected virtual void DisposeStore() { }
+
+    private static AgentId Agent(string id = "agent-1") => AgentId.From(id);
+    private static ConversationId NewId() => ConversationId.Create();
+
+    private static Conversation MakeConversation(AgentId? agentId = null, string? title = null) =>
+        new()
+        {
+            ConversationId = NewId(),
+            AgentId = agentId ?? Agent(),
+            Title = title ?? "Test conversation"
+        };
+
+    // ── GetAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAsync_ReturnsNull_WhenNotFound()
+    {
+        var store = CreateStore();
+        var result = await store.GetAsync(NewId());
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsConversation_AfterCreate()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation();
+
+        await store.CreateAsync(conv);
+        var loaded = await store.GetAsync(conv.ConversationId);
+
+        loaded.ShouldNotBeNull();
+        loaded!.ConversationId.ShouldBe(conv.ConversationId);
+        loaded.AgentId.ShouldBe(conv.AgentId);
+        loaded.Title.ShouldBe(conv.Title);
+    }
+
+    // ── CreateAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreatedConversation()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation();
+
+        var result = await store.CreateAsync(conv);
+
+        result.ShouldNotBeNull();
+        result.ConversationId.ShouldBe(conv.ConversationId);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ThrowsOnDuplicateId()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation();
+
+        await store.CreateAsync(conv);
+        await Should.ThrowAsync<Exception>(async () => await store.CreateAsync(conv));
+    }
+
+    // ── SaveAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveAsync_PersistsUpdatedTitle()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation(title: "Original");
+        await store.CreateAsync(conv);
+
+        conv = conv with { Title = "Updated" };
+        await store.SaveAsync(conv);
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.Title.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesIfNotExists()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation();
+
+        await store.SaveAsync(conv);
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.ConversationId.ShouldBe(conv.ConversationId);
+    }
+
+    // ── ListAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_ReturnsEmpty_WhenNoConversations()
+    {
+        var store = CreateStore();
+        var result = await store.ListAsync();
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsAll_WhenNoAgentFilter()
+    {
+        var store = CreateStore();
+        await store.CreateAsync(MakeConversation(Agent("a")));
+        await store.CreateAsync(MakeConversation(Agent("b")));
+
+        var result = await store.ListAsync();
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ListAsync_FiltersByAgent()
+    {
+        var store = CreateStore();
+        await store.CreateAsync(MakeConversation(Agent("a")));
+        await store.CreateAsync(MakeConversation(Agent("b")));
+
+        var result = await store.ListAsync(Agent("a"));
+        result.Count.ShouldBe(1);
+        result[0].AgentId.ShouldBe(Agent("a"));
+    }
+
+    // ── ArchiveAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ArchiveAsync_SetsStatusToArchived()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation();
+        await store.CreateAsync(conv);
+
+        await store.ArchiveAsync(conv.ConversationId);
+
+        var loaded = await store.GetAsync(conv.ConversationId);
+        loaded.ShouldNotBeNull();
+        loaded!.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_NoOp_WhenNotFound()
+    {
+        var store = CreateStore();
+        // Should not throw
+        await store.ArchiveAsync(NewId());
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_ConversationStillVisibleInListAsync()
+    {
+        // NOTE: ListAsync returns ALL conversations regardless of status.
+        // This is the actual contract behaviour across all implementations.
+        // GetSummariesAsync is the method that filters to Active-only.
+        var store = CreateStore();
+        var conv = MakeConversation();
+        await store.CreateAsync(conv);
+
+        await store.ArchiveAsync(conv.ConversationId);
+
+        var list = await store.ListAsync();
+        list.ShouldContain(c => c.ConversationId == conv.ConversationId);
+    }
+
+    // ── TouchAsync ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TouchAsync_UpdatesTimestamp()
+    {
+        var store = CreateStore();
+        var conv = MakeConversation();
+        await store.CreateAsync(conv);
+
+        var before = (await store.GetAsync(conv.ConversationId))!.UpdatedAt;
+        await Task.Delay(50); // Ensure time advances
+        await store.TouchAsync(conv.ConversationId);
+
+        var after = (await store.GetAsync(conv.ConversationId))!.UpdatedAt;
+        after.ShouldBeGreaterThan(before);
+    }
+
+    [Fact]
+    public async Task TouchAsync_NoOp_WhenNotFound()
+    {
+        var store = CreateStore();
+        // Should not throw
+        await store.TouchAsync(NewId());
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/FileConversationStoreParityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/FileConversationStoreParityTests.cs
@@ -1,0 +1,21 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Gateway.Abstractions.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Runs the <see cref="ConversationStoreContractTests"/> suite against <see cref="FileConversationStore"/>
+/// using an in-memory <see cref="MockFileSystem"/> (no real disk I/O).
+/// </summary>
+public sealed class FileConversationStoreParityTests : ConversationStoreContractTests
+{
+    private readonly MockFileSystem _fs = new();
+
+    protected override IConversationStore CreateStore()
+    {
+        var rootPath = "/conversations";
+        _fs.Directory.CreateDirectory(rootPath);
+        return new FileConversationStore(rootPath, NullLogger<FileConversationStore>.Instance, _fs);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/InMemoryConversationStoreParityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/InMemoryConversationStoreParityTests.cs
@@ -1,0 +1,11 @@
+using BotNexus.Gateway.Abstractions.Conversations;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Runs the <see cref="ConversationStoreContractTests"/> suite against <see cref="InMemoryConversationStore"/>.
+/// </summary>
+public sealed class InMemoryConversationStoreParityTests : ConversationStoreContractTests
+{
+    protected override IConversationStore CreateStore() => new InMemoryConversationStore();
+}

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreParityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/SqliteConversationStoreParityTests.cs
@@ -1,0 +1,19 @@
+using BotNexus.Gateway.Abstractions.Conversations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Runs the <see cref="ConversationStoreContractTests"/> suite against <see cref="SqliteConversationStore"/>.
+/// Uses a temporary SQLite database file per test class execution.
+/// </summary>
+public sealed class SqliteConversationStoreParityTests : ConversationStoreContractTests, IDisposable
+{
+    private readonly StoreFixture _fixture = new();
+
+    protected override IConversationStore CreateStore() => _fixture.CreateStore();
+
+    protected override void DisposeStore() => _fixture.Dispose();
+
+    public void Dispose() => _fixture.Dispose();
+}


### PR DESCRIPTION
Closes #939

## Changes

- **ConversationStoreContractTests** (abstract): 14 contract tests covering GetAsync, CreateAsync, SaveAsync, ListAsync, ArchiveAsync, and TouchAsync with happy paths and edge cases (not-found, duplicate, no-op).
- **InMemoryConversationStoreParityTests**: Concrete subclass running all 14 tests against InMemoryConversationStore.
- **SqliteConversationStoreParityTests**: Concrete subclass running all 14 tests against SqliteConversationStore (temp DB file).
- **FileConversationStoreParityTests**: Concrete subclass running all 14 tests against FileConversationStore (MockFileSystem, no real disk I/O).
- **ConversationStoreParityArchitectureTests**: 2 architecture enforcement tests ensuring all implementations exist and the count stays at 3+.

## Parity Finding

`ListAsync` doc says "Lists all **active** conversations" but all 3 implementations return conversations regardless of status (including Archived). The tests document this as the true contract — `GetSummariesAsync` is the Active-only listing method.

## Merge Notes

This PR is fully independent — new test files only, no production code changes. Safe to merge in any order.