### PR TITLE
fix(portal): map ToolExecutionUpdateEvent to UserInputRequired stream event

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -894,6 +894,13 @@ internal sealed class InProcessAgentHandle : IAgentHandle, IHealthCheckable, IAg
                                 CacheRead: assistant.Usage.CacheRead,
                                 CacheWrite: assistant.Usage.CacheWrite)
                         },
+                    ToolExecutionUpdateEvent { PartialResult.Details: AskUserRequest askUserRequest }
+                        => new AgentStreamEvent
+                        {
+                            Type = AgentStreamEventType.UserInputRequired,
+                            UserInputRequest = askUserRequest,
+                            MessageId = messageId
+                        },
                     TurnEndEvent
                         => new AgentStreamEvent { Type = AgentStreamEventType.TurnEnd, MessageId = messageId },
                     _ => null


### PR DESCRIPTION
## Problem

The \sk_user\ tool in the portal shows the tool call starting but the UI never updates to display the prompt to the user. The session stalls waiting for input that the user never sees.

## Root Cause

\InProcessIsolationStrategy.cs\ maps \AgentEvent\ → \AgentStreamEvent\ via a switch expression. The \AskUserTool\ emits a \ToolExecutionUpdateEvent\ (via its \onUpdate\ callback) containing the \AskUserRequest\ in \PartialResult.Details\, but there was no case for this event type — it fell through to \_ => null\ and was silently discarded.

The \UserInputRequired\ stream event never reached the SignalR hub, so the portal's \AskUserPrompt\ component was never triggered.

## Fix

Add a pattern match case for \ToolExecutionUpdateEvent\ where \PartialResult.Details\ is an \AskUserRequest\:

\\\csharp
ToolExecutionUpdateEvent { PartialResult.Details: AskUserRequest askUserRequest }
    => new AgentStreamEvent
    {
        Type = AgentStreamEventType.UserInputRequired,
        UserInputRequest = askUserRequest,
        MessageId = messageId
    },
\\\

## Testing

- All 20 existing AskUser gateway tests pass
- \	est-impacted.ps1\ passes: Architecture 178, Gateway Conversations, MCP, CLI, Gateway 2405, Scenarios 29
- 1 file changed, 7 insertions