### PR TITLE
feat(prompts): add shell-efficiency and skills-guidance prompt sections

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/ShellEfficiencySection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ShellEfficiencySection.cs
@@ -1,0 +1,37 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Provides the built-in shell-efficiency prompt section that guides agents to prefer
+/// scripts over repeated individual commands, avoid common shell anti-patterns, and
+/// minimize round-trips.
+/// </summary>
+public static class ShellEfficiencySection
+{
+    /// <summary>
+    /// The stable section identifier used for override resolution.
+    /// </summary>
+    public const string Id = "shell-efficiency";
+
+    /// <summary>
+    /// The ordering position for this section within the prompt pipeline.
+    /// Placed after tool-enforcement (32) to build on established tool-call behavior.
+    /// </summary>
+    public const int SectionOrder = 35;
+
+    private static readonly string[] Lines =
+    [
+        "## Shell Efficiency",
+        "Prefer writing a temporary script file and executing it over chaining many individual shell commands.",
+        "Combine related operations into a single shell invocation where possible.",
+        "Avoid repeated read-modify-write cycles — batch edits into one tool call.",
+        "Never use backtick line continuations in shell commands — they break across platforms.",
+        "Use single quotes for strings containing special characters ($, @, |, ;).",
+        "For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it."
+    ];
+
+    /// <summary>
+    /// Creates a <see cref="LambdaPromptSection"/> for shell-efficiency guidance.
+    /// </summary>
+    public static LambdaPromptSection Create() =>
+        new(SectionOrder, static _ => Lines, sectionId: Id);
+}

