### PR TITLE
fix(tools): use ArgumentList for shell invocation to eliminate double-parse escaping

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -172,4 +172,11 @@ public sealed record AgentDescriptor : ICitizen
         new Dictionary<string, System.Text.Json.JsonElement>();
 /// <summary>Conversation retention policy override for this agent. Null means world default applies.</summary>
     public AgentConversationRetentionConfig? ConversationRetention { get; init; }
+
+    /// <summary>
+    /// Custom shell command array for this agent. Overrides the gateway-level ShellCommand.
+    /// Element [0] is the executable, remaining elements are base arguments.
+    /// The agent's command string is appended as the final argument.
+    /// </summary>
+    public string[]? ShellCommand { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentToolFactory.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentToolFactory.cs
@@ -14,5 +14,5 @@ public interface IAgentToolFactory
     /// <param name="workingDirectory">Agent workspace root path.</param>
     /// <param name="pathValidator">Path validator used by file tools.</param>
     /// <returns>Built-in tools bound to the workspace.</returns>
-    IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null);
+    IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null);
 }

--- a/src/gateway/BotNexus.Gateway/Agents/DefaultAgentToolFactory.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/DefaultAgentToolFactory.cs
@@ -11,16 +11,19 @@ public sealed class DefaultAgentToolFactory : IAgentToolFactory
 {
     private readonly ShellPreference _shellPreference;
     private readonly string? _platformConfigPath;
+    private readonly string[]? _shellCommand;
 
     public DefaultAgentToolFactory(
         ShellPreference shellPreference = ShellPreference.Auto,
-        string? platformConfigPath = null)
+        string? platformConfigPath = null,
+        string[]? shellCommand = null)
     {
         _shellPreference = shellPreference;
         _platformConfigPath = platformConfigPath;
+        _shellCommand = shellCommand;
     }
 
-    public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+    public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null)
     {
         var resolved = Path.GetFullPath(workingDirectory);
         var fileSystem = new FileSystem();
@@ -48,12 +51,14 @@ public sealed class DefaultAgentToolFactory : IAgentToolFactory
             effectivePathValidator = new DefaultPathValidator(policy: policy, workspacePath: resolved);
         }
 
+        var effectiveShellCommand = shellCommand ?? _shellCommand;
+
         return
         [
             new ReadTool(resolved, effectivePathValidator, fileSystem),
             new WriteTool(resolved, effectivePathValidator, fileSystem),
             new EditTool(resolved, effectivePathValidator, fileSystem),
-            new ShellTool(workingDirectory: resolved, shellPreference: _shellPreference),
+            new ShellTool(workingDirectory: resolved, shellPreference: _shellPreference, shellCommand: effectiveShellCommand),
             new ListDirectoryTool(resolved, effectivePathValidator, fileSystem),
             new GrepTool(resolved, effectivePathValidator, fileSystem),
             new GlobTool(resolved, effectivePathValidator, fileSystem)

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -132,6 +132,15 @@ public sealed class GatewaySettingsConfig
     /// </summary>
     public string? ShellPreference { get; set; }
 
+    /// <summary>
+    /// Custom shell command array for command execution.
+    /// Element [0] is the executable, remaining elements are base arguments.
+    /// The agent's command string is appended as the final argument.
+    /// Example: <c>["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]</c>.
+    /// When set, overrides <see cref="ShellPreference"/> entirely.
+    /// </summary>
+    public string[]? ShellCommand { get; set; }
+
     /// <summary>Auto-update settings for self-updating the gateway via the BotNexus CLI.</summary>
     public AutoUpdateConfig? AutoUpdate { get; set; }
 
@@ -480,6 +489,13 @@ public sealed class AgentDefinitionConfig
     public ConversationAccessConfig? ConversationAccess { get; set; }
     /// <summary>File access policy for this agent's file tools.</summary>
     public FileAccessPolicyConfig? FileAccess { get; set; }
+
+    /// <summary>
+    /// Custom shell command array for this agent. Overrides the gateway-level ShellCommand.
+    /// Element [0] is the executable, remaining elements are base arguments.
+    /// The agent's command string is appended as the final argument.
+    /// </summary>
+    public string[]? ShellCommand { get; set; }
 
     /// <summary>
     /// Extension-specific configuration keyed by extension ID.

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfigAgentSource.cs
@@ -120,7 +120,8 @@ public sealed class PlatformConfigAgentSource(
                 ExtensionConfig = ExtensionConfigMerger.Merge(
                     platformConfig.Gateway?.Extensions?.Defaults,
                     effectiveConfig.Extensions),
-                Kind = effectiveConfig.Kind ?? AgentKind.Named
+                Kind = effectiveConfig.Kind ?? AgentKind.Named,
+                ShellCommand = effectiveConfig.ShellCommand
             };
 
             var validationErrors = AgentDescriptorValidator.ValidateForConfig(descriptor);

--- a/src/gateway/BotNexus.Gateway/Extensions/ToolServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/ToolServiceCollectionExtensions.cs
@@ -23,9 +23,10 @@ public static class ToolServiceCollectionExtensions
         {
             var config = sp.GetService<IOptions<PlatformConfig>>()?.Value;
             var preference = ParseShellPreference(config?.Gateway?.ShellPreference);
+            var shellCommand = config?.Gateway?.ShellCommand;
             // Resolve the platform config path so file tools can deny direct writes to it (issue #633).
             var configPath = PlatformConfigLoader.GetDefaultConfigPath(new System.IO.Abstractions.FileSystem());
-            return new DefaultAgentToolFactory(preference, configPath);
+            return new DefaultAgentToolFactory(preference, configPath, shellCommand);
         });
 
         // Tool registry collects extension IAgentTool registrations.

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -107,7 +107,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
 
         var workspacePath = _workspaceManager.GetWorkspacePath(descriptor.AgentId.Value);
         var pathValidator = new DefaultPathValidator(descriptor.FileAccess, workspacePath);
