### PR TITLE
fix(gateway): debounce agent configuration reload notifications

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/AgentConfigurationHostedService.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentConfigurationHostedService.cs
@@ -11,6 +11,13 @@ internal sealed class AgentConfigurationHostedService(
     IAgentRegistry registry,
     ILogger<AgentConfigurationHostedService> logger) : IHostedService, IDisposable
 {
+    /// <summary>
+    /// Debounce window for config change notifications. Multiple rapid file system events
+    /// (e.g. workspace writes triggering config reload) are coalesced into a single apply
+    /// after this delay. Prevents reload storms from starving the threadpool.
+    /// </summary>
+    internal static readonly TimeSpan DebounceDelay = TimeSpan.FromSeconds(5);
+
     private readonly IAgentConfigurationSource[] _sources = sources.ToArray();
     private readonly IAgentRegistry _registry = registry;
     private readonly ILogger<AgentConfigurationHostedService> _logger = logger;
@@ -19,6 +26,8 @@ internal sealed class AgentConfigurationHostedService(
     private readonly Dictionary<IAgentConfigurationSource, IReadOnlyList<AgentDescriptor>> _latestSourceDescriptors = [];
     private readonly Dictionary<string, AgentDescriptor> _appliedConfigDescriptors = new(StringComparer.OrdinalIgnoreCase);
     private HashSet<string> _codeBasedAgentIds = new(StringComparer.OrdinalIgnoreCase);
+    private CancellationTokenSource? _debounceCts;
+    private int _coalescedChangeCount;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -56,20 +65,64 @@ internal sealed class AgentConfigurationHostedService(
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = null;
         DisposeWatchers();
         return Task.CompletedTask;
     }
 
     public void Dispose()
-        => DisposeWatchers();
+    {
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = null;
+        DisposeWatchers();
+    }
 
     private void OnSourceChanged(IAgentConfigurationSource source, IReadOnlyList<AgentDescriptor> descriptors)
     {
         lock (_sync)
         {
             _latestSourceDescriptors[source] = descriptors;
-            ApplyMergedDescriptors();
+            Interlocked.Increment(ref _coalescedChangeCount);
+            ScheduleDebouncedApply();
         }
+    }
+
+    /// <summary>
+    /// Schedules a debounced apply. Each new change notification resets the timer so that
+    /// rapid-fire changes (workspace writes, editor saves) coalesce into a single apply.
+    /// </summary>
+    private void ScheduleDebouncedApply()
+    {
+        // Cancel any pending debounce timer
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = new CancellationTokenSource();
+        var token = _debounceCts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(DebounceDelay, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return; // Another change arrived, timer reset
+            }
+
+            var coalesced = Interlocked.Exchange(ref _coalescedChangeCount, 0);
+            _logger.LogInformation(
+                "Agent configuration reload debounced: applying {CoalescedCount} coalesced change notification(s).",
+                coalesced);
+
+            lock (_sync)
+            {
+                ApplyMergedDescriptors();
+            }
+        });
     }
 
     private void ApplyMergedDescriptors()

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentConfigurationHostedServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentConfigurationHostedServiceTests.cs
@@ -70,6 +70,9 @@ public sealed class AgentConfigurationHostedServiceTests
             CreateDescriptor("agent-c")
         ]);
 
+        // Wait for debounce window to expire and apply to fire
+        await Task.Delay(AgentConfigurationHostedService.DebounceDelay + TimeSpan.FromMilliseconds(500));
+
         registry.Contains(AgentId.From("agent-a")).ShouldBeTrue();
         registry.Get(AgentId.From("agent-a"))!.DisplayName.ShouldBe("Agent A v2");
         registry.Contains(AgentId.From("agent-b")).ShouldBeFalse();
@@ -100,6 +103,9 @@ public sealed class AgentConfigurationHostedServiceTests
         callback.ShouldNotBeNull();
 
         callback!([CreateDescriptor("agent-new")]);
