### PR TITLE
feat(canvas): add SignalR notifications for canvas state changes

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayEventHandler.cs
@@ -48,6 +48,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnSubAgentKilled += HandleSubAgentKilled;
         _hub.OnSteeringFeedback += HandleSteeringFeedback;
         _hub.OnCanvasUpdated += HandleCanvasUpdated;
+        _hub.OnCanvasStateChanged += HandleCanvasStateChanged;
         _hub.OnConversationChanged += HandleConversationChanged;
                 _hub.OnReconnecting += HandleReconnecting;
         _hub.OnReconnected += HandleReconnected;
@@ -598,6 +599,14 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _store.NotifyChanged();
     }
 
+    public void HandleCanvasStateChanged(string conversationId, string key, object? value)
+    {
+        // Notify store that canvas state changed — the CanvasPanel will re-read state.
+        // The actual state is fetched from the REST API by the iframe SDK; we just trigger
+        // the re-render so the portal can forward the notification to the iframe.
+        _store.NotifyChanged();
+    }
+
     // ── Connection lifecycle ──────────────────────────────────────────────
 
     public void HandleReconnecting()
@@ -943,6 +952,7 @@ public sealed class GatewayEventHandler : IGatewayEventHandler, IDisposable
         _hub.OnSubAgentKilled -= HandleSubAgentKilled;
         _hub.OnSteeringFeedback -= HandleSteeringFeedback;
         _hub.OnCanvasUpdated -= HandleCanvasUpdated;
+        _hub.OnCanvasStateChanged -= HandleCanvasStateChanged;
         _hub.OnConversationChanged -= HandleConversationChanged;
                 _hub.OnReconnecting -= HandleReconnecting;
         _hub.OnReconnected -= HandleReconnected;

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/GatewayHubConnection.cs
@@ -67,6 +67,9 @@ public sealed class GatewayHubConnection : IAsyncDisposable
     /// <summary>Raised when the current canvas HTML is updated for an agent.</summary>
     public event Action<string, string, string>? OnCanvasUpdated;
 
+    /// <summary>Raised when a canvas state key is changed or cleared.</summary>
+    public event Action<string, string, object?>? OnCanvasStateChanged;
+
     /// <summary>Raised when a conversation is created, updated, or archived on the server.</summary>
     public event Action<ConversationChangedPayload>? OnConversationChanged;
 
@@ -128,6 +131,7 @@ public sealed class GatewayHubConnection : IAsyncDisposable
         _connection.On<SubAgentEventPayload>("SubAgentKilled", p => OnSubAgentKilled?.Invoke(p));
         _connection.On<SteeringFeedbackPayload>("SteeringFeedback", p => OnSteeringFeedback?.Invoke(p));
         _connection.On<string, string, string>("CanvasUpdated", (agentId, conversationId, html) => OnCanvasUpdated?.Invoke(agentId, conversationId, html));
+        _connection.On<string, string, object?>("CanvasStateChanged", (conversationId, key, value) => OnCanvasStateChanged?.Invoke(conversationId, key, value));
         _connection.On<AgentsChangedPayload>("AgentsChanged", p => OnAgentsChanged?.Invoke(p));
                 _connection.On<ConversationChangedPayload>("ConversationChanged", p => OnConversationChanged?.Invoke(p));
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/IGatewayHubClient.cs
@@ -27,6 +27,8 @@ public interface IGatewayHubClient
 
     Task SteeringFeedback(SteeringFeedbackPayload payload);
     Task CanvasUpdated(string agentId, string conversationId, string html);
+    /// <summary>Server notifies the client that a canvas state key was changed or cleared.</summary>
+    Task CanvasStateChanged(string conversationId, string key, object? value);
 
     /// <summary>Server notifies the client that a gateway restart interrupted its active agent turn.</summary>
     Task TurnInterrupted(AgentStreamEvent evt);
@@ -34,3 +36,4 @@ public interface IGatewayHubClient
     /// <summary>Server signals that the agent turn has fully completed (all tool calls done, no more events).</summary>
     Task TurnEnd(AgentStreamEvent evt);
 }
