### PR TITLE
fix(portal): wrap update badge test clicks in InvokeAsync for async handler

### DIFF
--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -213,7 +213,7 @@ public sealed class MainLayoutTests : IDisposable
     }
 
     [Fact]
-    public void Virtual_cron_conversation_shows_badge_and_close_button()
+    public async Task Virtual_cron_conversation_shows_badge_and_close_button()
     {
         _store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
         _store.SeedConversations("a-1", [
@@ -227,7 +227,7 @@ public sealed class MainLayoutTests : IDisposable
         var cut = RenderLayout();
 
         // Cron conversations are now in a collapsed Scheduled group; expand it first
-        cut.Find("[data-testid='cron-group-toggle']").Click();
+        await cut.InvokeAsync(() => cut.Find("[data-testid='cron-group-toggle']").Click());
 
         Assert.Contains("Cron", cut.Markup);
         var archiveBtn = cut.Find(".conversation-archive-btn");

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
@@ -131,10 +131,10 @@ public sealed class UpdateBadgeTests : IDisposable
         _updateSvc.StartUpdateAsync(Arg.Any<CancellationToken>()).Returns(202);
 
         var cut = RenderLayout();
-        cut.Find(".update-badge").Click();
+        await cut.InvokeAsync(() => cut.Find(".update-badge").Click());
 
         // Click the confirm button inside the dialog
-        cut.Find(".update-confirm-btn").Click();
+        await cut.InvokeAsync(() => cut.Find(".update-confirm-btn").Click());
 
         await _updateSvc.Received(1).StartUpdateAsync(Arg.Any<CancellationToken>());
     }
@@ -155,12 +155,12 @@ public sealed class UpdateBadgeTests : IDisposable
     }
 
     [Fact]
-    public void MainLayout_WhenUpdateInProgress_UpdateButtonDisabled()
+    public async Task MainLayout_WhenUpdateInProgress_UpdateButtonDisabled()
     {
         _updateSvc.Status.Returns(MakeStatus(isUpdateAvailable: true, isUpdateInProgress: true));
 
         var cut = RenderLayout();
-        cut.Find(".update-badge").Click();
+        await cut.InvokeAsync(() => cut.Find(".update-badge").Click());
 
         // Confirm button (or the badge itself) must be disabled
         var btn = cut.Find(".update-confirm-btn");


### PR DESCRIPTION
Closes #1013

## Changes

Two tests in `UpdateBadgeTests.cs` used synchronous `.Click()` on elements whose handlers mutate component state (`_showUpdateConfirm = true`). The re-render hadn't flushed before the next `Find(...)` call, causing `ElementNotFoundException` on `.update-confirm-btn`.

**Fix:** Wrap state-changing clicks in `await cut.InvokeAsync(...)` — same pattern as PR #989 for the burger toggle.

- `MainLayout_UpdateConfirm_CallsUpdateService`: both clicks wrapped
- `MainLayout_WhenUpdateInProgress_UpdateButtonDisabled`: first click wrapped, method made async

## Merge Notes

Fully independent — no file overlap with any open PR. Safe to merge immediately.
This unblocks main CI (1 test failing since commit 8afdf795).