### PR TITLE
feat(gateway): add satellite authentication and connection tracking

### DIFF
--- a/src/gateway/BotNexus.Gateway.Abstractions/Satellites/ISatelliteRegistry.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/Satellites/ISatelliteRegistry.cs
@@ -1,0 +1,31 @@
+using BotNexus.Domain.World;
+
+namespace BotNexus.Gateway.Abstractions.Satellites;
+
+/// <summary>
+/// Registry for tracking satellite connection status. Satellites register on connect
+/// and are marked offline on disconnect. A background service detects stale connections.
+/// </summary>
+public interface ISatelliteRegistry
+{
+    /// <summary>Gets all registered satellites with current status.</summary>
+    IReadOnlyList<SatelliteConnectionInfo> GetAll();
+
+    /// <summary>Gets a satellite by ID, or null if not found.</summary>
+    SatelliteConnectionInfo? GetById(string satelliteId);
+
+    /// <summary>Gets all online satellites owned by a specific user.</summary>
+    IReadOnlyList<SatelliteConnectionInfo> GetOnlineForUser(string userId);
+
+    /// <summary>Marks a satellite as online with the given SignalR connection ID.</summary>
+    void MarkOnline(string satelliteId, string connectionId);
+
+    /// <summary>Marks a satellite as offline (disconnect or stale timeout).</summary>
+    void MarkOffline(string satelliteId);
+
+    /// <summary>Records a heartbeat from the satellite, updating LastSeen.</summary>
+    void RecordHeartbeat(string satelliteId);
+
+    /// <summary>Gets all satellites that have not sent a heartbeat within their stale timeout.</summary>
+    IReadOnlyList<SatelliteConnectionInfo> GetStaleSatellites(DateTimeOffset now);
+}

