### PR TITLE
fix(gateway): bypass orchestrator queue for steering to prevent serialization deadlock

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -360,36 +360,85 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var typedChannelType = ChannelKey.From("signalr");
         ArgumentException.ThrowIfNullOrWhiteSpace(content);
 
-        // Steering must target the caller-provided session so the control message
-        // reaches the active conversation the user is currently steering. Subscribe
-        // by conversation so post-compaction streams continue to arrive. #682
+        // Subscribe so post-compaction streams continue to arrive. #682
         await SubscribeInternalAsync(typedSessionId);
 
-        var connectionId = Context.ConnectionId;
-        var normalizedConversationId = string.IsNullOrWhiteSpace(conversationId) ? null : conversationId;
+        // Steering bypasses the per-session orchestrator queue and calls the handle
+        // directly. The old design routed steer through AcceptAsync → FIFO queue,
+        // which serialized behind the running dispatch — by the time the steer was
+        // dequeued, the agent had already finished and the steer was discarded.
+        //
+        // New design: get the live handle, call SteerAsync regardless of IsRunning.
+        // The agent's PendingMessageQueue accepts steers at any time; they are
+        // drained at the next turn boundary (mid-run) or at the start of the next
+        // run (if agent is idle). This matches how InterruptAndSteer already works.
+        var handle = _supervisor.GetHandle(typedAgentId, typedSessionId);
 
-        _ = SafeDispatchAsync(
-            () => _orchestrator.AcceptAsync(
-                new InboundMessage
-                {
-                    ChannelType = typedChannelType,
-                    SenderId = connectionId,
-                    Sender = CitizenId.Of(UserId.From(connectionId)),
-                    ChannelAddress = ChannelAddress.From(typedAgentId.Value),
-                    RoutingHints = new InboundMessageRoutingHints(
-                        RequestedAgentId: typedAgentId,
-                        RequestedSessionId: typedSessionId,
-                        RequestedConversationId: normalizedConversationId is null ? null : ConversationId.From(normalizedConversationId)),
-                    Content = content,
-                    Metadata = new Dictionary<string, object?>
+        if (handle is not null)
+        {
+            // Record steering message in session history
+            var session = await _sessions.GetOrCreateAsync(typedSessionId, typedAgentId, Context.ConnectionAborted);
+            session.AddEntry(new SessionEntry
+            {
+                Role = BotNexus.Domain.Primitives.MessageRole.User,
+                Content = content
+            });
+            await _sessions.SaveAsync(session, Context.ConnectionAborted);
+
+            // Inject into agent's steering queue (works whether running or idle)
+            await handle.SteerAsync(content, Context.ConnectionAborted);
+
+            await _activity.PublishAsync(new GatewayActivity
+            {
+                Type = GatewayActivityType.SteeringInjected,
+                AgentId = typedAgentId.Value,
+                SessionId = typedSessionId.Value,
+                ConversationId = conversationId
+            }, Context.ConnectionAborted);
+
+            _logger.LogInformation(
+                "Steering injected for agent {AgentId} session {SessionId} (running={IsRunning})",
+                typedAgentId.Value, typedSessionId.Value, handle.IsRunning);
+        }
+        else
+        {
+            // No handle exists — agent has never been started for this session,
+            // or was disposed. Queue the steer as a normal message so it triggers
+            // a new agent run (the orchestrator will create the handle on dispatch).
+            _logger.LogInformation(
+                "Steering queued as message for agent {AgentId} session {SessionId} (no active handle)",
+                typedAgentId.Value, typedSessionId.Value);
+
+            _ = SafeDispatchAsync(
+                () => _orchestrator.AcceptAsync(
+                    new InboundMessage
                     {
-                        ["messageType"] = "steer",
-                        ["control"] = "steer"
-                    }
-                },
-                CancellationToken.None),
-            typedAgentId,
-            typedSessionId);
+                        ChannelType = typedChannelType,
+                        SenderId = Context.ConnectionId,
+                        Sender = CitizenId.Of(UserId.From(Context.ConnectionId)),
+                        ChannelAddress = ChannelAddress.From(typedAgentId.Value),
+                        RoutingHints = new InboundMessageRoutingHints(
+                            RequestedAgentId: typedAgentId,
+                            RequestedSessionId: typedSessionId,
+                            RequestedConversationId: string.IsNullOrWhiteSpace(conversationId) ? null : ConversationId.From(conversationId)),
+                        Content = content,
+                        Metadata = new Dictionary<string, object?>
+                        {
+                            ["messageType"] = "steer"
+                        }
+                    },
+                    CancellationToken.None),
+                typedAgentId,
+                typedSessionId);
+
+            await _activity.PublishAsync(new GatewayActivity
+            {
+                Type = GatewayActivityType.SteeringQueued,
+                AgentId = typedAgentId.Value,
+                SessionId = typedSessionId.Value,
+                ConversationId = conversationId
+            }, Context.ConnectionAborted);
+        }
 
         return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
     }

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -866,15 +866,13 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
             catch { /* instance exists but handle creation failed */ }
         }
 
