### PR TITLE
feat(tools): add platform debug tool for read-only session and runtime inspection

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -7,6 +7,7 @@
     <Project Path="src/extensions/BotNexus.Extensions.WebTools/BotNexus.Extensions.WebTools.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.ProcessTool/BotNexus.Extensions.ProcessTool.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.DataStore/BotNexus.Extensions.DataStore.csproj" />
+    <Project Path="src/extensions/BotNexus.Extensions.DebugTool/BotNexus.Extensions.DebugTool.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.ExecTool/BotNexus.Extensions.ExecTool.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR/BotNexus.Extensions.Channels.SignalR.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/BotNexus.Extensions.Channels.SignalR.BlazorClient.csproj" />
@@ -72,6 +73,7 @@
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.DataStore.Tests/BotNexus.Extensions.DataStore.Tests.csproj" />
+    <Project Path="tests/extensions/BotNexus.Extensions.DebugTool.Tests/BotNexus.Extensions.DebugTool.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.ExecTool.Tests/BotNexus.Extensions.ExecTool.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Mcp.Tests/BotNexus.Extensions.Mcp.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.McpInvoke.Tests/BotNexus.Extensions.McpInvoke.Tests.csproj" />

--- a/src/extensions/BotNexus.Extensions.DebugTool/BotNexus.Extensions.DebugTool.csproj
+++ b/src/extensions/BotNexus.Extensions.DebugTool/BotNexus.Extensions.DebugTool.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Extensions.DebugTool</RootNamespace>
+    <Description>Platform debug tool providing agent-facing read-only access to sessions.db and gateway runtime state.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Extensions.DebugTool.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Core\BotNexus.Agent.Core.csproj" />
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/extensions/BotNexus.Extensions.DebugTool/DebugTool.cs
+++ b/src/extensions/BotNexus.Extensions.DebugTool/DebugTool.cs
@@ -1,0 +1,520 @@
+using System.Text;
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+using Microsoft.Data.Sqlite;
+
+namespace BotNexus.Extensions.DebugTool;
+
+/// <summary>
+/// Agent-facing read-only debug tool for inspecting platform state (sessions.db and runtime).
+/// All database access is read-only (Mode=ReadOnly). Queries are agent-scoped by default.
+/// </summary>
+public sealed class DebugTool : IAgentTool
+{
+    private readonly string _dbPath;
+    private readonly string _agentId;
+    private readonly DebugToolConfig _config;
+    private readonly IRuntimeStateProvider? _runtimeStateProvider;
+
+    internal const int DefaultLimit = 50;
+    internal const int MaxLimit = 500;
+
+    internal static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "query_sessions",
+        "query_conversations",
+        "query_history",
+        "query_sub_agents",
+        "session_info",
+        "conversation_info",
+        "runtime_status",
+        "raw_sql"
+    };
+
+    public DebugTool(string dbPath, string agentId, DebugToolConfig config, IRuntimeStateProvider? runtimeStateProvider = null)
+    {
+        _dbPath = dbPath ?? throw new ArgumentNullException(nameof(dbPath));
+        _agentId = agentId ?? throw new ArgumentNullException(nameof(agentId));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _runtimeStateProvider = runtimeStateProvider;
+    }
+
+    public string Name => "platform_debug";
+    public string Label => "Platform Debug";
+
+    public Tool Definition => new(
+        Name,
+        "Read-only inspection of platform sessions.db and gateway runtime state. Query sessions, conversations, history, sub-agents, or execute raw SELECT statements against the platform database.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": ["query_sessions", "query_conversations", "query_history", "query_sub_agents", "session_info", "conversation_info", "runtime_status", "raw_sql"],
+                  "description": "Action to perform."
+                },
+                "session_id": {
+                  "type": "string",
+                  "description": "Session ID filter (for query_history, query_sub_agents, session_info)."
+                },
+                "conversation_id": {
+                  "type": "string",
+                  "description": "Conversation ID filter (for query_sessions, conversation_info)."
+                },
+                "agent_id": {
+                  "type": "string",
+                  "description": "Agent ID filter. Defaults to current agent when omitted."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Status filter (for query_sessions, query_conversations)."
+                },
+                "kind": {
+                  "type": "string",
+                  "description": "Kind filter (for query_conversations)."
+                },
+                "role": {
+                  "type": "string",
+                  "description": "Message role filter (for query_history)."
+                },
+                "after": {
+                  "type": "string",
+                  "description": "ISO date/time lower bound (inclusive) for date range filtering."
+                },
+                "before": {
+                  "type": "string",
+                  "description": "ISO date/time upper bound (exclusive) for date range filtering."
+                },
+                "sql": {
+                  "type": "string",
+                  "description": "SELECT statement for 'raw_sql' action. Only SELECT is permitted."
+                },
+                "offset": {
+                  "type": "integer",
+                  "description": "Pagination offset. Default: 0."
+                },
+                "limit": {
+                  "type": "integer",
+                  "description": "Maximum rows to return. Default: 50, max: 500."
+                }
+              },
+              "required": ["action"]
+            }
+            """).RootElement.Clone());
+
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyDictionary<string, object?>>(
+            new Dictionary<string, object?>(arguments, StringComparer.OrdinalIgnoreCase));
+    }
+
+    public Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        var action = GetString(arguments, "action")?.ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(action) || !ValidActions.Contains(action))
+            return Task.FromResult(TextResult($"Error: Unknown action '{action}'. Valid actions: {string.Join(", ", ValidActions.Order())}."));
+
+        var result = action switch
+        {
+            "query_sessions" => QuerySessions(arguments),
+            "query_conversations" => QueryConversations(arguments),
+            "query_history" => QueryHistory(arguments),
+            "query_sub_agents" => QuerySubAgents(arguments),
+            "session_info" => SessionInfo(arguments),
+            "conversation_info" => ConversationInfo(arguments),
+            "runtime_status" => RuntimeStatus(),
+            "raw_sql" => RawSql(arguments),
+            _ => TextResult($"Error: Unhandled action '{action}'.")
+        };
+
+        return Task.FromResult(result);
+    }
+
+    // ── Action implementations ────────────────────────────────────────────────
+
+    private AgentToolResult QuerySessions(IReadOnlyDictionary<string, object?> args)
+    {
+        var agentId = GetString(args, "agent_id") ?? _agentId;
+        var conversationId = GetString(args, "conversation_id");
+        var status = GetString(args, "status");
+        var after = GetString(args, "after");
+        var before = GetString(args, "before");
+        var (offset, limit) = GetPagination(args);
+
+        var sb = new StringBuilder("SELECT * FROM sessions WHERE 1=1");
+        var parameters = new List<SqliteParameter>();
+
+        sb.Append(" AND conversation_id IN (SELECT id FROM conversations WHERE agent_id = @agentId)");
+        parameters.Add(new SqliteParameter("@agentId", agentId));
+
+        if (!string.IsNullOrWhiteSpace(conversationId))
+        {
+            sb.Append(" AND conversation_id = @conversationId");
+            parameters.Add(new SqliteParameter("@conversationId", conversationId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            sb.Append(" AND status = @status");
+            parameters.Add(new SqliteParameter("@status", status));
+        }
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            sb.Append(" AND created_at >= @after");
+            parameters.Add(new SqliteParameter("@after", after));
+        }
+
+        if (!string.IsNullOrWhiteSpace(before))
+        {
+            sb.Append(" AND created_at < @before");
+            parameters.Add(new SqliteParameter("@before", before));
+        }
+
+        sb.Append(" ORDER BY created_at DESC");
+        sb.Append($" LIMIT {limit} OFFSET {offset}");
+
+        return ExecuteReadQuery(sb.ToString(), parameters);
+    }
+
+    private AgentToolResult QueryConversations(IReadOnlyDictionary<string, object?> args)
+    {
+        var agentId = GetString(args, "agent_id") ?? _agentId;
+        var status = GetString(args, "status");
+        var kind = GetString(args, "kind");
+        var after = GetString(args, "after");
+        var before = GetString(args, "before");
+        var (offset, limit) = GetPagination(args);
+
+        var sb = new StringBuilder("SELECT * FROM conversations WHERE agent_id = @agentId");
+        var parameters = new List<SqliteParameter>
+        {
+            new("@agentId", agentId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            sb.Append(" AND status = @status");
+            parameters.Add(new SqliteParameter("@status", status));
+        }
+
+        if (!string.IsNullOrWhiteSpace(kind))
+        {
+            sb.Append(" AND kind = @kind");
+            parameters.Add(new SqliteParameter("@kind", kind));
+        }
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            sb.Append(" AND created_at >= @after");
+            parameters.Add(new SqliteParameter("@after", after));
+        }
+
+        if (!string.IsNullOrWhiteSpace(before))
+        {
+            sb.Append(" AND created_at < @before");
+            parameters.Add(new SqliteParameter("@before", before));
+        }
+
+        sb.Append(" ORDER BY created_at DESC");
+        sb.Append($" LIMIT {limit} OFFSET {offset}");
+
+        return ExecuteReadQuery(sb.ToString(), parameters);
+    }
+
+    private AgentToolResult QueryHistory(IReadOnlyDictionary<string, object?> args)
+    {
+        var sessionId = GetString(args, "session_id");
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return TextResult("Error: 'session_id' is required for query_history.");
+
+        var role = GetString(args, "role");
+        var after = GetString(args, "after");
+        var before = GetString(args, "before");
+        var (offset, limit) = GetPagination(args);
+
+        // Verify session belongs to this agent
+        var agentId = GetString(args, "agent_id") ?? _agentId;
+        var ownershipCheck = VerifySessionOwnership(sessionId, agentId);
+        if (ownershipCheck is not null)
+            return ownershipCheck;
+
+        var sb = new StringBuilder("SELECT * FROM session_history WHERE session_id = @sessionId");
+        var parameters = new List<SqliteParameter>
+        {
+            new("@sessionId", sessionId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(role))
+        {
+            sb.Append(" AND role = @role");
+            parameters.Add(new SqliteParameter("@role", role));
+        }
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            sb.Append(" AND timestamp >= @after");
+            parameters.Add(new SqliteParameter("@after", after));
+        }
+
+        if (!string.IsNullOrWhiteSpace(before))
+        {
+            sb.Append(" AND timestamp < @before");
+            parameters.Add(new SqliteParameter("@before", before));
+        }
+
+        sb.Append(" ORDER BY sequence_id ASC");
+        sb.Append($" LIMIT {limit} OFFSET {offset}");
+
+        return ExecuteReadQuery(sb.ToString(), parameters);
+    }
+
+    private AgentToolResult QuerySubAgents(IReadOnlyDictionary<string, object?> args)
+    {
+        var sessionId = GetString(args, "session_id");
+        var agentId = GetString(args, "agent_id") ?? _agentId;
+        var (offset, limit) = GetPagination(args);
+
+        var sb = new StringBuilder("SELECT * FROM sub_agent_sessions WHERE 1=1");
+        var parameters = new List<SqliteParameter>();
+
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            // Verify session belongs to this agent
+            var ownershipCheck = VerifySessionOwnership(sessionId, agentId);
+            if (ownershipCheck is not null)
+                return ownershipCheck;
+
+            sb.Append(" AND parent_session_id = @sessionId");
+            parameters.Add(new SqliteParameter("@sessionId", sessionId));
+        }
+        else
+        {
+            // Filter to sessions owned by the agent
+            sb.Append(" AND parent_session_id IN (SELECT id FROM sessions WHERE conversation_id IN (SELECT id FROM conversations WHERE agent_id = @agentId))");
+            parameters.Add(new SqliteParameter("@agentId", agentId));
+        }
+
+        sb.Append(" ORDER BY started_at DESC");
+        sb.Append($" LIMIT {limit} OFFSET {offset}");
+
+        return ExecuteReadQuery(sb.ToString(), parameters);
+    }
+
+    private AgentToolResult SessionInfo(IReadOnlyDictionary<string, object?> args)
+    {
+        var sessionId = GetString(args, "session_id");
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return TextResult("Error: 'session_id' is required for session_info.");
+
+        var agentId = GetString(args, "agent_id") ?? _agentId;
+        var ownershipCheck = VerifySessionOwnership(sessionId, agentId);
+        if (ownershipCheck is not null)
+            return ownershipCheck;
+
+        return ExecuteReadQuery(
+            "SELECT * FROM sessions WHERE id = @sessionId",
+            [new SqliteParameter("@sessionId", sessionId)]);
+    }
+
+    private AgentToolResult ConversationInfo(IReadOnlyDictionary<string, object?> args)
+    {
+        var conversationId = GetString(args, "conversation_id");
+        if (string.IsNullOrWhiteSpace(conversationId))
+            return TextResult("Error: 'conversation_id' is required for conversation_info.");
+
+        var agentId = GetString(args, "agent_id") ?? _agentId;
+
+        return ExecuteReadQuery(
+            "SELECT * FROM conversations WHERE id = @conversationId AND agent_id = @agentId",
+            [new SqliteParameter("@conversationId", conversationId), new SqliteParameter("@agentId", agentId)]);
+    }
+
+    private AgentToolResult RuntimeStatus()
+    {
+        if (_runtimeStateProvider is null)
+            return TextResult("Error: Runtime state provider is not available.");
+
+        return TextResult(_runtimeStateProvider.GetRuntimeStatus());
+    }
+
+    private AgentToolResult RawSql(IReadOnlyDictionary<string, object?> args)
+    {
+        if (!_config.AllowRawSql)
+            return TextResult("Error: raw_sql is disabled. Set 'allowRawSql: true' in the debug tool configuration to enable.");
+
+        var sql = GetString(args, "sql");
+        if (string.IsNullOrWhiteSpace(sql))
+            return TextResult("Error: 'sql' is required for raw_sql.");
+
+        if (!IsSelectOnly(sql))
+            return TextResult("Error: Only SELECT statements are permitted. The query must start with SELECT (after optional whitespace/comments).");
+
+        var (_, limit) = GetPagination(args);
+
+        return ExecuteReadQuery(sql, [], limit);
+    }
+
+    // ── Database helpers ──────────────────────────────────────────────────────
+
+    private SqliteConnection OpenReadOnly()
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _dbPath,
+            Mode = SqliteOpenMode.ReadOnly
+        }.ToString();
+
+        var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        return connection;
+    }
+
+    private AgentToolResult ExecuteReadQuery(string sql, List<SqliteParameter> parameters, int? rowLimit = null)
+    {
+        try
+        {
+            using var connection = OpenReadOnly();
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            foreach (var param in parameters)
+                command.Parameters.Add(param);
+
+            using var reader = command.ExecuteReader();
+            var rows = new List<Dictionary<string, object?>>();
+            var effectiveLimit = rowLimit ?? MaxLimit;
+            var rowCount = 0;
+
+            while (reader.Read() && rowCount < effectiveLimit)
+            {
+                var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    var name = reader.GetName(i);
+                    var value = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                    row[name] = value;
+                }
+                rows.Add(row);
+                rowCount++;
+            }
+
+            if (rows.Count == 0)
+                return TextResult("No results found.");
+
+            var json = JsonSerializer.Serialize(rows, JsonOptions);
+            return TextResult(json);
+        }
+        catch (SqliteException ex)
+        {
+            return TextResult($"Error: SQLite error — {ex.Message}");
+        }
+    }
+
+    private AgentToolResult? VerifySessionOwnership(string sessionId, string agentId)
+    {
+        try
+        {
+            using var connection = OpenReadOnly();
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+                SELECT COUNT(*) FROM sessions s
+                INNER JOIN conversations c ON s.conversation_id = c.id
+                WHERE s.id = @sessionId AND c.agent_id = @agentId";
+            command.Parameters.Add(new SqliteParameter("@sessionId", sessionId));
+            command.Parameters.Add(new SqliteParameter("@agentId", agentId));
+
+            var count = Convert.ToInt64(command.ExecuteScalar());
+            if (count == 0)
+                return TextResult($"Error: Session '{sessionId}' not found or not owned by agent '{agentId}'.");
+
+            return null;
+        }
+        catch (SqliteException ex)
+        {
+            return TextResult($"Error: SQLite error during ownership check — {ex.Message}");
+        }
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────────────────
+
+    internal static string? GetString(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var raw)) return null;
+        return raw switch
+        {
+            string s => s,
+            JsonElement je => je.ValueKind == JsonValueKind.String ? je.GetString() : je.GetRawText(),
+            _ => raw?.ToString()
+        };
+    }
+
+    internal static int GetInt(IReadOnlyDictionary<string, object?> args, string key, int defaultValue)
+    {
+        if (!args.TryGetValue(key, out var raw)) return defaultValue;
+        return raw switch
+        {
+            int i => i,
+            long l => (int)l,
+            string s when int.TryParse(s, out var parsed) => parsed,
+            JsonElement je when je.ValueKind == JsonValueKind.Number => je.GetInt32(),
+            JsonElement je when je.ValueKind == JsonValueKind.String && int.TryParse(je.GetString(), out var parsed) => parsed,
+            _ => defaultValue
+        };
+    }
+
+    internal static (int Offset, int Limit) GetPagination(IReadOnlyDictionary<string, object?> args)
+    {
+        var offset = Math.Max(0, GetInt(args, "offset", 0));
+        var limit = Math.Clamp(GetInt(args, "limit", DefaultLimit), 1, MaxLimit);
+        return (offset, limit);
+    }
+
+    internal static bool IsSelectOnly(string sql)
+    {
+        // Strip leading whitespace and line comments, then check first keyword
+        var trimmed = sql.AsSpan().TrimStart();
+
+        // Skip line comments (-- ...) and block comments (/* ... */)
+        while (true)
+        {
+            if (trimmed.StartsWith("--"))
+            {
+                var newlineIdx = trimmed.IndexOf('\n');
+                trimmed = newlineIdx >= 0 ? trimmed[(newlineIdx + 1)..].TrimStart() : [];
+            }
+            else if (trimmed.StartsWith("/*"))
+            {
+                var endIdx = trimmed.IndexOf("*/");
+                trimmed = endIdx >= 0 ? trimmed[(endIdx + 2)..].TrimStart() : [];
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return trimmed.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("WITH", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("EXPLAIN", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("PRAGMA", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static AgentToolResult TextResult(string text) =>
+        new([new AgentToolContent(AgentToolContentType.Text, text)]);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = false
+    };
+}

--- a/src/extensions/BotNexus.Extensions.DebugTool/DebugToolConfig.cs
+++ b/src/extensions/BotNexus.Extensions.DebugTool/DebugToolConfig.cs
@@ -1,0 +1,13 @@
+namespace BotNexus.Extensions.DebugTool;
+
+/// <summary>
+/// Configuration for the platform debug tool.
+/// </summary>
+public sealed class DebugToolConfig
+{
+    /// <summary>Whether the debug tool is enabled. Defaults to true.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Whether the raw_sql action is permitted. Defaults to false for safety.</summary>
+    public bool AllowRawSql { get; set; }
+}

--- a/src/extensions/BotNexus.Extensions.DebugTool/DebugToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.DebugTool/DebugToolContributor.cs
@@ -1,0 +1,63 @@
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Extensions.DebugTool;
+
+/// <summary>
+/// Contributes the <see cref="DebugTool"/> for each agent session.
+/// The tool is always contributed (default tool) unless disabled via extension config.
+/// </summary>
+public sealed class DebugToolContributor : IAgentToolContributor
+{
+    private readonly string _dbPath;
+    private readonly IRuntimeStateProvider? _runtimeStateProvider;
+
+    /// <summary>
+    /// Creates a new contributor with the platform sessions database path.
+    /// </summary>
+    /// <param name="dbPath">Absolute path to the sessions.sqlite database file.</param>
+    /// <param name="runtimeStateProvider">Optional runtime state provider for the runtime_status action.</param>
+    public DebugToolContributor(string dbPath, IRuntimeStateProvider? runtimeStateProvider = null)
+    {
+        _dbPath = dbPath ?? throw new ArgumentNullException(nameof(dbPath));
+        _runtimeStateProvider = runtimeStateProvider;
+    }
+
+    /// <inheritdoc />
+    public Task<AgentToolContribution> ContributeAsync(
+        AgentToolContributionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var config = ResolveConfig(context.Descriptor);
+
+        if (!config.Enabled)
+            return Task.FromResult(new AgentToolContribution(Array.Empty<IAgentTool>()));
+
+        var agentId = context.Descriptor.AgentId.Value;
+        IReadOnlyList<IAgentTool> tools = [new DebugTool(_dbPath, agentId, config, _runtimeStateProvider)];
+
+        return Task.FromResult(new AgentToolContribution(tools));
+    }
+
+    private static DebugToolConfig ResolveConfig(AgentDescriptor descriptor)
+    {
+        if (descriptor.ExtensionConfig.TryGetValue("botnexus-debug-tool", out var element))
+        {
+            try
+            {
+                var options = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                return System.Text.Json.JsonSerializer.Deserialize<DebugToolConfig>(element.GetRawText(), options)
+                       ?? new DebugToolConfig();
+            }
+            catch
+            {
+                return new DebugToolConfig();
+            }
+        }
+
+        return new DebugToolConfig();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.DebugTool/IRuntimeStateProvider.cs
+++ b/src/extensions/BotNexus.Extensions.DebugTool/IRuntimeStateProvider.cs
@@ -1,0 +1,13 @@
+namespace BotNexus.Extensions.DebugTool;
+
+/// <summary>
+/// Provides runtime state information for the debug tool's runtime_status action.
+/// Injected by the contributor so the tool doesn't depend on gateway internals directly.
+/// </summary>
+public interface IRuntimeStateProvider
+{
+    /// <summary>
+    /// Gets the current runtime status as a JSON-friendly string.
+    /// </summary>
+    string GetRuntimeStatus();
+}

--- a/src/extensions/BotNexus.Extensions.DebugTool/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.DebugTool/botnexus-extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "botnexus-debug-tool",
+  "name": "BotNexus Platform Debug Tool",
+  "description": "Agent-facing read-only access to sessions.db and gateway runtime state for debugging and introspection.",
+  "version": "1.0.0"
+}

--- a/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdColumnRemovedArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/SessionAgentIdColumnRemovedArchitectureTests.cs
@@ -186,6 +186,8 @@ public sealed class SessionAgentIdColumnRemovedArchitectureTests
         // DropLegacyAgentIdColumnAsync drops both legacy indexes then the column itself;
         // VerifyAgentIdColumnConsistencyAsync logs any pre-existing data corruption.
         "gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs",
+        // DebugTool queries conversations.agent_id (which still exists) for agent scope filtering.
+        "extensions/BotNexus.Extensions.DebugTool/DebugTool.cs",
     };
 
     private static IEnumerable<string> EnumerateProductionCsFiles(string srcRoot)

--- a/tests/extensions/BotNexus.Extensions.DebugTool.Tests/BotNexus.Extensions.DebugTool.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.DebugTool.Tests/BotNexus.Extensions.DebugTool.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.DebugTool\BotNexus.Extensions.DebugTool.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/extensions/BotNexus.Extensions.DebugTool.Tests/DebugToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DebugTool.Tests/DebugToolTests.cs
@@ -1,0 +1,731 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Extensions.DebugTool;
+using Microsoft.Data.Sqlite;
+
+namespace BotNexus.Extensions.DebugTool.Tests;
+
+public sealed class DebugToolTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _agentId = "test-agent";
+
+    public DebugToolTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"debug-tool-test-{Guid.NewGuid():N}.sqlite");
+        InitializeTestDatabase();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath))
+            File.Delete(_dbPath);
+    }
+
+    private void InitializeTestDatabase()
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _dbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString();
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                status TEXT DEFAULT 'active',
+                kind TEXT DEFAULT 'chat',
+                title TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                status TEXT DEFAULT 'Active',
+                channel_type TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+            );
+
+            CREATE TABLE session_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                sequence_id INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp TEXT NOT NULL,
+                FOREIGN KEY (session_id) REFERENCES sessions(id)
+            );
+
+            CREATE TABLE sub_agent_sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT NOT NULL,
+                sub_agent_id TEXT NOT NULL,
+                objective TEXT,
+                status TEXT DEFAULT 'Running',
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+            );
+
+            -- Test data: conversations
+            INSERT INTO conversations (id, agent_id, status, kind, title, created_at, updated_at)
+            VALUES ('conv-1', 'test-agent', 'active', 'chat', 'Test Conversation 1', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z');
+            INSERT INTO conversations (id, agent_id, status, kind, title, created_at, updated_at)
+            VALUES ('conv-2', 'test-agent', 'archived', 'task', 'Test Conversation 2', '2024-01-02T00:00:00Z', '2024-01-02T01:00:00Z');
+            INSERT INTO conversations (id, agent_id, status, kind, title, created_at, updated_at)
+            VALUES ('conv-3', 'other-agent', 'active', 'chat', 'Other Agent Conv', '2024-01-03T00:00:00Z', '2024-01-03T01:00:00Z');
+
+            -- Test data: sessions
+            INSERT INTO sessions (id, conversation_id, status, channel_type, created_at, updated_at)
+            VALUES ('sess-1', 'conv-1', 'Active', 'signalr', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z');
+            INSERT INTO sessions (id, conversation_id, status, channel_type, created_at, updated_at)
+            VALUES ('sess-2', 'conv-1', 'Sealed', 'signalr', '2024-01-01T02:00:00Z', '2024-01-01T03:00:00Z');
+            INSERT INTO sessions (id, conversation_id, status, channel_type, created_at, updated_at)
+            VALUES ('sess-3', 'conv-2', 'Active', 'telegram', '2024-01-02T00:00:00Z', '2024-01-02T01:00:00Z');
+            INSERT INTO sessions (id, conversation_id, status, channel_type, created_at, updated_at)
+            VALUES ('sess-4', 'conv-3', 'Active', 'signalr', '2024-01-03T00:00:00Z', '2024-01-03T01:00:00Z');
+
+            -- Test data: session_history
+            INSERT INTO session_history (session_id, sequence_id, role, content, timestamp)
+            VALUES ('sess-1', 1, 'user', 'Hello', '2024-01-01T00:00:01Z');
+            INSERT INTO session_history (session_id, sequence_id, role, content, timestamp)
+            VALUES ('sess-1', 2, 'assistant', 'Hi there!', '2024-01-01T00:00:02Z');
+            INSERT INTO session_history (session_id, sequence_id, role, content, timestamp)
+            VALUES ('sess-1', 3, 'user', 'How are you?', '2024-01-01T00:00:03Z');
+            INSERT INTO session_history (session_id, sequence_id, role, content, timestamp)
+            VALUES ('sess-1', 4, 'assistant', 'I am doing well!', '2024-01-01T00:00:04Z');
+
+            -- Test data: sub_agent_sessions
+            INSERT INTO sub_agent_sessions (id, parent_session_id, sub_agent_id, objective, status, started_at, ended_at)
+            VALUES ('sub-1', 'sess-1', 'coder-agent', 'Write code', 'Completed', '2024-01-01T00:01:00Z', '2024-01-01T00:02:00Z');
+            INSERT INTO sub_agent_sessions (id, parent_session_id, sub_agent_id, objective, status, started_at)
+            VALUES ('sub-2', 'sess-1', 'researcher', 'Research topic', 'Running', '2024-01-01T00:03:00Z');
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    private DebugTool CreateTool(DebugToolConfig? config = null, IRuntimeStateProvider? runtimeProvider = null)
+    {
+        return new DebugTool(_dbPath, _agentId, config ?? new DebugToolConfig(), runtimeProvider);
+    }
+
+    private static IReadOnlyDictionary<string, object?> Args(string action, params (string key, string value)[] extras)
+    {
+        var d = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["action"] = action };
+        foreach (var (k, v) in extras) d[k] = v;
+        return d;
+    }
+
+    private static IReadOnlyDictionary<string, object?> ArgsWithInt(string action, params (string key, object value)[] extras)
+    {
+        var d = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["action"] = action };
+        foreach (var (k, v) in extras) d[k] = v;
+        return d;
+    }
+
+    private static string TextOf(AgentToolResult r) => r.Content[0].Value;
+    private static bool IsError(AgentToolResult r) => r.Content[0].Value.StartsWith("Error:", StringComparison.OrdinalIgnoreCase);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // ValidActions
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ValidActions_ContainsAll8Actions()
+    {
+        var expected = new[]
+        {
+            "query_sessions", "query_conversations", "query_history",
+            "query_sub_agents", "session_info", "conversation_info",
+            "runtime_status", "raw_sql"
+        };
+        foreach (var a in expected)
+            Assert.Contains(a, DebugTool.ValidActions);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Unknown action
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("update")]
+    [InlineData("")]
+    [InlineData("drop_table")]
+    public async Task ExecuteAsync_UnknownAction_ReturnsError(string? action)
+    {
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["action"] = action };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.True(IsError(result));
+        Assert.Contains("Unknown action", TextOf(result));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // query_sessions
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task QuerySessions_ReturnsOwnAgentSessions()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sessions"));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        // Should include sess-1, sess-2, sess-3 (all belong to test-agent conversations)
+        Assert.Contains("sess-1", text);
+        Assert.Contains("sess-2", text);
+        Assert.Contains("sess-3", text);
+        // Should NOT include sess-4 (belongs to other-agent)
+        Assert.DoesNotContain("sess-4", text);
+    }
+
+    [Fact]
+    public async Task QuerySessions_FilterByStatus()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sessions", ("status", "Sealed")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sess-2", text);
+        Assert.DoesNotContain("sess-1", text);
+    }
+
+    [Fact]
+    public async Task QuerySessions_FilterByConversationId()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sessions", ("conversation_id", "conv-1")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sess-1", text);
+        Assert.Contains("sess-2", text);
+        Assert.DoesNotContain("sess-3", text);
+    }
+
+    [Fact]
+    public async Task QuerySessions_FilterByDateRange()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sessions",
+            ("after", "2024-01-02T00:00:00Z"), ("before", "2024-01-03T00:00:00Z")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sess-3", text);
+        Assert.DoesNotContain("sess-1", text);
+    }
+
+    [Fact]
+    public async Task QuerySessions_OtherAgentSessions_WhenExplicitAgentId()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sessions", ("agent_id", "other-agent")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sess-4", text);
+        Assert.DoesNotContain("sess-1", text);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // query_conversations
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task QueryConversations_ReturnsOwnAgentConversations()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_conversations"));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("conv-1", text);
+        Assert.Contains("conv-2", text);
+        Assert.DoesNotContain("conv-3", text);
+    }
+
+    [Fact]
+    public async Task QueryConversations_FilterByStatus()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_conversations", ("status", "archived")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("conv-2", text);
+        Assert.DoesNotContain("conv-1", text);
+    }
+
+    [Fact]
+    public async Task QueryConversations_FilterByKind()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_conversations", ("kind", "task")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("conv-2", text);
+        Assert.DoesNotContain("conv-1", text);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // query_history
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task QueryHistory_RequiresSessionId()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_history"));
+        Assert.True(IsError(result));
+        Assert.Contains("session_id", TextOf(result));
+    }
+
+    [Fact]
+    public async Task QueryHistory_ReturnsHistoryForOwnedSession()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_history", ("session_id", "sess-1")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("Hello", text);
+        Assert.Contains("Hi there!", text);
+    }
+
+    [Fact]
+    public async Task QueryHistory_DeniesAccessToOtherAgentSession()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_history", ("session_id", "sess-4")));
+        Assert.True(IsError(result));
+        Assert.Contains("not found or not owned", TextOf(result));
+    }
+
+    [Fact]
+    public async Task QueryHistory_FilterByRole()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_history",
+            ("session_id", "sess-1"), ("role", "user")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("Hello", text);
+        Assert.Contains("How are you?", text);
+        Assert.DoesNotContain("Hi there!", text);
+    }
+
+    [Fact]
+    public async Task QueryHistory_Pagination()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", ArgsWithInt("query_history",
+            ("session_id", "sess-1"), ("limit", 2), ("offset", 0)));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        // Should get first 2 entries
+        Assert.Contains("Hello", text);
+        Assert.Contains("Hi there!", text);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // query_sub_agents
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task QuerySubAgents_ReturnsSubAgentsForOwnedSession()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sub_agents", ("session_id", "sess-1")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sub-1", text);
+        Assert.Contains("sub-2", text);
+        Assert.Contains("coder-agent", text);
+    }
+
+    [Fact]
+    public async Task QuerySubAgents_DeniesAccessToOtherAgentSession()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sub_agents", ("session_id", "sess-4")));
+        Assert.True(IsError(result));
+        Assert.Contains("not found or not owned", TextOf(result));
+    }
+
+    [Fact]
+    public async Task QuerySubAgents_AllOwnedSubAgents_WhenNoSessionId()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_sub_agents"));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sub-1", text);
+        Assert.Contains("sub-2", text);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // session_info
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SessionInfo_RequiresSessionId()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("session_info"));
+        Assert.True(IsError(result));
+        Assert.Contains("session_id", TextOf(result));
+    }
+
+    [Fact]
+    public async Task SessionInfo_ReturnsInfoForOwnedSession()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("session_info", ("session_id", "sess-1")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("sess-1", text);
+        Assert.Contains("conv-1", text);
+        Assert.Contains("signalr", text);
+    }
+
+    [Fact]
+    public async Task SessionInfo_DeniesAccessToOtherAgentSession()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("session_info", ("session_id", "sess-4")));
+        Assert.True(IsError(result));
+        Assert.Contains("not found or not owned", TextOf(result));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // conversation_info
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ConversationInfo_RequiresConversationId()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("conversation_info"));
+        Assert.True(IsError(result));
+        Assert.Contains("conversation_id", TextOf(result));
+    }
+
+    [Fact]
+    public async Task ConversationInfo_ReturnsInfoForOwnedConversation()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("conversation_info", ("conversation_id", "conv-1")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("conv-1", text);
+        Assert.Contains("Test Conversation 1", text);
+    }
+
+    [Fact]
+    public async Task ConversationInfo_DeniesAccessToOtherAgentConversation()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("conversation_info", ("conversation_id", "conv-3")));
+        // Should return no results (filtered by agent_id)
+        var text = TextOf(result);
+        Assert.Contains("No results found", text);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // runtime_status
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task RuntimeStatus_ReturnsError_WhenNoProvider()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("runtime_status"));
+        Assert.True(IsError(result));
+        Assert.Contains("not available", TextOf(result));
+    }
+
+    [Fact]
+    public async Task RuntimeStatus_ReturnsStatus_WhenProviderAvailable()
+    {
+        var provider = new FakeRuntimeStateProvider("{ \"active_sessions\": 5 }");
+        var tool = CreateTool(runtimeProvider: provider);
+        var result = await tool.ExecuteAsync("tc1", Args("runtime_status"));
+        Assert.False(IsError(result));
+        Assert.Contains("active_sessions", TextOf(result));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // raw_sql
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task RawSql_DisabledByDefault()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql", ("sql", "SELECT * FROM sessions")));
+        Assert.True(IsError(result));
+        Assert.Contains("disabled", TextOf(result));
+    }
+
+    [Fact]
+    public async Task RawSql_RequiresSql()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql"));
+        Assert.True(IsError(result));
+        Assert.Contains("'sql' is required", TextOf(result));
+    }
+
+    [Fact]
+    public async Task RawSql_ExecutesSelectQuery()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql", ("sql", "SELECT id, agent_id FROM conversations")));
+        Assert.False(IsError(result));
+        var text = TextOf(result);
+        Assert.Contains("conv-1", text);
+        Assert.Contains("test-agent", text);
+    }
+
+    [Fact]
+    public async Task RawSql_AllowsWithClause()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "WITH cte AS (SELECT id FROM conversations) SELECT * FROM cte")));
+        Assert.False(IsError(result));
+        Assert.Contains("conv-1", TextOf(result));
+    }
+
+    [Fact]
+    public async Task RawSql_AllowsExplain()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "EXPLAIN QUERY PLAN SELECT * FROM conversations")));
+        Assert.False(IsError(result));
+    }
+
+    [Fact]
+    public async Task RawSql_AllowsPragma()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "PRAGMA table_info('conversations')")));
+        Assert.False(IsError(result));
+        Assert.Contains("agent_id", TextOf(result));
+    }
+
+    // ── Read-only enforcement ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("INSERT INTO conversations (id, agent_id, status, kind, title, created_at, updated_at) VALUES ('x','y','z','a','b','c','d')")]
+    [InlineData("UPDATE conversations SET status = 'deleted'")]
+    [InlineData("DELETE FROM conversations")]
+    [InlineData("DROP TABLE conversations")]
+    [InlineData("CREATE TABLE evil (id TEXT)")]
+    [InlineData("ALTER TABLE conversations ADD COLUMN evil TEXT")]
+    public async Task RawSql_RejectsNonSelectStatements(string sql)
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql", ("sql", sql)));
+        Assert.True(IsError(result));
+        Assert.Contains("Only SELECT statements are permitted", TextOf(result));
+    }
+
+    [Fact]
+    public async Task RawSql_RejectsCommentDisguisedDml()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        // After stripping the comment, the real statement is INSERT
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "-- this is a comment\nINSERT INTO conversations VALUES ('x','y','z','a','b','c','d')")));
+        Assert.True(IsError(result));
+        Assert.Contains("Only SELECT statements are permitted", TextOf(result));
+    }
+
+    // ── Pagination ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Pagination_RespectsLimitAndOffset()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", ArgsWithInt("query_sessions", ("limit", 1), ("offset", 0)));
+        Assert.False(IsError(result));
+        // Parse JSON to verify we got exactly 1 result
+        var array = JsonSerializer.Deserialize<JsonElement[]>(TextOf(result));
+        Assert.NotNull(array);
+        Assert.Single(array);
+    }
+
+    [Fact]
+    public async Task Pagination_DefaultLimitIs50()
+    {
+        // Just verify parsing works with no explicit limit
+        var (offset, limit) = DebugTool.GetPagination(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase));
+        Assert.Equal(0, offset);
+        Assert.Equal(DebugTool.DefaultLimit, limit);
+    }
+
+    [Fact]
+    public async Task Pagination_LimitClampedToMax()
+    {
+        var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["limit"] = 9999 };
+        var (_, limit) = DebugTool.GetPagination(args);
+        Assert.Equal(DebugTool.MaxLimit, limit);
+    }
+
+    // ── IsSelectOnly ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("SELECT * FROM t", true)]
+    [InlineData("  SELECT * FROM t", true)]
+    [InlineData("select count(*) from t", true)]
+    [InlineData("WITH cte AS (SELECT 1) SELECT * FROM cte", true)]
+    [InlineData("EXPLAIN SELECT 1", true)]
+    [InlineData("PRAGMA table_info('t')", true)]
+    [InlineData("-- comment\nSELECT 1", true)]
+    [InlineData("/* block */\nSELECT 1", true)]
+    [InlineData("INSERT INTO t VALUES (1)", false)]
+    [InlineData("UPDATE t SET x = 1", false)]
+    [InlineData("DELETE FROM t", false)]
+    [InlineData("DROP TABLE t", false)]
+    [InlineData("CREATE TABLE t (id INT)", false)]
+    [InlineData("", false)]
+    public void IsSelectOnly_CorrectlyClassifiesStatements(string sql, bool expected)
+    {
+        Assert.Equal(expected, DebugTool.IsSelectOnly(sql));
+    }
+
+    // ── Tool metadata ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Name_IsPlatformDebug()
+    {
+        var tool = CreateTool();
+        Assert.Equal("platform_debug", tool.Name);
+    }
+
+    [Fact]
+    public void Definition_HasCorrectName()
+    {
+        var tool = CreateTool();
+        Assert.Equal("platform_debug", tool.Definition.Name);
+    }
+
+    // ── Agent scope filtering ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AgentScopeFiltering_DefaultsToCurrentAgent()
+    {
+        var tool = CreateTool();
+        // When no agent_id is specified, should only see test-agent data
+        var result = await tool.ExecuteAsync("tc1", Args("query_conversations"));
+        Assert.False(IsError(result));
+        Assert.DoesNotContain("other-agent", TextOf(result));
+    }
+
+    [Fact]
+    public async Task AgentScopeFiltering_CanQueryOtherAgent_WhenExplicit()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("query_conversations", ("agent_id", "other-agent")));
+        Assert.False(IsError(result));
+        Assert.Contains("conv-3", TextOf(result));
+    }
+
+    // ── ReadOnly enforcement (database-level) ─────────────────────────────────
+
+    [Fact]
+    public async Task ReadOnly_CannotWriteViaRawSql()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        // Even if we somehow bypass the IsSelectOnly check, the connection is read-only
+        // This test verifies the conceptual guarantee is maintained via the check
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "INSERT INTO conversations VALUES ('x','y','z','a','b','c','d')")));
+        Assert.True(IsError(result));
+    }
+
+    // ── Contributor tests ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Contributor_ReturnsEmptyTools_WhenDisabled()
+    {
+        var contributor = new DebugToolContributor(_dbPath);
+        var context = CreateContributorContext(extensionConfig: """{"enabled": false}""");
+        var contribution = await contributor.ContributeAsync(context);
+        Assert.Empty(contribution.Tools);
+    }
+
+    [Fact]
+    public async Task Contributor_ReturnsDebugTool_WhenEnabled()
+    {
+        var contributor = new DebugToolContributor(_dbPath);
+        var context = CreateContributorContext();
+        var contribution = await contributor.ContributeAsync(context);
+        Assert.Single(contribution.Tools);
+        Assert.Equal("platform_debug", contribution.Tools[0].Name);
+    }
+
+    [Fact]
+    public async Task Contributor_DefaultsToEnabled()
+    {
+        var contributor = new DebugToolContributor(_dbPath);
+        var context = CreateContributorContext(extensionConfig: null);
+        var contribution = await contributor.ContributeAsync(context);
+        Assert.Single(contribution.Tools);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static BotNexus.Gateway.Abstractions.Agents.AgentToolContributionContext CreateContributorContext(
+        string? extensionConfig = null)
+    {
+        var extensionDict = new Dictionary<string, JsonElement>();
+        if (extensionConfig is not null)
+        {
+            extensionDict["botnexus-debug-tool"] = JsonDocument.Parse(extensionConfig).RootElement.Clone();
+        }
+
+        var descriptor = new BotNexus.Gateway.Abstractions.Models.AgentDescriptor
+        {
+            AgentId = BotNexus.Domain.Primitives.AgentId.From("test-agent"),
+            DisplayName = "Test Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ExtensionConfig = extensionDict
+        };
+
+        var executionContext = new BotNexus.Gateway.Abstractions.Models.AgentExecutionContext
+        {
+            SessionId = BotNexus.Domain.Primitives.SessionId.From("test-session")
+        };
+
+        return new BotNexus.Gateway.Abstractions.Agents.AgentToolContributionContext(
+            descriptor,
+            executionContext,
+            Path.GetTempPath(),
+            null!,
+            _ => null,
+            (_, _) => Task.FromResult<string?>(null));
+    }
+
+    private sealed class FakeRuntimeStateProvider(string status) : IRuntimeStateProvider
+    {
+        public string GetRuntimeStatus() => status;
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.DebugTool.Tests/xunit.runner.json
+++ b/tests/extensions/BotNexus.Extensions.DebugTool.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true
+}


### PR DESCRIPTION
Closes #985

## Changes

- New extension project `BotNexus.Extensions.DebugTool` with 8 read-only inspection actions:
  - `query_sessions` — filter by conversation_id, agent_id, status, date range
  - `query_conversations` — filter by agent_id, status, kind
  - `query_history` — paginated session history with role filter
  - `query_sub_agents` — sub-agent session listing
  - `session_info` — full session metadata for a given ID
  - `conversation_info` — full conversation record
  - `runtime_status` — live gateway state (requires IRuntimeStateProvider)
  - `raw_sql` — gated SELECT-only queries against sessions.db

- All connections opened with `Mode=ReadOnly` (enforced at SQLite level)
- Agent scope filtering: queries scoped to current agent by default
- Pagination: offset/limit (default 50, max 500) on all list queries
- `raw_sql` gated behind `AllowRawSql` config flag (default false)
- 66 unit tests covering all actions, scope enforcement, SQL injection prevention
- Architecture test allowlist updated for `conversations.agent_id` (still exists)
- Loaded via extension discovery (no direct Gateway.Api → Extensions reference)

## Merge Notes

This PR adds a new extension project to `BotNexus.slnx` (additive). It may conflict with PR #914 which also modifies slnx. Both are additive entries — merge in either order, resolve by keeping both entries.