### PR TITLE
feat(prompts): add model-guidance prompt section with per-family detection

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/ModelFamilyDetector.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ModelFamilyDetector.cs
@@ -1,0 +1,72 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Detects the model family from a model identifier string.
+/// Used by <see cref="ModelGuidanceSection"/> to select per-family prompt defaults.
+/// </summary>
+public static class ModelFamilyDetector
+{
+    /// <summary>Claude family (Anthropic).</summary>
+    public const string Claude = "claude";
+
+    /// <summary>GPT family (OpenAI).</summary>
+    public const string Gpt = "gpt";
+
+    /// <summary>Gemini family (Google).</summary>
+    public const string Gemini = "gemini";
+
+    /// <summary>Copilot family (GitHub).</summary>
+    public const string Copilot = "copilot";
+
+    /// <summary>DeepSeek family.</summary>
+    public const string DeepSeek = "deepseek";
+
+    /// <summary>Qwen family (Alibaba).</summary>
+    public const string Qwen = "qwen";
+
+    /// <summary>Llama family (Meta).</summary>
+    public const string Llama = "llama";
+
+    /// <summary>Unknown/unrecognized model family.</summary>
+    public const string Unknown = "unknown";
+
+    /// <summary>
+    /// Determines the model family from a model identifier.
+    /// Detection is case-insensitive and matches on common prefixes and substrings.
+    /// </summary>
+    /// <param name="modelId">The model identifier (e.g. "claude-sonnet-4-20250514", "gpt-4o", "gemini-2.5-pro").</param>
+    /// <returns>One of the family constants, or <see cref="Unknown"/> if no match.</returns>
+    public static string GetModelFamily(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+            return Unknown;
+
+        var id = modelId.AsSpan();
+
+        if (id.Contains("claude", StringComparison.OrdinalIgnoreCase))
+            return Claude;
+
+        if (id.StartsWith("gpt", StringComparison.OrdinalIgnoreCase) ||
+            id.Contains("o1", StringComparison.OrdinalIgnoreCase) ||
+            id.Contains("o3", StringComparison.OrdinalIgnoreCase) ||
+            id.Contains("o4", StringComparison.OrdinalIgnoreCase))
+            return Gpt;
+
+        if (id.Contains("gemini", StringComparison.OrdinalIgnoreCase))
+            return Gemini;
+
+        if (id.Contains("copilot", StringComparison.OrdinalIgnoreCase))
+            return Copilot;
+
+        if (id.Contains("deepseek", StringComparison.OrdinalIgnoreCase))
+            return DeepSeek;
+
+        if (id.Contains("qwen", StringComparison.OrdinalIgnoreCase))
+            return Qwen;
+
+        if (id.Contains("llama", StringComparison.OrdinalIgnoreCase))
+            return Llama;
+
+        return Unknown;
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Prompts/ModelGuidanceSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ModelGuidanceSection.cs
@@ -1,0 +1,79 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Provides the built-in model-guidance prompt section that injects per-model-family
+/// behavioral defaults into the system prompt. Detects the model family from the model
+/// identifier passed through <see cref="PromptContext.Extensions"/> and emits
+/// family-specific rules.
+/// </summary>
+public static class ModelGuidanceSection
+{
+    /// <summary>
+    /// The stable section identifier used for override resolution.
+    /// </summary>
+    public const string Id = "model-guidance";
+
+    /// <summary>
+    /// The ordering position for this section within the prompt pipeline.
+    /// Placed late (135) so model-specific instructions come after all content sections.
+    /// </summary>
+    public const int SectionOrder = 135;
+
+    /// <summary>
+    /// The <see cref="PromptContext.Extensions"/> key used to pass the model identifier
+    /// through to the section builder.
+    /// </summary>
+    public const string ModelIdExtensionKey = "modelId";
+
+    private static readonly string[] ClaudeGuidance =
+    [
+        "## Model Guidance (Claude)",
+        "Prefer the edit tool over write for modifying existing files — it preserves context and is more precise.",
+        "When editing, use the smallest possible oldText/newText to target changes precisely.",
+        "You have extended thinking capabilities — use them for complex reasoning before acting."
+    ];
+
+    private static readonly string[] GptGuidance =
+    [
+        "## Model Guidance (GPT)",
+        "Never answer from memory when a tool can verify the answer — always check the source.",
+        "When asked about file contents, always read the file rather than guessing from context.",
+        "Be explicit about uncertainty — say when you are unsure rather than confabulating."
+    ];
+
+    private static readonly string[] GeminiGuidance =
+    [
+        "## Model Guidance (Gemini)",
+        "Always use absolute paths in file operations — relative paths may resolve incorrectly.",
+        "When referencing files, use the full path from the workspace root.",
+        "Verify tool output carefully before proceeding — do not assume success without checking."
+    ];
+
+    /// <summary>
+    /// Creates a <see cref="LambdaPromptSection"/> for model-guidance.
+    /// The section is only included when a recognized model family is detected.
+    /// </summary>
+    public static LambdaPromptSection Create() =>
+        new(SectionOrder, BuildLines, sectionId: Id, shouldIncludeFunc: ShouldInclude);
+
+    private static bool ShouldInclude(PromptContext context)
+    {
+        var modelId = context.Get<string>(ModelIdExtensionKey);
+        var family = ModelFamilyDetector.GetModelFamily(modelId);
+        return family != ModelFamilyDetector.Unknown;
+    }
+
+    private static IReadOnlyList<string> BuildLines(PromptContext context)
+    {
+        var modelId = context.Get<string>(ModelIdExtensionKey);
+        var family = ModelFamilyDetector.GetModelFamily(modelId);
+
+        return family switch
+        {
+            ModelFamilyDetector.Claude => ClaudeGuidance,
+            ModelFamilyDetector.Gpt => GptGuidance,
+            ModelFamilyDetector.Gemini => GeminiGuidance,
+            _ => []
+        };
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/ModelFamilyDetectorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/ModelFamilyDetectorTests.cs
@@ -1,0 +1,86 @@
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class ModelFamilyDetectorTests
+{
+    [Theory]
+    [InlineData("claude-sonnet-4-20250514", ModelFamilyDetector.Claude)]
+    [InlineData("claude-3-opus-20240229", ModelFamilyDetector.Claude)]
+    [InlineData("claude-haiku-3.5", ModelFamilyDetector.Claude)]
+    [InlineData("CLAUDE-OPUS-4", ModelFamilyDetector.Claude)]
+    public void GetModelFamily_DetectsClaude(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("gpt-4o", ModelFamilyDetector.Gpt)]
+    [InlineData("gpt-4o-mini", ModelFamilyDetector.Gpt)]
+    [InlineData("gpt-4.1", ModelFamilyDetector.Gpt)]
+    [InlineData("o1-preview", ModelFamilyDetector.Gpt)]
+    [InlineData("o3-mini", ModelFamilyDetector.Gpt)]
+    [InlineData("o4-mini", ModelFamilyDetector.Gpt)]
+    public void GetModelFamily_DetectsGpt(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("gemini-2.5-pro", ModelFamilyDetector.Gemini)]
+    [InlineData("gemini-1.5-flash", ModelFamilyDetector.Gemini)]
+    public void GetModelFamily_DetectsGemini(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("copilot-chat", ModelFamilyDetector.Copilot)]
+    [InlineData("github-copilot-gpt-4", ModelFamilyDetector.Copilot)]
+    public void GetModelFamily_DetectsCopilot(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("deepseek-coder", ModelFamilyDetector.DeepSeek)]
+    [InlineData("deepseek-v2", ModelFamilyDetector.DeepSeek)]
+    public void GetModelFamily_DetectsDeepSeek(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("qwen-72b", ModelFamilyDetector.Qwen)]
+    [InlineData("qwen2.5-coder", ModelFamilyDetector.Qwen)]
+    public void GetModelFamily_DetectsQwen(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Meta-Llama-3.1-8B-Instruct", ModelFamilyDetector.Llama)]
+    [InlineData("llama-3-70b", ModelFamilyDetector.Llama)]
+    public void GetModelFamily_DetectsLlama(string modelId, string expected)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetModelFamily_ReturnsUnknownForNullOrWhitespace(string? modelId)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(ModelFamilyDetector.Unknown);
+    }
+
+    [Theory]
+    [InlineData("some-custom-model")]
+    [InlineData("phi-4")]
+    [InlineData("mistral-small")]
+    public void GetModelFamily_ReturnsUnknownForUnrecognized(string modelId)
+    {
+        ModelFamilyDetector.GetModelFamily(modelId).ShouldBe(ModelFamilyDetector.Unknown);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/ModelGuidanceSectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/ModelGuidanceSectionTests.cs
@@ -1,0 +1,164 @@
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class ModelGuidanceSectionTests
+{
+    private static PromptContext ContextWithClaude => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        Extensions = new Dictionary<string, object?> { [ModelGuidanceSection.ModelIdExtensionKey] = "claude-sonnet-4-20250514" }
+    };
+
+    private static PromptContext ContextWithGpt => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        Extensions = new Dictionary<string, object?> { [ModelGuidanceSection.ModelIdExtensionKey] = "gpt-4o" }
+    };
+
+    private static PromptContext ContextWithGemini => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        Extensions = new Dictionary<string, object?> { [ModelGuidanceSection.ModelIdExtensionKey] = "gemini-2.5-pro" }
+    };
+
+    private static PromptContext ContextWithUnknownModel => new()
+    {
+        WorkspaceDir = "C:/workspace",
+        Extensions = new Dictionary<string, object?> { [ModelGuidanceSection.ModelIdExtensionKey] = "phi-4" }
+    };
+
+    private static PromptContext ContextWithNoModel => new()
+    {
+        WorkspaceDir = "C:/workspace"
+    };
+
+    [Fact]
+    public void SectionId_IsModelGuidance()
+    {
+        ModelGuidanceSection.Id.ShouldBe("model-guidance");
+    }
+
+    [Fact]
+    public void SectionOrder_Is135()
+    {
+        ModelGuidanceSection.SectionOrder.ShouldBe(135);
+    }
+
+    [Fact]
+    public void Create_ReturnsLambdaPromptSection()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.ShouldNotBeNull();
+        section.ShouldBeOfType<LambdaPromptSection>();
+    }
+
+    [Fact]
+    public void Create_SectionHasCorrectOrder()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.Order.ShouldBe(135);
+    }
+
+    [Fact]
+    public void Create_SectionHasCorrectId()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.SectionId.ShouldBe("model-guidance");
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenClaudeModel_ReturnsTrue()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithClaude).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenGptModel_ReturnsTrue()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithGpt).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenGeminiModel_ReturnsTrue()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithGemini).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenUnknownModel_ReturnsFalse()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithUnknownModel).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldInclude_WhenNoModelId_ReturnsFalse()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        section.ShouldInclude(ContextWithNoModel).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Build_ForClaude_ReturnsClaudeGuidance()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithClaude);
+
+        lines.ShouldNotBeEmpty();
+        lines[0].ShouldContain("Claude");
+        lines.ShouldContain(l => l.Contains("edit tool", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_ForGpt_ReturnsGptGuidance()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithGpt);
+
+        lines.ShouldNotBeEmpty();
+        lines[0].ShouldContain("GPT");
+        lines.ShouldContain(l => l.Contains("memory", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_ForGemini_ReturnsGeminiGuidance()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithGemini);
+
+        lines.ShouldNotBeEmpty();
+        lines[0].ShouldContain("Gemini");
+        lines.ShouldContain(l => l.Contains("absolute path", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Build_ForUnknownModel_ReturnsEmptyList()
+    {
+        var section = ModelGuidanceSection.Create();
+
+        var lines = section.Build(ContextWithUnknownModel);
+
+        lines.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ModelIdExtensionKey_IsModelId()
+    {
+        ModelGuidanceSection.ModelIdExtensionKey.ShouldBe("modelId");
+    }
+}


### PR DESCRIPTION
Closes #997

## Changes

- **ModelFamilyDetector** static helper: detects claude/gpt/gemini/copilot/deepseek/qwen/llama from model ID string (case-insensitive)
- **ModelGuidanceSection** (Order 135, Id model-guidance): injects per-family behavioral defaults
  - Claude: prefer edit tool, smallest oldText/newText, extended thinking
  - GPT: never answer from memory, always read files, explicit uncertainty
  - Gemini: absolute paths, verify tool output
- Model ID threaded through PromptContext.Extensions["modelId"]
- Section only included when a recognized model family is detected

## Tests

- 22 theory tests for ModelFamilyDetector (all families + null/whitespace/unknown)
- 16 tests for ModelGuidanceSection (order, id, conditional inclusion, per-family content)
- 61/61 Prompts.Tests pass, 173/173 Architecture.Tests pass

## Merge Notes

Independent of all open PRs. No file overlap with #905, #914, or #1009. Part of #957 (system prompt improvements). Safe to merge in any order. Note: #1009 and this PR both add files to the same project but different files -- no merge conflict expected.