### PR TITLE
feat(prompts): add SectionId to IPromptSection and register tool-enforcement section

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/IPromptSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/IPromptSection.cs
@@ -1,13 +1,29 @@
 namespace BotNexus.Gateway.Prompts;
 
 /// <summary>
-/// Defines the contract for iprompt section.
+/// Defines the contract for a prompt section that contributes lines to the system prompt.
 /// </summary>
 public interface IPromptSection
 {
+    /// <summary>
+    /// Gets the ordering position of this section within the prompt pipeline.
+    /// Lower values appear earlier in the assembled prompt.
+    /// </summary>
     int Order { get; }
 
+    /// <summary>
+    /// Gets the optional stable identifier for this section. Used for override resolution
+    /// and diagnostics. Null indicates an anonymous section that cannot be overridden.
+    /// </summary>
+    string? SectionId => null;
+
+    /// <summary>
+    /// Determines whether this section should be included given the current prompt context.
+    /// </summary>
     bool ShouldInclude(PromptContext context);
 
+    /// <summary>
+    /// Builds the prompt lines for this section.
+    /// </summary>
     IReadOnlyList<string> Build(PromptContext context);
 }

--- a/src/gateway/BotNexus.Gateway.Prompts/LambdaPromptSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/LambdaPromptSection.cs
@@ -1,0 +1,45 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// A prompt section backed by a delegate that lazily builds its content lines.
+/// Supports an optional <see cref="SectionId"/> for override resolution.
+/// </summary>
+public sealed class LambdaPromptSection : IPromptSection
+{
+    private readonly Func<PromptContext, IReadOnlyList<string>> _buildFunc;
+    private readonly Func<PromptContext, bool>? _shouldIncludeFunc;
+
+    /// <summary>
+    /// Creates a new <see cref="LambdaPromptSection"/> with the given order and build delegate.
+    /// </summary>
+    /// <param name="order">Ordering position within the pipeline.</param>
+    /// <param name="buildFunc">Delegate that produces the prompt lines.</param>
+    /// <param name="sectionId">Optional stable identifier for override resolution.</param>
+    /// <param name="shouldIncludeFunc">Optional predicate controlling inclusion. Defaults to always included.</param>
+    public LambdaPromptSection(
+        int order,
+        Func<PromptContext, IReadOnlyList<string>> buildFunc,
+        string? sectionId = null,
+        Func<PromptContext, bool>? shouldIncludeFunc = null)
+    {
+        ArgumentNullException.ThrowIfNull(buildFunc);
+        Order = order;
+        _buildFunc = buildFunc;
+        SectionId = sectionId;
+        _shouldIncludeFunc = shouldIncludeFunc;
+    }
+
+    /// <inheritdoc/>
+    public int Order { get; }
+
+    /// <inheritdoc/>
+    public string? SectionId { get; }
+
+    /// <inheritdoc/>
+    public bool ShouldInclude(PromptContext context) =>
+        _shouldIncludeFunc?.Invoke(context) ?? true;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> Build(PromptContext context) =>
+        _buildFunc(context);
+}