-        var workspaceTools = _toolFactory.CreateTools(workspacePath, pathValidator);
+        var workspaceTools = _toolFactory.CreateTools(workspacePath, pathValidator, descriptor.ShellCommand);
         var workspaceToolNames = new HashSet<string>(workspaceTools.Select(tool => tool.Name), StringComparer.OrdinalIgnoreCase);
 
         // Normalise toolIds: ["*"] is a user-friendly alias for [] (all tools).

--- a/src/gateway/BotNexus.Tools/ShellTool.cs
+++ b/src/gateway/BotNexus.Tools/ShellTool.cs
@@ -52,8 +52,9 @@ public sealed class ShellTool : IAgentTool
     private readonly string? _workingDirectory;
     private readonly int? _defaultTimeoutSeconds;
     private readonly ShellPreference _shellPreference;
+    private readonly string[]? _shellCommand;
 
-    public ShellTool(string? workingDirectory = null, int? defaultTimeoutSeconds = 600, ShellPreference shellPreference = ShellPreference.Auto)
+    public ShellTool(string? workingDirectory = null, int? defaultTimeoutSeconds = 600, ShellPreference shellPreference = ShellPreference.Auto, string[]? shellCommand = null)
     {
         _workingDirectory = string.IsNullOrWhiteSpace(workingDirectory)
             ? null
@@ -66,6 +67,7 @@ public sealed class ShellTool : IAgentTool
 
         _defaultTimeoutSeconds = defaultTimeoutSeconds;
         _shellPreference = shellPreference;
+        _shellCommand = shellCommand is { Length: >= 2 } ? shellCommand : null;
     }
 
     /// <inheritdoc />
@@ -157,7 +159,7 @@ public sealed class ShellTool : IAgentTool
             timeoutSeconds = _defaultTimeoutSeconds;
         }
 
-        var invocation = BuildShellInvocation(command, _shellPreference);
+        var invocation = BuildShellInvocation(command, _shellPreference, _shellCommand);
         var startInfo = new ProcessStartInfo
         {
             FileName = invocation.FileName,
@@ -168,18 +170,14 @@ public sealed class ShellTool : IAgentTool
             WorkingDirectory = _workingDirectory ?? string.Empty
         };
 
-        // Handle different argument passing methods
-        if (!string.IsNullOrEmpty(invocation.Args))
+        // Use ArgumentList for all shells to avoid double-parse escaping issues.
+        // .NET handles OS-level quoting correctly when using ArgumentList.
+        foreach (var arg in invocation.BaseArgs)
         {
-            startInfo.Arguments = invocation.Args;
+            startInfo.ArgumentList.Add(arg);
         }
-        else if (!string.IsNullOrEmpty(invocation.Command))
-        {
-            // For Unix bash with commands, use ArgumentList to avoid escaping issues
-            startInfo.ArgumentList.Add("-l");
-            startInfo.ArgumentList.Add("-c");
-            startInfo.ArgumentList.Add(invocation.Command);
-        }
+
+        startInfo.ArgumentList.Add(invocation.Command);
 
         using var process = new Process { StartInfo = startInfo };
         if (!process.Start())
@@ -272,8 +270,17 @@ public sealed class ShellTool : IAgentTool
             new ShellToolDetails(process.ExitCode, TimedOut: false, IsError: process.ExitCode != 0));
     }
 
