### PR TITLE
docs(gateway): correct stale comments referencing deleted phases and obsolete infrastructure

### DIFF
--- a/src/domain/BotNexus.Domain/World/ICitizen.cs
+++ b/src/domain/BotNexus.Domain/World/ICitizen.cs
@@ -17,7 +17,7 @@ namespace BotNexus.Domain.World;
 /// timestamp — are intentionally deferred. Agents do not yet carry a back-reference to
 /// their <see cref="WorldDescriptor"/> (world membership is denormalised through
 /// <see cref="WorldDescriptor.HostedAgents"/>); the interface stays minimal so adoption
-/// is mechanical and Phase 7 can lift <c>World</c> when worlds become first-class.
+/// is mechanical. Lifting <c>World</c> to the interface was deferred.
 /// </para>
 /// </remarks>
 public interface ICitizen

--- a/src/domain/BotNexus.Domain/World/User.cs
+++ b/src/domain/BotNexus.Domain/World/User.cs
@@ -16,8 +16,8 @@ namespace BotNexus.Domain.World;
 /// </para>
 /// <para>
 /// <see cref="World"/> appears here even though <see cref="ICitizen"/> does not yet expose
-/// it (Phase 7 will lift <c>World</c> to the interface once worlds become first-class on
-/// the agent side too).
+/// it. Lifting <c>World</c> to the interface was deferred — currently only User
+/// carries it.
 /// </para>
 /// </remarks>
 public sealed record User : ICitizen

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -24,7 +24,7 @@ namespace BotNexus.Extensions.Channels.SignalR;
 #pragma warning disable CS1591 // Hub methods are self-documenting SignalR contracts
 
 /// <summary>
-/// SignalR hub for real-time agent communication. Replaces the raw WebSocket infrastructure.
+/// SignalR hub for real-time agent communication.
 /// Clients join session groups and receive streaming output for all active sessions simultaneously.
 /// </summary>
 public sealed class GatewayHub : Hub<IGatewayHubClient>

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/IConversationRouter.cs
@@ -73,7 +73,8 @@ public interface IConversationRouter
 
     /// <summary>
     /// Finds and mutes the binding associated with the given channel type and address.
-    /// Used by SignalR OnDisconnectedAsync to silence stale bindings by connection ID.
+    /// Typically called when a channel connection drops (e.g. SignalR disconnect,
+    /// Telegram webhook timeout) to silence stale bindings.
     /// </summary>
     /// <param name="agentId">The agent whose conversations should be searched, or <c>null</c> to search all agents.</param>
     /// <param name="channelType">The channel type (e.g. signalr).</param>

--- a/src/gateway/BotNexus.Gateway.Contracts/Security/IGatewayAuthHandler.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/IGatewayAuthHandler.cs
@@ -16,7 +16,7 @@ namespace BotNexus.Gateway.Abstractions.Security;
 ///   <item><b>ApiKeyAuthHandler</b> — Static API key validation. Suitable for development
 ///   and simple single-tenant deployments.</item>
 ///   <item><b>JwtAuthHandler</b> — JWT bearer token validation. For production multi-tenant
-///   scenarios. Phase 2.</item>
+///   scenarios. Not yet implemented (see #567).</item>
 /// </list>
 /// </remarks>
 public interface IGatewayAuthHandler


### PR DESCRIPTION
Part of #612 (W-2 scope)

## Changes

Corrects 5 stale XML doc comments and code comments that reference deleted phases, non-existent infrastructure, or future-tense promises that were deferred:

1. **IGatewayAuthHandler.cs** - 'Phase 2' replaced with issue link (#567) for JwtAuthHandler
2. **User.cs** - Removed future-tense 'Phase 7 will lift World' (lift was deferred)
3. **ICitizen.cs** - Same Phase 7 stale reference corrected
4. **GatewayHub.cs** - Removed 'Replaces the raw WebSocket infrastructure' (SignalR is the original and only real-time transport)
5. **IConversationRouter.cs** - MuteBindingByAddressAsync doc was pinned to SignalR; corrected to be transport-neutral

### Items from #612 W-2 that were already resolved

Items 6-10 from the W-2 checklist no longer exist in the codebase (files deleted or comments already cleaned up during prior refactoring waves):
- Session.cs, GatewaySession.cs, Conversation.cs - all deleted
- AssemblyLoadContextExtensionLoader.cs TODO - already removed
- SystemPromptBuilder line 273 - is agent prompt content (accurate as-is), not a stale code comment

## Merge Notes

No file overlap with any open PR. Safe to merge in any order.
