### PR TITLE
feat(cli): add global --target option for multi-instance support

### DIFF
--- a/src/gateway/BotNexus.Cli/CliApp.cs
+++ b/src/gateway/BotNexus.Cli/CliApp.cs
@@ -110,24 +110,26 @@ internal static class CliApp
     private static RootCommand BuildRootCommand(IServiceProvider serviceProvider)
     {
         var verboseOption = new Option<bool>("--verbose", "Show additional command output.");
+        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus or BOTNEXUS_HOME.");
         var root = new RootCommand("BotNexus platform CLI");
 
         root.AddGlobalOption(verboseOption);
-        root.AddCommand(serviceProvider.GetRequiredService<ValidateCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<InitCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<AgentCommands>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<MemoryCommands>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<ConfigCommands>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<LocationsCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<DoctorCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<InstallCommand>().Build(verboseOption));
+        root.AddGlobalOption(targetOption);
+        root.AddCommand(serviceProvider.GetRequiredService<ValidateCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<InitCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<AgentCommands>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<MemoryCommands>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<ConfigCommands>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<LocationsCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<DoctorCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<InstallCommand>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<BuildCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<ServeCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<GatewayCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<PromptCommands>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<UpdateCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<ProviderCommand>().Build(verboseOption));
-        root.AddCommand(serviceProvider.GetRequiredService<CronCommands>().Build(verboseOption));
+        root.AddCommand(serviceProvider.GetRequiredService<ServeCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<GatewayCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<PromptCommands>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<UpdateCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<ProviderCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<CronCommands>().Build(verboseOption, targetOption));
 
         return root;
     }

--- a/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/AgentCommands.cs
@@ -10,18 +10,16 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class AgentCommands
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("agent", "Manage configured agents.");
         command.AddAlias("agents");
 
         var listCommand = new Command("list", "List configured agents.");
-        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
@@ -36,7 +34,6 @@ internal sealed class AgentCommands
         var emojiOption = new Option<string?>("--emoji", () => null, "Emoji shown alongside the agent name in clients (e.g. \"🤖\").");
         var disabledFlag = new Option<bool>("--disabled", () => false, "Disable the agent (sets Enabled = false). Takes precedence over --enabled.");
 
