### PR TITLE
feat(portal): add descriptive tool call summaries with emoji and context in chat panel

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -169,7 +169,7 @@
                      style="@(!ShowTools ? "display:none" : "")">
                     <div class="tool-header" @onclick="() => ToggleToolDetails(msg.Id)">
                         <span class="tool-icon">@(msg.ToolResult is null ? "⏳" : (msg.ToolIsError == true ? "❌" : "✅"))</span>
-                        <span class="tool-name">@msg.ToolName</span>
+                        <span class="tool-name">@ToolDescriptionFormatter.FormatDescription(msg.ToolName ?? "tool", msg.ToolArgs)</span>
                         @if (msg.ToolDuration is not null)
                         {
                             <span class="tool-duration">@FormatDuration(msg.ToolDuration.Value)</span>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ToolDescriptionFormatter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ToolDescriptionFormatter.cs
@@ -1,0 +1,207 @@
+using System.Text.Json;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+
+/// <summary>
+/// Generates short, human-readable descriptions for tool calls displayed in the chat panel.
+/// Each description includes an emoji prefix and a context-aware summary extracted from tool arguments.
+/// </summary>
+public static class ToolDescriptionFormatter
+{
+    private const int MaxPreviewLength = 50;
+
+    /// <summary>
+    /// Build a short description like "📄 Read Agent.cs" from the tool name and its JSON arguments.
+    /// Falls back to "🔧 toolName" for unknown tools or when arguments can't be parsed.
+    /// </summary>
+    public static string FormatDescription(string toolName, string? toolArgs)
+    {
+        var emoji = GetEmoji(toolName);
+        JsonElement? args = null;
+
+        if (!string.IsNullOrEmpty(toolArgs))
+        {
+            try
+            {
+                args = JsonDocument.Parse(toolArgs).RootElement;
+            }
+            catch (JsonException)
+            {
+                // Malformed JSON — fall through to default
+            }
+        }
+
+        var detail = toolName switch
+        {
+            "read" => FormatFileOp("Read", args),
+            "write" => FormatFileOp("Write", args),
+            "edit" => FormatFileOp("Edit", args),
+            "shell" => FormatShell(args),
+            "exec" => FormatExec(args),
+            "web_search" => FormatStringArg("", args, "query"),
+            "web_fetch" => FormatUrl(args),
+            "grep" => FormatStringArg("Grep", args, "pattern"),
+            "glob" => FormatStringArg("Glob", args, "pattern"),
+            "ls" => FormatStringArg("List", args, "path"),
+            "memory_save" => "Save memory",
+            "memory_search" => FormatStringArg("Search memory:", args, "query"),
+            "memory_get" => "Get memory",
+            "cron" => FormatStringArg("Cron", args, "action"),
+            "canvas" => FormatStringArg("Canvas", args, "action"),
+            "ask_user" => "Ask user",
+            "spawn_subagent" => FormatSpawnSubagent(args),
+            "list_subagents" => "List sub-agents",
+            "manage_subagent" => "Manage sub-agent",
+            "conversation" => FormatStringArg("Conversation", args, "action"),
+            "sessions" => FormatStringArg("Sessions", args, "action"),
+            "skill_manage" => FormatSkillManage(args),
+            "skills" => FormatSkills(args),
+            "delay" => FormatDelay(args),
+            "get_datetime" => "Get datetime",
+            "agent_converse" => FormatStringArg("Talk to", args, "agentId"),
+            "watch_file" => FormatStringArg("Watch", args, "path"),
+            "create_agent" => FormatStringArg("Create agent", args, "id"),
+            "update_agent" => FormatStringArg("Update agent", args, "id"),
+            "list_agents" => "List agents",
+            _ => toolName,
+        };
+
+        return $"{emoji} {detail}";
+    }
+
+    private static string GetEmoji(string toolName) => toolName switch
+    {
+        "read" => "📄",
+        "write" or "edit" => "✏️",
+        "shell" or "exec" => "💻",
+        "web_search" => "🔍",
+        "web_fetch" => "🌐",
+        "grep" or "glob" => "🔎",
+        "ls" => "📂",
+        "memory_save" => "💾",
+        "memory_search" => "🧠",
+        "memory_get" => "🧠",
+        "cron" => "⏰",
+        "canvas" => "🎨",
+        "ask_user" => "❓",
+        "spawn_subagent" or "list_subagents" or "manage_subagent" => "🤖",
+        "conversation" => "💬",
+        "sessions" => "📋",
+        "skill_manage" => "🛠️",
+        "skills" => "📚",
+        "delay" => "⏳",
+        "get_datetime" => "🕐",
+        "agent_converse" => "🗣️",
+        "watch_file" => "👁️",
+        "create_agent" or "update_agent" or "list_agents" => "🤖",
+        _ => "🔧",
+    };
+
+    private static string FormatFileOp(string verb, JsonElement? args)
+    {
+        var path = GetString(args, "path");
+        if (path is null) return verb.ToLowerInvariant();
+        var fileName = Path.GetFileName(path);
+        return string.IsNullOrEmpty(fileName) ? $"{verb} {Truncate(path)}" : $"{verb} {fileName}";
+    }
+
+    private static string FormatShell(JsonElement? args)
+    {
+        var cmd = GetString(args, "command");
+        return cmd is null ? "shell" : Truncate(cmd);
+    }
+
+    private static string FormatExec(JsonElement? args)
+    {
+        if (args is null) return "exec";
+
+        if (args.Value.TryGetProperty("command", out var cmdProp))
+        {
+            if (cmdProp.ValueKind == JsonValueKind.Array)
+            {
+                var parts = new List<string>();
+                foreach (var element in cmdProp.EnumerateArray())
+                {
+                    if (element.ValueKind == JsonValueKind.String)
+                        parts.Add(element.GetString()!);
+                }
+                return parts.Count > 0 ? Truncate(string.Join(' ', parts)) : "exec";
+            }
+
+            if (cmdProp.ValueKind == JsonValueKind.String)
+            {
+                return Truncate(cmdProp.GetString()!);
+            }
+        }
+
+        return "exec";
+    }
+
+    private static string FormatUrl(JsonElement? args)
+    {
+        var url = GetString(args, "url");
+        if (url is null) return "web_fetch";
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            var display = uri.Host + uri.PathAndQuery.TrimEnd('/');
+            return Truncate(display);
+        }
+
+        return Truncate(url);
+    }
+
+    private static string FormatSpawnSubagent(JsonElement? args)
+    {
+        var name = GetString(args, "name");
+        return name is not null ? $"Spawn {name}" : "Spawn sub-agent";
+    }
+
+    private static string FormatSkillManage(JsonElement? args)
+    {
+        var action = GetString(args, "action");
+        var name = GetString(args, "name");
+        if (action is null) return "skill_manage";
+        return name is not null ? $"Skill {action} {name}" : $"Skill {action}";
+    }
+
+    private static string FormatSkills(JsonElement? args)
+    {
+        var action = GetString(args, "action");
+        var skillName = GetString(args, "skillName");
+        if (action == "load" && skillName is not null)
+            return $"Load skill {skillName}";
+        if (action is not null)
+            return $"Skills {action}";
+        return "skills";
+    }
+
+    private static string FormatDelay(JsonElement? args)
+    {
+        if (args is null) return "Delay";
+        if (args.Value.TryGetProperty("seconds", out var sec) && sec.ValueKind == JsonValueKind.Number)
+            return $"Delay {sec.GetInt32()}s";
+        return "Delay";
+    }
+
+    private static string FormatStringArg(string prefix, JsonElement? args, string propertyName)
+    {
+        var value = GetString(args, propertyName);
+        if (value is null) return string.IsNullOrEmpty(prefix) ? "tool" : prefix.ToLowerInvariant();
+        return string.IsNullOrEmpty(prefix) ? Truncate(value) : $"{prefix} {Truncate(value)}";
+    }
+
+    private static string? GetString(JsonElement? args, string propertyName)
+    {
+        if (args is null) return null;
+        if (args.Value.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String)
+            return prop.GetString();
+        return null;
+    }
+
+    private static string Truncate(string value)
+    {
+        if (value.Length <= MaxPreviewLength) return value;
+        return value[..MaxPreviewLength] + "…";
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ToolDescriptionFormatterTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ToolDescriptionFormatterTests.cs
@@ -1,0 +1,230 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for <see cref="ToolDescriptionFormatter"/>.
+/// </summary>
+public sealed class ToolDescriptionFormatterTests
+{
+    [Fact]
+    public void Read_WithPath_ShowsFilename()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("read", """{"path": "src/domain/Models/Agent.cs"}""");
+        Assert.Equal("📄 Read Agent.cs", result);
+    }
+
+    [Fact]
+    public void Write_WithPath_ShowsFilename()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("write", """{"path": "src/gateway/Host.cs", "content": "hello"}""");
+        Assert.Equal("✏️ Write Host.cs", result);
+    }
+
+    [Fact]
+    public void Edit_WithPath_ShowsFilename()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("edit", """{"path": "tests/MyTest.cs", "edits": []}""");
+        Assert.Equal("✏️ Edit MyTest.cs", result);
+    }
+
+    [Fact]
+    public void Shell_WithCommand_ShowsPreview()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("shell", """{"command": "git status --short"}""");
+        Assert.Equal("💻 git status --short", result);
+    }
+
+    [Fact]
+    public void Shell_WithLongCommand_Truncates()
+    {
+        var longCmd = new string('x', 100);
+        var result = ToolDescriptionFormatter.FormatDescription("shell", $$"""{"command": "{{longCmd}}"}""");
+        Assert.Equal("💻 " + longCmd[..50] + "…", result);
+    }
+
+    [Fact]
+    public void Exec_WithCommandArray_ShowsFirst()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("exec", """{"command": ["pwsh", "-c", "Get-Date"]}""");
+        Assert.Equal("💻 pwsh -c Get-Date", result);
+    }
+
+    [Fact]
+    public void Exec_WithLongCommandArray_Truncates()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("exec", """{"command": ["pwsh", "-NoProfile", "-c", "Get-ChildItem -Recurse -Include '*.cs' | Where-Object Name -Match 'Agent'"]}""");
+        Assert.StartsWith("💻 pwsh -NoProfile -c Get-ChildItem", result);
+        Assert.EndsWith("…", result);
+    }
+
+    [Fact]
+    public void WebSearch_WithQuery_ShowsQuery()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("web_search", """{"query": "BotNexus documentation"}""");
+        Assert.Equal("🔍 BotNexus documentation", result);
+    }
+
+    [Fact]
+    public void WebFetch_WithUrl_ShowsUrl()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("web_fetch", """{"url": "https://example.com/page"}""");
+        Assert.Equal("🌐 example.com/page", result);
+    }
+
+    [Fact]
+    public void WebFetch_WithLongUrl_Truncates()
+    {
+        var longPath = new string('x', 100);
+        var result = ToolDescriptionFormatter.FormatDescription("web_fetch", $$"""{"url": "https://example.com/{{longPath}}"}""");
+        Assert.StartsWith("🌐 example.com/", result);
+        Assert.EndsWith("…", result);
+    }
+
+    [Fact]
+    public void Grep_WithPattern_ShowsPattern()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("grep", """{"pattern": "SystemPrompt", "glob": "*.cs"}""");
+        Assert.Equal("🔎 Grep SystemPrompt", result);
+    }
+
+    [Fact]
+    public void Glob_WithPattern_ShowsPattern()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("glob", """{"pattern": "**/*.razor"}""");
+        Assert.Equal("🔎 Glob **/*.razor", result);
+    }
+
+    [Fact]
+    public void Ls_WithPath_ShowsPath()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("ls", """{"path": "src/gateway"}""");
+        Assert.Equal("📂 List src/gateway", result);
+    }
+
+    [Fact]
+    public void MemorySave_ShowsDescription()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("memory_save", """{"content": "some note"}""");
+        Assert.Equal("💾 Save memory", result);
+    }
+
+    [Fact]
+    public void MemorySearch_WithQuery_ShowsQuery()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("memory_search", """{"query": "cron schedule"}""");
+        Assert.Equal("🧠 Search memory: cron schedule", result);
+    }
+
+    [Fact]
+    public void Cron_ShowsAction()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("cron", """{"action": "list"}""");
+        Assert.Equal("⏰ Cron list", result);
+    }
+
+    [Fact]
+    public void Canvas_ShowsAction()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("canvas", """{"action": "render"}""");
+        Assert.Equal("🎨 Canvas render", result);
+    }
+
+    [Fact]
+    public void UnknownTool_ShowsToolName()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("custom_tool", """{"foo": "bar"}""");
+        Assert.Equal("🔧 custom_tool", result);
+    }
+
+    [Fact]
+    public void NullArgs_ShowsToolName()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("read", null);
+        Assert.Equal("📄 read", result);
+    }
+
+    [Fact]
+    public void EmptyArgs_ShowsToolName()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("read", "");
+        Assert.Equal("📄 read", result);
+    }
+
+    [Fact]
+    public void InvalidJson_ShowsToolName()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("read", "not json");
+        Assert.Equal("📄 read", result);
+    }
+
+    [Fact]
+    public void AskUser_ShowsDescription()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("ask_user", """{"prompt": "Which option?"}""");
+        Assert.Equal("❓ Ask user", result);
+    }
+
+    [Fact]
+    public void SpawnSubagent_ShowsName()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("spawn_subagent", """{"task": "Review code", "name": "reviewer"}""");
+        Assert.Equal("🤖 Spawn reviewer", result);
+    }
+
+    [Fact]
+    public void SpawnSubagent_WithoutName_ShowsTask()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("spawn_subagent", """{"task": "Review code changes"}""");
+        Assert.Equal("🤖 Spawn sub-agent", result);
+    }
+
+    [Fact]
+    public void Conversation_ShowsAction()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("conversation", """{"action": "new"}""");
+        Assert.Equal("💬 Conversation new", result);
+    }
+
+    [Fact]
+    public void Sessions_ShowsAction()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("sessions", """{"action": "search", "query": "maintenance"}""");
+        Assert.Equal("📋 Sessions search", result);
+    }
+
+    [Fact]
+    public void SkillManage_ShowsAction()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("skill_manage", """{"action": "create", "name": "my-skill"}""");
+        Assert.Equal("🛠️ Skill create my-skill", result);
+    }
+
+    [Fact]
+    public void Skills_ShowsAction()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("skills", """{"action": "load", "skillName": "web-scraping"}""");
+        Assert.Equal("📚 Load skill web-scraping", result);
+    }
+
+    [Fact]
+    public void Delay_ShowsDuration()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("delay", """{"seconds": 30, "reason": "waiting for build"}""");
+        Assert.Equal("⏳ Delay 30s", result);
+    }
+
+    [Fact]
+    public void GetDatetime_ShowsDescription()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("get_datetime", """{}""");
+        Assert.Equal("🕐 Get datetime", result);
+    }
+
+    [Fact]
+    public void AgentConverse_ShowsTarget()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("agent_converse", """{"agentId": "nova", "message": "hello"}""");
+        Assert.Equal("🗣️ Talk to nova", result);
+    }
+}