-        // If no handle or agent is not actively running, steering can't be
-        // injected mid-turn. Return false so the caller falls through to
-        // normal message processing (avoiding a recursive DispatchAsync
-        // deadlock on the single-reader session queue).
-        if (handle is null || !handle.IsRunning)
+        // If no handle exists at all, we can't inject. Return false so the
+        // caller discards the control message (it can't be delivered).
+        if (handle is null)
         {
             _logger.LogInformation(
-                "Steering received but agent is not running (instance={HasInstance}, running={IsRunning}). Steering will be discarded for session {SessionId}.",
-                instance is not null, handle?.IsRunning ?? false, sessionId);
+                "Steering received but no agent handle exists for session {SessionId}. Discarding.",
+                sessionId);
 
             await _activity.PublishAsync(new GatewayActivity
             {

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -654,9 +654,9 @@ public sealed class GatewayHostTests
 
         await host.DispatchAsync(CreateMessage("nudge", sessionId: "session-1", metadata: new Dictionary<string, object?> { ["control"] = "steer" }));
 
-        // Steering was NOT called because agent is not running
-        handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        // Steering was discarded — PromptAsync should NOT be called
+        // Steering IS called even though agent is not running (fix: no IsRunning gate)
+        handle.Verify(h => h.SteerAsync("nudge", It.IsAny<CancellationToken>()), Times.Once);
+        // Steering still does NOT fall through to PromptAsync
         handle.Verify(h => h.PromptAsync(It.Is<AgentUserMessage>(m => m.Content == "nudge"), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -420,7 +420,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         dispatcher.Messages[0].RoutingHints!.RequestedSessionId!.Value.Value.ShouldBe(sessionId);
         dispatcher.Messages[0].RoutingHints!.RequestedConversationId.ShouldBeNull();
         dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
-        dispatcher.Messages[0].Metadata["control"].ShouldBe("steer");
+        dispatcher.Messages[0].Metadata.ShouldNotContainKey("control"); // Fallback path omits control
     }
 
     [Fact]
@@ -445,7 +445,7 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
         dispatcher.Messages[0].RoutingHints!.RequestedSessionId!.Value.Value.ShouldBe(sessionId);
         dispatcher.Messages[0].RoutingHints!.RequestedConversationId!.Value.Value.ShouldBe("conv-42");
         dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
-        dispatcher.Messages[0].Metadata["control"].ShouldBe("steer");
+        dispatcher.Messages[0].Metadata.ShouldNotContainKey("control"); // Fallback path omits control
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
@@ -338,10 +338,12 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
         dispatched.Metadata.ShouldNotBeNull();
         dispatched.Metadata.ShouldContainKey("messageType");
         dispatched.Metadata["messageType"].ShouldBe("steer");
-        dispatched.Metadata.ShouldContainKey("control");
-        dispatched.Metadata["control"].ShouldBe(
-            "steer",
-            "Steer hub method must dispatch with control=steer metadata so it cannot be re-routed as a regular prompt; #192");
+        // After fix: fallback path (no handle) dispatches as a regular message
+        // with messageType=steer for tracing but without control=steer.
+        // The #192 concern (steer falling through as prompt) is now solved
+        // at the GatewayHub level: when a handle exists, Steer bypasses the
+        // queue entirely and calls SteerAsync directly.
+        dispatched.Metadata.ShouldNotContainKey("control");
     }
 
     /// <summary>

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -389,7 +389,7 @@ public sealed class SignalRHubTests
         dispatched.RoutingHints!.RequestedSessionId!.Value.Value.ShouldBe(requestedSessionId);
         dispatched.RoutingHints.RequestedConversationId.ShouldBeNull();
         dispatched.Metadata["messageType"].ShouldBe("steer");
-        dispatched.Metadata["control"].ShouldBe("steer");
+        dispatched.Metadata.ShouldNotContainKey("control"); // Fallback path doesn't mark as control
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Steering/GatewaySteeringTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Steering/GatewaySteeringTests.cs
@@ -109,9 +109,10 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Steer_WhenAgentNotRunning_DiscardsAndPublishesSteeringQueued()
+    public async Task Steer_WhenAgentNotRunning_StillInjectsViaHandle()
     {
-        // Agent has an instance but is NOT running
+        // After fix: handle exists but not running — SteerAsync is still called.
+        // The agent's PendingMessageQueue accepts steers at any time.
         var handle = CreateHandle(isRunning: false);
         var supervisor = CreateSupervisor(handle.Object, hasInstance: true);
         var session = CreateSession();
@@ -119,17 +120,17 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
         var activity = new RecordingActivityBroadcaster();
         await using var host = CreateHost(supervisor.Object, sessions.Object, activity);
 
-        await host.ProcessAsync(CreateSteerMessage("too late"), CancellationToken.None);
+        await host.ProcessAsync(CreateSteerMessage("late steer"), CancellationToken.None);
 
-        // Steering is discarded
-        handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        // SteeringQueued published (portal shows "🕒")
-        activity.Activities.ShouldContain(a => a.Type == GatewayActivityType.SteeringQueued);
-        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringInjected);
+        // Steering IS injected even though agent is idle
+        handle.Verify(h => h.SteerAsync("late steer", It.IsAny<CancellationToken>()), Times.Once);
+        // SteeringInjected published (portal clears pending entry)
+        activity.Activities.ShouldContain(a => a.Type == GatewayActivityType.SteeringInjected);
+        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringQueued);
     }
 
     [Fact]
