### PR TITLE
feat(canvas): add canvas state REST API endpoints for CRUD operations

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using Microsoft.Extensions.Logging;
@@ -660,6 +661,76 @@ public sealed class ConversationsController : ControllerBase
         if (conversation is null) return NotFound();
         await _conversations.PinAsync(ConversationId.From(conversationId), false, cancellationToken);
         await NotifyConversationChangedBestEffortAsync("updated", conversation.AgentId.Value, conversationId, cancellationToken);
+        return NoContent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Canvas State CRUD (Issue #1066)
+    // -----------------------------------------------------------------------
+
+    /// <summary>Returns the full canvas state dictionary for a conversation (empty object if none).</summary>
+    [HttpGet("{conversationId}/canvas-state")]
+    [ProducesResponseType(typeof(Dictionary<string, JsonElement>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetCanvasState(string conversationId, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+
+        var state = await _conversations.GetCanvasStateAsync(ConversationId.From(conversationId), cancellationToken);
+        return Ok(state ?? new Dictionary<string, JsonElement>());
+    }
+
+    /// <summary>Returns a single canvas state key value, or 404 if not found.</summary>
+    [HttpGet("{conversationId}/canvas-state/{key}")]
+    [ProducesResponseType(typeof(JsonElement), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetCanvasStateKey(string conversationId, string key, CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+
+        var state = await _conversations.GetCanvasStateAsync(ConversationId.From(conversationId), cancellationToken);
+        if (state is null || !state.TryGetValue(key, out var value))
+            return NotFound();
+
+        return Ok(value);
+    }
+
+    /// <summary>Upserts a canvas state key. Body is the raw JSON value.</summary>
+    [HttpPost("{conversationId}/canvas-state/{key}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> SetCanvasStateKey(
+        string conversationId,
+        string key,
+        [FromBody] JsonElement value,
+        CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+
+        await _conversations.SetCanvasStateKeyAsync(ConversationId.From(conversationId), key, value, cancellationToken);
+        return Ok();
+    }
+
+    /// <summary>Removes a canvas state key. Idempotent — returns 204 even if key didn't exist.</summary>
+    [HttpDelete("{conversationId}/canvas-state/{key}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeleteCanvasStateKey(
+        string conversationId,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
+        if (conversation is null)
+            return NotFound();
+
+        await _conversations.DeleteCanvasStateKeyAsync(ConversationId.From(conversationId), key, cancellationToken);
         return NoContent();
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerCanvasStateTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationsControllerCanvasStateTests.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for the canvas state REST API endpoints (Issue #1066).
+/// Verifies CRUD operations on conversation canvas state via ConversationsController.
+/// </summary>
+public sealed class ConversationsControllerCanvasStateTests
+{
+    private static readonly ConversationId TestConversationId = ConversationId.From("c_canvas_test");
+
+    [Fact]
+    public async Task GetCanvasState_EmptyConversation_ReturnsEmptyObject()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.GetCanvasState(TestConversationId.Value, CancellationToken.None);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        var state = okResult.Value as Dictionary<string, JsonElement>;
+        state.ShouldNotBeNull();
+        state.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetCanvasState_NonExistentConversation_Returns404()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.GetCanvasState("c_nonexistent", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetCanvasStateKey_ExistingKey_ReturnsValue()
+    {
+        var (controller, store) = CreateController();
+        var value = JsonDocument.Parse("42").RootElement.Clone();
+        await store.SetCanvasStateKeyAsync(TestConversationId, "counter", value);
+
+        var result = await controller.GetCanvasStateKey(TestConversationId.Value, "counter", CancellationToken.None);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        var returnedValue = (JsonElement)okResult.Value!;
+        returnedValue.GetInt32().ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task GetCanvasStateKey_MissingKey_Returns404()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.GetCanvasStateKey(TestConversationId.Value, "missing", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetCanvasStateKey_NonExistentConversation_Returns404()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.GetCanvasStateKey("c_nonexistent", "key", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task SetCanvasStateKey_NewKey_Returns200()
+    {
+        var (controller, store) = CreateController();
+        var value = JsonDocument.Parse("\"hello\"").RootElement.Clone();
+
+        var result = await controller.SetCanvasStateKey(TestConversationId.Value, "greeting", value, CancellationToken.None);
+
+        result.ShouldBeOfType<OkResult>();
+
+        // Verify persisted
+        var state = await store.GetCanvasStateAsync(TestConversationId);
+        state.ShouldNotBeNull();
+        state!["greeting"].GetString().ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task SetCanvasStateKey_ExistingKey_Upserts()
+    {
+        var (controller, store) = CreateController();
+        var first = JsonDocument.Parse("1").RootElement.Clone();
+        var second = JsonDocument.Parse("2").RootElement.Clone();
+
+        await controller.SetCanvasStateKey(TestConversationId.Value, "version", first, CancellationToken.None);
+        var result = await controller.SetCanvasStateKey(TestConversationId.Value, "version", second, CancellationToken.None);
+
+        result.ShouldBeOfType<OkResult>();
+        var state = await store.GetCanvasStateAsync(TestConversationId);
+        state!["version"].GetInt32().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task SetCanvasStateKey_NonExistentConversation_Returns404()
+    {
+        var (controller, _) = CreateController();
+        var value = JsonDocument.Parse("true").RootElement.Clone();
+
+        var result = await controller.SetCanvasStateKey("c_nonexistent", "key", value, CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task DeleteCanvasStateKey_ExistingKey_Returns204()
+    {
+        var (controller, store) = CreateController();
+        var value = JsonDocument.Parse("\"temp\"").RootElement.Clone();
+        await store.SetCanvasStateKeyAsync(TestConversationId, "temp", value);
+
+        var result = await controller.DeleteCanvasStateKey(TestConversationId.Value, "temp", CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+
+        // Verify deleted
+        var state = await store.GetCanvasStateAsync(TestConversationId);
+        state.ShouldNotBeNull();
+        state!.ContainsKey("temp").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteCanvasStateKey_MissingKey_Returns204()
+    {
+        var (controller, _) = CreateController();
+
+        // Deleting a non-existent key is idempotent
+        var result = await controller.DeleteCanvasStateKey(TestConversationId.Value, "no_such_key", CancellationToken.None);
+
+        result.ShouldBeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task DeleteCanvasStateKey_NonExistentConversation_Returns404()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.DeleteCanvasStateKey("c_nonexistent", "key", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundResult>();
+    }
+
+    private static (ConversationsController, InMemoryConversationStore) CreateController()
+    {
+        var store = new InMemoryConversationStore();
+        store.CreateAsync(new Conversation
+        {
+            ConversationId = TestConversationId,
+            AgentId = AgentId.From("test-agent"),
+            Title = "Test Canvas Conversation",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        }).GetAwaiter().GetResult();
+
+        var sessions = new InMemorySessionStore();
+        var controller = new ConversationsController(store, sessions);
+        return (controller, store);
+    }
+}


### PR DESCRIPTION
Closes #1066

## Summary
Adds REST API endpoints for canvas state CRUD operations on conversations. This is the second sub-issue of the canvas state feature (#972), building on the domain model and persistence layer from PR #1073.

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/conversations/{id}/canvas-state` | Full state dict (empty `{}` if none) |
| GET | `/api/conversations/{id}/canvas-state/{key}` | Single key value or 404 |
| POST | `/api/conversations/{id}/canvas-state/{key}` | Upsert key (body = JSON value) |
| DELETE | `/api/conversations/{id}/canvas-state/{key}` | Remove key (idempotent, 204) |

All endpoints validate conversation existence (404 if missing).

## Changes
- `ConversationsController.cs`: 4 new action methods
- 11 new tests covering all CRUD paths, edge cases, and 404 scenarios

## Merge Notes
No file overlap with PR #1092 (Anthropic provider). Safe to merge independently.

Part of #972 (canvas state feature chain, 2/4 sub-issues).