+

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRCanvasNotifier.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRCanvasNotifier.cs
@@ -6,4 +6,7 @@ public sealed class SignalRCanvasNotifier(IHubContext<GatewayHub, IGatewayHubCli
     private readonly IHubContext<GatewayHub, IGatewayHubClient> _hubContext = hubContext;
     public Task NotifyCanvasUpdatedAsync(string agentId, string conversationId, string html, CancellationToken cancellationToken = default)
         => _hubContext.Clients.All.CanvasUpdated(agentId, conversationId, html);
+
+    public Task NotifyCanvasStateChangedAsync(string conversationId, string key, object? value, CancellationToken cancellationToken = default)
+        => _hubContext.Clients.All.CanvasStateChanged(conversationId, key, value);
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -3,6 +3,7 @@ using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Services;
 using BotNexus.Gateway.Abstractions.Models;
@@ -29,6 +30,7 @@ public sealed class ConversationsController : ControllerBase
     private readonly ILogger<ConversationsController> _logger;
     private readonly IAskUserResponseRegistry? _askUserResponseRegistry;
     private readonly IConversationResetService? _resetService;
+    private readonly IReadOnlyList<IAgentCanvasNotifier> _canvasNotifiers;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConversationsController"/> class.
@@ -42,13 +44,15 @@ public sealed class ConversationsController : ControllerBase
     /// and Reset endpoints delegate the active-session seal + memory flush + ask-user cancel to it. When omitted,
     /// the controller falls back to a best-effort in-place seal — used only by tests that construct the controller
     /// directly without DI.</param>
+    /// <param name="canvasNotifiers">Optional notifiers that broadcast canvas state changes to connected clients.</param>
     public ConversationsController(
         IConversationStore conversations,
         ISessionStore sessions,
         IEnumerable<IConversationChangeNotifier>? conversationChangeNotifiers = null,
         ILogger<ConversationsController>? logger = null,
         IAskUserResponseRegistry? askUserResponseRegistry = null,
-        IConversationResetService? resetService = null)
+        IConversationResetService? resetService = null,
+        IEnumerable<IAgentCanvasNotifier>? canvasNotifiers = null)
     {
         _conversations = conversations;
         _sessions = sessions;
@@ -56,6 +60,7 @@ public sealed class ConversationsController : ControllerBase
         _logger = logger ?? NullLogger<ConversationsController>.Instance;
         _askUserResponseRegistry = askUserResponseRegistry;
         _resetService = resetService;
+        _canvasNotifiers = canvasNotifiers?.ToArray() ?? [];
     }
 
     /// <summary>
@@ -714,6 +719,10 @@ public sealed class ConversationsController : ControllerBase
             return NotFound();
 
         await _conversations.SetCanvasStateKeyAsync(ConversationId.From(conversationId), key, value, cancellationToken);
+
+        foreach (var notifier in _canvasNotifiers)
+            await notifier.NotifyCanvasStateChangedAsync(conversationId, key, value, cancellationToken);
+
         return Ok();
     }
 
@@ -731,6 +740,10 @@ public sealed class ConversationsController : ControllerBase
             return NotFound();
 
         await _conversations.DeleteCanvasStateKeyAsync(ConversationId.From(conversationId), key, cancellationToken);