--- a/src/gateway/BotNexus.Gateway.Prompts/ToolEnforcementSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ToolEnforcementSection.cs
@@ -1,0 +1,35 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Provides the built-in tool-enforcement prompt section that instructs the model
+/// to execute tools immediately rather than describing what it would do.
+/// </summary>
+public static class ToolEnforcementSection
+{
+    /// <summary>
+    /// The stable section identifier used for override resolution.
+    /// </summary>
+    public const string Id = "tool-enforcement";
+
+    /// <summary>
+    /// The ordering position for this section within the prompt pipeline.
+    /// Placed early (after safety at ~20) to establish tool behavior before content sections.
+    /// </summary>
+    public const int SectionOrder = 32;
+
+    private static readonly string[] Lines =
+    [
+        "## Tool Enforcement",
+        "When a task requires a tool call, execute the tool immediately.",
+        "Do not describe what you would do — do it.",
+        "Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.",
+        "If multiple independent tool calls are needed, batch them in a single response.",
+        "Never simulate or fabricate tool output — always call the real tool."
+    ];
+
+    /// <summary>
+    /// Creates a <see cref="LambdaPromptSection"/> for tool-enforcement guidance.
+    /// </summary>
+    public static LambdaPromptSection Create() =>
+        new(SectionOrder, static _ => Lines, sectionId: Id);
+}

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/LambdaPromptSectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/LambdaPromptSectionTests.cs
@@ -1,0 +1,181 @@
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class LambdaPromptSectionTests
+{
+    private static PromptContext DefaultContext => new() { WorkspaceDir = "C:/workspace" };
+
+    [Fact]
+    public void Constructor_ThrowsOnNullBuildFunc()
+    {
+        var ex = Should.Throw<ArgumentNullException>(() =>
+            new LambdaPromptSection(10, null!));
+        ex.ParamName.ShouldBe("buildFunc");
+    }
+
+    [Fact]
+    public void Order_ReturnsConfiguredValue()
+    {
+        var section = new LambdaPromptSection(42, static _ => ["line"]);
+
+        section.Order.ShouldBe(42);
+    }
+
+    [Fact]
+    public void SectionId_ReturnsNullByDefault()
+    {
+        var section = new LambdaPromptSection(10, static _ => ["line"]);
+
+        section.SectionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SectionId_ReturnsConfiguredValue()
+    {
+        var section = new LambdaPromptSection(10, static _ => ["line"], sectionId: "my-section");
+
+        section.SectionId.ShouldBe("my-section");
+    }
+
+    [Fact]
+    public void ShouldInclude_ReturnsTrueWhenNoPredicateProvided()
+    {
+        var section = new LambdaPromptSection(10, static _ => ["line"]);
+
+        section.ShouldInclude(DefaultContext).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldInclude_DelegatesToPredicate()
+    {
+        var section = new LambdaPromptSection(
+            10,
+            static _ => ["line"],
+            shouldIncludeFunc: static ctx => ctx.IsMinimal);
+
+        section.ShouldInclude(DefaultContext).ShouldBeFalse();
+        section.ShouldInclude(DefaultContext with { IsMinimal = true }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Build_DelegatesToBuildFunc()
+    {
+        var section = new LambdaPromptSection(10, static _ => ["hello", "world"]);
+
+        var lines = section.Build(DefaultContext);
+
+        lines.ShouldBe(new[] { "hello", "world" });
+    }
+
+    [Fact]
+    public void Build_ReceivesContext()
+    {
+        var section = new LambdaPromptSection(10, ctx => [$"workspace={ctx.WorkspaceDir}"]);
+
+        var lines = section.Build(DefaultContext);
+
+        lines.ShouldBe(new[] { "workspace=C:/workspace" });
+    }
+}
+
+public sealed class ToolEnforcementSectionTests
+{
+    private static PromptContext DefaultContext => new() { WorkspaceDir = "C:/workspace" };
+
+    [Fact]
+    public void Create_HasCorrectOrder()
+    {
+        var section = ToolEnforcementSection.Create();
+
+        section.Order.ShouldBe(32);
+    }
+
+    [Fact]
+    public void Create_HasCorrectSectionId()
+    {
+        var section = ToolEnforcementSection.Create();
+
+        section.SectionId.ShouldBe("tool-enforcement");
+    }
+
+    [Fact]
+    public void Create_AlwaysIncluded()
+    {
+        var section = ToolEnforcementSection.Create();
+
+        section.ShouldInclude(DefaultContext).ShouldBeTrue();
+        section.ShouldInclude(DefaultContext with { IsMinimal = true }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Create_ProducesEnforcementGuidance()
+    {
+        var section = ToolEnforcementSection.Create();
+
+        var lines = section.Build(DefaultContext);
+
+        lines.Count.ShouldBeGreaterThan(1);
+        lines[0].ShouldBe("## Tool Enforcement");
+        lines.ShouldContain(l => l.Contains("execute the tool immediately"));
+        lines.ShouldContain(l => l.Contains("Do not describe"));
+        lines.ShouldContain(l => l.Contains("Never simulate"));
+    }
+
+    [Fact]
+    public void Create_OrderIsBeforeSafety()
+    {
+        // Safety is at enum value 200; tool enforcement at 32 should always come first
+        var section = ToolEnforcementSection.Create();
+        section.Order.ShouldBeLessThan((int)PromptSection.Tools);
+    }
+
+    [Fact]
+    public void Pipeline_IntegrationTest_ToolEnforcementOrderedCorrectly()
+    {
+        var pipeline = new PromptPipeline()
+            .Add(new StaticSection(100, ["Tools content"]))
+            .Add(ToolEnforcementSection.Create())
+            .Add(new StaticSection(200, ["Safety content"]));
+
+        var lines = pipeline.BuildLines(DefaultContext);
+
+        var enforcementIdx = lines.ToList().FindIndex(l => l.Contains("Tool Enforcement"));
+        var toolsIdx = lines.ToList().FindIndex(l => l.Contains("Tools content"));
+        var safetyIdx = lines.ToList().FindIndex(l => l.Contains("Safety content"));
+
+        enforcementIdx.ShouldBeGreaterThanOrEqualTo(0);
+        toolsIdx.ShouldBeGreaterThan(enforcementIdx);
+        safetyIdx.ShouldBeGreaterThan(toolsIdx);
+    }
+
+    private sealed class StaticSection(int order, IReadOnlyList<string> lines) : IPromptSection
+    {
+        public int Order => order;
+        public bool ShouldInclude(PromptContext context) => true;
+        public IReadOnlyList<string> Build(PromptContext context) => lines;
+    }
+}
+
+public sealed class IPromptSectionSectionIdTests
+{
+    [Fact]
+    public void DefaultImplementation_ReturnsNull()
+    {
+        var section = new MinimalSection();
+
+        // The default interface implementation should return null
+        IPromptSection iface = section;
+        iface.SectionId.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A minimal IPromptSection that does NOT override SectionId, relying on the default.
+    /// </summary>
+    private sealed class MinimalSection : IPromptSection
+    {
+        public int Order => 0;
+        public bool ShouldInclude(PromptContext context) => true;
+        public IReadOnlyList<string> Build(PromptContext context) => [];
+    }
+}


### PR DESCRIPTION
Closes #995

## Changes

- Added `SectionId` property (string?, default null) to `IPromptSection` interface via default interface method (backward compatible)
- Created `LambdaPromptSection` — a concrete `IPromptSection` backed by a delegate + optional SectionId + optional inclusion predicate
- Created `ToolEnforcementSection` (Order 32, Id `tool-enforcement`) with Hermes-style execute-now language:
  - Execute tools immediately, don't describe
  - Don't ask confirmation unless destructive
  - Batch independent calls
  - Never simulate tool output
- 15 new unit tests covering: construction, ordering, SectionId, ShouldInclude delegation, Build delegation, tool-enforcement content, pipeline integration ordering, default interface implementation

## Merge Notes

Independent of all 10 open PRs. No file overlap. Safe to merge in any order.

Part of #957 — enables #996 (shell-efficiency + skills-guidance sections) and #999 (FilePromptOverrideResolver) to build on this foundation.