### PR TITLE
fix(hooks): use instance-based HookDispatcher registration to share with extension loader

### DIFF
--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -160,16 +160,12 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IGatewayAuthHandler, ApiKeyGatewayAuthHandler>();
         services.AddSingleton<IModelFilter, ConfigModelFilter>();
 
-        // Hook dispatcher with built-in handler registration
-        services.TryAddSingleton<IHookDispatcher>(sp =>
-        {
-            var dispatcher = new HookDispatcher();
-            dispatcher.Register<BeforeToolCallEvent, BeforeToolCallResult>(
-                sp.GetRequiredService<ToolPolicyHookHandler>());
-            dispatcher.Register<BeforePromptBuildEvent, BeforePromptBuildResult>(
-                sp.GetRequiredService<AgentsMdPromptHookHandler>());
-            return dispatcher;
-        });
+        // Hook dispatcher: register as a concrete singleton instance so that
+        // LoadConfiguredExtensionsAsync can locate it via ImplementationInstance
+        // and register extension-discovered hook handlers on the same instance.
+        // Built-in handlers are registered during startup via HookDispatcherInitializer.
+        services.TryAddSingleton<IHookDispatcher>(new HookDispatcher());
+        services.AddHostedService<HookDispatcherInitializer>();
 
         // Tool policy
         services.TryAddSingleton<DefaultToolPolicyProvider>();

