### PR TITLE
fix(gateway): filter non-live entries from auto-title guard condition

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -1133,16 +1133,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         if (_autoTitleService is null || !session.ConversationId.IsInitialized())
             return;
 
-        // Only fire on the first exchange: exactly 1 user entry + at least 1 assistant entry.
-        var userEntries = session.History.Count(e => e.Role == MessageRole.User);
-        var assistantEntries = session.History.Count(e => e.Role == MessageRole.Assistant);
-        if (userEntries != 1 || assistantEntries < 1)
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(session.History);
+        if (userText is null || assistantText is null)
             return;
-
-        var userText = session.History
-            .FirstOrDefault(e => e.Role == MessageRole.User)?.Content ?? string.Empty;
-        var assistantText = session.History
-            .LastOrDefault(e => e.Role == MessageRole.Assistant)?.Content ?? string.Empty;
 
         var titlingModel = _platformConfig?.Value?.Gateway?.Auxiliary?.Titling;
 

--- a/src/gateway/BotNexus.Gateway/Services/ConversationAutoTitleService.cs
+++ b/src/gateway/BotNexus.Gateway/Services/ConversationAutoTitleService.cs
@@ -4,6 +4,7 @@ using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Sessions;
 using Microsoft.Extensions.Logging;
 
 namespace BotNexus.Gateway.Services;