+
+        foreach (var notifier in _canvasNotifiers)
+            await notifier.NotifyCanvasStateChangedAsync(conversationId, key, null, cancellationToken);
+
         return NoContent();
     }
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentCanvasNotifier.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Agents/IAgentCanvasNotifier.cs
@@ -8,4 +8,10 @@ public interface IAgentCanvasNotifier
     /// Publishes the latest canvas HTML for a specific agent and conversation.
     /// </summary>
     Task NotifyCanvasUpdatedAsync(string agentId, string conversationId, string html, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a canvas state key change for a specific conversation.
+    /// A null value indicates the key was deleted.
+    /// </summary>
+    Task NotifyCanvasStateChangedAsync(string conversationId, string key, object? value, CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway.Conversations/ConversationCanvasNotifier.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/ConversationCanvasNotifier.cs
@@ -18,4 +18,11 @@ public sealed class ConversationCanvasNotifier(IConversationStore store) : IAgen
         conversation.CanvasHtml = string.IsNullOrEmpty(html) ? null : html;
         await _store.SaveAsync(conversation, cancellationToken).ConfigureAwait(false);
     }
+
+    public Task NotifyCanvasStateChangedAsync(string conversationId, string key, object? value, CancellationToken cancellationToken = default)
+    {
+        // State persistence is handled directly by IConversationStore canvas state methods.
+        // This notifier only persists HTML updates; state change signaling is via SignalRCanvasNotifier.
+        return Task.CompletedTask;
+    }
 }

