### PR TITLE
feat(#1108): add Satellite domain model, config schema, and CLI registration command

### DIFF
--- a/src/domain/BotNexus.Domain/Primitives/SatelliteId.cs
+++ b/src/domain/BotNexus.Domain/Primitives/SatelliteId.cs
@@ -1,0 +1,19 @@
+using Vogen;
+
+namespace BotNexus.Domain.Primitives;
+
+/// <summary>
+/// Identifies a satellite node in a BotNexus world. Construct via <see cref="From(string)"/>;
+/// the value must be non-null, non-empty, non-whitespace and is stored trimmed.
+/// </summary>
+[ValueObject<string>(conversions: Conversions.SystemTextJson)]
+public readonly partial struct SatelliteId
+{
+    private static Validation Validate(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? Validation.Invalid("SatelliteId cannot be null, empty, or whitespace.")
+            : Validation.Ok;
+
+    private static string NormalizeInput(string input) =>
+        input is null ? input! : input.Trim();
+}

--- a/src/domain/BotNexus.Domain/World/Satellite.cs
+++ b/src/domain/BotNexus.Domain/World/Satellite.cs
@@ -1,0 +1,30 @@
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Represents a satellite node — a lightweight persistent process running on a remote machine
+/// that connects to the gateway for bidirectional interaction (notifications, canvas rendering,
+/// and optionally remote command execution).
+/// </summary>
+public sealed record Satellite
+{
+    /// <summary>Unique satellite identifier (e.g., "sat_desktop_home").</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Human-readable display name (e.g., "Jon's Desktop").</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Platform the satellite runs on (windows, macos, linux).</summary>
+    public required SatellitePlatform Platform { get; init; }
+
+    /// <summary>User ID of the satellite's owner. Events are filtered to this user's conversations.</summary>
+    public required string OwnerUserId { get; init; }
+
+    /// <summary>Capabilities this satellite is allowed to perform.</summary>
+    public IReadOnlyList<SatelliteCapability> Capabilities { get; init; } = [];
+
+    /// <summary>Current connection status.</summary>
+    public SatelliteStatus Status { get; init; } = SatelliteStatus.Offline;
+
+    /// <summary>Last time the satellite sent a heartbeat or message.</summary>
+    public DateTimeOffset? LastSeen { get; init; }
+}

--- a/src/domain/BotNexus.Domain/World/SatelliteCapability.cs
+++ b/src/domain/BotNexus.Domain/World/SatelliteCapability.cs
@@ -1,0 +1,16 @@
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Capabilities a satellite node can perform. Each must be explicitly granted during registration.
+/// </summary>
+public enum SatelliteCapability
+{
+    /// <summary>Display desktop notifications (toast) for gateway events.</summary>
+    Notify,
+
+    /// <summary>Render HTML canvas content in a local window for conversations.</summary>
+    Canvas,
+
+    /// <summary>Execute commands sent by authorized agents (requires per-command approval on the satellite).</summary>
+    Exec
+}

--- a/src/domain/BotNexus.Domain/World/SatellitePlatform.cs
+++ b/src/domain/BotNexus.Domain/World/SatellitePlatform.cs
@@ -1,0 +1,16 @@
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Operating system platform a satellite runs on.
+/// </summary>
+public enum SatellitePlatform
+{
+    /// <summary>Microsoft Windows.</summary>
+    Windows,
+
+    /// <summary>Apple macOS.</summary>
+    MacOS,
+
+    /// <summary>Linux.</summary>
+    Linux
+}

--- a/src/domain/BotNexus.Domain/World/SatelliteStatus.cs
+++ b/src/domain/BotNexus.Domain/World/SatelliteStatus.cs
@@ -1,0 +1,16 @@
+namespace BotNexus.Domain.World;
+
+/// <summary>
+/// Connection status of a satellite node.
+/// </summary>
+public enum SatelliteStatus
+{
+    /// <summary>Satellite is not connected to the gateway.</summary>
+    Offline,
+
+    /// <summary>Satellite has an active connection and is sending heartbeats.</summary>
+    Online,
+
+    /// <summary>Satellite has not sent a heartbeat within the configured timeout.</summary>
+    Stale
+}

--- a/src/domain/BotNexus.Domain/World/WorldDescriptor.cs
+++ b/src/domain/BotNexus.Domain/World/WorldDescriptor.cs
@@ -34,4 +34,10 @@ public sealed record WorldDescriptor
     /// Gets or sets the cross world permissions.
     /// </summary>
     public IReadOnlyList<CrossWorldPermission> CrossWorldPermissions { get; init; } = [];
+
+    /// <summary>
+    /// Satellite nodes registered in this world — remote persistent processes that connect back
+    /// to the gateway for notifications, canvas rendering, and remote command execution.
+    /// </summary>
+    public IReadOnlyList<Satellite> Satellites { get; init; } = [];
 }

--- a/src/gateway/BotNexus.Cli/CliApp.cs
+++ b/src/gateway/BotNexus.Cli/CliApp.cs
@@ -104,6 +104,7 @@ internal static class CliApp
             .AddSingleton<UpdateCommand>()
             .AddSingleton<ProviderCommand>()
             .AddSingleton<CronCommands>()
+            .AddSingleton<SatelliteCommand>()
             .BuildServiceProvider();
     }
 
