### PR TITLE
fix(streaming): synthesize failed tool results for orphan tool calls and skip whitespace-only content

### DIFF
--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -34,6 +34,9 @@ public static class StreamingSessionHelper
         var streamedHistory = new List<SessionEntry>();
         var hadThinkingContent = false;
         var hadMessageEnd = false;
+        var toolStartIds = new HashSet<string>(StringComparer.Ordinal);
+        var toolEndIds = new HashSet<string>(StringComparer.Ordinal);
+        var toolStartEntries = new Dictionary<string, SessionEntry>(StringComparer.Ordinal);
 
         await foreach (var evt in stream.WithCancellation(cancellationToken))
         {
@@ -49,7 +52,7 @@ public static class StreamingSessionHelper
                     hadMessageEnd = true;
                     break;
                 case AgentStreamEventType.ToolStart when evt.ToolCallId is not null || evt.ToolName is not null:
-                    streamedHistory.Add(new SessionEntry
+                    var startEntry = new SessionEntry
                     {
                         Role = MessageRole.Tool,
                         Content = $"Tool '{evt.ToolName ?? "unknown"}' started.",
@@ -58,7 +61,13 @@ public static class StreamingSessionHelper
                         ToolArgs = evt.ToolArgs is { Count: > 0 }
                             ? System.Text.Json.JsonSerializer.Serialize(evt.ToolArgs)
                             : null
-                    });
+                    };
+                    streamedHistory.Add(startEntry);
+                    if (evt.ToolCallId is not null)
+                    {
+                        toolStartIds.Add(evt.ToolCallId);
+                        toolStartEntries[evt.ToolCallId] = startEntry;
+                    }
                     break;
                 case AgentStreamEventType.ToolEnd when evt.ToolCallId is not null || evt.ToolName is not null:
                     streamedHistory.Add(new SessionEntry
@@ -69,6 +78,8 @@ public static class StreamingSessionHelper
                         ToolCallId = evt.ToolCallId,
                         ToolIsError = evt.ToolIsError == true
                     });
+                    if (evt.ToolCallId is not null)
+                        toolEndIds.Add(evt.ToolCallId);
                     break;
                 case AgentStreamEventType.Error when options.IncludeErrorsInHistory && !string.IsNullOrWhiteSpace(evt.ErrorMessage):
                     streamedHistory.Add(new SessionEntry
@@ -112,12 +123,32 @@ public static class StreamingSessionHelper
             }
         }
 
+        // Synthesize failed tool results for orphan tool calls (#1001).
+        // A ToolStart with no matching ToolEnd means the tool call did not complete —
+        // append a failed result entry so the transcript is consistent and downstream
+        // consumers (e.g. provider message builders) do not encounter an orphan call.
+        foreach (var orphanId in toolStartIds.Except(toolEndIds))
+        {
+            var toolName = toolStartEntries.TryGetValue(orphanId, out var entry)
+                ? entry.ToolName ?? "unknown"
+                : "unknown";
+            streamedHistory.Add(new SessionEntry
+            {
+                Role = MessageRole.Tool,
+                Content = $"Tool '{toolName}' did not complete — result synthesized for transcript consistency.",
+                ToolName = toolName,
+                ToolCallId = orphanId,
+                ToolIsError = true
+            });
+        }
+
         // Final write: append any remaining content not yet flushed by a TurnEnd
         // (single-turn runs, or the last partial turn before AgentEnd).
         session.AddEntries(streamedHistory);
