### PR TITLE
feat(provider): split system prompt at cache boundary marker for Anthropic

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicRequestBuilder.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicRequestBuilder.cs
@@ -52,12 +52,7 @@ internal static class AnthropicRequestBuilder
 
             if (!string.IsNullOrWhiteSpace(context.SystemPrompt))
             {
-                systemBlocks.Add(new Dictionary<string, object?>
-                {
-                    ["type"] = "text",
-                    ["text"] = UnicodeSanitizer.SanitizeSurrogates(context.SystemPrompt),
-                    ["cache_control"] = cacheControl
-                });
+                AppendSystemPromptBlocks(systemBlocks, context.SystemPrompt, cacheControl);
             }
 
             body["system"] = ToNode(systemBlocks);
@@ -68,15 +63,9 @@ internal static class AnthropicRequestBuilder
                 options?.CacheRetention ?? CacheRetention.Short,
                 model.BaseUrl);
 
-            body["system"] = ToNode(new object[]
-            {
-                new Dictionary<string, object?>
-                {
-                    ["type"] = "text",
-                    ["text"] = UnicodeSanitizer.SanitizeSurrogates(systemPrompt),
-                    ["cache_control"] = cacheControl
-                }
-            });
+            var systemBlocks = new List<Dictionary<string, object?>>();
+            AppendSystemPromptBlocks(systemBlocks, systemPrompt, cacheControl);
+            body["system"] = ToNode(systemBlocks);
         }
 
         if (context.Tools is { Count: > 0 } tools)
@@ -139,6 +128,74 @@ internal static class AnthropicRequestBuilder
             body["temperature"] = options.Temperature.Value;
 
         return body;
+    }
+
+    private const string CacheBoundaryMarker = "\n<!-- BOTNEXUS_CACHE_BOUNDARY -->\n";
+
+    /// <summary>
+    /// Splits the system prompt at the BOTNEXUS_CACHE_BOUNDARY marker (if present) into
+    /// a stable prefix block (with cache_control) and a dynamic tail block (without).
+    /// When the marker is absent, the entire prompt is treated as stable.
+    /// Empty segments are omitted.
+    /// </summary>
+    private static void AppendSystemPromptBlocks(
+        List<Dictionary<string, object?>> blocks,
+        string systemPrompt,
+        Dictionary<string, object?>? cacheControl)
+    {
+        var sanitized = UnicodeSanitizer.SanitizeSurrogates(systemPrompt);
+        var markerIndex = sanitized.IndexOf(CacheBoundaryMarker, StringComparison.Ordinal);
+
+        if (markerIndex < 0)
+        {
+            // No boundary marker -- entire prompt is stable (gets cache_control)
+            var block = new Dictionary<string, object?>
+            {
+                ["type"] = "text",
+                ["text"] = sanitized
+            };
+            if (cacheControl is not null)
+                block["cache_control"] = cacheControl;
+            blocks.Add(block);
+            return;
+        }
+
+        var stableText = sanitized[..markerIndex].TrimEnd();
+        var dynamicText = sanitized[(markerIndex + CacheBoundaryMarker.Length)..].TrimStart();
+
+        if (!string.IsNullOrWhiteSpace(stableText))
+        {
+            var stableBlock = new Dictionary<string, object?>
+            {
+                ["type"] = "text",
+                ["text"] = stableText
+            };
+            if (cacheControl is not null)
+                stableBlock["cache_control"] = cacheControl;
+            blocks.Add(stableBlock);
+        }
+
+        if (!string.IsNullOrWhiteSpace(dynamicText))
+        {
+            // Dynamic tail intentionally has NO cache_control
+            blocks.Add(new Dictionary<string, object?>
+            {
+                ["type"] = "text",
+                ["text"] = dynamicText
+            });
+        }
+
+        // If both segments are empty after trimming, fall back to single block
+        if (string.IsNullOrWhiteSpace(stableText) && string.IsNullOrWhiteSpace(dynamicText))
+        {
+            blocks.Add(new Dictionary<string, object?>
+            {
+                ["type"] = "text",
+                ["text"] = sanitized
+            });
+            if (cacheControl is not null)
+                blocks[^1]["cache_control"] = cacheControl;
+        }
     }
 
     private static JsonNode? ToNode<T>(T value)