--- a/src/gateway/BotNexus.Gateway.Prompts/SkillsGuidanceSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/SkillsGuidanceSection.cs
@@ -1,0 +1,41 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Provides the built-in skills-guidance prompt section that instructs agents to
+/// proactively load skills for domain-specific knowledge and create new skills
+/// to capture reusable procedures.
+/// </summary>
+public static class SkillsGuidanceSection
+{
+    /// <summary>
+    /// The stable section identifier used for override resolution.
+    /// </summary>
+    public const string Id = "skills-guidance";
+
+    /// <summary>
+    /// The ordering position for this section within the prompt pipeline.
+    /// Placed later in the pipeline (55) after content/tool sections to serve as
+    /// behavioral guidance once the agent knows what tools and skills are available.
+    /// </summary>
+    public const int SectionOrder = 55;
+
+    private static readonly string[] Lines =
+    [
+        "## Skills",
+        "Before starting domain-specific work, check available skills with `skills list` and load relevant ones.",
+        "Skills contain reusable procedures, references, and templates — always load before improvising.",
+        "When you discover a repeatable multi-step procedure, create a skill to capture it for future use.",
+        "Skill names must be lowercase alphanumeric with hyphens (e.g. `deploy-staging`, `review-pr`).",
+        "Keep skill content focused: one skill per procedure, with clear steps and examples."
+    ];
+
+    /// <summary>
+    /// Creates a <see cref="LambdaPromptSection"/> for skills-guidance.
+    /// The section is only included when the agent has skill-related tools available.
+    /// </summary>
+    public static LambdaPromptSection Create() =>
+        new(SectionOrder, static _ => Lines, sectionId: Id, shouldIncludeFunc: HasSkillTools);
+
+    private static bool HasSkillTools(PromptContext context) =>
+        context.AvailableTools.Contains("skills") || context.AvailableTools.Contains("skill_manage");
+}

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/ShellEfficiencySectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/ShellEfficiencySectionTests.cs
@@ -1,0 +1,100 @@
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class ShellEfficiencySectionTests
+{
+    private static PromptContext DefaultContext => new() { WorkspaceDir = "C:/workspace" };
+
+    [Fact]
+    public void SectionId_IsShellEfficiency()
+    {
+        ShellEfficiencySection.Id.ShouldBe("shell-efficiency");
+    }
+
+    [Fact]
+    public void SectionOrder_Is35()
+    {
+        ShellEfficiencySection.SectionOrder.ShouldBe(35);
+    }
+
+    [Fact]
+    public void Create_ReturnsLambdaPromptSection()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        section.ShouldNotBeNull();
+        section.ShouldBeOfType<LambdaPromptSection>();
+    }
+
+    [Fact]
+    public void Create_SectionHasCorrectOrder()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        section.Order.ShouldBe(35);
+    }
+
+    [Fact]
+    public void Create_SectionHasCorrectId()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        section.SectionId.ShouldBe("shell-efficiency");
+    }
+
+    [Fact]
+    public void ShouldInclude_AlwaysReturnsTrue()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        section.ShouldInclude(DefaultContext).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Build_ReturnsNonEmptyLines()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        var lines = section.Build(DefaultContext);
+
+        lines.ShouldNotBeEmpty();
+        lines.Count.ShouldBeGreaterThan(1);
+    }
+
+    [Fact]
+    public void Build_StartsWithMarkdownHeader()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        var lines = section.Build(DefaultContext);
+
+        lines[0].ShouldBe("## Shell Efficiency");
+    }
+
+    [Fact]
+    public void Build_ContainsScriptFirstGuidance()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        var lines = section.Build(DefaultContext);
+
+        lines.ShouldContain(l => l.Contains("script", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_ContainsAntiPatternGuidance()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        var lines = section.Build(DefaultContext);
+
+        lines.ShouldContain(l => l.Contains("backtick", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void OrderIsAfterToolEnforcement()
+    {
+        ShellEfficiencySection.SectionOrder.ShouldBeGreaterThan(ToolEnforcementSection.SectionOrder);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/SkillsGuidanceSectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/SkillsGuidanceSectionTests.cs
@@ -1,0 +1,148 @@
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class SkillsGuidanceSectionTests
+{
+    private static PromptContext DefaultContext => new() { WorkspaceDir = "C:/workspace" };
+
+    private static PromptContext ContextWithSkillTools => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        AvailableTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "skills", "read", "write" }
+    };
+
+    private static PromptContext ContextWithSkillManageTool => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        AvailableTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "skill_manage", "read" }
+    };
+
+    private static PromptContext ContextWithoutSkillTools => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        AvailableTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "read", "write", "shell" }
+    };
+
+    [Fact]
+    public void SectionId_IsSkillsGuidance()
+    {
+        SkillsGuidanceSection.Id.ShouldBe("skills-guidance");
+    }
+
+    [Fact]
+    public void SectionOrder_Is55()
+    {
+        SkillsGuidanceSection.SectionOrder.ShouldBe(55);
+    }
+
+    [Fact]
+    public void Create_ReturnsLambdaPromptSection()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.ShouldNotBeNull();
+        section.ShouldBeOfType<LambdaPromptSection>();
+    }
+
+    [Fact]
+    public void Create_SectionHasCorrectOrder()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.Order.ShouldBe(55);
+    }
+
+    [Fact]
+    public void Create_SectionHasCorrectId()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.SectionId.ShouldBe("skills-guidance");
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenSkillsToolAvailable_ReturnsTrue()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithSkillTools).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenSkillManageToolAvailable_ReturnsTrue()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithSkillManageTool).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenNoSkillToolsAvailable_ReturnsFalse()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithoutSkillTools).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenNoToolsAtAll_ReturnsFalse()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.ShouldInclude(DefaultContext).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Build_ReturnsNonEmptyLines()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithSkillTools);
+
+        lines.ShouldNotBeEmpty();
+        lines.Count.ShouldBeGreaterThan(1);
+    }
+
+    [Fact]
+    public void Build_StartsWithMarkdownHeader()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithSkillTools);
+
+        lines[0].ShouldBe("## Skills");
+    }
+
+    [Fact]
+    public void Build_ContainsMandatoryLoadGuidance()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithSkillTools);
+
+        lines.ShouldContain(l => l.Contains("load", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_ContainsProactiveCreateGuidance()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithSkillTools);
+
+        lines.ShouldContain(l => l.Contains("create", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void OrderIsAfterToolEnforcement()
+    {
+        SkillsGuidanceSection.SectionOrder.ShouldBeGreaterThan(ToolEnforcementSection.SectionOrder);
+    }
+
+    [Fact]
+    public void OrderIsAfterShellEfficiency()
+    {
+        SkillsGuidanceSection.SectionOrder.ShouldBeGreaterThan(ShellEfficiencySection.SectionOrder);
+    }
+}


### PR DESCRIPTION
Closes #996

## Changes

- ShellEfficiencySection (Order 35, Id shell-efficiency): script-first guidance, anti-patterns (backtick, single quotes), batch edit rule
- SkillsGuidanceSection (Order 55, Id skills-guidance): mandatory-load before improvising, proactive-create for repeatable procedures. Only included when agent has skills or skill_manage tools available.

Both follow the LambdaPromptSection pattern established by ToolEnforcementSection.

## Tests

- 11 tests for ShellEfficiencySection (order, id, content, header, anti-patterns, ordering)
- 15 tests for SkillsGuidanceSection (order, id, content, conditional inclusion, ordering)
- 46/46 Prompts.Tests pass, 173/173 Architecture.Tests pass

## Merge Notes

Independent of all open PRs. No file overlap with #905 or #914. Part of #957 (system prompt improvements). Safe to merge in any order.