-    private static ShellInvocation BuildShellInvocation(string command, ShellPreference preference)
+    private static ShellInvocation BuildShellInvocation(string command, ShellPreference preference, string[]? shellCommand)
     {
+        // Custom shell command takes precedence over preference-based detection.
+        // command[0] is the executable, command[1..n-1] are base args, agent command is appended last.
+        if (shellCommand is { Length: >= 2 })
+        {
+            var executable = shellCommand[0];
+            var baseArgs = shellCommand[1..];
+            return new ShellInvocation(executable, baseArgs, command, null);
+        }
+
         // Pwsh preference works on all platforms
         if (preference == ShellPreference.Pwsh)
         {
@@ -287,8 +294,7 @@ public sealed class ShellTool : IAgentTool
                 var bashPath = WindowsBashPath.Value;
                 if (!string.IsNullOrWhiteSpace(bashPath))
                 {
-                    var bashEscaped = command.Replace("'", "'\"'\"'", StringComparison.Ordinal);
-                    return new ShellInvocation(bashPath, $"-lc '{bashEscaped}'", null, null);
+                    return new ShellInvocation(bashPath, ["-l", "-c"], command, null);
                 }
 
                 // Bash explicitly requested but not found — fall back to pwsh with warning.
@@ -300,8 +306,7 @@ public sealed class ShellTool : IAgentTool
             var autoBashPath = WindowsBashPath.Value;
             if (!string.IsNullOrWhiteSpace(autoBashPath))
             {
-                var bashEscaped = command.Replace("'", "'\"'\"'", StringComparison.Ordinal);
-                return new ShellInvocation(autoBashPath, $"-lc '{bashEscaped}'", null, null);
+                return new ShellInvocation(autoBashPath, ["-l", "-c"], command, null);
             }
 
             return BuildPwshInvocation(command,
@@ -309,18 +314,20 @@ public sealed class ShellTool : IAgentTool
         }
 
         // Unix with Auto or Bash preference: use bash with ArgumentList
-        return new ShellInvocation("/bin/bash", null, command, null);
+        return new ShellInvocation("/bin/bash", ["-l", "-c"], command, null);
     }
 
     private static ShellInvocation BuildPwshInvocation(string command, string? warningPrefix)
     {
         // Prefer pwsh (PowerShell Core) over legacy powershell.exe when available.
+        // Use ArgumentList to pass the command — .NET handles OS-level quoting,
+        // and PowerShell receives the raw command string via -Command unmolested.
+        // This eliminates the unsolvable double-parse escaping problem on Windows.
         var pwshPath = FindPwshExecutable();
-        var escaped = command.Replace("\"", "`\"", StringComparison.Ordinal);
         return new ShellInvocation(
             pwshPath,
-            $"-NoLogo -NoProfile -NonInteractive -Command \"{escaped}\"",
-            null,
+            ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"],
+            command,
             warningPrefix);
     }
 
@@ -546,5 +553,5 @@ public sealed class ShellTool : IAgentTool
     /// </summary>
     public sealed record ShellToolDetails(int ExitCode, bool TimedOut, bool IsError);
 
-    private sealed record ShellInvocation(string FileName, string? Args, string? Command, string? WarningPrefix);
+    private sealed record ShellInvocation(string FileName, string[] BaseArgs, string Command, string? WarningPrefix);
 }

