### PR TITLE
fix(portal): add confirmation dialog to mobile new session action

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -70,6 +70,7 @@
   </Folder>
   <Folder Name="/tests/extensions/">
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj" />
+    <Project Path="tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.DataStore.Tests/BotNexus.Extensions.DataStore.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.ExecTool.Tests/BotNexus.Extensions.ExecTool.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Mcp.Tests/BotNexus.Extensions.Mcp.Tests.csproj" />

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -67,7 +67,7 @@ else
                         <div class="menu-session-id" title="Session ID">
                             <span>Session: </span><span class="session-id-text">@(activeAgent?.SessionId ?? "&#x2014;")</span>
                         </div>
-                        <button class="menu-action" @onclick="NewSession">New session</button>
+                        <button class="menu-action" data-testid="new-session-btn" @onclick="NewSession">New session</button>
                     </div>
                 }
             </div>
@@ -134,6 +134,19 @@ else
             </button>
         </div>
     </div>
+    <!-- NEW SESSION CONFIRM OVERLAY -->
+    @if (_showNewSessionConfirm)
+    {
+        <div class="reset-confirm-overlay" @onclick="CancelNewSession">
+            <div class="reset-confirm-box" @onclick:stopPropagation="true">
+                <p>Start a new session? Prior messages will remain visible but the agent will start with a fresh context.</p>
+                <div class="reset-confirm-actions">
+                    <button class="cancel-btn" @onclick="CancelNewSession">Cancel</button>
+                    <button class="confirm-btn" data-testid="new-session-confirm-btn" @onclick="DoNewSession">New session</button>
+                </div>
+            </div>
+        </div>
+    }
     <!-- TOOL CALL MODAL -->
     @if (_modalToolMessage is not null)
     {
@@ -176,6 +189,7 @@ else
     private bool _isSending;
     private bool _isRefreshing;
     private bool _menuOpen;
+    private bool _showNewSessionConfirm;
     private ElementReference _messageStreamRef;
     private readonly Dictionary<string, string> _markdownCache = new();
     private ChatMessage? _modalToolMessage;
@@ -430,11 +444,25 @@ else
 
     private void ToggleMenu() => _menuOpen = !_menuOpen;
 
-    private async Task NewSession()
+    private void NewSession()
     {
+        _showNewSessionConfirm = true;
         _menuOpen = false;
+    }
+
+    private async Task DoNewSession()
+    {
+        _showNewSessionConfirm = false;
         if (Store.ActiveAgentId is not null)
+        {
             await Interaction.ResetSessionAsync(Store.ActiveAgentId);
+            await ForceScrollToBottomAsync();
+        }
+    }
+
+    private void CancelNewSession()
+    {
+        _showNewSessionConfirm = false;
     }
 
     private void OpenToolModal(ChatMessage msg)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
@@ -499,3 +499,55 @@ body {
 }
 .reconnect-inline-btn:hover:not(:disabled) { background: rgba(248, 113, 113, 0.15); }
 .reconnect-inline-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ── New session confirmation overlay ─────────────────────────────────────── */
+.reset-confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.reset-confirm-box {
+    background: var(--surface, #1e1e2e);
+    border-radius: 12px;
+    padding: 1.5rem;
+    max-width: 320px;
+    width: 90%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.reset-confirm-box p {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: var(--text, #cdd6f4);
+}
+
+.reset-confirm-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
+.reset-confirm-actions .cancel-btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border, #45475a);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-muted, #a6adc8);
+    cursor: pointer;
+}
+
+.reset-confirm-actions .confirm-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 6px;
+    background: var(--accent, #89b4fa);
+    color: var(--surface, #1e1e2e);
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileNewSessionTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileNewSessionTests.cs
@@ -1,0 +1,159 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Pages;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for issue #983: mobile "New Session" button should show a confirm dialog,
+/// call ResetSessionAsync on confirm, and scroll to bottom afterwards.
+/// </summary>
+public sealed class MobileNewSessionTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store;
+    private readonly IPortalLoadService _portalLoad;
+    private readonly IAgentInteractionService _interaction;
+
+    public MobileNewSessionTests()
+    {
+        _store = Substitute.For<IClientStateStore>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+        _interaction = Substitute.For<IAgentInteractionService>();
+
+        _portalLoad.IsReady.Returns(true);
+        _portalLoad.IsSignalRConnected.Returns(true);
+        _portalLoad.LoadError.Returns((string?)null);
+        _portalLoad.InitializeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var convState = new ConversationState
+        {
+            ConversationId = "conv-1",
+            Title = "Test",
+            Status = "Active",
+            ActiveSessionId = "session-1",
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        var agentState = new AgentState
+        {
+            AgentId = "agent-1",
+            DisplayName = "Agent 1",
+            Emoji = null,
+            SessionId = "session-1",
+            ActiveConversationId = "conv-1"
+        };
+        agentState.Conversations["conv-1"] = convState;
+
+        _store.Agents.Returns(new Dictionary<string, AgentState> { ["agent-1"] = agentState }.AsReadOnly());
+        _store.ActiveAgentId.Returns("agent-1");
+        _store.GetAgent("agent-1").Returns(agentState);
+        _store.GetMessages("conv-1").Returns(new List<ChatMessage>().AsReadOnly());
+        _store.GetStreamState("conv-1").Returns(new ConversationStreamState());
+
+        _interaction.ResetSessionAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        _ctx.Services.AddSingleton(_store);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void NewSession_button_shows_confirm_dialog()
+    {
+        var cut = _ctx.Render<Chat>();
+
+        // Open the overflow menu
+        cut.Find(".overflow-btn").Click();
+
+        // Click "New session" button
+        cut.Find("[data-testid='new-session-btn']").Click();
+
+        // Confirm overlay should now be visible
+        var overlay = cut.Find(".reset-confirm-overlay");
+        Assert.NotNull(overlay);
+        var confirmBtn = cut.Find("[data-testid='new-session-confirm-btn']");
+        Assert.NotNull(confirmBtn);
+    }
+
+    [Fact]
+    public async Task NewSession_confirm_calls_ResetSessionAsync()
+    {
+        var cut = _ctx.Render<Chat>();
+
+        // Open menu and click "New session"
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='new-session-btn']").Click();
+
+        // Click confirm
+        cut.Find("[data-testid='new-session-confirm-btn']").Click();
+
+        // ResetSessionAsync should have been called with the active agent
+        await _interaction.Received(1).ResetSessionAsync("agent-1");
+    }
+
+    [Fact]
+    public void NewSession_cancel_hides_dialog()
+    {
+        var cut = _ctx.Render<Chat>();
+
+        // Open menu and click "New session"
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='new-session-btn']").Click();
+
+        // Verify overlay is shown
+        Assert.NotNull(cut.Find(".reset-confirm-overlay"));
+
+        // Click cancel
+        cut.Find(".cancel-btn").Click();
+
+        // Overlay should be gone
+        Assert.Empty(cut.FindAll(".reset-confirm-overlay"));
+    }
+
+    [Fact]
+    public void NewSession_overlay_backdrop_click_cancels()
+    {
+        var cut = _ctx.Render<Chat>();
+
+        // Open menu and click "New session"
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='new-session-btn']").Click();
+
+        // Verify overlay is shown
+        Assert.NotNull(cut.Find(".reset-confirm-overlay"));
+
+        // Click the backdrop (the overlay div itself)
+        cut.Find(".reset-confirm-overlay").Click();
+
+        // Overlay should be gone
+        Assert.Empty(cut.FindAll(".reset-confirm-overlay"));
+    }
+
+    [Fact]
+    public void NewSession_scrolls_to_bottom_after_reset()
+    {
+        var cut = _ctx.Render<Chat>();
+
+        // Open menu and click "New session"
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='new-session-btn']").Click();
+
+        // Click confirm to trigger DoNewSession
+        cut.Find("[data-testid='new-session-confirm-btn']").Click();
+
+        // Verify that JS interop for forceScrollToBottom was invoked
+        // (first call is from OnAfterRenderAsync, subsequent from DoNewSession)
+        var invocations = _ctx.JSInterop.Invocations
+            .Where(i => i.Identifier == "chatScroll.forceScrollToBottom")
+            .ToList();
+
+        // At least 2: one from first render, one from DoNewSession
+        Assert.True(invocations.Count >= 2,
+            $"Expected at least 2 forceScrollToBottom calls but got {invocations.Count}");
+    }
+}


### PR DESCRIPTION
Closes #983

## Changes
- Added confirmation dialog overlay to the mobile New session menu action
- User must confirm before session is reset (prevents accidental resets)
- Clicking backdrop or Cancel dismisses the dialog
- On confirm: calls ResetSessionAsync then ForceScrollToBottomAsync
- Added CSS for overlay, confirm box, and action buttons
- Added Mobile.Tests project to BotNexus.slnx for test discoverability
- 5 new bUnit tests covering confirm shown, reset called, cancel, backdrop, scroll

## Merge Notes
Independent of all other open PRs. Safe to merge in any order.