### PR TITLE
fix(tests): serialize AnsiConsole-dependent test classes to prevent static writer race

### DIFF
--- a/tests/gateway/BotNexus.Cli.Tests/AnsiConsoleTestCollection.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/AnsiConsoleTestCollection.cs
@@ -1,0 +1,9 @@
+namespace BotNexus.Cli.Tests;
+
+/// <summary>
+/// Serializes all test classes that mutate the static <see cref="Spectre.Console.AnsiConsole.Console"/>
+/// property. Without this collection, xUnit runs test classes in parallel and the shared
+/// writer can be swapped mid-assertion — producing empty or interleaved output.
+/// </summary>
+[CollectionDefinition("AnsiConsole")]
+public sealed class AnsiConsoleTestCollection;

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/ProviderCommandTests.cs
@@ -4,6 +4,7 @@ using Spectre.Console;
 
 namespace BotNexus.Cli.Tests.Commands;
 
+[Collection("AnsiConsole")]
 public class ProviderCommandTests : IDisposable
 {
     private readonly IAnsiConsole _originalConsole;

--- a/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -6,6 +6,7 @@ using Spectre.Console;
 
 namespace BotNexus.Cli.Tests.Commands;
 
+[Collection("AnsiConsole")]
 public class UpdateCommandTests
 {
     /// <summary>


### PR DESCRIPTION
Closes #1050

## Changes

- Created `AnsiConsoleTestCollection.cs` with `[CollectionDefinition(`AnsiConsole`)]` to serialize test classes that mutate the static `AnsiConsole.Console` property
- Added `[Collection(`AnsiConsole`)]` to `UpdateCommandTests` and `ProviderCommandTests`
- Prevents xUnit parallel execution from racing on the shared static writer

## Root Cause

`UpdateCommandTests.CaptureAnsiConsoleOutputAsync` temporarily replaces `AnsiConsole.Console` (a process-wide static) with a captured `StringWriter`. When `ProviderCommandTests` runs in parallel (it also replaces `AnsiConsole.Console` in its constructor), the two classes race — one test's output goes to the other's writer, producing empty assertions.

## Merge Notes

Independent of all open PRs. Unblocks main CI (red since `02d11157`).