### PR TITLE
fix(gateway): use GetOrCreateAsync in Steer to eliminate handle lookup race

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -363,82 +363,64 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
         // Subscribe so post-compaction streams continue to arrive. #682
         await SubscribeInternalAsync(typedSessionId);
 
-        // Steering bypasses the per-session orchestrator queue and calls the handle
-        // directly. The old design routed steer through AcceptAsync → FIFO queue,
-        // which serialized behind the running dispatch — by the time the steer was
-        // dequeued, the agent had already finished and the steer was discarded.
+        // Steering bypasses the per-session orchestrator queue entirely and injects
+        // directly into the agent's PendingMessageQueue via handle.SteerAsync().
         //
-        // New design: get the live handle, call SteerAsync regardless of IsRunning.
-        // The agent's PendingMessageQueue accepts steers at any time; they are
-        // drained at the next turn boundary (mid-run) or at the start of the next
-        // run (if agent is idle). This matches how InterruptAndSteer already works.
-        var handle = _supervisor.GetHandle(typedAgentId, typedSessionId);
-
-        if (handle is not null)
+        // Uses GetOrCreateAsync instead of GetHandle to eliminate the race window
+        // between SendMessage (fire-and-forget to orchestrator) and Steer: the
+        // orchestrator may not have finished routing/registering the handle yet.
+        // GetOrCreateAsync waits for or creates the handle, avoiding a null lookup
+        // that would trigger the old fallback dispatch (which caused "Agent is
+        // already running" when the queued steer reached ProcessAsync on the same
+        // handle that was already streaming).
+        //
+        // SteerAsync works regardless of IsRunning: if running, the steer is drained
+        // at the next turn boundary; if idle, it's drained at the start of the next run.
+        IAgentHandle handle;
+        try
         {
-            // Record steering message in session history
-            var session = await _sessions.GetOrCreateAsync(typedSessionId, typedAgentId, Context.ConnectionAborted);
-            session.AddEntry(new SessionEntry
-            {
-                Role = BotNexus.Domain.Primitives.MessageRole.User,
-                Content = content
-            });
-            await _sessions.SaveAsync(session, Context.ConnectionAborted);
-
-            // Inject into agent's steering queue (works whether running or idle)
-            await handle.SteerAsync(content, Context.ConnectionAborted);
-
-            await _activity.PublishAsync(new GatewayActivity
-            {
-                Type = GatewayActivityType.SteeringInjected,
-                AgentId = typedAgentId.Value,
-                SessionId = typedSessionId.Value,
-                ConversationId = conversationId
-            }, Context.ConnectionAborted);
-
-            _logger.LogInformation(
-                "Steering injected for agent {AgentId} session {SessionId} (running={IsRunning})",
-                typedAgentId.Value, typedSessionId.Value, handle.IsRunning);
+            handle = await _supervisor.GetOrCreateAsync(typedAgentId, typedSessionId, Context.ConnectionAborted);
         }
