### PR TITLE
feat(portal): render compaction boundaries as styled separators in conversation history

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -495,6 +495,16 @@ public sealed class AgentInteractionService : IAgentInteractionService
                             BoundarySessionId = entry.SessionId
                         });
                     }
+                    else if (entry.Kind == "compaction")
+                    {
+                        var label = "Context compacted \u00b7 " + entry.Timestamp.ToLocalTime().ToString("MMM d HH:mm");
+                        conv.Messages.Add(new ChatMessage("System", entry.Content ?? string.Empty, entry.Timestamp)
+                        {
+                            Kind = "compaction",
+                            BoundaryLabel = label,
+                            BoundarySessionId = entry.SessionId
+                        });
+                    }
                     else
                     {
                         var isToolCall = entry.ToolName is not null;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateModels.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateModels.cs
@@ -113,6 +113,9 @@ public sealed record ChatMessage(string Role, string Content, DateTimeOffset Tim
     /// <summary>Whether this entry is a session boundary divider.</summary>
     public bool IsBoundary => Kind == "boundary";
 
+    /// <summary>Whether this entry is a compaction boundary (context was summarised).</summary>
+    public bool IsCompaction => Kind == "compaction";
+
     /// <summary>CSS class derived from the message role.</summary>
     public string CssClass => Role.ToLowerInvariant();
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -159,6 +159,14 @@
                     <span class="session-boundary-line"></span>
                 </div>
             }
+            else if (msg.IsCompaction)
+            {
+                <div class="compaction-boundary" role="separator" aria-label="Context compacted" data-testid="compaction-boundary">
+                    <span class="compaction-boundary-line"></span>
+                    <span class="compaction-boundary-label">&#x1F4E6; @msg.BoundaryLabel</span>
+                    <span class="compaction-boundary-line"></span>
+                </div>
+            }
             else if (msg.Role == "System")
             {
                 <div class="system-message" data-testid="chat-system-message">@msg.Content</div>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/wwwroot/css/app.css
@@ -3652,6 +3652,32 @@ details[open] > .thinking-summary::before {
     white-space: nowrap;
 }
 
+/* ── Compaction Boundary Divider ─────────────────────────────────────────── */
+
+.compaction-boundary {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+    width: 100%;
+    margin: 0.75rem 0;
+}
+
+.compaction-boundary-line {
+    flex: 1;
+    height: 1px;
+    background: var(--accent);
+    opacity: 0.4;
+}
+
+.compaction-boundary-label {
+    padding: 0 0.75rem;
+    font-size: 0.75rem;
+    color: var(--accent);
+    font-family: var(--font-mono);
+    white-space: nowrap;
+}
+
 /* Chat Header - Conversation Title Heading (was: Conversation Title Row) */
 
 .chat-title-heading-row {

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -395,9 +395,28 @@ public sealed class ConversationsController : ControllerBase
             var snapshot = session.GetHistorySnapshot();
             foreach (var entry in snapshot)
             {
+                // Skip folded entries that have been superseded by compaction summaries.
+                if (entry.IsHistory)
+                    continue;
+
                 if (entry.Role == MessageRole.Assistant &&
                     string.Equals(entry.Content?.Trim(), "NO_REPLY", StringComparison.Ordinal))
                     continue;
+
+                // Emit compaction summaries as distinct boundary markers so the portal
+                // can render them as separators rather than normal system messages.
+                if (entry.IsCompactionSummary)
+                {
+                    allEntries.Add(new ConversationHistoryEntry
+                    {
+                        Kind = "compaction",
+                        SessionId = session.SessionId.Value,
+                        Timestamp = entry.Timestamp,
+                        Reason = "compaction",
+                        Content = entry.Content
+                    });
+                    continue;
+                }
 
                 allEntries.Add(new ConversationHistoryEntry
                 {

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CompactionBoundaryTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CompactionBoundaryTests.cs
@@ -1,0 +1,66 @@
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for compaction boundary rendering in the chat panel.
+/// Verifies that entries with Kind="compaction" are correctly identified and labeled.
+/// </summary>
+public sealed class CompactionBoundaryTests
+{
+    [Fact]
+    public void ChatMessage_WithKindCompaction_IsCompaction_ReturnsTrue()
+    {
+        var msg = new ChatMessage("System", "Summary content", DateTimeOffset.UtcNow)
+        {
+            Kind = "compaction",
+            BoundaryLabel = "Context compacted \u00b7 Jun 7 10:30"
+        };
+
+        Assert.True(msg.IsCompaction);
+        Assert.False(msg.IsBoundary);
+    }
+
+    [Fact]
+    public void ChatMessage_WithKindBoundary_IsCompaction_ReturnsFalse()
+    {
+        var msg = new ChatMessage("System", string.Empty, DateTimeOffset.UtcNow)
+        {
+            Kind = "boundary",
+            BoundaryLabel = "Session \u00b7 Jun 7 10:30"
+        };
+
+        Assert.False(msg.IsCompaction);
+        Assert.True(msg.IsBoundary);
+    }
+
+    [Fact]
+    public void ChatMessage_WithKindMessage_IsCompaction_ReturnsFalse()
+    {
+        var msg = new ChatMessage("Assistant", "Hello", DateTimeOffset.UtcNow)
+        {
+            Kind = "message"
+        };
+
+        Assert.False(msg.IsCompaction);
+        Assert.False(msg.IsBoundary);
+    }
+
+    [Fact]
+    public void ConversationHistoryEntryDto_CompactionKind_CarriesContent()
+    {
+        var entry = new ConversationHistoryEntryDto
+        {
+            Kind = "compaction",
+            SessionId = "sess-123",
+            Timestamp = DateTimeOffset.UtcNow,
+            Reason = "compaction",
+            Content = "## Summary\nUser asked about X. Agent resolved Y."
+        };
+
+        Assert.Equal("compaction", entry.Kind);
+        Assert.Equal("compaction", entry.Reason);
+        Assert.NotNull(entry.Content);
+        Assert.Contains("Summary", entry.Content);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerHistoryTests.cs
@@ -395,4 +395,55 @@ public sealed class ConversationsControllerHistoryTests
         response.Entries.ShouldContain(e => e.Content == "NO_REPLY" && e.Role == "user");
         response.Entries.ShouldContain(e => e.Content == "I understand you typed NO_REPLY");
     }
+
+    [Fact]
+    public async Task GetHistory_CompactionSummaryEntry_EmittedAsCompactionKind()
+    {
+        var conversationId = ConversationId.From("c_compaction_boundary");
+        var sessions = new InMemorySessionStore();
+        var conversationStore = new StubConversationStore(CreateConversation(conversationId, "quill"));
+        var session = await sessions.GetOrCreateAsync(SessionId.From("s-compact-1"), AgentId.From("quill"));
+        session.Session.ConversationId = conversationId;
+
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "Hello", Timestamp = DateTimeOffset.UtcNow.AddMinutes(1) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.System, Content = "Summary of prior context", IsCompactionSummary = true, Timestamp = DateTimeOffset.UtcNow.AddMinutes(2) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "Follow-up", Timestamp = DateTimeOffset.UtcNow.AddMinutes(3) });
+
+        await sessions.SaveAsync(session);
+        var controller = new ConversationsController(conversationStore, sessions);
+
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 200, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+        var compactionEntry = response!.Entries.Single(e => e.Kind == "compaction");
+        compactionEntry.Reason.ShouldBe("compaction");
+        compactionEntry.Content.ShouldBe("Summary of prior context");
+    }
+
+    [Fact]
+    public async Task GetHistory_HistoricalEntries_AreExcluded()
+    {
+        var conversationId = ConversationId.From("c_history_excluded");
+        var sessions = new InMemorySessionStore();
+        var conversationStore = new StubConversationStore(CreateConversation(conversationId, "quill"));
+        var session = await sessions.GetOrCreateAsync(SessionId.From("s-hist-1"), AgentId.From("quill"));
+        session.Session.ConversationId = conversationId;
+
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "Old message", IsHistory = true, Timestamp = DateTimeOffset.UtcNow.AddMinutes(1) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.System, Content = "Compaction summary", IsCompactionSummary = true, Timestamp = DateTimeOffset.UtcNow.AddMinutes(2) });
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "New message", Timestamp = DateTimeOffset.UtcNow.AddMinutes(3) });
+
+        await sessions.SaveAsync(session);
+        var controller = new ConversationsController(conversationStore, sessions);
+
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 200, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+        response!.TotalCount.ShouldBe(2); // historical entry excluded
+        response.Entries.ShouldNotContain(e => e.Content == "Old message");
+        response.Entries.ShouldContain(e => e.Kind == "compaction" && e.Content == "Compaction summary");
+        response.Entries.ShouldContain(e => e.Content == "New message");
+    }
 }


