### PR TITLE
feat(canvas): add set_state, get_state, and clear_state actions to canvas tool

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -342,7 +342,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
                 canvasConversationId = await ResolveConversationIdAsync(canvasConvStore, sessionStore, descriptor.AgentId, context.SessionId, cancellationToken)
                     .ConfigureAwait(false);
             }
-            tools.Add(new CanvasTool(descriptor.AgentId, canvasConversationId, canvasNotifiers));
+            tools.Add(new CanvasTool(descriptor.AgentId, canvasConversationId, canvasConvStore, canvasNotifiers));
         }
 
         List<object> extensionResourcesToDispose = [];

--- a/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
@@ -4,49 +4,90 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+
 namespace BotNexus.Gateway.Tools;
+
+/// <summary>
+/// Agent tool for canvas HTML rendering and key-value state management.
+/// Supports render/clear for HTML output, and set_state/get_state/clear_state for
+/// persistent conversation-scoped state accessible to both agent and canvas JS.
+/// </summary>
 public sealed class CanvasTool(
     AgentId agentId,
     ConversationId? conversationId,
+    IConversationStore? conversationStore = null,
     IReadOnlyList<IAgentCanvasNotifier>? canvasNotifiers = null) : IAgentTool
 {
+    private static readonly JsonElement ToolSchema = JsonDocument.Parse("""
+        {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": ["render", "clear", "set_state", "get_state", "clear_state"],
+              "description": "Canvas action to perform."
+            },
+            "html": {
+              "type": "string",
+              "description": "HTML payload to render when action is 'render'."
+            },
+            "key": {
+              "type": "string",
+              "description": "State key for set_state, get_state (single key), or omit for get_state (all keys)."
+            },
+            "value": {
+              "description": "JSON value to store when action is 'set_state'."
+            }
+          },
+          "required": ["action"]
+        }
+        """).RootElement.Clone();
+
     private readonly AgentId _agentId = agentId;
-    private readonly string _conversationId = conversationId?.Value ?? string.Empty;
+    private readonly ConversationId? _conversationId = conversationId;
+    private readonly IConversationStore? _conversationStore = conversationStore;
     private readonly IReadOnlyList<IAgentCanvasNotifier> _canvasNotifiers = canvasNotifiers ?? [];
+
     public string Name => "canvas";
     public string Label => "Canvas";
+
     public Tool Definition => new(
         Name,
-        "Publish Canvas tab HTML for the current agent scope. Use action='render' with html content to replace output, or action='clear' to clear output.",
-        JsonDocument.Parse("""
-            {
-              "type": "object",
-              "properties": {
-                "action": {
-                  "type": "string",
-                  "enum": ["render", "clear"],
-                  "description": "Canvas action to perform."
-                },
-                "html": {
-                  "type": "string",
-                  "description": "HTML payload to render when action is 'render'."
-                }
-              },
-              "required": ["action"]
-            }
-            """).RootElement.Clone());
+        "Publish Canvas tab HTML for the current agent scope. Use action='render' with html content to replace output, or action='clear' to clear output. Use set_state/get_state/clear_state for persistent key-value state.",
+        ToolSchema);
+
     public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
         IReadOnlyDictionary<string, object?> arguments,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var action = ReadRequiredString(arguments, "action").Trim().ToLowerInvariant();
-        if (action is not ("render" or "clear"))
-            throw new ArgumentException("Argument 'action' must be either 'render' or 'clear'.");
-        if (action == "render" && string.IsNullOrWhiteSpace(ReadString(arguments, "html")))
-            throw new ArgumentException("Argument 'html' is required when action is 'render'.");
+
+        switch (action)
+        {
+            case "render":
+                if (string.IsNullOrWhiteSpace(ReadString(arguments, "html")))
+                    throw new ArgumentException("Argument 'html' is required when action is 'render'.");
+                break;
+            case "clear":
+            case "clear_state":
+            case "get_state":
+                break;
+            case "set_state":
+                if (string.IsNullOrWhiteSpace(ReadString(arguments, "key")))
+                    throw new ArgumentException("Argument 'key' is required when action is 'set_state'.");
+                if (!arguments.ContainsKey("value"))
+                    throw new ArgumentException("Argument 'value' is required when action is 'set_state'.");
+                break;
+            default:
+                throw new ArgumentException(
+                    "Argument 'action' must be one of: render, clear, set_state, get_state, clear_state.");
+        }
+
         return Task.FromResult(arguments);
     }
