### PR TITLE
feat(gateway): add IExtensionStateStore with SQLite persistence

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Extensions/IExtensionStateStore.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Extensions/IExtensionStateStore.cs
@@ -1,0 +1,38 @@
+namespace BotNexus.Gateway.Abstractions.Extensions;
+
+/// <summary>
+/// Key-value state persistence for extensions. Provides a unified SQLite-backed
+/// alternative to per-extension JSON file state management.
+/// </summary>
+public interface IExtensionStateStore
+{
+    /// <summary>
+    /// Initializes the store, creating the backing database and schema if needed.
+    /// </summary>
+    Task InitializeAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a value by extension ID and key. Returns <c>null</c> if the key does not exist.
+    /// </summary>
+    Task<string?> GetAsync(string extensionId, string key, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets (upserts) a value for the given extension ID and key.
+    /// </summary>
+    Task SetAsync(string extensionId, string key, string value, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a single key for the given extension. No-op if the key does not exist.
+    /// </summary>
+    Task DeleteAsync(string extensionId, string key, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists all keys stored for the given extension.
+    /// </summary>
+    Task<IReadOnlyList<string>> ListKeysAsync(string extensionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Clears all keys for the given extension.
+    /// </summary>
+    Task ClearAsync(string extensionId, CancellationToken ct = default);
+}

--- a/src/gateway/BotNexus.Gateway/BotNexus.Gateway.csproj
+++ b/src/gateway/BotNexus.Gateway/BotNexus.Gateway.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="NJsonSchema" />
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -183,6 +183,16 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IIsolationStrategy, ContainerIsolationStrategy>();
         services.AddSingleton<IIsolationStrategy, RemoteIsolationStrategy>();
 
+        // Extension state store
+        services.TryAddSingleton<IExtensionStateStore>(serviceProvider =>
+        {
+            var home = serviceProvider.GetRequiredService<BotNexusHome>();
+            var dbPath = Path.Combine(home.RootPath, "data", "extension-state.db");
+            var fs = serviceProvider.GetRequiredService<IFileSystem>();
+            var storeLogger = serviceProvider.GetRequiredService<ILogger<SqliteExtensionStateStore>>();
+            return new SqliteExtensionStateStore(dbPath, fs, storeLogger);
+        });
+
         // Built-in tools
         services.AddBotNexusTools();
 

--- a/src/gateway/BotNexus.Gateway/Extensions/InMemoryExtensionStateStore.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/InMemoryExtensionStateStore.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+
+namespace BotNexus.Gateway.Extensions;
+
+/// <summary>
+/// In-memory implementation of <see cref="Abstractions.Extensions.IExtensionStateStore"/> for testing.
+/// </summary>
+public sealed class InMemoryExtensionStateStore : Abstractions.Extensions.IExtensionStateStore
+{
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _store = new();
+
+    public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<string?> GetAsync(string extensionId, string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        if (_store.TryGetValue(extensionId, out var keys) && keys.TryGetValue(key, out var value))
+            return Task.FromResult<string?>(value);
+
+        return Task.FromResult<string?>(null);
+    }
+
+    public Task SetAsync(string extensionId, string key, string value, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        var keys = _store.GetOrAdd(extensionId, _ => new ConcurrentDictionary<string, string>());
+        keys[key] = value;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string extensionId, string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        if (_store.TryGetValue(extensionId, out var keys))
+            keys.TryRemove(key, out _);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<string>> ListKeysAsync(string extensionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+
+        if (_store.TryGetValue(extensionId, out var keys))
+            return Task.FromResult<IReadOnlyList<string>>(keys.Keys.OrderBy(k => k).ToList());
+
+        return Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    public Task ClearAsync(string extensionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+
+        _store.TryRemove(extensionId, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/SqliteExtensionStateStore.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/SqliteExtensionStateStore.cs
@@ -1,0 +1,198 @@
+using Microsoft.Data.Sqlite;
+using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Extensions;
+
+/// <summary>
+/// SQLite-backed implementation of <see cref="Abstractions.Extensions.IExtensionStateStore"/>.
+/// Uses WAL mode and a write lock for concurrent safety.
+/// </summary>
+public sealed class SqliteExtensionStateStore(
+    string dbPath,
+    IFileSystem? fileSystem = null,
+    ILogger<SqliteExtensionStateStore>? logger = null)
+    : Abstractions.Extensions.IExtensionStateStore
+{
+    private readonly string _dbPath = dbPath;
+    private readonly string _connectionString = $"Data Source={dbPath};Mode=ReadWriteCreate";
+    private readonly IFileSystem _fileSystem = fileSystem ?? new FileSystem();
+    private readonly ILogger<SqliteExtensionStateStore> _logger = logger ?? NullLogger<SqliteExtensionStateStore>.Instance;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private bool _initialized;
+
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        if (_initialized)
+            return;
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+                return;
+
+            _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(_dbPath) ?? ".");
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                PRAGMA journal_mode = WAL;
+
+                CREATE TABLE IF NOT EXISTS extension_state (
+                    extension_id TEXT NOT NULL,
+                    key TEXT NOT NULL,
+                    value TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (extension_id, key)
+                );
+                """;
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            _initialized = true;
+            _logger.LogDebug("Extension state store initialized at {DbPath}.", _dbPath);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<string?> GetAsync(string extensionId, string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT value
+            FROM extension_state
+            WHERE extension_id = $extensionId AND key = $key
+            """;
+        command.Parameters.AddWithValue("$extensionId", extensionId);
+        command.Parameters.AddWithValue("$key", key);
+
+        var result = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return result is null or DBNull ? null : (string)result;
+    }
+
+    public async Task SetAsync(string extensionId, string key, string value, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO extension_state (extension_id, key, value, updated_at)
+                VALUES ($extensionId, $key, $value, $updatedAt)
+                ON CONFLICT(extension_id, key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """;
+            command.Parameters.AddWithValue("$extensionId", extensionId);
+            command.Parameters.AddWithValue("$key", key);
+            command.Parameters.AddWithValue("$value", value);
+            command.Parameters.AddWithValue("$updatedAt", DateTimeOffset.UtcNow.ToString("O"));
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task DeleteAsync(string extensionId, string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                DELETE FROM extension_state
+                WHERE extension_id = $extensionId AND key = $key
+                """;
+            command.Parameters.AddWithValue("$extensionId", extensionId);
+            command.Parameters.AddWithValue("$key", key);
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> ListKeysAsync(string extensionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT key
+            FROM extension_state
+            WHERE extension_id = $extensionId
+            ORDER BY key
+            """;
+        command.Parameters.AddWithValue("$extensionId", extensionId);
+
+        var keys = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            keys.Add(reader.GetString(0));
+
+        return keys;
+    }
+
+    public async Task ClearAsync(string extensionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+        await InitializeAsync(ct).ConfigureAwait(false);
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await using var connection = CreateConnection();
+            await connection.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                DELETE FROM extension_state
+                WHERE extension_id = $extensionId
+                """;
+            command.Parameters.AddWithValue("$extensionId", extensionId);
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            _logger.LogInformation("Cleared all state for extension '{ExtensionId}'.", extensionId);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private SqliteConnection CreateConnection() => new(_connectionString);
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionStateStoreTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Extensions/ExtensionStateStoreTests.cs
@@ -1,0 +1,333 @@
+using BotNexus.Gateway.Abstractions.Extensions;
+using BotNexus.Gateway.Extensions;
+using Microsoft.Data.Sqlite;
+using System.IO.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Extensions;
+
+public sealed class ExtensionStateStoreTests
+{
+    #region Test Infrastructure
+
+    private sealed class SqliteTestContext : IAsyncDisposable
+    {
+        private SqliteTestContext(string tempDirectory, string dbPath, SqliteExtensionStateStore store)
+        {
+            TempDirectory = tempDirectory;
+            DbPath = dbPath;
+            Store = store;
+        }
+
+        public string TempDirectory { get; }
+        public string DbPath { get; }
+        public SqliteExtensionStateStore Store { get; }
+
+        public static async Task<SqliteTestContext> CreateAsync()
+        {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), "botnexus-ext-state-tests", Guid.NewGuid().ToString("N"));
+            var dbPath = Path.Combine(tempDirectory, "extension-state.db");
+            var store = new SqliteExtensionStateStore(dbPath, new FileSystem());
+            await store.InitializeAsync();
+            return new SqliteTestContext(tempDirectory, dbPath, store);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            SqliteConnection.ClearAllPools();
+            if (!Directory.Exists(TempDirectory))
+                return;
+
+            for (var attempt = 0; attempt < 5; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(TempDirectory, recursive: true);
+                    break;
+                }
+                catch (IOException) when (attempt < 4)
+                {
+                    await Task.Delay(50);
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    #region SQLite Store Tests
+
+    [Fact]
+    public async Task Sqlite_InitializeAsync_CreatesDirectoryAndTable()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        Assert.True(Directory.Exists(context.TempDirectory));
+
+        await using var connection = new SqliteConnection($"Data Source={context.DbPath}");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM sqlite_master WHERE type = 'table'";
+
+        var tables = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            tables.Add(reader.GetString(0));
+
+        Assert.Contains("extension_state", tables);
+    }
+
+    [Fact]
+    public async Task Sqlite_SetAndGet_RoundTrips()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        await context.Store.SetAsync("ext-1", "api-key", "secret-123");
+        var result = await context.Store.GetAsync("ext-1", "api-key");
+
+        Assert.Equal("secret-123", result);
+    }
+
+    [Fact]
+    public async Task Sqlite_Get_NonExistentKey_ReturnsNull()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        var result = await context.Store.GetAsync("ext-1", "missing-key");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Sqlite_Set_Overwrite_UpdatesValue()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        await context.Store.SetAsync("ext-1", "counter", "1");
+        await context.Store.SetAsync("ext-1", "counter", "2");
+        var result = await context.Store.GetAsync("ext-1", "counter");
+
+        Assert.Equal("2", result);
+    }
+
+    [Fact]
+    public async Task Sqlite_Delete_RemovesKey()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        await context.Store.SetAsync("ext-1", "temp", "value");
+        await context.Store.DeleteAsync("ext-1", "temp");
+        var result = await context.Store.GetAsync("ext-1", "temp");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Sqlite_Delete_NonExistentKey_IsNoOp()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        // Should not throw
+        await context.Store.DeleteAsync("ext-1", "nonexistent");
+    }
+
+    [Fact]
+    public async Task Sqlite_ListKeys_ReturnsAllKeysForExtension()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        await context.Store.SetAsync("ext-1", "key-b", "val-b");
+        await context.Store.SetAsync("ext-1", "key-a", "val-a");
+        await context.Store.SetAsync("ext-2", "other-key", "val-other");
+
+        var keys = await context.Store.ListKeysAsync("ext-1");
+
+        Assert.Equal(2, keys.Count);
+        Assert.Equal(["key-a", "key-b"], keys); // alphabetical order
+    }
+
+    [Fact]
+    public async Task Sqlite_ListKeys_NoKeys_ReturnsEmpty()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        var keys = await context.Store.ListKeysAsync("ext-nonexistent");
+
+        Assert.Empty(keys);
+    }
+
+    [Fact]
+    public async Task Sqlite_Clear_RemovesAllKeysForExtension()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        await context.Store.SetAsync("ext-1", "key-a", "val-a");
+        await context.Store.SetAsync("ext-1", "key-b", "val-b");
+        await context.Store.SetAsync("ext-2", "key-c", "val-c");
+
+        await context.Store.ClearAsync("ext-1");
+
+        var ext1Keys = await context.Store.ListKeysAsync("ext-1");
+        var ext2Keys = await context.Store.ListKeysAsync("ext-2");
+
+        Assert.Empty(ext1Keys);
+        Assert.Single(ext2Keys);
+    }
+
+    [Fact]
+    public async Task Sqlite_IsolatesBetweenExtensions()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        await context.Store.SetAsync("ext-1", "shared-key", "value-1");
+        await context.Store.SetAsync("ext-2", "shared-key", "value-2");
+
+        var result1 = await context.Store.GetAsync("ext-1", "shared-key");
+        var result2 = await context.Store.GetAsync("ext-2", "shared-key");
+
+        Assert.Equal("value-1", result1);
+        Assert.Equal("value-2", result2);
+    }
+
+    [Fact]
+    public async Task Sqlite_ConcurrentWrites_AreSafe()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        var tasks = Enumerable.Range(0, 50).Select(i =>
+            context.Store.SetAsync("ext-1", $"key-{i}", $"value-{i}"));
+
+        await Task.WhenAll(tasks);
+
+        var keys = await context.Store.ListKeysAsync("ext-1");
+        Assert.Equal(50, keys.Count);
+    }
+
+    [Fact]
+    public async Task Sqlite_InitializeAsync_IsIdempotent()
+    {
+        await using var context = await SqliteTestContext.CreateAsync();
+
+        // Initialize was already called in CreateAsync; call again
+        await context.Store.InitializeAsync();
+        await context.Store.InitializeAsync();
+
+        // Should still work
+        await context.Store.SetAsync("ext-1", "key", "value");
+        var result = await context.Store.GetAsync("ext-1", "key");
+        Assert.Equal("value", result);
+    }
+
+    #endregion
+
+    #region InMemory Store Tests
+
+    [Fact]
+    public async Task InMemory_SetAndGet_RoundTrips()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        await store.SetAsync("ext-1", "key", "value");
+        var result = await store.GetAsync("ext-1", "key");
+
+        Assert.Equal("value", result);
+    }
+
+    [Fact]
+    public async Task InMemory_Get_NonExistentKey_ReturnsNull()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        var result = await store.GetAsync("ext-1", "missing");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task InMemory_Set_Overwrite_UpdatesValue()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        await store.SetAsync("ext-1", "key", "original");
+        await store.SetAsync("ext-1", "key", "updated");
+        var result = await store.GetAsync("ext-1", "key");
+
+        Assert.Equal("updated", result);
+    }
+
+    [Fact]
+    public async Task InMemory_Delete_RemovesKey()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        await store.SetAsync("ext-1", "key", "value");
+        await store.DeleteAsync("ext-1", "key");
+        var result = await store.GetAsync("ext-1", "key");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task InMemory_Delete_NonExistentKey_IsNoOp()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        // Should not throw
+        await store.DeleteAsync("ext-1", "missing");
+    }
+
+    [Fact]
+    public async Task InMemory_ListKeys_ReturnsOrderedKeys()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        await store.SetAsync("ext-1", "z-key", "val");
+        await store.SetAsync("ext-1", "a-key", "val");
+        await store.SetAsync("ext-2", "other", "val");
+
+        var keys = await store.ListKeysAsync("ext-1");
+
+        Assert.Equal(["a-key", "z-key"], keys);
+    }
+
+    [Fact]
+    public async Task InMemory_ListKeys_NoKeys_ReturnsEmpty()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        var keys = await store.ListKeysAsync("ext-unknown");
+
+        Assert.Empty(keys);
+    }
+
+    [Fact]
+    public async Task InMemory_Clear_RemovesAllKeysForExtension()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        await store.SetAsync("ext-1", "a", "1");
+        await store.SetAsync("ext-1", "b", "2");
+        await store.SetAsync("ext-2", "c", "3");
+
+        await store.ClearAsync("ext-1");
+
+        var ext1Keys = await store.ListKeysAsync("ext-1");
+        var ext2Keys = await store.ListKeysAsync("ext-2");
+
+        Assert.Empty(ext1Keys);
+        Assert.Single(ext2Keys);
+    }
+
+    [Fact]
+    public async Task InMemory_IsolatesBetweenExtensions()
+    {
+        var store = new InMemoryExtensionStateStore();
+
+        await store.SetAsync("ext-1", "key", "val-1");
+        await store.SetAsync("ext-2", "key", "val-2");
+
+        Assert.Equal("val-1", await store.GetAsync("ext-1", "key"));
+        Assert.Equal("val-2", await store.GetAsync("ext-2", "key"));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Closes #1006

## Changes

- Added `IExtensionStateStore` interface in `BotNexus.Gateway.Contracts/Extensions/`
- Implemented `SqliteExtensionStateStore` with WAL mode, SemaphoreSlim write lock, and composite primary key
- Implemented `InMemoryExtensionStateStore` for testing
- Registered as singleton in `GatewayServiceCollectionExtensions.cs`
- DB path: `{homePath}/data/extension-state.db`

## API Surface

```csharp
public interface IExtensionStateStore
{
    Task InitializeAsync(CancellationToken ct = default);
    Task<string?> GetAsync(string extensionId, string key, CancellationToken ct = default);
    Task SetAsync(string extensionId, string key, string value, CancellationToken ct = default);
    Task DeleteAsync(string extensionId, string key, CancellationToken ct = default);
    Task<IReadOnlyList<string>> ListKeysAsync(string extensionId, CancellationToken ct = default);
    Task ClearAsync(string extensionId, CancellationToken ct = default);
}
```

## Tests

21 tests covering: CRUD operations, overwrite, concurrent writes, initialize idempotency, clear, delete non-existent.

## Merge Notes

No file overlap with any open PR. Touches only `GatewayServiceCollectionExtensions.cs` (DI registration) which is not in any other PR. Safe to merge independently.