@@ -174,6 +175,46 @@ public sealed class ConversationAutoTitleService
     public static bool IsDefaultTitle(string? title)
         => string.IsNullOrWhiteSpace(title) ||
            string.Equals(title, DefaultTitle, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when the entry is a live conversation entry that should be counted
+    /// for auto-title guard logic. Uses <see cref="SessionContextProjector.IsVisibleInLiveContext"/>
+    /// as the base filter (excludes historical, crash sentinels, notifications), then further
+    /// excludes tool results, compaction summaries, and system entries since only user and
+    /// assistant messages matter for first-exchange detection.
+    /// </summary>
+    public static bool IsLiveConversationEntry(SessionEntry entry)
+        => SessionContextProjector.IsVisibleInLiveContext(entry)
+           && !entry.IsCompactionSummary
+           && entry.Role != MessageRole.Tool
+           && entry.Role != MessageRole.System;
+
+    /// <summary>
+    /// Evaluates the session history to determine if this is the first user+assistant exchange.
+    /// Returns the user text and the last non-empty assistant text if the guard passes, or
+    /// (null, null) if auto-title should not fire.
+    /// </summary>
+    public static (string? UserText, string? AssistantText) ShouldTriggerAutoTitle(
+        IReadOnlyList<SessionEntry> history)
+    {
+        var liveEntries = history.Where(IsLiveConversationEntry).ToList();
+
+        var userEntries = liveEntries.Where(e => e.Role == MessageRole.User).ToList();
+        var assistantEntries = liveEntries.Where(e => e.Role == MessageRole.Assistant).ToList();
+
+        // Only fire on the first exchange: exactly 1 user entry + at least 1 assistant entry.
+        if (userEntries.Count != 1 || assistantEntries.Count < 1)
+            return (null, null);
+
+        var userText = userEntries[0].Content;
+        // Pick the last assistant entry with non-empty content (handles tool-call turns
+        // where intermediate assistant entries have empty content).
+        var assistantText = assistantEntries
+            .LastOrDefault(e => !string.IsNullOrWhiteSpace(e.Content))?.Content
+            ?? assistantEntries[^1].Content;
+
+        return (userText, assistantText);
+    }
 
     internal static string BuildPrompt(string userText, string assistantText)
         => $"In 5 words or fewer, give a descriptive title for this conversation based on the " +

--- a/tests/gateway/BotNexus.Gateway.Tests/AutoTitleGuardConditionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AutoTitleGuardConditionTests.cs
@@ -1,0 +1,258 @@
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+/// <summary>
+/// Tests for the auto-title guard condition logic.
+/// Validates that compaction summaries, crash sentinels, historical entries, and tool
+/// entries do not disrupt the "first user+assistant exchange" detection.
+/// </summary>
+public sealed class AutoTitleGuardConditionTests
+{
+    private static readonly AgentId TestAgentId = AgentId.From("test-agent");
+    private static readonly ConversationId TestConversationId = ConversationId.From("c_test-conv");
+
+    // ═══════════════════════════════════════════════════════════════════
+    // IsLiveConversationEntry — individual entry filtering
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void IsLiveConversationEntry_CompactionSummary_ReturnsFalse()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "Compacted summary",
+            IsCompactionSummary = true
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_CrashSentinel_ReturnsFalse()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "Crash sentinel",
+            IsCrashSentinel = true
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_HistoricalEntry_ReturnsFalse()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "Old user message",
+            IsHistory = true
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_ToolEntry_ReturnsFalse()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.Tool,
+            Content = "tool result",
+            ToolName = "web_search"
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_NormalUserEntry_ReturnsTrue()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "Normal message"
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_NormalAssistantEntry_ReturnsTrue()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "Normal response"
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_SystemEntry_ReturnsFalse()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.System,
+            Content = "System prompt"
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsLiveConversationEntry_NotificationEntry_ReturnsFalse()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.Notification,
+            Content = "Gateway restarted"
+        };
+
+        ConversationAutoTitleService.IsLiveConversationEntry(entry).ShouldBeFalse();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // ShouldTriggerAutoTitle — combined guard logic
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ShouldTrigger_CompactionPlusOneUser_ReturnsTexts()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.Assistant, Content = "Summary of prior conversation", IsCompactionSummary = true },
+            new() { Role = MessageRole.User, Content = "What is the weather?" },
+            new() { Role = MessageRole.Assistant, Content = "It is sunny today." }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBe("What is the weather?");
+        assistantText.ShouldBe("It is sunny today.");
+    }
+
+    [Fact]
+    public void ShouldTrigger_MultipleRealUsers_ReturnsNull()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = "First question" },
+            new() { Role = MessageRole.Assistant, Content = "First answer" },
+            new() { Role = MessageRole.User, Content = "Second question" },
+            new() { Role = MessageRole.Assistant, Content = "Second answer" }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBeNull();
+        assistantText.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ShouldTrigger_ToolHeavyFirstTurn_ReturnsTexts()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = "Find me a hotel" },
+            new() { Role = MessageRole.Assistant, Content = "" },
+            new() { Role = MessageRole.Tool, Content = "hotel results", ToolName = "web_search" },
+            new() { Role = MessageRole.Assistant, Content = "I found several hotels for you." }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBe("Find me a hotel");
+        assistantText.ShouldBe("I found several hotels for you.");
+    }
+
+    [Fact]
+    public void ShouldTrigger_NoAssistantEntry_ReturnsNull()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = "Hello" }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBeNull();
+        assistantText.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ShouldTrigger_OnlyCrashSentinels_ReturnsNull()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = "sentinel", IsCrashSentinel = true },
+            new() { Role = MessageRole.Assistant, Content = "response", IsCrashSentinel = true }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBeNull();
+        assistantText.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ShouldTrigger_EmptyAssistantText_UsesLastNonEmpty()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = "Search for cats" },
+            new() { Role = MessageRole.Assistant, Content = "" },
+            new() { Role = MessageRole.Tool, Content = "results", ToolName = "web_search" },
+            new() { Role = MessageRole.Assistant, Content = "Here are the results about cats." }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBe("Search for cats");
+        assistantText.ShouldBe("Here are the results about cats.");
+    }
+
+    [Fact]
+    public void ShouldTrigger_HistoricalUserEntries_Excluded()
+    {
+        var history = new List<SessionEntry>
+        {
+            new() { Role = MessageRole.User, Content = "Old question 1", IsHistory = true },
+            new() { Role = MessageRole.Assistant, Content = "Old answer 1", IsHistory = true },
+            new() { Role = MessageRole.User, Content = "Old question 2", IsHistory = true },
+            new() { Role = MessageRole.Assistant, Content = "Old answer 2", IsHistory = true },
+            new() { Role = MessageRole.Assistant, Content = "Compaction summary", IsCompactionSummary = true },
+            new() { Role = MessageRole.User, Content = "Fresh question" },
+            new() { Role = MessageRole.Assistant, Content = "Fresh answer" }
+        };
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBe("Fresh question");
+        assistantText.ShouldBe("Fresh answer");
+    }
+
+    [Fact]
+    public void ShouldTrigger_EmptyHistory_ReturnsNull()
+    {
+        var history = new List<SessionEntry>();
+
+        var (userText, assistantText) = ConversationAutoTitleService.ShouldTriggerAutoTitle(history);
+
+        userText.ShouldBeNull();
+        assistantText.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Closes #1106

## Problem

The `TryTriggerAutoTitle` guard in `GatewayHost.cs` counted **all** session history entries when checking for the first user+assistant exchange. This included compaction summaries, crash sentinels, historical (folded) entries, and tool results. In practice:

- Sessions with compacted history had `userEntries > 1` (old folded entries counted)
- Tool-heavy first turns had multiple assistant entries with empty content (tool call placeholders)
- The guard silently evaluated to false on every session, so auto-title **never fired**

## Fix

- Extract `ShouldTriggerAutoTitle` as a public static method on `ConversationAutoTitleService`
- Delegate base filtering to `SessionContextProjector.IsVisibleInLiveContext` (canonical projector, excludes IsHistory/IsCrashSentinel/Notification per architecture fence)
- Further exclude Tool, System, and CompactionSummary entries to isolate only live User/Assistant messages
- Pick the last non-empty assistant entry (handles tool-call turns with empty intermediate assistant entries)
- `GatewayHost.TryTriggerAutoTitle` now calls the extracted method -- 7 lines shorter, logic testable

## Tests

- 16 new tests in `AutoTitleGuardConditionTests.cs` covering:
  - IsLiveConversationEntry for each entry type (8 tests)
  - ShouldTriggerAutoTitle combined scenarios (8 tests): compaction+user, multiple users, tool-heavy turn, no assistant, crash sentinels only, empty assistant text, historical entries, empty history
- Architecture fence (`SessionContextProjectorArchitectureTests`) passes -- no inline IsHistory+IsCrashSentinel

## Merge Notes

Independent of all other PRs. Safe to merge any time.
