### PR TITLE
docs: daily documentation grooming 2026-06-09

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,6 +68,7 @@ export default defineConfig({
           {
             text: 'Channels',
             items: [
+              { text: 'SignalR (Web Portal)', link: '/user-guide/channels/signalr' },
               { text: 'Telegram', link: '/user-guide/channels/telegram' },
               { text: 'Azure Service Bus', link: '/user-guide/channels/service-bus' },
               { text: 'Service Bus Envelope', link: '/user-guide/channels/service-bus-envelope' },
@@ -98,8 +99,14 @@ export default defineConfig({
         text: 'Extensions',
         items: [
           { text: 'Extension Development', link: '/extension-development' },
-          { text: 'Media Handlers', link: '/extensions/media-handlers' },
+          { text: 'Exec Tool', link: '/extensions/exec-tool' },
+          { text: 'Process Tool', link: '/extensions/process-tool' },
+          { text: 'Web Tools', link: '/extensions/web-tools' },
+          { text: 'Data Store', link: '/extensions/data-store' },
+          { text: 'MCP', link: '/extensions/mcp' },
+          { text: 'MCP Invoke', link: '/extensions/mcp-invoke' },
           { text: 'Debug Tool', link: '/extensions/debug-tool' },
+          { text: 'Media Handlers', link: '/extensions/media-handlers' },
         ],
       },
       {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -79,6 +79,20 @@ You should see the root command help listing all available subcommands.
 
 All commands support these options:
 
+### `--target <DIR>`
+
+Override the BotNexus home directory (where config, workspaces, and extensions live). Defaults to `~/.botnexus` or the `BOTNEXUS_HOME` environment variable.
+
+This enables managing multiple BotNexus instances from a single CLI installation.
+
+```powershell
+# Use a custom home directory
+botnexus --target D:\my-botnexus agent list
+
+# Validate config for a different instance
+botnexus --target /opt/botnexus-prod validate
+```
+
 ### `--verbose` (or `-v`)
 
 Show additional command output, including file paths and full JSON responses.

--- a/docs/extensions/data-store.md
+++ b/docs/extensions/data-store.md
@@ -1,0 +1,144 @@
+# Data Store
+
+The Data Store extension provides agents with a per-agent structured SQLite database for persistent data storage. Agents can ingest JSON arrays, run SQL queries, and manage tables — all through a single tool.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-data-store` |
+| Tool name | `data_store` |
+| Source | `BotNexus.Extensions.DataStore` |
+
+## Capabilities
+
+- Bulk ingest JSON arrays with automatic schema inference
+- Run SELECT queries against stored data
+- Insert individual rows
+- Delete rows matching conditions
+- Inspect table schemas
+- List all tables
+- Drop tables
+
+## Tool Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | Action: `ingest`, `query`, `insert`, `delete`, `schema`, `tables`, or `drop`. |
+| `table` | string | Conditional | Table name. Required for `ingest`, `insert`, `delete`, `schema`, `drop`. Lowercase alphanumeric + underscores only. |
+| `data` | string | Conditional | JSON array of objects for `ingest`, or single JSON object for `insert`. |
+| `sql` | string | Conditional | SELECT statement for `query` action. Only SELECT is permitted. |
+| `where` | string | Conditional | WHERE clause for `delete` action (required to prevent accidental full-table wipe). |
+
+## Configuration
+
+Enable the data store in your agent's extension config:
+
+```json
+{
+  "extensions": {
+    "botnexus-data-store": {
+      "enabled": true,
+      "maxSizeBytes": 52428800
+    }
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | false | Whether the data store tool is available to this agent. |
+| `maxSizeBytes` | integer | 52428800 (50 MB) | Maximum size for the per-agent SQLite database. |
+
+## Actions
+
+### `ingest`
+
+Bulk load a JSON array into a table. If the table doesn't exist, it is created with columns inferred from the first object's keys and value types.
+
+```json
+{
+  "action": "ingest",
+  "table": "contacts",
+  "data": "[{\"name\": \"Alice\", \"email\": \"alice@example.com\"}, {\"name\": \"Bob\", \"email\": \"bob@example.com\"}]"
+}
+```
+
+### `query`
+
+Run a SELECT statement and return results as JSON.
+
+```json
+{
+  "action": "query",
+  "sql": "SELECT name, email FROM contacts WHERE name LIKE 'A%'"
+}
+```
+
+### `insert`
+
+Add a single row to a table.
+
+```json
+{
+  "action": "insert",
+  "table": "contacts",
+  "data": "{\"name\": \"Charlie\", \"email\": \"charlie@example.com\"}"
+}
+```
+
+### `delete`
+
+Remove rows matching a WHERE clause. The `where` parameter is required to prevent accidental full-table deletion.
+
+```json
+{
+  "action": "delete",
+  "table": "contacts",
+  "where": "name = 'Bob'"
+}
+```
+
+### `schema`
+
+Show column names and types for a table.
+
+```json
+{
+  "action": "schema",
+  "table": "contacts"
+}
+```
+
+### `tables`
+
+List all tables in the agent's data store.
+
+```json
+{
+  "action": "tables"
+}
+```
+
+### `drop`
+
+Drop (permanently delete) a table.
+
+```json
+{
+  "action": "drop",
+  "table": "old_data"
+}
+```
+
+## Behavior Notes
+
+- Each agent has its own isolated SQLite database file.
+- Only SELECT queries are permitted via the `query` action — INSERT, UPDATE, DELETE, and DDL are blocked.
+- Schema is inferred from JSON types: strings → TEXT, numbers → REAL, booleans → INTEGER.
+- The database size is enforced at the configured limit; ingestion fails if the limit would be exceeded.
+- Table names must be lowercase alphanumeric with underscores only.
+
+## Related
+
+- [Configuration Reference](/configuration) — Full platform configuration reference

--- a/docs/extensions/exec-tool.md
+++ b/docs/extensions/exec-tool.md
@@ -1,0 +1,92 @@
+# Exec Tool
+
+The Exec Tool provides agents with advanced shell command execution including timeouts, background processes, stdin piping, and environment variable merging.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-exec-tool` |
+| Tool name | `exec` |
+| Source | `BotNexus.Extensions.ExecTool` |
+
+## Capabilities
+
+- Execute commands with configurable timeouts
+- Run processes in the background (returns PID immediately)
+- Pipe input to stdin
+- Set additional environment variables per invocation
+- Override working directory
+- Kill processes on inactivity (no-output timeout)
+- Windows `.cmd`/`.bat` resolution
+
+## Tool Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `command` | string[] | Yes | Command and arguments as an array. First element is the command, rest are args. |
+| `timeoutMs` | integer | No | Max execution time in milliseconds. Default: 120000 (2 min). |
+| `noOutputTimeoutMs` | integer | No | Kill if no output for this many ms. |
+| `input` | string | No | String to pipe to stdin. |
+| `background` | boolean | No | If true, start in background and return PID immediately. |
+| `env` | object | No | Additional environment variables to set. |
+| `workingDir` | string | No | Working directory override. |
+
+## Configuration
+
+The Exec Tool is enabled by default for all agents. No additional configuration is required.
+
+The tool respects the agent's workspace directory as the default working directory. Background processes are tracked in a shared registry and can be managed via the [Process Tool](./process-tool.md).
+
+## Usage Examples
+
+**Simple command:**
+```json
+{
+  "command": ["git", "status"]
+}
+```
+
+**With timeout and working directory:**
+```json
+{
+  "command": ["npm", "run", "build"],
+  "timeoutMs": 300000,
+  "workingDir": "/home/user/project"
+}
+```
+
+**Background process:**
+```json
+{
+  "command": ["npm", "run", "dev"],
+  "background": true
+}
+```
+
+**Piping stdin:**
+```json
+{
+  "command": ["pwsh", "-NoProfile", "-c", "Get-Content -"],
+  "input": "Hello from stdin"
+}
+```
+
+## Behavior Notes
+
+- Output is capped at 100 KB to prevent memory issues with verbose commands.
+- Background processes persist across tool calls within the same session and can be managed with the [Process Tool](./process-tool.md).
+- On Windows, the tool resolves `.cmd` and `.bat` files automatically when the command is not a full path.
+- The default timeout of 2 minutes applies unless overridden. Background processes have a separate 10-minute default.
+- When `noOutputTimeoutMs` is set, the process is killed if it produces no stdout/stderr within that window.
+
+## Security
+
+- Commands run with the same permissions as the BotNexus gateway process.
+- The `workingDir` parameter is validated against the agent's allowed paths when path policies are configured.
+- Environment variables set via `env` are merged with (not replacing) the parent process environment.
+
+## Related
+
+- [Process Tool](./process-tool.md) — Manage background processes started by Exec Tool
+- [Shell Execution Guide](/features/shell-execution) — Feature deep-dive on shell execution patterns

--- a/docs/extensions/mcp-invoke.md
+++ b/docs/extensions/mcp-invoke.md
@@ -1,0 +1,92 @@
+# MCP Invoke
+
+The MCP Invoke extension provides a single `invoke_mcp` tool for calling MCP servers on demand, without bridging their tools into the agent's main tool palette. Servers start lazily on first use and stay alive for the session.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-mcp-invoke` |
+| Tool name | `invoke_mcp` |
+| Source | `BotNexus.Extensions.McpInvoke` |
+
+## When to Use
+
+Use **MCP** (bridging) when:
+- You want MCP tools to appear directly in the agent's tool list
+- The agent should see and choose MCP tools naturally
+
+Use **MCP Invoke** when:
+- You have many MCP servers and don't want to pollute the tool list
+- Skills describe which servers and tools to call
+- You want on-demand server startup (no warmup cost)
+
+## Tool Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `server` | string | Yes | Server ID as configured in the extension config. |
+| `tool` | string | Yes | Tool name to invoke on the server. |
+| `arguments` | object | No | Arguments to pass to the MCP tool. |
+
+## Configuration
+
+```json
+{
+  "extensions": {
+    "botnexus-mcp-invoke": {
+      "enabled": true,
+      "servers": {
+        "github": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-github"],
+          "env": {
+            "GITHUB_TOKEN": "${env:GITHUB_TOKEN}"
+          }
+        },
+        "postgres": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-postgres"],
+          "env": {
+            "DATABASE_URL": "${env:DATABASE_URL}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | true | Whether the invoke_mcp tool is available. |
+| `servers` | object | `{}` | MCP servers accessible via invoke_mcp, keyed by server ID. |
+
+Server configuration follows the same schema as the [MCP extension](./mcp.md) (supports both stdio and HTTP/SSE transport).
+
+## Usage Example
+
+```json
+{
+  "server": "github",
+  "tool": "create_issue",
+  "arguments": {
+    "owner": "myorg",
+    "repo": "myrepo",
+    "title": "Bug: login page broken",
+    "body": "Steps to reproduce..."
+  }
+}
+```
+
+## Behavior Notes
+
+- Servers start lazily on first `invoke_mcp` call and remain alive for the session duration.
+- The agent never sees individual MCP tool schemas — it relies on skills or instructions to know which servers and tools are available.
+- If a server fails to start or a tool call times out, an error is returned to the agent.
+- Server configuration reuses the same `McpServerConfig` schema as the MCP bridging extension.
+
+## Related
+
+- [MCP](./mcp.md) — Bridge MCP tools directly into the agent's tool palette
+- [Skills](/skills) — Define skill documents that guide agents on which MCP tools to invoke

--- a/docs/extensions/mcp.md
+++ b/docs/extensions/mcp.md
@@ -1,0 +1,113 @@
+# MCP (Model Context Protocol)
+
+The MCP extension connects agents to external [Model Context Protocol](https://modelcontextprotocol.io/) servers, bridging their tools directly into the agent's tool palette. Each MCP server's tools appear as native agent tools.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-mcp` |
+| Tool names | Bridged from connected MCP servers (optionally prefixed with server ID) |
+| Source | `BotNexus.Extensions.Mcp` |
+
+## Capabilities
+
+- Connect to MCP servers via stdio (subprocess) or HTTP/SSE transport
+- Bridge MCP tools as native agent tools
+- Optional tool name prefixing for disambiguation
+- Server warmup and caching for faster session starts
+- Per-server timeouts for initialization and tool calls
+- Provider-based auth injection for HTTP/SSE servers
+
+## Configuration
+
+Configure MCP servers in your agent's extension config:
+
+```json
+{
+  "extensions": {
+    "botnexus-mcp": {
+      "servers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"],
+          "initTimeoutMs": 30000,
+          "callTimeoutMs": 60000
+        },
+        "remote-api": {
+          "url": "https://mcp.example.com/sse",
+          "headers": {
+            "X-Custom-Header": "value"
+          },
+          "auth": "my-provider-key"
+        }
+      },
+      "toolPrefix": true
+    }
+  }
+}
+```
+
+### Top-Level Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `servers` | object | `{}` | MCP servers keyed by server ID. |
+| `toolPrefix` | boolean | true | Prefix tool names with server ID (e.g., `filesystem__read_file`). |
+
+### Server Configuration (stdio transport)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | — | Command to spawn the MCP server process. |
+| `args` | string[] | — | Arguments for the server command. |
+| `env` | object | — | Environment variables for the server process. |
+| `workingDirectory` | string | — | Working directory for the server process. |
+| `inheritEnv` | boolean | true | Inherit parent process environment. Set `false` for production security. |
+| `initTimeoutMs` | integer | 30000 | Timeout for server initialization in milliseconds. |
+| `callTimeoutMs` | integer | 60000 | Timeout for tool calls in milliseconds. |
+
+### Server Configuration (HTTP/SSE transport)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `url` | string | — | URL for the MCP server endpoint. |
+| `headers` | object | — | Additional HTTP headers for requests. |
+| `auth` | string | — | BotNexus provider key for automatic Bearer token injection. |
+| `initTimeoutMs` | integer | 30000 | Timeout for server initialization. |
+| `callTimeoutMs` | integer | 60000 | Timeout for tool calls. |
+
+## Transport Types
+
+### Stdio
+
+The server runs as a subprocess. BotNexus spawns the process using `command` and `args`, communicating via stdin/stdout using the MCP JSON-RPC protocol.
+
+Best for: local tools, filesystem access, development servers.
+
+### HTTP/SSE
+
+The server runs externally and BotNexus connects via HTTP with Server-Sent Events for streaming.
+
+Best for: remote services, shared infrastructure, cloud-hosted MCP servers.
+
+## Auth Injection
+
+For HTTP/SSE servers, set the `auth` field to a BotNexus provider key. At session start, BotNexus resolves a Bearer token via `GetProviderApiKeyAsync` and injects it as an `Authorization: Bearer <token>` header.
+
+An explicit `Authorization` header in the `headers` config takes precedence over `auth`.
+
+## Security Considerations
+
+- **`inheritEnv: true` (default)**: The MCP subprocess inherits all parent environment variables, which may include secrets not intended for the server. Set to `false` for production servers.
+- **Tool prefixing**: When multiple servers expose tools with the same name, prefixing prevents collisions and makes tool provenance clear.
+- **Timeouts**: Configure `initTimeoutMs` and `callTimeoutMs` to prevent hung servers from blocking agent sessions.
+
+## Warmup Cache
+
+MCP servers are pre-started at gateway boot via `McpServerWarmupHostedService`. Tool schemas are cached so that agents don't wait for server initialization on their first tool call.
+
+## Related
+
+- [MCP Invoke](./mcp-invoke.md) — On-demand MCP server access without bridging
+- [Extension Development](/extension-development) — Building custom extensions

--- a/docs/extensions/process-tool.md
+++ b/docs/extensions/process-tool.md
@@ -1,0 +1,111 @@
+# Process Tool
+
+The Process Tool enables agents to manage background processes that were started via the [Exec Tool](./exec-tool.md). It provides listing, status checks, output reading, stdin writes, and process termination.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-process-tool` |
+| Tool name | `process` |
+| Source | `BotNexus.Extensions.ProcessTool` |
+
+## Capabilities
+
+- List all tracked background processes
+- Check process status (running, exited, exit code)
+- Read process output (stdout + stderr, with tail support)
+- Send input to a process's stdin
+- Kill a running process
+
+## Tool Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | Action to perform: `status`, `output`, `input`, `kill`, or `list`. |
+| `pid` | integer | Conditional | Process ID. Required for `status`, `output`, `input`, and `kill`. |
+| `content` | string | Conditional | Content to send to stdin (for `input` action). |
+| `tail` | integer | No | Number of lines from end of output (for `output` action). Default: 50. |
+| `timeout` | integer | No | For `status` action: wait up to N ms for the process to produce output. Default: 0 (no wait). |
+
+## Actions
+
+### `list`
+
+Returns all tracked background processes with their PIDs, commands, and running state.
+
+### `status`
+
+Returns whether a process is running or exited, its exit code (if exited), and duration. Optionally waits for output with a timeout.
+
+### `output`
+
+Returns the most recent output from a process. Use `tail` to limit the number of lines returned.
+
+### `input`
+
+Writes content to a process's stdin. Useful for interactive processes expecting input.
+
+### `kill`
+
+Terminates a running process and its entire process tree.
+
+## Configuration
+
+The Process Tool is enabled by default alongside the Exec Tool. No additional configuration is required.
+
+## Usage Examples
+
+**List all background processes:**
+```json
+{
+  "action": "list"
+}
+```
+
+**Check process status with wait:**
+```json
+{
+  "action": "status",
+  "pid": 12345,
+  "timeout": 5000
+}
+```
+
+**Read last 20 lines of output:**
+```json
+{
+  "action": "output",
+  "pid": 12345,
+  "tail": 20
+}
+```
+
+**Send input to a process:**
+```json
+{
+  "action": "input",
+  "pid": 12345,
+  "content": "yes\n"
+}
+```
+
+**Kill a process:**
+```json
+{
+  "action": "kill",
+  "pid": 12345
+}
+```
+
+## Behavior Notes
+
+- The Process Tool shares its process registry with the Exec Tool — it only manages processes started via `exec` with `background: true`.
+- Process output is buffered in memory. Very long-running processes may accumulate significant output.
+- The `kill` action terminates the entire process tree, not just the root process.
+- Process state persists within a session but does not survive gateway restarts.
+
+## Related
+
+- [Exec Tool](./exec-tool.md) — Start background processes
+- [Shell Execution Guide](/features/shell-execution) — Feature deep-dive on shell execution patterns

--- a/docs/extensions/web-tools.md
+++ b/docs/extensions/web-tools.md
@@ -1,0 +1,118 @@
+# Web Tools
+
+The Web Tools extension provides agents with web search and URL fetching capabilities. It supports multiple search providers and includes SSRF protection for secure deployments.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Extension ID | `botnexus-web-tools` |
+| Tool names | `web_search`, `web_fetch` |
+| Source | `BotNexus.Extensions.WebTools` |
+
+## Tools
+
+### `web_search`
+
+Search the web using a configurable provider and return formatted markdown results.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query. |
+
+### `web_fetch`
+
+Fetch a URL and return content as readable text or raw HTML. Supports pagination for large pages.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | Yes | URL to fetch. |
+| `raw` | boolean | No | If true, return raw HTML; if false, convert to readable text. Default: false. |
+| `max_length` | integer | No | Maximum characters to return. Default: 5000, max: 20000. |
+| `start_index` | integer | No | Character offset for pagination. Default: 0. |
+
+## Configuration
+
+Configure in your agent's extension config block:
+
+```json
+{
+  "extensions": {
+    "botnexus-web-tools": {
+      "search": {
+        "provider": "brave",
+        "apiKey": "${env:BRAVE_API_KEY}",
+        "maxResults": 5
+      },
+      "fetch": {
+        "maxLengthChars": 20000,
+        "timeoutSeconds": 30,
+        "userAgent": "BotNexus/1.0 (compatible; bot)",
+        "allowPrivateNetworks": false,
+        "additionalBlockedHosts": []
+      }
+    }
+  }
+}
+```
+
+### Search Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `provider` | string | `"brave"` | Search provider: `brave`, `tavily`, `bing`, or `copilot`. |
+| `apiKey` | string | — | API key for the search provider. Supports `${env:VAR}` syntax. |
+| `maxResults` | integer | 5 | Maximum number of results to return. |
+
+### Fetch Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `maxLengthChars` | integer | 20000 | Maximum content length in characters. |
+| `timeoutSeconds` | integer | 30 | HTTP timeout in seconds. |
+| `userAgent` | string | `"BotNexus/1.0 (compatible; bot)"` | User-Agent header for requests. |
+| `allowPrivateNetworks` | boolean | false | Allow requests to private/loopback IPs. See [Security](#security). |
+| `additionalBlockedHosts` | string[] | `[]` | Hostnames always blocked, even when `allowPrivateNetworks` is true. |
+
+## Search Providers
+
+| Provider | API Key Required | Notes |
+|----------|-----------------|-------|
+| `brave` | Yes | Brave Search API. Set `BRAVE_API_KEY`. |
+| `tavily` | Yes | Tavily Search API. Set `TAVILY_API_KEY`. |
+| `bing` | Yes | Bing Web Search API. Set `BING_API_KEY`. |
+| `copilot` | No | Uses GitHub Copilot MCP bridge (requires Copilot provider configured). |
+
+## Security
+
+### SSRF Protection
+
+By default, the fetch tool blocks requests to:
+
+- Private IP ranges (10.x.x.x, 172.16-31.x.x, 192.168.x.x)
+- Loopback addresses (127.0.0.1, ::1)
+- Link-local addresses (169.254.x.x, fe80::)
+- Cloud metadata endpoints (169.254.169.254)
+- Reserved IP ranges
+
+Set `allowPrivateNetworks: true` only for self-hosted deployments where agents legitimately need to reach internal services.
+
+### Host Blocking
+
+Use `additionalBlockedHosts` to block specific hostnames that resolve to public IPs but serve internal content:
+
+```json
+{
+  "additionalBlockedHosts": ["internal.corp.example", "secrets.internal"]
+}
+```
+
+## Behavior Notes
+
+- HTML content is automatically converted to readable text using an internal `HtmlToText` converter unless `raw: true` is specified.
+- The fetch tool respects `max_length` and `start_index` for paginating through large documents.
+- Search results are returned as formatted markdown with titles, URLs, and snippets.
+
+## Related
+
+- [Configuration Reference](/configuration) — Full platform configuration reference

--- a/docs/user-guide/channels/signalr.md
+++ b/docs/user-guide/channels/signalr.md
@@ -1,0 +1,84 @@
+# SignalR Channel
+
+The SignalR channel provides real-time bidirectional communication between agents and the BotNexus web portal (Blazor WebAssembly client). It is the primary channel for interactive browser-based agent conversations.
+
+## Overview
+
+The SignalR channel is built into the gateway and does not require external service setup. It uses ASP.NET Core SignalR with WebSocket transport for low-latency streaming.
+
+## Features
+
+- Real-time message streaming (token-by-token)
+- Tool call progress indicators
+- Conversation switching
+- Agent selection
+- Sub-agent session visibility
+- Steering queue display
+- Canvas rendering
+- File upload support
+
+## Configuration
+
+The SignalR channel is enabled by default when the gateway starts. The Blazor portal connects automatically at the configured gateway URL.
+
+```json
+{
+  "gateway": {
+    "urls": "http://localhost:5000"
+  }
+}
+```
+
+No additional channel-specific configuration is needed. The SignalR hub is exposed at `/hub/gateway`.
+
+## Architecture
+
+```text
+Browser (Blazor WASM)
+    ↕ WebSocket (SignalR)
+Gateway (/hub/gateway)
+    ↕
+SignalRChannelAdapter → GatewayHost → Agent Session
+```
+
+### Key Components
+
+| Component | Role |
+|-----------|------|
+| `GatewayHub` | ASP.NET Core SignalR hub handling client connections |
+| `SignalRChannelAdapter` | Implements `IChannelAdapter` for SignalR message routing |
+| `SignalRAgentChangeNotifier` | Pushes agent state changes to connected clients |
+| `SignalRConversationChangeNotifier` | Pushes conversation updates to clients |
+| `SignalRCanvasNotifier` | Delivers canvas HTML renders to the portal |
+| `SteeringSignalRBridge` | Routes steering queue events to the portal |
+| `SubAgentSignalRBridge` | Exposes sub-agent session events to the portal |
+
+## Portal Features
+
+The Blazor portal communicates exclusively via the SignalR channel:
+
+- **Chat panel**: Send messages, view streaming responses, tool call summaries
+- **Agent switcher**: Change active agent mid-conversation
+- **Conversation list**: Create, switch, and manage conversations
+- **Steering queue**: View pending steering entries per conversation
+- **Debug panel**: Inspect session state and history
+- **Canvas tab**: View agent-rendered HTML content
+- **PWA support**: Offline caching, installable as a desktop/mobile app
+
+## Comparison with Other Channels
+
+| Feature | SignalR | Telegram | Service Bus |
+|---------|--------|----------|-------------|
+| Transport | WebSocket | HTTPS polling | AMQP |
+| Latency | Very low | Medium | Low |
+| Streaming | Token-by-token | Message-level | Message-level |
+| Rich UI | Full (Blazor) | Limited (Telegram formatting) | None (headless) |
+| Auth | Cookie/Token | Bot token | Connection string |
+| Multi-user | Yes (per-connection) | Yes (per-chat) | Yes (per-subscription) |
+
+## Related
+
+- [WebUI Connection](/development/webui-connection) — Developer docs on the SignalR connection lifecycle
+- [WebSocket Protocol](/websocket-protocol) — Low-level protocol reference
+- [Telegram Channel](/user-guide/channels/telegram) — Alternative channel
+- [Service Bus Channel](/user-guide/channels/service-bus) — Alternative channel


### PR DESCRIPTION
## Changes

### New Extension Pages (6)
- `docs/extensions/exec-tool.md` — Shell execution tool with timeouts, background mode, stdin piping
- `docs/extensions/process-tool.md` — Background process management (list, status, output, kill)
- `docs/extensions/web-tools.md` — Web search (Brave/Tavily/Bing/Copilot) and URL fetch with SSRF protection
- `docs/extensions/data-store.md` — Per-agent SQLite data store with JSON ingestion and SQL queries
- `docs/extensions/mcp.md` — MCP server bridging (stdio + HTTP/SSE transport, warmup, auth injection)
- `docs/extensions/mcp-invoke.md` — On-demand MCP server access without tool bridging

### New Channel Page (1)
- `docs/user-guide/channels/signalr.md` — SignalR/WebSocket channel powering the Blazor web portal

### Content Updates
- `docs/cli-reference.md` — Added `--target` global option (from PR #1027) for multi-instance support

### Sidebar Changes
- Extensions section: added 6 new extension pages, reordered (Extension Dev → tools → utilities → Debug → Media)
- Channels sub-group: added SignalR (Web Portal) as first entry

---
Automated by the daily documentation groomer.