### PR TITLE
feat(copilot): parse copilot_usage billing snapshot and emit Activity tags (Phase 5B, #810)

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
@@ -215,7 +215,8 @@ public sealed class CopilotCompletionsProvider(
             ExtractProviderErrorMessage,
             EmitError,
             () => logger.LogDebug("Skipping malformed SSE chunk"),
-            ct);
+            ct,
+            inspectChunk: root => Telemetry.CopilotUsageActivity.TryParseAndEmit(root, Activity.Current));
     }
 
     #region Payload Building

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesStreamParser.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesStreamParser.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using BotNexus.Agent.Providers.Copilot.Telemetry;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Streaming;
 using BotNexus.Agent.Providers.Core.Utilities;
@@ -66,6 +68,10 @@ internal static class CopilotMessagesStreamParser
 
             using (doc)
             {
+                // Surface copilot_usage tagged on whichever SSE event Copilot
+                // attaches it to (captures show it on message_delta).
+                CopilotUsageActivity.TryParseAndEmit(doc.RootElement, Activity.Current);
+
                 ProcessSseEvent(
                     currentEvent,
                     doc.RootElement,

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
@@ -493,6 +493,8 @@ public sealed class CopilotResponsesProvider(
             {
                 var root = doc.RootElement;
 
+                Telemetry.CopilotUsageActivity.TryParseAndEmit(root, Activity.Current);
+
                 if (evt.Event is "response.created")
                 {
                     if (root.TryGetProperty("response", out var responseEl))

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Telemetry/CopilotUsage.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Telemetry/CopilotUsage.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.Copilot.Telemetry;
+
+/// <summary>
+/// Strongly typed representation of the <c>copilot_usage</c> object that
+/// GitHub Copilot tacks onto every successful API response (Anthropic
+/// Messages, OpenAI Responses, and OpenAI Chat Completions).
+/// </summary>
+/// <remarks>
+/// Wire shape captured from real Copilot CLI traffic:
+/// <code>
+/// "copilot_usage": {
+///   "token_details": [
+///     { "batch_size": 1000000, "cost_per_batch": 30000000000, "token_count": 157, "token_type": "input"      },
+///     { "batch_size": 1000000, "cost_per_batch": 15000000000, "token_count":   0, "token_type": "cache_read" },
+///     { "batch_size": 1000000, "cost_per_batch":           0, "token_count":   0, "token_type": "cache_write"},
+///     { "batch_size": 1000000, "cost_per_batch":120000000000, "token_count":  14, "token_type": "output"     }
+///   ],
+///   "total_nano_aiu": 6390000
+/// }
+/// </code>
+/// <c>total_nano_aiu</c> is the call's billed premium-interaction cost in
+/// nano-AIU. Each <see cref="CopilotTokenDetail"/> entry records the per-token-type
+/// breakdown the server used to derive that total, so callers can compute
+/// "what would this cost have been if I'd cached more aggressively".
+/// </remarks>
+public sealed record CopilotUsage(
+    long TotalNanoAiu,
+    IReadOnlyList<CopilotTokenDetail> TokenDetails);
+
+/// <summary>
+/// One entry in <see cref="CopilotUsage.TokenDetails"/>: the per-token-type
+/// price the Copilot billing pipeline applied for this call.
+/// </summary>
+/// <param name="TokenType">
+/// One of <c>input</c>, <c>output</c>, <c>cache_read</c>, <c>cache_write</c>
+/// at time of writing. Captured verbatim so future Copilot additions are
+/// surfaced without code change.
+/// </param>
+/// <param name="TokenCount">Number of tokens of this type billed.</param>
+/// <param name="BatchSize">
+/// Batch size used by the pricing engine (constant 1_000_000 in current captures).
+/// </param>
+/// <param name="CostPerBatch">
+/// Cost in nano-AIU per <see cref="BatchSize"/> tokens. The contribution to
+/// <see cref="CopilotUsage.TotalNanoAiu"/> is approximately
+/// <c>TokenCount * CostPerBatch / BatchSize</c>.
+/// </param>
+public sealed record CopilotTokenDetail(
+    string TokenType,
+    long TokenCount,
+    long BatchSize,
+    long CostPerBatch);

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Telemetry/CopilotUsageActivity.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Telemetry/CopilotUsageActivity.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.Copilot.Telemetry;
+
+/// <summary>
+/// Emits the contents of a <see cref="CopilotUsage"/> as structured Activity
+/// tags so cost/billing information ends up on the same trace as the rest of
+/// a Copilot call. Tag namespace: <c>botnexus.copilot.usage.*</c>.
+/// </summary>
+/// <remarks>
+/// The total cost is emitted as <c>botnexus.copilot.usage.total_nano_aiu</c>.
+/// Per-token-type entries become three tags each:
+/// <list type="bullet">
+///   <item><c>botnexus.copilot.usage.tokens.{type}</c> — token_count</item>
+///   <item><c>botnexus.copilot.usage.cost_per_batch.{type}</c> — cost_per_batch</item>
+///   <item><c>botnexus.copilot.usage.batch_size.{type}</c> — batch_size</item>
+/// </list>
+/// Token-type names are taken verbatim from the wire so any new types Copilot
+/// introduces will surface automatically.
+/// </remarks>
+public static class CopilotUsageActivity
+{
+    private const string TagPrefix = "botnexus.copilot.usage.";
+
+    /// <summary>
+    /// Attach the contents of <paramref name="usage"/> to <paramref name="activity"/>.
+    /// No-op when either argument is null.
+    /// </summary>
+    public static void Emit(CopilotUsage? usage, Activity? activity)
+    {
+        if (usage is null || activity is null)
+            return;
+
+        activity.SetTag(TagPrefix + "total_nano_aiu", usage.TotalNanoAiu);
+
+        foreach (var detail in usage.TokenDetails)
+        {
+            var type = detail.TokenType;
+            activity.SetTag(TagPrefix + "tokens." + type, detail.TokenCount);
+            activity.SetTag(TagPrefix + "cost_per_batch." + type, detail.CostPerBatch);
+            activity.SetTag(TagPrefix + "batch_size." + type, detail.BatchSize);
+        }
+    }
+
+    /// <summary>
+    /// Convenience wrapper: parse <paramref name="root"/> with
+    /// <see cref="CopilotUsageParser.TryParse"/> and emit to
+    /// <paramref name="activity"/> if a <c>copilot_usage</c> object is present.
+    /// Safe to call on every SSE chunk — non-Copilot or chunks without the
+    /// field are ignored.
+    /// </summary>
+    public static void TryParseAndEmit(JsonElement root, Activity? activity)
+    {
+        if (activity is null)
+            return;
+        if (CopilotUsageParser.TryParse(root, out var usage))
+            Emit(usage, activity);
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Telemetry/CopilotUsageParser.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Telemetry/CopilotUsageParser.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+
+namespace BotNexus.Agent.Providers.Copilot.Telemetry;
+
+/// <summary>
+/// Parses a <see cref="CopilotUsage"/> out of an arbitrary JSON root that may
+/// or may not carry a <c>copilot_usage</c> object. Designed to be called on
+/// every SSE chunk / non-stream response body the three Copilot providers see —
+/// a missing or malformed <c>copilot_usage</c> is silently ignored.
+/// </summary>
+public static class CopilotUsageParser
+{
+    /// <summary>
+    /// Look for <c>copilot_usage</c> directly on <paramref name="root"/> (the
+    /// shape used by Chat Completions, the Responses <c>response.completed</c>
+    /// event, and the Messages <c>message_delta</c> event) and try to
+    /// materialise it.
+    /// </summary>
+    public static bool TryParse(JsonElement root, out CopilotUsage usage)
+    {
+        usage = null!;
+        if (root.ValueKind != JsonValueKind.Object)
+            return false;
+        if (!root.TryGetProperty("copilot_usage", out var node) || node.ValueKind != JsonValueKind.Object)
+            return false;
+
+        return TryParseObject(node, out usage);
+    }
+
+    /// <summary>
+    /// Materialise <paramref name="node"/> as a <see cref="CopilotUsage"/>.
+    /// <paramref name="node"/> must already point at the <c>copilot_usage</c>
+    /// object itself.
+    /// </summary>
+    public static bool TryParseObject(JsonElement node, out CopilotUsage usage)
+    {
+        usage = null!;
+        if (node.ValueKind != JsonValueKind.Object)
+            return false;
+
+        long total = 0;
+        if (node.TryGetProperty("total_nano_aiu", out var totalProp)
+            && totalProp.ValueKind == JsonValueKind.Number
+            && totalProp.TryGetInt64(out var t))
+        {
+            total = t;
+        }
+
+        var details = new List<CopilotTokenDetail>();
+        if (node.TryGetProperty("token_details", out var detailsProp)
+            && detailsProp.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var entry in detailsProp.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var type = entry.TryGetProperty("token_type", out var typeProp)
+                    && typeProp.ValueKind == JsonValueKind.String
+                        ? typeProp.GetString() ?? string.Empty
+                        : string.Empty;
+                if (type.Length == 0)
+                    continue;
+
+                details.Add(new CopilotTokenDetail(
+                    TokenType: type,
+                    TokenCount: ReadInt64(entry, "token_count"),
+                    BatchSize: ReadInt64(entry, "batch_size"),
+                    CostPerBatch: ReadInt64(entry, "cost_per_batch")));
+            }
+        }
+
+        usage = new CopilotUsage(total, details);
+        return true;
+    }
+
+    private static long ReadInt64(JsonElement obj, string name)
+    {
+        if (obj.TryGetProperty(name, out var prop)
+            && prop.ValueKind == JsonValueKind.Number
+            && prop.TryGetInt64(out var v))
+        {
+            return v;
+        }
+        return 0;
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Core/Streaming/OpenAIStreamProcessor.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Streaming/OpenAIStreamProcessor.cs
@@ -22,6 +22,12 @@ public sealed class OpenAIStreamProcessor
     /// <param name="extractProviderErrorMessage">The extract provider error message.</param>
     /// <param name="emitError">The emit error.</param>
     /// <param name="onMalformedChunk">The on malformed chunk.</param>
+    /// <param name="inspectChunk">
+    /// Optional per-chunk callback receiving the root JSON element of every
+    /// SSE <c>data:</c> payload. Used by provider-specific transports to
+    /// surface fields beyond the OpenAI shape (e.g. Copilot's
+    /// <c>copilot_usage</c>) without coupling Core to those providers.
+    /// </param>
     /// <returns>The parse open ai completions async result.</returns>
     public async Task ParseOpenAiCompletionsAsync(
         LlmStream stream,
@@ -33,7 +39,8 @@ public sealed class OpenAIStreamProcessor
         Func<string, LlmModel, string> extractProviderErrorMessage,
         Action<LlmStream, LlmModel, string, List<ContentBlock>?> emitError,
         Action? onMalformedChunk,
-        CancellationToken ct)
+        CancellationToken ct,
+        Action<JsonElement>? inspectChunk = null)
     {
         var contentBlocks = new List<ContentBlock>();
         var usage = Usage.Empty();
@@ -87,6 +94,8 @@ public sealed class OpenAIStreamProcessor
             using (doc)
             {
                 var root = doc.RootElement;
+
+                inspectChunk?.Invoke(root);
 
                 if (root.TryGetProperty("error", out _))
                 {

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Telemetry/CopilotUsageActivityTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Telemetry/CopilotUsageActivityTests.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics;
+using System.Text.Json;
+using BotNexus.Agent.Providers.Copilot.Telemetry;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Telemetry;
+
+/// <summary>
+/// Pins <see cref="CopilotUsageActivity"/>: emits the right Activity tags
+/// for each token_type and total_nano_aiu, no-ops cleanly on null inputs,
+/// and silently ignores chunks that do not carry a <c>copilot_usage</c> field.
+/// </summary>
+public class CopilotUsageActivityTests
+{
+    private static (ActivityListener Listener, ActivitySource Source) NewListener(string name)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        return (listener, new ActivitySource(name));
+    }
+
+    [Fact]
+    public void Emit_PopulatesPerTokenTypeAndTotalTags()
+    {
+        var (listener, source) = NewListener("BotNexus.Test.UsageEmit");
+        using var _l = listener;
+        using var _s = source;
+        using var activity = source.StartActivity("test", ActivityKind.Client)!;
+        activity.ShouldNotBeNull();
+
+        var usage = new CopilotUsage(
+            TotalNanoAiu: 6_390_000,
+            TokenDetails:
+            [
+                new CopilotTokenDetail("input",  157, 1_000_000, 30_000_000_000),
+                new CopilotTokenDetail("output",  14, 1_000_000, 120_000_000_000),
+                new CopilotTokenDetail("cache_read", 0, 1_000_000, 15_000_000_000),
+            ]);
+
+        CopilotUsageActivity.Emit(usage, activity);
+
+        var tags = activity.TagObjects.ToDictionary(t => t.Key, t => t.Value!);
+        tags["botnexus.copilot.usage.total_nano_aiu"].ShouldBe(6_390_000L);
+
+        tags["botnexus.copilot.usage.tokens.input"].ShouldBe(157L);
+        tags["botnexus.copilot.usage.tokens.output"].ShouldBe(14L);
+        tags["botnexus.copilot.usage.tokens.cache_read"].ShouldBe(0L);
+
+        tags["botnexus.copilot.usage.cost_per_batch.input"].ShouldBe(30_000_000_000L);
+        tags["botnexus.copilot.usage.cost_per_batch.output"].ShouldBe(120_000_000_000L);
+
+        tags["botnexus.copilot.usage.batch_size.input"].ShouldBe(1_000_000L);
+    }
+
+    [Fact]
+    public void Emit_NullUsage_DoesNotThrow()
+    {
+        var (listener, source) = NewListener("BotNexus.Test.UsageEmit.Null");
+        using var _l = listener;
+        using var _s = source;
+        using var activity = source.StartActivity("t", ActivityKind.Client)!;
+
+        Should.NotThrow(() => CopilotUsageActivity.Emit(null, activity));
+        activity.TagObjects.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Emit_NullActivity_DoesNotThrow()
+    {
+        var usage = new CopilotUsage(1, []);
+        Should.NotThrow(() => CopilotUsageActivity.Emit(usage, null));
+    }
+
+    [Fact]
+    public void TryParseAndEmit_ChunkWithoutCopilotUsage_NoTags()
+    {
+        var (listener, source) = NewListener("BotNexus.Test.UsageEmit.Skip");
+        using var _l = listener;
+        using var _s = source;
+        using var activity = source.StartActivity("t", ActivityKind.Client)!;
+
+        using var doc = JsonDocument.Parse("""{ "id": "x", "choices": [] }""");
+        CopilotUsageActivity.TryParseAndEmit(doc.RootElement, activity);
+
+        activity.TagObjects.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TryParseAndEmit_ChunkWithCopilotUsage_EmitsTags()
+    {
+        var (listener, source) = NewListener("BotNexus.Test.UsageEmit.Parse");
+        using var _l = listener;
+        using var _s = source;
+        using var activity = source.StartActivity("t", ActivityKind.Client)!;
+
+        using var doc = JsonDocument.Parse("""
+            {
+              "copilot_usage": {
+                "token_details": [{ "batch_size": 1000000, "cost_per_batch": 1, "token_count": 5, "token_type": "input" }],
+                "total_nano_aiu": 5
+              }
+            }
+            """);
+        CopilotUsageActivity.TryParseAndEmit(doc.RootElement, activity);
+
+        var tags = activity.TagObjects.ToDictionary(t => t.Key, t => t.Value!);
+        tags["botnexus.copilot.usage.total_nano_aiu"].ShouldBe(5L);
+        tags["botnexus.copilot.usage.tokens.input"].ShouldBe(5L);
+    }
+}

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Telemetry/CopilotUsageParserTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Telemetry/CopilotUsageParserTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using BotNexus.Agent.Providers.Copilot.Telemetry;
+
+namespace BotNexus.Agent.Providers.Copilot.Tests.Telemetry;
+
+/// <summary>
+/// Pins <see cref="CopilotUsageParser"/> against the exact wire shape captured
+/// from real Copilot CLI traffic (chat-completions body, Anthropic-Messages
+/// <c>message_delta</c> SSE event, Responses <c>response.completed</c> SSE event).
+/// </summary>
+public class CopilotUsageParserTests
+{
+    private const string SampleJson = """
+        {
+          "copilot_usage": {
+            "token_details": [
+              { "batch_size": 1000000, "cost_per_batch": 30000000000,  "token_count": 157, "token_type": "input"       },
+              { "batch_size": 1000000, "cost_per_batch": 15000000000,  "token_count":   0, "token_type": "cache_read"  },
+              { "batch_size": 1000000, "cost_per_batch":           0,  "token_count":   0, "token_type": "cache_write" },
+              { "batch_size": 1000000, "cost_per_batch": 120000000000, "token_count":  14, "token_type": "output"      }
+            ],
+            "total_nano_aiu": 6390000
+          }
+        }
+        """;
+
+    [Fact]
+    public void TryParse_PopulatesEveryField()
+    {
+        using var doc = JsonDocument.Parse(SampleJson);
+
+        var ok = CopilotUsageParser.TryParse(doc.RootElement, out var usage);
+
+        ok.ShouldBeTrue();
+        usage.TotalNanoAiu.ShouldBe(6_390_000);
+        usage.TokenDetails.Count.ShouldBe(4);
+
+        var input = usage.TokenDetails.Single(d => d.TokenType == "input");
+        input.TokenCount.ShouldBe(157);
+        input.BatchSize.ShouldBe(1_000_000);
+        input.CostPerBatch.ShouldBe(30_000_000_000);
+
+        var output = usage.TokenDetails.Single(d => d.TokenType == "output");
+        output.TokenCount.ShouldBe(14);
+        output.CostPerBatch.ShouldBe(120_000_000_000);
+
+        usage.TokenDetails.ShouldContain(d => d.TokenType == "cache_read");
+        usage.TokenDetails.ShouldContain(d => d.TokenType == "cache_write");
+    }
+
+    [Fact]
+    public void TryParse_NoCopilotUsageProperty_ReturnsFalse()
+    {
+        using var doc = JsonDocument.Parse("""{ "usage": { "input_tokens": 5 } }""");
+
+        CopilotUsageParser.TryParse(doc.RootElement, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_MalformedCopilotUsage_ReturnsFalse()
+    {
+        using var doc = JsonDocument.Parse("""{ "copilot_usage": "not-an-object" }""");
+
+        CopilotUsageParser.TryParse(doc.RootElement, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_EmptyTokenDetails_YieldsEmptyList()
+    {
+        using var doc = JsonDocument.Parse("""
+            { "copilot_usage": { "token_details": [], "total_nano_aiu": 0 } }
+            """);
+
+        CopilotUsageParser.TryParse(doc.RootElement, out var usage).ShouldBeTrue();
+        usage.TotalNanoAiu.ShouldBe(0);
+        usage.TokenDetails.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TryParse_UnknownTokenType_IsPreservedVerbatim()
+    {
+        using var doc = JsonDocument.Parse("""
+            {
+              "copilot_usage": {
+                "token_details": [
+                  { "batch_size": 1000000, "cost_per_batch": 1, "token_count": 1, "token_type": "future_field" }
+                ],
+                "total_nano_aiu": 1
+              }
+            }
+            """);
+
+        CopilotUsageParser.TryParse(doc.RootElement, out var usage).ShouldBeTrue();
+        usage.TokenDetails.Single().TokenType.ShouldBe("future_field");
+    }
+
+    [Fact]
+    public void TryParse_MessageDeltaShape_WorksOnRealCapturedFixture()
+    {
+        // Verbatim shape from cat_v1_messages.txt (numbers preserved as captured).
+        using var doc = JsonDocument.Parse("""
+            {
+              "copilot_usage": {
+                "token_details": [
+                  { "batch_size": 1000000, "cost_per_batch":  500000000000, "token_count":     6, "token_type": "input"       },
+                  { "batch_size": 1000000, "cost_per_batch":   50000000000, "token_count":     0, "token_type": "cache_read"  },
+                  { "batch_size": 1000000, "cost_per_batch":  625000000000, "token_count": 35112, "token_type": "cache_write" },
+                  { "batch_size": 1000000, "cost_per_batch": 2500000000000, "token_count":    80, "token_type": "output"      }
+                ],
+                "total_nano_aiu": 22148000000
+              },
+              "delta": { "stop_reason": "tool_use" },
+              "type": "message_delta",
+              "usage": { "input_tokens": 6, "output_tokens": 80 }
+            }
+            """);
+
+        CopilotUsageParser.TryParse(doc.RootElement, out var usage).ShouldBeTrue();
+        usage.TotalNanoAiu.ShouldBe(22_148_000_000);
+        usage.TokenDetails.Single(d => d.TokenType == "cache_write").TokenCount.ShouldBe(35112);
+    }
+}


### PR DESCRIPTION
## Phase 5B — Parse `copilot_usage` billing snapshot and emit Activity tags (#810)

Every successful Copilot response (Anthropic Messages, OpenAI Responses, OpenAI Chat Completions) carries a `copilot_usage` object that records the call's billed premium-interaction cost (`total_nano_aiu`) plus the per-token-type breakdown the server used to derive it.

Until now we deserialised the OpenAI/Anthropic native `usage` field but **silently dropped `copilot_usage`** — hiding the actual nano-AIU cost from observability.

### What this adds

#### Telemetry namespace (Copilot-owned)
- `CopilotUsage` + `CopilotTokenDetail` records modelling the wire shape verbatim.
- `CopilotUsageParser.TryParse(JsonElement)` — looks for a top-level `copilot_usage` object on any JSON root. Safe to call on every SSE chunk; silently no-ops when absent or malformed.
- `CopilotUsageActivity.Emit(CopilotUsage, Activity?)` + `TryParseAndEmit(JsonElement, Activity?)` — attaches `botnexus.copilot.usage.*` tags:
  - `total_nano_aiu` (call cost)
  - `tokens.{type}` (per-token-type count: `input`, `output`, `cache_read`, `cache_write`, plus any new type Copilot adds)
  - `cost_per_batch.{type}` (per-token-type nano-AIU price)
  - `batch_size.{type}` (batch denominator)
- Token-type names are passed through verbatim so any new buckets Copilot introduces surface automatically.

#### Core hook (non-breaking)
- `OpenAIStreamProcessor.ParseOpenAiCompletionsAsync` gains an **optional** `Action<JsonElement>? inspectChunk = null` parameter so the Copilot Completions provider can peek at each SSE chunk's root without coupling Core to anything Copilot-specific. Existing OpenAI/Compat callers pass nothing and behave identically.

#### Wiring
- `CopilotCompletionsProvider` passes a lambda calling `CopilotUsageActivity.TryParseAndEmit` per chunk.
- `CopilotResponsesProvider` and `CopilotMessagesStreamParser` already own their chunk-parse loops, so the call is inlined per event there (covers `message_delta` / `response.completed`).
- All three use `Activity.Current` so tags land on the existing `provider.copilot-*.stream` activity.

#### Naming
Namespace is `Telemetry` rather than `Usage` to avoid shadowing the `BotNexus.Agent.Providers.Core.Models.Usage` type inside Copilot files that already import it.

### Tests (11 new, all green)

- `CopilotUsageParserTests` (6): full-field round-trip, missing/malformed/empty handling, unknown `token_type` pass-through, and a verbatim `message_delta` shape from `cat_v1_messages.txt`.
- `CopilotUsageActivityTests` (5): per-token-type tag names + types, null-usage/null-activity no-ops, chunk-without-copilot_usage no-op, chunk-with-copilot_usage emits tags.

### Validation

- `dotnet build BotNexus.slnx --nologo --tl:off`: **0 warnings, 0 errors**
- `scripts/repo/test-impacted.ps1 -NoBuild`: all green except the pre-existing `GatewayProcessManagerTests.GetStatusAsync_WhenRunning_ReturnsPidAndUptime` PID-recycle flake (confirmed on `main`).
- Parity tests (`CopilotMessages/Responses/CompletionsProviderParityTests` + `CopilotRequestSnapshotTests` + `CopilotGatewayRoutingTests`): all 19 still pass — wire requests unchanged.

### Why Activity tags only

Per the Phase 5 rubber-duck design discussion: Activity tags are the lowest-coupling way to surface this data. A typed callback / event on `AssistantMessage` would muddy the cross-provider `Usage` record and force every consumer to learn about Copilot-specific billing. Activity tags are queryable via any OTel exporter and add zero shape to `Usage`. If we later decide consumers need programmatic access, we can layer a callback on top.

Refs #810