### PR TITLE
docs(training): fix stale BotNexus.Providers.* namespace references

### DIFF
--- a/docs/extension-development.md
+++ b/docs/extension-development.md
@@ -326,7 +326,7 @@ The (legacy, non-functional) `LlmProviderBase` example below is preserved only t
 ```csharp
 using System.Runtime.CompilerServices;
 using BotNexus.Core.Models;
-using BotNexus.Providers.Base;
+using BotNexus.Agent.Providers.Core;
 using Microsoft.Extensions.Logging;
 using OpenAI;
 using OpenAI.Chat;
@@ -534,7 +534,7 @@ public sealed class OpenAiExtensionRegistrar : IExtensionRegistrar
 {
     public void Register(IServiceCollection services, IConfiguration configuration)
     {
-        services.AddSingleton<ILlmProvider>(sp =>
+        services.AddSingleton<IApiProvider>(sp =>
         {
             var botConfig = sp.GetRequiredService<IOptions<BotNexusConfig>>().Value;
             var providerConfig = configuration.Get<OpenAiProviderConfig>() ?? new OpenAiProviderConfig();

--- a/docs/training/04-building-your-own.md
+++ b/docs/training/04-building-your-own.md
@@ -771,8 +771,8 @@ This section is a full tutorial for implementing a provider from scratch. If you
 ### 10.1: Create the project
 
 ```bash
-dotnet new classlib -n BotNexus.Providers.MyLLM
-cd BotNexus.Providers.MyLLM
+dotnet new classlib -n BotNexus.Agent.Providers.MyLLM
+cd BotNexus.Agent.Providers.MyLLM
 dotnet add reference ../BotNexus.Agent.Providers.Core/BotNexus.Agent.Providers.Core.csproj
 ```
 
@@ -800,7 +800,7 @@ using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
 using BotNexus.Agent.Providers.Core.Streaming;
 
-namespace BotNexus.Providers.MyLLM;
+namespace BotNexus.Agent.Providers.MyLLM;
 
 public sealed class MyLlmProvider(HttpClient httpClient) : IApiProvider
 {

--- a/docs/training/05-glossary.md
+++ b/docs/training/05-glossary.md
@@ -334,7 +334,7 @@ Thread-safe queue for steering and follow-up messages injected into the agent lo
 
 An `IApiProvider` implementation that communicates with a specific LLM API (Anthropic, OpenAI, GitHub Copilot, etc.). Each provider translates between the BotNexus streaming protocol and the vendor's wire format.
 
-**Source:** `BotNexus.Providers.*`
+**Source:** `BotNexus.Agent.Providers.*`
 **Training:** [Provider System](01-providers.md)
 
 ---

--- a/docs/training/11-provider-development-guide.md
+++ b/docs/training/11-provider-development-guide.md
@@ -29,7 +29,7 @@ using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Agent.Providers.Core.Registry;
 using BotNexus.Agent.Providers.Core.Streaming;
 
-namespace BotNexus.Providers.MyProvider;
+namespace BotNexus.Agent.Providers.MyProvider;
 
 public sealed class MyProvider(HttpClient httpClient) : IApiProvider
 {


### PR DESCRIPTION
Closes #596

## Changes

- Replace dead `BotNexus.Providers.*` namespaces with current `BotNexus.Agent.Providers.*` in:
  - `docs/training/04-building-your-own.md` (project name + namespace)
  - `docs/training/11-provider-development-guide.md` (namespace)
  - `docs/training/05-glossary.md` (source reference)
  - `docs/extension-development.md` (using directive + interface name)
- Update `ILlmProvider` → `IApiProvider` in extension registration example

## Merge Notes

Pure docs change — no code, no test impact. Independent of all open PRs.