### PR TITLE
fix(tools): add 5-second regex timeout to GrepTool to prevent ReDoS

### DIFF
--- a/src/gateway/BotNexus.Tools/GrepTool.cs
+++ b/src/gateway/BotNexus.Tools/GrepTool.cs
@@ -20,6 +20,7 @@ public sealed class GrepTool : IAgentTool
     private const int MaxOutputBytes = 50 * 1024;
     private const int MaxLineLength = 500;
     private const int BinaryProbeBytes = 4096;
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(5);
     private readonly string _workingDirectory;
     private readonly IPathValidator? _validator;
     private readonly IFileSystem _fileSystem;
@@ -100,7 +101,7 @@ public sealed class GrepTool : IAgentTool
         var effectivePattern = literal ? Regex.Escape(pattern) : pattern;
         try
         {
-            _ = new Regex(effectivePattern, RegexOptions.Compiled);
+            _ = new Regex(effectivePattern, RegexOptions.Compiled, RegexTimeout);
         }
         catch (ArgumentException ex)
         {
@@ -185,7 +186,7 @@ public sealed class GrepTool : IAgentTool
         var literal = arguments.TryGetValue("literal", out var literalObj) && literalObj is bool parsedLiteral && parsedLiteral;
         var effectivePattern = literal ? Regex.Escape(pattern) : pattern;
         var ignoreCase = arguments.TryGetValue("ignore_case", out var ignoreCaseObj) && ignoreCaseObj is bool parsedIgnoreCase && parsedIgnoreCase;
-        var regex = new Regex(effectivePattern, ignoreCase ? RegexOptions.Compiled | RegexOptions.IgnoreCase : RegexOptions.Compiled);
+        var regex = new Regex(effectivePattern, ignoreCase ? RegexOptions.Compiled | RegexOptions.IgnoreCase : RegexOptions.Compiled, RegexTimeout);
         var contextLines = arguments.TryGetValue("context", out var contextObj) && contextObj is int parsedContext
             ? Math.Max(0, parsedContext)
             : 0;
@@ -214,6 +215,7 @@ public sealed class GrepTool : IAgentTool
 
         var matches = new List<string>(capacity: maxResults);
         var hadReadErrors = false;
+        var hadRegexTimeout = false;
         var matchCount = 0;
 
         var candidateFiles = EnumerateCandidateFiles(targetPath, include)
@@ -287,6 +289,11 @@ public sealed class GrepTool : IAgentTool
             {
                 hadReadErrors = true;
             }
+            catch (RegexMatchTimeoutException)
+            {
+                hadRegexTimeout = true;
+                break;
+            }
 
             if (matchCount >= maxResults)
             {
@@ -296,6 +303,12 @@ public sealed class GrepTool : IAgentTool
 
         if (matches.Count == 0)
         {
+            if (hadRegexTimeout)
+            {
+                return new AgentToolResult(
+                    [new AgentToolContent(AgentToolContentType.Text, "[warning] Pattern matching timed out -- the regex may have catastrophic backtracking. Simplify the pattern or use literal mode.")]);
+            }
+
             return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "No matches.")]);
         }
 
@@ -328,6 +341,11 @@ public sealed class GrepTool : IAgentTool
         if (hadReadErrors)
         {
             builder.AppendLine("[warning] Some files could not be read.");
+        }
+
+        if (hadRegexTimeout)
+        {
+            builder.AppendLine("[warning] Pattern matching timed out -- the regex may have catastrophic backtracking. Simplify the pattern or use literal mode.");
         }
 
         return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, builder.ToString().TrimEnd())]);

--- a/tests/BotNexus.CodingAgent.Tests/Tools/GrepToolTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/GrepToolTests.cs
@@ -149,6 +149,56 @@ public sealed class GrepToolTests : IDisposable
         result.Content[0].Value.ShouldContain("[warning] Results truncated at 100 matches.");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenEvilRegexPattern_TimesOutInsteadOfHanging()
+    {
+        // Classic ReDoS pattern: (a+)+b against a long string of 'a's with no trailing 'b'
+        var evilInput = new string('a', 30);
+        await File.WriteAllTextAsync(Path.Combine(_tempDirectory, "redos.txt"), evilInput);
+
+        var result = await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["pattern"] = "(a+)+b"
+        });
+
+        // Should return gracefully with timeout warning instead of hanging
+        result.Content.ShouldNotBeEmpty();
+        result.Content[0].Value.ShouldContain("timed out");
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenEvilRegexPattern_DoesNotHang()
+    {
+        // PrepareArguments also compiles the regex for validation — must not hang
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var args = new Dictionary<string, object?>
+        {
+            ["pattern"] = "(a+)+b"
+        };
+
+        // Should complete quickly (regex compilation with timeout doesn't hang)
+        var prepared = await _tool.PrepareArgumentsAsync(args, cts.Token);
+        prepared["pattern"].ShouldBe("(a+)+b");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRegexTimesOut_ReturnsTimeoutWarning()
+    {
+        // Catastrophic backtracking pattern: nested quantifiers against non-matching input
+        var input = new string('a', 50) + "!";
+        await File.WriteAllTextAsync(Path.Combine(_tempDirectory, "backtrack.txt"), input);
+
+        var result = await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["pattern"] = "(a+)+$"
+        });
+
+        result.Content.ShouldNotBeEmpty();
+        // (a+)+$ against 'aaa...!' will timeout due to catastrophic backtracking
+        // The result should contain the timeout warning message
+        result.Content[0].Value.ShouldContain("timed out");
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))


### PR DESCRIPTION
Closes #1039

## Changes

- Added `RegexTimeout` (5 seconds) to both regex instantiation sites in `GrepTool.cs`
- Wrapped `regex.IsMatch()` in try/catch for `RegexMatchTimeoutException`
- On timeout: returns actionable warning message suggesting pattern simplification or literal mode
- 3 new tests verifying ReDoS patterns timeout gracefully instead of hanging

## Merge Notes

No file overlap with any open PR. Safe to merge in any order.