-    public async Task Steer_WhenAgentNotRunning_DoesNotRecordInHistory()
+    public async Task Steer_WhenAgentNotRunning_RecordsInHistory()
     {
         var handle = CreateHandle(isRunning: false);
         var supervisor = CreateSupervisor(handle.Object, hasInstance: true);
@@ -137,9 +138,9 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
         var sessions = CreateSessionStore(session);
         await using var host = CreateHost(supervisor.Object, sessions.Object, new RecordingActivityBroadcaster());
 
-        await host.ProcessAsync(CreateSteerMessage("discarded"), CancellationToken.None);
+        await host.ProcessAsync(CreateSteerMessage("recorded"), CancellationToken.None);
 
-        session.History.ShouldNotContain(e => e.Content == "discarded");
+        session.History.ShouldContain(e => e.Role == MessageRole.User && e.Content == "recorded");
     }
 
     [Fact]
@@ -160,9 +161,9 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Steer_WhenAgentNotRunning_DoesNotFallThroughToNormalProcessing()
+    public async Task Steer_WhenHandleExists_DoesNotFallThroughToNormalProcessing()
     {
-        // Critical: discarded steer must NOT become a normal user prompt
+        // Critical: an injected steer must NOT also trigger a normal user prompt
         var handle = CreateHandle(isRunning: false);
         var supervisor = CreateSupervisor(handle.Object, hasInstance: true);
         var session = CreateSession();
@@ -171,6 +172,8 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
 
         await host.ProcessAsync(CreateSteerMessage("should not prompt"), CancellationToken.None);
 
+        // SteerAsync called (steer injected) but no prompt/stream issued
+        handle.Verify(h => h.SteerAsync("should not prompt", It.IsAny<CancellationToken>()), Times.Once);
         handle.Verify(h => h.PromptAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()), Times.Never);
         handle.Verify(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         handle.Verify(h => h.StreamAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -180,27 +183,24 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
     // TIER 2: Orchestrator integration — queue serialization (THE BUG)
     // ─────────────────────────────────────────────────────────────────────────────
 
-    [Fact(DisplayName = "BUG: Steer sent while agent is running is ALWAYS discarded due to queue serialization")]
-    public async Task Steer_WhileAgentRunning_IsBlockedByQueueAndDiscarded()
+    [Fact(DisplayName = "FIX: Steer queued behind running dispatch is now injected when dequeued")]
+    public async Task Steer_WhileAgentRunning_IsQueuedThenInjectedOnDequeue()
     {
-        // This test PROVES the design flaw:
-        // 1. A normal message enters the queue → agent starts running
-        // 2. While agent is running, a steer message enters the SAME queue
-        // 3. The queue is SingleReader — steer waits behind the running dispatch
-        // 4. When the normal message finishes, agent stops running (IsRunning=false)
-        // 5. Steer is dequeued → HandleSteeringAsync → IsRunning=false → DISCARDED
+        // After the fix: the steer still waits in the queue (queue serialization
+        // is correct for ordering), but when dequeued, HandleSteeringAsync no
+        // longer checks IsRunning — it calls SteerAsync regardless.
         //
-        // Expected: steer should be injected mid-turn
-        // Actual: steer is always too late
+        // For SignalR portal, GatewayHub.Steer bypasses the queue entirely.
+        // This test validates the fallback path for other channels.
 
         var agentRunning = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var agentCanFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var isRunning = true;
 
         var handle = new Mock<IAgentHandle>();
         handle.SetupGet(h => h.AgentId).Returns(AgentA);
         handle.SetupGet(h => h.SessionId).Returns(SessionA);
-        handle.Setup(h => h.IsRunning).Returns(() => isRunning);
+        handle.Setup(h => h.IsRunning).Returns(false); // Not running when steer is dequeued
+        handle.Setup(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         handle.Setup(h => h.StreamAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
             .Returns(BlockingStream(agentRunning, agentCanFinish));
 
@@ -210,53 +210,39 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
         var activity = new RecordingActivityBroadcaster();
         var host = CreateHost(supervisor.Object, sessions.Object, activity);
 
-        // Wire up the orchestrator — messages go through the per-session queue
         await using var orchestrator = new DefaultInboundMessageOrchestrator(
             host, NullLogger<DefaultInboundMessageOrchestrator>.Instance);
 
-        // Step 1: Normal message enters queue — agent starts running
+        // Step 1: Normal message enters queue → agent starts running
         var normalTask = orchestrator.AcceptAsync(CreateMessage("do work"));
         await agentRunning.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // Step 2: While agent IS running, send a steer message on the same queue
+        // Step 2: Steer enters the same queue (blocked behind running dispatch)
         var steerTask = orchestrator.AcceptAsync(CreateSteerMessage("change direction"));
 
-        // Step 3: The steer is stuck in the queue. Verify it hasn't been processed yet.
-        await Task.Delay(200);
-        handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never,
-            "Steer should still be in queue while agent is running");
-
-        // Step 4: Agent finishes — IsRunning transitions to false
-        isRunning = false;
+        // Step 3: Agent finishes
         agentCanFinish.TrySetResult();
         await normalTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // Step 5: NOW the steer is dequeued, but agent is no longer running
+        // Step 4: Steer dequeued — NOW it’s processed
         await steerTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // ASSERT THE BUG: SteerAsync was NEVER called
-        handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never,
-            "BUG PROVEN: Steer was discarded because queue serialization guarantees IsRunning=false by dequeue time");
-
-        // SteeringQueued was published (UI shows 🕒 forever)
-        activity.Activities.ShouldContain(a => a.Type == GatewayActivityType.SteeringQueued,
-            "Portal stuck showing '🕒 Steer queued' with no resolution");
-        // SteeringInjected was NEVER published (UI never clears)
-        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringInjected,
-            "No SteeringInjected means portal UI never resolves");
+        // FIXED: SteerAsync IS called even though agent finished
+        handle.Verify(h => h.SteerAsync("change direction", It.IsAny<CancellationToken>()), Times.Once);
+        activity.Activities.ShouldContain(a => a.Type == GatewayActivityType.SteeringInjected);
     }
 
-    [Fact(DisplayName = "BUG: Multiple steers while agent running are ALL discarded")]
-    public async Task MultipleSteer_WhileAgentRunning_AllDiscarded()
+    [Fact(DisplayName = "FIX: Multiple steers queued behind running dispatch are all injected")]
+    public async Task MultipleSteer_WhileAgentRunning_AllInjectedOnDequeue()
     {
         var agentRunning = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var agentCanFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var isRunning = true;
 
         var handle = new Mock<IAgentHandle>();
         handle.SetupGet(h => h.AgentId).Returns(AgentA);
         handle.SetupGet(h => h.SessionId).Returns(SessionA);
-        handle.Setup(h => h.IsRunning).Returns(() => isRunning);
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         handle.Setup(h => h.StreamAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
             .Returns(BlockingStream(agentRunning, agentCanFinish));
 
@@ -278,14 +264,13 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
         var steer3 = orchestrator.AcceptAsync(CreateSteerMessage("steer-3"));
 
         // Agent finishes
-        isRunning = false;
         agentCanFinish.TrySetResult();
         await Task.WhenAll(normalTask, steer1, steer2, steer3).WaitAsync(TimeSpan.FromSeconds(10));
 
-        // ALL steers discarded
-        handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        activity.Activities.Count(a => a.Type == GatewayActivityType.SteeringQueued).ShouldBe(3);
-        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringInjected);
+        // ALL steers injected
+        handle.Verify(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        activity.Activities.Count(a => a.Type == GatewayActivityType.SteeringInjected).ShouldBe(3);
+        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringQueued);
     }
 
     [Fact]
@@ -390,8 +375,9 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
     [Fact]
     public async Task SteeringQueued_IncludesAgentIdAndSessionId()
     {
-        var handle = CreateHandle(isRunning: false);
-        var supervisor = CreateSupervisor(handle.Object, hasInstance: true);
+        // SteeringQueued only fires when NO handle exists at all
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetInstance(AgentA, SessionA)).Returns((AgentInstance?)null);
         var session = CreateSession();
         var sessions = CreateSessionStore(session);
         var activity = new RecordingActivityBroadcaster();
@@ -404,20 +390,19 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
         queued.SessionId.ShouldBe("session-1");
     }
 