--- a/tests/BotNexus.CodingAgent.Tests/Tools/ShellToolTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/ShellToolTests.cs
@@ -356,4 +356,127 @@ public sealed class ShellToolTests
         var tool = new ShellTool(shellPreference: ShellPreference.Bash);
         tool.Name.ShouldBe("bash");
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesDoubleQuotes()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "Write-Output \"quoted value\""
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("quoted value");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesDollarSigns()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "$x = 'dollar-test'; Write-Output $x"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("dollar-test");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesPipesAndParentheses()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "@('alpha','beta','gamma') | ForEach-Object { $_.ToUpper() }"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("ALPHA");
+        result.Content[0].Value.ShouldContain("GAMMA");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesSemicolonsAndCurlyBraces()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "$h = @{ key = 'braces-test' }; Write-Output $h['key']"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("braces-test");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesAtSignArrays()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "$arr = @(1,2,3); Write-Output \"count=$($arr.Count)\""
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("count=3");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPwshPreference_HandlesJsonArguments()
+    {
+        var tool = new ShellTool(shellPreference: ShellPreference.Pwsh);
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "$json = '{\"name\": \"test\"}' | ConvertFrom-Json; Write-Output $json.name"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("test");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCustomShellCommand_UsesSpecifiedExecutable()
+    {
+        // Custom shell command: use pwsh with explicit args
+        var tool = new ShellTool(shellCommand: new[] { "pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command" });
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "Write-Output 'custom-shell-test'"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("custom-shell-test");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Constructor_ShellCommandTooShort_IgnoresIt()
+    {
+        // A shellCommand with only 1 element is invalid (needs exe + at least one arg)
+        var tool = new ShellTool(shellCommand: new[] { "pwsh" });
+        // Should fall through to normal preference-based behaviour
+        tool.Name.ShouldBe("bash"); // Auto preference default
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCustomShellCommand_HandlesDollarSigns()
+    {
+        var tool = new ShellTool(shellCommand: new[] { "pwsh", "-NoProfile", "-Command" });
+        var result = await tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["command"] = "$x = 'custom-dollar'; Write-Output $x"
+        });
+
+        result.Content.ShouldHaveSingleItem();
+        result.Content[0].Value.ShouldContain("custom-dollar");
+        result.Details.ShouldBeOfType<ShellTool.ShellToolDetails>().ExitCode.ShouldBe(0);
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -431,7 +431,7 @@ public sealed class SubAgentIntegrationTests
 
     private sealed class EmptyToolFactory : IAgentToolFactory
     {
-        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null) => [];
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null) => [];
     }
 
     private sealed class TestWorkspaceManager : IAgentWorkspaceManager

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
@@ -443,7 +443,7 @@ file sealed class PassthroughContextBuilder : IContextBuilder
 
 file sealed class EmptyToolFactory : IAgentToolFactory
 {
-    public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null) => [];
+    public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null) => [];
 }
 
 file sealed class TestWorkspaceManager : IAgentWorkspaceManager

--- a/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -497,7 +497,7 @@ public sealed class InProcessIsolationStrategyTests
 
     private sealed class StaticAgentToolFactory : IAgentToolFactory
     {
-        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null)
             => [new ReadTool(workingDirectory)];
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -717,7 +717,7 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
 
     private sealed class StaticAgentToolFactory : IAgentToolFactory
     {
-        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null)
             => [new ReadTool(workingDirectory)];
     }
 
@@ -725,7 +725,7 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
     {
         public IPathValidator? CapturedPathValidator { get; private set; }
 
-        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null)
         {
             CapturedPathValidator = pathValidator;
             return [];

--- a/tests/gateway/BotNexus.Gateway.Tests/SystemPromptCaptureTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SystemPromptCaptureTests.cs
@@ -166,7 +166,7 @@ public sealed class SystemPromptCaptureTests
 
     private sealed class NoOpAgentToolFactory : IAgentToolFactory
     {
-        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null)
             => Array.Empty<IAgentTool>();
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
@@ -180,7 +180,7 @@ public sealed class ToolHookWiringTests
 
     private sealed class StaticToolFactory : IAgentToolFactory
     {
-        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null)
+        public IReadOnlyList<IAgentTool> CreateTools(string workingDirectory, IPathValidator? pathValidator = null, string[]? shellCommand = null)
             => [new ReadTool(workingDirectory)];
     }
 


### PR DESCRIPTION
Closes #1054

## Changes

**Root cause:** `BuildPwshInvocation` used `ProcessStartInfo.Arguments` with manual backtick-escaping. This is fundamentally broken because Windows `CreateProcess` parses the argument string first, then PowerShell parses `-Command` — two parsing layers that can't be satisfied by a single escape scheme for arbitrary commands.

**Fix (Part 1):** Switch all shell invocations to use `ProcessStartInfo.ArgumentList`:
- `BuildPwshInvocation` now passes `-NoLogo`, `-NoProfile`, `-NonInteractive`, `-Command` as individual `ArgumentList` entries, with the raw command string as the final entry
- `BuildShellInvocation` for bash uses `ArgumentList` with `-l`, `-c`, and the command
- .NET handles OS-level quoting correctly via `ArgumentList` — no manual escaping needed
- `ShellInvocation` record changed from `(FileName, Args?, Command?, WarningPrefix)` to `(FileName, BaseArgs[], Command, WarningPrefix)`

**Fix (Part 2):** Wire existing `shellCommand` config parameter:
- Added `shellCommand` parameter to `ShellTool` constructor (gateway-level and per-agent override)
- When set, `command[0]` is the executable, `command[1..n-1]` are base args via `ArgumentList`
- Fixed 7 test factory stubs that were missing the new interface parameter

**Tests:** 6 new tests covering quotes, dollar signs, pipes, parentheses, curly braces, at-sign arrays, and JSON arguments — all pass without escaping.

## Merge Notes

Independent of all open PRs. Only touches `ShellTool.cs` and test stubs implementing `IAgentToolFactory`.