### PR TITLE
fix(provider): change Copilot limits dict to JsonElement for mixed-type values

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotModelInfo.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotModelInfo.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace BotNexus.Agent.Providers.Copilot.Discovery;
@@ -62,7 +63,7 @@ public sealed class CopilotModelCapabilities
     public CopilotModelSupports? Supports { get; set; }
 
     [JsonPropertyName("limits")]
-    public Dictionary<string, double>? Limits { get; set; }
+    public Dictionary<string, JsonElement>? Limits { get; set; }
 }
 
 public sealed class CopilotModelSupports

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Discovery/CopilotDiscoveryClientTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Discovery/CopilotDiscoveryClientTests.cs
@@ -77,6 +77,46 @@ public class CopilotDiscoveryClientTests
     }
 
     [Fact]
+    public void ModelsResponse_deserializes_mixed_type_limits()
+    {
+        var path = Path.Combine(FixturesDir, "models-mixed-limits.json");
+        var json = File.ReadAllText(path);
+
+        var resp = JsonSerializer.Deserialize<CopilotModelsResponse>(json, JsonOptions);
+
+        resp.ShouldNotBeNull();
+        resp!.Data.ShouldNotBeNull();
+        resp.Data!.Count.ShouldBe(1);
+
+        var model = resp.Data[0];
+        model.Id.ShouldBe("gpt-5-mini");
+        model.Capabilities.ShouldNotBeNull();
+        model.Capabilities!.Limits.ShouldNotBeNull();
+        model.Capabilities.Limits!.Count.ShouldBe(4);
+
+        // Numeric values accessible via JsonElement
+        model.Capabilities.Limits["max_context_window_tokens"].GetInt64().ShouldBe(264000);
+        model.Capabilities.Limits["max_output_tokens"].GetInt64().ShouldBe(64000);
+
+        // Non-numeric value (boolean) should not crash deserialization
+        model.Capabilities.Limits["vision"].ValueKind.ShouldBe(System.Text.Json.JsonValueKind.True);
+    }
+
+    [Fact]
+    public void ModelsResponse_numeric_limits_display_as_string()
+    {
+        var path = Path.Combine(FixturesDir, "models-mixed-limits.json");
+        var json = File.ReadAllText(path);
+
+        var resp = JsonSerializer.Deserialize<CopilotModelsResponse>(json, JsonOptions);
+        var limits = resp!.Data![0].Capabilities!.Limits!;
+
+        // ToString() on JsonElement works for display purposes regardless of value kind
+        limits["max_output_tokens"].ToString().ShouldBe("64000");
+        limits["vision"].ToString().ShouldBe("True");
+    }
+
+    [Fact]
     public async Task GetUserAsync_sends_bearer_auth_and_accepts_json()
     {
         var fixtureJson = await File.ReadAllTextAsync(Path.Combine(FixturesDir, "user-enterprise.json"));

--- a/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/models-mixed-limits.json
+++ b/tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/models-mixed-limits.json
@@ -1,0 +1,36 @@
+{
+  "data": [
+    {
+      "id": "gpt-5-mini",
+      "name": "GPT-5 mini",
+      "vendor": "OpenAI",
+      "version": "gpt-5-mini",
+      "model_picker_enabled": true,
+      "preview": false,
+      "capabilities": {
+        "family": "gpt-5",
+        "type": "chat",
+        "tokenizer": "o200k_base",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true,
+          "parallel_tool_calls": true,
+          "vision": true,
+          "structured_outputs": true
+        },
+        "limits": {
+          "max_context_window_tokens": 264000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 264000,
+          "vision": true
+        }
+      },
+      "billing": {
+        "is_premium": false,
+        "multiplier": 0,
+        "restricted_to": []
+      }
+    }
+  ],
+  "object": "list"
+}


### PR DESCRIPTION
Closes #1046

## Changes

- Changed `CopilotModelCapabilities.Limits` from `Dictionary<string, double>?` to `Dictionary<string, JsonElement>?`
- The Copilot API now returns mixed types in the `limits` object (e.g. `vision: true` alongside numeric values like `max_output_tokens: 64000`)
- `System.Text.Json` deserialization crashed with `JsonException` when encountering non-numeric values in the dictionary
- `JsonElement` handles any JSON value type; callers use `.GetInt64()` for numeric access or `.ToString()` for display
- Added fixture file `models-mixed-limits.json` with boolean `vision` limit value
- 2 new tests verifying mixed-type deserialization and display formatting

## Files Changed

- `src/agent/BotNexus.Agent.Providers.Copilot/Discovery/CopilotModelInfo.cs` — type change + using
- `tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Discovery/CopilotDiscoveryClientTests.cs` — 2 new tests
- `tests/agent/BotNexus.Agent.Providers.Copilot.Tests/Fixtures/Discovery/models-mixed-limits.json` — new fixture

## Merge Notes

No file overlap with any open PR. Safe to merge independently in any order.