### PR TITLE
feat(portal): group conversations in sidebar with collapsible scheduled section

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
@@ -211,6 +211,9 @@ public sealed class ConversationState
     /// <summary>Whether this is the agent's default conversation.</summary>
     public bool IsDefault { get; set; }
 
+    /// <summary>Whether this conversation is pinned to the top.</summary>
+    public bool IsPinned { get; set; }
+
     /// <summary>Conversation status (Active, Archived, etc.).</summary>
     public string Status { get; set; } = "Active";
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -103,6 +103,7 @@ public sealed class ClientStateStore : IClientStateStore
                 // Preserve local-only state; update server-sourced fields
                 existing.Title = dto.Title;
                 existing.IsDefault = dto.IsDefault;
+                existing.IsPinned = dto.IsPinned;
                 existing.Status = dto.Status;
                 existing.ActiveSessionId = dto.ActiveSessionId;
                 existing.CreatedAt = dto.CreatedAt;
@@ -115,6 +116,7 @@ public sealed class ClientStateStore : IClientStateStore
                     ConversationId = dto.ConversationId,
                     Title = dto.Title,
                     IsDefault = dto.IsDefault,
+                    IsPinned = dto.IsPinned,
                     Status = dto.Status,
                     ActiveSessionId = dto.ActiveSessionId,
                     CreatedAt = dto.CreatedAt,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ConversationContracts.cs
