### PR TITLE
fix(cli): render startup banner before console encoding strands stderr writer

### DIFF
--- a/src/gateway/BotNexus.Cli/CliApp.cs
+++ b/src/gateway/BotNexus.Cli/CliApp.cs
@@ -13,7 +13,6 @@ internal static class CliApp
 {
     internal static async Task<int> RunAsync(string[] args, TextWriter bannerWriter)
     {
-        ConfigureOutputEncoding();
         CliBanner.WriteTo(bannerWriter);
 
         using var serviceProvider = BuildServiceProvider();
@@ -43,11 +42,35 @@ internal static class CliApp
         return isOutputRedirected ? TextWriter.Null : consoleError;
     }
 
-    private static void ConfigureOutputEncoding()
+    /// <summary>
+    /// Switches the console standard output and error streams to UTF-8 so the
+    /// Unicode box-drawing and shaded-block characters in the startup banner
+    /// render correctly on consoles whose default code page cannot represent them
+    /// (notably Windows, where the legacy OEM code page produces replacement glyphs).
+    /// <para>
+    /// Must be called <b>before</b> <see cref="Console.Out"/> or <see cref="Console.Error"/>
+    /// are captured for later use: assigning <see cref="Console.OutputEncoding"/> recreates
+    /// both writers, so any reference captured beforehand keeps the old encoding.
+    /// </para>
+    /// </summary>
+    internal static void ConfigureOutputEncoding()
+        => ApplyOutputEncoding(static encoding => Console.OutputEncoding = encoding);
+
+    /// <summary>
+    /// Applies the banner-safe UTF-8 encoding via the supplied setter, swallowing the
+    /// failures that legitimately occur on locked-down or redirected hosts. The setter
+    /// is injected so the resilience contract can be verified without mutating the
+    /// process-global <see cref="Console.OutputEncoding"/>, which would recreate
+    /// <see cref="Console.Out"/>/<see cref="Console.Error"/> and break console-writing
+    /// tests running in parallel.
+    /// </summary>
+    /// <param name="applyEncoding">Receives the encoding the CLI wants the console to use.</param>
+    internal static void ApplyOutputEncoding(Action<Encoding> applyEncoding)
     {
+        ArgumentNullException.ThrowIfNull(applyEncoding);
         try
         {
-            Console.OutputEncoding = Encoding.UTF8;
+            applyEncoding(Encoding.UTF8);
         }
         catch (IOException)
         {

--- a/src/gateway/BotNexus.Cli/Program.cs
+++ b/src/gateway/BotNexus.Cli/Program.cs
@@ -1,1 +1,2 @@
+BotNexus.Cli.CliApp.ConfigureOutputEncoding();
 return await BotNexus.Cli.CliApp.RunAsync(args, BotNexus.Cli.CliApp.ResolveBannerWriter(Console.Error, Console.IsOutputRedirected));

--- a/tests/gateway/BotNexus.Cli.Tests/CliAppOutputEncodingTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/CliAppOutputEncodingTests.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using BotNexus.Cli;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class CliAppOutputEncodingTests
+{
+    [Fact]
+    public void ApplyOutputEncoding_RequestsUtf8()
+    {
+        Encoding? requested = null;
+
+        CliApp.ApplyOutputEncoding(encoding => requested = encoding);
+
+        // UTF-8 (code page 65001) is required so the banner's Unicode box-drawing
+        // and shaded-block glyphs render instead of '?'/'\uFFFD' replacement chars.
+        requested.ShouldNotBeNull();
+        requested.CodePage.ShouldBe(Encoding.UTF8.CodePage);
+    }
+
+    [Fact]
+    public void ApplyOutputEncoding_SwallowsIOException()
+    {
+        // Locked-down / redirected consoles throw IOException when reassigning the
+        // encoding; CLI startup must stay alive rather than crash before any command runs.
+        Action act = () => CliApp.ApplyOutputEncoding(_ => throw new IOException("no tty"));
+
+        Should.NotThrow(act);
+    }
+
+    [Fact]
+    public void ApplyOutputEncoding_SwallowsArgumentException()
+    {
+        Action act = () => CliApp.ApplyOutputEncoding(_ => throw new ArgumentException("bad encoding"));
+
+        Should.NotThrow(act);
+    }
+
+    [Fact]
+    public void ApplyOutputEncoding_PropagatesUnexpectedExceptions()
+    {
+        // Only the two documented, host-specific failures are swallowed; anything else
+        // is a real bug and must surface rather than be silently hidden.
+        Action act = () => CliApp.ApplyOutputEncoding(_ => throw new InvalidOperationException("boom"));
+
+        Should.Throw<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void ApplyOutputEncoding_ThrowsWhenSetterIsNull()
+    {
+        Action act = () => CliApp.ApplyOutputEncoding(null!);
+
+        Should.Throw<ArgumentNullException>(act);
+    }
+}


### PR DESCRIPTION
## Summary

The CLI startup banner rendered as garbled replacement characters (mojibake / `ï¿½`) on Windows consoles whose default code page is not UTF-8 — e.g. running `botnexus update`.

## Root cause

`Program.cs` captured `Console.Error` for the banner writer **before** `CliApp.RunAsync` called `ConfigureOutputEncoding()`. Assigning `Console.OutputEncoding = Encoding.UTF8` recreates `Console.Out` and `Console.Error` with fresh writers, so the already-captured `Console.Error` reference kept the old OEM code page and could not render the banner's Unicode box-drawing / shaded-block glyphs.

## Fix

- Call `ConfigureOutputEncoding()` in `Program.cs` **before** resolving the banner writer, so stderr is already UTF-8 when captured.
- Extract an injectable `ApplyOutputEncoding(Action<Encoding>)` seam so the UTF-8 selection and host-failure resilience (`IOException`/`ArgumentException` swallowed, other exceptions propagated) are covered **without** mutating process-global console state — which would recreate `Console.Out` and break console-writing tests running in parallel.

## Tests

- New `CliAppOutputEncodingTests` covering: requests UTF-8, swallows `IOException`/`ArgumentException`, propagates unexpected exceptions, and null-guards the setter.
- `scripts/repo/test-impacted.ps1` green (Architecture, Cli, Gateway, Scenarios).

> Note: `GatewayProcessManagerTests.GetStatusAsync_WhenRunning_ReturnsPidAndUptime` is a pre-existing environmental flake (spawns a real `dotnet --info` process; PID-reuse/timing sensitive) — it fails identically on clean `main` and is unrelated to this change.

Closes #977