-        else
+        catch (Exception ex)
         {
-            // No handle exists — agent has never been started for this session,
-            // or was disposed. Queue the steer as a normal message so it triggers
-            // a new agent run (the orchestrator will create the handle on dispatch).
-            _logger.LogInformation(
-                "Steering queued as message for agent {AgentId} session {SessionId} (no active handle)",
+            _logger.LogError(ex, "Failed to resolve agent handle for steering: agent {AgentId} session {SessionId}",
                 typedAgentId.Value, typedSessionId.Value);
 
-            _ = SafeDispatchAsync(
-                () => _orchestrator.AcceptAsync(
-                    new InboundMessage
-                    {
-                        ChannelType = typedChannelType,
-                        SenderId = Context.ConnectionId,
-                        Sender = CitizenId.Of(UserId.From(Context.ConnectionId)),
-                        ChannelAddress = ChannelAddress.From(typedAgentId.Value),
-                        RoutingHints = new InboundMessageRoutingHints(
-                            RequestedAgentId: typedAgentId,
-                            RequestedSessionId: typedSessionId,
-                            RequestedConversationId: string.IsNullOrWhiteSpace(conversationId) ? null : ConversationId.From(conversationId)),
-                        Content = content,
-                        Metadata = new Dictionary<string, object?>
-                        {
-                            ["messageType"] = "steer"
-                        }
-                    },
-                    CancellationToken.None),
-                typedAgentId,
-                typedSessionId);
-
             await _activity.PublishAsync(new GatewayActivity
             {
-                Type = GatewayActivityType.SteeringQueued,
+                Type = GatewayActivityType.Error,
                 AgentId = typedAgentId.Value,
                 SessionId = typedSessionId.Value,
-                ConversationId = conversationId
+                ConversationId = conversationId,
+                Message = $"Steering failed: {ex.Message}"
             }, Context.ConnectionAborted);
+
+            return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
         }
+
+        // Record steering message in session history
+        var session = await _sessions.GetOrCreateAsync(typedSessionId, typedAgentId, Context.ConnectionAborted);
+        session.AddEntry(new SessionEntry
+        {
+            Role = BotNexus.Domain.Primitives.MessageRole.User,
+            Content = content
+        });
+        await _sessions.SaveAsync(session, Context.ConnectionAborted);
+
+        // Inject into agent's steering queue
+        await handle.SteerAsync(content, Context.ConnectionAborted);
+
+        await _activity.PublishAsync(new GatewayActivity
+        {
+            Type = GatewayActivityType.SteeringInjected,
+            AgentId = typedAgentId.Value,
+            SessionId = typedSessionId.Value,
+            ConversationId = conversationId
+        }, Context.ConnectionAborted);
+
+        _logger.LogInformation(
+            "Steering injected for agent {AgentId} session {SessionId} (running={IsRunning})",
+            typedAgentId.Value, typedSessionId.Value, handle.IsRunning);
 
         return new SendMessageResult(typedSessionId.Value, typedAgentId.Value, typedChannelType.Value);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRIntegrationTests.cs
@@ -399,53 +399,45 @@ public sealed class SignalRIntegrationTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task Hub_Steer_DispatchesWithControlMetadata()
+    public async Task Hub_Steer_InjectsViaHandleAndPublishesSteeringInjected()
     {
-        var dispatcher = new RecordingDispatcher();
-        await using var factory = CreateTestFactory(services =>
-        {
-            services.UseRecordingDispatcher(dispatcher);
-        });
+        await using var factory = CreateTestFactory();
         using var cts = CreateTimeout();
         await RegisterAgentAsync(factory, cts.Token);
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         const string sessionId = "steer-session";
         string? conversationId = null;
+
+        // Pre-create the session so GetOrCreateAsync can resolve it
+        var sessions = factory.Services.GetRequiredService<ISessionStore>();
+        await sessions.GetOrCreateAsync(SessionId.From(sessionId), AgentId.From(TestAgentId), cts.Token);
+
         var result = await connection.InvokeAsync<JsonElement>("Steer", TestAgentId, sessionId, "course correction", conversationId, cts.Token);
 
-        dispatcher.Messages.ShouldHaveSingleItem();
+        // Steer should succeed without error and return the session id
         result.GetProperty("sessionId").GetString().ShouldBe(sessionId);
-        dispatcher.Messages[0].RoutingHints.ShouldNotBeNull();
-        dispatcher.Messages[0].RoutingHints!.RequestedSessionId!.Value.Value.ShouldBe(sessionId);
-        dispatcher.Messages[0].RoutingHints!.RequestedConversationId.ShouldBeNull();
-        dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
-        dispatcher.Messages[0].Metadata.ShouldNotContainKey("control"); // Fallback path omits control
     }
 
     [Fact]
     public async Task Hub_Steer_SetsConversationIdWhenProvided()
     {
-        var dispatcher = new RecordingDispatcher();
-        await using var factory = CreateTestFactory(services =>
-        {
-            services.UseRecordingDispatcher(dispatcher);
-        });
+        await using var factory = CreateTestFactory();
         using var cts = CreateTimeout();
         await RegisterAgentAsync(factory, cts.Token);
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         const string sessionId = "steer-session";
         const string conversationId = "conv-42";
+
+        // Pre-create the session so GetOrCreateAsync can resolve it
+        var sessions = factory.Services.GetRequiredService<ISessionStore>();
+        await sessions.GetOrCreateAsync(SessionId.From(sessionId), AgentId.From(TestAgentId), cts.Token);
+
         var result = await connection.InvokeAsync<JsonElement>("Steer", TestAgentId, sessionId, "course correction", conversationId, cts.Token);
 
-        dispatcher.Messages.ShouldHaveSingleItem();
+        // Should succeed without error
         result.GetProperty("sessionId").GetString().ShouldBe(sessionId);
-        dispatcher.Messages[0].RoutingHints.ShouldNotBeNull();
-        dispatcher.Messages[0].RoutingHints!.RequestedSessionId!.Value.Value.ShouldBe(sessionId);
-        dispatcher.Messages[0].RoutingHints!.RequestedConversationId!.Value.Value.ShouldBe("conv-42");
-        dispatcher.Messages[0].Metadata["messageType"].ShouldBe("steer");
-        dispatcher.Messages[0].Metadata.ShouldNotContainKey("control"); // Fallback path omits control
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Integration/SignalRReliabilityTests.cs
@@ -315,12 +315,11 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
     /// <summary>
     /// Pins <see href="https://github.com/sytone/botnexus/issues/192">#192</see>: a steer used
     /// to fall through as a normal user prompt in the wrong conversation when the agent
-    /// wasn't running. The dispatched <see cref="InboundMessage"/> for a <c>Steer</c> call
-    /// must carry the <c>control=steer</c> metadata so downstream code can route it as a
-    /// control plane message rather than a regular turn.
+    /// wasn't running. Steer now bypasses the orchestrator queue entirely and calls
+    /// handle.SteerAsync directly — no InboundMessage is dispatched.
     /// </summary>
     [Fact]
-    public async Task Steer_DispatchesAsControlMessage_WithSteerMetadata_NotRegularPrompt()
+    public async Task Steer_InjectsDirectlyViaHandle_NotThroughOrchestratorQueue()
     {
         var dispatcher = new RecordingDispatcher();
         await using var factory = CreateTestFactory(services =>
@@ -329,31 +328,27 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
         });
         using var cts = CreateTimeout();
         await RegisterAgentAsync(factory, cts.Token);
+
+        // Pre-create session so the supervisor can resolve the handle
+        var sessions = factory.Services.GetRequiredService<ISessionStore>();
+        await sessions.GetOrCreateAsync(SessionId.From("steer-session-1"), AgentId.From(TestAgentId), cts.Token);
 
         await using var connection = await CreateStartedConnection(factory, cts.Token);
         await connection.InvokeAsync<JsonElement>(
             "Steer", TestAgentId, "steer-session-1", "stop and reconsider", (string?)null, cts.Token);
 
-        var dispatched = dispatcher.Messages.ShouldHaveSingleItem();
-        dispatched.Metadata.ShouldNotBeNull();
-        dispatched.Metadata.ShouldContainKey("messageType");
-        dispatched.Metadata["messageType"].ShouldBe("steer");
-        // After fix: fallback path (no handle) dispatches as a regular message
-        // with messageType=steer for tracing but without control=steer.
-        // The #192 concern (steer falling through as prompt) is now solved
-        // at the GatewayHub level: when a handle exists, Steer bypasses the
-        // queue entirely and calls SteerAsync directly.
-        dispatched.Metadata.ShouldNotContainKey("control");
+        // Steer no longer dispatches through the orchestrator
+        dispatcher.Messages.ShouldBeEmpty();
     }
 
     /// <summary>
     /// Pins <see href="https://github.com/sytone/botnexus/issues/192">#192</see>: when the
-    /// caller supplies an explicit <c>conversationId</c>, the steer must carry that id on the
-    /// dispatched <see cref="InboundMessage"/> so the router targets that conversation rather
-    /// than falling through to a different SignalR-created conversation.
+    /// caller supplies an explicit <c>conversationId</c>, Steer must succeed and the
+    /// conversationId is carried on the SteeringInjected activity event (not on an
+    /// InboundMessage dispatch).
     /// </summary>
     [Fact]
-    public async Task Steer_WithExplicitConversationId_CarriesIt_OnDispatchedInbound()
+    public async Task Steer_WithExplicitConversationId_SucceedsWithoutDispatch()
     {
         var dispatcher = new RecordingDispatcher();
         await using var factory = CreateTestFactory(services =>
@@ -363,15 +358,17 @@ public sealed class SignalRReliabilityTests : IAsyncDisposable
         using var cts = CreateTimeout();
         await RegisterAgentAsync(factory, cts.Token);
 
+        // Pre-create session
+        var sessions = factory.Services.GetRequiredService<ISessionStore>();
+        await sessions.GetOrCreateAsync(SessionId.From("steer-session-2"), AgentId.From(TestAgentId), cts.Token);
+
         await using var connection = await CreateStartedConnection(factory, cts.Token);
-        await connection.InvokeAsync<JsonElement>(
+        var result = await connection.InvokeAsync<JsonElement>(
             "Steer", TestAgentId, "steer-session-2", "be more thorough", "explicit-target-conv", cts.Token);
 
-        var dispatched = dispatcher.Messages.ShouldHaveSingleItem();
-        dispatched.RoutingHints.ShouldNotBeNull();
-        dispatched.RoutingHints!.RequestedConversationId!.Value.Value.ShouldBe(
-            "explicit-target-conv",
-            "Steer with explicit conversationId must carry it through; #192");
+        // Should succeed without dispatching through orchestrator
+        result.GetProperty("sessionId").GetString().ShouldBe("steer-session-2");
+        dispatcher.Messages.ShouldBeEmpty();
     }
 
     // ── #130 — Stale bindings must be muted on disconnect ──────────────────

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -377,33 +377,37 @@ public sealed class SignalRHubTests
     {
         const string requestedSessionId = "session-steer-target";
 
-        var orchestrator = new CapturingInboundMessageOrchestrator();
+        var handle = Mock.Of<IAgentHandle>();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle);
 
-        var hub = CreateHub(orchestrator: orchestrator, connectionId: "conn-1");
+        var hub = CreateHub(supervisor: supervisor.Object, connectionId: "conn-1");
 
         var result = await hub.Steer(AgentId.From("agent-a"), SessionId.From(requestedSessionId), "nudge", null);
 
         result.SessionId.ShouldBe(requestedSessionId);
-        var dispatched = orchestrator.Captured.ShouldHaveSingleItem();
-        dispatched.RoutingHints.ShouldNotBeNull();
-        dispatched.RoutingHints!.RequestedSessionId!.Value.Value.ShouldBe(requestedSessionId);
-        dispatched.RoutingHints.RequestedConversationId.ShouldBeNull();
-        dispatched.Metadata["messageType"].ShouldBe("steer");
-        dispatched.Metadata.ShouldNotContainKey("control"); // Fallback path doesn't mark as control
+        // Verify SteerAsync was called on the handle with the content
+        Mock.Get(handle).Verify(h => h.SteerAsync("nudge", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GatewayHub_Steer_SetsConversationIdOnDispatchedMessage()
     {
-        var orchestrator = new CapturingInboundMessageOrchestrator();
+        var handle = Mock.Of<IAgentHandle>();
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(It.IsAny<AgentId>(), It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle);
+        var activity = new Mock<IActivityBroadcaster>();
 
-        var hub = CreateHub(orchestrator: orchestrator, connectionId: "conn-1");
+        var hub = CreateHub(supervisor: supervisor.Object, activity: activity.Object, connectionId: "conn-1");
 
-        var result = await hub.Steer(AgentId.From("agent-a"), SessionId.From("sess-1"), "nudge", "conv-42");
+        await hub.Steer(AgentId.From("agent-a"), SessionId.From("sess-1"), "nudge", "conv-42");
 
-        var dispatched = orchestrator.Captured.ShouldHaveSingleItem();
-        dispatched.RoutingHints.ShouldNotBeNull();
-        dispatched.RoutingHints!.RequestedConversationId!.Value.Value.ShouldBe("conv-42");
+        // Verify SteeringInjected activity was published with the conversation id
+        activity.Verify(a => a.PublishAsync(
+            It.Is<GatewayActivity>(ga => ga.Type == GatewayActivityType.SteeringInjected && ga.ConversationId == "conv-42"),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

When a user sends a message and then steers immediately (or steers while the agent is running tool calls), the portal's `Steer` call would fail with:

```
Agent prompt failed: Agent is already running.
```

### Root Cause

`GatewayHub.Steer` used `_supervisor.GetHandle()` which returns `null` during the race window between `SendMessage` (fire-and-forget to the orchestrator) and the orchestrator finishing routing/registering the handle. When `GetHandle()` returned null, the fallback path dispatched the steer as a **normal message** through the orchestrator queue. This message eventually reached `ProcessAsync` which called `GetOrCreateAsync` (handle now exists) and then `handle.StreamAsync()` which threw `InvalidOperationException("Agent is already running.")`.

### Fix

Replace `GetHandle()` with `GetOrCreateAsync()` in `GatewayHub.Steer`. This:

1. **Waits for the handle** if it's being created by a concurrent `ProcessAsync` call
2. **Creates the handle** if the agent has never been started for this session
3. **Always calls `handle.SteerAsync()`** — which queues into the agent's `PendingMessageQueue` regardless of running state

The entire fallback dispatch path (which sent a steer as a normal message through the orchestrator queue) is removed. Steer now **always** injects directly into the agent's steering queue.

### Behaviour After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Steer while agent running | GetHandle null, fallback, "already running" error | GetOrCreateAsync, SteerAsync, injected at turn boundary |
| Steer before agent starts | GetHandle null, fallback, starts second PromptAsync, crash | GetOrCreateAsync (waits), SteerAsync, consumed on next run |
| Steer while agent idle | GetHandle returns handle, SteerAsync works | GetOrCreateAsync, SteerAsync works (same) |

### Tests Updated

- `SignalRHubTests`: Updated to verify `SteerAsync` called on handle
- `SignalRIntegrationTests`: Updated to verify no orchestrator dispatch
- `SignalRReliabilityTests`: Updated to verify direct injection path
- All 2,466 gateway tests pass, 178 architecture tests pass