--- a/src/gateway/BotNexus.Gateway/Hooks/HookDispatcherInitializer.cs
+++ b/src/gateway/BotNexus.Gateway/Hooks/HookDispatcherInitializer.cs
@@ -1,0 +1,48 @@
+using BotNexus.Gateway.Abstractions.Hooks;
+using BotNexus.Gateway.Agents;
+using Microsoft.Extensions.Hosting;
+
+namespace BotNexus.Gateway.Hooks;
+
+/// <summary>
+/// Registers built-in hook handlers on the shared <see cref="HookDispatcher"/> singleton
+/// during application startup.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built-in handlers require DI-resolved services (e.g. <see cref="ToolPolicyHookHandler"/>
+/// depends on <see cref="Security.DefaultToolPolicyProvider"/>). These services are not available
+/// at service-collection time when extensions are loaded. This hosted service bridges that gap
+/// by registering the handlers once the service provider is fully built.
+/// </para>
+/// <para>
+/// Extension-discovered handlers are registered by <see cref="Extensions.AssemblyLoadContextExtensionLoader"/>
+/// during <c>LoadConfiguredExtensionsAsync</c> (before the host starts). Built-in handlers
+/// registered here augment the same dispatcher instance.
+/// </para>
+/// </remarks>
+public sealed class HookDispatcherInitializer : IHostedService
+{
+    private readonly IHookDispatcher _hookDispatcher;
+    private readonly ToolPolicyHookHandler _toolPolicyHandler;
+    private readonly AgentsMdPromptHookHandler _agentsMdHandler;
+
+    public HookDispatcherInitializer(
+        IHookDispatcher hookDispatcher,
+        ToolPolicyHookHandler toolPolicyHandler,
+        AgentsMdPromptHookHandler agentsMdHandler)
+    {
+        _hookDispatcher = hookDispatcher;
+        _toolPolicyHandler = toolPolicyHandler;
+        _agentsMdHandler = agentsMdHandler;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _hookDispatcher.Register<BeforeToolCallEvent, BeforeToolCallResult>(_toolPolicyHandler);
+        _hookDispatcher.Register<BeforePromptBuildEvent, BeforePromptBuildResult>(_agentsMdHandler);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/HookDispatcherTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/HookDispatcherTests.cs
@@ -1,6 +1,7 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Hooks;
 using BotNexus.Gateway.Hooks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -136,6 +137,80 @@ public sealed class HookDispatcherTests
         var denied = results.FirstOrDefault(r => r.Denied);
         denied.ShouldNotBeNull();
         denied!.DenyReason.ShouldBe("Extension policy blocks this tool.");
+    }
+
+    // ── Instance registration discoverability (regression test for #1088) ────
+
+    [Fact]
+    public void InstanceRegistration_IsDiscoverableViaServiceDescriptorImplementationInstance()
+    {
+        // The bug: factory-based TryAddSingleton<IHookDispatcher>(sp => ...) has
+        // ImplementationInstance == null, making it invisible to LoadConfiguredExtensionsAsync.
+        // The fix: register as an instance so extension loader finds the same dispatcher.
+        var services = new ServiceCollection();
+        var dispatcher = new HookDispatcher();
+        services.AddSingleton<IHookDispatcher>(dispatcher);
+
+        var found = services
+            .Where(d => d.ServiceType == typeof(IHookDispatcher))
+            .Select(d => d.ImplementationInstance as IHookDispatcher)
+            .FirstOrDefault();
+
+        found.ShouldNotBeNull();
+        found.ShouldBeSameAs(dispatcher);
+    }
+
+    [Fact]
+    public async Task HookDispatcherInitializer_RegistersBuiltInHandlers_OnSameInstance()
+    {
+        // Verify that HookDispatcherInitializer wires handlers onto the shared instance
+        var dispatcher = new HookDispatcher();
+
+        // Before initializer runs: no handlers
+        var evt = new BeforePromptBuildEvent(AgentId.From("agent-1"), "prompt", []);
+        var before = await dispatcher.DispatchAsync<BeforePromptBuildEvent, BeforePromptBuildResult>(evt);
+        before.ShouldBeEmpty();
+
+        // Simulate what HookDispatcherInitializer.StartAsync does
+        dispatcher.Register<BeforePromptBuildEvent, BeforePromptBuildResult>(
+            new DelegateHookHandler<BeforePromptBuildEvent, BeforePromptBuildResult>(
+                priority: 200, _ => new BeforePromptBuildResult { AppendSystemContext = "AGENTS.md content" }));
+
+        var after = await dispatcher.DispatchAsync<BeforePromptBuildEvent, BeforePromptBuildResult>(evt);
+        after.ShouldHaveSingleItem().AppendSystemContext.ShouldBe("AGENTS.md content");
+    }
+
+    [Fact]
+    public async Task ExtensionHooksAndBuiltInHooks_ShareSameDispatcher_WhenRegisteredAsInstance()
+    {
+        // End-to-end simulation: extension loader registers on instance found in services,
+        // then HookDispatcherInitializer registers built-in handlers later. Both fire.
+        var services = new ServiceCollection();
+        var dispatcher = new HookDispatcher();
+        services.AddSingleton<IHookDispatcher>(dispatcher);
+
+        // Simulate extension loader finding the instance and registering a handler
+        var foundFromServices = services
+            .Where(d => d.ServiceType == typeof(IHookDispatcher))
+            .Select(d => d.ImplementationInstance as IHookDispatcher)
+            .FirstOrDefault()!;
+
+        foundFromServices.Register<BeforePromptBuildEvent, BeforePromptBuildResult>(
+            new DelegateHookHandler<BeforePromptBuildEvent, BeforePromptBuildResult>(
+                priority: 100, _ => new BeforePromptBuildResult { AppendSystemContext = "skills-list" }));
+
+        // Simulate HookDispatcherInitializer registering built-in handlers
+        dispatcher.Register<BeforePromptBuildEvent, BeforePromptBuildResult>(
+            new DelegateHookHandler<BeforePromptBuildEvent, BeforePromptBuildResult>(
+                priority: 200, _ => new BeforePromptBuildResult { AppendSystemContext = "AGENTS.md" }));
+
+        // Both should fire on the same dispatcher
+        var evt = new BeforePromptBuildEvent(AgentId.From("agent-1"), "prompt", []);
+        var results = await dispatcher.DispatchAsync<BeforePromptBuildEvent, BeforePromptBuildResult>(evt);
+
+        results.Count.ShouldBe(2);
+        results[0].AppendSystemContext.ShouldBe("skills-list"); // Extension (priority 100)
+        results[1].AppendSystemContext.ShouldBe("AGENTS.md");   // Built-in (priority 200)
     }
 
     // ── Test helper ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extension-discovered hook handlers (specifically SkillPromptHookHandler from BotNexus.Extensions.Skills) were never dispatched at runtime. The system prompt did not contain the available skills list despite the extension loading successfully.

## Root Cause

LoadConfiguredExtensionsAsync() in ServiceCollectionExtensions.cs tries to locate the IHookDispatcher from service descriptors via ImplementationInstance:

`csharp
var hookDispatcher = services
    .Where(d => d.ServiceType == typeof(IHookDispatcher))
    .Select(d => d.ImplementationInstance as IHookDispatcher)
    .FirstOrDefault()
    ?? new HookDispatcher();
`

But IHookDispatcher was registered as a **factory-based** TryAddSingleton in GatewayServiceCollectionExtensions:

`csharp
services.TryAddSingleton<IHookDispatcher>(sp => { ... });
`

Factory-based registrations have ImplementationInstance == null on the ServiceDescriptor. The extension loader always fell through to ?? new HookDispatcher(), creating an **orphaned** instance. Extension hooks were registered there and silently lost when DI built the real singleton.

## Fix

1. **GatewayServiceCollectionExtensions.cs**: Changed from factory-based to instance-based registration:
   `csharp
   services.TryAddSingleton<IHookDispatcher>(new HookDispatcher());
   `

2. **New HookDispatcherInitializer**: A hosted service that registers built-in handlers (ToolPolicyHookHandler, AgentsMdPromptHookHandler) on startup when DI is fully available.

Now both the extension loader (at startup bootstrap time) and the built-in handlers (at hosted service start) register on the **same** HookDispatcher instance.

## Testing

- 3 new regression tests in HookDispatcherTests.cs:
  - Instance registration is discoverable via ImplementationInstance
  - Built-in handlers register on the shared instance
  - Extension + built-in hooks both fire on the same dispatcher
- All impacted tests pass (Architecture 178, Gateway 2389, Scenarios 29)

Closes #1088