### PR TITLE
fix(portal): move modal panels outside app-shell to escape flex containment

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -297,13 +297,14 @@
         </main>
     </div>
 
-    @* Modal overlays — rendered at end of shell so they layer above all content *@
-    <PortalSettingsPanel @ref="_settingsPanel" />
-    @if (_showDebugPanel)
-    {
-        <SessionDebugPanel SessionId="@GetActiveSessionId()" OnClose="CloseDebug" />
-    }
 </div>
+
+@* Modal overlays — rendered outside app-shell to avoid flex/overflow containment *@
+<PortalSettingsPanel @ref="_settingsPanel" />
+@if (_showDebugPanel)
+{
+    <SessionDebugPanel SessionId="@GetActiveSessionId()" OnClose="CloseDebug" />
+}
 
 @code {
     private bool _cronGroupCollapsed = true;


### PR DESCRIPTION
The settings and debug panels were rendering inside `<div class="app-shell">` which has `display: flex; flex-direction: column; height: 100vh; overflow: hidden`. Even though the overlays use `position: fixed`, the flex container was constraining them to render at the bottom of the layout rather than as proper viewport-covering modals.

**Fix:** Move `<PortalSettingsPanel>` and `<SessionDebugPanel>` to render as **siblings** of `.app-shell` rather than children. This ensures no parent flex/overflow properties interfere with the fixed positioning.

**Before:** Panels rendered at the bottom of the flex column, clipped by overflow
**After:** Panels render as viewport-covering modal overlays with backdrop

No CSS changes needed — the existing `position: fixed; inset: 0; z-index: 2000` styles now work correctly since no ancestor flex container participates in the stacking.

Tests: BlazorClient 527 ✅ | Architecture 178 ✅ | Gateway 2405 ✅