### PR TITLE
fix(gateway): detect and clean up abandoned tool calls before dispatching new user messages

### DIFF
--- a/src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SessionContextProjector.cs
@@ -79,4 +79,107 @@ public static class SessionContextProjector
         ArgumentNullException.ThrowIfNull(history);
         return history.Where(IsVisibleInLiveContext).ToList();
     }
+
+    /// <summary>
+    /// Detects whether the session history contains an abandoned turn — a sequence of
+    /// tool-start entries without matching tool-end entries that precedes the most recent
+    /// user message. This indicates a prior turn stalled mid-execution and the dangling
+    /// context should not be replayed to the agent.
+    /// </summary>
+    /// <remarks>
+    /// A ToolStart entry is identified by having <see cref="SessionEntry.ToolArgs"/> set
+    /// (populated from the <c>AgentStreamEventType.ToolStart</c> event). A matching ToolEnd
+    /// shares the same <see cref="SessionEntry.ToolCallId"/> but has no <c>ToolArgs</c>.
+    /// The detection scans backward from the most recent user message and checks all tool
+    /// entries in the preceding turn for unmatched starts.
+    /// </remarks>
+    public static AbandonedTurnResult DetectAbandonedTurn(IReadOnlyList<SessionEntry> history)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+
+        if (history.Count < 2)
+            return AbandonedTurnResult.None;
+
+        // Find the index of the most recent user message (the new inbound message).
+        int lastUserIndex = -1;
+        for (int i = history.Count - 1; i >= 0; i--)
+        {
+            if (history[i].Role.Equals(MessageRole.User) && !history[i].IsHistory)
+            {
+                lastUserIndex = i;
+                break;
+            }
+        }
+
+        if (lastUserIndex <= 0)
+            return AbandonedTurnResult.None;
+
+        // Find the second-to-last user message (start of the previous turn).
+        int prevUserIndex = -1;
+        for (int i = lastUserIndex - 1; i >= 0; i--)
+        {
+            if (history[i].Role.Equals(MessageRole.User) && !history[i].IsHistory)
+            {
+                prevUserIndex = i;
+                break;
+            }
+        }
+
+        if (prevUserIndex < 0)
+            return AbandonedTurnResult.None;
+
+        // Scan the entries between prevUserIndex and lastUserIndex for dangling tool starts.
+        // A ToolStart has ToolArgs set; a ToolEnd for the same call has the same ToolCallId
+        // but no ToolArgs.
+        var toolStarts = new HashSet<string>(StringComparer.Ordinal);
+        var toolEnds = new HashSet<string>(StringComparer.Ordinal);
+        int abandonedCount = 0;
+
+        for (int i = prevUserIndex + 1; i < lastUserIndex; i++)
+        {
+            var entry = history[i];
+            if (entry.IsCrashSentinel || entry.IsHistory)
+                continue;
+
+            if (!entry.Role.Equals(MessageRole.Tool))
+                continue;
+
+            if (entry.ToolCallId is null)
+                continue;
+
+            if (entry.ToolArgs is not null)
+            {
+                // This is a ToolStart entry
+                toolStarts.Add(entry.ToolCallId);
+            }
+            else
+            {
+                // This is a ToolEnd entry
+                toolEnds.Add(entry.ToolCallId);
+            }
+        }
+
+        // Dangling starts = ToolStarts that have no matching ToolEnd
+        foreach (var startId in toolStarts)
+        {
+            if (!toolEnds.Contains(startId))
+                abandonedCount++;
+        }
+
+        if (abandonedCount == 0)
+            return AbandonedTurnResult.None;
+
+        return new AbandonedTurnResult(HasAbandonedTurn: true, AbandonedEntryCount: abandonedCount);
+    }
+}
+
+/// <summary>
+/// Result of abandoned turn detection.
+/// </summary>
+/// <param name="HasAbandonedTurn">True if dangling tool calls were found in the previous turn.</param>
+/// <param name="AbandonedEntryCount">Number of tool-start entries without matching completions.</param>
+public sealed record AbandonedTurnResult(bool HasAbandonedTurn, int AbandonedEntryCount)
+{
+    /// <summary>Singleton for the no-abandoned-turn case.</summary>
+    public static readonly AbandonedTurnResult None = new(HasAbandonedTurn: false, AbandonedEntryCount: 0);
 }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -457,6 +457,32 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                 }
             }
 
