### PR TITLE
refactor(gateway): remove dead session metadata conversationStatus shadow writes

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/CrossWorldFederationController.cs
@@ -231,7 +231,6 @@ public sealed class CrossWorldFederationController(
                 // any further sender turn that tries to reuse this RemoteSessionId, so the
                 // sender cannot accidentally continue an exchange the target said was done.
                 session.Status = GatewaySessionStatus.Sealed;
-                session.Metadata["conversationStatus"] = "sealed";
             }
             await sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
 
@@ -255,7 +254,6 @@ public sealed class CrossWorldFederationController(
                     // finish_agent_exchange. Seal the session now so the receiver-side
                     // state machine matches: Archived conversation  +  Sealed session.
                     session.Status = GatewaySessionStatus.Sealed;
-                    session.Metadata["conversationStatus"] = "sealed";
                     await sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
                 }
                 await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -203,7 +203,6 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
             session.Metadata.Remove(FinishAgentExchangeTool.ActiveExchangeIdKey);
             session.Status = GatewaySessionStatus.Sealed;
-            session.Metadata["conversationStatus"] = "sealed";
             await _sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
             await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
         }
@@ -219,7 +218,6 @@ public sealed class AgentExchangeService : IAgentExchangeService
             _logger.LogWarning(ex, "Agent conversation failed for session '{SessionId}'.", sessionId);
             session.Metadata.Remove(FinishAgentExchangeTool.ActiveExchangeIdKey);
             session.Status = GatewaySessionStatus.Sealed;
-            session.Metadata["conversationStatus"] = "error";
             session.Metadata["error"] = ex.Message;
             await _sessionStore.SaveAsync(session, CancellationToken.None).ConfigureAwait(false);
             await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
@@ -392,7 +390,6 @@ public sealed class AgentExchangeService : IAgentExchangeService
             }
 
             session.Status = GatewaySessionStatus.Sealed;
-            session.Metadata["conversationStatus"] = "sealed";
             session.Metadata["remoteSessionId"] = remoteSessionId;
             await _sessionStore.SaveAsync(session, cancellationToken).ConfigureAwait(false);
             await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);
@@ -407,7 +404,6 @@ public sealed class AgentExchangeService : IAgentExchangeService
         {
             _logger.LogWarning(ex, "Cross-world conversation failed for session '{SessionId}'.", sessionId);
             session.Status = GatewaySessionStatus.Sealed;
-            session.Metadata["conversationStatus"] = "error";
             session.Metadata["error"] = ex.Message;
             await _sessionStore.SaveAsync(session, CancellationToken.None).ConfigureAwait(false);
             await ArchiveOnExchangeEndAsync(conversation, sessionId, CancellationToken.None).ConfigureAwait(false);

--- a/tests/architecture/BotNexus.Architecture.Tests/ConversationStatusMetadataRemovedTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/ConversationStatusMetadataRemovedTests.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fence ensuring no production code writes to the dead
+/// <c>session.Metadata["conversationStatus"]</c> shadow key.
+/// </summary>
+/// <remarks>
+/// The metadata key <c>conversationStatus</c> was a redundant shadow of the typed
+/// <c>session.Status</c> property (GatewaySessionStatus enum). It was written at 6
+/// call sites in <c>AgentExchangeService.cs</c> and
+/// <c>CrossWorldFederationController.cs</c> but never read by any code — the typed
+/// <c>Status</c> field is the canonical state. Removed in #1019 (Part of #612 CC-2).
+/// </remarks>
+public sealed class ConversationStatusMetadataRemovedTests
+{
+    /// <summary>
+    /// No production file under <c>src/</c> may write or read the dead
+    /// <c>Metadata["conversationStatus"]</c> key. The typed
+    /// <c>GatewaySessionStatus</c> enum on <c>session.Status</c> is the only
+    /// correct way to express session seal/error state.
+    /// </summary>
+    [Fact]
+    public void NoCode_References_ConversationStatus_Metadata_Key()
+    {
+        var srcRoot = FindSourceRoot();
+        var pattern = new Regex(
+            @"Metadata\s*\[\s*""conversationStatus""\s*\]",
+            RegexOptions.Compiled);
+
+        var offenders = Directory
+            .EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(IsProductionSource)
+            .Where(path => pattern.IsMatch(File.ReadAllText(path)))
+            .Select(path => Path.GetRelativePath(srcRoot, path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            "Files under src/ reference Metadata[\"conversationStatus\"] — this dead shadow " +
+            "key was removed in #1019 (Part of #612 CC-2). Use the typed session.Status " +
+            "(GatewaySessionStatus enum) instead. The metadata key was never read by any " +
+            "code and only duplicated information already expressed by the Status property.\n" +
+            "Offenders:\n  " + string.Join("\n  ", offenders));
+    }
+
+    private static string FindSourceRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "BotNexus.slnx")))
+            dir = dir.Parent;
+
+        return dir is not null
+            ? Path.Combine(dir.FullName, "src")
+            : throw new InvalidOperationException("Cannot locate repo root (BotNexus.slnx not found).");
+    }
+
+    private static bool IsProductionSource(string path) =>
+        !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+        !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+}


### PR DESCRIPTION
Closes #1019

Part of #612 (CC-2)

## Changes

- Removed 6 dead `session.Metadata["conversationStatus"]` write sites across `AgentExchangeService.cs` (4) and `CrossWorldFederationController.cs` (2)
- These writes produced values ("sealed" / "error") that were **never read** by any production code or test
- The typed `session.Status` (GatewaySessionStatus enum) already captures the session state correctly
- Added architecture fitness test `ConversationStatusMetadataRemovedTests` to prevent reintroduction

## Verification

- Full codebase grep confirms zero readers of `Metadata["conversationStatus"]` in `src/` and `tests/`
- Architecture.Tests: 174/174 pass
- Gateway.Tests: 2295/2296 pass (1 pre-existing skip)
- Scenarios.Tests: 29/29 pass

## Merge Notes

No file overlap with any open PR. Safe to merge in any order.