@@ -14,7 +14,9 @@ public sealed record ConversationSummaryDto(
     [property: JsonPropertyName("bindingCount")] int BindingCount,
     [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
     [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt,
-    [property: JsonPropertyName("kind")] string Kind = "HumanAgent");
+    [property: JsonPropertyName("kind")] string Kind = "HumanAgent",
+    [property: JsonPropertyName("isPinned")] bool IsPinned = false,
+    [property: JsonPropertyName("pinnedAt")] DateTimeOffset? PinnedAt = null);
 
 public sealed record CreateConversationRequestDto(
     [property: JsonPropertyName("agentId")] string AgentId,

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -23,7 +23,7 @@
                 <span class="burger-line"></span>
                 <span class="burger-line"></span>
             </button>
-            <span class="banner-logo">🤖</span>
+            <span class="banner-logo">&#x1F916;</span>
             <span class="banner-title">BotNexus</span>
             <button class="banner-settings-btn" @onclick="OpenSettings" title="Portal settings" data-testid="banner-settings-btn">&#x2699;&#xFE0F;</button>
             @if (Prefs.Current.DebugModeEnabled)
@@ -41,7 +41,7 @@
             {
                 <div class="announcement-item @ann.Type">
                     <span class="announcement-content">@ann.Text</span>
-                    <button class="announcement-dismiss" @onclick="() => DismissAnnouncement(ann.Id)">✕</button>
+                    <button class="announcement-dismiss" @onclick="() => DismissAnnouncement(ann.Id)">&#x2715;</button>
                 </div>
             }
         </div>
@@ -63,7 +63,7 @@
 
             @* Nav links *@
             <nav class="sidebar-nav">
-                <a href="chat" class="sidebar-nav-item @NavClass("")" @onclick="OnNavClick">💬 Chat</a>
+                <a href="chat" class="sidebar-nav-item @NavClass("")" @onclick="OnNavClick">&#x1F4AC; Chat</a>
 
                 @* Scrollable agent/conversation section *@
                 <div class="sidebar-scroll-region">
@@ -79,7 +79,7 @@
                             {
                                 <option value="@agentId">
                                     @FormatAgentName(agent)
-                                    @if (agent.IsStreaming) { <text> ●</text> }
+                                    @if (agent.IsStreaming) { <text> &#x25CF;</text> }
                                     @if (agent.UnreadCount > 0) { <text> (@agent.UnreadCount)</text> }
                                 </option>
                             }
@@ -108,7 +108,7 @@
                             <div class="conversation-list-scroll">
                                 @if (activeAgent.IsLoadingConversations)
                                 {
-                                    <div class="conversation-list-loading">Loading conversations…</div>
+                                    <div class="conversation-list-loading">Loading conversations&#x2026;</div>
                                 }
                                 else if (activeAgent.Conversations.Count == 0)
                                 {
@@ -116,49 +116,52 @@
                                 }
                                 else
                                 {
-                                    @foreach (var conversation in activeAgent.Conversations.Values
+                                    var allUserConversations = activeAgent.Conversations.Values
                                         .Where(IsUserFacingConversation)
                                         .OrderByDescending(c => c.IsDefault)
-                                        .ThenByDescending(c => c.UpdatedAt))
+                                        .ThenByDescending(c => c.UpdatedAt)
+                                        .ToList();
+                                    var pinnedConversations = allUserConversations.Where(IsPinnedConversation).ToList();
+                                    var cronConversations = allUserConversations.Where(IsCronConversation).ToList();
+                                    var normalConversations = allUserConversations.Where(c => !IsPinnedConversation(c) && !IsCronConversation(c)).ToList();
+
+                                    @if (pinnedConversations.Count > 0)
                                     {
-                                        <div class="conversation-list-item" data-testid="conversation-list-item" data-conversation-id="@conversation.ConversationId">
-                                            <a class="conversation-list-item-btn @(conversation.ConversationId == activeAgent.ActiveConversationId ? "active" : "")"
-                                               href="chat/@Uri.EscapeDataString(activeAgent.AgentId)/@Uri.EscapeDataString(conversation.ConversationId)"
-                                               @onclick="() => SelectConversationAsync(activeAgent.AgentId, conversation.ConversationId)"
-                                               @onclick:preventDefault="true">
-                                                <span class="conversation-list-item-main">
-                                                    <span class="conversation-list-item-title">@conversation.Title</span>
-
-                                                    @if (conversation.IsDefault)
-                                                    {
-                                                        <span class="conversation-default-badge">Default</span>
-                                                    }
-                                                    @if (GetVirtualConversationBadge(conversation) is { } badge)
-                                                    {
-                                                        <span class="conversation-default-badge">@badge</span>
-                                                    }
-                                                </span>
-
-                                                <span class="conversation-list-item-meta">
-                                                    @if (conversation.UnreadCount > 0)
-                                                    {
-                                                        <span class="conversation-unread-dot"
-                                                              aria-label="Unread messages"></span>
-                                                    }
-
-                                                    <span class="conversation-updated-at">
-                                                        @FormatConversationTimestamp(conversation.UpdatedAt)
-                                                    </span>
-                                                </span>
-                                            </a>
-                                            @if (!conversation.IsDefault && !activeAgent.IsReadOnly)
+                                        <div class="conversation-group conversation-group-pinned" data-testid="conversation-group-pinned">
+                                            <div class="conversation-group-header">
+                                                <span class="conversation-group-label">&#x1F4CC; Pinned</span>
+                                            </div>
+                                            @foreach (var conversation in pinnedConversations)
                                             {
-                                                <button class="conversation-archive-btn" data-testid="conversation-archive-btn"
-                                                        title="@(conversation.IsVirtualSession ? "Close conversation — reopens on next trigger" : "Archive conversation")"
-                                                        @onclick:stopPropagation="true"
-                                                        @onclick="() => ArchiveConversationAsync(activeAgent.AgentId, conversation.ConversationId, conversation.Title, conversation.IsVirtualSession)">
-                                                    @(conversation.IsVirtualSession ? "✕" : "🗑️")
-                                                </button>
+                                                @RenderConversationItem(activeAgent, conversation)
+                                            }
+                                        </div>
+                                    }
+
+                                    <div class="conversation-group conversation-group-conversations" data-testid="conversation-group-conversations">
+                                        <div class="conversation-group-header">
+                                            <span class="conversation-group-label">Conversations</span>
+                                        </div>
+                                        @foreach (var conversation in normalConversations)
+                                        {
+                                            @RenderConversationItem(activeAgent, conversation)
+                                        }
+                                    </div>
+
+                                    @if (cronConversations.Count > 0)
+                                    {
+                                        <div class="conversation-group conversation-group-scheduled" data-testid="conversation-group-scheduled">
+                                            <button class="conversation-group-header conversation-group-header-toggle" data-testid="cron-group-toggle" @onclick="ToggleCronGroup">
+                                                <span class="group-chevron @(!_cronGroupCollapsed ? "expanded" : "")">&#x25B6;</span>
+                                                <span class="conversation-group-label">&#x23F0; Scheduled</span>
+                                                <span class="conversation-group-count">@cronConversations.Count</span>
+                                            </button>
+                                            @if (!_cronGroupCollapsed)
+                                            {
+                                                @foreach (var conversation in cronConversations)
+                                                {
+                                                    @RenderConversationItem(activeAgent, conversation)
+                                                }
                                             }
                                         </div>
                                     }
@@ -188,37 +191,37 @@
 
                 </div>@* end sidebar-scroll-region *@
 
-                <a href="configuration" class="sidebar-nav-item @NavClass("configuration")" @onclick="OnNavClick">⚙️ Configuration</a>
+                <a href="configuration" class="sidebar-nav-item @NavClass("configuration")" @onclick="OnNavClick">&#x2699;&#xFE0F; Configuration</a>
 
                 @* Config section sub-nav — only shown when on the configuration page *@
                 @if (IsOnPage("configuration"))
                 {
                     <div class="sidebar-subnav">
-                        <a href="configuration/gateway"   class="sidebar-subnav-item" @onclick="CloseSidebar">🌐 Gateway</a>
-                        <a href="configuration/providers" class="sidebar-subnav-item" @onclick="CloseSidebar">🔌 Providers</a>
-                        <a href="configuration/channels"  class="sidebar-subnav-item" @onclick="CloseSidebar">📡 Channels</a>
-                        <a href="configuration/locations" class="sidebar-subnav-item" @onclick="CloseSidebar">📍 Locations</a>
-                        <a href="configuration/world"     class="sidebar-subnav-item" @onclick="CloseSidebar">🌍 World Settings</a>
-                        <a href="configuration/cron"      class="sidebar-subnav-item" @onclick="CloseSidebar">⏰ Cron</a>
-                        <a href="configuration/apikey"    class="sidebar-subnav-item" @onclick="CloseSidebar">🔑 Global API Key</a>
-                        <a href="configuration/extensions" class="sidebar-subnav-item" @onclick="CloseSidebar">🔌 Extensions</a>
+                        <a href="configuration/gateway"   class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F310; Gateway</a>
+                        <a href="configuration/providers" class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F50C; Providers</a>
+                        <a href="configuration/channels"  class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F4E1; Channels</a>
+                        <a href="configuration/locations" class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F4CD; Locations</a>
+                        <a href="configuration/world"     class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F30D; World Settings</a>
+                        <a href="configuration/cron"      class="sidebar-subnav-item" @onclick="CloseSidebar">&#x23F0; Cron</a>
+                        <a href="configuration/apikey"    class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F511; Global API Key</a>
+                        <a href="configuration/extensions" class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F50C; Extensions</a>
                     </div>
                 }
 
                 @if (ExtensionFeatures.SkillsEnabled)
                 {
-                    <a href="skills" class="sidebar-nav-item @NavClass("skills")" @onclick="OnNavClick">🧠 Skills</a>
+                    <a href="skills" class="sidebar-nav-item @NavClass("skills")" @onclick="OnNavClick">&#x1F9E0; Skills</a>
 
                     @* Skills sub-nav -- shown when on the skills page *@
                     @if (IsOnPage("skills"))
                     {
                         <div class="sidebar-subnav">
-                            <a href="skills/explorer" class="sidebar-subnav-item" @onclick="CloseSidebar">🗂️ Explorer</a>
+                            <a href="skills/explorer" class="sidebar-subnav-item" @onclick="CloseSidebar">&#x1F5C2;&#xFE0F; Explorer</a>
                         </div>
                     }
                 }
 
-                <a href="agents" class="sidebar-nav-item @NavClass("agents")" @onclick="OnNavClick">🤖 Agents</a>
+                <a href="agents" class="sidebar-nav-item @NavClass("agents")" @onclick="OnNavClick">&#x1F916; Agents</a>
 
                 @* Agents sub-nav -- only shown when on the agents page *@
                 @if (IsOnPage("agents"))
@@ -240,7 +243,7 @@
                 {
                     <div class="gateway-info">
                         <span class="gateway-started" title="@GatewayInfo.Info.StartedAt.ToString("o")">
-                            ↺ @FormatStarted(GatewayInfo.Info.StartedAt)
+                            &#x21BA; @FormatStarted(GatewayInfo.Info.StartedAt)
                         </span>
                         <a class="gateway-commit"
                            href="https://github.com/sytone/botnexus/commit/@GatewayInfo.Info.CommitSha"
@@ -258,11 +261,11 @@
                          title="Update to @UpdateStatus.Status.LatestCommitShort">
                         @if (UpdateStatus.Status.IsUpdateInProgress)
                         {
-                            <span>⏳ Updating…</span>
+                            <span>&#x231B; Updating&#x2026;</span>
                         }
                         else
                         {
-                            <span>↑ @UpdateStatus.Status.LatestCommitShort available</span>
+                            <span>&#x2191; @UpdateStatus.Status.LatestCommitShort available</span>
                         }
                     </div>
                 }
@@ -297,6 +300,9 @@
 </div>
 
 @code {
+    private bool _cronGroupCollapsed = true;
+    private const string CronCollapsedKey = "botnexus-cron-collapsed";
+
     private record Announcement(string Id, string Text, string Type = "info");
     private record SidebarAgentItem(string AgentId, string DisplayLabel);
     private List<Announcement> _announcements = [];
@@ -323,6 +329,8 @@
         {
             var stored = await JS.InvokeAsync<string?>("localStorage.getItem", SidebarKey);
             _sidebarOpen = stored == "true";
+            var cronStored = await JS.InvokeAsync<string?>("localStorage.getItem", CronCollapsedKey);
+            _cronGroupCollapsed = cronStored != "false";
             _isMobile = await JS.InvokeAsync<bool>("chatScroll.isMobileView");
             await Prefs.LoadAsync();
             // Re-render immediately after mobile detection so layout responds without waiting for gateway load.
@@ -464,9 +472,9 @@
 
     private static string SubAgentIcon(string status) => status switch
     {
-        "Running"   => "🔄",
-        "Completed" => "✅",
-        _           => "🤖"
+        "Running"   => "\uD83D\uDD04",
+        "Completed" => "\u2705",
+        _           => "\uD83E\uDD16"
     };
 
     private static bool IsUserFacingConversation(ConversationState conversation)
@@ -486,6 +494,62 @@
 
         return true;
     }
+
+    private static bool IsCronConversation(ConversationState c) =>
+        c.ConversationId.StartsWith("cronconv:", StringComparison.OrdinalIgnoreCase) ||
+        (c.IsVirtualSession && string.Equals(c.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsPinnedConversation(ConversationState c) => c.IsPinned;
+
+    private async Task ToggleCronGroup()
+    {
+        _cronGroupCollapsed = !_cronGroupCollapsed;
+        await JS.InvokeVoidAsync("localStorage.setItem", CronCollapsedKey, _cronGroupCollapsed ? "true" : "false");
+    }
+
+    private RenderFragment RenderConversationItem(AgentState agent, ConversationState conversation) => __builder =>
+    {
+        <div class="conversation-list-item" data-testid="conversation-list-item" data-conversation-id="@conversation.ConversationId">
+            <a class="conversation-list-item-btn @(conversation.ConversationId == agent.ActiveConversationId ? "active" : "")"
+               href="chat/@Uri.EscapeDataString(agent.AgentId)/@Uri.EscapeDataString(conversation.ConversationId)"
+               @onclick="() => SelectConversationAsync(agent.AgentId, conversation.ConversationId)"
+               @onclick:preventDefault="true">
+                <span class="conversation-list-item-main">
+                    <span class="conversation-list-item-title">@conversation.Title</span>
+
+                    @if (conversation.IsDefault)
+                    {
+                        <span class="conversation-default-badge">Default</span>
+                    }
+                    @if (GetVirtualConversationBadge(conversation) is { } badge)
+                    {
+                        <span class="conversation-default-badge">@badge</span>
+                    }
+                </span>
+
+                <span class="conversation-list-item-meta">
+                    @if (conversation.UnreadCount > 0)
+                    {
+                        <span class="conversation-unread-dot"
+                              aria-label="Unread messages"></span>
+                    }
+
+                    <span class="conversation-updated-at">
+                        @FormatConversationTimestamp(conversation.UpdatedAt)
+                    </span>
+                </span>
+            </a>
+            @if (!conversation.IsDefault && !agent.IsReadOnly)
+            {
+                <button class="conversation-archive-btn" data-testid="conversation-archive-btn"
+                        title="@(conversation.IsVirtualSession ? "Close conversation \u2014 reopens on next trigger" : "Archive conversation")"
+                        @onclick:stopPropagation="true"
+                        @onclick="() => ArchiveConversationAsync(agent.AgentId, conversation.ConversationId, conversation.Title, conversation.IsVirtualSession)">
+                    @(conversation.IsVirtualSession ? "\u2715" : "\uD83D\uDDD1\uFE0F")
+                </button>
+            }
+        </div>
+    };
 
     private static string FormatAgentName(AgentState agent) =>
         string.IsNullOrWhiteSpace(agent.Emoji)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -3564,6 +3564,69 @@ details[open] > .thinking-summary::before {
     color: var(--error, #e55);
 }
 
+/* ── Conversation Group Headers ───────────────────────────────────────────────────────── */
+
+.conversation-group {
+    margin-bottom: 0.25rem;
+}
+
+.conversation-group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-muted, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    border: none;
+    background: none;
+    width: 100%;
+    text-align: left;
+}
+
+.conversation-group-header-toggle {
+    cursor: pointer;
+}
+
+.conversation-group-header-toggle:hover {
+    color: var(--text, #ccc);
+}
+
+.group-chevron {
+    display: inline-block;
+    font-size: 0.55rem;
+    transition: transform 0.2s ease;
+}
+
+.group-chevron.expanded {
+    transform: rotate(90deg);
+}
+
+.conversation-group-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.1rem;
+    height: 1.1rem;
+    padding: 0 0.3rem;
+    border-radius: 0.55rem;
+    background: var(--surface-hover, #333);
+    color: var(--text-muted, #888);
+    font-size: 0.6rem;
+    font-weight: 600;
+}
+
+.conversation-group-scheduled .conversation-list-item-btn {
+    opacity: 0.75;
+    font-size: 0.85em;
+}
+
+.conversation-group-scheduled .conversation-list-item-btn:hover {
+    opacity: 1;
+}
+
 /* ── Session Boundary Divider ─────────────────────────────────────────────── */
 
 .session-boundary {

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationGroupingTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationGroupingTests.cs
@@ -1,0 +1,202 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+public sealed class ConversationGroupingTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly ClientStateStore _store;
+    private readonly IAgentInteractionService _interaction;
+    private readonly IPortalLoadService _portalLoad;
+
+    public ConversationGroupingTests()
+    {
+        _store = new ClientStateStore();
+        _interaction = Substitute.For<IAgentInteractionService>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+
+        _portalLoad.IsReady.Returns(false);
+        _portalLoad.IsLoading.Returns(true);
+        _portalLoad.LoadError.Returns((string?)null);
+
+        var hub = new GatewayHubConnection();
+        var restClient = Substitute.For<IGatewayRestClient>();
+        restClient.ApiBaseUrl.Returns("");
+        var http = new HttpClient { BaseAddress = new Uri("http://localhost/") };
+        var gatewayInfo = new GatewayInfoService(http, restClient);
+
+        _ctx.Services.AddSingleton<IClientStateStore>(_store);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(hub);
+        _ctx.Services.AddSingleton(gatewayInfo);
+        _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
+        var mockPrefs = Substitute.For<IPortalPreferencesService>();
+        mockPrefs.Current.Returns(new PortalPreferences());
+        _ctx.Services.AddSingleton(mockPrefs);
+        _ctx.Services.AddSingleton(restClient);
+        _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
+        _ctx.Services.AddSingleton(http);
+        _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    private IRenderedComponent<MainLayout> RenderLayout() =>
+        _ctx.Render<MainLayout>(p => p
+            .Add(c => c.Body, (RenderFragment)(_ => { })));
+
+    private void SeedAgentWithConversations(params ConversationSummaryDto[] conversations)
+    {
+        _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        _store.SeedConversations("a-1", conversations);
+        _store.ActiveAgentId = "a-1";
+    }
+
+    [Fact]
+    public void CronConversations_RenderedInScheduledGroup()
+    {
+        // Arrange: one cronconv:-prefixed conversation
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("cronconv:daily-check", "a-1", "Daily Check", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("c-1", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+
+        var cut = RenderLayout();
+
+        // The scheduled group should exist
+        var scheduledGroup = cut.Find("[data-testid='conversation-group-scheduled']");
+        Assert.NotNull(scheduledGroup);
+
+        // The cron conversation title should be inside the scheduled group (when expanded)
+        // First expand the group
+        cut.Find("[data-testid='cron-group-toggle']").Click();
+        scheduledGroup = cut.Find("[data-testid='conversation-group-scheduled']");
+        Assert.Contains("Daily Check", scheduledGroup.TextContent);
+    }
+
+    [Fact]
+    public void CronConversations_VirtualKind_RenderedInScheduledGroup()
+    {
+        // Arrange: conversation with IsVirtualSession + VirtualSessionKind = "cron"
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("c-1", "a-1", "Cron Task", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("c-2", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+        var cronConv = _store.GetAgent("a-1")!.Conversations["c-1"];
+        cronConv.IsVirtualSession = true;
+        cronConv.VirtualSessionKind = "cron";
+
+        var cut = RenderLayout();
+
+        var scheduledGroup = cut.Find("[data-testid='conversation-group-scheduled']");
+        Assert.NotNull(scheduledGroup);
+
+        // Expand and verify
+        cut.Find("[data-testid='cron-group-toggle']").Click();
+        scheduledGroup = cut.Find("[data-testid='conversation-group-scheduled']");
+        Assert.Contains("Cron Task", scheduledGroup.TextContent);
+    }
+
+    [Fact]
+    public void ScheduledGroup_CollapsedByDefault()
+    {
+        // Arrange: a cron conversation
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("cronconv:job-1", "a-1", "Cron Job", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("c-1", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+
+        var cut = RenderLayout();
+
+        // The scheduled group should exist
+        var scheduledGroup = cut.Find("[data-testid='conversation-group-scheduled']");
+        Assert.NotNull(scheduledGroup);
+
+        // But the cron conversation items should NOT be visible (collapsed by default)
+        var itemsInGroup = scheduledGroup.QuerySelectorAll("[data-testid='conversation-list-item']");
+        Assert.Empty(itemsInGroup);
+    }
+
+    [Fact]
+    public void ScheduledGroup_ShowsCount()
+    {
+        // Arrange: two cron conversations
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("cronconv:job-1", "a-1", "Cron Job 1", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("cronconv:job-2", "a-1", "Cron Job 2", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("c-1", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+
+        var cut = RenderLayout();
+
+        // Find the count badge
+        var countBadge = cut.Find(".conversation-group-count");
+        Assert.Equal("2", countBadge.TextContent.Trim());
+    }
+
+    [Fact]
+    public void PinnedGroup_OnlyShownWhenPinnedExist()
+    {
+        // Arrange: no pinned conversations
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("c-1", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+
+        var cut = RenderLayout();
+
+        // Pinned group should NOT be rendered
+        Assert.Empty(cut.FindAll("[data-testid='conversation-group-pinned']"));
+
+        // Conversations group should still be present
+        cut.Find("[data-testid='conversation-group-conversations']");
+    }
+
+    [Fact]
+    public void PinnedConversations_RenderedInPinnedGroup()
+    {
+        // Arrange: one pinned conversation
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("c-1", "a-1", "Important Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, IsPinned: true),
+            new ConversationSummaryDto("c-2", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+
+        var cut = RenderLayout();
+
+        // Pinned group should be rendered
+        var pinnedGroup = cut.Find("[data-testid='conversation-group-pinned']");
+        Assert.Contains("Important Chat", pinnedGroup.TextContent);
+
+        // Normal Chat should NOT be in the pinned group
+        Assert.DoesNotContain("Normal Chat", pinnedGroup.TextContent);
+    }
+
+    [Fact]
+    public void NormalConversations_RenderedInConversationsGroup()
+    {
+        // Arrange: mix of pinned, normal, and cron conversations
+        SeedAgentWithConversations(
+            new ConversationSummaryDto("c-1", "a-1", "Pinned Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, IsPinned: true),
+            new ConversationSummaryDto("c-2", "a-1", "Normal Chat", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("cronconv:job-1", "a-1", "Cron Job", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        );
+
+        var cut = RenderLayout();
+
+        // Normal conversations group should have "Normal Chat"
+        var convsGroup = cut.Find("[data-testid='conversation-group-conversations']");
+        Assert.Contains("Normal Chat", convsGroup.TextContent);
+
+        // Pinned should NOT be in the normal conversations group
+        Assert.DoesNotContain("Pinned Chat", convsGroup.TextContent);
+
+        // Cron should NOT be in the normal conversations group
+        Assert.DoesNotContain("Cron Job", convsGroup.TextContent);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -226,6 +226,9 @@ public sealed class MainLayoutTests : IDisposable
 
         var cut = RenderLayout();
 
+        // Cron conversations are now in a collapsed Scheduled group; expand it first
+        cut.Find("[data-testid='cron-group-toggle']").Click();
+
         Assert.Contains("Cron", cut.Markup);
         var archiveBtn = cut.Find(".conversation-archive-btn");
         Assert.Contains("✕", archiveBtn.TextContent);


### PR DESCRIPTION
Closes #934

## Changes

Groups the conversation list in the sidebar into three collapsible sections:

1. **📌 Pinned** — conversations where `IsPinned == true` (only shown when pinned conversations exist)
2. **Conversations** — non-pinned, non-cron conversations (the default view)
3. **⏰ Scheduled** — cron conversations (collapsed by default, count badge shown)

### Implementation

- Added `IsPinned` and `PinnedAt` to `ConversationSummaryDto` and `ConversationState`
- Mapped pin state in `ClientStateStore.SeedConversations`
- `MainLayout.razor`: replaced flat conversation list with grouped rendering
- `IsCronConversation` helper classifies by `cronconv:` prefix or `VirtualSessionKind == `cron``
- Scheduled group collapse state persisted via localStorage (`botnexus-cron-collapsed`)
- CSS: group headers, chevron rotation, muted scheduled items

### Tests

- `ConversationGroupingTests.cs` — 6 new bUnit tests covering all AC points
- 456/456 BlazorClient tests pass
- 173/173 Architecture tests pass