+            // Abandoned turn detection (#790): before starting the new turn, check if
+            // the previous turn stalled mid-tool-execution. If so, destroy the existing
+            // agent handle (forces fresh context on recreate) and notify the user.
+            var abandonedTurnResult = SessionContextProjector.DetectAbandonedTurn(session.History);
+            if (abandonedTurnResult.HasAbandonedTurn)
+            {
+                _logger.LogWarning(
+                    "Abandoned turn detected for session '{SessionId}': {Count} dangling tool call(s). " +
+                    "Destroying stale agent handle to prevent context replay.",
+                    sessionId, abandonedTurnResult.AbandonedEntryCount);
+
+                // Kill the existing handle so the supervisor creates a fresh one with
+                // clean context from ProjectForResume (which drops tool entries).
+                var stopTask = _supervisor.StopAsync(AgentId.From(agentId), SessionId.From(sessionId), cancellationToken);
+                if (stopTask is not null)
+                    await stopTask;
+
+                // Add a notification entry so the user knows the prior turn was incomplete.
+                session.AddEntry(new SessionEntry
+                {
+                    Role = MessageRole.Notification,
+                    Content = $"[Previous turn did not complete — {abandonedTurnResult.AbandonedEntryCount} tool call(s) were abandoned. Starting fresh.]"
+                });
+                await _sessions.SaveAsync(session, cancellationToken);
+            }
+
             // Write-ahead Layer 2: crash sentinel written before the LLM call.
             // If the gateway restarts mid-turn, this sentinel survives in the session store,
             // showing an interrupted-turn marker to the user rather than a silent gap (#363).

