### PR TITLE
fix(tests): use delta assertion in MCP warmup cache test for parallel safety

### DIFF
--- a/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpServerManagerTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Mcp.Tests/McpServerManagerTests.cs
@@ -271,6 +271,7 @@ public class McpServerManagerTests
     public async Task McpServerWarmupHostedService_StartAsync_KicksOffConfiguredAgents()
     {
         await McpServerWarmupCache.DisposeAllAsync();
+        var countBefore = McpServerWarmupCache.Count;
         var descriptor = CreateDescriptor(new McpExtensionConfig
         {
             Servers = new Dictionary<string, McpServerConfig>
@@ -285,7 +286,10 @@ public class McpServerManagerTests
         {
             await service.StartAsync(CancellationToken.None);
 
-            McpServerWarmupCache.Count.ShouldBe(1);
+            // Assert that the service added exactly one entry to the cache.
+            // Use delta instead of absolute count to avoid flakes when other
+            // tests running in parallel also interact with the static cache.
+            (McpServerWarmupCache.Count - countBefore).ShouldBe(1);
         }
         finally
         {


### PR DESCRIPTION
Closes #1030

## Changes

`McpServerWarmupHostedService_StartAsync_KicksOffConfiguredAgents` flaked on CI because it asserted `McpServerWarmupCache.Count.ShouldBe(1)` after calling `DisposeAllAsync()`. The static `ConcurrentDictionary` is shared across all test classes running in parallel — another test calling `EnsureStarted` between the `DisposeAllAsync` and the `Count` assertion makes the count 2.

Fix: capture the count before the operation and assert the **delta** is 1 (`Count - countBefore == 1`). This is robust regardless of what other tests do with the shared cache.

## Merge Notes

Independent of all open PRs. No file overlap with any other branch.