### PR TITLE
feat(gateway): add per-agent Docker sandbox configuration and DI registration

### DIFF
--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -179,6 +179,8 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IIsolationStrategy, SandboxIsolationStrategy>();
         services.AddSingleton<IIsolationStrategy, ContainerIsolationStrategy>();
         services.AddSingleton<IIsolationStrategy, RemoteIsolationStrategy>();
+        services.AddSingleton<IIsolationStrategy, DockerSandboxIsolationStrategy>();
+        services.TryAddSingleton<IDockerSandboxRunner, NullDockerSandboxRunner>();
 
         // Extension state store
         services.TryAddSingleton<IExtensionStateStore>(serviceProvider =>

--- a/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxIsolationStrategy.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Isolation;
 using BotNexus.Gateway.Abstractions.Models;
@@ -20,6 +19,10 @@ namespace BotNexus.Gateway.Isolation;
 /// (warm reuse) and stops after a configurable idle period to conserve resources.
 /// </para>
 /// <para>
+/// Per-agent configuration is resolved by merging global <see cref="DockerSandboxOptions"/>
+/// with agent-level <see cref="AgentDescriptor.IsolationOptions"/> overrides.
+/// </para>
+/// <para>
 /// The lifecycle state machine transitions are:
 /// <list type="bullet">
 ///   <item><b>None → Creating</b> — First dispatch triggers sandbox creation.</item>
@@ -37,6 +40,7 @@ public sealed class DockerSandboxIsolationStrategy : IIsolationStrategy, IAsyncD
     private readonly IOptions<DockerSandboxOptions> _options;
     private readonly ILogger<DockerSandboxIsolationStrategy> _logger;
     private readonly ConcurrentDictionary<AgentId, SandboxState> _sandboxes = new();
+    private readonly ConcurrentDictionary<AgentId, ResolvedDockerSandboxOptions> _resolvedOptions = new();
     private readonly SemaphoreSlim _createLock = new(1, 1);
 
     public DockerSandboxIsolationStrategy(
@@ -66,15 +70,16 @@ public sealed class DockerSandboxIsolationStrategy : IIsolationStrategy, IAsyncD
                 $"Agent '{descriptor.AgentId}' cannot use the '{Name}' isolation strategy.");
         }
 
+        var resolved = ResolveOptions(descriptor);
         var sandboxName = GetSandboxName(descriptor.AgentId);
