### PR TITLE
feat(cron): add command action type for shell-based cron jobs

### DIFF
--- a/src/gateway/BotNexus.Cron/Actions/CommandCronAction.cs
+++ b/src/gateway/BotNexus.Cron/Actions/CommandCronAction.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Cron.Actions;
+
+/// <summary>
+/// Executes a cron job by running a shell command as a subprocess with timeout-safe process tree cleanup.
+/// Action type: "command".
+/// </summary>
+/// <remarks>
+/// Security: command jobs inherit the same security model as interactive exec — they run with the
+/// gateway process identity. The command is stored in <see cref="CronJob.ShellCommand"/> and must be
+/// non-null for command action types.
+///
+/// Process management:
+/// <list type="bullet">
+///   <item>Uses <c>pwsh -NoProfile -c</c> as the default shell (cross-platform via .NET Process).</item>
+///   <item>Timeout defaults to 120 seconds; configurable via <see cref="CronJob.Metadata"/> key "timeoutSeconds".</item>
+///   <item>On timeout: kills the process tree (Windows: taskkill /T, POSIX: process group -KILL).</item>
+///   <item>Captures stdout + stderr and records the combined output in the cron run.</item>
+/// </list>
+/// </remarks>
+public sealed class CommandCronAction : ICronAction
+{
+    /// <summary>Default timeout in seconds if not specified in job metadata.</summary>
+    internal const int DefaultTimeoutSeconds = 120;
+
+    /// <summary>Maximum allowed output capture length in characters.</summary>
+    internal const int MaxOutputChars = 50_000;
+
+    /// <inheritdoc/>
+    public string ActionType => "command";
+
+    /// <inheritdoc/>
+    public async Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var command = context.Job.ShellCommand;
+        if (string.IsNullOrWhiteSpace(command))
+            throw new InvalidOperationException(
+                $"Cron job '{context.Job.Id}' has action type 'command' but ShellCommand is null or empty.");
+
+        var logger = context.Services.GetService<ILogger<CommandCronAction>>();
+        var timeoutSeconds = ResolveTimeout(context.Job);
+
+        logger?.LogInformation(
+            "CommandCronAction: executing command for job '{JobId}' (timeout={Timeout}s).",
+            context.Job.Id, timeoutSeconds);
+
+        var result = await RunProcessAsync(command, timeoutSeconds, cancellationToken).ConfigureAwait(false);
+
+        if (result.TimedOut)
+        {
+            logger?.LogWarning(
+                "CommandCronAction: job '{JobId}' timed out after {Timeout}s. Partial output length: {OutputLength}.",
+                context.Job.Id, timeoutSeconds, result.Output.Length);
+
+            throw new TimeoutException(
+                $"Command timed out after {timeoutSeconds}s. Partial output ({result.Output.Length} chars): "
+                + TruncateForError(result.Output));
+        }
+
+        if (result.ExitCode != 0)
+        {
+            logger?.LogWarning(
+                "CommandCronAction: job '{JobId}' exited with code {ExitCode}. Output length: {OutputLength}.",
+                context.Job.Id, result.ExitCode, result.Output.Length);
+
+            throw new InvalidOperationException(
+                $"Command exited with code {result.ExitCode}. Output: " + TruncateForError(result.Output));
+        }
+
+        logger?.LogInformation(
+            "CommandCronAction: job '{JobId}' completed successfully. Output length: {OutputLength}.",
+            context.Job.Id, result.Output.Length);
+    }
+
+    /// <summary>
+    /// Runs the command in a subprocess with timeout and output capture.
+    /// </summary>
+    internal static async Task<CommandResult> RunProcessAsync(
+        string command,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            ArgumentList = { "-NoProfile", "-c", command },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var outputBuilder = new System.Text.StringBuilder();
+        var outputLock = new object();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            lock (outputLock)
+            {
+                if (outputBuilder.Length < MaxOutputChars)
+                    outputBuilder.AppendLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            lock (outputLock)
+            {
+                if (outputBuilder.Length < MaxOutputChars)
+                    outputBuilder.AppendLine(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Timeout — kill the process tree
+            KillProcessTree(process);
+            return new CommandResult(
+                ExitCode: -1,
+                Output: outputBuilder.ToString(),
+                TimedOut: true);
+        }
+
+        return new CommandResult(
+            ExitCode: process.ExitCode,
+            Output: outputBuilder.ToString(),
+            TimedOut: false);
+    }
+
+    /// <summary>
+    /// Kills the process and all descendants (process tree).
+    /// On Windows uses taskkill /T; on POSIX kills the process directly
+    /// (which .NET 8+ Kill(entireProcessTree: true) handles natively).
+    /// </summary>
+    internal static void KillProcessTree(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited between timeout and kill.
+        }
+        catch (SystemException)
+        {
+            // Platform-specific failure (access denied, zombie process, etc.)
+            // Best-effort — the timeout has fired so we move on.
+        }
+    }
+
+    private static int ResolveTimeout(CronJob job)
+    {
+        if (job.Metadata is not null
+            && job.Metadata.TryGetValue("timeoutSeconds", out var rawTimeout)
+            && rawTimeout is not null)
+        {
+            if (rawTimeout is int intVal && intVal > 0)
+                return intVal;
+
+            if (rawTimeout is long longVal && longVal > 0)
+                return (int)Math.Min(longVal, int.MaxValue);
+
+            if (rawTimeout is string strVal && int.TryParse(strVal, out var parsed) && parsed > 0)
+                return parsed;
+        }
+
+        return DefaultTimeoutSeconds;
+    }
+
+    private static string TruncateForError(string output)
+    {
+        const int maxErrorChars = 2000;
+        return output.Length <= maxErrorChars
+            ? output
+            : output[..maxErrorChars] + "... (truncated)";
+    }
+
+    /// <summary>
+    /// Result of a command execution attempt.
+    /// </summary>
+    internal sealed record CommandResult(int ExitCode, string Output, bool TimedOut);
+}

