### PR TITLE
fix(tests): isolate ProviderCommandTests from static AnsiConsole writer disposal

### DIFF
--- a/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
@@ -1,10 +1,31 @@
 using System.Text.Json;
 using BotNexus.Cli.Commands;
+using Spectre.Console;
 
 namespace BotNexus.Cli.Tests.Commands;
 
-public class ProviderCommandTests
+public class ProviderCommandTests : IDisposable
 {
+    private readonly IAnsiConsole _originalConsole;
+
+    public ProviderCommandTests()
+    {
+        // Redirect the static AnsiConsole to a per-test StringWriter so that
+        // production code calling AnsiConsole.MarkupLine does not race with
+        // other test classes that may dispose the shared writer.
+        _originalConsole = AnsiConsole.Console;
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(new StringWriter()),
+            Interactive = InteractionSupport.No
+        });
+    }
+
+    public void Dispose()
+    {
+        AnsiConsole.Console = _originalConsole;
+    }
+
     [Fact]
     public void AuthFileEntry_serializes_in_GatewayAuthManager_compatible_format()
     {


### PR DESCRIPTION
Closes #1029

## Changes

`ProviderCommandTests` was flaking on CI with `ObjectDisposedException: Cannot write to a closed TextWriter` because tests calling `ProviderCommand.ExecuteAddAsync` / `ExecuteRemoveAsync` used the static `AnsiConsole.MarkupLine` singleton without redirecting output.

Fix: implement `IDisposable` on the test class to redirect `AnsiConsole.Console` to a per-test `StringWriter` in the constructor, restoring the original in `Dispose()`. This is the same pattern already used by `CaptureAnsiConsoleOutputAsync` in UpdateCommandTests but applied at class scope.

## Merge Notes

Independent of all open PRs. Note: PR #1027 also touches CLI tests but different files (`GlobalTargetOptionTests.cs`, `CopilotProviderSubcommandTests.cs`, `UpdateCommandTests.cs`). This fix is in `ProviderCommandTests.cs` only — no merge conflict.