### PR TITLE
fix(portal): preserve streamed text during history reconciliation and reconnect

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
@@ -436,6 +436,14 @@ public sealed class AgentInteractionService : IAgentInteractionService
         if (conv is null || conv.IsLoadingHistory) return;
         if (conv.HistoryLoaded)
             return; // Already loaded from server — don't reload
+
+        // Guard: never load history while the conversation is mid-stream.
+        // Messages.Clear() would wipe tool-call messages and the partially-built
+        // assistant buffer that HandleContentDelta is accumulating. The deferred
+        // refresh mechanism (DrainPendingConversationRefreshes) handles post-stream
+        // updates; attempting a load here would lose visible streamed text (#759).
+        if (conv.StreamState.IsStreaming)
+            return;
 
         conv.IsLoadingHistory = true;
         _store.NotifyChanged();

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
@@ -596,31 +596,35 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
             var result = await _hub.SubscribeAllAsync();
             foreach (var session in result.Sessions)
                 _store.RegisterSession(session.AgentId, session.SessionId, session.ChannelType);
-
-            foreach (var agentId in _streamingWhenDisconnected)
-            {
-                if (_store.GetAgent(agentId) is { } agent)
-                {
-                    agent.IsStreaming = false;
-                    agent.ProcessingStage = null;
-
-                    if (agent.ActiveConversationId is not null &&
-                        agent.Conversations.GetValueOrDefault(agent.ActiveConversationId) is { } conv)
-                    {
-                        conv.StreamState.Buffer = "";
-                        conv.StreamState.ThinkingBuffer = "";
-                        conv.StreamState.IsStreaming = false;
-                    }
-                }
-            }
-
-            _streamingWhenDisconnected.Clear();
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"GatewayEventHandler: reconnect recovery failed: {ex.Message}");
         }
 
+        // Clear stale streaming state unconditionally (even if SubscribeAllAsync failed).
+        // The portal must never get stuck in a perpetual streaming indicator (#759).
+        foreach (var agentId in _streamingWhenDisconnected)
+        {
+            if (_store.GetAgent(agentId) is { } agent)
+            {
+                agent.IsStreaming = false;
+                agent.ProcessingStage = null;
+
+                if (agent.ActiveConversationId is not null &&
+                    agent.Conversations.GetValueOrDefault(agent.ActiveConversationId) is { } conv)
+                {
+                    conv.StreamState.Buffer = "";
+                    conv.StreamState.ThinkingBuffer = "";
+                    conv.StreamState.IsStreaming = false;
+                    // Force history reload so the UI fetches server-persisted state.
+                    // HandleMessageEnd never committed the buffer to Messages (#759).
+                    conv.HistoryLoaded = false;
+                }
+            }
+        }
+
+        _streamingWhenDisconnected.Clear();
         _store.NotifyChanged();
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/AgentInteractionServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
@@ -561,5 +561,52 @@ public sealed class AgentInteractionServiceTests
         var conv = agent.Conversations["conv-new-streaming"];
         Assert.False(conv.StreamState.IsStreaming);
         Assert.Single(conv.Messages);
+    }
+
+
+    // ---- Stream/history reconciliation tests (issue #759) ----
+
+
+    [Fact]
+    public async Task LoadHistory_not_called_when_streaming_active()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.ActiveConversationId = "conv-active";
+        agent.Conversations["conv-active"] = new ConversationState
+        {
+            ConversationId = "conv-active",
+            Title = "Active",
+            HistoryLoaded = false,
+            ActiveSessionId = "sess-active"
+        };
+        var conv = agent.Conversations["conv-active"];
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "in progress";
+        conv.Messages.Add(new ChatMessage("Tool", "running tool", DateTimeOffset.UtcNow));
+
+        // Trigger SelectConversation which internally calls LoadConversationHistoryAsync
+        // But fix #789 resets IsStreaming first, so we need to test the direct path.
+        // Instead, use the internal mechanism: set HistoryLoaded=false then call Select.
+        // The SelectConversation fix (#789) resets streaming first, allowing reload.
+        // Our guard protects the non-SelectConversation path (DrainPending, RefreshConversations).
+        // To test our guard: manually trigger via the public RefreshConversationsAsync.
+
+        _restClient.GetConversationsAsync(Arg.Any<string>())
+            .Returns(new List<ConversationSummaryDto>
+            {
+                new("conv-active", "agent-1", "Active", false, "Active", "sess-active", 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+            });
+        _restClient.GetSessionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionSummary>() as IReadOnlyList<SessionSummary>);
+
+        // This should NOT trigger a history load because conversation is streaming
+        await _service.RefreshConversationsAsync("agent-1");
+
+        // History endpoint should NOT have been called
+        await _restClient.DidNotReceive().GetHistoryAsync(Arg.Any<string>(), Arg.Any<int>());
+
+        // Messages should be preserved
+        Assert.Single(conv.Messages);
+        Assert.Equal("running tool", conv.Messages[0].Content);
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/GatewayEventHandlerTests.cs
@@ -835,4 +835,72 @@ public sealed class GatewayEventHandlerTests
         Assert.Equal(msgCountBefore, conv.Messages.Count);
     }
 