-        if (streamedContent.Length > 0)
+        var finalContent = streamedContent.ToString();
+        if (!string.IsNullOrWhiteSpace(finalContent))
         {
-            session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = streamedContent.ToString() });
+            session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = finalContent });
         }
         else if (streamedHistory.Count == 0 && hadThinkingContent && hadMessageEnd)
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/OrphanToolCallTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/OrphanToolCallTests.cs
@@ -1,0 +1,204 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Streaming;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for orphan tool call handling in StreamingSessionHelper.
+/// When a ToolStart event has no matching ToolEnd, the helper should synthesize
+/// a failed tool result entry for transcript consistency while still delivering
+/// any assistant content that was produced.
+/// </summary>
+public sealed class OrphanToolCallTests
+{
+    [Fact]
+    public async Task OrphanToolStart_SynthesizesFailedToolResult()
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From("session-1"),
+            AgentId = AgentId.From("agent-1")
+        };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc1", ToolName = "web_fetch" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Here is the result." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        // Should have: ToolStart entry, synthesized ToolEnd (failed), and assistant content
+        session.History.Count.ShouldBeGreaterThanOrEqualTo(3);
+
+        var synthesized = session.History.FirstOrDefault(e =>
+            e.Role.Equals(MessageRole.Tool) &&
+            e.ToolCallId == "tc1" &&
+            e.ToolIsError);
+        synthesized.ShouldNotBeNull();
+        synthesized.Content.ShouldContain("did not complete");
+
+        var assistant = session.History.FirstOrDefault(e => e.Role.Equals(MessageRole.Assistant));
+        assistant.ShouldNotBeNull();
+        assistant.Content.ShouldBe("Here is the result.");
+    }
+
+    [Fact]
+    public async Task OrphanToolStart_StillDeliversAssistantText()
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From("session-2"),
+            AgentId = AgentId.From("agent-2")
+        };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc1", ToolName = "shell" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "I encountered an issue but here is what I found." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        // Assistant content must be present — orphan tools must not suppress delivery
+        var assistantEntry = session.History.FirstOrDefault(e => e.Role.Equals(MessageRole.Assistant));
+        assistantEntry.ShouldNotBeNull();
+        assistantEntry.Content.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task MatchedToolCalls_NoSynthesizedEntries()
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From("session-3"),
+            AgentId = AgentId.From("agent-3")
+        };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc1", ToolName = "read" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolEnd, ToolCallId = "tc1", ToolName = "read", ToolResult = "file content" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Done." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        // No synthesized entries — tool call completed normally
+        var toolEntries = session.History.Where(e => e.Role.Equals(MessageRole.Tool)).ToList();
+        toolEntries.Count.ShouldBe(2); // start + end
+        toolEntries.Any(e => e.ToolIsError).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task MultipleOrphanToolStarts_AllGetSynthesizedResults()
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From("session-4"),
+            AgentId = AgentId.From("agent-4")
+        };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc1", ToolName = "shell" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc2", ToolName = "read" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Partial results." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        var synthesized = session.History.Where(e =>
+            e.Role.Equals(MessageRole.Tool) && e.ToolIsError).ToList();
+        synthesized.Count.ShouldBe(2);
+        synthesized.Select(e => e.ToolCallId).ShouldBe(["tc1", "tc2"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task MixedOrphanAndCompleted_OnlyOrphansGetSynthesized()
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From("session-5"),
+            AgentId = AgentId.From("agent-5")
+        };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc1", ToolName = "read" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolEnd, ToolCallId = "tc1", ToolName = "read", ToolResult = "ok" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc2", ToolName = "shell" },
+                // tc2 never gets a ToolEnd — orphaned
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Partial." },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        var errorEntries = session.History.Where(e =>
+            e.Role.Equals(MessageRole.Tool) && e.ToolIsError).ToList();
+        errorEntries.Count.ShouldBe(1);
+        errorEntries[0].ToolCallId.ShouldBe("tc2");
+
+        // tc1 should have completed normally
+        var tc1End = session.History.FirstOrDefault(e =>
+            e.Role.Equals(MessageRole.Tool) && e.ToolCallId == "tc1" && !e.ToolIsError && e.ToolArgs is null);
+        tc1End.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task WhitespaceOnlyAssistantContent_NotDelivered()
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From("session-6"),
+            AgentId = AgentId.From("agent-6")
+        };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ToolStart, ToolCallId = "tc1", ToolName = "shell" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "   " },
+                new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }
+            ]),
+            session,
+            store.Object);
+
+        // Whitespace-only content should not be added as an assistant entry
+        var assistantEntry = session.History.FirstOrDefault(e => e.Role.Equals(MessageRole.Assistant));
+        assistantEntry.ShouldBeNull();
+
+        // But the orphan tool should still get synthesized
+        var synthesized = session.History.FirstOrDefault(e =>
+            e.Role.Equals(MessageRole.Tool) && e.ToolIsError);
+        synthesized.ShouldNotBeNull();
+    }
+
+    private static async IAsyncEnumerable<AgentStreamEvent> ToAsyncEnumerable(IEnumerable<AgentStreamEvent> events)
+    {
+        foreach (var evt in events)
+        {
+            yield return evt;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
@@ -99,7 +99,8 @@ public sealed class StreamingSessionHelperTests
             session,
             store.Object);
 
-        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        result.HistoryEntries.Count.ShouldBe(2); // start + synthesized orphan result
+        var entry = result.HistoryEntries[0];
         entry.ToolArgs.ShouldNotBeNull();
         entry.ToolArgs.ShouldContain("query");
         entry.ToolArgs.ShouldContain("dotnet");
@@ -125,7 +126,8 @@ public sealed class StreamingSessionHelperTests
             session,
             store.Object);
 
-        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        result.HistoryEntries.Count.ShouldBe(2); // start + synthesized orphan result
+        var entry = result.HistoryEntries[0];
         entry.ToolArgs.ShouldBeNull();
     }
 
@@ -149,7 +151,8 @@ public sealed class StreamingSessionHelperTests
             session,
             store.Object);
 
-        var entry = result.HistoryEntries.ShouldHaveSingleItem();
+        result.HistoryEntries.Count.ShouldBe(2); // start + synthesized orphan result
+        var entry = result.HistoryEntries[0];
         entry.ToolArgs.ShouldBeNull();
     }
 


### PR DESCRIPTION
Closes #1001

## Changes

When a streaming turn produces ToolStart events without matching ToolEnd events (orphan tool calls), the helper now:

1. Synthesizes failed tool result entries for transcript consistency
2. Still delivers assistant text (orphan tools do not suppress content delivery)
3. Skips whitespace-only assistant content

### Implementation

- Track toolStartIds and toolEndIds during stream processing
- After stream completes, diff the two sets and synthesize failed results for unmatched starts
- Changed final content guard from Length > 0 to IsNullOrWhiteSpace check
- Updated 3 existing ToolArgs tests to account for synthesized orphan entries

### Tests

- 6 new tests in OrphanToolCallTests.cs
- 3 existing tests updated for new orphan synthesis behavior

## Merge Notes

Independent of all open PRs. Safe to merge in any order.