### PR TITLE
feat(gateway): add memory pressure diagnostics with threshold monitoring and REST endpoint

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
@@ -11,10 +11,12 @@ namespace BotNexus.Gateway.Api.Controllers;
 [Route("api/diagnostics")]
 public sealed class DiagnosticsController(
     ILogger<DiagnosticsController> logger,
-    LogDiagnosticsRingBuffer? logBuffer = null) : ControllerBase
+    LogDiagnosticsRingBuffer? logBuffer = null,
+    MemoryPressureMonitor? memoryMonitor = null) : ControllerBase
 {
     private readonly ILogger<DiagnosticsController> _logger = logger;
     private readonly LogDiagnosticsRingBuffer? _logBuffer = logBuffer;
+    private readonly MemoryPressureMonitor? _memoryMonitor = memoryMonitor;
 
     /// <summary>
     /// Accepts an error report from any channel adapter and logs it at Error level.
@@ -87,6 +89,71 @@ public sealed class DiagnosticsController(
     }
 
     /// <summary>
+    /// Returns a point-in-time memory pressure snapshot with readable metrics,
+    /// threshold ratios, and actionable operator guidance.
+    /// </summary>
+    [HttpGet("memory-pressure")]
+    public IActionResult GetMemoryPressure()
+    {
+        if (_memoryMonitor is null)
+            return NotFound("Memory pressure monitoring not enabled.");
+
+        var snapshot = _memoryMonitor.CaptureSnapshot();
+        return Ok(new MemoryPressureDto
+        {
+            CapturedAt = snapshot.CapturedAt,
+            WorkingSetBytes = snapshot.WorkingSetBytes,
+            GcCommittedBytes = snapshot.GcCommittedBytes,
+            TotalAvailableBytes = snapshot.TotalAvailableBytes,
+            Gen0Collections = snapshot.Gen0Collections,
+            Gen1Collections = snapshot.Gen1Collections,
+            Gen2Collections = snapshot.Gen2Collections,
+            PressurePercent = snapshot.PressurePercent,
+            WorkingSetReadable = snapshot.WorkingSetReadable,
+            GcCommittedReadable = snapshot.GcCommittedReadable,
+            TotalAvailableReadable = snapshot.TotalAvailableReadable,
+            Level = snapshot.Level.ToString(),
+            Guidance = snapshot.Guidance
+        });
+    }
+
+    /// <summary>
+    /// Returns recent memory pressure snapshots for trend analysis.
+    /// </summary>
+    /// <param name="count">Number of recent snapshots to return (default 10, max 100).</param>
+    [HttpGet("memory-pressure/history")]
+    public IActionResult GetMemoryPressureHistory([FromQuery] int count = 10)
+    {
+        if (_memoryMonitor is null)
+            return NotFound("Memory pressure monitoring not enabled.");
+
+        count = Math.Clamp(count, 1, 100);
+        var history = _memoryMonitor.GetHistory(count);
+
+        return Ok(new MemoryPressureHistoryResponse
+        {
+            Snapshots = history.Select(s => new MemoryPressureDto
+            {
+                CapturedAt = s.CapturedAt,
+                WorkingSetBytes = s.WorkingSetBytes,
+                GcCommittedBytes = s.GcCommittedBytes,
+                TotalAvailableBytes = s.TotalAvailableBytes,
+                Gen0Collections = s.Gen0Collections,
+                Gen1Collections = s.Gen1Collections,
+                Gen2Collections = s.Gen2Collections,
+                PressurePercent = s.PressurePercent,
+                WorkingSetReadable = s.WorkingSetReadable,
+                GcCommittedReadable = s.GcCommittedReadable,
+                TotalAvailableReadable = s.TotalAvailableReadable,
+                Level = s.Level.ToString(),
+                Guidance = s.Guidance
+            }).ToList(),
+            Count = history.Count,
+            SnapshotsRetained = _memoryMonitor.SnapshotCount
+        });
+    }
+
+    /// <summary>
     /// Strips newline and carriage-return characters from a user-supplied string to prevent
     /// log injection (CodeQL: cs/log-forging). Null-safe.
     /// </summary>
@@ -141,4 +208,64 @@ public sealed class LogPatternsResponse
 
     /// <summary>Time window in hours that was queried.</summary>
     public required int Hours { get; init; }
+}
+
+/// <summary>
+/// DTO for a single memory pressure snapshot.
+/// </summary>
+public sealed class MemoryPressureDto
+{
+    /// <summary>When the snapshot was captured.</summary>
+    public required DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>Process working set (RSS) in bytes.</summary>
+    public required long WorkingSetBytes { get; init; }
+
+    /// <summary>GC committed bytes (managed heap + overhead).</summary>
+    public required long GcCommittedBytes { get; init; }
+
+    /// <summary>Total available memory as reported by GC.</summary>
+    public required long TotalAvailableBytes { get; init; }
+
+    /// <summary>Gen0 collection count.</summary>
+    public required int Gen0Collections { get; init; }
+
+    /// <summary>Gen1 collection count.</summary>
+    public required int Gen1Collections { get; init; }
+
+    /// <summary>Gen2 collection count.</summary>
+    public required int Gen2Collections { get; init; }
+
+    /// <summary>Percentage of available memory committed by GC (0-100).</summary>
+    public required double PressurePercent { get; init; }
+
+    /// <summary>Human-readable RSS (e.g. "142.3 MB").</summary>
+    public required string WorkingSetReadable { get; init; }
+
+    /// <summary>Human-readable GC committed (e.g. "98.7 MB").</summary>
+    public required string GcCommittedReadable { get; init; }
+
+    /// <summary>Human-readable total available (e.g. "2.0 GB").</summary>
+    public required string TotalAvailableReadable { get; init; }
+
+    /// <summary>Pressure level: Normal, Elevated, Critical.</summary>
+    public required string Level { get; init; }
+
+    /// <summary>Actionable next-step guidance for the operator.</summary>
+    public required string Guidance { get; init; }
+}
+
+/// <summary>
+/// Response wrapper for memory pressure history.
+/// </summary>
+public sealed class MemoryPressureHistoryResponse
+{
+    /// <summary>Recent snapshots ordered newest-first.</summary>
+    public required IReadOnlyList<MemoryPressureDto> Snapshots { get; init; }
+
+    /// <summary>Number of snapshots in this response.</summary>
+    public required int Count { get; init; }
+
+    /// <summary>Total snapshots retained in the ring buffer.</summary>
+    public required int SnapshotsRetained { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway/Diagnostics/MemoryPressureHostedService.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/MemoryPressureHostedService.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Background service that periodically captures memory pressure snapshots
+/// for trend analysis and proactive alerting.
+/// </summary>
+/// <remarks>
+/// Runs every 60 seconds by default. Snapshots are stored in the
+/// <see cref="MemoryPressureMonitor"/> ring buffer and surfaced via
+/// the diagnostics REST endpoint.
+/// </remarks>
+public sealed class MemoryPressureHostedService : BackgroundService
+{
+    private readonly MemoryPressureMonitor _monitor;
+    private readonly ILogger<MemoryPressureHostedService> _logger;
+    private readonly TimeSpan _interval;
+
+    /// <summary>
+    /// Creates a new memory pressure hosted service.
+    /// </summary>
+    /// <param name="monitor">The memory pressure monitor singleton.</param>
+    /// <param name="logger">Logger instance.</param>
+    /// <param name="interval">Optional override for the capture interval (default 60s).</param>
+    public MemoryPressureHostedService(
+        MemoryPressureMonitor monitor,
+        ILogger<MemoryPressureHostedService> logger,
+        TimeSpan? interval = null)
+    {
+        _monitor = monitor;
+        _logger = logger;
+        _interval = interval ?? TimeSpan.FromSeconds(60);
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Memory pressure monitoring started (interval: {Interval}s)", _interval.TotalSeconds);
+
+        // Capture an initial snapshot immediately
+        _monitor.CaptureSnapshot();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(_interval, stoppingToken).ConfigureAwait(false);
+            _monitor.CaptureSnapshot();
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/MemoryPressureMonitor.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/MemoryPressureMonitor.cs
@@ -1,0 +1,169 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Monitors memory pressure via GC and Process APIs, periodically captures snapshots,
+/// and logs actionable warnings when thresholds are exceeded.
+/// </summary>
+/// <remarks>
+/// Snapshots are retained in a bounded ring buffer for API consumption.
+/// The monitor logs at WARN level when pressure is Elevated, and ERROR when Critical.
+/// </remarks>
+public sealed class MemoryPressureMonitor
+{
+    private readonly ILogger<MemoryPressureMonitor> _logger;
+    private readonly List<MemoryPressureSnapshot> _history = new();
+    private readonly object _lock = new();
+    private readonly int _maxSnapshots;
+
+    /// <summary>Threshold ratio (0-1) above which pressure is considered Elevated.</summary>
+    public const double ElevatedThreshold = 0.70;
+
+    /// <summary>Threshold ratio (0-1) above which pressure is considered Critical.</summary>
+    public const double CriticalThreshold = 0.90;
+
+    /// <summary>
+    /// Creates a new memory pressure monitor.
+    /// </summary>
+    /// <param name="logger">Logger instance for pressure events.</param>
+    /// <param name="maxSnapshots">Maximum number of snapshots to retain (default 100).</param>
+    public MemoryPressureMonitor(ILogger<MemoryPressureMonitor> logger, int maxSnapshots = 100)
+    {
+        _logger = logger;
+        _maxSnapshots = maxSnapshots;
+    }
+
+    /// <summary>
+    /// Captures a point-in-time memory pressure snapshot and adds it to the history ring buffer.
+    /// Logs at WARN or ERROR level if pressure thresholds are exceeded.
+    /// </summary>
+    /// <returns>The captured snapshot.</returns>
+    public MemoryPressureSnapshot CaptureSnapshot()
+    {
+        var gcInfo = GC.GetGCMemoryInfo();
+        var process = Process.GetCurrentProcess();
+
+        var workingSet = process.WorkingSet64;
+        var gcCommitted = gcInfo.TotalCommittedBytes;
+        var totalAvailable = gcInfo.TotalAvailableMemoryBytes;
+
+        var pressurePercent = totalAvailable > 0
+            ? (double)gcCommitted / totalAvailable * 100.0
+            : 0.0;
+
+        var level = pressurePercent switch
+        {
+            >= CriticalThreshold * 100 => MemoryPressureLevel.Critical,
+            >= ElevatedThreshold * 100 => MemoryPressureLevel.Elevated,
+            _ => MemoryPressureLevel.Normal
+        };
+
+        var guidance = level switch
+        {
+            MemoryPressureLevel.Critical =>
+                "Memory pressure is critical. Consider restarting the gateway, reducing concurrent sessions, or increasing available memory.",
+            MemoryPressureLevel.Elevated =>
+                "Memory pressure is elevated. Monitor for growth trends. Consider compacting long-running sessions or archiving idle conversations.",
+            _ =>
+                "Memory usage is within normal bounds. No action required."
+        };
+
+        var snapshot = new MemoryPressureSnapshot
+        {
+            CapturedAt = DateTimeOffset.UtcNow,
+            WorkingSetBytes = workingSet,
+            GcCommittedBytes = gcCommitted,
+            TotalAvailableBytes = totalAvailable,
+            Gen0Collections = GC.CollectionCount(0),
+            Gen1Collections = GC.CollectionCount(1),
+            Gen2Collections = GC.CollectionCount(2),
+            PressurePercent = Math.Round(pressurePercent, 2),
+            WorkingSetReadable = FormatBytes(workingSet),
+            GcCommittedReadable = FormatBytes(gcCommitted),
+            TotalAvailableReadable = FormatBytes(totalAvailable),
+            Level = level,
+            Guidance = guidance
+        };
+
+        LogIfPressured(snapshot);
+        AddToHistory(snapshot);
+
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Returns the most recent N snapshots (newest first).
+    /// </summary>
+    /// <param name="count">Number of snapshots to return (default 10, max equals maxSnapshots).</param>
+    public IReadOnlyList<MemoryPressureSnapshot> GetHistory(int count = 10)
+    {
+        lock (_lock)
+        {
+            count = Math.Clamp(count, 1, _history.Count);
+            return _history
+                .OrderByDescending(s => s.CapturedAt)
+                .Take(count)
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of snapshots currently retained.
+    /// </summary>
+    public int SnapshotCount
+    {
+        get { lock (_lock) { return _history.Count; } }
+    }
+
+    private void AddToHistory(MemoryPressureSnapshot snapshot)
+    {
+        lock (_lock)
+        {
+            _history.Add(snapshot);
+            if (_history.Count > _maxSnapshots)
+                _history.RemoveAt(0);
+        }
+    }
+
+    private void LogIfPressured(MemoryPressureSnapshot snapshot)
+    {
+        if (snapshot.Level == MemoryPressureLevel.Critical)
+        {
+            _logger.LogError(
+                "Memory pressure CRITICAL: {PressurePercent}% committed ({GcCommitted} / {TotalAvailable}). RSS={WorkingSet}. {Guidance}",
+                snapshot.PressurePercent,
+                snapshot.GcCommittedReadable,
+                snapshot.TotalAvailableReadable,
+                snapshot.WorkingSetReadable,
+                snapshot.Guidance);
+        }
+        else if (snapshot.Level == MemoryPressureLevel.Elevated)
+        {
+            _logger.LogWarning(
+                "Memory pressure elevated: {PressurePercent}% committed ({GcCommitted} / {TotalAvailable}). RSS={WorkingSet}. {Guidance}",
+                snapshot.PressurePercent,
+                snapshot.GcCommittedReadable,
+                snapshot.TotalAvailableReadable,
+                snapshot.WorkingSetReadable,
+                snapshot.Guidance);
+        }
+    }
+
+    /// <summary>
+    /// Formats a byte count into a human-readable string (e.g. "142.3 MB").
+    /// </summary>
+    internal static string FormatBytes(long bytes)
+    {
+        if (bytes < 0) return "0 B";
+
+        return bytes switch
+        {
+            < 1024L => $"{bytes} B",
+            < 1024L * 1024 => $"{bytes / 1024.0:F1} KB",
+            < 1024L * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
+            _ => $"{bytes / (1024.0 * 1024 * 1024):F2} GB"
+        };
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/MemoryPressureSnapshot.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/MemoryPressureSnapshot.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Represents a point-in-time memory pressure snapshot with readable metrics,
+/// threshold ratios, and actionable operator guidance.
+/// </summary>
+public sealed class MemoryPressureSnapshot
+{
+    /// <summary>Timestamp when the snapshot was captured.</summary>
+    public required DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>Process Resident Set Size (working set) in bytes.</summary>
+    public required long WorkingSetBytes { get; init; }
+
+    /// <summary>GC total committed bytes (managed heap + GC overhead).</summary>
+    public required long GcCommittedBytes { get; init; }
+
+    /// <summary>GC total available memory in bytes (as reported by GCMemoryInfo).</summary>
+    public required long TotalAvailableBytes { get; init; }
+
+    /// <summary>Current Gen0 collection count since process start.</summary>
+    public required int Gen0Collections { get; init; }
+
+    /// <summary>Current Gen1 collection count since process start.</summary>
+    public required int Gen1Collections { get; init; }
+
+    /// <summary>Current Gen2 collection count since process start.</summary>
+    public required int Gen2Collections { get; init; }
+
+    /// <summary>Percentage of total available memory currently committed by the GC (0-100).</summary>
+    public required double PressurePercent { get; init; }
+
+    /// <summary>Human-readable RSS (e.g. "142.3 MB").</summary>
+    public required string WorkingSetReadable { get; init; }
+
+    /// <summary>Human-readable GC committed (e.g. "98.7 MB").</summary>
+    public required string GcCommittedReadable { get; init; }
+
+    /// <summary>Human-readable total available (e.g. "2.0 GB").</summary>
+    public required string TotalAvailableReadable { get; init; }
+
+    /// <summary>
+    /// Pressure level: Normal, Elevated, Critical.
+    /// </summary>
+    public required MemoryPressureLevel Level { get; init; }
+
+    /// <summary>
+    /// Actionable next-step guidance for the operator based on the current pressure level.
+    /// </summary>
+    public required string Guidance { get; init; }
+}
+
+/// <summary>
+/// Discrete pressure levels for memory diagnostics.
+/// </summary>
+public enum MemoryPressureLevel
+{
+    /// <summary>Memory usage is within normal bounds (&lt;70% of available).</summary>
+    Normal,
+
+    /// <summary>Memory usage is elevated (70-90% of available). Monitor closely.</summary>
+    Elevated,
+
+    /// <summary>Memory usage is critical (&gt;90% of available). Consider restarting or reducing load.</summary>
+    Critical
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -193,6 +193,10 @@ public static class GatewayServiceCollectionExtensions
             return new SqliteExtensionStateStore(dbPath, fs, storeLogger);
         });
 
+        // Memory pressure diagnostics
+        services.AddSingleton<Diagnostics.MemoryPressureMonitor>();
+        services.AddHostedService<Diagnostics.MemoryPressureHostedService>();
+
         // Built-in tools
         services.AddBotNexusTools();
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/MemoryPressureEndpointTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/MemoryPressureEndpointTests.cs
@@ -1,0 +1,106 @@
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Diagnostics;
+
+public sealed class MemoryPressureEndpointTests
+{
+    private readonly MemoryPressureMonitor _monitor;
+    private readonly DiagnosticsController _controller;
+
+    public MemoryPressureEndpointTests()
+    {
+        _monitor = new MemoryPressureMonitor(
+            NullLogger<MemoryPressureMonitor>.Instance);
+        _controller = new DiagnosticsController(
+            NullLogger<DiagnosticsController>.Instance,
+            logBuffer: null,
+            memoryMonitor: _monitor);
+    }
+
+    [Fact]
+    public void GetMemoryPressure_ReturnsOkWithSnapshot()
+    {
+        var result = _controller.GetMemoryPressure();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<MemoryPressureDto>(ok.Value);
+        Assert.True(dto.WorkingSetBytes > 0);
+        Assert.True(dto.GcCommittedBytes > 0);
+        Assert.True(dto.TotalAvailableBytes > 0);
+        Assert.True(dto.PressurePercent >= 0);
+        Assert.NotEmpty(dto.WorkingSetReadable);
+        Assert.NotEmpty(dto.GcCommittedReadable);
+        Assert.NotEmpty(dto.TotalAvailableReadable);
+        Assert.NotEmpty(dto.Level);
+        Assert.NotEmpty(dto.Guidance);
+    }
+
+    [Fact]
+    public void GetMemoryPressure_ReturnsNotFound_WhenMonitorNull()
+    {
+        var controller = new DiagnosticsController(
+            NullLogger<DiagnosticsController>.Instance,
+            logBuffer: null,
+            memoryMonitor: null);
+
+        var result = controller.GetMemoryPressure();
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetMemoryPressureHistory_ReturnsOkWithSnapshots()
+    {
+        // Capture a few snapshots first
+        _monitor.CaptureSnapshot();
+        _monitor.CaptureSnapshot();
+
+        var result = _controller.GetMemoryPressureHistory(count: 10);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<MemoryPressureHistoryResponse>(ok.Value);
+        // +1 because GetMemoryPressureHistory doesn't capture, but GetMemoryPressure does
+        // so we just check we get at least 2 from our manual captures
+        Assert.True(response.Snapshots.Count >= 2);
+        Assert.True(response.SnapshotsRetained >= 2);
+    }
+
+    [Fact]
+    public void GetMemoryPressureHistory_ClampsCount()
+    {
+        _monitor.CaptureSnapshot();
+
+        var result = _controller.GetMemoryPressureHistory(count: 500);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<MemoryPressureHistoryResponse>(ok.Value);
+        Assert.Single(response.Snapshots);
+    }
+
+    [Fact]
+    public void GetMemoryPressureHistory_ReturnsNotFound_WhenMonitorNull()
+    {
+        var controller = new DiagnosticsController(
+            NullLogger<DiagnosticsController>.Instance,
+            logBuffer: null,
+            memoryMonitor: null);
+
+        var result = controller.GetMemoryPressureHistory();
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetMemoryPressure_Dto_LevelIsValidString()
+    {
+        var result = _controller.GetMemoryPressure();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<MemoryPressureDto>(ok.Value);
+        Assert.Contains(dto.Level, new[] { "Normal", "Elevated", "Critical" });
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/MemoryPressureMonitorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/MemoryPressureMonitorTests.cs
@@ -1,0 +1,161 @@
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Diagnostics;
+
+public sealed class MemoryPressureMonitorTests
+{
+    private readonly MemoryPressureMonitor _monitor;
+
+    public MemoryPressureMonitorTests()
+    {
+        _monitor = new MemoryPressureMonitor(
+            NullLogger<MemoryPressureMonitor>.Instance);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_ReturnsValidSnapshot()
+    {
+        var snapshot = _monitor.CaptureSnapshot();
+
+        Assert.True(snapshot.WorkingSetBytes > 0);
+        Assert.True(snapshot.GcCommittedBytes > 0);
+        Assert.True(snapshot.TotalAvailableBytes > 0);
+        Assert.True(snapshot.PressurePercent >= 0);
+        Assert.True(snapshot.PressurePercent <= 100);
+        Assert.NotNull(snapshot.WorkingSetReadable);
+        Assert.NotNull(snapshot.GcCommittedReadable);
+        Assert.NotNull(snapshot.TotalAvailableReadable);
+        Assert.NotNull(snapshot.Guidance);
+        Assert.True(snapshot.CapturedAt <= DateTimeOffset.UtcNow);
+        Assert.True(snapshot.Gen0Collections >= 0);
+        Assert.True(snapshot.Gen1Collections >= 0);
+        Assert.True(snapshot.Gen2Collections >= 0);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_AddsToHistory()
+    {
+        Assert.Equal(0, _monitor.SnapshotCount);
+
+        _monitor.CaptureSnapshot();
+
+        Assert.Equal(1, _monitor.SnapshotCount);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_MultipleCaptures_IncrementsHistory()
+    {
+        _monitor.CaptureSnapshot();
+        _monitor.CaptureSnapshot();
+        _monitor.CaptureSnapshot();
+
+        Assert.Equal(3, _monitor.SnapshotCount);
+    }
+
+    [Fact]
+    public void GetHistory_ReturnsNewestFirst()
+    {
+        _monitor.CaptureSnapshot();
+        Thread.Sleep(10);
+        _monitor.CaptureSnapshot();
+
+        var history = _monitor.GetHistory(2);
+
+        Assert.Equal(2, history.Count);
+        Assert.True(history[0].CapturedAt >= history[1].CapturedAt);
+    }
+
+    [Fact]
+    public void GetHistory_RespectsCount()
+    {
+        for (int i = 0; i < 5; i++)
+            _monitor.CaptureSnapshot();
+
+        var history = _monitor.GetHistory(3);
+
+        Assert.Equal(3, history.Count);
+    }
+
+    [Fact]
+    public void GetHistory_ClampsToAvailable()
+    {
+        _monitor.CaptureSnapshot();
+        _monitor.CaptureSnapshot();
+
+        var history = _monitor.GetHistory(50);
+
+        Assert.Equal(2, history.Count);
+    }
+
+    [Fact]
+    public void RingBuffer_EvictsOldestWhenFull()
+    {
+        var smallMonitor = new MemoryPressureMonitor(
+            NullLogger<MemoryPressureMonitor>.Instance, maxSnapshots: 3);
+
+        for (int i = 0; i < 5; i++)
+            smallMonitor.CaptureSnapshot();
+
+        Assert.Equal(3, smallMonitor.SnapshotCount);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_Level_IsNormal_UnderTypicalConditions()
+    {
+        // Under test conditions, memory usage should be well under 70%
+        var snapshot = _monitor.CaptureSnapshot();
+
+        // Most test environments won't hit Elevated or Critical
+        Assert.Equal(MemoryPressureLevel.Normal, snapshot.Level);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_Guidance_IsNotEmpty()
+    {
+        var snapshot = _monitor.CaptureSnapshot();
+
+        Assert.NotEmpty(snapshot.Guidance);
+        Assert.Contains("action", snapshot.Guidance, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(0L, "0 B")]
+    [InlineData(512L, "512 B")]
+    [InlineData(1024L, "1.0 KB")]
+    [InlineData(1024L * 1024, "1.0 MB")]
+    [InlineData(1024L * 1024 * 500, "500.0 MB")]
+    [InlineData(1024L * 1024 * 1024, "1.00 GB")]
+    [InlineData(1024L * 1024 * 1024 * 2, "2.00 GB")]
+    public void FormatBytes_FormatsCorrectly(long bytes, string expected)
+    {
+        var result = MemoryPressureMonitor.FormatBytes(bytes);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FormatBytes_NegativeBytes_ReturnsZero()
+    {
+        var result = MemoryPressureMonitor.FormatBytes(-100);
+
+        Assert.Equal("0 B", result);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_LogsWarning_WhenElevated()
+    {
+        // We can't easily force elevated pressure in tests, but we verify
+        // the monitor doesn't throw under normal conditions
+        var snapshot = _monitor.CaptureSnapshot();
+        Assert.NotNull(snapshot);
+    }
+
+    [Fact]
+    public void PressureLevel_ThresholdsAreCorrect()
+    {
+        Assert.Equal(0.70, MemoryPressureMonitor.ElevatedThreshold);
+        Assert.Equal(0.90, MemoryPressureMonitor.CriticalThreshold);
+    }
+}


### PR DESCRIPTION
Closes #1005

## Changes

- **MemoryPressureMonitor**: singleton that captures GC/Process memory snapshots, classifies pressure level (Normal/Elevated/Critical), provides human-readable metrics and actionable operator guidance
- **MemoryPressureHostedService**: background service capturing snapshots every 60s into a bounded ring buffer
- **MemoryPressureSnapshot**: model with raw bytes, readable strings, GC generation counts, and pressure percentage
- **REST endpoints**: GET /api/diagnostics/memory-pressure (live snapshot) and GET /api/diagnostics/memory-pressure/history (recent trend)
- **DI registration**: registered in GatewayServiceCollectionExtensions alongside existing diagnostics
- **25 tests**: 13 monitor unit tests (ring buffer, formatting, thresholds, history ordering) + 6 endpoint tests (OK/NotFound/clamping/level validation)

### Key design decisions
- Pressure thresholds: Elevated at 70%, Critical at 90% of GC TotalAvailableMemoryBytes
- Ring buffer retains 100 snapshots (default) with oldest eviction
- Logs at WARN for Elevated, ERROR for Critical with actionable guidance
- FormatBytes helper provides human-readable units (B/KB/MB/GB)
- Endpoint returns both raw bytes AND readable strings for diagnostics consumers

## Merge Notes
Independent of all open PRs. DiagnosticsController.cs is not touched by any other PR. Safe to merge in any order.