-    [Fact(DisplayName = "BUG: No SteeringInjected event ever fires when steer is queued behind running dispatch")]
-    public async Task QueuedSteer_NeverEmitsSteeringInjected_LeavingUIStuck()
+    [Fact(DisplayName = "FIX: SteeringInjected event fires even when steer is processed after dispatch completes")]
+    public async Task QueuedSteer_EmitsSteeringInjected_UIResolvesCorrectly()
     {
-        // This test proves the portal UI bug: 🕒 Steer stuck forever
-        // The portal adds to PendingSteeringQueue on SteeringQueued event,
-        // but never receives SteeringInjected to clear it.
+        // After the fix: even though the steer waits in the queue, when processed
+        // it emits SteeringInjected so the portal clears the pending entry.
         var agentRunning = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var agentCanFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var isRunning = true;
 
         var handle = new Mock<IAgentHandle>();
         handle.SetupGet(h => h.AgentId).Returns(AgentA);
         handle.SetupGet(h => h.SessionId).Returns(SessionA);
-        handle.Setup(h => h.IsRunning).Returns(() => isRunning);
+        handle.Setup(h => h.IsRunning).Returns(false);
+        handle.Setup(h => h.SteerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         handle.Setup(h => h.StreamAsync(It.IsAny<UserMessage>(), It.IsAny<CancellationToken>()))
             .Returns(BlockingStream(agentRunning, agentCanFinish));
 
@@ -437,16 +422,13 @@ public sealed class GatewaySteeringTests : IAsyncLifetime
         var steerTask = orchestrator.AcceptAsync(CreateSteerMessage("redirect"));
 
         // Agent finishes
-        isRunning = false;
         agentCanFinish.TrySetResult();
         await Task.WhenAll(normalTask, steerTask).WaitAsync(TimeSpan.FromSeconds(10));
 
-        // PROVE THE UI BUG:
-        // SteeringQueued was published (portal adds to pending queue, shows 🕒)
-        activity.Activities.ShouldContain(a => a.Type == GatewayActivityType.SteeringQueued);
-        // SteeringInjected was NEVER published (portal never clears the pending entry)
-        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringInjected);
-        // This means the "🕒 Steer redirect..." stays in the UI PERMANENTLY
+        // FIXED: SteeringInjected IS published (portal resolves 🕒 to ✅)
+        activity.Activities.ShouldContain(a => a.Type == GatewayActivityType.SteeringInjected);
+        // No SteeringQueued (handle exists, injection succeeded)
+        activity.Activities.ShouldNotContain(a => a.Type == GatewayActivityType.SteeringQueued);
     }
 
     // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the root cause of steering never being injected mid-turn. The portal UI showing "🕒 Steer..." permanently is now resolved.

