### PR TITLE
feat(prompts): add IPromptOverrideResolver and FilePromptOverrideResolver for section overrides

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/BotNexus.Gateway.Prompts.csproj
+++ b/src/gateway/BotNexus.Gateway.Prompts/BotNexus.Gateway.Prompts.csproj
@@ -3,6 +3,9 @@
     <RootNamespace>BotNexus.Gateway.Prompts</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/src/gateway/BotNexus.Gateway.Prompts/FilePromptOverrideResolver.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/FilePromptOverrideResolver.cs
@@ -1,0 +1,84 @@
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Resolves prompt section overrides from markdown files on disk.
+/// <para>
+/// Directory layout:
+/// <code>
+/// {promptsDir}/
+///   system/
+///     {sectionId}.md          — section-level override (any model)
+///     model/
+///       {family}.md           — model-family-specific guidance override
+/// </code>
+/// </para>
+/// <para>
+/// Files are read fresh on every call (hot-reload, no restart required).
+/// </para>
+/// </summary>
+public sealed class FilePromptOverrideResolver : IPromptOverrideResolver
+{
+    private readonly IFileSystem _fileSystem;
+    private readonly string _promptsDir;
+
+    /// <summary>
+    /// Section IDs that cannot be overridden (safety-critical or runtime data).
+    /// </summary>
+    internal static readonly HashSet<string> NonOverridableSections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "safety",
+        "runtime-data",
+        "runtime-info",
+        "identity"
+    };
+
+    /// <summary>
+    /// Creates a new <see cref="FilePromptOverrideResolver"/>.
+    /// </summary>
+    /// <param name="promptsDir">The root prompts directory (e.g. ~/.botnexus/prompts).</param>
+    /// <param name="fileSystem">File system abstraction for testability.</param>
+    public FilePromptOverrideResolver(string promptsDir, IFileSystem? fileSystem = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(promptsDir);
+        _promptsDir = promptsDir;
+        _fileSystem = fileSystem ?? new FileSystem();
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string>? TryResolveOverride(string sectionId, string? modelFamily = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sectionId);
+
+        if (NonOverridableSections.Contains(sectionId))
+            return null;
+
+        // For model-guidance overrides, check model/{family}.md
+        if (sectionId == "model-guidance" && !string.IsNullOrWhiteSpace(modelFamily))
+        {
+            var modelPath = _fileSystem.Path.Combine(_promptsDir, "system", "model", $"{modelFamily}.md");
+            var modelLines = TryReadFile(modelPath);
+            if (modelLines is not null)
+                return modelLines;
+        }
+
+        // General section override: system/{sectionId}.md
+        var sectionPath = _fileSystem.Path.Combine(_promptsDir, "system", $"{sectionId}.md");
+        return TryReadFile(sectionPath);
+    }
+
+    private IReadOnlyList<string>? TryReadFile(string path)
+    {
+        if (!_fileSystem.File.Exists(path))
+            return null;
+
+        var content = _fileSystem.File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        return content.Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .ToList();
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Prompts/IPromptOverrideResolver.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/IPromptOverrideResolver.cs
@@ -1,0 +1,16 @@
+namespace BotNexus.Gateway.Prompts;
+
+/// <summary>
+/// Resolves prompt section overrides from external sources (e.g. filesystem).
+/// When an override is found for a section, its content replaces the built-in default.
+/// </summary>
+public interface IPromptOverrideResolver
+{
+    /// <summary>
+    /// Attempts to resolve an override for the given section identifier.
+    /// </summary>
+    /// <param name="sectionId">The stable section identifier (e.g. "tool-enforcement", "shell-efficiency").</param>
+    /// <param name="modelFamily">The current model family (e.g. "claude", "gpt"). Used for model-specific overrides.</param>
+    /// <returns>The override content lines if found; <c>null</c> if no override exists.</returns>
+    IReadOnlyList<string>? TryResolveOverride(string sectionId, string? modelFamily = null);
+}

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/BotNexus.Gateway.Prompts.Tests.csproj
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/BotNexus.Gateway.Prompts.Tests.csproj
@@ -4,6 +4,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/FilePromptOverrideResolverTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/FilePromptOverrideResolverTests.cs
@@ -1,0 +1,173 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class FilePromptOverrideResolverTests
+{
+    private const string PromptsDir = "/home/user/.botnexus/prompts";
+
+    [Fact]
+    public void TryResolveOverride_SectionFileExists_ReturnsLines()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/shell-efficiency.md", new MockFileData("Use scripts over inline commands\nMinimize shell invocations"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("shell-efficiency");
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+        result[0].ShouldBe("Use scripts over inline commands");
+        result[1].ShouldBe("Minimize shell invocations");
+    }
+
+    [Fact]
+    public void TryResolveOverride_SectionFileDoesNotExist_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("nonexistent-section");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolveOverride_EmptyFile_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/shell-efficiency.md", new MockFileData("   "));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("shell-efficiency");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolveOverride_NonOverridableSection_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/safety.md", new MockFileData("Overridden safety content"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("safety");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolveOverride_RuntimeDataSection_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/runtime-data.md", new MockFileData("Overridden runtime data"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("runtime-data");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolveOverride_IdentitySection_ReturnsNull()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/identity.md", new MockFileData("Overridden identity"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("identity");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolveOverride_ModelGuidanceWithFamily_ChecksModelDir()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/model/claude.md", new MockFileData("Claude-specific guidance\nPrefer edit tool"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("model-guidance", modelFamily: "claude");
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+        result[0].ShouldBe("Claude-specific guidance");
+    }
+
+    [Fact]
+    public void TryResolveOverride_ModelGuidanceWithFamily_FallsBackToGeneral()
+    {
+        var fs = new MockFileSystem();
+        // No model/gpt.md but general model-guidance.md exists
+        fs.AddFile($"{PromptsDir}/system/model-guidance.md", new MockFileData("General model guidance"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("model-guidance", modelFamily: "gpt");
+
+        result.ShouldNotBeNull();
+        result[0].ShouldBe("General model guidance");
+    }
+
+    [Fact]
+    public void TryResolveOverride_ModelGuidanceWithFamily_PrefersModelSpecific()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/model/claude.md", new MockFileData("Claude-specific"));
+        fs.AddFile($"{PromptsDir}/system/model-guidance.md", new MockFileData("General fallback"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("model-guidance", modelFamily: "claude");
+
+        result.ShouldNotBeNull();
+        result[0].ShouldBe("Claude-specific");
+    }
+
+    [Fact]
+    public void TryResolveOverride_ModelGuidanceNoFamily_ChecksGeneral()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{PromptsDir}/system/model-guidance.md", new MockFileData("General guidance"));
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        var result = resolver.TryResolveOverride("model-guidance");
+
+        result.ShouldNotBeNull();
+        result[0].ShouldBe("General guidance");
+    }
+
+    [Fact]
+    public void TryResolveOverride_HotReload_ReadsNewContentOnNextCall()
+    {
+        var fs = new MockFileSystem();
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        // First call — no file
+        resolver.TryResolveOverride("shell-efficiency").ShouldBeNull();
+
+        // Create file after resolver instantiation
+        fs.AddFile($"{PromptsDir}/system/shell-efficiency.md", new MockFileData("New content"));
+
+        // Second call — should pick up new file without restart
+        var result = resolver.TryResolveOverride("shell-efficiency");
+        result.ShouldNotBeNull();
+        result[0].ShouldBe("New content");
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullOrWhitespaceDir()
+    {
+        Should.Throw<ArgumentException>(() => new FilePromptOverrideResolver(""));
+        Should.Throw<ArgumentException>(() => new FilePromptOverrideResolver("   "));
+    }
+
+    [Fact]
+    public void TryResolveOverride_ThrowsOnNullOrWhitespaceSectionId()
+    {
+        var fs = new MockFileSystem();
+        var resolver = new FilePromptOverrideResolver(PromptsDir, fs);
+
+        Should.Throw<ArgumentException>(() => resolver.TryResolveOverride(""));
+        Should.Throw<ArgumentException>(() => resolver.TryResolveOverride("   "));
+    }
+}


### PR DESCRIPTION
Closes #999

Part of #957

## Changes

Adds the prompt section override resolution system:

### IPromptOverrideResolver interface
- TryResolveOverride(sectionId, modelFamily) returns override content lines or null
- Clean contract for swapping implementations (file, config, remote)

### FilePromptOverrideResolver implementation
- Reads markdown files from ~/.botnexus/prompts/system/{sectionId}.md
- Model-family overrides at system/model/{family}.md (e.g. claude.md, gpt.md)
- Non-overridable sections blocked: safety, runtime-data, runtime-info, identity
- Hot-reload: files read fresh on every prompt build (no restart required)
- Uses System.IO.Abstractions for testability (MockFileSystem in tests)

### Tests (13 tests)
- Section file resolution (exists, missing, empty)
- Non-overridable section blocking (safety, runtime-data, identity)
- Model-family override hierarchy (specific > general fallback)
- Hot-reload behavior (file created after resolver instantiation)
- Input validation (null/whitespace args)

## Merge Notes

Independent of all open PRs. Safe to merge in any order.
Depends on #995 (SectionId on IPromptSection) which is already merged.