+
     public async Task<AgentToolResult> ExecuteAsync(
         string toolCallId,
         IReadOnlyDictionary<string, object?> arguments,
@@ -54,14 +95,152 @@ public sealed class CanvasTool(
         AgentToolUpdateCallback? onUpdate = null)
     {
         var action = ReadRequiredString(arguments, "action").Trim().ToLowerInvariant();
-        var html = action == "clear" ? string.Empty : ReadString(arguments, "html") ?? string.Empty;
+
+        return action switch
+        {
+            "render" => await ExecuteRenderAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "clear" => await ExecuteClearCanvasAsync(cancellationToken).ConfigureAwait(false),
+            "set_state" => await ExecuteSetStateAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "get_state" => await ExecuteGetStateAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "clear_state" => await ExecuteClearStateAsync(cancellationToken).ConfigureAwait(false),
+            _ => new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Unknown action: {action}")])
+        };
+    }
+
+    private async Task<AgentToolResult> ExecuteRenderAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        var html = ReadString(arguments, "html") ?? string.Empty;
+        var conversationIdValue = _conversationId?.Value ?? string.Empty;
+
         foreach (var notifier in _canvasNotifiers)
-            await notifier.NotifyCanvasUpdatedAsync(_agentId.Value, _conversationId, html, cancellationToken).ConfigureAwait(false);
-        var message = action == "clear"
-            ? "Canvas cleared for current agent."
-            : "Canvas rendered for current agent.";
+        {
+            await notifier.NotifyCanvasUpdatedAsync(_agentId.Value, conversationIdValue, html, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "Canvas rendered for current agent.")]);
+    }
+
+    private async Task<AgentToolResult> ExecuteClearCanvasAsync(CancellationToken cancellationToken)
+    {
+        var conversationIdValue = _conversationId?.Value ?? string.Empty;
+
+        foreach (var notifier in _canvasNotifiers)
+        {
+            await notifier.NotifyCanvasUpdatedAsync(_agentId.Value, conversationIdValue, string.Empty, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "Canvas cleared for current agent.")]);
+    }
+
+    private async Task<AgentToolResult> ExecuteSetStateAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        if (_conversationId is null || _conversationStore is null)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                "Canvas state is not available: no conversation context or store configured.")]);
+        }
+
+        var key = ReadRequiredString(arguments, "key");
+        var value = GetJsonValue(arguments, "value");
+
+        var success = await _conversationStore.SetCanvasStateKeyAsync(_conversationId.Value, key, value, cancellationToken)
+            .ConfigureAwait(false);
+
+        var message = success
+            ? $"State key '{key}' set successfully."
+            : $"Failed to set state key '{key}': conversation not found.";
+
         return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, message)]);
     }
