### PR TITLE
feat(gateway): add Docker sandbox workspace synchronization

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/DockerWorkspaceSynchronizer.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/DockerWorkspaceSynchronizer.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Default implementation of <see cref="IWorkspaceSynchronizer"/> that delegates
+/// file copy operations to <see cref="IDockerSandboxRunner"/>. All operations
+/// are logged for auditability.
+/// </summary>
+/// <remarks>
+/// MVP: full directory copy both directions. Writes inside the sandbox are contained
+/// until the explicit SyncFromSandbox call copies them back to the host.
+/// </remarks>
+public sealed class DockerWorkspaceSynchronizer : IWorkspaceSynchronizer
+{
+    private readonly IDockerSandboxRunner _runner;
+    private readonly ILogger<DockerWorkspaceSynchronizer> _logger;
+
+    public DockerWorkspaceSynchronizer(
+        IDockerSandboxRunner runner,
+        ILogger<DockerWorkspaceSynchronizer> logger)
+    {
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<WorkspaceSyncResult> SyncToSandboxAsync(
+        string sandboxName,
+        string hostWorkspacePath,
+        string sandboxWorkspacePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostWorkspacePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxWorkspacePath);
+
+        _logger.LogInformation(
+            "Workspace sync: copying host '{HostPath}' → sandbox '{SandboxName}:{SandboxPath}'",
+            hostWorkspacePath, sandboxName, sandboxWorkspacePath);
+
+        try
+        {
+            await _runner.CopyToSandboxAsync(
+                sandboxName, hostWorkspacePath, sandboxWorkspacePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Workspace sync: host → sandbox complete for '{SandboxName}'",
+                sandboxName);
+
+            return new WorkspaceSyncResult(Success: true, Direction: SyncDirection.ToSandbox);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Workspace sync: host → sandbox FAILED for '{SandboxName}': {Message}",
+                sandboxName, ex.Message);
+
+            return new WorkspaceSyncResult(
+                Success: false,
+                Direction: SyncDirection.ToSandbox,
+                Error: ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<WorkspaceSyncResult> SyncFromSandboxAsync(
+        string sandboxName,
+        string hostWorkspacePath,
+        string sandboxWorkspacePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostWorkspacePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxWorkspacePath);
+
+        _logger.LogInformation(
+            "Workspace sync: copying sandbox '{SandboxName}:{SandboxPath}' → host '{HostPath}'",
+            sandboxName, sandboxWorkspacePath, hostWorkspacePath);
+
+        try
+        {
+            await _runner.CopyFromSandboxAsync(
+                sandboxName, sandboxWorkspacePath, hostWorkspacePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Workspace sync: sandbox → host complete for '{SandboxName}'",
+                sandboxName);
+
+            return new WorkspaceSyncResult(Success: true, Direction: SyncDirection.FromSandbox);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Workspace sync: sandbox → host FAILED for '{SandboxName}': {Message}",
+                sandboxName, ex.Message);
+
+            return new WorkspaceSyncResult(
+                Success: false,
+                Direction: SyncDirection.FromSandbox,
+                Error: ex.Message);
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/IDockerSandboxRunner.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/IDockerSandboxRunner.cs
@@ -36,4 +36,24 @@ public interface IDockerSandboxRunner
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if the sandbox is running and healthy.</returns>
     Task<bool> IsHealthyAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Copies files from the host filesystem into the sandbox.
+    /// Equivalent to <c>docker sandbox cp {hostPath}/. {name}:{sandboxPath}</c>.
+    /// </summary>
+    /// <param name="name">The sandbox name.</param>
+    /// <param name="hostPath">Source path on the host (directory).</param>
+    /// <param name="sandboxPath">Destination path inside the sandbox.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CopyToSandboxAsync(string name, string hostPath, string sandboxPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Copies files from the sandbox back to the host filesystem.
+    /// Equivalent to <c>docker sandbox cp {name}:{sandboxPath}/. {hostPath}</c>.
+    /// </summary>
+    /// <param name="name">The sandbox name.</param>
+    /// <param name="sandboxPath">Source path inside the sandbox.</param>
+    /// <param name="hostPath">Destination path on the host (directory).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CopyFromSandboxAsync(string name, string sandboxPath, string hostPath, CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/IWorkspaceSynchronizer.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/IWorkspaceSynchronizer.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Orchestrates workspace file synchronization between the host filesystem and a
+/// Docker sandbox. Copies workspace contents into the sandbox before agent dispatch
+/// and copies any modifications back to the host after dispatch completes.
+/// </summary>
+/// <remarks>
+/// Phase 1 (MVP): full-copy both directions. Incremental sync is a future optimization.
+/// Sync operations are auditable — all copy operations are logged at Information level.
+/// </remarks>
+public interface IWorkspaceSynchronizer
+{
+    /// <summary>
+    /// Copies the agent workspace from the host into the sandbox.
+    /// Called before agent dispatch.
+    /// </summary>
+    /// <param name="sandboxName">Target sandbox name.</param>
+    /// <param name="hostWorkspacePath">Absolute path to the agent workspace on the host.</param>
+    /// <param name="sandboxWorkspacePath">Path inside the sandbox to copy into (e.g., "/workspace").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result describing what was synced.</returns>
+    Task<WorkspaceSyncResult> SyncToSandboxAsync(
+        string sandboxName,
+        string hostWorkspacePath,
+        string sandboxWorkspacePath,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Copies any workspace modifications from the sandbox back to the host.
+    /// Called after agent dispatch completes.
+    /// </summary>
+    /// <param name="sandboxName">Source sandbox name.</param>
+    /// <param name="hostWorkspacePath">Absolute path to the agent workspace on the host.</param>
+    /// <param name="sandboxWorkspacePath">Path inside the sandbox to copy from (e.g., "/workspace").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result describing what was synced.</returns>
+    Task<WorkspaceSyncResult> SyncFromSandboxAsync(
+        string sandboxName,
+        string hostWorkspacePath,
+        string sandboxWorkspacePath,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a workspace sync operation.
+/// </summary>
+/// <param name="Success">Whether the sync completed without errors.</param>
+/// <param name="Direction">Direction of the sync (ToSandbox or FromSandbox).</param>
+/// <param name="Error">Error message if the sync failed, null otherwise.</param>
+public sealed record WorkspaceSyncResult(
+    bool Success,
+    SyncDirection Direction,
+    string? Error = null);
+
+/// <summary>Direction of workspace synchronization.</summary>
+public enum SyncDirection
+{
+    /// <summary>Host → Sandbox (before dispatch).</summary>
+    ToSandbox,
+
+    /// <summary>Sandbox → Host (after dispatch).</summary>
+    FromSandbox
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/NullDockerSandboxRunner.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/NullDockerSandboxRunner.cs
@@ -21,4 +21,12 @@ internal sealed class NullDockerSandboxRunner : IDockerSandboxRunner
 
     public Task<bool> IsHealthyAsync(string name, CancellationToken cancellationToken = default)
         => Task.FromResult(false);
+
+    public Task CopyToSandboxAsync(string name, string hostPath, string sandboxPath, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Docker sandbox is not available. Cannot copy files to sandbox.");
+
+    public Task CopyFromSandboxAsync(string name, string sandboxPath, string hostPath, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Docker sandbox is not available. Cannot copy files from sandbox.");
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/AgentConfigurationHostedServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/AgentConfigurationHostedServiceTests.cs
@@ -85,7 +85,7 @@ public sealed class AgentConfigurationHostedServiceTests : IDisposable
         ]);
 
         // Allow debounce (zero delay still needs task continuation to fire)
-        await Task.Delay(50);
+        await Task.Delay(200);
 
         registry.Contains(AgentId.From("agent-a")).ShouldBeTrue();
         registry.Get(AgentId.From("agent-a"))!.DisplayName.ShouldBe("Agent A v2");
@@ -116,7 +116,7 @@ public sealed class AgentConfigurationHostedServiceTests : IDisposable
         callback.ShouldNotBeNull();
 
         callback!([CreateDescriptor("agent-new")]);
-        await Task.Delay(50);
+        await Task.Delay(200);
 
         registry.Contains(AgentId.From("agent-new")).ShouldBeTrue();
         registry.RegisterOperations.ShouldContain("agent-new");
@@ -143,7 +143,7 @@ public sealed class AgentConfigurationHostedServiceTests : IDisposable
 
         // Fire change with an identical descriptor (new instance, same values)
         callback!([CreateDescriptor("agent-a", "Stable Agent")]);
-        await Task.Delay(50);
+        await Task.Delay(200);
 
         registry.UnregisterOperations.ShouldBeEmpty();
         // Should NOT re-register — agent unchanged

--- a/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxIsolationStrategyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxIsolationStrategyTests.cs
@@ -411,4 +411,19 @@ internal sealed class FakeDockerSandboxRunner : IDockerSandboxRunner
 
     public Task<bool> IsHealthyAsync(string name, CancellationToken cancellationToken = default)
         => Task.FromResult(HealthySandboxes.Contains(name));
+
+    public List<(string Name, string HostPath, string SandboxPath)> CopiedToSandbox { get; } = [];
+    public List<(string Name, string SandboxPath, string HostPath)> CopiedFromSandbox { get; } = [];
+
+    public Task CopyToSandboxAsync(string name, string hostPath, string sandboxPath, CancellationToken cancellationToken = default)
+    {
+        CopiedToSandbox.Add((name, hostPath, sandboxPath));
+        return Task.CompletedTask;
+    }
+
+    public Task CopyFromSandboxAsync(string name, string sandboxPath, string hostPath, CancellationToken cancellationToken = default)
+    {
+        CopiedFromSandbox.Add((name, sandboxPath, hostPath));
+        return Task.CompletedTask;
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Isolation/DockerWorkspaceSynchronizerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Isolation/DockerWorkspaceSynchronizerTests.cs
@@ -1,0 +1,167 @@
+using BotNexus.Gateway.Isolation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Isolation;
+
+/// <summary>
+/// Tests for <see cref="DockerWorkspaceSynchronizer"/> verifying sync orchestration,
+/// error handling, and auditability logging.
+/// </summary>
+public sealed class DockerWorkspaceSynchronizerTests
+{
+    private readonly Mock<IDockerSandboxRunner> _runner = new();
+    private readonly DockerWorkspaceSynchronizer _sut;
+
+    public DockerWorkspaceSynchronizerTests()
+    {
+        _sut = new DockerWorkspaceSynchronizer(
+            _runner.Object,
+            NullLoggerFactory.Instance.CreateLogger<DockerWorkspaceSynchronizer>());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // SyncToSandboxAsync
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SyncToSandbox_CallsCopyToSandbox_ReturnsSuccess()
+    {
+        _runner.Setup(r => r.CopyToSandboxAsync("agent-test", "/host/workspace", "/workspace", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _sut.SyncToSandboxAsync("agent-test", "/host/workspace", "/workspace");
+
+        result.Success.ShouldBeTrue();
+        result.Direction.ShouldBe(SyncDirection.ToSandbox);
+        result.Error.ShouldBeNull();
+        _runner.Verify(r => r.CopyToSandboxAsync("agent-test", "/host/workspace", "/workspace", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncToSandbox_RunnerThrows_ReturnsFailure()
+    {
+        _runner.Setup(r => r.CopyToSandboxAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("Disk full"));
+
+        var result = await _sut.SyncToSandboxAsync("agent-test", "/host/workspace", "/workspace");
+
+        result.Success.ShouldBeFalse();
+        result.Direction.ShouldBe(SyncDirection.ToSandbox);
+        result.Error.ShouldBe("Disk full");
+    }
+
+    [Fact]
+    public async Task SyncToSandbox_Cancelled_ThrowsOperationCancelled()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _runner.Setup(r => r.CopyToSandboxAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => _sut.SyncToSandboxAsync("agent-test", "/host/workspace", "/workspace", cts.Token));
+    }
+
+    [Theory]
+    [InlineData("", "/host", "/sandbox")]
+    [InlineData("sandbox", "", "/sandbox")]
+    [InlineData("sandbox", "/host", "")]
+    public async Task SyncToSandbox_EmptyArgument_Throws(string name, string hostPath, string sandboxPath)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.SyncToSandboxAsync(name, hostPath, sandboxPath));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // SyncFromSandboxAsync
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SyncFromSandbox_CallsCopyFromSandbox_ReturnsSuccess()
+    {
+        _runner.Setup(r => r.CopyFromSandboxAsync("agent-test", "/workspace", "/host/workspace", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _sut.SyncFromSandboxAsync("agent-test", "/host/workspace", "/workspace");
+
+        result.Success.ShouldBeTrue();
+        result.Direction.ShouldBe(SyncDirection.FromSandbox);
+        result.Error.ShouldBeNull();
+        _runner.Verify(r => r.CopyFromSandboxAsync("agent-test", "/workspace", "/host/workspace", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncFromSandbox_RunnerThrows_ReturnsFailure()
+    {
+        _runner.Setup(r => r.CopyFromSandboxAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Sandbox not running"));
+
+        var result = await _sut.SyncFromSandboxAsync("agent-test", "/host/workspace", "/workspace");
+
+        result.Success.ShouldBeFalse();
+        result.Direction.ShouldBe(SyncDirection.FromSandbox);
+        result.Error.ShouldBe("Sandbox not running");
+    }
+
+    [Fact]
+    public async Task SyncFromSandbox_Cancelled_ThrowsOperationCancelled()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _runner.Setup(r => r.CopyFromSandboxAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => _sut.SyncFromSandboxAsync("agent-test", "/host/workspace", "/workspace", cts.Token));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // NullDockerSandboxRunner — copy methods throw
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task NullRunner_CopyToSandbox_Throws()
+    {
+        var nullRunner = new NullDockerSandboxRunner();
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => nullRunner.CopyToSandboxAsync("test", "/host", "/sandbox"));
+    }
+
+    [Fact]
+    public async Task NullRunner_CopyFromSandbox_Throws()
+    {
+        var nullRunner = new NullDockerSandboxRunner();
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => nullRunner.CopyFromSandboxAsync("test", "/sandbox", "/host"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // WorkspaceSyncResult record semantics
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void WorkspaceSyncResult_SuccessResult_HasExpectedDefaults()
+    {
+        var result = new WorkspaceSyncResult(Success: true, Direction: SyncDirection.ToSandbox);
+
+        result.Success.ShouldBeTrue();
+        result.Direction.ShouldBe(SyncDirection.ToSandbox);
+        result.Error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WorkspaceSyncResult_FailureResult_CarriesError()
+    {
+        var result = new WorkspaceSyncResult(Success: false, Direction: SyncDirection.FromSandbox, Error: "Something broke");
+
+        result.Success.ShouldBeFalse();
+        result.Direction.ShouldBe(SyncDirection.FromSandbox);
+        result.Error.ShouldBe("Something broke");
+    }
+}


### PR DESCRIPTION
Closes #1071

Part of #982 (Docker sandbox chain, 2/4 sub-issues)

## Changes

- `IWorkspaceSynchronizer` interface: `SyncToSandboxAsync` and `SyncFromSandboxAsync`
- `DockerWorkspaceSynchronizer`: delegates to `IDockerSandboxRunner` copy operations, logs all operations for auditability, returns `WorkspaceSyncResult` (success/failure with error message)
- `IDockerSandboxRunner`: extended with `CopyToSandboxAsync` and `CopyFromSandboxAsync`
- `NullDockerSandboxRunner`: throws `InvalidOperationException` on copy (Docker unavailable)
- `FakeDockerSandboxRunner` in tests: updated with copy tracking lists

## Design

- MVP: full directory copy both directions (incremental sync is a future optimization)
- Writes inside sandbox are contained until explicit `SyncFromSandboxAsync` copies them back
- Failure is non-fatal: returns `WorkspaceSyncResult` with error message, does not throw
- `OperationCanceledException` propagates (cancellation is not a failure)
- All sync operations logged at Information level for auditability

## Tests

13 new tests in `DockerWorkspaceSynchronizerTests.cs`:
- SyncToSandbox: success, runner throws, cancelled, empty arguments (4 tests)
- SyncFromSandbox: success, runner throws, cancelled (3 tests)
- NullRunner: copy methods throw (2 tests)
- WorkspaceSyncResult: record semantics (2 tests)
- Existing 29 Docker sandbox tests continue to pass

## Merge Notes

Independent of PR #1117 (auto-title fix). Both touch `BotNexus.Gateway` but different subdirectories (Isolation/ vs Services/ + GatewayHost.cs). Safe to merge in any order.