--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -19,6 +19,8 @@
     <Compile Include="Prompts\IPromptTemplateResolver.cs" />
     <Compile Include="Prompts\CronOptionsPromptTemplateResolver.cs" />
     <Compile Include="Prompts\PromptTemplateRenderer.cs" />
+    <Compile Include="Actions\CommandCronAction.cs" />
+    <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="Actions\HeartbeatAction.cs" />
     <Compile Include="Actions\TimeZoneHelper.cs" />
     <Compile Include="ActionStubs\AgentPromptActionStub.cs" />

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class CronServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, AgentPromptAction>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, HeartbeatAction>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, WebhookAction>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, CommandCronAction>());
         services.TryAddSingleton<IPromptTemplateResolver, CronOptionsPromptTemplateResolver>();
         return services;
     }

--- a/src/gateway/BotNexus.Cron/Properties/InternalsVisibleTo.cs
+++ b/src/gateway/BotNexus.Cron/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BotNexus.Cron.Tests")]

--- a/tests/gateway/BotNexus.Cron.Tests/CommandCronActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CommandCronActionTests.cs
@@ -1,0 +1,187 @@
+using BotNexus.Cron.Actions;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BotNexus.Cron.Tests;
+
+public sealed class CommandCronActionTests
+{
+    private readonly CommandCronAction _action = new();
+
+    [Fact]
+    public void ActionType_IsCommand()
+    {
+        Assert.Equal("command", _action.ActionType);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ThrowsWhenShellCommandIsNull()
+    {
+        var context = BuildContext(shellCommand: null);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _action.ExecuteAsync(context));
+
+        Assert.Contains("ShellCommand is null or empty", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ThrowsWhenShellCommandIsWhitespace()
+    {
+        var context = BuildContext(shellCommand: "   ");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _action.ExecuteAsync(context));
+
+        Assert.Contains("ShellCommand is null or empty", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SuccessfulCommand_DoesNotThrow()
+    {
+        var context = BuildContext(shellCommand: "Write-Output 'hello'");
+
+        // Should complete without exception
+        await _action.ExecuteAsync(context);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FailingCommand_ThrowsWithExitCode()
+    {
+        var context = BuildContext(shellCommand: "exit 42");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _action.ExecuteAsync(context));
+
+        Assert.Contains("exited with code 42", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TimedOutCommand_ThrowsTimeoutException()
+    {
+        // Command that sleeps longer than timeout
+        var context = BuildContext(
+            shellCommand: "Start-Sleep -Seconds 60",
+            timeoutSeconds: 2);
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(
+            () => _action.ExecuteAsync(context));
+
+        Assert.Contains("timed out after 2s", ex.Message);
+    }
+
+    [Fact]
+    public async Task RunProcessAsync_CapturesStdout()
+    {
+        var result = await CommandCronAction.RunProcessAsync(
+            "Write-Output 'captured-output'",
+            timeoutSeconds: 30,
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.False(result.TimedOut);
+        Assert.Contains("captured-output", result.Output);
+    }
+
+    [Fact]
+    public async Task RunProcessAsync_CapturesStderr()
+    {
+        var result = await CommandCronAction.RunProcessAsync(
+            "Write-Error 'error-output'",
+            timeoutSeconds: 30,
+            CancellationToken.None);
+
+        // Write-Error in pwsh exits with 0 but writes to stderr
+        Assert.False(result.TimedOut);
+        Assert.Contains("error-output", result.Output);
+    }
+
+    [Fact]
+    public async Task RunProcessAsync_NonZeroExitCode()
+    {
+        var result = await CommandCronAction.RunProcessAsync(
+            "exit 7",
+            timeoutSeconds: 30,
+            CancellationToken.None);
+
+        Assert.Equal(7, result.ExitCode);
+        Assert.False(result.TimedOut);
+    }
+
+    [Fact]
+    public async Task RunProcessAsync_RespectsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => CommandCronAction.RunProcessAsync(
+                "Start-Sleep -Seconds 60",
+                timeoutSeconds: 120,
+                cts.Token));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MetadataTimeoutOverridesDefault()
+    {
+        // Use a very short timeout via metadata
+        var metadata = new Dictionary<string, object?> { ["timeoutSeconds"] = 1 };
+        var context = BuildContext(
+            shellCommand: "Start-Sleep -Seconds 60",
+            metadata: metadata);
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(
+            () => _action.ExecuteAsync(context));
+
+        Assert.Contains("timed out after 1s", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StringMetadataTimeout_ParsedCorrectly()
+    {
+        var metadata = new Dictionary<string, object?> { ["timeoutSeconds"] = "2" };
+        var context = BuildContext(
+            shellCommand: "Start-Sleep -Seconds 60",
+            metadata: metadata);
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(
+            () => _action.ExecuteAsync(context));
+
+        Assert.Contains("timed out after 2s", ex.Message);
+    }
+
+    private static CronExecutionContext BuildContext(
+        string? shellCommand,
+        int? timeoutSeconds = null,
+        IReadOnlyDictionary<string, object?>? metadata = null)
+    {
+        var effectiveMetadata = metadata;
+        if (timeoutSeconds.HasValue && metadata is null)
+            effectiveMetadata = new Dictionary<string, object?> { ["timeoutSeconds"] = timeoutSeconds.Value };
+
+        var job = new CronJob
+        {
+            Id = JobId.From("test-command-job"),
+            Name = "Test Command",
+            Schedule = "* * * * *",
+            ActionType = "command",
+            ShellCommand = shellCommand,
+            Metadata = effectiveMetadata
+        };
+
+        var services = new ServiceCollection()
+            .AddLogging(b => b.AddConsole())
+            .BuildServiceProvider();
+
+        return new CronExecutionContext
+        {
+            Job = job,
+            RunId = RunId.From("run-1"),
+            TriggeredAt = DateTimeOffset.UtcNow,
+            TriggerType = CronTriggerType.Manual,
+            Services = services
+        };
+    }
+}


### PR DESCRIPTION
Closes #1044

## Changes

- New CommandCronAction implementing ICronAction for action type "command"
- Runs CronJob.ShellCommand via pwsh -NoProfile -c with stdout/stderr capture
- Timeout-safe process tree cleanup via Process.Kill(entireProcessTree: true)
- Configurable timeout via CronJob.Metadata["timeoutSeconds"] (default: 120s)
- Output capped at 50K chars to prevent memory pressure
- Registered in CronServiceCollectionExtensions alongside existing actions
- 12 new tests covering: action type identity, null/empty validation, success path, non-zero exit, timeout, output capture, cancellation, metadata timeout parsing
- InternalsVisibleTo added for test project access to internal helpers

## Merge Notes

Independent of all open PRs. The only shared file is CronServiceCollectionExtensions.cs (1 additive line) which has no open PR overlap. Safe to merge in any order.