### PR TITLE
fix(gateway): wire prompt guidance sections into system prompt pipeline

### DIFF
--- a/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
@@ -106,7 +106,8 @@ public static class SystemPromptBuilder
                     runtimeCapabilities,
                     inlineButtonsEnabled,
                     stableContextFiles,
-                    dynamicContextFiles)
+                    dynamicContextFiles),
+                [ModelGuidanceSection.ModelIdExtensionKey] = @params.Runtime?.Model
             }
         };
 
@@ -114,7 +115,10 @@ public static class SystemPromptBuilder
             .Add(new LambdaPromptSection(10, BuildToolingSection))
             .Add(new LambdaPromptSection(20, BuildToolCallStyleSection))
             .Add(new LambdaPromptSection(30, static context => buildOverridablePromptSection(null, buildExecutionBiasSection(GetGatewayData(context).IsMinimal))))
+            .Add(ToolEnforcementSection.Create())
+            .Add(ShellEfficiencySection.Create())
             .Add(new LambdaPromptSection(40, BuildSafetyAndCliSection))
+            .Add(SkillsGuidanceSection.Create())
             .Add(new LambdaPromptSection(60, static context => buildMemorySection(
                 GetGatewayData(context).IsMinimal,
                 GetGatewayData(context).Parameters.MemoryPromptInjection,
@@ -128,6 +132,7 @@ public static class SystemPromptBuilder
             .Add(new LambdaPromptSection(125, BuildConversationContextSection, HasConversationContext))
             .Add(new LambdaPromptSection(127, BuildConversationInstructionsSection, HasConversationInstructions))
             .Add(new LambdaPromptSection(130, static _ => ["## Workspace Files (injected)", "These user-editable files are loaded by BotNexus and included below in Project Context.", string.Empty]))
+            .Add(ModelGuidanceSection.Create())
             .Add(new LambdaPromptSection(140, static context => buildReplyTagsSection(GetGatewayData(context).IsMinimal), static _ => IncludeReplyTagsSectionByDefault))
             .Add(new LambdaPromptSection(150, static context => buildMessagingSection(GetGatewayData(context).IsMinimal, GetGatewayData(context).NormalizedTools, GetGatewayData(context).RuntimeChannel, GetGatewayData(context).InlineButtonsEnabled)))
             .Add(new LambdaPromptSection(160, static context => buildVoiceSection(GetGatewayData(context).IsMinimal, GetGatewayData(context).Parameters.TtsHint)))

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/PromptSectionWiringTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/PromptSectionWiringTests.cs
@@ -1,0 +1,140 @@
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class PromptSectionWiringTests
+{
+    private static string BuildFullPrompt(string? model = null, IReadOnlyList<string>? tools = null)
+    {
+        return SystemPromptBuilder.Build(new SystemPromptParams
+        {
+            WorkspaceDir = Path.Combine(Path.GetTempPath(), "test-workspace"),
+            ToolNames = tools ?? ["read", "write", "shell", "skills", "skill_manage"],
+            PromptMode = PromptMode.Full,
+            Runtime = new RuntimeInfo
+            {
+                AgentId = "test-agent",
+                Channel = "signalr",
+                Model = model
+            }
+        });
+    }
+
+    [Fact]
+    public void ToolEnforcementSection_AppearsInFullPrompt()
+    {
+        var prompt = BuildFullPrompt();
+
+        prompt.ShouldContain("## Tool Enforcement");
+        prompt.ShouldContain("execute the tool immediately");
+    }
+
+    [Fact]
+    public void ShellEfficiencySection_AppearsInFullPrompt()
+    {
+        var prompt = BuildFullPrompt();
+
+        prompt.ShouldContain("## Shell Efficiency");
+        prompt.ShouldContain("temporary script file");
+    }
+
+    [Fact]
+    public void SkillsGuidanceSection_AppearsWhenSkillToolsAvailable()
+    {
+        var prompt = BuildFullPrompt(tools: ["read", "skills", "skill_manage"]);
+
+        prompt.ShouldContain("## Skills");
+        prompt.ShouldContain("check available skills");
+    }
+
+    [Fact]
+    public void SkillsGuidanceSection_OmittedWhenNoSkillTools()
+    {
+        var prompt = BuildFullPrompt(tools: ["read", "write", "shell"]);
+
+        prompt.ShouldNotContain("check available skills");
+    }
+
+    [Fact]
+    public void ModelGuidanceSection_AppearsForClaudeModel()
+    {
+        var prompt = BuildFullPrompt(model: "claude-sonnet-4-20250514");
+
+        prompt.ShouldContain("## Model Guidance (Claude)");
+        prompt.ShouldContain("edit tool over write");
+    }
+
+    [Fact]
+    public void ModelGuidanceSection_AppearsForGptModel()
+    {
+        var prompt = BuildFullPrompt(model: "gpt-4.1");
+
+        prompt.ShouldContain("## Model Guidance (GPT)");
+        prompt.ShouldContain("Never answer from memory");
+    }
+
+    [Fact]
+    public void ModelGuidanceSection_AppearsForGeminiModel()
+    {
+        var prompt = BuildFullPrompt(model: "gemini-2.5-pro");
+
+        prompt.ShouldContain("## Model Guidance (Gemini)");
+        prompt.ShouldContain("absolute paths");
+    }
+
+    [Fact]
+    public void ModelGuidanceSection_OmittedForUnknownModel()
+    {
+        var prompt = BuildFullPrompt(model: "some-unknown-model-v1");
+
+        prompt.ShouldNotContain("## Model Guidance");
+    }
+
+    [Fact]
+    public void ModelGuidanceSection_OmittedWhenModelIsNull()
+    {
+        var prompt = BuildFullPrompt(model: null);
+
+        prompt.ShouldNotContain("## Model Guidance");
+    }
+
+    [Fact]
+    public void SectionOrder_ToolEnforcement_BeforeSafety()
+    {
+        var prompt = BuildFullPrompt();
+
+        var toolEnforcementIdx = prompt.IndexOf("## Tool Enforcement", StringComparison.Ordinal);
+        var safetyIdx = prompt.IndexOf("## Safety", StringComparison.Ordinal);
+
+        toolEnforcementIdx.ShouldBeGreaterThan(-1);
+        safetyIdx.ShouldBeGreaterThan(-1);
+        toolEnforcementIdx.ShouldBeLessThan(safetyIdx);
+    }
+
+    [Fact]
+    public void SectionOrder_ShellEfficiency_BeforeSafety()
+    {
+        var prompt = BuildFullPrompt();
+
+        var shellIdx = prompt.IndexOf("## Shell Efficiency", StringComparison.Ordinal);
+        var safetyIdx = prompt.IndexOf("## Safety", StringComparison.Ordinal);
+
+        shellIdx.ShouldBeGreaterThan(-1);
+        safetyIdx.ShouldBeGreaterThan(-1);
+        shellIdx.ShouldBeLessThan(safetyIdx);
+    }
+
+    [Fact]
+    public void SectionOrder_ModelGuidance_AfterWorkspaceFiles()
+    {
+        var prompt = BuildFullPrompt(model: "claude-sonnet-4-20250514");
+
+        var workspaceIdx = prompt.IndexOf("## Workspace Files (injected)", StringComparison.Ordinal);
+        var modelIdx = prompt.IndexOf("## Model Guidance (Claude)", StringComparison.Ordinal);
+
+        workspaceIdx.ShouldBeGreaterThan(-1);
+        modelIdx.ShouldBeGreaterThan(-1);
+        workspaceIdx.ShouldBeLessThan(modelIdx);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
@@ -1,4 +1,4 @@
-You are a personal assistant running inside BotNexus.
+﻿You are a personal assistant running inside BotNexus.
 ## Tooling
 Structured tool definitions are the source of truth for tool names, descriptions, and parameters.
 Tool names are case-sensitive. Call tools exactly as listed in the structured tool definitions.
@@ -29,6 +29,19 @@ If the user asks you to do the work, start doing it in the same turn.
 Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.
 Commentary-only turns are incomplete when tools are available and the next action is clear.
 If the work will take multiple steps or a while to finish, send one short progress update before or while acting.
+## Tool Enforcement
+When a task requires a tool call, execute the tool immediately.
+Do not describe what you would do — do it.
+Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+If multiple independent tool calls are needed, batch them in a single response.
+Never simulate or fabricate tool output — always call the real tool.
+## Shell Efficiency
+Prefer writing a temporary script file and executing it over chaining many individual shell commands.
+Combine related operations into a single shell invocation where possible.
+Avoid repeated read-modify-write cycles — batch edits into one tool call.
+Never use backtick line continuations in shell commands — they break across platforms.
+Use single quotes for strings containing special characters ($, @, |, ;).
+For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it.
 ## Safety
 You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.
 Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)
@@ -77,6 +90,10 @@ Owner: Jon
 Time zone: Pacific/Auckland
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.
+## Model Guidance (GPT)
+Never answer from memory when a tool can verify the answer — always check the source.
+When asked about file contents, always read the file rather than guessing from context.
+Be explicit about uncertainty — say when you are unsure rather than confabulating.
 ## Messaging
 - Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)
 - Cross-session messaging → use sessions_send(sessionKey, message)

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
@@ -1,4 +1,4 @@
-You are a personal assistant running inside BotNexus.
+﻿You are a personal assistant running inside BotNexus.
 ## Tooling
 Structured tool definitions are the source of truth for tool names, descriptions, and parameters.
 Tool names are case-sensitive. Call tools exactly as listed in the structured tool definitions.
@@ -18,6 +18,19 @@ When exec returns approval-pending, include the concrete /approve command from t
 Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.
 Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.
 When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.
+## Tool Enforcement
+When a task requires a tool call, execute the tool immediately.
+Do not describe what you would do — do it.
+Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+If multiple independent tool calls are needed, batch them in a single response.
+Never simulate or fabricate tool output — always call the real tool.
+## Shell Efficiency
+Prefer writing a temporary script file and executing it over chaining many individual shell commands.
+Combine related operations into a single shell invocation where possible.
+Avoid repeated read-modify-write cycles — batch edits into one tool call.
+Never use backtick line continuations in shell commands — they break across platforms.
+Use single quotes for strings containing special characters ($, @, |, ;).
+For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it.
 ## Safety
 You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.
 Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)
@@ -39,6 +52,10 @@ Minimal note
 Time zone: UTC
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.
+## Model Guidance (GPT)
+Never answer from memory when a tool can verify the answer — always check the source.
+When asked about file contents, always read the file rather than guessing from context.
+Be explicit about uncertainty — say when you are unsure rather than confabulating.
 ## Reasoning Format
 ALL internal reasoning MUST be inside <think>...</think>. Do not output any analysis outside <think>. Format every reply as <think>...</think> then <final>...</final>, with no other text. Only the final user-visible reply may appear inside <final>. Only text inside <final> is shown to the user; everything else is discarded and never seen by the user. Example: <think>Short internal reasoning.</think> <final>Hey there! What would you like to do next?</final>
 # Project Context

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
@@ -25,6 +25,19 @@ If the user asks you to do the work, start doing it in the same turn.
 Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.
 Commentary-only turns are incomplete when tools are available and the next action is clear.
 If the work will take multiple steps or a while to finish, send one short progress update before or while acting.
+## Tool Enforcement
+When a task requires a tool call, execute the tool immediately.
+Do not describe what you would do — do it.
+Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+If multiple independent tool calls are needed, batch them in a single response.
+Never simulate or fabricate tool output — always call the real tool.
+## Shell Efficiency
+Prefer writing a temporary script file and executing it over chaining many individual shell commands.
+Combine related operations into a single shell invocation where possible.
+Avoid repeated read-modify-write cycles — batch edits into one tool call.
+Never use backtick line continuations in shell commands — they break across platforms.
+Use single quotes for strings containing special characters ($, @, |, ;).
+For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it.
 ## Safety
 You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.
 Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)


### PR DESCRIPTION
Closes #1049

## Changes

1. Added `ToolEnforcementSection.Create()` (order 32) to the pipeline
2. Added `ShellEfficiencySection.Create()` (order 35) to the pipeline
3. Added `SkillsGuidanceSection.Create()` (order 55, conditional on skills tools) to the pipeline
4. Added `ModelGuidanceSection.Create()` (order 135, conditional on model family) to the pipeline
5. Set `ModelGuidanceSection.ModelIdExtensionKey` in `PromptContext.Extensions` from `@params.Runtime?.Model`
6. Updated prompt snapshot files to reflect new sections

## Root Cause

PRs #1007, #1009, and #1010 introduced standalone prompt section classes but never wired them into `SystemPromptBuilder.Build()`. The pipeline only used inline `LambdaPromptSection` instances. The standalone classes were well-tested dead code.

## Tests

- 12 new tests in `PromptSectionWiringTests.cs` covering:
  - Section presence in full prompt
  - Skills section conditional inclusion/exclusion
  - Model guidance for Claude, GPT, Gemini, unknown, and null
  - Section ordering verification
- 3 existing snapshot tests updated via `UPDATE_PROMPT_SNAPSHOTS=1`
- All 2330 Gateway tests + 178 Architecture tests pass

## Merge Notes

Independent of all open PRs. No file overlap.