### PR DESCRIPTION
Closes #673

Part of #655 (Compaction improvements Phase 3)

## Changes

### Backend (ConversationsController)
- `IsCompactionSummary` entries now emitted as `Kind = "compaction"` with `Reason` and `Content`
- `IsHistory = true` entries skipped entirely (folded into compaction summary, not user-visible)

### Portal (ChatPanel + AgentInteractionService)
- New `IsCompaction` property on `ChatMessage` (mirrors `IsBoundary`)
- `AgentInteractionService.LoadConversationHistoryAsync` maps `kind=compaction` entries to ChatMessage with distinct label
- ChatPanel renders compaction boundaries as accent-colored separators: `📦 Context compacted · Jun 7 10:30`
- CSS: `.compaction-boundary` with accent color, distinct from session boundaries

### Tests (7 new)
- 4 portal unit tests (IsCompaction true/false, IsBoundary preserved, DTO contract)
- 2 backend tests (compaction entry emitted correctly, historical entries excluded)

## Acceptance Criteria Addressed
- [x] `CompactionBoundary` entry type rendered in portal as styled separator
- [x] Historical (folded) entries hidden from conversation history API
- [ ] Session split on compaction (deferred — separate PR)
- [ ] Portal session list linked pair view (deferred — separate PR)

## Merge Notes
Fully independent — no file overlap with PR #905 or #914. Safe to merge in any order.