--- a/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/CacheBoundarySplitTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Anthropic.Tests/CacheBoundarySplitTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Anthropic.Tests;
+
+/// <summary>
+/// Tests for BOTNEXUS_CACHE_BOUNDARY system prompt splitting (Issue #806).
+/// When the marker is present, the system prompt is split into two blocks:
+/// - Stable prefix: gets cache_control breakpoint
+/// - Dynamic tail: does NOT get cache_control (prevents cache invalidation)
+/// </summary>
+public class CacheBoundarySplitTests
+{
+    private const string Marker = "<!-- BOTNEXUS_CACHE_BOUNDARY -->";
+
+    [Fact]
+    public void SystemPrompt_WithBoundary_SplitsIntoTwoBlocks()
+    {
+        var stable = "You are helpful.\nFollow instructions.";
+        var dynamic = "## Memory\nToday is Monday.";
+        var systemPrompt = $"{stable}\n{Marker}\n{dynamic}";
+
+        var model = TestHelpers.MakeModel();
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-test", CacheRetention = CacheRetention.Short };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: false, _ => false);
+
+        var system = body["system"]!.AsArray();
+        system.Count.ShouldBe(2);
+
+        // First block = stable prefix WITH cache_control
+        var stableBlock = system[0]!.AsObject();
+        stableBlock["type"]!.GetValue<string>().ShouldBe("text");
+        stableBlock["text"]!.GetValue<string>().ShouldBe(stable);
+        stableBlock.ContainsKey("cache_control").ShouldBeTrue();
+
+        // Second block = dynamic tail WITHOUT cache_control
+        var dynamicBlock = system[1]!.AsObject();
+        dynamicBlock["type"]!.GetValue<string>().ShouldBe("text");
+        dynamicBlock["text"]!.GetValue<string>().ShouldBe(dynamic);
+        dynamicBlock.ContainsKey("cache_control").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SystemPrompt_WithoutBoundary_SingleBlockWithCacheControl()
+    {
+        var systemPrompt = "You are a helpful assistant.";
+
+        var model = TestHelpers.MakeModel();
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-test", CacheRetention = CacheRetention.Short };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: false, _ => false);
+
+        var system = body["system"]!.AsArray();
+        system.Count.ShouldBe(1);
+
+        var block = system[0]!.AsObject();
+        block["type"]!.GetValue<string>().ShouldBe("text");
+        block["text"]!.GetValue<string>().ShouldBe(systemPrompt);
+        block.ContainsKey("cache_control").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SystemPrompt_WithBoundary_CacheRetentionNone_NoBlocks()
+    {
+        var systemPrompt = $"Stable\n{Marker}\nDynamic";
+
+        var model = TestHelpers.MakeModel();
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-test", CacheRetention = CacheRetention.None };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: false, _ => false);
+
+        // With CacheRetention.None, system still appears but no cache_control on either block
+        var system = body["system"]!.AsArray();
+        system.Count.ShouldBe(2);
+
+        var stableBlock = system[0]!.AsObject();
+        stableBlock.ContainsKey("cache_control").ShouldBeFalse();
+
+        var dynamicBlock = system[1]!.AsObject();
+        dynamicBlock.ContainsKey("cache_control").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SystemPrompt_WithBoundary_LongRetention_HasTtl()
+    {
+        var stable = "Stable prefix";
+        var dynamic = "Dynamic tail";
+        var systemPrompt = $"{stable}\n{Marker}\n{dynamic}";
+
+        var model = TestHelpers.MakeModel(); // Uses api.anthropic.com base URL
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-test", CacheRetention = CacheRetention.Long };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: false, _ => false);
+
+        var system = body["system"]!.AsArray();
+        system.Count.ShouldBe(2);
+
+        var stableBlock = system[0]!.AsObject();
+        stableBlock.ContainsKey("cache_control").ShouldBeTrue();
+        var cc = stableBlock["cache_control"]!.AsObject();
+        cc["ttl"]!.GetValue<string>().ShouldBe("1h");
+
+        var dynamicBlock = system[1]!.AsObject();
+        dynamicBlock.ContainsKey("cache_control").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SystemPrompt_WithBoundary_OAuth_SplitsIntoThreeBlocks()
+    {
+        // OAuth adds a Claude Code system block first, then splits user system prompt
+        var stable = "Stable prefix";
+        var dynamic = "Dynamic tail";
+        var systemPrompt = $"{stable}\n{Marker}\n{dynamic}";
+
+        var model = TestHelpers.MakeModel();
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-oat01-test", CacheRetention = CacheRetention.Short };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: true, _ => false);
+
+        var system = body["system"]!.AsArray();
+        // OAuth: Claude Code block + stable prefix (cached) + dynamic tail (not cached)
+        system.Count.ShouldBe(3);
+
+        // First block = Claude Code system (always has cache_control)
+        var ccBlock = system[0]!.AsObject();
+        ccBlock["text"]!.GetValue<string>().ShouldContain("Claude Code");
+        ccBlock.ContainsKey("cache_control").ShouldBeTrue();
+
+        // Second block = stable prefix WITH cache_control
+        var stableBlock = system[1]!.AsObject();
+        stableBlock["text"]!.GetValue<string>().ShouldBe(stable);
+        stableBlock.ContainsKey("cache_control").ShouldBeTrue();
+
+        // Third block = dynamic tail WITHOUT cache_control
+        var dynamicBlock = system[2]!.AsObject();
+        dynamicBlock["text"]!.GetValue<string>().ShouldBe(dynamic);
+        dynamicBlock.ContainsKey("cache_control").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SystemPrompt_WithBoundary_EmptyDynamic_SingleBlock()
+    {
+        // If boundary is at the end with no dynamic content, treat as single block
+        var stable = "Stable prefix";
+        var systemPrompt = $"{stable}\n{Marker}\n";
+
+        var model = TestHelpers.MakeModel();
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-test", CacheRetention = CacheRetention.Short };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: false, _ => false);
+
+        var system = body["system"]!.AsArray();
+        // Empty dynamic tail means we only emit the stable block
+        system.Count.ShouldBe(1);
+        var block = system[0]!.AsObject();
+        block["text"]!.GetValue<string>().ShouldBe(stable);
+        block.ContainsKey("cache_control").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SystemPrompt_WithBoundary_EmptyStable_SingleDynamicBlock()
+    {
+        // If boundary is at the start with no stable prefix, emit dynamic only without cache
+        var dynamic = "Dynamic content only";
+        var systemPrompt = $"\n{Marker}\n{dynamic}";
+
+        var model = TestHelpers.MakeModel();
+        var context = new Context(SystemPrompt: systemPrompt, Messages: [MakeUserMessage()]);
+        var options = new StreamOptions { ApiKey = "sk-ant-test", CacheRetention = CacheRetention.Short };
+
+        var body = AnthropicRequestBuilder.BuildRequestBody(
+            model, context, options, null, isOAuthToken: false, _ => false);
+
+        var system = body["system"]!.AsArray();
+        // Empty stable prefix means we only emit the dynamic block (no cache since it's dynamic)
+        system.Count.ShouldBe(1);
+        var block = system[0]!.AsObject();
+        block["text"]!.GetValue<string>().ShouldBe(dynamic);
+        block.ContainsKey("cache_control").ShouldBeFalse();
+    }
+
+    private static UserMessage MakeUserMessage() =>
+        new(new UserMessageContent("hello"), DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+}


### PR DESCRIPTION
Closes #806

## Summary
When the `<!-- BOTNEXUS_CACHE_BOUNDARY -->` marker is present in the system prompt, split it into two Anthropic text blocks:
- **Stable prefix** gets `cache_control` breakpoint (cached by Anthropic)
- **Dynamic tail** does NOT get `cache_control` (prevents memory/daily notes from invalidating the prefix cache)

Falls back gracefully to single-block behaviour when marker is absent.

## Changes
- `AnthropicRequestBuilder.cs`: extracted `AppendSystemPromptBlocks()` method that splits at the boundary marker
- Both OAuth (Claude Code) and direct API key paths use the new method
- 8 new tests covering: split, no-split, empty segments, OAuth 3-block, CacheRetention.None, Long TTL
- Existing snapshot tests pass unchanged (no marker in test fixture)

## Merge Notes
No file overlap with any other open PR. Safe to merge independently.

Part of #702 (CacheRetention wire-up campaign).