### PR TITLE
feat(providers): add claude-opus-4.8 to Copilot built-in models

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/Registry/BuiltInModels.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Registry/BuiltInModels.cs
@@ -42,6 +42,7 @@ public sealed class BuiltInModels
         Register(modelRegistry, "github-copilot", "claude-haiku-4.5", "Claude Haiku 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
         Register(modelRegistry, "github-copilot", "claude-opus-4.5", "Claude Opus 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 160000, 32000, headers: CopilotHeaders);
         Register(modelRegistry, "github-copilot", "claude-opus-4.6", "Claude Opus 4.6", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 64000, supportsExtraHighThinking: true, headers: CopilotHeaders);
+        Register(modelRegistry, "github-copilot", "claude-opus-4.8", "Claude Opus 4.8", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 64000, supportsExtraHighThinking: true, headers: CopilotHeaders);
         Register(modelRegistry, "github-copilot", "claude-sonnet-4", "Claude Sonnet 4", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 216000, 16000, headers: CopilotHeaders);
         Register(modelRegistry, "github-copilot", "claude-sonnet-4.5", "Claude Sonnet 4.5", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 144000, 32000, headers: CopilotHeaders);
         Register(modelRegistry, "github-copilot", "claude-sonnet-4.6", "Claude Sonnet 4.6", "github-copilot-messages", CopilotBaseUrl, true, ["text", "image"], 1000000, 32000, headers: CopilotHeaders);


### PR DESCRIPTION
Adds claude-opus-4.8 to the BuiltInModels static catalog for the github-copilot provider.

Same parameters as claude-opus-4.6 (1M context, 64K output, extra-high thinking, Messages API).

Unblocks Keel immediately. The long-term fix for this class of issue is #1091 (dynamic model discovery at startup).

## Changes
- 1 line added to BuiltInModels.cs — RegisterCopilotModels() method