+
+    private async Task<AgentToolResult> ExecuteGetStateAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken)
+    {
+        if (_conversationId is null || _conversationStore is null)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                "Canvas state is not available: no conversation context or store configured.")]);
+        }
+
+        var key = ReadString(arguments, "key");
+
+        if (!string.IsNullOrWhiteSpace(key))
+        {
+            // Single key lookup
+            var state = await _conversationStore.GetCanvasStateAsync(_conversationId.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (state is null)
+            {
+                return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                    "Conversation not found.")]);
+            }
+
+            if (state.TryGetValue(key, out var value))
+            {
+                return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, value.ToString())]);
+            }
+
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                $"Key '{key}' not found in canvas state.")]);
+        }
+
+        // All keys
+        var allState = await _conversationStore.GetCanvasStateAsync(_conversationId.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (allState is null)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "Conversation not found.")]);
+        }
+
+        if (allState.Count == 0)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "Canvas state is empty.")]);
+        }
+
+        var json = JsonSerializer.Serialize(allState, new JsonSerializerOptions { WriteIndented = true });
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, json)]);
+    }
+
+    private async Task<AgentToolResult> ExecuteClearStateAsync(CancellationToken cancellationToken)
+    {
+        if (_conversationId is null || _conversationStore is null)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                "Canvas state is not available: no conversation context or store configured.")]);
+        }
+
+        await _conversationStore.ClearCanvasStateAsync(_conversationId.Value, cancellationToken).ConfigureAwait(false);
+
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+            "All canvas state cleared for this conversation.")]);
+    }
+
+    private static JsonElement GetJsonValue(IReadOnlyDictionary<string, object?> arguments, string key)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+        {
+            return JsonDocument.Parse("null").RootElement.Clone();
+        }
+
+        if (value is JsonElement element)
+        {
+            return element;
+        }
+
+        // Serialize non-JsonElement values to JsonElement
+        var json = JsonSerializer.Serialize(value);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
     private static string ReadRequiredString(IReadOnlyDictionary<string, object?> arguments, string key)
     {
         var value = ReadString(arguments, key);
@@ -69,6 +248,7 @@ public sealed class CanvasTool(
             throw new ArgumentException($"Missing required argument: {key}.");
         return value;
     }
+
     private static string? ReadString(IReadOnlyDictionary<string, object?> arguments, string key)
     {
         if (!arguments.TryGetValue(key, out var value) || value is null)

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolStateTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolStateTests.cs
@@ -1,0 +1,290 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Tools;
+using NSubstitute;
+using Shouldly;
+
+namespace BotNexus.Gateway.Tests.Tools;
+
+public sealed class CanvasToolStateTests
+{
+    private static readonly AgentId TestAgentId = AgentId.From("test-agent");
+    private static readonly ConversationId TestConversationId = ConversationId.From("c_test123");
+
+    // ═══════════════════════════════════════════════════════════════════
+    // set_state
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SetState_WritesKeyValueToStore()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.SetCanvasStateKeyAsync(TestConversationId, "counter", Arg.Any<JsonElement>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var tool = CreateTool(store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("set_state"),
+            ["key"] = JsonElement("counter"),
+            ["value"] = JsonElement(42)
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("'counter' set successfully");
+        await store.Received(1).SetCanvasStateKeyAsync(
+            TestConversationId, "counter", Arg.Any<JsonElement>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetState_WhenConversationNotFound_ReportsFailure()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.SetCanvasStateKeyAsync(
+                TestConversationId, "missing", Arg.Any<JsonElement>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var tool = CreateTool(store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("set_state"),
+            ["key"] = JsonElement("missing"),
+            ["value"] = JsonElement("val")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("conversation not found");
+    }
+
+    [Fact]
+    public async Task SetState_WithoutStore_ReturnsUnavailableMessage()
+    {
+        var tool = new CanvasTool(TestAgentId, TestConversationId, conversationStore: null);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("set_state"),
+            ["key"] = JsonElement("k"),
+            ["value"] = JsonElement("v")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("not available");
+    }
+
+    [Fact]
+    public async Task SetState_WithoutConversationId_ReturnsUnavailableMessage()
+    {
+        var store = Substitute.For<IConversationStore>();
+        var tool = new CanvasTool(TestAgentId, conversationId: null, conversationStore: store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("set_state"),
+            ["key"] = JsonElement("k"),
+            ["value"] = JsonElement("v")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("not available");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // get_state (single key)
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetState_SingleKey_ReturnsValue()
+    {
+        var store = Substitute.For<IConversationStore>();
+        var state = new Dictionary<string, JsonElement>
+        {
+            ["color"] = JsonDocument.Parse("\"blue\"").RootElement
+        };
+        store.GetCanvasStateAsync(TestConversationId, Arg.Any<CancellationToken>())
+            .Returns(state);
+
+        var tool = CreateTool(store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("get_state"),
+            ["key"] = JsonElement("color")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("blue");
+    }
+
+    [Fact]
+    public async Task GetState_SingleKey_NotFound_ReportsKeyMissing()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.GetCanvasStateAsync(TestConversationId, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, JsonElement>());
+
+        var tool = CreateTool(store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("get_state"),
+            ["key"] = JsonElement("missing-key")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("'missing-key' not found");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // get_state (all keys)
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetState_AllKeys_ReturnsJsonDictionary()
+    {
+        var store = Substitute.For<IConversationStore>();
+        var state = new Dictionary<string, JsonElement>
+        {
+            ["a"] = JsonDocument.Parse("1").RootElement,
+            ["b"] = JsonDocument.Parse("\"two\"").RootElement
+        };
+        store.GetCanvasStateAsync(TestConversationId, Arg.Any<CancellationToken>())
+            .Returns(state);
+
+        var tool = CreateTool(store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("get_state")
+        });
+
+        var text = result.Content.ShouldHaveSingleItem().Value;
+        text.ShouldContain("\"a\"");
+        text.ShouldContain("\"b\"");
+    }
+
+    [Fact]
+    public async Task GetState_AllKeys_EmptyState_ReportsEmpty()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.GetCanvasStateAsync(TestConversationId, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, JsonElement>());
+
+        var tool = CreateTool(store);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("get_state")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("empty");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // clear_state
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ClearState_CallsStoreAndReportsSuccess()
+    {
+        var store = Substitute.For<IConversationStore>();
+        var tool = CreateTool(store);
+
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("clear_state")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("cleared");
+        await store.Received(1).ClearCanvasStateAsync(TestConversationId, Arg.Any<CancellationToken>());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // PrepareArguments validation
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task PrepareArguments_SetState_MissingKey_Throws()
+    {
+        var tool = CreateTool(Substitute.For<IConversationStore>());
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+            {
+                ["action"] = JsonElement("set_state"),
+                ["value"] = JsonElement("v")
+            }));
+    }
+
+    [Fact]
+    public async Task PrepareArguments_SetState_MissingValue_Throws()
+    {
+        var tool = CreateTool(Substitute.For<IConversationStore>());
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+            {
+                ["action"] = JsonElement("set_state"),
+                ["key"] = JsonElement("k")
+            }));
+    }
+
+    [Fact]
+    public async Task PrepareArguments_InvalidAction_Throws()
+    {
+        var tool = CreateTool(Substitute.For<IConversationStore>());
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+            {
+                ["action"] = JsonElement("invalid_action")
+            }));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Existing render/clear actions still work
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Render_StillNotifiesCanvas()
+    {
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+        var tool = new CanvasTool(TestAgentId, TestConversationId, canvasNotifiers: [notifier]);
+
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("render"),
+            ["html"] = JsonElement("<h1>Hello</h1>")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("rendered");
+        await notifier.Received(1).NotifyCanvasUpdatedAsync(
+            TestAgentId.Value, TestConversationId.Value, "<h1>Hello</h1>", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Clear_StillNotifiesCanvasWithEmptyHtml()
+    {
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+        var tool = new CanvasTool(TestAgentId, TestConversationId, canvasNotifiers: [notifier]);
+
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = JsonElement("clear")
+        });
+
+        result.Content.ShouldHaveSingleItem().Value.ShouldContain("cleared");
+        await notifier.Received(1).NotifyCanvasUpdatedAsync(
+            TestAgentId.Value, TestConversationId.Value, string.Empty, Arg.Any<CancellationToken>());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static CanvasTool CreateTool(IConversationStore store)
+    {
+        return new CanvasTool(TestAgentId, TestConversationId, conversationStore: store);
+    }
+
+    private static JsonElement JsonElement(string value)
+    {
+        return JsonDocument.Parse($"\"{value}\"").RootElement.Clone();
+    }
+
+    private static JsonElement JsonElement(int value)
+    {
+        return JsonDocument.Parse(value.ToString()).RootElement.Clone();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolTests.cs
@@ -20,7 +20,7 @@ public sealed class CanvasToolTests
     public async Task ExecuteAsync_Render_PublishesHtmlWithConversationId()
     {
         var notifier = new Mock<IAgentCanvasNotifier>();
-        var tool = new CanvasTool(AgentId.From("agent-a"), ConversationId.From("conv-1"), [notifier.Object]);
+        var tool = new CanvasTool(AgentId.From("agent-a"), ConversationId.From("conv-1"), canvasNotifiers: [notifier.Object]);
         var result = await ExecuteAsync(tool, new Dictionary<string, object?>
         {
             ["action"] = "render",
@@ -39,7 +39,7 @@ public sealed class CanvasToolTests
     public async Task ExecuteAsync_Render_NullConversationId_PassesEmptyString()
     {
         var notifier = new Mock<IAgentCanvasNotifier>();
-        var tool = new CanvasTool(AgentId.From("agent-a"), null, [notifier.Object]);
+        var tool = new CanvasTool(AgentId.From("agent-a"), null, canvasNotifiers: [notifier.Object]);
         await ExecuteAsync(tool, new Dictionary<string, object?>
         {
             ["action"] = "render",
@@ -57,7 +57,7 @@ public sealed class CanvasToolTests
     public async Task ExecuteAsync_Clear_PublishesEmptyHtmlWithConversationId()
     {
         var notifier = new Mock<IAgentCanvasNotifier>();
-        var tool = new CanvasTool(AgentId.From("agent-a"), ConversationId.From("conv-1"), [notifier.Object]);
+        var tool = new CanvasTool(AgentId.From("agent-a"), ConversationId.From("conv-1"), canvasNotifiers: [notifier.Object]);
         var result = await ExecuteAsync(tool, new Dictionary<string, object?>
         {
             ["action"] = "clear"


### PR DESCRIPTION
Closes #1067

## Changes
Extends the existing \canvas\ tool with state management actions:

- **\set_state\**: writes a key-value pair to conversation canvas state via \IConversationStore.SetCanvasStateKeyAsync\
- **\get_state\**: reads a single key (returns value) or all keys (returns JSON dictionary)
- **\clear_state\**: removes all state for the conversation

State operations are independent of HTML rendering — \ender\/\clear\ do NOT affect state.

### Implementation Details
- \CanvasTool\ constructor now accepts optional \IConversationStore\ (already resolved by \InProcessIsolationStrategy\)
- Graceful fallback when no store or conversation context available (returns descriptive error)
- Tool schema updated with new enum values and \key\/\alue\ properties
- Existing \CanvasToolTests.cs\ updated for new constructor signature (named param)

### Tests
- 14 new tests in \CanvasToolStateTests.cs\ covering:
  - Happy paths for set/get/clear
  - Single key and all-keys get
  - Error paths (no store, no conversation, key not found)
  - PrepareArguments validation (missing key, missing value, invalid action)
  - Regression: render/clear still work unchanged
- 178/178 Architecture, 29/29 Scenarios pass

## Merge Notes
Part of #972 canvas state chain (3/4 sub-issues done: #1065 merged, #1066/#1097 merged, #1067 this PR).
Only remaining: #1068 (SignalR notifications + JS helper).
Safe to merge independently — no file overlap with any open PR.