--- a/src/gateway/BotNexus.Gateway.Abstractions/Satellites/SatelliteConnectionInfo.cs
+++ b/src/gateway/BotNexus.Gateway.Abstractions/Satellites/SatelliteConnectionInfo.cs
@@ -1,0 +1,37 @@
+using BotNexus.Domain.World;
+
+namespace BotNexus.Gateway.Abstractions.Satellites;
+
+/// <summary>
+/// Runtime connection information for a satellite node, combining static config
+/// with dynamic connection state.
+/// </summary>
+public sealed record SatelliteConnectionInfo
+{
+    /// <summary>Satellite identifier from config.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Human-readable display name.</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Platform the satellite runs on.</summary>
+    public required string Platform { get; init; }
+
+    /// <summary>Owner user ID. Events are filtered to this user's conversations.</summary>
+    public required string OwnerUserId { get; init; }
+
+    /// <summary>Capabilities this satellite supports.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Current connection status.</summary>
+    public SatelliteStatus Status { get; set; } = SatelliteStatus.Offline;
+
+    /// <summary>SignalR connection ID when online, null otherwise.</summary>
+    public string? ConnectionId { get; set; }
+
+    /// <summary>Last time a heartbeat or connect event was received.</summary>
+    public DateTimeOffset? LastSeen { get; set; }
+
+    /// <summary>Configured stale timeout in seconds.</summary>
+    public int StaleTimeoutSeconds { get; init; } = 120;
+}

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/SatellitesController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/SatellitesController.cs
@@ -1,0 +1,81 @@
+using BotNexus.Gateway.Abstractions.Satellites;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+/// <summary>
+/// REST endpoints for querying satellite node status and connection information.
+/// </summary>
+[ApiController]
+[Route("api/satellites")]
+public sealed class SatellitesController(ISatelliteRegistry registry) : ControllerBase
+{
+    private readonly ISatelliteRegistry _registry = registry;
+
+    /// <summary>Lists all registered satellites with their current connection status.</summary>
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        var satellites = _registry.GetAll();
+        return Ok(satellites.Select(s => new SatelliteStatusDto
+        {
+            Id = s.Id,
+            DisplayName = s.DisplayName,
+            Platform = s.Platform,
+            OwnerUserId = s.OwnerUserId,
+            Capabilities = s.Capabilities,
+            Status = s.Status.ToString().ToLowerInvariant(),
+            LastSeen = s.LastSeen,
+            ConnectionId = s.ConnectionId
+        }));
+    }
+
+    /// <summary>Gets a single satellite's status and connection information.</summary>
+    [HttpGet("{satelliteId}")]
+    public IActionResult GetById(string satelliteId)
+    {
+        var satellite = _registry.GetById(satelliteId);
+        if (satellite is null)
+            return NotFound(new { error = $"Satellite '{satelliteId}' not found." });
+
+        return Ok(new SatelliteStatusDto
+        {
+            Id = satellite.Id,
+            DisplayName = satellite.DisplayName,
+            Platform = satellite.Platform,
+            OwnerUserId = satellite.OwnerUserId,
+            Capabilities = satellite.Capabilities,
+            Status = satellite.Status.ToString().ToLowerInvariant(),
+            LastSeen = satellite.LastSeen,
+            ConnectionId = satellite.ConnectionId
+        });
+    }
+}
+
+/// <summary>Response DTO for satellite status queries.</summary>
+public sealed class SatelliteStatusDto
+{
+    /// <summary>Satellite identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Human-readable display name.</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Platform (windows, macos, linux).</summary>
+    public required string Platform { get; init; }
+
+    /// <summary>Owner user ID.</summary>
+    public required string OwnerUserId { get; init; }
+
+    /// <summary>Capabilities.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Current status (online, offline, stale).</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Last heartbeat time.</summary>
+    public DateTimeOffset? LastSeen { get; init; }
+
+    /// <summary>SignalR connection ID when online.</summary>
+    public string? ConnectionId { get; init; }
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using BotNexus.Gateway.Abstractions.Services;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Abstractions.Configuration;
 using BotNexus.Gateway.Abstractions.Extensions;
+using BotNexus.Gateway.Abstractions.Satellites;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Activity;
 using BotNexus.Gateway.Agents;
@@ -223,6 +224,10 @@ public static class GatewayServiceCollectionExtensions
         services.AddSingleton<IActivityTracker, ActivityTracker>();
         services.Configure<LivenessWatchdogOptions>(_ => { });
         services.AddHostedService<LivenessWatchdogService>();
+
+        // Satellite registry and stale detection
+        services.AddSingleton<ISatelliteRegistry, Satellites.InMemorySatelliteRegistry>();
+        services.AddHostedService<Satellites.SatelliteStaleDetectionService>();
 
         // Auto-update: register once as singleton, expose as interface and hosted service.
         services.AddSingleton<Updates.UpdateCheckService>();

--- a/src/gateway/BotNexus.Gateway/Satellites/InMemorySatelliteRegistry.cs
+++ b/src/gateway/BotNexus.Gateway/Satellites/InMemorySatelliteRegistry.cs
@@ -1,0 +1,120 @@
+using System.Collections.Concurrent;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Satellites;
+using BotNexus.Gateway.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Satellites;
+
+/// <summary>
+/// In-memory satellite registry that tracks connection state. Initialized from
+/// <see cref="GatewaySettingsConfig.Satellites"/> configuration on startup.
+/// </summary>
+public sealed class InMemorySatelliteRegistry : ISatelliteRegistry
+{
+    private readonly ConcurrentDictionary<string, SatelliteConnectionInfo> _satellites = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ILogger<InMemorySatelliteRegistry> _logger;
+
+    /// <summary>Creates a new registry, seeding from platform config satellites.</summary>
+    public InMemorySatelliteRegistry(
+        IOptionsMonitor<PlatformConfig> platformConfig,
+        ILogger<InMemorySatelliteRegistry> logger)
+    {
+        _logger = logger;
+        SeedFromConfig(platformConfig.CurrentValue);
+    }
+
+    /// <summary>Test constructor that accepts pre-built entries.</summary>
+    internal InMemorySatelliteRegistry(
+        IEnumerable<SatelliteConnectionInfo> entries,
+        ILogger<InMemorySatelliteRegistry> logger)
+    {
+        _logger = logger;
+        foreach (var entry in entries)
+            _satellites[entry.Id] = entry;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SatelliteConnectionInfo> GetAll() =>
+        _satellites.Values.ToList().AsReadOnly();
+
+    /// <inheritdoc />
+    public SatelliteConnectionInfo? GetById(string satelliteId) =>
+        _satellites.GetValueOrDefault(satelliteId);
+
+    /// <inheritdoc />
+    public IReadOnlyList<SatelliteConnectionInfo> GetOnlineForUser(string userId) =>
+        _satellites.Values
+            .Where(s => s.Status == SatelliteStatus.Online &&
+                        string.Equals(s.OwnerUserId, userId, StringComparison.OrdinalIgnoreCase))
+            .ToList()
+            .AsReadOnly();
+
+    /// <inheritdoc />
+    public void MarkOnline(string satelliteId, string connectionId)
+    {
+        if (!_satellites.TryGetValue(satelliteId, out var info))
+        {
+            _logger.LogWarning("Attempted to mark unknown satellite {SatelliteId} as online", satelliteId);
+            return;
+        }
+
+        info.Status = SatelliteStatus.Online;
+        info.ConnectionId = connectionId;
+        info.LastSeen = DateTimeOffset.UtcNow;
+        _logger.LogInformation("Satellite {SatelliteId} connected (connection={ConnectionId})", satelliteId, connectionId);
+    }
+
+    /// <inheritdoc />
+    public void MarkOffline(string satelliteId)
+    {
+        if (!_satellites.TryGetValue(satelliteId, out var info))
+            return;
+
+        info.Status = SatelliteStatus.Offline;
+        info.ConnectionId = null;
+        _logger.LogInformation("Satellite {SatelliteId} disconnected", satelliteId);
+    }
+
+    /// <inheritdoc />
+    public void RecordHeartbeat(string satelliteId)
+    {
+        if (_satellites.TryGetValue(satelliteId, out var info))
+            info.LastSeen = DateTimeOffset.UtcNow;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SatelliteConnectionInfo> GetStaleSatellites(DateTimeOffset now) =>
+        _satellites.Values
+            .Where(s => s.Status == SatelliteStatus.Online &&
+                        s.LastSeen.HasValue &&
+                        (now - s.LastSeen.Value).TotalSeconds > s.StaleTimeoutSeconds)
+            .ToList()
+            .AsReadOnly();
+
+    private void SeedFromConfig(PlatformConfig config)
+    {
+        var satellites = config.Gateway?.Satellites;
+        if (satellites is null || satellites.Count == 0)
+            return;
+
+        foreach (var (id, satConfig) in satellites)
+        {
+            if (!satConfig.Enabled)
+                continue;
+
+            _satellites[id] = new SatelliteConnectionInfo
+            {
+                Id = id,
+                DisplayName = satConfig.DisplayName ?? id,
+                Platform = satConfig.Platform,
+                OwnerUserId = satConfig.OwnerUserId ?? "unknown",
+                Capabilities = satConfig.Capabilities ?? [],
+                StaleTimeoutSeconds = satConfig.StaleTimeoutSeconds
+            };
+        }
+
+        _logger.LogInformation("Satellite registry seeded with {Count} satellites from config", _satellites.Count);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Satellites/SatelliteStaleDetectionService.cs
+++ b/src/gateway/BotNexus.Gateway/Satellites/SatelliteStaleDetectionService.cs
@@ -1,0 +1,67 @@
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Satellites;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Satellites;
+
+/// <summary>
+/// Background service that periodically checks for stale satellite connections
+/// (no heartbeat within configured timeout) and marks them offline.
+/// </summary>
+public sealed class SatelliteStaleDetectionService : BackgroundService
+{
+    private readonly ISatelliteRegistry _registry;
+    private readonly ILogger<SatelliteStaleDetectionService> _logger;
+    private readonly TimeSpan _checkInterval;
+
+    /// <summary>Creates the stale detection service with a 30-second check interval.</summary>
+    public SatelliteStaleDetectionService(
+        ISatelliteRegistry registry,
+        ILogger<SatelliteStaleDetectionService> logger,
+        TimeSpan? checkInterval = null)
+    {
+        _registry = registry;
+        _logger = logger;
+        _checkInterval = checkInterval ?? TimeSpan.FromSeconds(30);
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogDebug("Satellite stale detection service started (interval={Interval}s)", _checkInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_checkInterval, stoppingToken);
+                DetectAndMarkStale();
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during satellite stale detection sweep");
+            }
+        }
+    }
+
+    private void DetectAndMarkStale()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var stale = _registry.GetStaleSatellites(now);
+
+        foreach (var satellite in stale)
+        {
+            _logger.LogWarning(
+                "Satellite {SatelliteId} marked stale (last seen {LastSeen}, timeout={Timeout}s)",
+                satellite.Id,
+                satellite.LastSeen,
+                satellite.StaleTimeoutSeconds);
+            _registry.MarkOffline(satellite.Id);
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Security/ApiKeyGatewayAuthHandler.cs
+++ b/src/gateway/BotNexus.Gateway/Security/ApiKeyGatewayAuthHandler.cs
@@ -59,7 +59,7 @@ public sealed class ApiKeyGatewayAuthHandler : IGatewayAuthHandler
         ArgumentNullException.ThrowIfNull(platformConfig);
         _logger = logger;
         _platformConfig = null;
-        _identitiesByApiKey = BuildIdentityMap(platformConfig.ApiKey, platformConfig.Gateway?.ApiKeys);
+        _identitiesByApiKey = BuildIdentityMap(platformConfig.ApiKey, platformConfig.Gateway?.ApiKeys, platformConfig.Gateway?.Satellites);
     }
 
     /// <summary>
@@ -115,7 +115,8 @@ public sealed class ApiKeyGatewayAuthHandler : IGatewayAuthHandler
 
     private static Dictionary<string, GatewayCallerIdentity> BuildIdentityMap(
         string? legacyApiKey,
-        Dictionary<string, ApiKeyConfig>? apiKeys)
+        Dictionary<string, ApiKeyConfig>? apiKeys,
+        Dictionary<string, SatelliteConfig>? satellites = null)
     {
         var map = new Dictionary<string, GatewayCallerIdentity>(StringComparer.Ordinal);
 
@@ -131,30 +132,49 @@ public sealed class ApiKeyGatewayAuthHandler : IGatewayAuthHandler
             };
         }
 
-        if (apiKeys is null)
-            return map;
-
-        foreach (var (keyId, keyConfig) in apiKeys)
+        if (apiKeys is not null)
         {
-            if (string.IsNullOrWhiteSpace(keyConfig.ApiKey))
-                continue;
-
-            var callerId = !string.IsNullOrWhiteSpace(keyConfig.CallerId)
-                ? keyConfig.CallerId
-                : $"gateway-key:{keyId}";
-            var tenantId = !string.IsNullOrWhiteSpace(keyConfig.TenantId)
-                ? keyConfig.TenantId
-                : "default";
-
-            map[keyConfig.ApiKey] = new GatewayCallerIdentity
+            foreach (var (keyId, keyConfig) in apiKeys)
             {
-                CallerId = callerId,
-                DisplayName = keyConfig.DisplayName,
-                TenantId = tenantId,
-                AllowedAgents = keyConfig.AllowedAgents ?? [],
-                Permissions = keyConfig.Permissions ?? [],
-                IsAdmin = keyConfig.IsAdmin
-            };
+                if (string.IsNullOrWhiteSpace(keyConfig.ApiKey))
+                    continue;
+
+                var callerId = !string.IsNullOrWhiteSpace(keyConfig.CallerId)
+                    ? keyConfig.CallerId
+                    : $"gateway-key:{keyId}";
+                var tenantId = !string.IsNullOrWhiteSpace(keyConfig.TenantId)
+                    ? keyConfig.TenantId
+                    : "default";
+
+                map[keyConfig.ApiKey] = new GatewayCallerIdentity
+                {
+                    CallerId = callerId,
+                    DisplayName = keyConfig.DisplayName,
+                    TenantId = tenantId,
+                    AllowedAgents = keyConfig.AllowedAgents ?? [],
+                    Permissions = keyConfig.Permissions ?? [],
+                    IsAdmin = keyConfig.IsAdmin
+                };
+            }
+        }
+
+        if (satellites is not null)
+        {
+            foreach (var (satId, satConfig) in satellites)
+            {
+                if (!satConfig.Enabled || string.IsNullOrWhiteSpace(satConfig.ApiKey))
+                    continue;
+
+                map[satConfig.ApiKey] = new GatewayCallerIdentity
+                {
+                    CallerId = $"satellite:{satId}",
+                    DisplayName = satConfig.DisplayName ?? $"Satellite {satId}",
+                    TenantId = "default",
+                    AllowedAgents = [],
+                    Permissions = ["satellite:connect", "satellite:heartbeat"],
+                    IsAdmin = false
+                };
+            }
         }
 
         return map;
@@ -166,7 +186,10 @@ public sealed class ApiKeyGatewayAuthHandler : IGatewayAuthHandler
             return _identitiesByApiKey;
 
         var currentConfig = _platformConfig.CurrentValue;
-        var rebuilt = BuildIdentityMap(currentConfig.ApiKey, currentConfig.Gateway?.ApiKeys);
+        var rebuilt = BuildIdentityMap(
+            currentConfig.ApiKey,
+            currentConfig.Gateway?.ApiKeys,
+            currentConfig.Gateway?.Satellites);
 
         lock (_sync)
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Satellites/InMemorySatelliteRegistryTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Satellites/InMemorySatelliteRegistryTests.cs
@@ -1,0 +1,224 @@
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Satellites;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Satellites;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Satellites;
+
+public sealed class InMemorySatelliteRegistryTests
+{
+    private static InMemorySatelliteRegistry CreateRegistry(
+        Dictionary<string, SatelliteConfig>? satellites = null)
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                Satellites = satellites
+            }
+        };
+        var monitor = new TestOptionsMonitor<PlatformConfig>(config);
+        return new InMemorySatelliteRegistry(monitor, NullLogger<InMemorySatelliteRegistry>.Instance);
+    }
+
+    [Fact]
+    public void GetAll_EmptyConfig_ReturnsEmpty()
+    {
+        var registry = CreateRegistry();
+        Assert.Empty(registry.GetAll());
+    }
+
+    [Fact]
+    public void GetAll_SeededFromConfig_ReturnsSatellites()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["sat1"] = new() { DisplayName = "Desktop", Platform = "windows", OwnerUserId = "jon", ApiKey = "sat_key1" },
+            ["sat2"] = new() { DisplayName = "Laptop", Platform = "macos", OwnerUserId = "jon", ApiKey = "sat_key2" }
+        });
+
+        var all = registry.GetAll();
+        Assert.Equal(2, all.Count);
+        Assert.Contains(all, s => s.Id == "sat1" && s.DisplayName == "Desktop");
+        Assert.Contains(all, s => s.Id == "sat2" && s.DisplayName == "Laptop");
+    }
+
+    [Fact]
+    public void GetAll_DisabledSatellite_Excluded()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["enabled"] = new() { DisplayName = "Enabled", Platform = "windows", OwnerUserId = "jon", ApiKey = "k1", Enabled = true },
+            ["disabled"] = new() { DisplayName = "Disabled", Platform = "linux", OwnerUserId = "jon", ApiKey = "k2", Enabled = false }
+        });
+
+        var all = registry.GetAll();
+        Assert.Single(all);
+        Assert.Equal("enabled", all[0].Id);
+    }
+
+    [Fact]
+    public void GetById_Existing_ReturnsSatellite()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["sat1"] = new() { DisplayName = "Desktop", Platform = "windows", OwnerUserId = "jon", ApiKey = "k1" }
+        });
+
+        var result = registry.GetById("sat1");
+        Assert.NotNull(result);
+        Assert.Equal("sat1", result.Id);
+    }
+
+    [Fact]
+    public void GetById_Unknown_ReturnsNull()
+    {
+        var registry = CreateRegistry();
+        Assert.Null(registry.GetById("nonexistent"));
+    }
+
+    [Fact]
+    public void MarkOnline_UpdatesStatusAndConnectionId()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["sat1"] = new() { DisplayName = "Desktop", Platform = "windows", OwnerUserId = "jon", ApiKey = "k1" }
+        });
+
+        registry.MarkOnline("sat1", "conn-123");
+
+        var sat = registry.GetById("sat1");
+        Assert.NotNull(sat);
+        Assert.Equal(SatelliteStatus.Online, sat.Status);
+        Assert.Equal("conn-123", sat.ConnectionId);
+        Assert.NotNull(sat.LastSeen);
+    }
+
+    [Fact]
+    public void MarkOnline_UnknownSatellite_NoOp()
+    {
+        var registry = CreateRegistry();
+        registry.MarkOnline("nonexistent", "conn-123"); // Should not throw
+    }
+
+    [Fact]
+    public void MarkOffline_ClearsConnectionId()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["sat1"] = new() { DisplayName = "Desktop", Platform = "windows", OwnerUserId = "jon", ApiKey = "k1" }
+        });
+
+        registry.MarkOnline("sat1", "conn-123");
+        registry.MarkOffline("sat1");
+
+        var sat = registry.GetById("sat1");
+        Assert.NotNull(sat);
+        Assert.Equal(SatelliteStatus.Offline, sat.Status);
+        Assert.Null(sat.ConnectionId);
+    }
+
+    [Fact]
+    public void RecordHeartbeat_UpdatesLastSeen()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["sat1"] = new() { DisplayName = "Desktop", Platform = "windows", OwnerUserId = "jon", ApiKey = "k1" }
+        });
+
+        registry.MarkOnline("sat1", "conn-123");
+        var firstSeen = registry.GetById("sat1")!.LastSeen;
+
+        Thread.Sleep(10); // ensure time advances
+        registry.RecordHeartbeat("sat1");
+
+        var afterHeartbeat = registry.GetById("sat1")!.LastSeen;
+        Assert.True(afterHeartbeat > firstSeen);
+    }
+
+    [Fact]
+    public void GetOnlineForUser_FiltersCorrectly()
+    {
+        var registry = CreateRegistry(new Dictionary<string, SatelliteConfig>
+        {
+            ["sat1"] = new() { DisplayName = "Jon Desktop", Platform = "windows", OwnerUserId = "jon", ApiKey = "k1" },
+            ["sat2"] = new() { DisplayName = "Jon Laptop", Platform = "macos", OwnerUserId = "jon", ApiKey = "k2" },
+            ["sat3"] = new() { DisplayName = "Other User", Platform = "linux", OwnerUserId = "alice", ApiKey = "k3" }
+        });
+
+        registry.MarkOnline("sat1", "c1");
+        registry.MarkOnline("sat2", "c2");
+        registry.MarkOnline("sat3", "c3");
+
+        var jonSats = registry.GetOnlineForUser("jon");
+        Assert.Equal(2, jonSats.Count);
+        Assert.All(jonSats, s => Assert.Equal("jon", s.OwnerUserId));
+    }
+
+    [Fact]
+    public void GetStaleSatellites_DetectsStale()
+    {
+        var entries = new[]
+        {
+            new SatelliteConnectionInfo
+            {
+                Id = "stale-sat",
+                DisplayName = "Stale",
+                Platform = "windows",
+                OwnerUserId = "jon",
+                Status = SatelliteStatus.Online,
+                LastSeen = DateTimeOffset.UtcNow.AddMinutes(-5),
+                StaleTimeoutSeconds = 120
+            },
+            new SatelliteConnectionInfo
+            {
+                Id = "fresh-sat",
+                DisplayName = "Fresh",
+                Platform = "windows",
+                OwnerUserId = "jon",
+                Status = SatelliteStatus.Online,
+                LastSeen = DateTimeOffset.UtcNow.AddSeconds(-10),
+                StaleTimeoutSeconds = 120
+            }
+        };
+
+        var registry = new InMemorySatelliteRegistry(entries, NullLogger<InMemorySatelliteRegistry>.Instance);
+        var stale = registry.GetStaleSatellites(DateTimeOffset.UtcNow);
+
+        Assert.Single(stale);
+        Assert.Equal("stale-sat", stale[0].Id);
+    }
+
+    [Fact]
+    public void GetStaleSatellites_OfflineSatellites_NotReported()
+    {
+        var entries = new[]
+        {
+            new SatelliteConnectionInfo
+            {
+                Id = "offline-sat",
+                DisplayName = "Offline",
+                Platform = "windows",
+                OwnerUserId = "jon",
+                Status = SatelliteStatus.Offline,
+                LastSeen = DateTimeOffset.UtcNow.AddMinutes(-10),
+                StaleTimeoutSeconds = 120
+            }
+        };
+
+        var registry = new InMemorySatelliteRegistry(entries, NullLogger<InMemorySatelliteRegistry>.Instance);
+        var stale = registry.GetStaleSatellites(DateTimeOffset.UtcNow);
+        Assert.Empty(stale);
+    }
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public TestOptionsMonitor(T value) => CurrentValue = value;
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Satellites/SatelliteAuthTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Satellites/SatelliteAuthTests.cs
@@ -1,0 +1,171 @@
+using BotNexus.Gateway.Abstractions.Security;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Satellites;
+
+public sealed class SatelliteAuthTests
+{
+    [Fact]
+    public async Task SatelliteApiKey_AuthenticatesWithSatelliteIdentity()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["desktop"] = new()
+                    {
+                        DisplayName = "Jon Desktop",
+                        ApiKey = "sat_test123",
+                        Platform = "windows",
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    }
+                }
+            }
+        };
+
+        var handler = new ApiKeyGatewayAuthHandler(config, NullLogger<ApiKeyGatewayAuthHandler>.Instance);
+        var context = new GatewayAuthContext
+        {
+            Headers = new Dictionary<string, string> { ["X-Api-Key"] = "sat_test123" },
+            QueryParameters = new Dictionary<string, string>(),
+            Path = "/api/satellites",
+            Method = "GET"
+        };
+
+        var result = await handler.AuthenticateAsync(context);
+
+        Assert.True(result.IsAuthenticated);
+        Assert.NotNull(result.Identity);
+        Assert.Equal("satellite:desktop", result.Identity.CallerId);
+        Assert.Equal("Jon Desktop", result.Identity.DisplayName);
+        Assert.False(result.Identity.IsAdmin);
+        Assert.Contains("satellite:connect", result.Identity.Permissions);
+        Assert.Contains("satellite:heartbeat", result.Identity.Permissions);
+    }
+
+    [Fact]
+    public async Task SatelliteApiKey_DisabledSatellite_Rejected()
+    {
+        var config = new PlatformConfig
+        {
+            ApiKey = "admin_key",
+            Gateway = new GatewaySettingsConfig
+            {
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["disabled"] = new()
+                    {
+                        DisplayName = "Disabled",
+                        ApiKey = "sat_disabled",
+                        Platform = "windows",
+                        OwnerUserId = "jon",
+                        Enabled = false
+                    }
+                }
+            }
+        };
+
+        var handler = new ApiKeyGatewayAuthHandler(config, NullLogger<ApiKeyGatewayAuthHandler>.Instance);
+        var context = new GatewayAuthContext
+        {
+            Headers = new Dictionary<string, string> { ["X-Api-Key"] = "sat_disabled" },
+            QueryParameters = new Dictionary<string, string>(),
+            Path = "/api/satellites",
+            Method = "GET"
+        };
+
+        var result = await handler.AuthenticateAsync(context);
+        Assert.False(result.IsAuthenticated);
+    }
+
+    [Fact]
+    public async Task SatelliteApiKey_NoApiKeyConfigured_Rejected()
+    {
+        var config = new PlatformConfig
+        {
+            ApiKey = "admin_key",
+            Gateway = new GatewaySettingsConfig
+            {
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["nokey"] = new()
+                    {
+                        DisplayName = "No Key",
+                        Platform = "windows",
+                        OwnerUserId = "jon",
+                        Enabled = true
+                        // ApiKey intentionally null
+                    }
+                }
+            }
+        };
+
+        var handler = new ApiKeyGatewayAuthHandler(config, NullLogger<ApiKeyGatewayAuthHandler>.Instance);
+        var context = new GatewayAuthContext
+        {
+            Headers = new Dictionary<string, string> { ["X-Api-Key"] = "anything" },
+            QueryParameters = new Dictionary<string, string>(),
+            Path = "/api/satellites",
+            Method = "GET"
+        };
+
+        var result = await handler.AuthenticateAsync(context);
+        Assert.False(result.IsAuthenticated);
+    }
+
+    [Fact]
+    public async Task SatelliteAndApiKeys_BothWork()
+    {
+        var config = new PlatformConfig
+        {
+            Gateway = new GatewaySettingsConfig
+            {
+                ApiKeys = new Dictionary<string, ApiKeyConfig>
+                {
+                    ["admin"] = new() { ApiKey = "admin_key", CallerId = "admin-caller", IsAdmin = true }
+                },
+                Satellites = new Dictionary<string, SatelliteConfig>
+                {
+                    ["sat1"] = new()
+                    {
+                        DisplayName = "Satellite",
+                        ApiKey = "sat_key",
+                        Platform = "windows",
+                        OwnerUserId = "jon",
+                        Enabled = true
+                    }
+                }
+            }
+        };
+
+        var handler = new ApiKeyGatewayAuthHandler(config, NullLogger<ApiKeyGatewayAuthHandler>.Instance);
+
+        // Admin key works
+        var adminResult = await handler.AuthenticateAsync(new GatewayAuthContext
+        {
+            Headers = new Dictionary<string, string> { ["X-Api-Key"] = "admin_key" },
+            QueryParameters = new Dictionary<string, string>(),
+            Path = "/api/agents",
+            Method = "GET"
+        });
+        Assert.True(adminResult.IsAuthenticated);
+        Assert.Equal("admin-caller", adminResult.Identity!.CallerId);
+
+        // Satellite key works
+        var satResult = await handler.AuthenticateAsync(new GatewayAuthContext
+        {
+            Headers = new Dictionary<string, string> { ["X-Api-Key"] = "sat_key" },
+            QueryParameters = new Dictionary<string, string>(),
+            Path = "/api/satellites",
+            Method = "GET"
+        });
+        Assert.True(satResult.IsAuthenticated);
+        Assert.Equal("satellite:sat1", satResult.Identity!.CallerId);
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Satellites/SatelliteStaleDetectionServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Satellites/SatelliteStaleDetectionServiceTests.cs
@@ -1,0 +1,100 @@
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Satellites;
+using BotNexus.Gateway.Satellites;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Satellites;
+
+public sealed class SatelliteStaleDetectionServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_DetectsAndMarksStale()
+    {
+        var entries = new[]
+        {
+            new SatelliteConnectionInfo
+            {
+                Id = "stale-sat",
+                DisplayName = "Stale",
+                Platform = "windows",
+                OwnerUserId = "jon",
+                Status = SatelliteStatus.Online,
+                LastSeen = DateTimeOffset.UtcNow.AddMinutes(-5),
+                StaleTimeoutSeconds = 60
+            }
+        };
+
+        var registry = new InMemorySatelliteRegistry(entries, NullLogger<InMemorySatelliteRegistry>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        var service = new SatelliteStaleDetectionService(
+            registry,
+            NullLogger<SatelliteStaleDetectionService>.Instance,
+            checkInterval: TimeSpan.FromMilliseconds(50));
+
+        // Start service and let it run one cycle
+        var task = service.StartAsync(cts.Token);
+        await Task.Delay(200);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        var sat = registry.GetById("stale-sat");
+        Assert.NotNull(sat);
+        Assert.Equal(SatelliteStatus.Offline, sat.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FreshSatellites_NotMarkedStale()
+    {
+        var entries = new[]
+        {
+            new SatelliteConnectionInfo
+            {
+                Id = "fresh-sat",
+                DisplayName = "Fresh",
+                Platform = "windows",
+                OwnerUserId = "jon",
+                Status = SatelliteStatus.Online,
+                LastSeen = DateTimeOffset.UtcNow,
+                StaleTimeoutSeconds = 120
+            }
+        };
+
+        var registry = new InMemorySatelliteRegistry(entries, NullLogger<InMemorySatelliteRegistry>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        var service = new SatelliteStaleDetectionService(
+            registry,
+            NullLogger<SatelliteStaleDetectionService>.Instance,
+            checkInterval: TimeSpan.FromMilliseconds(50));
+
+        var task = service.StartAsync(cts.Token);
+        await Task.Delay(200);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        var sat = registry.GetById("fresh-sat");
+        Assert.NotNull(sat);
+        Assert.Equal(SatelliteStatus.Online, sat.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancellationStopsGracefully()
+    {
+        var entries = Array.Empty<SatelliteConnectionInfo>();
+        var registry = new InMemorySatelliteRegistry(entries, NullLogger<InMemorySatelliteRegistry>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        var service = new SatelliteStaleDetectionService(
+            registry,
+            NullLogger<SatelliteStaleDetectionService>.Instance,
+            checkInterval: TimeSpan.FromSeconds(60));
+
+        var task = service.StartAsync(cts.Token);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        // Should complete without throwing
+    }
+}


### PR DESCRIPTION
Closes #1109

Part of #1107 (Satellite node system, 2/5 sub-issues)

## Changes

- **Auth pipeline integration**: Extended `ApiKeyGatewayAuthHandler.BuildIdentityMap` to include satellite API keys from `gateway.satellites` config. Satellite keys produce a `GatewayCallerIdentity` with `CallerId = satellite:{id}` and restricted permissions (`satellite:connect`, `satellite:heartbeat`). Disabled satellites and those without API keys are excluded.

- **ISatelliteRegistry interface** (`BotNexus.Gateway.Abstractions`): Defines connection tracking operations — `MarkOnline`, `MarkOffline`, `RecordHeartbeat`, `GetStaleSatellites`, queries by ID/user.

- **InMemorySatelliteRegistry**: Seeds from platform config on startup, tracks online/offline/stale state per satellite with connection IDs and last-seen timestamps.

- **SatelliteStaleDetectionService** (IHostedService): 30-second sweep interval, detects satellites exceeding their configured `StaleTimeoutSeconds` without a heartbeat and marks them offline.

- **SatellitesController** (REST API): `GET /api/satellites` (list all) and `GET /api/satellites/{id}` (single) with `SatelliteStatusDto` responses.

- **DI registration**: `ISatelliteRegistry` as singleton + `SatelliteStaleDetectionService` as hosted service in `GatewayServiceCollectionExtensions`.

## Tests

17 new tests across 3 test classes:
- `InMemorySatelliteRegistryTests` (12): seeding, online/offline, heartbeat, stale detection, user filtering
- `SatelliteStaleDetectionServiceTests` (3): stale marking, fresh preservation, graceful cancellation
- `SatelliteAuthTests` (4): key auth, disabled rejection, missing key, coexistence with admin keys

Gateway 2513 ✅, Architecture 178 ✅, Domain 326 ✅

## Merge Notes

Independent of PR #1118 (Docker workspace sync). Both touch Gateway but different subdirectories (Satellites/ vs Isolation/). Safe to merge in any order.