--- a/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
@@ -152,6 +152,15 @@ public sealed class CanvasTool(
         var success = await _conversationStore.SetCanvasStateKeyAsync(_conversationId.Value, key, value, cancellationToken)
             .ConfigureAwait(false);
 
+        if (success)
+        {
+            foreach (var notifier in _canvasNotifiers)
+            {
+                await notifier.NotifyCanvasStateChangedAsync(_conversationId.Value.Value, key, value, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
         var message = success
             ? $"State key '{key}' set successfully."
             : $"Failed to set state key '{key}': conversation not found.";
@@ -219,6 +228,12 @@ public sealed class CanvasTool(
         }
 
         await _conversationStore.ClearCanvasStateAsync(_conversationId.Value, cancellationToken).ConfigureAwait(false);
+
+        foreach (var notifier in _canvasNotifiers)
+        {
+            await notifier.NotifyCanvasStateChangedAsync(_conversationId.Value.Value, "*", null, cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
             "All canvas state cleared for this conversation.")]);

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolStateNotificationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/CanvasToolStateNotificationTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Tools;
+using NSubstitute;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Tools;
+
+public sealed class CanvasToolStateNotificationTests
+{
+    private static CanvasTool CreateTool(
+        IConversationStore? store = null,
+        IAgentCanvasNotifier? notifier = null)
+    {
+        var agentId = AgentId.From("test-agent");
+        var conversationId = ConversationId.From("c_test123");
+        var notifiers = notifier is not null
+            ? new List<IAgentCanvasNotifier> { notifier }
+            : new List<IAgentCanvasNotifier>();
+        return new CanvasTool(agentId, conversationId, store, notifiers);
+    }
+
+    [Fact]
+    public async Task SetState_Success_FiresCanvasStateChanged()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.SetCanvasStateKeyAsync(
+            ConversationId.From("c_test123"), "counter", Arg.Any<JsonElement>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+        var tool = CreateTool(store, notifier);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["action"] = JsonDocument.Parse("\"set_state\"").RootElement,
+            ["key"] = JsonDocument.Parse("\"counter\"").RootElement,
+            ["value"] = JsonDocument.Parse("42").RootElement
+        };
+
+        await tool.ExecuteAsync("tc1", args, CancellationToken.None);
+
+        await notifier.Received(1).NotifyCanvasStateChangedAsync(
+            "c_test123", "counter", Arg.Any<object?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetState_Failure_DoesNotFireEvent()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.SetCanvasStateKeyAsync(
+            ConversationId.From("c_test123"), "counter", Arg.Any<JsonElement>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(false));
+
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+        var tool = CreateTool(store, notifier);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["action"] = JsonDocument.Parse("\"set_state\"").RootElement,
+            ["key"] = JsonDocument.Parse("\"counter\"").RootElement,
+            ["value"] = JsonDocument.Parse("42").RootElement
+        };
+
+        await tool.ExecuteAsync("tc1", args, CancellationToken.None);
+
+        await notifier.DidNotReceive().NotifyCanvasStateChangedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ClearState_FiresCanvasStateChangedWithWildcard()
+    {
+        var store = Substitute.For<IConversationStore>();
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+        var tool = CreateTool(store, notifier);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["action"] = JsonDocument.Parse("\"clear_state\"").RootElement
+        };
+
+        await tool.ExecuteAsync("tc1", args, CancellationToken.None);
+
+        await notifier.Received(1).NotifyCanvasStateChangedAsync(
+            "c_test123", "*", null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetState_DoesNotFireEvent()
+    {
+        var store = Substitute.For<IConversationStore>();
+        store.GetCanvasStateAsync(ConversationId.From("c_test123"), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, JsonElement>());
+
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+        var tool = CreateTool(store, notifier);
+
+        var args = new Dictionary<string, object?>
+        {
+            ["action"] = JsonDocument.Parse("\"get_state\"").RootElement
+        };
+
+        await tool.ExecuteAsync("tc1", args, CancellationToken.None);
+
+        await notifier.DidNotReceive().NotifyCanvasStateChangedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetState_NoConversationId_DoesNotFireEvent()
+    {
+        var store = Substitute.For<IConversationStore>();
+        var notifier = Substitute.For<IAgentCanvasNotifier>();
+
+        // Create tool with no conversationId
+        var tool = new CanvasTool(
+            AgentId.From("test"),
+            conversationId: null,
+            store,
+            new List<IAgentCanvasNotifier> { notifier });
+
+        var args = new Dictionary<string, object?>
+        {
+            ["action"] = JsonDocument.Parse("\"set_state\"").RootElement,
+            ["key"] = JsonDocument.Parse("\"k\"").RootElement,
+            ["value"] = JsonDocument.Parse("1").RootElement
+        };
+
+        await tool.ExecuteAsync("tc1", args, CancellationToken.None);
+
+        await notifier.DidNotReceive().NotifyCanvasStateChangedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object?>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Closes #1068

Part of #972 (Canvas state chain, 3/4 sub-issues)

## Changes

- **`IGatewayHubClient.CanvasStateChanged`**: New SignalR event `(conversationId, key, value)` fired when canvas state keys are set or cleared.

- **`IAgentCanvasNotifier.NotifyCanvasStateChangedAsync`**: New method on the canvas notifier interface. Null value = key deleted. Key `"*"` = all keys cleared.

- **`SignalRCanvasNotifier`**: Implements the new method, broadcasting via `IHubContext<GatewayHub>`.

- **`ConversationCanvasNotifier`**: Returns `Task.CompletedTask` (persistence is handled by IConversationStore directly; this notifier only handles HTML).

- **`CanvasTool`**: `set_state` fires `CanvasStateChanged` on success; `clear_state` fires with key=`"*"`, value=null.

- **`ConversationsController`**: POST and DELETE canvas-state endpoints fire `CanvasStateChanged` after persisting.

- **`GatewayHubConnection`**: Subscribes to `CanvasStateChanged` and exposes `OnCanvasStateChanged` event.

- **`GatewayEventHandler`**: Forwards `CanvasStateChanged` to store notification (triggers re-render so CanvasPanel can forward to iframe).

## Tests

5 new tests in `CanvasToolStateNotificationTests`:
- set_state success fires event
- set_state failure does NOT fire event
- clear_state fires event with wildcard key
- get_state does NOT fire event
- set_state with no conversation does NOT fire event

Gateway 2500 ✅, BlazorClient 531 ✅, Architecture 178 ✅, Conversations 192 ✅, Scenarios 29 ✅

## Merge Notes

Independent of PR #1118 (Docker sync) and PR #1120 (Satellite auth). Touches SignalR extension + CanvasTool + ConversationsController — no file overlap with either PR. Safe to merge in any order.

## Remaining for #972

The final sub-issue is injecting the `BotNexus` JS helper into the iframe with `onChanged()` callback support. The bridge SDK script in CanvasPanel.razor already provides `window.canvasState` with get/set/delete/getAll/clear. The `onChanged` listener can now be implemented as a follow-up by forwarding the `CanvasStateChanged` postMessage from portal → iframe.
