### PR TITLE
docs(cli): document .NET 10 SDK requirement in README and NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ BotNexus gives you a local playground for running and observing agents:
 - **Extension system** - load providers, channels, and tools dynamically instead
   of welding every experiment into the gateway.
 
+## Prerequisites
+
+| Requirement | Version | Notes |
+|---|---|---|
+| **.NET SDK** | **10.0 or later** | Required. Earlier SDK versions (including .NET 9) are **not supported**. |
+| **GitHub account** | — | Required for the default `github-copilot` provider (active Copilot subscription). |
+
+Verify your SDK version:
+
+```bash
+dotnet --version
+# Must output 10.0.x or later
+```
+
+Download .NET 10 SDK: <https://dotnet.microsoft.com/download/dotnet/10.0>
+
+> **Troubleshooting:** If `dotnet tool install` fails with
+> `DotnetToolSettings.xml was not found`, your .NET SDK is too old. BotNexus
+> targets `net10.0` exclusively — install the .NET 10 SDK and try again.
+
 ## Quick Install
 
 BotNexus ships as a global .NET CLI tool. You need the .NET 10 SDK or Runtime
@@ -107,10 +127,6 @@ botnexus gateway start
 ```
 
 Open the WebUI at `http://localhost:5005`.
-
-> **Prerequisites:** [.NET 10 SDK](https://dotnet.microsoft.com/download) — verify
-> with `dotnet --version`. A GitHub account with an active Copilot subscription is
-> required for the default `github-copilot` provider.
 
 ## First Provider Setup
 

--- a/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
+++ b/src/gateway/BotNexus.Cli/BotNexus.Cli.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>BotNexus.Cli</RootNamespace>
-    <Description>BotNexus platform CLI — install and run the BotNexus AI agent platform.</Description>
+    <Description>BotNexus platform CLI — install and run the BotNexus AI agent platform. Requires .NET 10 SDK.</Description>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>botnexus</ToolCommandName>
     <PackageId>BotNexus.Cli</PackageId>
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/sytone/botnexus</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>ai;agent;botnexus;dotnet;cli</PackageTags>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <!-- When the CLI invokes 'dotnet build' on the solution, it passes SkipCli=true
          so the CLI project skips rebuilding itself (the DLL is already loaded and locked). -->
     <IsExcludedFromBuild Condition="'$(SkipCli)' == 'true'">true</IsExcludedFromBuild>
@@ -37,6 +38,10 @@
     <EmbeddedResource Include="Resources\Prompts\*.prompt.*">
       <LogicalName>PromptSamples/%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/gateway/BotNexus.Cli/NUGET_README.md
+++ b/src/gateway/BotNexus.Cli/NUGET_README.md
@@ -1,0 +1,49 @@
+# BotNexus CLI
+
+The `botnexus` CLI installs, configures, and runs the BotNexus AI agent platform.
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|---|---|---|
+| **.NET SDK** | **10.0 or later** | Required. Earlier versions (including .NET 9) are not supported. |
+| **GitHub account** | — | Required for the default `github-copilot` provider (active Copilot subscription needed). |
+
+> **Common install error:** If you see `DotnetToolSettings.xml was not found` during
+> `dotnet tool install`, your .NET SDK is too old. BotNexus targets `net10.0` and
+> requires the .NET 10 SDK. Download it from
+> <https://dotnet.microsoft.com/download/dotnet/10.0>.
+
+## Quick Start
+
+```bash
+# Install the CLI as a global .NET tool
+dotnet tool install -g BotNexus.Cli
+
+# Initialize platform directories and default config
+botnexus init
+
+# Set up your first LLM provider (interactive)
+botnexus provider setup
+
+# Validate configuration
+botnexus validate
+
+# Start the gateway (serves WebUI at http://localhost:5005)
+botnexus gateway start
+```
+
+## Updating
+
+```bash
+dotnet tool update -g BotNexus.Cli
+botnexus gateway restart
+```
+
+## Documentation
+
+Full documentation: <https://github.com/sytone/botnexus>
+
+## License
+
+MIT

--- a/tests/architecture/BotNexus.Architecture.Tests/CliPackageReadmeTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/CliPackageReadmeTests.cs
@@ -1,0 +1,79 @@
+using System.Xml.Linq;
+using Shouldly;
+
+namespace BotNexus.Architecture.Tests;
+
+/// <summary>
+/// Architecture fitness function: the CLI NuGet package must include a readme that
+/// documents the .NET 10 SDK requirement so users see it before install.
+/// </summary>
+public sealed class CliPackageReadmeTests
+{
+    private static string RepoRoot => Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
+
+    private static string CliCsproj => Path.Combine(
+        RepoRoot, "src", "gateway", "BotNexus.Cli", "BotNexus.Cli.csproj");
+
+    [Fact]
+    public void Cli_Csproj_Has_PackageReadmeFile_Property()
+    {
+        File.Exists(CliCsproj).ShouldBeTrue($"CLI csproj not found at {CliCsproj}");
+
+        var doc = XDocument.Load(CliCsproj);
+        var ns = doc.Root!.GetDefaultNamespace();
+
+        var readmeElement = doc.Descendants(ns + "PackageReadmeFile").FirstOrDefault();
+        readmeElement.ShouldNotBeNull(
+            "BotNexus.Cli.csproj must have a <PackageReadmeFile> element so the NuGet package " +
+            "includes a readme documenting the .NET 10 SDK requirement.");
+    }
+
+    [Fact]
+    public void Cli_PackageReadmeFile_Exists_On_Disk()
+    {
+        var doc = XDocument.Load(CliCsproj);
+        var ns = doc.Root!.GetDefaultNamespace();
+        var readmeFileName = doc.Descendants(ns + "PackageReadmeFile").FirstOrDefault()?.Value;
+
+        readmeFileName.ShouldNotBeNullOrWhiteSpace();
+
+        var cliDir = Path.GetDirectoryName(CliCsproj)!;
+        var readmePath = Path.Combine(cliDir, readmeFileName);
+
+        File.Exists(readmePath).ShouldBeTrue(
+            $"PackageReadmeFile '{readmeFileName}' referenced in csproj does not exist at {readmePath}");
+    }
+
+    [Fact]
+    public void Cli_PackageReadme_Documents_DotNet10_Requirement()
+    {
+        var doc = XDocument.Load(CliCsproj);
+        var ns = doc.Root!.GetDefaultNamespace();
+        var readmeFileName = doc.Descendants(ns + "PackageReadmeFile").FirstOrDefault()?.Value;
+
+        readmeFileName.ShouldNotBeNullOrWhiteSpace();
+
+        var cliDir = Path.GetDirectoryName(CliCsproj)!;
+        var readmePath = Path.Combine(cliDir, readmeFileName);
+        var content = File.ReadAllText(readmePath);
+
+        content.ShouldContain(".NET", Case.Insensitive,
+            "Package readme must mention .NET SDK requirement");
+        content.ShouldContain("10", Case.Sensitive,
+            "Package readme must mention version 10 (the minimum required SDK)");
+    }
+
+    [Fact]
+    public void Cli_Description_Mentions_DotNet10()
+    {
+        var doc = XDocument.Load(CliCsproj);
+        var ns = doc.Root!.GetDefaultNamespace();
+        var description = doc.Descendants(ns + "Description").FirstOrDefault()?.Value;
+
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain(".NET 10", Case.Insensitive,
+            "CLI package <Description> should mention .NET 10 so NuGet gallery users see " +
+            "the requirement before installing.");
+    }
+}


### PR DESCRIPTION
Closes #742

## Changes

- **README.md**: Added a dedicated `## Prerequisites` section with a version table, `dotnet --version` verification command, download link, and troubleshooting note for the common `DotnetToolSettings.xml was not found` error that occurs with .NET 9 SDK
- **NUGET_README.md** (new): NuGet package readme with .NET 10 requirement prominently displayed, common error callout, and quick start instructions
- **BotNexus.Cli.csproj**: Added `<PackageReadmeFile>NUGET_README.md</PackageReadmeFile>` and `<None Include="NUGET_README.md" Pack="true" />` so the readme appears in NuGet gallery. Updated `<Description>` to mention .NET 10 SDK.
- **CliPackageReadmeTests.cs** (new): 4 architecture tests verifying csproj has PackageReadmeFile, file exists, mentions .NET 10, and Description mentions .NET 10

## Merge Notes

No file overlap with any open PR. Safe to merge in any order.