-        var addTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var addCommand = new Command("add", "Add an agent to config.json.")
         {
             idArgument,
@@ -46,8 +43,7 @@ internal sealed class AgentCommands
             displayNameOption,
             descriptionOption,
             emojiOption,
-            disabledFlag,
-            addTargetOption
+            disabledFlag
         };
         addCommand.SetHandler(async context =>
         {
@@ -60,7 +56,7 @@ internal sealed class AgentCommands
             var description = context.ParseResult.GetValueForOption(descriptionOption);
             var emoji = context.ParseResult.GetValueForOption(emojiOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(addTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             // --disabled flag takes precedence over --enabled
@@ -68,50 +64,42 @@ internal sealed class AgentCommands
             context.ExitCode = await ExecuteAddAsync(id, provider, model, enabled, displayName, description, emoji, configPath, verbose, CancellationToken.None);
         });
 
-        var removeTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var removeCommand = new Command("remove", "Remove an agent from config.json.")
         {
-            idArgument,
-            removeTargetOption
+            idArgument
         };
         removeCommand.SetHandler(async context =>
         {
             var id = context.ParseResult.GetValueForArgument(idArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(removeTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteRemoveAsync(id, configPath, verbose, CancellationToken.None);
         });
 
-        var wizardTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        var wizardCommand = new Command("wizard", "Interactively create a new agent using a step-by-step wizard.")
-        {
-            wizardTargetOption
-        };
+        var wizardCommand = new Command("wizard", "Interactively create a new agent using a step-by-step wizard.");
         wizardCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(wizardTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteWizardAsync(configPath, verbose, CancellationToken.None);
         });
 
         var showIdArgument = new Argument<string>("id", "Agent ID.");
-        var showTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var showJsonOption = new Option<bool>("--json", "Emit raw JSON instead of a formatted table.");
         var showCommand = new Command("show", "Show the resolved configuration for a single agent.")
         {
             showIdArgument,
-            showTargetOption,
             showJsonOption
         };
         showCommand.SetHandler(async context =>
         {
             var id = context.ParseResult.GetValueForArgument(showIdArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(showTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var asJson = context.ParseResult.GetValueForOption(showJsonOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");

--- a/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ConfigCommands.cs
@@ -9,41 +9,37 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class ConfigCommands(IConfigPathResolver configPathResolver)
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("config", "Read and update BotNexus configuration.");
 
         var keyArgument = new Argument<string>("key", "Dotted config key path (example: gateway.listenUrl).");
-        var getTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var getCommand = new Command("get", "Get a config value by dotted key.")
         {
-            keyArgument,
-            getTargetOption
+            keyArgument
         };
         getCommand.SetHandler(async context =>
         {
             var key = context.ParseResult.GetValueForArgument(keyArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(getTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteGetAsync(key, configPath, verbose, CancellationToken.None);
         });
 
         var valueArgument = new Argument<string>("value", "Value to set.");
-        var setTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var setCommand = new Command("set", "Set a config value by dotted key.")
         {
             keyArgument,
-            valueArgument,
-            setTargetOption
+            valueArgument
         };
         setCommand.SetHandler(async context =>
         {
             var key = context.ParseResult.GetValueForArgument(keyArgument);
             var value = context.ParseResult.GetValueForArgument(valueArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(setTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteSetAsync(key, value, configPath, verbose, CancellationToken.None);

--- a/src/gateway/BotNexus.Cli/Commands/CronCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/CronCommands.cs
@@ -33,7 +33,7 @@ internal sealed class CronCommands
     //  Command tree
     // ──────────────────────────────────────────────────────────────────────
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("cron", "Manage cron jobs on a running BotNexus gateway.");
 

--- a/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorCommand.cs
@@ -8,14 +8,10 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class DoctorCommand
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("doctor", "Run CLI diagnostics.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        var locationsCommand = new Command("locations", "Check location accessibility.")
-        {
-            targetOption
-        };
+        var locationsCommand = new Command("locations", "Check location accessibility.");
         locationsCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
@@ -26,7 +22,7 @@ internal sealed class DoctorCommand
         });
 
         command.AddCommand(locationsCommand);
-        command.AddCommand(new DoctorConfigCommand().Build(verboseOption));
+        command.AddCommand(new DoctorConfigCommand().Build(verboseOption, targetOption));
         return command;
     }
 

--- a/src/gateway/BotNexus.Cli/Commands/DoctorConfigCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DoctorConfigCommand.cs
@@ -22,15 +22,13 @@ internal sealed class DoctorConfigCommand
         new MemoryAgentDefaultCheck(),
     ];
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
         var yesOption = new Option<bool>("--yes", "Apply all applicable fixes without prompting.");
         var dryRunOption = new Option<bool>("--dry-run", "Report what would change but do not write anything.");
 
         var command = new Command("config", "Guided config migration — detect and apply missing settings.")
         {
-            targetOption,
             yesOption,
             dryRunOption
         };

--- a/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/GatewayCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using BotNexus.Cli.Services;
 using BotNexus.Gateway.Configuration;
 using Spectre.Console;
@@ -17,14 +17,13 @@ internal sealed class GatewayCommand
         _processManager = processManager;
     }
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("gateway", "Manage the BotNexus Gateway lifecycle (start detached, stop, status, restart). For foreground/dev mode use 'serve' or 'serve gateway'");
 
         // Common options for start/restart
         var portOption = new Option<int>("--port", () => 5005, "Port to listen on.");
         var sourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         // Start command
         var attachedOption = new Option<bool>("--attached", "Run in foreground instead of detached mode.");
@@ -33,7 +32,6 @@ internal sealed class GatewayCommand
         {
             portOption,
             sourceOption,
-            targetOption,
             attachedOption,
             skipBuildOption
         };
@@ -51,46 +49,36 @@ internal sealed class GatewayCommand
         });
 
         // Stop command
-        var stopTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
-        var stopCommand = new Command("stop", "Stop the gateway process")
-        {
-            stopTargetOption
-        };
+        var stopCommand = new Command("stop", "Stop the gateway process");
         stopCommand.SetHandler(async context =>
         {
-            var target = context.ParseResult.GetValueForOption(stopTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var home = CliPaths.ResolveTarget(target);
             context.ExitCode = await StopAsync(home, verbose, context.GetCancellationToken());
         });
 
         // Status command
-        var statusTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
-        var statusCommand = new Command("status", "Check gateway process status")
-        {
-            statusTargetOption
-        };
+        var statusCommand = new Command("status", "Check gateway process status");
         statusCommand.SetHandler(async context =>
         {
-            var target = context.ParseResult.GetValueForOption(statusTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var home = CliPaths.ResolveTarget(target);
             context.ExitCode = await StatusAsync(home, verbose, context.GetCancellationToken());
         });
 
         // Restart command
-        var restartTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
         var restartCommand = new Command("restart", "Restart the gateway process")
         {
             portOption,
-            sourceOption,
-            restartTargetOption
+            sourceOption
         };
         restartCommand.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(portOption);
             var source = context.ParseResult.GetValueForOption(sourceOption);
-            var target = context.ParseResult.GetValueForOption(restartTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var repoRoot = CliPaths.ResolveSource(source);
             var home = CliPaths.ResolveTarget(target);

--- a/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InitCommand.cs
@@ -9,14 +9,12 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class InitCommand
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var forceOption = new Option<bool>("--force", "Overwrite existing config.json.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var command = new Command("init", "Initialize ~/.botnexus with a default config and required directories.")
         {
-            forceOption,
-            targetOption
+            forceOption
         };
 
         command.SetHandler(async context =>

--- a/src/gateway/BotNexus.Cli/Commands/InstallCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/InstallCommand.cs
@@ -8,7 +8,7 @@ internal sealed class InstallCommand
 {
     private const string DefaultRepo = "https://github.com/sytone/botnexus.git";
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var sourceOption = new Option<string?>(
             "--source",

--- a/src/gateway/BotNexus.Cli/Commands/LocationsCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/LocationsCommand.cs
@@ -10,18 +10,16 @@ internal sealed class LocationsCommand
     private static readonly string[] ValidTypes = ["filesystem", "api", "mcp-server", "database", "remote-node"];
     private const string RedactedConnectionStringDisplay = "(redacted)";
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("locations", "Manage configured locations.");
         command.AddAlias("location");
 
         var listCommand = new Command("list", "List all registered locations.");
-        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
@@ -40,7 +38,6 @@ internal sealed class LocationsCommand
         var connectionStringOption = new Option<string?>("--connection-string", "Connection string for database locations.");
         var descriptionOption = new Option<string?>("--description", "Location description.");
 
-        var addTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var addCommand = new Command("add", "Add a location to config.json.")
         {
             nameArgument,
@@ -48,8 +45,7 @@ internal sealed class LocationsCommand
             pathOption,
             endpointOption,
             connectionStringOption,
-            descriptionOption,
-            addTargetOption
+            descriptionOption
         };
         addCommand.SetHandler(async context =>
         {
@@ -60,7 +56,7 @@ internal sealed class LocationsCommand
             var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
             var description = context.ParseResult.GetValueForOption(descriptionOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(addTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteAddAsync(name, type, path, endpoint, connectionString, description, configPath, verbose, CancellationToken.None);
@@ -69,14 +65,12 @@ internal sealed class LocationsCommand
         var updatePathOption = new Option<string?>("--path", "Updated path.");
         var updateEndpointOption = new Option<string?>("--endpoint", "Updated endpoint.");
         var updateDescriptionOption = new Option<string?>("--description", "Updated description.");
-        var updateTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var updateCommand = new Command("update", "Update an existing location.")
         {
             nameArgument,
             updatePathOption,
             updateEndpointOption,
-            updateDescriptionOption,
-            updateTargetOption
+            updateDescriptionOption
         };
         updateCommand.SetHandler(async context =>
         {
@@ -85,24 +79,22 @@ internal sealed class LocationsCommand
             var endpoint = context.ParseResult.GetValueForOption(updateEndpointOption);
             var description = context.ParseResult.GetValueForOption(updateDescriptionOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(updateTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteUpdateAsync(name, path, endpoint, description, configPath, verbose, CancellationToken.None);
         });
 
-        var deleteTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var deleteCommand = new Command("delete", "Delete a location from config.json.")
         {
-            nameArgument,
-            deleteTargetOption
+            nameArgument
         };
         deleteCommand.AddAlias("remove");
         deleteCommand.SetHandler(async context =>
         {
             var name = context.ParseResult.GetValueForArgument(nameArgument);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(deleteTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteDeleteAsync(name, configPath, verbose, CancellationToken.None);

--- a/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/MemoryCommands.cs
@@ -14,17 +14,15 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class MemoryCommands
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("memory", "Memory store operations.");
 
         var agentOption = new Option<string?>("--agent", "Backfill only this agent. If omitted, backfill all agents.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         var backfillCommand = new Command("backfill", "Index conversation turns from existing sessions into memory stores.")
         {
-            agentOption,
-            targetOption
+            agentOption
         };
 
         backfillCommand.SetHandler(async context =>

--- a/src/gateway/BotNexus.Cli/Commands/PromptCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/PromptCommands.cs
@@ -15,11 +15,10 @@ internal sealed class PromptCommands
 {
     private const string PromptSampleResourcePrefix = "PromptSamples/";
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var prompt = new Command("prompt", "Manage prompt templates.");
 
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var configOption = new Option<string?>("--config", () => null, "Explicit config.json path. Overrides --target.");
         var agentOption = new Option<string?>("--agent", () => null, "Agent ID. Defaults to gateway.defaultAgentId.");
         var parameterOption = new Option<string[]>("--param", "Template parameter as key=value. Repeat for multiple values.")
@@ -47,7 +46,6 @@ internal sealed class PromptCommands
         var renderCommand = new Command("render", "Render a prompt template.")
         {
             templateArgument,
-            targetOption,
             configOption,
             agentOption,
             parameterOption
@@ -75,7 +73,6 @@ internal sealed class PromptCommands
         var runCommand = new Command("run", "Render and run a prompt template.")
         {
             templateArgument,
-            targetOption,
             configOption,
             agentOption,
             parameterOption,

--- a/src/gateway/BotNexus.Cli/Commands/Provider/CopilotProviderSubcommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/Provider/CopilotProviderSubcommand.cs
@@ -33,11 +33,9 @@ internal static class CopilotProviderSubcommand
     /// authoritative in <see cref="ProviderCommand.ExecuteSetupAsync(string,string,bool,string?,CancellationToken)"/>
     /// — this subcommand contributes diagnostics, not new auth code paths.
     /// </summary>
-    public static Command Build(Option<bool> verboseOption, Func<string, string, bool, CancellationToken, Task<int>> setupAlias)
+    public static Command Build(Option<bool> verboseOption, Option<string?> targetOption, Func<string, string, bool, CancellationToken, Task<int>> setupAlias)
     {
         var copilot = new Command("copilot", "GitHub Copilot diagnostics and auth helpers.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory. Defaults to ~/.botnexus.");
-        copilot.AddGlobalOption(targetOption);
 
         copilot.AddCommand(BuildLogin(verboseOption, targetOption, setupAlias));
         copilot.AddCommand(BuildWhoami(targetOption));

--- a/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ProviderCommand.cs
@@ -28,20 +28,18 @@ internal sealed class ProviderCommand
         ["anthropic"] = "apikey"
     };
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("provider", "Configure and authenticate LLM providers.");
 
         var setupCommand = new Command("setup", "Interactively add and authenticate a new provider.");
-        var setupTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var setupProviderOption = new Option<string?>("--provider", () => null,
             $"Pre-select the provider to configure ({string.Join(" | ", KnownProviders)}). Skips the interactive provider-selection prompt and runs the rest of the setup flow (API-key prompt or OAuth device-code flow). Useful for scripting and integration tests.");
-        setupCommand.Add(setupTargetOption);
         setupCommand.Add(setupProviderOption);
         setupCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(setupTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var preselected = context.ParseResult.GetValueForOption(setupProviderOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
@@ -49,12 +47,10 @@ internal sealed class ProviderCommand
         });
 
         var listCommand = new Command("list", "List configured providers.");
-        var listTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
-        listCommand.Add(listTargetOption);
         listCommand.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(listTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             context.ExitCode = await ExecuteListAsync(configPath, verbose, CancellationToken.None);
@@ -62,22 +58,20 @@ internal sealed class ProviderCommand
 
         command.AddCommand(setupCommand);
         command.AddCommand(listCommand);
-        command.AddCommand(BuildAddCommand(verboseOption));
-        command.AddCommand(BuildRemoveCommand(verboseOption));
+        command.AddCommand(BuildAddCommand(verboseOption, targetOption));
+        command.AddCommand(BuildRemoveCommand(verboseOption, targetOption));
         command.AddCommand(CopilotProviderSubcommand.Build(
-            verboseOption,
+            verboseOption, targetOption,
             (configPath, home, verbose, ct) => ExecuteSetupAsync(configPath, home, verbose, "github-copilot", ct)));
 
         // Default to setup when no subcommand given
-        var defaultTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.") { IsHidden = true };
         var defaultProviderOption = new Option<string?>("--provider", () => null,
             $"Pre-select the provider to configure ({string.Join(" | ", KnownProviders)}). Skips the interactive provider-selection prompt.") { IsHidden = true };
-        command.Add(defaultTargetOption);
         command.Add(defaultProviderOption);
         command.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(defaultTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var preselected = context.ParseResult.GetValueForOption(defaultProviderOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
@@ -89,7 +83,7 @@ internal sealed class ProviderCommand
         return command;
     }
 
-    private static Command BuildAddCommand(Option<bool> verboseOption)
+    private static Command BuildAddCommand(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var cmd = new Command("add", "Add or update a provider non-interactively. Useful for scripts and CI.");
         var nameOpt = new Option<string>("--name", "Provider name (e.g. 'openai', 'integration-mock').") { IsRequired = true };
@@ -102,7 +96,6 @@ internal sealed class ProviderCommand
             AllowMultipleArgumentsPerToken = true
         };
         var disabledOpt = new Option<bool>("--disabled", () => false, "Mark the provider as disabled. Disabled providers are hidden from the API.");
-        var targetOpt = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         cmd.AddOption(nameOpt);
         cmd.AddOption(apiOpt);
@@ -111,12 +104,11 @@ internal sealed class ProviderCommand
         cmd.AddOption(defaultModelOpt);
         cmd.AddOption(modelsOpt);
         cmd.AddOption(disabledOpt);
-        cmd.AddOption(targetOpt);
 
         cmd.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(targetOpt);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             var name = context.ParseResult.GetValueForOption(nameOpt)!;
@@ -134,19 +126,17 @@ internal sealed class ProviderCommand
         return cmd;
     }
 
-    private static Command BuildRemoveCommand(Option<bool> verboseOption)
+    private static Command BuildRemoveCommand(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var cmd = new Command("remove", "Remove a provider non-interactively.");
         var nameOpt = new Option<string>("--name", "Provider name to remove.") { IsRequired = true };
-        var targetOpt = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         cmd.AddOption(nameOpt);
-        cmd.AddOption(targetOpt);
 
         cmd.SetHandler(async context =>
         {
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
-            var target = context.ParseResult.GetValueForOption(targetOpt);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var home = CliPaths.ResolveTarget(target);
             var configPath = Path.Combine(home, "config.json");
             var name = context.ParseResult.GetValueForOption(nameOpt)!;

--- a/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ServeCommand.cs
@@ -15,10 +15,10 @@ internal sealed class ServeCommand
         _gatewayCommand = gatewayCommand;
     }
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         // Gateway lifecycle management
-        var gatewayCommand = _gatewayCommand.Build(verboseOption);
+        var gatewayCommand = _gatewayCommand.Build(verboseOption, targetOption);
 
         var probePortOption = new Option<int>("--port", () => 5050, "Port for the Probe web UI.");
         var probeSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
@@ -43,20 +43,18 @@ internal sealed class ServeCommand
         // serve (default = gateway)
         var servePortOption = new Option<int>("--port", () => 5005, "Port to listen on.");
         var serveSourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
-        var serveTargetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
 
         var command = new Command("serve", "Start a BotNexus service in the foreground (development mode). Defaults to the gateway. Note: for production/background use, prefer 'gateway start' which runs the gateway as a detached process.")
         {
             servePortOption,
-            serveSourceOption,
-            serveTargetOption
+            serveSourceOption
         };
 
         command.SetHandler(async context =>
         {
             var port = context.ParseResult.GetValueForOption(servePortOption);
             var source = context.ParseResult.GetValueForOption(serveSourceOption);
-            var target = context.ParseResult.GetValueForOption(serveTargetOption);
+            var target = context.ParseResult.GetValueForOption(targetOption);
             var verbose = context.ParseResult.GetValueForOption(verboseOption);
             var repoRoot = CliPaths.ResolveSource(source);
             var home = CliPaths.ResolveTarget(target);

--- a/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/UpdateCommand.cs
@@ -21,16 +21,14 @@ internal class UpdateCommand
         _processManager = processManager;
     }
 
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var sourceOption = new Option<string?>("--source", () => null, "Path to the BotNexus repository root. Defaults to ~/botnexus.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var portOption = new Option<int>("--port", () => 5005, "Gateway port.");
 
         var command = new Command("update", "Pull latest source, build, and restart the BotNexus gateway.")
         {
             sourceOption,
-            targetOption,
             portOption
         };
 

--- a/src/gateway/BotNexus.Cli/Commands/ValidateCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ValidateCommand.cs
@@ -7,16 +7,14 @@ namespace BotNexus.Cli.Commands;
 
 internal sealed class ValidateCommand
 {
-    public Command Build(Option<bool> verboseOption)
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var remoteOption = new Option<bool>("--remote", "Validate using the running gateway /api/config/validate endpoint.");
         var gatewayUrlOption = new Option<string?>("--gateway-url", "Gateway base URL override for remote validation.");
-        var targetOption = new Option<string?>("--target", () => null, "BotNexus home directory (config, workspace, extensions). Defaults to ~/.botnexus.");
         var command = new Command("validate", "Validate BotNexus platform configuration.")
         {
             remoteOption,
-            gatewayUrlOption,
-            targetOption
+            gatewayUrlOption
         };
 
         command.SetHandler(async context =>

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/Provider/CopilotProviderSubcommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/Provider/CopilotProviderSubcommandTests.cs
@@ -17,7 +17,7 @@ public class CopilotProviderSubcommandTests
     public void Build_registers_copilot_command_under_provider()
     {
         var verbose = new Option<bool>("--verbose");
-        var providerCmd = new ProviderCommand().Build(verbose);
+        var providerCmd = new ProviderCommand().Build(verbose, new Option<string?>("--target"));
 
         var copilot = providerCmd.Subcommands.SingleOrDefault(c => c.Name == "copilot");
         copilot.ShouldNotBeNull();
@@ -33,7 +33,7 @@ public class CopilotProviderSubcommandTests
     public void Build_registers_subcommand(string name)
     {
         var verbose = new Option<bool>("--verbose");
-        var providerCmd = new ProviderCommand().Build(verbose);
+        var providerCmd = new ProviderCommand().Build(verbose, new Option<string?>("--target"));
         var copilot = providerCmd.Subcommands.Single(c => c.Name == "copilot");
 
         copilot.Subcommands.ShouldContain(c => c.Name == name);
@@ -43,7 +43,7 @@ public class CopilotProviderSubcommandTests
     public void Test_subcommand_exposes_model_and_prompt_options()
     {
         var verbose = new Option<bool>("--verbose");
-        var providerCmd = new ProviderCommand().Build(verbose);
+        var providerCmd = new ProviderCommand().Build(verbose, new Option<string?>("--target"));
         var copilot = providerCmd.Subcommands.Single(c => c.Name == "copilot");
         var test = copilot.Subcommands.Single(c => c.Name == "test");
 
@@ -55,12 +55,17 @@ public class CopilotProviderSubcommandTests
     public void Copilot_command_exposes_target_global_option()
     {
         var verbose = new Option<bool>("--verbose");
-        var providerCmd = new ProviderCommand().Build(verbose);
-        var copilot = providerCmd.Subcommands.Single(c => c.Name == "copilot");
+        var targetOption = new Option<string?>("--target");
+        var providerCmd = new ProviderCommand().Build(verbose, targetOption);
 
-        // --target is added as a global option on the copilot group so every
-        // subcommand inherits it (login/whoami/models/quota/test).
-        copilot.Options.ShouldContain(o => o.Name == "target");
+        // --target is now a root-level global option that all subcommands
+        // (including copilot/login/whoami/models/quota/test) inherit.
+        // Verify the provider command tree can parse --target without error.
+        var root = new RootCommand();
+        root.AddGlobalOption(targetOption);
+        root.AddCommand(providerCmd);
+        var result = root.Parse("provider copilot whoami --target /tmp/test");
+        result.Errors.ShouldBeEmpty();
     }
 
     [Fact]
@@ -74,7 +79,7 @@ public class CopilotProviderSubcommandTests
             return Task.FromResult(0);
         };
 
-        var copilot = CopilotProviderSubcommand.Build(verbose, alias);
+        var copilot = CopilotProviderSubcommand.Build(verbose, new Option<string?>("--target"), alias);
 
         // Build a root command so System.CommandLine can resolve handlers.
         var root = new RootCommand();

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -108,7 +108,7 @@ public class UpdateCommandTests
     public void Update_command_is_registered_on_root()
     {
         var verbose = new Option<bool>("--verbose");
-        var command = BuildCommand().Build(verbose);
+        var command = BuildCommand().Build(verbose, new Option<string?>("--target"));
 
         command.Name.ShouldBe("update");
     }
@@ -117,7 +117,7 @@ public class UpdateCommandTests
     public void Update_command_registers_check_subcommand()
     {
         var verbose = new Option<bool>("--verbose");
-        var command = BuildCommand().Build(verbose);
+        var command = BuildCommand().Build(verbose, new Option<string?>("--target"));
 
         command.Subcommands.Any(c => c.Name == "check").ShouldBeTrue();
     }
@@ -126,11 +126,10 @@ public class UpdateCommandTests
     public void Update_command_has_expected_options()
     {
         var verbose = new Option<bool>("--verbose");
-        var command = BuildCommand().Build(verbose);
+        var command = BuildCommand().Build(verbose, new Option<string?>("--target"));
 
         var names = command.Options.Select(o => o.Name).ToList();
         names.ShouldContain("source");
-        names.ShouldContain("target");
         names.ShouldContain("port");
     }
 

--- a/tests/gateway/BotNexus.Cli.Tests/GlobalTargetOptionTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/GlobalTargetOptionTests.cs
@@ -1,0 +1,72 @@
+using System.CommandLine;
+using BotNexus.Cli;
+using BotNexus.Cli.Commands;
+using Shouldly;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class GlobalTargetOptionTests
+{
+    [Fact]
+    public void Root_command_has_global_target_option()
+    {
+        // Build a minimal root with just the validate command to verify structure.
+        var verbose = new Option<bool>("--verbose");
+        var target = new Option<string?>("--target");
+        var root = new RootCommand("test");
+        root.AddGlobalOption(verbose);
+        root.AddGlobalOption(target);
+        root.AddCommand(new ValidateCommand().Build(verbose, target));
+
+        // Global options are inherited by all subcommands.
+        var result = root.Parse("validate --target /tmp/my-instance");
+        result.Errors.ShouldBeEmpty();
+        result.GetValueForOption(target).ShouldBe("/tmp/my-instance");
+    }
+
+    [Fact]
+    public void Target_option_is_accessible_from_nested_subcommands()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var target = new Option<string?>("--target");
+        var root = new RootCommand("test");
+        root.AddGlobalOption(verbose);
+        root.AddGlobalOption(target);
+        root.AddCommand(new AgentCommands().Build(verbose, target));
+
+        // Verify --target works on nested subcommands (agent list).
+        var result = root.Parse("agent list --target /tmp/dev");
+        result.Errors.ShouldBeEmpty();
+        result.GetValueForOption(target).ShouldBe("/tmp/dev");
+    }
+
+    [Fact]
+    public void Target_option_defaults_to_null_when_not_specified()
+    {
+        var verbose = new Option<bool>("--verbose");
+        var target = new Option<string?>("--target");
+        var root = new RootCommand("test");
+        root.AddGlobalOption(verbose);
+        root.AddGlobalOption(target);
+        root.AddCommand(new ValidateCommand().Build(verbose, target));
+
+        var result = root.Parse("validate");
+        result.Errors.ShouldBeEmpty();
+        result.GetValueForOption(target).ShouldBeNull();
+    }
+
+    [Fact]
+    public void CliPaths_ResolveTarget_uses_explicit_path_over_default()
+    {
+        var resolved = CliPaths.ResolveTarget("/custom/path");
+        resolved.ShouldBe("/custom/path");
+    }
+
+    [Fact]
+    public void CliPaths_ResolveTarget_falls_back_to_default_when_null()
+    {
+        var resolved = CliPaths.ResolveTarget(null);
+        // Returns BOTNEXUS_HOME env var or ~/.botnexus — not null.
+        resolved.ShouldNotBeNullOrWhiteSpace();
+    }
+}


### PR DESCRIPTION
Closes #226

## Changes

- Promoted `--target` from per-command local options to a single global option on the root command
- All 14 command files updated to accept and use the shared global target option
- Removed 30 redundant `--target` option declarations across command files
- Added 5 new tests verifying global option parsing and inheritance
- Updated existing tests to pass the global target option parameter

## Behavior

`botnexus --target ~/.botnexus-dev <any-command>` now works uniformly across all commands.
Commands that previously had their own `--target` (validate, init, agent, config, doctor, gateway, provider, memory, locations, prompt, serve, update) now share one definition.

The `BOTNEXUS_HOME` environment variable fallback in `CliPaths.ResolveTarget` is preserved.

## Merge Notes

No file overlap with any open PR. Safe to merge independently.