### PR TITLE
fix(portal): wrap burger toggle test clicks in InvokeAsync for async handler

### DIFF
--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -85,12 +85,12 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
-    public void Clicking_burger_twice_closes_sidebar()
+    public async Task Clicking_burger_twice_closes_sidebar()
     {
         var cut = RenderLayout();
 
-        cut.Find(".burger-btn").Click();
-        cut.Find(".burger-btn").Click();
+        await cut.InvokeAsync(() => cut.Find(".burger-btn").Click());
+        await cut.InvokeAsync(() => cut.Find(".burger-btn").Click());
 
         cut.Find(".sidebar-closed");
     }


### PR DESCRIPTION
Closes #988

## Changes
- `MainLayoutTests.Clicking_burger_twice_closes_sidebar` changed from sync `void` to `async Task`
- Both `Click()` calls wrapped in `await cut.InvokeAsync(...)` to match `ToggleSidebar`'s async Task signature
- Root cause: `ToggleSidebar` calls `await JS.InvokeVoidAsync(...)` - bare sync clicks race with the async state change, causing the `.sidebar-closed` selector to be evaluated before re-render

## Merge Notes
Independent - no file overlap with any open PR. Safe to merge immediately to unblock main CI.