### PR TITLE
fix(gateway): prevent cron session reuse by interactive channels

### DIFF
--- a/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/DefaultConversationRouter.cs
@@ -84,7 +84,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
                     existingBinding.Mode = BindingMode.Interactive;
                     reactivated = true;
                 }
-                var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct);
+                var (directSessionId, directIsNew, directSessionChanged) = await ResolveOrCreateSessionAsync(direct, agentId, ct, channelType);
                 var changed = directSessionChanged;
                 if (changed)
                 {
@@ -141,7 +141,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
 
         // 3. Resolve or create the active session
         var conversationChanged = addedBinding;
-        var (sessionId, isNewSession, sessionChanged) = await ResolveOrCreateSessionAsync(conversation, agentId, ct);
+        var (sessionId, isNewSession, sessionChanged) = await ResolveOrCreateSessionAsync(conversation, agentId, ct, channelType);
         conversationChanged |= sessionChanged;
 
         if (conversationChanged)
@@ -291,7 +291,7 @@ public sealed class DefaultConversationRouter : IConversationRouter
     // Stamps session.ConversationId and conversation.ActiveSessionId when changed.
     // Returns the sessionId, whether it is new, and whether the conversation was mutated.
     private async Task<(SessionId sessionId, bool isNewSession, bool conversationChanged)> ResolveOrCreateSessionAsync(
-        Conversation conversation, AgentId agentId, CancellationToken ct)
+        Conversation conversation, AgentId agentId, CancellationToken ct, ChannelKey? inboundChannelType = null)
     {
         SessionId sessionId;
         var isNewSession = false;
@@ -300,10 +300,13 @@ public sealed class DefaultConversationRouter : IConversationRouter
         if (conversation.ActiveSessionId.HasValue)
         {
             var existingSession = await _sessionStore.GetAsync(conversation.ActiveSessionId.Value, ct);
-            if (existingSession is { Status: not SessionStatus.Sealed })
+            if (existingSession is { Status: not SessionStatus.Sealed } &&
+                !IsCrossChannelConflict(existingSession, inboundChannelType))
             {
                 // Reuse Active AND Expired sessions -- GatewayHost reactivates Expired sessions.
                 // Only Sealed sessions (explicit reset/archive) should trigger a new session.
+                // Cross-channel conflicts (e.g. cron session reused by SignalR) also trigger
+                // a new session to prevent channel context bleeding (#731).
                 sessionId = conversation.ActiveSessionId.Value;
                 _logger.LogDebug("Reusing {Status} session {SessionId} for conversation {ConversationId}",
                     existingSession.Status, sessionId, conversation.ConversationId);
@@ -347,6 +350,29 @@ public sealed class DefaultConversationRouter : IConversationRouter
         }
 
         return (sessionId, isNewSession, conversationChanged);
+    }
+
+    /// <summary>
+    /// Returns true when the existing session was created by a different channel type
+    /// (e.g. cron) and the inbound channel is interactive (e.g. signalr). Reusing such
+    /// a session would leak the prior channel's context into the new channel (#731).
+    /// </summary>
+    private static bool IsCrossChannelConflict(GatewaySession existingSession, ChannelKey? inboundChannelType)
+    {
+        if (inboundChannelType is null)
+            return false;
+
+        if (existingSession.ChannelType is null)
+            return false;
+
+        // Same channel type — no conflict.
+        if (existingSession.ChannelType == inboundChannelType)
+            return false;
+
+        // A cron-owned session must not be reused by interactive channels.
+        // The session's metadata, SessionType, and ChannelType all reflect the cron context
+        // which would confuse diagnostics and potentially leak trigger metadata.
+        return string.Equals(existingSession.ChannelType.Value.Value, "cron", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<Conversation?> TryReopenArchivedConversationAsync(

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/Conversations/DefaultConversationRouterTests.cs
@@ -568,5 +568,156 @@ public sealed class DefaultConversationRouterTests
         result.Conversation.ConversationId.ShouldBe(conversation.ConversationId);
         result.Conversation.Initiator!.Value.ShouldBe(original);
     }
+
+    // ── Cross-channel conflict (#731) ─────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveInbound_CronSessionNotReusedBySignalR_CreatesNewSession()
+    {
+        // Arrange: a cron trigger created a session on a conversation
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(conversationStore, sessionStore);
+        var agentId = Agent();
+        var signalrChannel = ChannelKey.From("signalr");
+        var cronChannel = ChannelKey.From("cron");
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:test-731"),
+            AgentId = agentId,
+            Title = "test",
+            IsDefault = false
+        };
+        conversation.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = cronChannel,
+            ChannelAddress = ChannelAddress.From(agentId.Value),
+            Mode = BindingMode.Interactive
+        });
+        await conversationStore.CreateAsync(conversation);
+
+        // Simulate cron trigger creating a session and stamping ActiveSessionId
+        var cronSessionId = SessionId.From("cron:test:202606071234:abc");
+        var cronSession = await sessionStore.GetOrCreateAsync(cronSessionId, agentId);
+        cronSession.ChannelType = cronChannel;
+        cronSession.ConversationId = conversation.ConversationId;
+        await sessionStore.SaveAsync(cronSession);
+
+        conversation.ActiveSessionId = cronSessionId;
+        await conversationStore.SaveAsync(conversation);
+
+        // Act: SignalR user sends a message targeting the same conversation
+        var result = await router.ResolveInboundAsync(
+            agentId,
+            signalrChannel,
+            ChannelAddress.From(agentId.Value),
+            conversation.ConversationId.Value);
+
+        // Assert: a NEW session is created, not the cron one
+        result.SessionId.ShouldNotBe(cronSessionId);
+        result.IsNewSession.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveInbound_SameChannelSessionReused_NoConflict()
+    {
+        // Arrange: a signalr session already exists
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(conversationStore, sessionStore);
+        var agentId = Agent();
+        var signalrChannel = ChannelKey.From("signalr");
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:test-731b"),
+            AgentId = agentId,
+            Title = "test",
+            IsDefault = false
+        };
+        conversation.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = signalrChannel,
+            ChannelAddress = ChannelAddress.From(agentId.Value),
+            Mode = BindingMode.Interactive
+        });
+        await conversationStore.CreateAsync(conversation);
+
+        var existingSessionId = SessionId.From("session:signalr-existing");
+        var existingSession = await sessionStore.GetOrCreateAsync(existingSessionId, agentId);
+        existingSession.ChannelType = signalrChannel;
+        existingSession.ConversationId = conversation.ConversationId;
+        await sessionStore.SaveAsync(existingSession);
+
+        conversation.ActiveSessionId = existingSessionId;
+        await conversationStore.SaveAsync(conversation);
+
+        // Act: another signalr message arrives
+        var result = await router.ResolveInboundAsync(
+            agentId,
+            signalrChannel,
+            ChannelAddress.From(agentId.Value),
+            conversation.ConversationId.Value);
+
+        // Assert: same session reused
+        result.SessionId.ShouldBe(existingSessionId);
+        result.IsNewSession.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ResolveInbound_CronSessionViaBindingLookup_CreatesNewSession()
+    {
+        // Arrange: no explicit conversationId — binding lookup path
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore();
+        var router = CreateRouter(conversationStore, sessionStore);
+        var agentId = Agent();
+        var signalrChannel = ChannelKey.From("signalr");
+        var cronChannel = ChannelKey.From("cron");
+        var address = ChannelAddress.From(agentId.Value);
+
+        var conversation = new Conversation
+        {
+            ConversationId = ConversationId.From("conv:test-731c"),
+            AgentId = agentId,
+            Title = "test",
+            IsDefault = false
+        };
+        // Both channels have bindings to this conversation
+        conversation.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = cronChannel,
+            ChannelAddress = address,
+            Mode = BindingMode.Interactive
+        });
+        conversation.ChannelBindings.Add(new ChannelBinding
+        {
+            ChannelType = signalrChannel,
+            ChannelAddress = address,
+            Mode = BindingMode.Interactive
+        });
+        await conversationStore.CreateAsync(conversation);
+
+        // Cron session is active
+        var cronSessionId = SessionId.From("cron:job:202606071234:xyz");
+        var cronSession = await sessionStore.GetOrCreateAsync(cronSessionId, agentId);
+        cronSession.ChannelType = cronChannel;
+        cronSession.ConversationId = conversation.ConversationId;
+        await sessionStore.SaveAsync(cronSession);
+
+        conversation.ActiveSessionId = cronSessionId;
+        await conversationStore.SaveAsync(conversation);
+
+        // Act: SignalR resolves via binding (no explicit conversationId)
+        var result = await router.ResolveInboundAsync(
+            agentId,
+            signalrChannel,
+            address);
+
+        // Assert: fresh session, not the cron one
+        result.SessionId.ShouldNotBe(cronSessionId);
+        result.IsNewSession.ShouldBeTrue();
+    }
 }
 