### PR DESCRIPTION
Closes #577

## Changes

### Problem
Tool calls in the chat panel showed only the raw tool name (e.g. `read`, `exec`, `web_search`), giving no context about what the tool was doing without expanding the details.

### Fix
`ToolDescriptionFormatter` — a new static helper that generates short, human-readable descriptions from the tool name and its JSON arguments:

| Tool | Before | After |
|------|--------|-------|
| `read` | `read` | `📄 Read Agent.cs` |
| `write` | `write` | `✏️ Write Host.cs` |
| `shell` | `shell` | `💻 git status --short` |
| `web_search` | `web_search` | `🔍 BotNexus documentation` |
| `web_fetch` | `web_fetch` | `🌐 example.com/page` |
| `grep` | `grep` | `🔎 Grep SystemPrompt` |
| `spawn_subagent` | `spawn_subagent` | `🤖 Spawn reviewer` |
| `cron` | `cron` | `⏰ Cron list` |
| Unknown | `custom_tool` | `🔧 custom_tool` |

Long command strings are truncated at 50 characters with `…`. Invalid/missing JSON args fall back to showing the tool name with an emoji.

### Design
- Pure static function — no state, no DI, no side effects
- Extracts context from tool-specific JSON properties (`path`, `command`, `query`, `url`, `pattern`, `action`, `name`, etc.)
- Status icons (⏳/✅/❌) remain separate — they show execution state, not description
- Descriptive emoji is per-tool-type (📄 for file ops, 💻 for shell, 🔍 for search, etc.)

### Tests
30 new unit tests covering all supported tools, edge cases (null/empty/invalid JSON, long strings, array vs string commands), and unknown tool fallback.

## Merge Notes
This PR is fully independent — touches only `ChatPanel.razor` (one-line change), `ToolDescriptionFormatter.cs` (new file), and test file. No overlap with any open PR. Safe to merge in any order.