## Root Cause

`GatewayHub.Steer` routed steer messages through `orchestrator.AcceptAsync()` → per-session FIFO queue → `ProcessAsync`. Since the queue is SingleReader and serial, the steer could never reach `HandleSteeringAsync` while the agent was running (it was stuck behind the running dispatch). By the time it was dequeued, `IsRunning=false` → discarded.

## Fix

Two changes:

### 1. GatewayHub.Steer bypasses the queue (primary path)
When a handle exists, call `handle.SteerAsync()` directly (like `InterruptAndSteer` already does). This works whether the agent is running or idle — the agent PendingMessageQueue accepts steers at any time and drains them at the next turn boundary.

When NO handle exists (agent never started), fall back to dispatching as a normal message (triggers agent creation).

### 2. GatewayHost.HandleSteeringAsync removes IsRunning gate (secondary path)
For other channels that send `control=steer` through the queue (ServiceBus, etc.), the IsRunning check is removed. If a handle exists, `SteerAsync` is called regardless of running state.

## Tests

- Updated 6 existing tests to validate correct behaviour (steer is now injected)
- 3 former BUG-proving tests converted to FIX-validating tests
- All 2,452 gateway tests pass
- All 178 architecture tests pass

## Related PRs
- #1080 (agent core steering loop tests — merged)
- #1094 (gateway steering pipeline tests that proved the bug — merged)

Closes the UI issue where steering showed "🕒 Steer queued" permanently.