### PR TITLE
fix(compaction): use PreservedTurns=0 for forced compaction to guarantee summarization

### DIFF
--- a/src/gateway/BotNexus.Gateway/Sessions/SessionCompactionCoordinator.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/SessionCompactionCoordinator.cs
@@ -47,12 +47,14 @@ public sealed class SessionCompactionCoordinator : ISessionCompactionCoordinator
         var options = _options.CurrentValue;
 
         // When the user explicitly requests compaction, override PreservedTurns
-        // to 1 so the compactor always has entries to summarise. The user's
-        // intent ("compact now") supersedes the automatic heuristic that
-        // protects the last N turns from summarisation.
-        if (force && options.PreservedTurns > 1)
+        // to 0 so the compactor always has entries to summarise regardless of
+        // how few user turns exist. The user's intent ("compact now") supersedes
+        // the automatic heuristic. PreservedTurns=0 causes SplitHistory to place
+        // ALL visible entries in toSummarize (the summary captures full context
+        // including the most recent exchange).
+        if (force)
         {
-            options = options with { PreservedTurns = 1 };
+            options = options with { PreservedTurns = 0 };
         }
         var sessionId = session.SessionId;
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/ForceCompactionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/ForceCompactionTests.cs
@@ -50,8 +50,9 @@ public sealed class ForceCompactionTests
     }
 
     /// <summary>
-    /// Proves that force=true reduces PreservedTurns to 1, enabling compaction
+    /// Proves that force=true reduces PreservedTurns to 0, enabling compaction
     /// even when there are fewer user turns than the configured threshold.
+    /// PreservedTurns=0 causes SplitHistory to place ALL entries in toSummarize.
     /// </summary>
     [Fact]
     public async Task CompactAsync_ForceTrue_FewUserTurns_OverridesPreservedTurns()
@@ -60,14 +61,14 @@ public sealed class ForceCompactionTests
         var coordinator = CreateCoordinator(preservedTurns: 3, out var compactor);
 
         compactor
-            .Setup(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 1), It.IsAny<CancellationToken>()))
+            .Setup(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 0), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CompactionResult
             {
                 Summary = "Forced compaction summary",
                 Succeeded = true,
                 CompactedHistory = [new SessionEntry { Role = MessageRole.System, Content = "summary", IsCompactionSummary = true }],
-                EntriesSummarized = 1,
-                EntriesPreserved = 1,
+                EntriesSummarized = 2,
+                EntriesPreserved = 0,
                 TokensBefore = 100,
                 TokensAfter = 50,
                 SnapshotDestructiveVersion = 0,
@@ -78,29 +79,29 @@ public sealed class ForceCompactionTests
 
         outcome.Succeeded.ShouldBeTrue();
         outcome.Applied.ShouldBeTrue();
-        // Verify the compactor was called with PreservedTurns=1 (force override)
-        compactor.Verify(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 1), It.IsAny<CancellationToken>()), Times.Once);
+        // Verify the compactor was called with PreservedTurns=0 (force override — summarize everything)
+        compactor.Verify(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 0), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
-    /// When PreservedTurns is already 1, force=true should not change anything
-    /// (no need to override an already-minimal value).
+    /// When PreservedTurns is already 1, force=true still overrides to 0
+    /// to guarantee compaction proceeds unconditionally.
     /// </summary>
     [Fact]
-    public async Task CompactAsync_ForceTrue_PreservedTurnsAlready1_NoChange()
+    public async Task CompactAsync_ForceTrue_PreservedTurnsAlready1_StillOverridesToZero()
     {
         var session = CreateSessionWithUserTurns(5);
         var coordinator = CreateCoordinator(preservedTurns: 1, out var compactor);
 
         compactor
-            .Setup(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 1), It.IsAny<CancellationToken>()))
+            .Setup(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 0), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CompactionResult
             {
                 Summary = "Summary",
                 Succeeded = true,
                 CompactedHistory = [new SessionEntry { Role = MessageRole.System, Content = "summary", IsCompactionSummary = true }],
-                EntriesSummarized = 4,
-                EntriesPreserved = 1,
+                EntriesSummarized = 5,
+                EntriesPreserved = 0,
                 TokensBefore = 500,
                 TokensAfter = 100,
                 SnapshotDestructiveVersion = 0,
@@ -110,7 +111,7 @@ public sealed class ForceCompactionTests
         var outcome = await coordinator.CompactAsync(TestAgent, session, CancellationToken.None, force: true);
 
         outcome.Succeeded.ShouldBeTrue();
-        compactor.Verify(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 1), It.IsAny<CancellationToken>()), Times.Once);
+        compactor.Verify(c => c.CompactAsync(session, It.Is<CompactionOptions>(o => o.PreservedTurns == 0), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/LlmSessionCompactorTests.cs
@@ -158,6 +158,30 @@ public sealed class LlmSessionCompactorTests
     }
 
     [Fact]
+    public async Task CompactAsync_PreservedTurnsZero_SummarizesEverything()
+    {
+        // This is the force-compact scenario: even with only 1 user turn (the
+        // exact case that broke before), PreservedTurns=0 forces ALL visible
+        // entries into toSummarize.
+        var session = CreateSession(
+            ("user", "the only user message"),
+            ("assistant", "long response about the topic"),
+            ("tool", "tool result data"));
+        var compactor = CreateCompactor("forced summary of everything");
+
+        var result = await compactor.CompactAsync(session, new CompactionOptions
+        {
+            PreservedTurns = 0,
+            SummarizationModel = TestModel.Id
+        });
+
+        result.Succeeded.ShouldBeTrue();
+        result.CompactedHistory.ShouldNotBeNull();
+        result.EntriesSummarized.ShouldBe(3);
+        result.EntriesPreserved.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task CompactAsync_SetsIsCompactionSummaryFlag()
     {
         var session = CreateSession(


### PR DESCRIPTION
Fixes the /compact command not actually compacting when the user explicitly requests it.

## Root Cause

PR #1084 set PreservedTurns=1 for forced compaction, but this was insufficient. The SplitHistory algorithm walks backward counting user turns — with PreservedTurns=1, it finds the last user message and sets splitIndex to that position. Take(splitIndex) then captures only entries *before* that user message.

If the session has a structure like:
- 1 user message at index 0
- 214 assistant/tool entries after it

Then splitIndex=0 → Take(0) = empty list → **nothing to summarize**.

The same happens in any session where most entries are assistant/tool turns with relatively few user messages scattered throughout (common in agent sessions with heavy tool use).

## Fix

Changed orce mode from PreservedTurns=1 to PreservedTurns=0. When preservedTurns <= 0, SplitHistory returns (history.ToList(), []) — placing ALL visible entries in 	oSummarize with nothing in 	oPreserve. This guarantees compaction **always** proceeds when the user explicitly requests it.

The summary itself captures the full context of the session, so the agent retains awareness of recent work through the compaction summary entry.

## Changes
- SessionCompactionCoordinator.cs: PreservedTurns = 0 (was 1) when orce=true
- ForceCompactionTests.cs: updated assertions to match PreservedTurns=0 behavior
- LlmSessionCompactorTests.cs: added CompactAsync_PreservedTurnsZero_SummarizesEverything test proving the fix

## Testing
All impacted tests pass: Architecture 178, Gateway 2406, Conversations 192, CLI 157, MCP 186, Scenarios 29.