+
+    // ---- Stream/history reconciliation tests (issue #759) ----
+
+    [Fact]
+    public async Task HandleReconnectedAsync_marks_HistoryLoaded_false_for_streaming_conversations()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        conv.HistoryLoaded = true;
+        agent.IsStreaming = true;
+        conv.StreamState.IsStreaming = true;
+        conv.StreamState.Buffer = "partial response";
+
+        // Simulate disconnect while streaming
+        _handler.HandleReconnecting();
+
+        // Now reconnect
+        await _handler.HandleReconnectedAsync();
+
+        // History should be marked for reload so the UI fetches server state
+        Assert.False(conv.HistoryLoaded);
+        // Stream state should be cleared
+        Assert.False(conv.StreamState.IsStreaming);
+        Assert.Equal(string.Empty, conv.StreamState.Buffer);
+    }
+
+    [Fact]
+    public async Task HandleReconnectedAsync_does_not_mark_HistoryLoaded_false_for_non_streaming_agents()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+        conv.HistoryLoaded = true;
+        agent.IsStreaming = false;
+
+        // Simulate disconnect while NOT streaming
+        _handler.HandleReconnecting();
+
+        // Reconnect
+        await _handler.HandleReconnectedAsync();
+
+        // History should remain loaded (no stream was lost)
+        Assert.True(conv.HistoryLoaded);
+    }
+
+    [Fact]
+    public void HandleConversationChanged_defers_refresh_when_streaming_then_drains_on_MessageEnd()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        var conv = agent.Conversations["conv-1"];
+
+        // Start streaming
+        _handler.HandleMessageStart(new AgentStreamEvent { SessionId = "sess-1" });
+
+        // Simulate a conversation change event mid-stream
+        var refreshCalled = false;
+        _handler.ConversationRefreshDelegate = _ => { refreshCalled = true; return Task.CompletedTask; };
+        _handler.HandleConversationChanged(new ConversationChangedPayload("update", "agent-1", "conv-1"));
+        Assert.False(refreshCalled, "refresh must be deferred while streaming");
+
+        // End the stream
+        conv.StreamState.Buffer = "response text";
+        _handler.HandleMessageEnd(new AgentStreamEvent { SessionId = "sess-1" });
+
+        // Now the deferred refresh should have fired
+        Assert.True(refreshCalled, "deferred refresh must fire after MessageEnd");
+        // And the message should still be in the list (not lost)
+        Assert.Contains(conv.Messages, m => m.Content == "response text");
+    }
 }


### PR DESCRIPTION
Closes #759

## Changes

Two guards added to prevent stream text loss in the portal:

1. **LoadConversationHistoryAsync guard**: Skip history load if the conversation is mid-stream. Without this, `Messages.Clear()` wipes accumulated tool-call messages and the partially-built assistant buffer that `HandleContentDelta` is accumulating.

2. **HandleReconnectedAsync restructure**: Move streaming state cleanup OUTSIDE the try block (after the catch) so it executes even when `SubscribeAllAsync` fails. Additionally, set `HistoryLoaded = false` on reconnect for conversations that were streaming — forces the UI to fetch server-persisted state instead of showing a blank conversation.

## Tests

- `HandleReconnectedAsync_marks_HistoryLoaded_false_for_streaming_conversations` — verifies history is marked for reload
- `HandleReconnectedAsync_does_not_mark_HistoryLoaded_false_for_non_streaming_agents` — no false positives
- `HandleConversationChanged_defers_refresh_when_streaming_then_drains_on_MessageEnd` — verifies existing deferred-refresh pattern plus message preservation
- `LoadHistory_not_called_when_streaming_active` — verifies the streaming guard prevents history API calls

All 429 BlazorClient tests + 173 Architecture tests pass.

## Merge Notes

Independent — no file overlap with any open PR. Safe to merge in any order.
