### PR TITLE
fix(compaction): surface failure reason in CompactSessionResult to prevent misleading success notifications

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicRequestBuilder.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicRequestBuilder.cs
@@ -121,7 +121,19 @@ internal static class AnthropicRequestBuilder
         }
         else if (model.Reasoning && anthropicOpts?.ThinkingEnabled == false)
         {
-            body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "disabled" });
+            // Adaptive thinking models (Opus 4.6, Sonnet 4.6) do not support
+            // thinking: {type: disabled} — the API returns an empty response.
+            // Instead, use adaptive mode with minimal effort so the model still
+            // produces output text without expensive reasoning.
+            if (isAdaptiveThinkingModel(model.Id))
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "adaptive" });
+                body["output_config"] = ToNode(new Dictionary<string, object?> { ["effort"] = "low" });
+            }
+            else
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "disabled" });
+            }
         }
 
         if (options?.Temperature.HasValue == true && anthropicOpts?.ThinkingEnabled != true)

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesRequestBuilder.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesRequestBuilder.cs
@@ -105,7 +105,19 @@ internal static class CopilotMessagesRequestBuilder
         }
         else if (model.Reasoning && copilotOpts?.ThinkingEnabled == false)
         {
-            body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "disabled" });
+            // Adaptive thinking models (Opus 4.6, Sonnet 4.6) do not support
+            // thinking: {type: disabled} — the API returns an empty response.
+            // Instead, use adaptive mode with minimal effort so the model still
+            // produces output text without expensive reasoning.
+            if (isAdaptiveThinkingModel(model.Id))
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "adaptive" });
+                body["output_config"] = ToNode(new Dictionary<string, object?> { ["effort"] = "low" });
+            }
+            else
+            {
+                body["thinking"] = ToNode(new Dictionary<string, object?> { ["type"] = "disabled" });
+            }
         }
 
         if (options?.Temperature.HasValue == true && copilotOpts?.ThinkingEnabled != true)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -181,9 +181,10 @@ public sealed class AgentInteractionService : IAgentInteractionService
             var convId = agent.ActiveConversationId;
             if (convId is not null && agent.Conversations.GetValueOrDefault(convId) is { } conv)
             {
-                conv.Messages.Add(new ChatMessage("System",
-                    $"_[Session context compacted: {result.Summarized} older messages summarised, {result.Preserved} recent messages preserved. Continuing…]_",
-                    DateTimeOffset.UtcNow));
+                var notificationText = result.Succeeded
+                    ? $"_[Session context compacted: {result.Summarized} older messages summarised, {result.Preserved} recent messages preserved. Continuing…]_"
+                    : $"_[Compaction failed: {result.FailureReason ?? "unknown error"}]_";
+                conv.Messages.Add(new ChatMessage("System", notificationText, DateTimeOffset.UtcNow));
                 _store.NotifyChanged();
             }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
@@ -182,10 +182,12 @@ public sealed record SessionSummary(
 
 /// <summary>Result returned by <c>CompactSession</c>.</summary>
 public sealed record CompactSessionResult(
+    [property: JsonPropertyName("succeeded")] bool Succeeded,
     [property: JsonPropertyName("summarized")] int Summarized,
     [property: JsonPropertyName("preserved")] int Preserved,
     [property: JsonPropertyName("tokensBefore")] int TokensBefore,
-    [property: JsonPropertyName("tokensAfter")] int TokensAfter);
+    [property: JsonPropertyName("tokensAfter")] int TokensAfter,
+    [property: JsonPropertyName("failureReason")] string? FailureReason = null);
 
 // ── Client-side history DTOs (matches ChannelHistoryController response) ─────
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -589,10 +589,12 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         var outcome = await coordinator.CompactAsync(typedAgentId, session, CancellationToken.None, force: true).ConfigureAwait(false);
 
         return new CompactSessionResult(
+            outcome.Succeeded && outcome.Applied,
             outcome.EntriesSummarized,
             outcome.EntriesPreserved,
             outcome.TokensBefore,
-            outcome.TokensAfter);
+            outcome.TokensAfter,
+            outcome.FailureReason);
     }
 
     /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/HubContracts.cs
@@ -19,10 +19,12 @@ public sealed record SubscribeAllResult(
 
 /// <summary>Result returned by <c>CompactSession</c>.</summary>
 public sealed record CompactSessionResult(
+    [property: JsonPropertyName("succeeded")] bool Succeeded,
     [property: JsonPropertyName("summarized")] int Summarized,
     [property: JsonPropertyName("preserved")] int Preserved,
     [property: JsonPropertyName("tokensBefore")] int TokensBefore,
-    [property: JsonPropertyName("tokensAfter")] int TokensAfter);
+    [property: JsonPropertyName("tokensAfter")] int TokensAfter,
+    [property: JsonPropertyName("failureReason")] string? FailureReason = null);
 
 // ── Server → Client event payloads ──────────────────────────────────────
 


### PR DESCRIPTION
## Problem

When \/compact\ is invoked from the portal, compaction silently fails in two ways:

1. **Misleading notification**: The portal shows \_[Session context compacted: 0 older messages summarised, 215 recent messages preserved]_\ (success format) even when compaction failed
2. **Model returns empty**: The summarization model (\claude-opus-4.6\ via Copilot) returns zero content blocks, so there's never a summary to apply

## Root Causes

### Bug 1: No success indicator in CompactSessionResult DTO
\CompactSessionResult\ had no \Succeeded\/\FailureReason\ fields. The client formatted \Summarized\/\Preserved\ counts into the success template regardless of outcome.

### Bug 2: \	hinking: {type: disabled}\ breaks adaptive models
\claude-opus-4.6\ is an adaptive thinking model. The Copilot/Anthropic request builders sent \	hinking: {type: disabled}\ when \ThinkingEnabled=false\ (the default for non-reasoning callers like compaction). **Adaptive models do not support \disabled\** — they silently return empty content blocks.

## Fix

### Portal reliability (4 files)
- Added \Succeeded\ + \FailureReason\ to \CompactSessionResult\ (server + client DTOs)
- Hub populates from \SessionCompactionOutcome\
- Client shows failure text: \_[Compaction failed: {reason}]_\

### Provider fix (2 files)
- When \ThinkingEnabled=false\ and the model is adaptive (\opus-4.6\, \sonnet-4.6\):
  - Send \	hinking: {type: adaptive}\ + \output_config: {effort: low}\ instead of \{type: disabled}\
  - Model produces output text without expensive reasoning
- Applied to both \CopilotMessagesRequestBuilder\ and \AnthropicRequestBuilder\

## Files changed (6)
- \HubContracts.cs\ (server) — added Succeeded, FailureReason
- \HubContracts.cs\ (client) — mirrored DTO change
- \GatewayHub.cs\ — populate new fields
- \AgentInteractionService.cs\ — conditional notification
- \CopilotMessagesRequestBuilder.cs\ — adaptive model fix
- \AnthropicRequestBuilder.cs\ — adaptive model fix (same pattern)

## Tests
All impacted tests pass: Architecture 178, BlazorClient 527+28, Conversations 192, Gateway 2466, Scenarios 29