-        var state = await EnsureSandboxRunningAsync(descriptor.AgentId, sandboxName, cancellationToken)
+        var state = await EnsureSandboxRunningAsync(descriptor.AgentId, sandboxName, resolved, cancellationToken)
             .ConfigureAwait(false);
 
         state.RecordActivity();
 
         _logger.LogInformation(
-            "Dispatching to Docker sandbox '{SandboxName}' for agent '{AgentId}' session '{SessionId}'",
-            sandboxName, descriptor.AgentId, context.SessionId);
+            "Dispatching to Docker sandbox '{SandboxName}' for agent '{AgentId}' session '{SessionId}' (image: {Image}, network: {NetworkEnabled})",
+            sandboxName, descriptor.AgentId, context.SessionId, resolved.Image, resolved.NetworkEnabled);
 
         return new DockerSandboxAgentHandle(
             descriptor.AgentId,
@@ -94,18 +99,29 @@ public sealed class DockerSandboxIsolationStrategy : IIsolationStrategy, IAsyncD
             : SandboxLifecycleStatus.None;
 
     /// <summary>
+    /// Gets the resolved options for a given agent, or null if no sandbox has been created.
+    /// Useful for diagnostics and tests.
+    /// </summary>
+    public ResolvedDockerSandboxOptions? GetResolvedOptions(AgentId agentId)
+        => _resolvedOptions.TryGetValue(agentId, out var options) ? options : null;
+
+    /// <summary>
     /// Checks all running sandboxes for idle timeout and stops any that have exceeded it.
+    /// Uses per-agent resolved idle timeout (not the global default).
     /// Called by the hosted service on a timer.
     /// </summary>
     public async Task CheckIdleTimeoutsAsync(CancellationToken cancellationToken = default)
     {
-        var timeout = _options.Value.IdleTimeout;
         var now = DateTimeOffset.UtcNow;
 
         foreach (var (agentId, state) in _sandboxes)
         {
             if (state.Status != SandboxLifecycleStatus.Running)
                 continue;
+
+            var timeout = _resolvedOptions.TryGetValue(agentId, out var opts)
+                ? opts.IdleTimeout
+                : _options.Value.IdleTimeout;
 
             if (now - state.LastActivity > timeout)
             {
@@ -118,9 +134,17 @@ public sealed class DockerSandboxIsolationStrategy : IIsolationStrategy, IAsyncD
         }
     }
 
+    private ResolvedDockerSandboxOptions ResolveOptions(AgentDescriptor descriptor)
+    {
+        var resolved = DockerSandboxOptionsResolver.Resolve(_options.Value, descriptor);
+        _resolvedOptions[descriptor.AgentId] = resolved;
+        return resolved;
+    }
+
     private async Task<SandboxState> EnsureSandboxRunningAsync(
         AgentId agentId,
         string sandboxName,
+        ResolvedDockerSandboxOptions resolved,
         CancellationToken cancellationToken)
     {
         // Fast path: sandbox already running
@@ -152,10 +176,10 @@ public sealed class DockerSandboxIsolationStrategy : IIsolationStrategy, IAsyncD
             _sandboxes[agentId] = state;
 
             _logger.LogInformation(
-                "Creating Docker sandbox '{SandboxName}' for agent '{AgentId}'",
-                sandboxName, agentId);
+                "Creating Docker sandbox '{SandboxName}' for agent '{AgentId}' with image '{Image}' (network: {NetworkEnabled}, memory: {MemoryLimit})",
+                sandboxName, agentId, resolved.Image, resolved.NetworkEnabled, resolved.MemoryLimit ?? "unlimited");
 
-            await _runner.CreateAsync(sandboxName, cancellationToken).ConfigureAwait(false);
+            await _runner.CreateAsync(sandboxName, resolved, cancellationToken).ConfigureAwait(false);
             state.TransitionTo(SandboxLifecycleStatus.Running);
 
             _logger.LogInformation(
@@ -223,6 +247,7 @@ public sealed class DockerSandboxIsolationStrategy : IIsolationStrategy, IAsyncD
         }
 
         _sandboxes.Clear();
+        _resolvedOptions.Clear();
         _createLock.Dispose();
     }
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxOptions.cs
@@ -2,6 +2,8 @@ namespace BotNexus.Gateway.Isolation;
 
 /// <summary>
 /// Configuration options for the Docker sandbox isolation strategy.
+/// These serve as global defaults; per-agent overrides are specified
+/// in <c>AgentDescriptor.IsolationOptions</c>.
 /// </summary>
 public sealed class DockerSandboxOptions
 {
@@ -10,4 +12,22 @@ public sealed class DockerSandboxOptions
     /// Default: 10 minutes.
     /// </summary>
     public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Docker image to use for sandbox containers.
+    /// Default: "mcr.microsoft.com/dotnet/runtime:9.0" — lightweight .NET runtime base.
+    /// </summary>
+    public string Image { get; set; } = "mcr.microsoft.com/dotnet/runtime:9.0";
+
+    /// <summary>
+    /// Whether sandbox containers have network access.
+    /// Default: false (sandboxed agents are network-isolated for security).
+    /// </summary>
+    public bool NetworkEnabled { get; set; }
+
+    /// <summary>
+    /// Maximum memory limit for the sandbox container (e.g. "512m", "1g").
+    /// Null means no explicit limit (uses Docker daemon defaults).
+    /// </summary>
+    public string? MemoryLimit { get; set; }
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxOptionsResolver.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxOptionsResolver.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Resolves effective Docker sandbox options for a given agent by merging
+/// global <see cref="DockerSandboxOptions"/> defaults with per-agent overrides
+/// from <see cref="AgentDescriptor.IsolationOptions"/>.
+/// </summary>
+/// <remarks>
+/// Per-agent overrides are specified in the agent's JSON config under <c>isolationOptions</c>:
+/// <code>
+/// {
+///   "isolation": "docker-sandbox",
+///   "isolationOptions": {
+///     "image": "custom-image:latest",
+///     "networkEnabled": true,
+///     "memoryLimit": "1g",
+///     "idleTimeout": "00:05:00"
+///   }
+/// }
+/// </code>
+/// Any field not specified in <c>isolationOptions</c> falls back to the global default.
+/// </remarks>
+internal static class DockerSandboxOptionsResolver
+{
+    /// <summary>
+    /// Resolves effective sandbox options for the given agent descriptor.
+    /// </summary>
+    /// <param name="defaults">Global default options.</param>
+    /// <param name="descriptor">Agent descriptor with optional per-agent overrides.</param>
+    /// <returns>Effective options for this agent's sandbox.</returns>
+    public static ResolvedDockerSandboxOptions Resolve(
+        DockerSandboxOptions defaults,
+        AgentDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(defaults);
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        var options = descriptor.IsolationOptions;
+
+        return new ResolvedDockerSandboxOptions
+        {
+            Image = GetStringOption(options, "image") ?? defaults.Image,
+            NetworkEnabled = GetBoolOption(options, "networkEnabled") ?? defaults.NetworkEnabled,
+            MemoryLimit = GetStringOption(options, "memoryLimit") ?? defaults.MemoryLimit,
+            IdleTimeout = GetTimeSpanOption(options, "idleTimeout") ?? defaults.IdleTimeout
+        };
+    }
+
+    private static string? GetStringOption(IReadOnlyDictionary<string, object?> options, string key)
+    {
+        if (!options.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        if (value is string s)
+            return s;
+
+        if (value is JsonElement element)
+        {
+            return element.ValueKind == JsonValueKind.String
+                ? element.GetString()
+                : element.GetRawText().Trim('"');
+        }
+
+        return value.ToString();
+    }
+
+    private static bool? GetBoolOption(IReadOnlyDictionary<string, object?> options, string key)
+    {
+        if (!options.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        if (value is bool b)
+            return b;
+
+        if (value is JsonElement element)
+        {
+            return element.ValueKind == JsonValueKind.True
+                ? true
+                : element.ValueKind == JsonValueKind.False
+                    ? false
+                    : bool.TryParse(element.GetRawText(), out var parsed) ? parsed : null;
+        }
+
+        return bool.TryParse(value.ToString(), out var result) ? result : null;
+    }
+
+    private static TimeSpan? GetTimeSpanOption(IReadOnlyDictionary<string, object?> options, string key)
+    {
+        if (!options.TryGetValue(key, out var value) || value is null)
+            return null;
+
+        if (value is TimeSpan ts)
+            return ts;
+
+        var raw = value is JsonElement element
+            ? element.ValueKind == JsonValueKind.String ? element.GetString() : element.GetRawText()
+            : value.ToString();
+
+        return TimeSpan.TryParse(raw, out var parsed) ? parsed : null;
+    }
+}
+
+/// <summary>
+/// Fully-resolved Docker sandbox options for a specific agent.
+/// All fields are guaranteed non-null (defaults have been applied).
+/// </summary>
+public sealed class ResolvedDockerSandboxOptions
+{
+    /// <summary>Docker image for the sandbox container.</summary>
+    public required string Image { get; init; }
+
+    /// <summary>Whether the sandbox has network access.</summary>
+    public required bool NetworkEnabled { get; init; }
+
+    /// <summary>Memory limit (e.g. "512m", "1g"). Null = no limit.</summary>
+    public string? MemoryLimit { get; init; }
+
+    /// <summary>Idle timeout before the sandbox is stopped.</summary>
+    public required TimeSpan IdleTimeout { get; init; }
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/IDockerSandboxRunner.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/IDockerSandboxRunner.cs
@@ -13,12 +13,13 @@ public interface IDockerSandboxRunner
     Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates a new Docker sandbox with the given name.
-    /// Equivalent to <c>docker sandbox create --name {name}</c>.
+    /// Creates a new Docker sandbox with the given name and resolved configuration.
+    /// Equivalent to <c>docker sandbox create --name {name} [--image ...] [--memory ...] [--network ...]</c>.
     /// </summary>
     /// <param name="name">The sandbox name (e.g., "agent-farnsworth").</param>
+    /// <param name="options">Resolved per-agent sandbox configuration (image, network, memory).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task CreateAsync(string name, CancellationToken cancellationToken = default);
+    Task CreateAsync(string name, ResolvedDockerSandboxOptions options, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stops and removes a running Docker sandbox.

--- a/src/gateway/BotNexus.Gateway/Isolation/NullDockerSandboxRunner.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/NullDockerSandboxRunner.cs
@@ -1,0 +1,24 @@
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// No-op implementation of <see cref="IDockerSandboxRunner"/> used when Docker is
+/// not configured or available. Always reports Docker as unavailable, causing the
+/// <see cref="DockerSandboxIsolationStrategy"/> to throw a descriptive error if
+/// any agent is configured to use the "docker-sandbox" isolation strategy.
+/// </summary>
+internal sealed class NullDockerSandboxRunner : IDockerSandboxRunner
+{
+    public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task CreateAsync(string name, ResolvedDockerSandboxOptions options, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Docker sandbox is not available. NullDockerSandboxRunner is active — " +
+            "Docker is not installed or the sandbox feature is not enabled.");
+
+    public Task StopAsync(string name, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<bool> IsHealthyAsync(string name, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxIsolationStrategyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxIsolationStrategyTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Isolation;
@@ -20,13 +21,16 @@ public sealed class DockerSandboxIsolationStrategyTests
             NullLogger<DockerSandboxIsolationStrategy>.Instance);
     }
 
-    private static AgentDescriptor MakeDescriptor(string agentId = "test-agent") => new()
+    private static AgentDescriptor MakeDescriptor(
+        string agentId = "test-agent",
+        IReadOnlyDictionary<string, object?>? isolationOptions = null) => new()
     {
         AgentId = AgentId.From(agentId),
         DisplayName = "Test Agent",
         ModelId = "model",
         ApiProvider = "provider",
-        IsolationStrategy = "docker-sandbox"
+        IsolationStrategy = "docker-sandbox",
+        IsolationOptions = isolationOptions ?? new Dictionary<string, object?>()
     };
 
     private static AgentExecutionContext MakeContext(string sessionId = "session-1") => new()
@@ -229,6 +233,147 @@ public sealed class DockerSandboxIsolationStrategyTests
 
         await act.ShouldThrowAsync<NotSupportedException>();
     }
+
+    [Fact]
+    public async Task CreateAsync_WithPerAgentImage_PassesImageToRunner()
+    {
+        _runner.Available = true;
+
+        var options = new Dictionary<string, object?>
+        {
+            ["image"] = "custom-sandbox:v2"
+        };
+        var descriptor = MakeDescriptor(isolationOptions: options);
+        var context = MakeContext();
+
+        await _strategy.CreateAsync(descriptor, context);
+
+        _runner.LastOptions.ShouldNotBeNull();
+        _runner.LastOptions!.Image.ShouldBe("custom-sandbox:v2");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutPerAgentOptions_UsesGlobalDefaults()
+    {
+        _runner.Available = true;
+        _options.Image = "global-image:latest";
+        _options.NetworkEnabled = true;
+        _options.MemoryLimit = "2g";
+
+        var descriptor = MakeDescriptor();
+        var context = MakeContext();
+
+        await _strategy.CreateAsync(descriptor, context);
+
+        _runner.LastOptions.ShouldNotBeNull();
+        _runner.LastOptions!.Image.ShouldBe("global-image:latest");
+        _runner.LastOptions!.NetworkEnabled.ShouldBeTrue();
+        _runner.LastOptions!.MemoryLimit.ShouldBe("2g");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithPerAgentNetworkAndMemory_OverridesGlobals()
+    {
+        _runner.Available = true;
+        _options.NetworkEnabled = false;
+        _options.MemoryLimit = "512m";
+
+        var options = new Dictionary<string, object?>
+        {
+            ["networkEnabled"] = true,
+            ["memoryLimit"] = "1g"
+        };
+        var descriptor = MakeDescriptor(isolationOptions: options);
+        var context = MakeContext();
+
+        await _strategy.CreateAsync(descriptor, context);
+
+        _runner.LastOptions.ShouldNotBeNull();
+        _runner.LastOptions!.NetworkEnabled.ShouldBeTrue();
+        _runner.LastOptions!.MemoryLimit.ShouldBe("1g");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithJsonElementOptions_ParsesCorrectly()
+    {
+        _runner.Available = true;
+
+        // Simulate JSON deserialization: values come as JsonElement
+        var json = JsonSerializer.SerializeToElement(new
+        {
+            image = "json-image:3.0",
+            networkEnabled = true,
+            memoryLimit = "256m",
+            idleTimeout = "00:02:30"
+        });
+
+        var options = new Dictionary<string, object?>();
+        foreach (var prop in json.EnumerateObject())
+        {
+            options[prop.Name] = prop.Value;
+        }
+
+        var descriptor = MakeDescriptor(isolationOptions: options);
+        var context = MakeContext();
+
+        await _strategy.CreateAsync(descriptor, context);
+
+        _runner.LastOptions.ShouldNotBeNull();
+        _runner.LastOptions!.Image.ShouldBe("json-image:3.0");
+        _runner.LastOptions!.NetworkEnabled.ShouldBeTrue();
+        _runner.LastOptions!.MemoryLimit.ShouldBe("256m");
+        _runner.LastOptions!.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task CheckIdleTimeouts_UsesPerAgentTimeout()
+    {
+        _runner.Available = true;
+        _options.IdleTimeout = TimeSpan.FromMinutes(60); // Global: very long
+
+        // Agent with short per-agent timeout
+        var shortOptions = new Dictionary<string, object?>
+        {
+            ["idleTimeout"] = "00:00:00.050" // 50ms
+        };
+        var descriptor = MakeDescriptor("short-timeout-agent", shortOptions);
+
+        await _strategy.CreateAsync(descriptor, MakeContext());
+        await Task.Delay(100);
+
+        await _strategy.CheckIdleTimeoutsAsync();
+
+        _strategy.GetStatus(descriptor.AgentId).ShouldBe(SandboxLifecycleStatus.Stopped);
+    }
+
+    [Fact]
+    public async Task GetResolvedOptions_AfterCreate_ReturnsResolvedConfig()
+    {
+        _runner.Available = true;
+
+        var options = new Dictionary<string, object?>
+        {
+            ["image"] = "my-image:1.0",
+            ["networkEnabled"] = false,
+            ["memoryLimit"] = "768m"
+        };
+        var descriptor = MakeDescriptor(isolationOptions: options);
+
+        await _strategy.CreateAsync(descriptor, MakeContext());
+
+        var resolved = _strategy.GetResolvedOptions(descriptor.AgentId);
+        resolved.ShouldNotBeNull();
+        resolved!.Image.ShouldBe("my-image:1.0");
+        resolved.NetworkEnabled.ShouldBeFalse();
+        resolved.MemoryLimit.ShouldBe("768m");
+    }
+
+    [Fact]
+    public void GetResolvedOptions_BeforeCreate_ReturnsNull()
+    {
+        var agentId = AgentId.From("never-created");
+        _strategy.GetResolvedOptions(agentId).ShouldBeNull();
+    }
 }
 
 /// <summary>
@@ -241,17 +386,19 @@ internal sealed class FakeDockerSandboxRunner : IDockerSandboxRunner
     public List<string> CreatedSandboxes { get; } = [];
     public List<string> StoppedSandboxes { get; } = [];
     public HashSet<string> HealthySandboxes { get; } = [];
+    public ResolvedDockerSandboxOptions? LastOptions { get; private set; }
 
     public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(Available);
 
-    public Task CreateAsync(string name, CancellationToken cancellationToken = default)
+    public Task CreateAsync(string name, ResolvedDockerSandboxOptions options, CancellationToken cancellationToken = default)
     {
         if (ThrowOnCreate)
             throw new InvalidOperationException("Docker create failed");
 
         CreatedSandboxes.Add(name);
         HealthySandboxes.Add(name);
+        LastOptions = options;
         return Task.CompletedTask;
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxOptionsResolverTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxOptionsResolverTests.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Isolation;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class DockerSandboxOptionsResolverTests
+{
+    private static readonly DockerSandboxOptions Defaults = new()
+    {
+        Image = "default-image:1.0",
+        NetworkEnabled = false,
+        MemoryLimit = "512m",
+        IdleTimeout = TimeSpan.FromMinutes(10)
+    };
+
+    private static AgentDescriptor MakeDescriptor(
+        IReadOnlyDictionary<string, object?>? isolationOptions = null) => new()
+    {
+        AgentId = AgentId.From("test-agent"),
+        DisplayName = "Test",
+        ModelId = "model",
+        ApiProvider = "provider",
+        IsolationStrategy = "docker-sandbox",
+        IsolationOptions = isolationOptions ?? new Dictionary<string, object?>()
+    };
+
+    [Fact]
+    public void Resolve_NoOverrides_ReturnsGlobalDefaults()
+    {
+        var descriptor = MakeDescriptor();
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.Image.ShouldBe("default-image:1.0");
+        result.NetworkEnabled.ShouldBeFalse();
+        result.MemoryLimit.ShouldBe("512m");
+        result.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Resolve_StringOverrides_Applied()
+    {
+        var options = new Dictionary<string, object?>
+        {
+            ["image"] = "custom:2.0",
+            ["memoryLimit"] = "1g"
+        };
+        var descriptor = MakeDescriptor(options);
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.Image.ShouldBe("custom:2.0");
+        result.MemoryLimit.ShouldBe("1g");
+        // Unspecified fields remain defaults
+        result.NetworkEnabled.ShouldBeFalse();
+        result.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Resolve_BoolOverride_Applied()
+    {
+        var options = new Dictionary<string, object?>
+        {
+            ["networkEnabled"] = true
+        };
+        var descriptor = MakeDescriptor(options);
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.NetworkEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Resolve_TimeSpanOverride_Applied()
+    {
+        var options = new Dictionary<string, object?>
+        {
+            ["idleTimeout"] = "00:05:00"
+        };
+        var descriptor = MakeDescriptor(options);
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public void Resolve_JsonElementValues_ParsedCorrectly()
+    {
+        var json = JsonSerializer.SerializeToElement(new
+        {
+            image = "json-img:latest",
+            networkEnabled = true,
+            memoryLimit = "2g",
+            idleTimeout = "00:15:00"
+        });
+
+        var options = new Dictionary<string, object?>();
+        foreach (var prop in json.EnumerateObject())
+        {
+            options[prop.Name] = prop.Value;
+        }
+
+        var descriptor = MakeDescriptor(options);
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.Image.ShouldBe("json-img:latest");
+        result.NetworkEnabled.ShouldBeTrue();
+        result.MemoryLimit.ShouldBe("2g");
+        result.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public void Resolve_NullValues_FallBackToDefaults()
+    {
+        var options = new Dictionary<string, object?>
+        {
+            ["image"] = null,
+            ["networkEnabled"] = null,
+            ["memoryLimit"] = null,
+            ["idleTimeout"] = null
+        };
+        var descriptor = MakeDescriptor(options);
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.Image.ShouldBe("default-image:1.0");
+        result.NetworkEnabled.ShouldBeFalse();
+        result.MemoryLimit.ShouldBe("512m");
+        result.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Resolve_InvalidTimeSpan_FallsBackToDefault()
+    {
+        var options = new Dictionary<string, object?>
+        {
+            ["idleTimeout"] = "not-a-timespan"
+        };
+        var descriptor = MakeDescriptor(options);
+        var result = DockerSandboxOptionsResolver.Resolve(Defaults, descriptor);
+
+        result.IdleTimeout.ShouldBe(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Resolve_NullDefaults_Throws()
+    {
+        var descriptor = MakeDescriptor();
+        Should.Throw<ArgumentNullException>(() => DockerSandboxOptionsResolver.Resolve(null!, descriptor));
+    }
+
+    [Fact]
+    public void Resolve_NullDescriptor_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => DockerSandboxOptionsResolver.Resolve(Defaults, null!));
+    }
+
+    [Fact]
+    public void Resolve_GlobalMemoryLimitNull_ReturnsNull()
+    {
+        var defaults = new DockerSandboxOptions
+        {
+            Image = "img",
+            NetworkEnabled = false,
+            MemoryLimit = null,
+            IdleTimeout = TimeSpan.FromMinutes(5)
+        };
+        var descriptor = MakeDescriptor();
+        var result = DockerSandboxOptionsResolver.Resolve(defaults, descriptor);
+
+        result.MemoryLimit.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Closes #1070

## Changes

- **DockerSandboxOptions**: expanded with `Image`, `NetworkEnabled`, `MemoryLimit` fields (global defaults)
- **DockerSandboxOptionsResolver**: merges global defaults with per-agent `IsolationOptions` dictionary (supports string, bool, JsonElement, TimeSpan parsing)
- **ResolvedDockerSandboxOptions**: fully-resolved options struct with all fields guaranteed non-null
- **IDockerSandboxRunner.CreateAsync**: now accepts `ResolvedDockerSandboxOptions` so the runner knows what image/network/memory to use
- **NullDockerSandboxRunner**: default no-op implementation; always reports Docker unavailable (strategy throws descriptive error if an agent tries to use it)
- **GatewayServiceCollectionExtensions**: registers `DockerSandboxIsolationStrategy` as `IIsolationStrategy` + `NullDockerSandboxRunner` as fallback `IDockerSandboxRunner`
- **DockerSandboxIsolationStrategy**: uses resolver for per-agent options, stores resolved config, passes to runner on create. Per-agent idle timeout used in `CheckIdleTimeoutsAsync`.

### Per-agent config example

```json
{
  "isolation": "docker-sandbox",
  "isolationOptions": {
    "image": "custom-sandbox:latest",
    "networkEnabled": true,
    "memoryLimit": "1g",
    "idleTimeout": "00:05:00"
  }
}
```

## Tests

- 29 Docker sandbox strategy tests (existing + 7 new config-specific tests)
- 10 options resolver tests (string, bool, JsonElement, null, invalid, boundary cases)
- Architecture 178 pass, Gateway 2422 pass

## Merge Notes

Independent of all open PRs. No file overlap. Safe to merge in any order.
Part of #982 Docker sandbox chain (2/4 sub-issues).