@@ -130,6 +131,7 @@ internal static class CliApp
         root.AddCommand(serviceProvider.GetRequiredService<UpdateCommand>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<ProviderCommand>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<CronCommands>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<SatelliteCommand>().Build(verboseOption, targetOption));
 
         return root;
     }

--- a/src/gateway/BotNexus.Cli/Commands/SatelliteCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/SatelliteCommand.cs
@@ -1,0 +1,245 @@
+using System.CommandLine;
+using System.IO.Abstractions;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BotNexus.Gateway.Configuration;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+internal sealed class SatelliteCommand
+{
+    private static readonly string[] ValidPlatforms = ["windows", "macos", "linux"];
+    private static readonly string[] ValidCapabilities = ["notify", "canvas", "exec"];
+
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
+    {
+        var command = new Command("satellite", "Manage satellite nodes.");
+        command.AddAlias("satellites");
+
+        // --- list ---
+        var listCommand = new Command("list", "List all registered satellites.");
+        listCommand.SetHandler(async context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteListAsync(configPath, CancellationToken.None);
+        });
+
+        // --- register ---
+        var nameArgument = new Argument<string>("name", "Satellite ID (e.g., sat_desktop_home).");
+        var displayNameOption = new Option<string?>("--display-name", "Human-readable display name.");
+        var platformOption = new Option<string>("--platform", () => "windows", "Platform: windows, macos, linux.");
+        var capabilitiesOption = new Option<string>("--capabilities", () => "notify,canvas", "Comma-separated capabilities: notify, canvas, exec.");
+        var ownerOption = new Option<string>("--owner", "Owner user ID.") { IsRequired = true };
+
+        var registerCommand = new Command("register", "Register a new satellite and generate its API key.")
+        {
+            nameArgument,
+            displayNameOption,
+            platformOption,
+            capabilitiesOption,
+            ownerOption
+        };
+        registerCommand.SetHandler(async context =>
+        {
+            var name = context.ParseResult.GetValueForArgument(nameArgument);
+            var displayName = context.ParseResult.GetValueForOption(displayNameOption);
+            var platform = context.ParseResult.GetValueForOption(platformOption) ?? "windows";
+            var capabilities = context.ParseResult.GetValueForOption(capabilitiesOption) ?? "notify,canvas";
+            var owner = context.ParseResult.GetValueForOption(ownerOption)!;
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteRegisterAsync(name, displayName, platform, capabilities, owner, configPath, CancellationToken.None);
+        });
+
+        // --- remove ---
+        var removeCommand = new Command("remove", "Remove a satellite from config.")
+        {
+            nameArgument
+        };
+        removeCommand.AddAlias("delete");
+        removeCommand.SetHandler(async context =>
+        {
+            var name = context.ParseResult.GetValueForArgument(nameArgument);
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var home = CliPaths.ResolveTarget(target);
+            var configPath = Path.Combine(home, "config.json");
+            context.ExitCode = await ExecuteRemoveAsync(name, configPath, CancellationToken.None);
+        });
+
+        command.AddCommand(listCommand);
+        command.AddCommand(registerCommand);
+        command.AddCommand(removeCommand);
+        return command;
+    }
+
+    private static async Task<int> ExecuteListAsync(string configPath, CancellationToken ct)
+    {
+        var fileSystem = new FileSystem();
+        if (!fileSystem.File.Exists(configPath))
+        {
+            AnsiConsole.MarkupLine("[yellow]No config.json found.[/]");
+            return 1;
+        }
+
+        var json = await fileSystem.File.ReadAllTextAsync(configPath, ct);
+        var config = JsonSerializer.Deserialize<PlatformConfig>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var satellites = config?.Gateway?.Satellites;
+
+        if (satellites is null || satellites.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No satellites registered.[/]");
+            return 0;
+        }
+
+        var table = new Table()
+            .AddColumn("ID")
+            .AddColumn("Display Name")
+            .AddColumn("Platform")
+            .AddColumn("Owner")
+            .AddColumn("Capabilities")
+            .AddColumn("Enabled");
+
+        foreach (var (id, sat) in satellites.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            table.AddRow(
+                Markup.Escape(id),
+                Markup.Escape(sat.DisplayName ?? "(none)"),
+                Markup.Escape(sat.Platform),
+                Markup.Escape(sat.OwnerUserId ?? "(none)"),
+                Markup.Escape(string.Join(", ", sat.Capabilities ?? [])),
+                sat.Enabled ? "[green]yes[/]" : "[red]no[/]");
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine($"\n{satellites.Count} satellite(s) registered.");
+        return 0;
+    }
+
+    private static async Task<int> ExecuteRegisterAsync(
+        string name, string? displayName, string platform, string capabilities,
+        string owner, string configPath, CancellationToken ct)
+    {
+        // Validate platform
+        if (!ValidPlatforms.Contains(platform.ToLowerInvariant()))
+        {
+            AnsiConsole.MarkupLine($"[red]Invalid platform: {Markup.Escape(platform)}. Must be one of: {string.Join(", ", ValidPlatforms)}[/]");
+            return 1;
+        }
+
+        // Validate capabilities
+        var capList = capabilities.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(c => c.ToLowerInvariant())
+            .ToList();
+        var invalidCaps = capList.Except(ValidCapabilities).ToList();
+        if (invalidCaps.Count > 0)
+        {
+            AnsiConsole.MarkupLine($"[red]Invalid capabilities: {string.Join(", ", invalidCaps)}. Valid: {string.Join(", ", ValidCapabilities)}[/]");
+            return 1;
+        }
+
+        // Generate API key
+        var apiKey = SatelliteKeyGenerator.GenerateApiKey();
+
+        // Build config entry
+        var satConfig = new SatelliteConfig
+        {
+            DisplayName = displayName ?? name,
+            Platform = platform.ToLowerInvariant(),
+            ApiKey = apiKey,
+            Capabilities = capList,
+            OwnerUserId = owner,
+            Enabled = true
+        };
+
+        // Write to config
+        var fileSystem = new FileSystem();
+        var writer = new PlatformConfigWriter(configPath, fileSystem);
+
+        await writer.MutateAsync(root =>
+        {
+            if (root["gateway"] is not JsonObject gateway)
+            {
+                gateway = new JsonObject();
+                root["gateway"] = gateway;
+            }
+
+            if (gateway["satellites"] is not JsonObject satellites)
+            {
+                satellites = new JsonObject();
+                gateway["satellites"] = satellites;
+            }
+
+            if (satellites.ContainsKey(name))
+            {
+                throw new InvalidOperationException($"Satellite '{name}' already exists. Use 'satellite remove' first.");
+            }
+
+            var serialized = JsonSerializer.SerializeToNode(satConfig, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+            });
+            satellites[name] = serialized;
+        }, "satellite-register", ct);
+
+        // Display success
+        AnsiConsole.MarkupLine($"[green]✓[/] Satellite [bold]{Markup.Escape(name)}[/] registered.");
+        AnsiConsole.WriteLine();
+
+        var panel = new Panel(
+            new Rows(
+                new Markup($"[bold]Satellite ID:[/]  {Markup.Escape(name)}"),
+                new Markup($"[bold]Display Name:[/] {Markup.Escape(displayName ?? name)}"),
+                new Markup($"[bold]Platform:[/]     {Markup.Escape(platform)}"),
+                new Markup($"[bold]Owner:[/]        {Markup.Escape(owner)}"),
+                new Markup($"[bold]Capabilities:[/] {Markup.Escape(string.Join(", ", capList))}"),
+                new Markup(""),
+                new Markup($"[bold yellow]API Key:[/]      [bold]{Markup.Escape(apiKey)}[/]")))
+        {
+            Header = new PanelHeader(" Satellite Registered "),
+            Border = BoxBorder.Rounded
+        };
+        AnsiConsole.Write(panel);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[yellow]⚠ Save this API key now — it cannot be recovered.[/]");
+        AnsiConsole.MarkupLine("[dim]The satellite will use this key to authenticate with the gateway.[/]");
+
+        return 0;
+    }
+
+    private static async Task<int> ExecuteRemoveAsync(string name, string configPath, CancellationToken ct)
+    {
+        var fileSystem = new FileSystem();
+        if (!fileSystem.File.Exists(configPath))
+        {
+            AnsiConsole.MarkupLine("[red]No config.json found.[/]");
+            return 1;
+        }
+
+        var removed = false;
+        await new PlatformConfigWriter(configPath, fileSystem).MutateAsync(root =>
+        {
+            if (root["gateway"] is JsonObject gateway &&
+                gateway["satellites"] is JsonObject satellites &&
+                satellites.ContainsKey(name))
+            {
+                satellites.Remove(name);
+                removed = true;
+            }
+        }, "satellite-remove", ct);
+
+        if (removed)
+        {
+            AnsiConsole.MarkupLine($"[green]✓[/] Satellite [bold]{Markup.Escape(name)}[/] removed.");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine($"[yellow]Satellite '{Markup.Escape(name)}' not found in config.[/]");
+        return 1;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -170,6 +170,13 @@ public sealed class GatewaySettingsConfig
     /// Per-agent overrides take precedence over this world default.
     /// </summary>
     public DateTimeInjectionConfig? DateTimeInjection { get; set; }
+
+    /// <summary>
+    /// Registered satellite nodes keyed by satellite ID.
+    /// Satellites are remote persistent processes that connect to the gateway for
+    /// notifications, canvas rendering, and optionally remote command execution.
+    /// </summary>
+    public Dictionary<string, SatelliteConfig>? Satellites { get; set; }
 }
 
 /// <summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/SatelliteConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/SatelliteConfig.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Configuration for a registered satellite node. Stored in <c>config.json</c> under
+/// <c>gateway.satellites.{id}</c>.
+/// </summary>
+public sealed class SatelliteConfig
+{
+    /// <summary>Human-readable display name for this satellite.</summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>Platform the satellite runs on. Values: <c>windows</c>, <c>macos</c>, <c>linux</c>.</summary>
+    public string Platform { get; set; } = "windows";
+
+    /// <summary>
+    /// API key the satellite uses to authenticate with the gateway.
+    /// Generated via <c>botnexus satellite register</c> and never displayed again after creation.
+    /// Prefixed with <c>sat_</c> for identification.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Capabilities this satellite is allowed to perform.
+    /// Valid values: <c>notify</c>, <c>canvas</c>, <c>exec</c>.
+    /// </summary>
+    public List<string>? Capabilities { get; set; }
+
+    /// <summary>User ID of the satellite's owner. Events are filtered server-side to this user's conversations.</summary>
+    public string? OwnerUserId { get; set; }
+
+    /// <summary>
+    /// Seconds without a heartbeat before the satellite is marked stale.
+    /// Defaults to 120 seconds.
+    /// </summary>
+    public int StaleTimeoutSeconds { get; set; } = 120;
+
+    /// <summary>Whether this satellite is enabled. Disabled satellites are rejected on connect.</summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/SatelliteKeyGenerator.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/SatelliteKeyGenerator.cs
@@ -1,0 +1,44 @@
+using System.Security.Cryptography;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Generates cryptographically secure API keys for satellite registration.
+/// </summary>
+public static class SatelliteKeyGenerator
+{
+    private const string Prefix = "sat_";
+    private const int KeyByteLength = 32;
+
+    // Base62 alphabet: 0-9, A-Z, a-z (no confusing symbols)
+    private static readonly char[] Base62Chars =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".ToCharArray();
+
+    /// <summary>
+    /// Generates a new satellite API key. Format: <c>sat_&lt;43 base62 chars&gt;</c>.
+    /// The key is shown to the user exactly once during registration and cannot be recovered.
+    /// </summary>
+    /// <returns>A cryptographically random satellite API key.</returns>
+    public static string GenerateApiKey()
+    {
+        Span<byte> bytes = stackalloc byte[KeyByteLength];
+        RandomNumberGenerator.Fill(bytes);
+        return Prefix + ToBase62(bytes);
+    }
+
+    private static string ToBase62(ReadOnlySpan<byte> bytes)
+    {
+        // Convert bytes to base62 characters using modular arithmetic.
+        // This produces ~43 characters from 32 bytes (256 bits of entropy).
+        var chars = new char[43];
+        var bigInt = new System.Numerics.BigInteger(bytes, isUnsigned: true, isBigEndian: true);
+
+        for (int i = chars.Length - 1; i >= 0; i--)
+        {
+            bigInt = System.Numerics.BigInteger.DivRem(bigInt, 62, out var remainder);
+            chars[i] = Base62Chars[(int)remainder];
+        }
+
+        return new string(chars);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/WorldDescriptorBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/WorldDescriptorBuilder.cs
@@ -23,7 +23,8 @@ public static class WorldDescriptorBuilder
             HostedAgents = hostedAgents,
             Locations = ResolveLocations(platformConfig, hostedAgents),
             AvailableStrategies = ResolveExecutionStrategies(platformConfig, agentRegistry, isolationStrategies),
-            CrossWorldPermissions = ResolveCrossWorldPermissions(platformConfig)
+            CrossWorldPermissions = ResolveCrossWorldPermissions(platformConfig),
+            Satellites = ResolveSatellites(platformConfig)
         };
     }
 
@@ -328,4 +329,51 @@ public static class WorldDescriptorBuilder
 
         return property.GetString();
     }
+
+    private static IReadOnlyList<Satellite> ResolveSatellites(PlatformConfig config)
+    {
+        var satellites = config.Gateway?.Satellites;
+        if (satellites is null || satellites.Count == 0)
+            return [];
+
+        return satellites
+            .Where(kvp => kvp.Value.Enabled && !string.IsNullOrWhiteSpace(kvp.Value.OwnerUserId))
+            .Select(kvp =>
+            {
+                var (id, satConfig) = kvp;
+                var platform = ParsePlatform(satConfig.Platform);
+                var capabilities = satConfig.Capabilities?
+                    .Select(ParseCapability)
+                    .Where(c => c.HasValue)
+                    .Select(c => c!.Value)
+                    .ToArray() ?? [];
+
+                return new Satellite
+                {
+                    Id = id.Trim(),
+                    DisplayName = satConfig.DisplayName ?? id,
+                    Platform = platform,
+                    OwnerUserId = satConfig.OwnerUserId!,
+                    Capabilities = capabilities
+                };
+            })
+            .OrderBy(s => s.Id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static SatellitePlatform ParsePlatform(string? value) => value?.ToLowerInvariant() switch
+    {
+        "windows" => SatellitePlatform.Windows,
+        "macos" => SatellitePlatform.MacOS,
+        "linux" => SatellitePlatform.Linux,
+        _ => SatellitePlatform.Windows
+    };
+
+    private static SatelliteCapability? ParseCapability(string value) => value.ToLowerInvariant() switch
+    {
+        "notify" => SatelliteCapability.Notify,
+        "canvas" => SatelliteCapability.Canvas,
+        "exec" => SatelliteCapability.Exec,
+        _ => null
+    };
 }

--- a/tests/domain/BotNexus.Domain.Tests/SatelliteIdTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/SatelliteIdTests.cs
@@ -1,0 +1,52 @@
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class SatelliteIdTests
+{
+    [Fact]
+    public void From_ValidValue_CreatesInstance()
+    {
+        var id = SatelliteId.From("sat_desktop_home");
+
+        id.Value.ShouldBe("sat_desktop_home");
+    }
+
+    [Fact]
+    public void From_TrimsWhitespace()
+    {
+        var id = SatelliteId.From("  sat_test  ");
+
+        id.Value.ShouldBe("sat_test");
+    }
+
+    [Fact]
+    public void From_EmptyString_Throws()
+    {
+        Should.Throw<Exception>(() => SatelliteId.From(""));
+    }
+
+    [Fact]
+    public void From_Whitespace_Throws()
+    {
+        Should.Throw<Exception>(() => SatelliteId.From("   "));
+    }
+
+    [Fact]
+    public void Equality_SameValue_AreEqual()
+    {
+        var id1 = SatelliteId.From("sat_one");
+        var id2 = SatelliteId.From("sat_one");
+
+        id1.ShouldBe(id2);
+    }
+
+    [Fact]
+    public void Equality_DifferentValue_AreNotEqual()
+    {
+        var id1 = SatelliteId.From("sat_one");
+        var id2 = SatelliteId.From("sat_two");
+
+        id1.ShouldNotBe(id2);
+    }
+}

--- a/tests/domain/BotNexus.Domain.Tests/SatelliteTests.cs
+++ b/tests/domain/BotNexus.Domain.Tests/SatelliteTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using BotNexus.Domain.World;
+
+namespace BotNexus.Domain.Tests;
+
+public sealed class SatelliteTests
+{
+    [Fact]
+    public void Satellite_Defaults_StatusIsOfflineAndCapabilitiesEmpty()
+    {
+        var satellite = new Satellite
+        {
+            Id = "sat_desktop_home",
+            DisplayName = "Jon's Desktop",
+            Platform = SatellitePlatform.Windows,
+            OwnerUserId = "jon"
+        };
+
+        satellite.Status.ShouldBe(SatelliteStatus.Offline);
+        satellite.Capabilities.ShouldBeEmpty();
+        satellite.LastSeen.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Satellite_WithAllProperties_PreservesValues()
+    {
+        var lastSeen = DateTimeOffset.UtcNow;
+        var satellite = new Satellite
+        {
+            Id = "sat_laptop_work",
+            DisplayName = "Work Laptop",
+            Platform = SatellitePlatform.MacOS,
+            OwnerUserId = "jon",
+            Capabilities = [SatelliteCapability.Notify, SatelliteCapability.Canvas, SatelliteCapability.Exec],
+            Status = SatelliteStatus.Online,
+            LastSeen = lastSeen
+        };
+
+        satellite.Id.ShouldBe("sat_laptop_work");
+        satellite.DisplayName.ShouldBe("Work Laptop");
+        satellite.Platform.ShouldBe(SatellitePlatform.MacOS);
+        satellite.OwnerUserId.ShouldBe("jon");
+        satellite.Capabilities.Count.ShouldBe(3);
+        satellite.Capabilities.ShouldContain(SatelliteCapability.Notify);
+        satellite.Capabilities.ShouldContain(SatelliteCapability.Canvas);
+        satellite.Capabilities.ShouldContain(SatelliteCapability.Exec);
+        satellite.Status.ShouldBe(SatelliteStatus.Online);
+        satellite.LastSeen.ShouldBe(lastSeen);
+    }
+
+    [Fact]
+    public void Satellite_JsonRoundTrip_PreservesAllValues()
+    {
+        var original = new Satellite
+        {
+            Id = "sat_desktop",
+            DisplayName = "Desktop",
+            Platform = SatellitePlatform.Linux,
+            OwnerUserId = "admin",
+            Capabilities = [SatelliteCapability.Notify, SatelliteCapability.Canvas],
+            Status = SatelliteStatus.Stale,
+            LastSeen = new DateTimeOffset(2026, 6, 10, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<Satellite>(json);
+
+        deserialized.ShouldNotBeNull();
+        deserialized!.Id.ShouldBe("sat_desktop");
+        deserialized.DisplayName.ShouldBe("Desktop");
+        deserialized.Platform.ShouldBe(SatellitePlatform.Linux);
+        deserialized.OwnerUserId.ShouldBe("admin");
+        deserialized.Capabilities.Count.ShouldBe(2);
+        deserialized.Status.ShouldBe(SatelliteStatus.Stale);
+        deserialized.LastSeen.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void SatellitePlatform_EnumValues_MatchExpected()
+    {
+        Enum.GetValues<SatellitePlatform>().Length.ShouldBe(3);
+        ((int)SatellitePlatform.Windows).ShouldBe(0);
+        ((int)SatellitePlatform.MacOS).ShouldBe(1);
+        ((int)SatellitePlatform.Linux).ShouldBe(2);
+    }
+
+    [Fact]
+    public void SatelliteCapability_EnumValues_MatchExpected()
+    {
+        Enum.GetValues<SatelliteCapability>().Length.ShouldBe(3);
+        ((int)SatelliteCapability.Notify).ShouldBe(0);
+        ((int)SatelliteCapability.Canvas).ShouldBe(1);
+        ((int)SatelliteCapability.Exec).ShouldBe(2);
+    }
+
+    [Fact]
+    public void SatelliteStatus_EnumValues_MatchExpected()
+    {
+        Enum.GetValues<SatelliteStatus>().Length.ShouldBe(3);
+        ((int)SatelliteStatus.Offline).ShouldBe(0);
+        ((int)SatelliteStatus.Online).ShouldBe(1);
+        ((int)SatelliteStatus.Stale).ShouldBe(2);
+    }
+
+    [Fact]
+    public void WorldDescriptor_WithSatellites_PreservesInRoundTrip()
+    {
+        var descriptor = new WorldDescriptor
+        {
+            Identity = new WorldIdentity
+            {
+                Id = "test-world",
+                Name = "Test World"
+            },
+            Satellites =
+            [
+                new Satellite
+                {
+                    Id = "sat_one",
+                    DisplayName = "Satellite One",
+                    Platform = SatellitePlatform.Windows,
+                    OwnerUserId = "user1",
+                    Capabilities = [SatelliteCapability.Notify]
+                },
+                new Satellite
+                {
+                    Id = "sat_two",
+                    DisplayName = "Satellite Two",
+                    Platform = SatellitePlatform.MacOS,
+                    OwnerUserId = "user2",
+                    Capabilities = [SatelliteCapability.Canvas, SatelliteCapability.Exec]
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(descriptor);
+        var deserialized = JsonSerializer.Deserialize<WorldDescriptor>(json);
+
+        deserialized.ShouldNotBeNull();
+        deserialized!.Satellites.Count.ShouldBe(2);
+        deserialized.Satellites[0].Id.ShouldBe("sat_one");
+        deserialized.Satellites[0].Platform.ShouldBe(SatellitePlatform.Windows);
+        deserialized.Satellites[1].Id.ShouldBe("sat_two");
+        deserialized.Satellites[1].Capabilities.ShouldContain(SatelliteCapability.Exec);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/SatelliteConfigTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/SatelliteConfigTests.cs
@@ -1,0 +1,218 @@
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Configuration;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public sealed class SatelliteConfigTests
+{
+    [Fact]
+    public void WorldDescriptorBuilder_WithSatellites_ResolvesSatellitesFromConfig()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat_desktop"] = new()
+                    {
+                        DisplayName = "Desktop",
+                        Platform = "windows",
+                        ApiKey = "sat_testkey123",
+                        Capabilities = ["notify", "canvas"],
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    },
+                    ["sat_laptop"] = new()
+                    {
+                        DisplayName = "Laptop",
+                        Platform = "macos",
+                        ApiKey = "sat_testkey456",
+                        Capabilities = ["notify", "canvas", "exec"],
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    }
+                }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        world.Satellites.Count.ShouldBe(2);
+
+        var desktop = world.Satellites.First(s => s.Id == "sat_desktop");
+        desktop.DisplayName.ShouldBe("Desktop");
+        desktop.Platform.ShouldBe(SatellitePlatform.Windows);
+        desktop.OwnerUserId.ShouldBe("jon");
+        desktop.Capabilities.Count.ShouldBe(2);
+        desktop.Capabilities.ShouldContain(SatelliteCapability.Notify);
+        desktop.Capabilities.ShouldContain(SatelliteCapability.Canvas);
+
+        var laptop = world.Satellites.First(s => s.Id == "sat_laptop");
+        laptop.Platform.ShouldBe(SatellitePlatform.MacOS);
+        laptop.Capabilities.Count.ShouldBe(3);
+        laptop.Capabilities.ShouldContain(SatelliteCapability.Exec);
+    }
+
+    [Fact]
+    public void WorldDescriptorBuilder_DisabledSatellites_AreExcluded()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat_active"] = new()
+                    {
+                        DisplayName = "Active",
+                        Platform = "windows",
+                        Capabilities = ["notify"],
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    },
+                    ["sat_disabled"] = new()
+                    {
+                        DisplayName = "Disabled",
+                        Platform = "linux",
+                        Capabilities = ["notify"],
+                        OwnerUserId = "jon",
+                        Enabled = false
+                    }
+                }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        world.Satellites.Count.ShouldBe(1);
+        world.Satellites[0].Id.ShouldBe("sat_active");
+    }
+
+    [Fact]
+    public void WorldDescriptorBuilder_SatelliteWithoutOwner_IsExcluded()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat_orphan"] = new()
+                    {
+                        DisplayName = "Orphan",
+                        Platform = "windows",
+                        Capabilities = ["notify"],
+                        OwnerUserId = null, // No owner
+                        Enabled = true
+                    }
+                }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        world.Satellites.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WorldDescriptorBuilder_InvalidCapabilities_AreSkipped()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat_test"] = new()
+                    {
+                        DisplayName = "Test",
+                        Platform = "windows",
+                        Capabilities = ["notify", "unknown_cap", "canvas"],
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    }
+                }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        var sat = world.Satellites.ShouldHaveSingleItem();
+        sat.Capabilities.Count.ShouldBe(2);
+        sat.Capabilities.ShouldContain(SatelliteCapability.Notify);
+        sat.Capabilities.ShouldContain(SatelliteCapability.Canvas);
+    }
+
+    [Fact]
+    public void WorldDescriptorBuilder_UnknownPlatform_DefaultsToWindows()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat_test"] = new()
+                    {
+                        DisplayName = "Test",
+                        Platform = "freebsd",
+                        Capabilities = ["notify"],
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    }
+                }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        world.Satellites.ShouldHaveSingleItem().Platform.ShouldBe(SatellitePlatform.Windows);
+    }
+
+    [Fact]
+    public void WorldDescriptorBuilder_NoSatellitesConfig_ReturnsEmptyList()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        world.Satellites.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WorldDescriptorBuilder_SatellitesAreSortedById()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                World = new BotNexus.Domain.WorldIdentity { Id = "test", Name = "Test" },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat_zulu"] = new() { Platform = "linux", Capabilities = ["notify"], OwnerUserId = "jon", Enabled = true },
+                    ["sat_alpha"] = new() { Platform = "windows", Capabilities = ["notify"], OwnerUserId = "jon", Enabled = true },
+                    ["sat_mike"] = new() { Platform = "macos", Capabilities = ["notify"], OwnerUserId = "jon", Enabled = true }
+                }
+            }
+        };
+
+        var world = WorldDescriptorBuilder.Build(config, null, null);
+
+        world.Satellites.Count.ShouldBe(3);
+        world.Satellites[0].Id.ShouldBe("sat_alpha");
+        world.Satellites[1].Id.ShouldBe("sat_mike");
+        world.Satellites[2].Id.ShouldBe("sat_zulu");
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/SatelliteKeyGeneratorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/SatelliteKeyGeneratorTests.cs
@@ -1,0 +1,57 @@
+using BotNexus.Gateway.Configuration;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public sealed class SatelliteKeyGeneratorTests
+{
+    [Fact]
+    public void GenerateApiKey_StartsWithSatPrefix()
+    {
+        var key = SatelliteKeyGenerator.GenerateApiKey();
+
+        key.ShouldStartWith("sat_");
+    }
+
+    [Fact]
+    public void GenerateApiKey_HasExpectedLength()
+    {
+        var key = SatelliteKeyGenerator.GenerateApiKey();
+
+        // "sat_" (4) + 43 base62 chars = 47 total
+        key.Length.ShouldBe(47);
+    }
+
+    [Fact]
+    public void GenerateApiKey_ContainsOnlyBase62Characters()
+    {
+        var key = SatelliteKeyGenerator.GenerateApiKey();
+        var body = key["sat_".Length..];
+
+        body.ShouldAllBe(c =>
+            (c >= '0' && c <= '9') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= 'a' && c <= 'z'));
+    }
+
+    [Fact]
+    public void GenerateApiKey_ProducesUniqueKeys()
+    {
+        var keys = Enumerable.Range(0, 100)
+            .Select(_ => SatelliteKeyGenerator.GenerateApiKey())
+            .ToHashSet();
+
+        // All 100 keys should be distinct (probability of collision is astronomically small)
+        keys.Count.ShouldBe(100);
+    }
+
+    [Fact]
+    public void GenerateApiKey_HasSufficientEntropy()
+    {
+        // 32 bytes = 256 bits of entropy. Base62-encoded to 43 chars.
+        // Verify the key body is not all zeros or all same char.
+        var key = SatelliteKeyGenerator.GenerateApiKey();
+        var body = key["sat_".Length..];
+
+        body.Distinct().Count().ShouldBeGreaterThan(5);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the foundational satellite node system to the BotNexus world model — domain types, gateway configuration schema, key generation, WorldDescriptor integration, and a CLI command for satellite registration.

Closes #1108
Part of #1107

## Changes

### Domain Model (BotNexus.Domain.World)
- **Satellite** record: Id, DisplayName, Platform, OwnerUserId, Capabilities, Status, LastSeen
- **SatelliteStatus** enum: Offline, Online, Stale
- **SatelliteCapability** enum: Notify, Canvas, Exec
- **SatellitePlatform** enum: Windows, MacOS, Linux
- **SatelliteId** Vogen value object (type-safe primitive)
- **WorldDescriptor.Satellites** property added

### Gateway Configuration
- **SatelliteConfig** class: DisplayName, Platform, ApiKey, Capabilities, OwnerUserId, StaleTimeoutSeconds, Enabled
- **GatewaySettingsConfig.Satellites** property (`Dictionary<string, SatelliteConfig>`)
- **SatelliteKeyGenerator**: cryptographically random keys (32 bytes → 43 base62 chars, `sat_` prefix)
- **WorldDescriptorBuilder.ResolveSatellites()**: converts config → domain model (filters disabled, validates owner, parses platform/capabilities, sorts by ID)

### CLI
- **`botnexus satellite register`**: generates API key, writes to config.json, displays once
- **`botnexus satellite list`**: table view of all registered satellites
- **`botnexus satellite remove`**: deletes satellite from config

### Config Schema Example
```json
{
  ""gateway"": {
    ""satellites"": {
      ""sat_desktop_home"": {
        ""displayName"": ""Jon's Desktop"",
        ""platform"": ""windows"",
        ""apiKey"": ""sat_7KpX9mQ...(43 chars)"",
        ""capabilities"": [""notify"", ""canvas""],
        ""ownerUserId"": ""jon"",
        ""staleTimeoutSeconds"": 120,
        ""enabled"": true
      }
    }
  }
}
```

## Tests

- **Domain** (326 total): 8 new tests (Satellite model, SatelliteId, WorldDescriptor round-trip)
- **Gateway** (2478 total): 12 new tests (WorldDescriptorBuilder satellite resolution, key generator)
- **Architecture** (178 total): all pass

## What's NOT in this PR

- No gateway-side connection tracking or SignalR hub changes (#1109)
- No Windows satellite client process (#1110)
- No notification/canvas rendering (#1111)
- No remote execution (#1112)

This is purely the foundation: data model + config + CLI for registration.