### PR DESCRIPTION
Closes #731

## Problem

When a cron job creates a session on a conversation and stamps `channel_type = cron` on the session record, subsequent SignalR (portal) messages targeting the same conversation would **reuse** that cron session. This caused:
- Session `channel_type` remaining as `cron` for user-initiated messages
- Cron metadata (triggerType, cronJobId) bleeding into user sessions
- Diagnostics misidentifying portal sessions as cron-initiated
- Spurious cron bindings registered against SignalR conversations

## Root Cause

`DefaultConversationRouter.ResolveOrCreateSessionAsync` reused any `ActiveSessionId` that was not `Sealed`, without checking whether the session belonged to a different channel type. A cron session (ChannelType=`cron`) would be reused by a SignalR inbound because it was still `Active`.

## Fix

Added `IsCrossChannelConflict` guard that detects when an existing session was created by the `cron` channel and the inbound is from a different channel type (e.g. `signalr`). In this case, the router creates a fresh session instead of reusing the cron one.

The guard is intentionally narrow: only cron-to-interactive conflicts trigger new sessions. Same-channel reuse (signalr→signalr, telegram→telegram) is unaffected.

## Tests

3 new regression tests in `DefaultConversationRouterTests`:
- `ResolveInbound_CronSessionNotReusedBySignalR_CreatesNewSession` — explicit conversationId path
- `ResolveInbound_SameChannelSessionReused_NoConflict` — same-channel reuse still works
- `ResolveInbound_CronSessionViaBindingLookup_CreatesNewSession` — binding lookup path

## Merge Notes

Independent PR — touches only `DefaultConversationRouter.cs` and its test file. No file overlap with any open PR. Safe to merge in any order.