### PR TITLE
fix(tools): handle surrogate pairs in EditTool fuzzy text normalization

### DIFF
--- a/src/gateway/BotNexus.Tools/EditTool.cs
+++ b/src/gateway/BotNexus.Tools/EditTool.cs
@@ -396,6 +396,36 @@ public sealed class EditTool : IAgentTool
 
             for (var i = lineStart; i < trimmedEnd; i++)
             {
+                // Surrogate pairs (emoji, supplementary plane chars) must be emitted together.
+                // Processing a lone high surrogate through .Normalize() throws ArgumentException.
+                if (char.IsHighSurrogate(text[i]))
+                {
+                    if (i + 1 < trimmedEnd && char.IsLowSurrogate(text[i + 1]))
+                    {
+                        normalized.Append(text[i]);
+                        indexMap.Add(i);
+                        normalized.Append(text[i + 1]);
+                        indexMap.Add(i + 1);
+                        i++;
+                    }
+                    else
+                    {
+                        // Lone surrogate — emit replacement character to avoid crash
+                        normalized.Append('\uFFFD');
+                        indexMap.Add(i);
+                    }
+
+                    continue;
+                }
+
+                // Lone low surrogate without preceding high — also replace
+                if (char.IsLowSurrogate(text[i]))
+                {
+                    normalized.Append('\uFFFD');
+                    indexMap.Add(i);
+                    continue;
+                }
+
                 var mapped = NormalizeFuzzyText(text[i]);
                 foreach (var mappedChar in mapped)
                 {

--- a/tests/BotNexus.CodingAgent.Tests/Tools/EditToolSurrogatePairTests.cs
+++ b/tests/BotNexus.CodingAgent.Tests/Tools/EditToolSurrogatePairTests.cs
@@ -1,0 +1,166 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Tools;
+
+namespace BotNexus.CodingAgent.Tests.Tools;
+
+/// <summary>
+/// Tests for surrogate pair and emoji handling in EditTool fuzzy matching.
+/// Regression coverage for issue #1061: NormalizeFuzzyText crashed on files containing
+/// emoji or supplementary plane characters because it processed surrogate pairs char-by-char.
+/// </summary>
+public sealed class EditToolSurrogatePairTests
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), "tools", "edit-surrogate");
+    private readonly MockFileSystem _fileSystem = new();
+    private readonly EditTool _tool;
+
+    public EditToolSurrogatePairTests()
+    {
+        _fileSystem.Directory.CreateDirectory(_tempDirectory);
+        _tool = new EditTool(_tempDirectory, _fileSystem);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FileContainingEmoji_EditsSuccessfully()
+    {
+        // Regression: surrogate pairs (emoji) crashed NormalizeFuzzyText with
+        // "String contains invalid Unicode code points" (ArgumentException)
+        var filePath = Path.Combine(_tempDirectory, "emoji.txt");
+        // U+1F52C = microscope emoji, stored as surrogate pair \uD83D\uDD2C
+        await _fileSystem.File.WriteAllTextAsync(filePath, "Hello \U0001F52C world");
+
+        await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["path"] = "emoji.txt",
+            ["edits"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["oldText"] = "Hello \U0001F52C world",
+                    ["newText"] = "Goodbye \U0001F52C world"
+                }
+            }
+        });
+
+        (await _fileSystem.File.ReadAllTextAsync(filePath)).ShouldBe("Goodbye \U0001F52C world");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleEmojiInFile_FuzzyMatchStillWorks()
+    {
+        // File has emoji + smart quotes - fuzzy match should handle both
+        var filePath = Path.Combine(_tempDirectory, "emoji-fuzzy.txt");
+        // U+1F680 = rocket, U+1F389 = party popper, with curly quotes
+        await _fileSystem.File.WriteAllTextAsync(filePath, "\U0001F680 Launch \u201Capp\u201D now \U0001F389");
+
+        await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["path"] = "emoji-fuzzy.txt",
+            ["edits"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    // Agent sends straight quotes - fuzzy match should find curly quotes
+                    ["oldText"] = "\U0001F680 Launch \"app\" now \U0001F389",
+                    ["newText"] = "\U0001F680 Deploy \"app\" now \U0001F389"
+                }
+            }
+        });
+
+        (await _fileSystem.File.ReadAllTextAsync(filePath)).ShouldContain("Deploy");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmojiAdjacentToEditTarget_DoesNotCrash()
+    {
+        // Edit target is sandwiched between emoji - ensures index mapping stays correct
+        var filePath = Path.Combine(_tempDirectory, "emoji-adjacent.txt");
+        await _fileSystem.File.WriteAllTextAsync(filePath, "prefix\U0001F52Ctarget\U0001F52Csuffix");
+
+        await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["path"] = "emoji-adjacent.txt",
+            ["edits"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["oldText"] = "target",
+                    ["newText"] = "replaced"
+                }
+            }
+        });
+
+        (await _fileSystem.File.ReadAllTextAsync(filePath)).ShouldBe("prefix\U0001F52Creplaced\U0001F52Csuffix");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReplacementCharInFile_DoesNotCrash()
+    {
+        // U+FFFD (replacement character) appears in files when .NET reads corrupt UTF-8.
+        // The fuzzy matcher should handle it gracefully.
+        var filePath = Path.Combine(_tempDirectory, "replacement-char.txt");
+        _fileSystem.File.WriteAllText(filePath, "before \uFFFD after");
+
+        await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["path"] = "replacement-char.txt",
+            ["edits"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["oldText"] = "before",
+                    ["newText"] = "changed"
+                }
+            }
+        });
+
+        (await _fileSystem.File.ReadAllTextAsync(filePath)).ShouldStartWith("changed");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EditTargetContainsEmoji_ExactMatch()
+    {
+        // The oldText itself contains emoji - exact match path
+        var filePath = Path.Combine(_tempDirectory, "emoji-in-oldtext.txt");
+        // U+1F7E2 = green circle, U+1F534 = red circle
+        await _fileSystem.File.WriteAllTextAsync(filePath, "Status: \U0001F7E2 Online\nEnd");
+
+        await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["path"] = "emoji-in-oldtext.txt",
+            ["edits"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["oldText"] = "Status: \U0001F7E2 Online",
+                    ["newText"] = "Status: \U0001F534 Offline"
+                }
+            }
+        });
+
+        (await _fileSystem.File.ReadAllTextAsync(filePath)).ShouldBe("Status: \U0001F534 Offline\nEnd");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmojiOnlyLine_FuzzyMatchPreservesIndexing()
+    {
+        // A line that is entirely emoji - tests that index map stays valid
+        var filePath = Path.Combine(_tempDirectory, "emoji-line.txt");
+        await _fileSystem.File.WriteAllTextAsync(filePath, "line1\n\U0001F52C\U0001F680\U0001F389\nline3");
+
+        await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["path"] = "emoji-line.txt",
+            ["edits"] = new object[]
+            {
+                new Dictionary<string, object?>
+                {
+                    ["oldText"] = "line3",
+                    ["newText"] = "updated"
+                }
+            }
+        });
+
+        (await _fileSystem.File.ReadAllTextAsync(filePath)).ShouldBe("line1\n\U0001F52C\U0001F680\U0001F389\nupdated");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `EditTool.NormalizeFuzzyText()` crashing on files containing emoji or supplementary plane characters.

