### PR TITLE
docs: daily documentation grooming 2026-06-08

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -69,6 +69,8 @@ export default defineConfig({
             text: 'Channels',
             items: [
               { text: 'Telegram', link: '/user-guide/channels/telegram' },
+              { text: 'Azure Service Bus', link: '/user-guide/channels/service-bus' },
+              { text: 'Service Bus Envelope', link: '/user-guide/channels/service-bus-envelope' },
             ],
           },
           { text: 'Troubleshooting', link: '/user-guide/troubleshooting' },
@@ -84,10 +86,28 @@ export default defineConfig({
         ],
       },
       {
+        text: 'Providers',
+        items: [
+          { text: 'Anthropic', link: '/providers/anthropic' },
+          { text: 'OpenAI', link: '/providers/openai' },
+          { text: 'OpenAI-Compatible', link: '/providers/openai-compatible' },
+          { text: 'GitHub Copilot', link: '/providers/github-copilot' },
+        ],
+      },
+      {
+        text: 'Extensions',
+        items: [
+          { text: 'Extension Development', link: '/extension-development' },
+          { text: 'Media Handlers', link: '/extensions/media-handlers' },
+          { text: 'Debug Tool', link: '/extensions/debug-tool' },
+        ],
+      },
+      {
         text: 'Architecture',
         items: [
           { text: 'Overview', link: '/architecture/overview' },
           { text: 'Domain Model', link: '/architecture/domain-model' },
+          { text: 'Gateway Flow', link: '/architecture/gateway-flow' },
           { text: 'Channel Binding', link: '/architecture/channel-binding' },
           { text: 'Extension Guide', link: '/architecture/extension-guide' },
           { text: 'Principles', link: '/architecture/principles' },
@@ -105,36 +125,27 @@ export default defineConfig({
           { text: 'Session Stores', link: '/development/session-stores' },
           { text: 'Workspace and Memory', link: '/development/workspace-and-memory' },
           { text: 'DDD Patterns', link: '/development/ddd-patterns' },
+          { text: 'CLI Wizard Framework', link: '/development/cli-wizard' },
+          { text: 'Container Integration Testing', link: '/development/container-integration-testing' },
+          { text: 'E2E Tests', link: '/development/e2e-tests' },
           { text: 'Triggers and Federation', link: '/development/triggers-and-federation' },
           { text: 'WebUI Connection', link: '/development/webui-connection' },
-        ],
-      },
-      {
-        text: 'Guides',
-        items: [
-          { text: 'Audio Recording', link: '/guides/audio-recording' },
-          { text: 'Watchdog Setup', link: '/guides/watchdog-setup' },
         ],
       },
       {
         text: 'Features',
         items: [
           { text: 'Sub-Agent Spawning', link: '/features/sub-agent-spawning' },
-        ],
-      },
-      {
-        text: 'Extensions',
-        items: [
-          { text: 'Extension Development', link: '/extension-development' },
-          { text: 'Media Handlers', link: '/extensions/media-handlers' },
-        ],
-      },
-      {
-        text: 'More',
-        items: [
-          { text: 'Observability', link: '/observability' },
           { text: 'Skills', link: '/skills' },
           { text: 'Cron & Scheduling', link: '/cron-and-scheduling' },
+        ],
+      },
+      {
+        text: 'Guides',
+        items: [
+          { text: 'Audio Recording', link: '/guides/audio-recording' },
+          { text: 'Observability', link: '/observability' },
+          { text: 'Watchdog Setup', link: '/guides/watchdog-setup' },
         ],
       },
       {

--- a/docs/development/prompt-pipeline.md
+++ b/docs/development/prompt-pipeline.md
@@ -34,6 +34,10 @@ IPromptContributor[]
 public interface IPromptSection
 {
     int Order { get; }
+
+    /// Stable identifier for override resolution and diagnostics.
+    /// Null indicates an anonymous section that cannot be overridden.
+    string? SectionId => null;
     
     bool ShouldInclude(PromptContext context);
     
@@ -44,6 +48,7 @@ public interface IPromptSection
 **Responsibilities:**
 
 - Define relative ordering (lower = earlier in prompt)
+- Provide a stable `SectionId` for override resolution (optional, default interface member)
 - Conditional inclusion based on context
 - Generate prompt lines
 
@@ -441,6 +446,72 @@ const string SystemPromptCacheBoundary = "\n<!-- BOTNEXUS_CACHE_BOUNDARY -->\n";
 - Cache stable sections (identity, tools, guidelines)
 - Reduce latency for dynamic sections (context files, current task)
 - Lower costs (cached tokens are cheaper)
+
+## Prompt Section Overrides
+
+BotNexus supports overriding built-in prompt sections with custom content from the filesystem. This enables per-deployment customization without modifying source code.
+
+### IPromptOverrideResolver
+
+```csharp
+public interface IPromptOverrideResolver
+{
+    IReadOnlyList<string>? TryResolveOverride(string sectionId, string? modelFamily = null);
+}
+```
+
+The `FilePromptOverrideResolver` reads overrides from markdown files:
+
+```text
+~/.botnexus/prompts/
+  system/
+    {sectionId}.md              — section-level override (any model)
+    model/
+      {family}.md               — model-family-specific guidance
+```
+
+**Override resolution:**
+
+1. If `sectionId` is in the non-overridable list (`safety`, `runtime-data`, `runtime-info`, `identity`), return null
+2. For `model-guidance` with a known family, check `system/model/{family}.md` first
+3. Fall back to `system/{sectionId}.md`
+
+Files are read fresh on every call — hot-reload, no restart required.
+
+### Non-Overridable Sections
+
+The following section IDs cannot be overridden (safety-critical or runtime data):
+
+- `safety`
+- `runtime-data`
+- `runtime-info`
+- `identity`
+
+### Built-in Section IDs
+
+| Section ID | Order | Description |
+|-----------|-------|-------------|
+| `tool-enforcement` | 32 | Tool calling rules and constraints |
+| `shell-efficiency` | 35 | Shell scripting best practices |
+| `skills-guidance` | 55 | Skills loading and creation guidance (conditional: only when skills tools available) |
+| `model-guidance` | 135 | Per-model-family behavioral defaults (conditional: only for recognized families) |
+
+### LambdaPromptSection
+
+A convenience class for creating sections with a delegate, optional `SectionId`, and optional inclusion predicate:
+
+```csharp
+public static LambdaPromptSection Create() =>
+    new(SectionOrder, static _ => Lines, sectionId: Id, shouldIncludeFunc: HasSkillTools);
+```
+
+## Model Family Detection
+
+`ModelFamilyDetector.GetModelFamily(modelId)` identifies the model family from a model identifier string. Used by `ModelGuidanceSection` to select per-family prompt defaults.
+
+Recognized families: `claude`, `gpt`, `gemini`, `copilot`, `deepseek`, `qwen`, `llama`.
+
+Detection is case-insensitive and matches on common prefixes and substrings. Unrecognized models return `"unknown"` and receive no model-specific guidance.
 
 ## Extension Prompt Contributions
 

--- a/docs/extensions/debug-tool.md
+++ b/docs/extensions/debug-tool.md
@@ -1,0 +1,109 @@
+# Debug Tool Extension
+
+The Debug Tool provides agents with read-only access to the platform's `sessions.db` database and gateway runtime state. It enables agents to inspect their own sessions, conversations, history entries, and sub-agent relationships for debugging and introspection.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-debug-tool` |
+| Tool name | `platform_debug` |
+| Access | Read-only (SQLite `Mode=ReadOnly`) |
+| Scope | Agent-scoped by default |
+
+## Enabling
+
+The Debug Tool is loaded via extension discovery. Add it to your agent's tool list in `config.json`:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "tools": ["platform_debug"]
+    }
+  }
+}
+```
+
+## Actions
+
+The tool supports the following actions:
+
+| Action | Description |
+|--------|-------------|
+| `query_sessions` | List sessions for the current agent (filterable by conversation, status) |
+| `query_conversations` | List conversations (filterable by status, kind) |
+| `query_history` | Retrieve session history entries (filterable by role, kind) |
+| `query_sub_agents` | List sub-agent sessions spawned from a parent session |
+| `session_info` | Get detailed information about a specific session |
+| `conversation_info` | Get detailed information about a specific conversation |
+| `runtime_status` | Query gateway runtime state (active sessions, memory, uptime) |
+| `raw_sql` | Execute arbitrary SELECT statements (gated, must be enabled) |
+
+## Parameters
+
+Common parameters available across actions:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `action` | string | Required. The action to perform. |
+| `session_id` | string | Session ID filter |
+| `conversation_id` | string | Conversation ID filter |
+| `agent_id` | string | Agent ID filter (defaults to current agent) |
+| `status` | string | Status filter |
+| `kind` | string | Kind filter (for conversations) |
+| `role` | string | Role filter (for history entries) |
+| `limit` | integer | Max results (default: 50, max: 500) |
+| `offset` | integer | Pagination offset |
+| `sql` | string | SQL query (for `raw_sql` action only) |
+
+## Usage Examples
+
+### List recent sessions
+
+```
+platform_debug action=query_sessions limit=10
+```
+
+### Inspect a session's history
+
+```
+platform_debug action=query_history session_id=sess_abc123 role=assistant
+```
+
+### Check runtime status
+
+```
+platform_debug action=runtime_status
+```
+
+### Raw SQL (when enabled)
+
+```
+platform_debug action=raw_sql sql="SELECT COUNT(*) as total FROM sessions WHERE agent_id = 'my-agent'"
+```
+
+## Security
+
+- All database access is **read-only** — no writes are possible through this tool
+- Queries are **agent-scoped** by default — agents can only see their own data unless `agent_id` is explicitly specified
+- The `raw_sql` action is **gated** behind a configuration flag and only allows SELECT statements
+- No access to credentials, API keys, or other sensitive configuration
+
+## Configuration
+
+```json
+{
+  "extensions": {
+    "debugTool": {
+      "enabled": true,
+      "allowRawSql": false
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Whether the debug tool is available |
+| `allowRawSql` | `false` | Whether the `raw_sql` action is permitted |

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,0 +1,90 @@
+# Anthropic Provider
+
+The Anthropic provider connects BotNexus to Claude models via the Anthropic Messages API. It supports streaming, extended thinking, prompt caching, and tool use.
+
+## Prerequisites
+
+- An Anthropic API key (from [console.anthropic.com](https://console.anthropic.com/))
+- Or an Anthropic OAuth token (for Max subscribers)
+
+## Configuration
+
+Set the provider on your agent in `config.json`:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "anthropic",
+      "modelId": "claude-sonnet-4-20250514"
+    }
+  }
+}
+```
+
+### API Key
+
+BotNexus resolves the key from environment variables in priority order:
+
+1. `ANTHROPIC_OAUTH_TOKEN` — OAuth token (Max subscribers)
+2. `ANTHROPIC_API_KEY` — Standard API key
+
+Alternatively, set the key directly in agent configuration (not recommended for production):
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "anthropic",
+      "modelId": "claude-sonnet-4-20250514",
+      "apiKey": "sk-ant-..."
+    }
+  }
+}
+```
+
+## Supported Models
+
+| Model | Identifier |
+|-------|-----------|
+| Claude Opus 4 | `claude-opus-4-20250514` |
+| Claude Sonnet 4 | `claude-sonnet-4-20250514` |
+| Claude Haiku 3.5 | `claude-3-5-haiku-20241022` |
+
+Use the full model identifier in your `modelId` field.
+
+## Features
+
+### Extended Thinking
+
+Claude supports extended thinking (chain-of-thought reasoning before responding). Configure via reasoning settings:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "anthropic",
+      "modelId": "claude-sonnet-4-20250514",
+      "reasoning": {
+        "effort": "medium"
+      }
+    }
+  }
+}
+```
+
+Effort levels: `low`, `medium`, `high`, `max`.
+
+### Prompt Caching
+
+BotNexus automatically uses Anthropic's prompt caching. The system prompt is split at the `<!-- BOTNEXUS_CACHE_BOUNDARY -->` marker — content before the boundary is cached across turns, reducing latency and cost.
+
+### Tool Use
+
+All registered agent tools are automatically converted to Anthropic's tool format. No additional configuration required.
+
+## Known Limitations
+
+- Extended thinking requires models that support it (Opus 4, Sonnet 4)
+- Maximum output tokens depend on the model and whether thinking is enabled
+- Anthropic enforces rate limits per API key — monitor usage in the Anthropic console

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -1,0 +1,89 @@
+# GitHub Copilot Provider
+
+The GitHub Copilot provider connects BotNexus to models available through the GitHub Copilot API. It uses your existing Copilot subscription — no separate API key required. BotNexus supports both the Completions and Responses API paths, and includes dynamic model discovery.
+
+## Prerequisites
+
+- An active GitHub Copilot subscription (Individual, Business, or Enterprise)
+- GitHub CLI (`gh`) authenticated with a Copilot-enabled account
+- BotNexus running on a machine where `gh auth status` shows an active session
+
+## Configuration
+
+Set the provider on your agent in `config.json`:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "copilot",
+      "modelId": "claude-sonnet-4-20250514"
+    }
+  }
+}
+```
+
+### Authentication
+
+BotNexus automatically discovers Copilot credentials via:
+
+1. `COPILOT_GITHUB_TOKEN` environment variable
+2. `GH_TOKEN` environment variable
+3. `GITHUB_TOKEN` environment variable
+4. GitHub CLI auth state (automatic OAuth refresh)
+
+No API key configuration is needed when `gh` is authenticated.
+
+### CLI Setup
+
+Use the BotNexus CLI to verify and configure Copilot access:
+
+```bash
+# Check Copilot provider status
+botnexus provider copilot status
+
+# Discover available models
+botnexus provider copilot discover
+```
+
+## Supported Models
+
+Copilot provides access to models from multiple families. Availability depends on your subscription tier:
+
+| Model | Family |
+|-------|--------|
+| `claude-sonnet-4-20250514` | Claude (Anthropic) |
+| `claude-opus-4-20250514` | Claude (Anthropic) |
+| `gpt-4o` | GPT (OpenAI) |
+| `gpt-4.1` | GPT (OpenAI) |
+| `o3-mini` | GPT (OpenAI) |
+
+Run `botnexus provider copilot discover` to see the full list available to your account.
+
+## Features
+
+### Dynamic Model Discovery
+
+BotNexus can query Copilot's model catalog at runtime to discover available models and their capabilities. This happens automatically when using the CLI discovery command.
+
+### Dual API Path
+
+- **Messages API** — Claude models are accessed via the Messages-compatible path
+- **Responses API** — OpenAI models use the Responses API for native tool call flow
+
+The provider automatically selects the correct path based on the model family.
+
+### Usage Tracking
+
+BotNexus parses Copilot usage billing snapshots and emits activity tags for observability. Monitor per-agent token consumption through the platform diagnostics.
+
+### Prompt Caching
+
+Copilot supports prompt caching for compatible models. The `<!-- BOTNEXUS_CACHE_BOUNDARY -->` marker is respected.
+
+## Known Limitations
+
+- Model availability varies by Copilot subscription tier
+- Rate limits are managed by GitHub — not configurable per-user
+- Some models may not support all features (e.g., extended thinking availability depends on the model)
+- OAuth token refresh requires `gh` CLI to be installed and authenticated

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -1,0 +1,67 @@
+# OpenAI-Compatible Provider
+
+The OpenAI-Compatible provider connects BotNexus to any LLM API that implements the OpenAI Chat Completions protocol. This covers a wide range of self-hosted and third-party inference services.
+
+## Prerequisites
+
+- Access to an OpenAI-compatible API endpoint
+- An API key for that service (if required)
+
+## Configuration
+
+Set the provider on your agent in `config.json`:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "openai-compat",
+      "modelId": "deepseek-chat",
+      "apiBaseUrl": "https://api.deepseek.com/v1",
+      "apiKey": "your-api-key"
+    }
+  }
+}
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `apiProvider` | Must be `"openai-compat"` |
+| `modelId` | The model identifier as expected by the target API |
+| `apiBaseUrl` | The base URL for the API (e.g. `https://api.deepseek.com/v1`) |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `apiKey` | API key for authentication (if the service requires one) |
+
+## Compatible Services
+
+This provider works with any service implementing the OpenAI Chat Completions protocol, including:
+
+- **DeepSeek** — `https://api.deepseek.com/v1`
+- **Groq** — `https://api.groq.com/openai/v1`
+- **Together AI** — `https://api.together.xyz/v1`
+- **Ollama** — `http://localhost:11434/v1` (local)
+- **vLLM** — `http://localhost:8000/v1` (local)
+- **LM Studio** — `http://localhost:1234/v1` (local)
+- **OpenRouter** — `https://openrouter.ai/api/v1`
+
+## Features
+
+### Streaming
+
+Streaming is supported via the standard SSE (Server-Sent Events) protocol. Most compatible APIs support streaming out of the box.
+
+### Tool Use
+
+Function calling is converted to the OpenAI format. Compatibility depends on the target API — some services support function calling while others do not.
+
+## Known Limitations
+
+- Feature support varies by target API — not all support function calling, streaming, or structured outputs
+- Token counting may be inaccurate for non-OpenAI models (BotNexus uses tiktoken-compatible estimates)
+- Some APIs may not support all parameters (temperature, top_p, etc.) — unsupported parameters are silently ignored by most services

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1,0 +1,77 @@
+# OpenAI Provider
+
+The OpenAI provider connects BotNexus to GPT models via both the Chat Completions API and the newer Responses API. It supports streaming, function calling, and structured outputs.
+
+## Prerequisites
+
+- An OpenAI API key (from [platform.openai.com](https://platform.openai.com/))
+
+## Configuration
+
+Set the provider on your agent in `config.json`:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "openai",
+      "modelId": "gpt-4o"
+    }
+  }
+}
+```
+
+### API Key
+
+BotNexus resolves the key from the `OPENAI_API_KEY` environment variable.
+
+Alternatively, set it directly in agent configuration:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "apiProvider": "openai",
+      "modelId": "gpt-4o",
+      "apiKey": "sk-..."
+    }
+  }
+}
+```
+
+## Supported Models
+
+| Model | Identifier |
+|-------|-----------|
+| GPT-4o | `gpt-4o` |
+| GPT-4.1 | `gpt-4.1` |
+| GPT-4.1 mini | `gpt-4.1-mini` |
+| o3 | `o3` |
+| o4-mini | `o4-mini` |
+
+Use the model identifier as published by OpenAI in your `modelId` field.
+
+## Features
+
+### Dual API Support
+
+BotNexus supports two OpenAI API paths:
+
+- **Responses API** — newer, supports streaming with native tool call flow
+- **Completions API** — legacy Chat Completions endpoint
+
+The provider automatically selects the appropriate API based on the model and configuration.
+
+### Function Calling
+
+All registered agent tools are automatically converted to OpenAI function definitions. No additional configuration required.
+
+### Prompt Caching
+
+OpenAI's automatic prompt caching is leveraged when available. The system prompt cache boundary marker helps optimize cache hit rates.
+
+## Known Limitations
+
+- Rate limits are per-organization — monitor usage in the OpenAI dashboard
+- Some models (o3, o4-mini) have different token pricing and capability profiles
+- Reasoning models (o-series) do not support all tool use patterns