--- a/tests/gateway/BotNexus.Gateway.Sessions.Tests/AbandonedTurnDetectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Sessions.Tests/AbandonedTurnDetectionTests.cs
@@ -1,0 +1,175 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+
+namespace BotNexus.Gateway.Sessions.Tests;
+
+/// <summary>
+/// Tests for <see cref="SessionContextProjector.DetectAbandonedTurn"/> which identifies
+/// incomplete tool call sequences left over from stalled turns (#790).
+/// </summary>
+public sealed class AbandonedTurnDetectionTests
+{
+    private static SessionEntry User(string content = "hello") => new()
+    {
+        Role = MessageRole.User,
+        Content = content,
+    };
+
+    private static SessionEntry Assistant(string content = "response") => new()
+    {
+        Role = MessageRole.Assistant,
+        Content = content,
+    };
+
+    private static SessionEntry ToolStart(string toolName = "exec", string callId = "call_1") => new()
+    {
+        Role = MessageRole.Tool,
+        Content = $"Tool '{toolName}' started.",
+        ToolName = toolName,
+        ToolCallId = callId,
+        ToolArgs = "{\"command\":\"ls\"}",
+    };
+
+    private static SessionEntry ToolEnd(string toolName = "exec", string callId = "call_1") => new()
+    {
+        Role = MessageRole.Tool,
+        Content = "file1.txt\nfile2.txt",
+        ToolName = toolName,
+        ToolCallId = callId,
+    };
+
+    private static SessionEntry CrashSentinel() => new()
+    {
+        Role = MessageRole.System,
+        Content = "[agent turn in progress — gateway restarted if visible]",
+        IsCrashSentinel = true,
+    };
+
+    [Fact]
+    public void CleanSession_NoAbandonedTurn()
+    {
+        var history = new List<SessionEntry>
+        {
+            User("hi"),
+            Assistant("hello!"),
+            User("thanks"),
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeFalse();
+        result.AbandonedEntryCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CompletedToolCycle_NoAbandonedTurn()
+    {
+        var history = new List<SessionEntry>
+        {
+            User("list files"),
+            ToolStart("exec", "call_1"),
+            ToolEnd("exec", "call_1"),
+            Assistant("Here are your files."),
+            User("thanks"),
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DanglingToolStart_DetectsAbandonedTurn()
+    {
+        // Turn stalled: tool started but never completed
+        var history = new List<SessionEntry>
+        {
+            User("run a long command"),
+            ToolStart("exec", "call_1"),
+            // No ToolEnd — turn stalled
+            User("thanks"),  // new user message
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeTrue();
+        result.AbandonedEntryCount.ShouldBe(1); // the dangling ToolStart
+    }
+
+    [Fact]
+    public void MultipleDanglingToolCalls_DetectsAll()
+    {
+        var history = new List<SessionEntry>
+        {
+            User("do multiple things"),
+            ToolStart("exec", "call_1"),
+            ToolEnd("exec", "call_1"),
+            ToolStart("read", "call_2"),
+            // call_2 never completed, then more tools started
+            ToolStart("write", "call_3"),
+            User("stop that"),  // new user message
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeTrue();
+        result.AbandonedEntryCount.ShouldBe(2); // call_2 ToolStart + call_3 ToolStart
+    }
+
+    [Fact]
+    public void CrashSentinelWithDanglingTools_DetectsAbandonedTurn()
+    {
+        var history = new List<SessionEntry>
+        {
+            User("run something"),
+            ToolStart("exec", "call_1"),
+            CrashSentinel(),
+            User("hello again"),  // new user message after restart
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeTrue();
+        result.AbandonedEntryCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void EmptyHistory_NoAbandonedTurn()
+    {
+        var history = new List<SessionEntry>();
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SingleUserMessage_NoAbandonedTurn()
+    {
+        var history = new List<SessionEntry>
+        {
+            User("hello"),
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AssistantResponseWithoutTools_NoAbandonedTurn()
+    {
+        // Normal conversation flow — assistant responded but user hasn't spoken yet
+        var history = new List<SessionEntry>
+        {
+            User("hi"),
+            Assistant("hello!"),
+            User("what next?"),
+        };
+
+        var result = SessionContextProjector.DetectAbandonedTurn(history);
+
+        result.HasAbandonedTurn.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Closes #790

## Changes

### Problem
When an agent turn stalls mid-tool-execution (tool call in progress but never completes), the partial turn context remains in the session store. On the next user message, the agent picks up the full history including dangling tool-call entries and continues the stale turn instead of starting fresh.

### Fix
1. **`SessionContextProjector.DetectAbandonedTurn`** — new static method that scans session history for incomplete tool call sequences (ToolStart entries without matching ToolEnd entries in the previous turn window).
2. **`GatewayHost.ProcessAsync`** — before starting a new agent turn, calls `DetectAbandonedTurn`. If dangling tool calls are found:
   - Stops the existing agent handle (forces fresh context on recreate via `ProjectForResume` which drops tool entries)
   - Adds a `MessageRole.Notification` entry informing the user the prior turn was incomplete
   - Saves the session before proceeding

### Detection Logic
- Identifies the two most recent user messages in the non-historical session entries
- Scans all Tool entries between them for ToolStart (has `ToolArgs`) without matching ToolEnd (same `ToolCallId`, no `ToolArgs`)
- Returns an `AbandonedTurnResult` with count of dangling calls

### Tests
- 8 new unit tests covering: clean session, completed tool cycle, single dangling start, multiple dangling starts, crash sentinel + dangling, empty history, single user message, normal assistant flow
- All 2289 Gateway.Tests pass, 173 Architecture.Tests pass, 29 Scenarios.Tests pass

## Merge Notes
Independent of all 7 open PRs. Safe to merge in any order.