## Root Cause

`NormalizeFuzzyMatchWithMap` iterated `text[i]` char-by-char and called `.ToString().Normalize(NormalizationForm.FormKC)` on each character. For supplementary Unicode characters (emoji like `U+1F52C`), .NET stores them as a surrogate pair (`U+D83D` + `U+DD2C`). Processing `U+D83D` alone produces a string with a lone surrogate, which `.Normalize()` rejects with `ArgumentException("String contains invalid Unicode code points")`.

This was the **#1 failure mode** across all file tools — **113 occurrences** in the session database, representing **77% of all edit tool errors**.

## Fix

- **Surrogate pairs**: detected and emitted together without normalization (supplementary plane characters don't have meaningful NFKC equivalents)
- **Lone surrogates**: replaced with U+FFFD (replacement character) to prevent crashes on corrupt files

## Tests

6 new tests in `EditToolSurrogatePairTests.cs`:
- File containing emoji edits successfully
- Multiple emoji with fuzzy match (smart quotes)
- Emoji adjacent to edit target (index mapping correctness)
- Replacement character in file
- Edit target contains emoji (exact match path)
- Emoji-only line (index map stability)

All 224 CodingAgent tests pass. All 178 Architecture tests pass. Full impacted-tests green.

## Affected Files

- `src/gateway/BotNexus.Tools/EditTool.cs` — surrogate handling in `NormalizeFuzzyMatchWithMap`
- `tests/BotNexus.CodingAgent.Tests/Tools/EditToolSurrogatePairTests.cs` — new test file

Closes #1061