### PR DESCRIPTION
## Changes

### Sidebar restructuring
- Eliminated "More" catch-all section: Skills and Cron moved to Features, Observability moved to Guides
- Added Providers section with 4 new pages
- Added Extensions > Debug Tool
- Added Architecture > Gateway Flow (was orphaned)
- Added Development > CLI Wizard, Container Integration Testing, E2E Tests (were orphaned)
- Added User Guide > Channels > Azure Service Bus + Envelope Reference (were orphaned)

### New pages (5)
- `docs/providers/anthropic.md` — configuration, auth, models, extended thinking, caching
- `docs/providers/openai.md` — configuration, auth, models, dual API support
- `docs/providers/openai-compatible.md` — configuration, compatible services list
- `docs/providers/github-copilot.md` — configuration, CLI setup, discovery, dual API path
- `docs/extensions/debug-tool.md` — actions, parameters, security, configuration

### Content updates
- `docs/development/prompt-pipeline.md`: documented `SectionId` (default interface member), `IPromptOverrideResolver`, `FilePromptOverrideResolver`, built-in section IDs table, `LambdaPromptSection`, `ModelFamilyDetector`

### Structural fixes
- 7 pages that existed on disk but were missing from sidebar are now discoverable
- No orphan pages remain in the non-excluded docs tree

---
Automated by the daily documentation groomer.