+
+        // Wait for debounce window to expire and apply to fire
+        await Task.Delay(AgentConfigurationHostedService.DebounceDelay + TimeSpan.FromMilliseconds(500));
 
         registry.Contains(AgentId.From("agent-new")).ShouldBeTrue();
         registry.RegisterOperations.ShouldContain("agent-new");

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/AgentConfigurationDebounceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/AgentConfigurationDebounceTests.cs
@@ -1,0 +1,228 @@
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public sealed class AgentConfigurationDebounceTests
+{
+    [Fact]
+    public async Task RapidConfigChanges_AreDebounced_IntoSingleApply()
+    {
+        // Arrange: a source that fires multiple rapid change notifications
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([]);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var applyCount = 0;
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback(() => Interlocked.Increment(ref applyCount));
+
+        var source = new CallbackAgentConfigurationSource();
+        var service = new AgentConfigurationHostedService(
+            [source],
+            registry.Object,
+            NullLogger<AgentConfigurationHostedService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Act: fire 10 rapid changes within the debounce window
+        var descriptor = CreateDescriptor("agent-1");
+        for (var i = 0; i < 10; i++)
+        {
+            source.FireChange([descriptor]);
+            await Task.Delay(20); // well within debounce window
+        }
+
+        // Wait for debounce to settle (default is 5 seconds + buffer)
+        await Task.Delay(6000);
+
+        // Assert: only applied once (or at most twice if first fires before debounce kicks in)
+        applyCount.ShouldBeLessThanOrEqualTo(2,
+            "Rapid config changes within debounce window should coalesce into at most one apply after the initial load");
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ChangeAfterDebounceWindow_TriggersNewApply()
+    {
+        // Arrange
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([]);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var applyCount = 0;
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback(() => Interlocked.Increment(ref applyCount));
+
+        var source = new CallbackAgentConfigurationSource();
+        var service = new AgentConfigurationHostedService(
+            [source],
+            registry.Object,
+            NullLogger<AgentConfigurationHostedService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Act: fire first change, wait for debounce, then fire second
+        source.FireChange([CreateDescriptor("agent-1")]);
+        await Task.Delay(6000); // wait for debounce to settle
+
+        var countAfterFirst = applyCount;
+
+        source.FireChange([CreateDescriptor("agent-1"), CreateDescriptor("agent-2")]);
+        await Task.Delay(6000); // wait for second debounce
+
+        // Assert: second change triggered a new apply
+        applyCount.ShouldBeGreaterThan(countAfterFirst,
+            "A change after the debounce window should trigger a new apply");
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task InitialLoad_AppliesImmediately_WithoutDebounce()
+    {
+        // Arrange
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([]);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var source = new CallbackAgentConfigurationSource(
+            initialDescriptors: [CreateDescriptor("agent-initial")]);
+
+        var service = new AgentConfigurationHostedService(
+            [source],
+            registry.Object,
+            NullLogger<AgentConfigurationHostedService>.Instance);
+
+        // Act
+        await service.StartAsync(CancellationToken.None);
+
+        // Assert: registered immediately during StartAsync (no debounce for initial load)
+        registry.Verify(r => r.Register(It.Is<AgentDescriptor>(
+            d => d.AgentId == AgentId.From("agent-initial"))), Times.Once);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_CancelsDebounceTimer()
+    {
+        // Arrange
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([]);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var applyCount = 0;
+        registry.Setup(r => r.Register(It.IsAny<AgentDescriptor>()))
+            .Callback(() => Interlocked.Increment(ref applyCount));
+
+        var source = new CallbackAgentConfigurationSource();
+        var service = new AgentConfigurationHostedService(
+            [source],
+            registry.Object,
+            NullLogger<AgentConfigurationHostedService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Act: fire change then immediately stop (before debounce window expires)
+        source.FireChange([CreateDescriptor("agent-1")]);
+        await Task.Delay(100); // short delay
+        await service.StopAsync(CancellationToken.None);
+
+        var countAtStop = applyCount;
+        await Task.Delay(6000); // wait past what would have been the debounce window
+
+        // Assert: no additional applies after stop
+        applyCount.ShouldBe(countAtStop,
+            "No applies should fire after StopAsync cancels the debounce timer");
+    }
+
+    [Fact]
+    public async Task DebounceLogMessage_IsEmitted_OnCoalescedApply()
+    {
+        // Arrange
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([]);
+        registry.Setup(r => r.Contains(It.IsAny<AgentId>())).Returns(false);
+
+        var logMessages = new List<string>();
+        var logger = new CapturingLogger<AgentConfigurationHostedService>(logMessages);
+
+        var source = new CallbackAgentConfigurationSource();
+        var service = new AgentConfigurationHostedService(
+            [source],
+            registry.Object,
+            logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Act: fire multiple rapid changes
+        for (var i = 0; i < 5; i++)
+        {
+            source.FireChange([CreateDescriptor("agent-1")]);
+            await Task.Delay(20);
+        }
+
+        await Task.Delay(6000);
+
+        // Assert: log message indicates debounced reload
+        logMessages.ShouldContain(m => m.Contains("debounced", StringComparison.OrdinalIgnoreCase),
+            "Should log a single debounced reload message for coalesced changes");
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private static AgentDescriptor CreateDescriptor(string id) => new()
+    {
+        AgentId = AgentId.From(id),
+        DisplayName = id,
+        ModelId = "test-model",
+        ApiProvider = "test"
+    };
+
+    /// <summary>
+    /// Test-only agent configuration source that allows programmatic change notification.
+    /// </summary>
+    private sealed class CallbackAgentConfigurationSource(
+        IReadOnlyList<AgentDescriptor>? initialDescriptors = null) : IAgentConfigurationSource
+    {
+        private Action<IReadOnlyList<AgentDescriptor>>? _callback;
+
+        public Task<IReadOnlyList<AgentDescriptor>> LoadAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(initialDescriptors ?? (IReadOnlyList<AgentDescriptor>)[]);
+
+        public IDisposable? Watch(Action<IReadOnlyList<AgentDescriptor>> onChanged)
+        {
+            _callback = onChanged;
+            return null;
+        }
+
+        public void FireChange(IReadOnlyList<AgentDescriptor> descriptors)
+            => _callback?.Invoke(descriptors);
+    }
+
+    /// <summary>
+    /// Simple capturing logger for verifying log output in tests.
+    /// </summary>
+    private sealed class CapturingLogger<T>(List<string> messages) : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            lock (messages)
+            {
+                messages.Add(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1074

## Changes

Adds a 5-second sliding debounce window to \AgentConfigurationHostedService.OnSourceChanged()\ so rapid file system events (workspace writes, memory saves during autonomous maintenance runs) coalesce into a single agent re-registration cycle.

### Root cause
The \IOptionsMonitor<PlatformConfig>.OnChange()\ callback fires on every file system event touching the config directory. During autonomous maintenance, workspace file writes (memory notes, temp files) trigger 2,000+ reload notifications per day with bursts of 100+ in 30 seconds. Each reload cycles all agent registrations while sessions are actively running, contributing to threadpool starvation.

### Fix
- \OnSourceChanged()\ now records the latest descriptors and schedules a debounced apply via \Task.Delay(5s)\
- Each new change cancels and resets the timer (sliding window)
- A single INFO log emits after the debounce window with the coalesced count
- \CancellationTokenSource\ is properly disposed on \StopAsync\ and \Dispose\
- Initial \StartAsync\ load is NOT debounced (applies immediately at startup)

### Tests
- 5 new debounce-specific tests: rapid coalesce, separation after window, initial load immediate, stop cancels pending, log emission
- 2 existing \OnSourceChange\ tests updated to await the debounce window

## Merge Notes

This PR is independent of all other open PRs. Only touches \AgentConfigurationHostedService.cs\ (not in any other PR's diff). Safe to merge in any order.