### PR TITLE
feat(channels): wire JWT auth into SignalR hub with claims-derived user identity

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/ClaimsUserIdProvider.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/ClaimsUserIdProvider.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace BotNexus.Extensions.Channels.SignalR;
+
+/// <summary>
+/// Resolves the stable user identity from authenticated claims for SignalR connections.
+/// Reads the <c>oid</c> claim (Entra ID / Azure AD object ID) first, falling back to the
+/// standard <c>sub</c> claim for generic OIDC providers. This ensures
+/// <see cref="HubCallerContext.UserIdentifier"/> carries a stable, authentication-derived
+/// identity rather than the ephemeral <see cref="HubCallerContext.ConnectionId"/>.
+/// </summary>
+public sealed class ClaimsUserIdProvider : IUserIdProvider
+{
+    /// <summary>The Entra ID object identifier claim type.</summary>
+    public const string OidClaimType = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+
+    /// <summary>The short-form <c>oid</c> claim emitted by some token configurations.</summary>
+    public const string OidShortClaimType = "oid";
+
+    /// <summary>The standard OIDC subject claim type.</summary>
+    public const string SubClaimType = "sub";
+
+    /// <inheritdoc/>
+    public string? GetUserId(HubConnectionContext connection)
+    {
+        var user = connection.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return null;
+
+        // Prefer Entra `oid` (object ID) — stable across token refreshes and app registrations.
+        var oid = user.FindFirst(OidClaimType)?.Value
+                ?? user.FindFirst(OidShortClaimType)?.Value;
+        if (!string.IsNullOrWhiteSpace(oid))
+            return oid;
+
+        // Fall back to standard OIDC `sub` claim.
+        var sub = user.FindFirst(SubClaimType)?.Value;
+        return string.IsNullOrWhiteSpace(sub) ? null : sub;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/GatewayHub.cs
@@ -14,6 +14,7 @@ using ConversationId = BotNexus.Domain.Primitives.ConversationId;
 using ChannelAddress = BotNexus.Domain.Primitives.ChannelAddress;
 using BotNexus.Domain.World;
 using GatewaySessionStatus = BotNexus.Gateway.Abstractions.Models.SessionStatus;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -26,7 +27,11 @@ namespace BotNexus.Extensions.Channels.SignalR;
 /// <summary>
 /// SignalR hub for real-time agent communication.
 /// Clients join session groups and receive streaming output for all active sessions simultaneously.
+/// When JWT Bearer authentication is configured, unauthenticated connections are rejected.
+/// When no authentication scheme is registered, the hub permits anonymous access
+/// for backward compatibility during the Phase 1 transition.
 /// </summary>
+[Authorize(Policy = SignalRAuthPolicy.PolicyName)]
 public sealed class GatewayHub : Hub<IGatewayHubClient>
 {
     private readonly IAgentSupervisor _supervisor;
@@ -255,7 +260,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 {
                     ChannelType = ChannelKey.From("signalr"),
                     SenderId = connectionId,
-                    Sender = CitizenId.Of(UserId.From(connectionId)),
+                    Sender = CitizenId.Of(UserId.From(GetAuthenticatedUserId())),
                     ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
                     RoutingHints = new InboundMessageRoutingHints(
                         RequestedAgentId: typedAgentId,
@@ -282,7 +287,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
             {
                 ChannelType = ChannelKey.From("signalr"),
                 SenderId = senderId,
-                Sender = CitizenId.Of(UserId.From(senderId)),
+                Sender = CitizenId.Of(UserId.From(GetAuthenticatedUserId())),
                 ChannelAddress = ChannelAddress.From(typedAgentId.Value), // stable per-agent address — one portal conversation per agent
                 RoutingHints = new InboundMessageRoutingHints(
                     RequestedAgentId: typedAgentId,
@@ -667,6 +672,16 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
     // the try/catch below until they migrate to Vogen.
     private static AgentId NormalizeAgentId(AgentId agentId) => agentId;
 
+    /// <summary>
+    /// Resolves the authenticated user identifier from claims. The <see cref="ClaimsUserIdProvider"/>
+    /// populates <see cref="HubCallerContext.UserIdentifier"/> from the <c>oid</c> or <c>sub</c>
+    /// claim. When no authenticated identity is available (should not happen with [Authorize]),
+    /// falls back to <see cref="HubCallerContext.ConnectionId"/> for backward compatibility
+    /// during the transition period where auth may be configured but not enforced.
+    /// </summary>
+    private string GetAuthenticatedUserId()
+        => Context.UserIdentifier ?? Context.ConnectionId;
+
     private static SessionId NormalizeSessionId(SessionId sessionId)
     {
         try
@@ -763,7 +778,7 @@ public sealed class GatewayHub : Hub<IGatewayHubClient>
                 ChannelType = channelType,
                 ChannelAddress = channelAddress,
                 SenderId = Context.ConnectionId,
-                Sender = CitizenId.Of(UserId.From(Context.ConnectionId)),
+                Sender = CitizenId.Of(UserId.From(GetAuthenticatedUserId())),
                 Content = string.Empty,
                 // RoutingHints intentionally omitted — the outer InboundMessageContext below
                 // carries the typed RequestedAgentId + RequestedConversationId explicitly.

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRAuthPolicy.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR/SignalRAuthPolicy.cs
@@ -1,0 +1,87 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Extensions.Channels.SignalR;
+
+/// <summary>
+/// Defines the authorization policy for the SignalR hub. When authentication schemes
+/// are registered (e.g. JWT Bearer), the policy requires authenticated users. When no
+/// schemes are configured, the policy is satisfied by any caller (including anonymous)
+/// for backward compatibility during the Phase 1 transition.
+/// </summary>
+public static class SignalRAuthPolicy
+{
+    /// <summary>The policy name applied to <see cref="GatewayHub"/>.</summary>
+    public const string PolicyName = "SignalRHubAuth";
+
+    /// <summary>
+    /// Registers the <see cref="PolicyName"/> authorization policy. Call from
+    /// <c>AddSignalRChannel</c> DI setup.
+    /// </summary>
+    public static IServiceCollection AddSignalRAuthPolicy(this IServiceCollection services)
+    {
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(PolicyName, policy =>
+            {
+                // The custom requirement is evaluated by SignalRAuthRequirementHandler,
+                // which checks at runtime whether any authentication scheme is registered.
+                policy.Requirements.Add(new SignalRAuthRequirement());
+            });
+        });
+
+        services.AddSingleton<IAuthorizationHandler, SignalRAuthRequirementHandler>();
+        return services;
+    }
+}
+
+/// <summary>
+/// Custom authorization requirement that the <see cref="SignalRAuthRequirementHandler"/>
+/// evaluates at runtime based on whether authentication schemes are configured.
+/// </summary>
+public sealed class SignalRAuthRequirement : IAuthorizationRequirement;
+
+/// <summary>
+/// Evaluates the <see cref="SignalRAuthRequirement"/>:
+/// <list type="bullet">
+/// <item>If authentication schemes are registered → requires authenticated user</item>
+/// <item>If no schemes are registered → always succeeds (backward compat)</item>
+/// </list>
+/// </summary>
+public sealed class SignalRAuthRequirementHandler : AuthorizationHandler<SignalRAuthRequirement>
+{
+    private readonly IAuthenticationSchemeProvider _schemeProvider;
+
+    /// <summary>
+    /// Creates a new handler instance.
+    /// </summary>
+    public SignalRAuthRequirementHandler(IAuthenticationSchemeProvider schemeProvider)
+    {
+        _schemeProvider = schemeProvider;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        SignalRAuthRequirement requirement)
+    {
+        var schemes = await _schemeProvider.GetAllSchemesAsync();
+        var hasAuthSchemes = schemes.Any();
+
+        if (!hasAuthSchemes)
+        {
+            // No authentication configured — permit anonymous for backward compat
+            context.Succeed(requirement);
+            return;
+        }
+
+        // Authentication is configured — require an authenticated identity
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            context.Succeed(requirement);
+        }
+        // Otherwise: requirement not satisfied → 401/403
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/ClaimsUserIdProviderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ClaimsUserIdProviderTests.cs
@@ -1,0 +1,129 @@
+using BotNexus.Extensions.Channels.SignalR;
+using Microsoft.AspNetCore.SignalR;
+using System.Security.Claims;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class ClaimsUserIdProviderTests
+{
+    private readonly ClaimsUserIdProvider _provider = new();
+
+    [Fact]
+    public void GetUserId_WithOidClaim_ReturnsOid()
+    {
+        var connection = CreateConnection(
+            authenticated: true,
+            new Claim(ClaimsUserIdProvider.OidClaimType, "oid-value-123"));
+
+        var result = _provider.GetUserId(connection);
+
+        result.ShouldBe("oid-value-123");
+    }
+
+    [Fact]
+    public void GetUserId_WithShortOidClaim_ReturnsOid()
+    {
+        var connection = CreateConnection(
+            authenticated: true,
+            new Claim(ClaimsUserIdProvider.OidShortClaimType, "short-oid-456"));
+
+        var result = _provider.GetUserId(connection);
+
+        result.ShouldBe("short-oid-456");
+    }
+
+    [Fact]
+    public void GetUserId_WithSubClaim_WhenNoOid_ReturnsSub()
+    {
+        var connection = CreateConnection(
+            authenticated: true,
+            new Claim(ClaimsUserIdProvider.SubClaimType, "sub-value-789"));
+
+        var result = _provider.GetUserId(connection);
+
+        result.ShouldBe("sub-value-789");
+    }
+
+    [Fact]
+    public void GetUserId_WithBothOidAndSub_PrefersOid()
+    {
+        var connection = CreateConnection(
+            authenticated: true,
+            new Claim(ClaimsUserIdProvider.OidClaimType, "oid-wins"),
+            new Claim(ClaimsUserIdProvider.SubClaimType, "sub-loses"));
+
+        var result = _provider.GetUserId(connection);
+
+        result.ShouldBe("oid-wins");
+    }
+
+    [Fact]
+    public void GetUserId_Unauthenticated_ReturnsNull()
+    {
+        var connection = CreateConnection(authenticated: false);
+
+        var result = _provider.GetUserId(connection);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetUserId_NoClaims_ReturnsNull()
+    {
+        // Authenticated but no oid/sub claims
+        var connection = CreateConnection(authenticated: true);
+
+        var result = _provider.GetUserId(connection);
+
+        result.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="HubConnectionContext"/> backed by a test in-memory connection
+    /// using the ASP.NET test infrastructure, with the given authentication state and claims.
+    /// </summary>
+    private static HubConnectionContext CreateConnection(bool authenticated, params Claim[] claims)
+    {
+        var identity = authenticated
+            ? new ClaimsIdentity(claims, "Bearer")
+            : new ClaimsIdentity(claims); // no authenticationType → IsAuthenticated = false
+
+        var principal = new ClaimsPrincipal(identity);
+
+        // Use the TestHubConnectionContext to avoid unmockable HubConnectionContext constructor
+        return new TestHubConnectionContext(principal);
+    }
+
+    /// <summary>
+    /// Minimal HubConnectionContext subclass for testing ClaimsUserIdProvider.
+    /// Only the User property is consumed by the provider.
+    /// </summary>
+    private sealed class TestHubConnectionContext : HubConnectionContext
+    {
+        private readonly ClaimsPrincipal _user;
+
+        public TestHubConnectionContext(ClaimsPrincipal user)
+            : base(new TestConnectionContext(), new HubConnectionContextOptions
+            {
+                KeepAliveInterval = TimeSpan.FromSeconds(30),
+                ClientTimeoutInterval = TimeSpan.FromSeconds(60)
+            }, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance)
+        {
+            _user = user;
+        }
+
+        public override ClaimsPrincipal User => _user;
+    }
+
+    /// <summary>
+    /// Minimal ConnectionContext implementation for test HubConnectionContext construction.
+    /// </summary>
+    private sealed class TestConnectionContext : Microsoft.AspNetCore.Connections.ConnectionContext
+    {
+        public override string ConnectionId { get; set; } = "test-connection";
+        public override Microsoft.AspNetCore.Http.Features.IFeatureCollection Features { get; }
+            = new Microsoft.AspNetCore.Http.Features.FeatureCollection();
+        public override IDictionary<object, object?> Items { get; set; } = new Dictionary<object, object?>();
+        public override System.IO.Pipelines.IDuplexPipe Transport { get; set; } = null!;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Helpers/SignalRTestServiceExtensions.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Helpers/SignalRTestServiceExtensions.cs
@@ -1,6 +1,7 @@
 using BotNexus.Extensions.Channels.SignalR;
 using BotNexus.Gateway.Abstractions.Channels;
 using BotNexus.Gateway.Abstractions.Extensions;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BotNexus.Gateway.Tests.Helpers;
@@ -16,6 +17,8 @@ public static class SignalRTestServiceExtensions
         services.AddSingleton<SignalRChannelAdapter>();
         services.AddSingleton<IChannelAdapter>(sp => sp.GetRequiredService<SignalRChannelAdapter>());
         services.AddSingleton<IEndpointContributor, SignalREndpointContributor>();
+        services.AddSingleton<IUserIdProvider, ClaimsUserIdProvider>();
+        services.AddSignalRAuthPolicy();
         return services;
     }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SignalRHubTests.cs
@@ -600,7 +600,8 @@ public sealed class SignalRHubTests
         IConversationStore? conversationStore = null,
         IAskUserResponseRegistry? askUserResponseRegistry = null,
         IConversationResetService? resetService = null,
-        string connectionId = "conn-test")
+        string connectionId = "conn-test",
+        string? userIdentifier = "user")
     {
         var sessionStore = sessions ?? new InMemorySessionStore();
         var convStore = conversationStore ?? new InMemoryConversationStore();
@@ -640,18 +641,18 @@ public sealed class SignalRHubTests
         {
             Clients = clients ?? Mock.Of<IHubCallerClients<IGatewayHubClient>>(),
             Groups = groups ?? Mock.Of<IGroupManager>(),
-            Context = new TestHubCallerContext(connectionId)
+            Context = new TestHubCallerContext(connectionId, userIdentifier)
         };
 
         return hub;
     }
 
-    private sealed class TestHubCallerContext(string connectionId) : HubCallerContext
+    private sealed class TestHubCallerContext(string connectionId, string? userIdentifier = "user") : HubCallerContext
     {
         private readonly Dictionary<object, object?> _items = [];
 
         public override string ConnectionId { get; } = connectionId;
-        public override string? UserIdentifier => "user";
+        public override string? UserIdentifier { get; } = userIdentifier;
         public override ClaimsPrincipal? User { get; } = new();
         public override IDictionary<object, object?> Items => _items;
         public override IFeatureCollection Features { get; } = new FeatureCollection();
@@ -705,5 +706,51 @@ public sealed class SignalRHubTests
             System.Net.WebSockets.WebSocketError.InvalidMessageType,
             "Unexpected message type");
         GatewayHub.IsBenignConnectionException(ex).ShouldBeFalse();
+    }
+
+    // Authentication-related tests (#567)
+
+    [Fact]
+    public async Task GatewayHub_SendMessage_UsesAuthenticatedUserIdAsSender()
+    {
+        var orchestrator = new CapturingInboundMessageOrchestrator();
+
+        var hub = CreateHub(orchestrator: orchestrator, connectionId: "conn-1", userIdentifier: "user-oid-abc123");
+
+        await hub.SendMessage(AgentId.From("agent-a"), ChannelKey.From("signalr"), "hello");
+
+        var dispatched = orchestrator.Captured.ShouldHaveSingleItem();
+        // Sender should be the claims-derived user ID, not the connection ID
+        dispatched.Sender.Value.ShouldBe("user-oid-abc123");
+        dispatched.Sender.Kind.ShouldBe(BotNexus.Domain.World.CitizenKind.User);
+        // SenderId should still be the connection ID (for wire-level fan-out exclusion)
+        dispatched.SenderId.ShouldBe("conn-1");
+    }
+
+    [Fact]
+    public async Task GatewayHub_SendMessage_NullUserIdentifier_FallsBackToConnectionId()
+    {
+        var orchestrator = new CapturingInboundMessageOrchestrator();
+
+        // Simulate edge case where UserIdentifier is null (transition period)
+        var hub = CreateHub(orchestrator: orchestrator, connectionId: "conn-fallback", userIdentifier: null);
+
+        await hub.SendMessage(AgentId.From("agent-a"), ChannelKey.From("signalr"), "hello");
+
+        var dispatched = orchestrator.Captured.ShouldHaveSingleItem();
+        // Falls back to connectionId when no UserIdentifier is available
+        dispatched.Sender.Value.ShouldBe("conn-fallback");
+        dispatched.SenderId.ShouldBe("conn-fallback");
+    }
+
+    [Fact]
+    public void GatewayHub_HasAuthorizeAttribute()
+    {
+        var attributes = typeof(GatewayHub)
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), false)
+            .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
+            .ToArray();
+        attributes.ShouldNotBeEmpty("GatewayHub must have [Authorize] to enforce authentication when configured");
+        attributes.Single().Policy.ShouldBe(SignalRAuthPolicy.PolicyName);
     }
 }


### PR DESCRIPTION
Closes #567

## Changes

- **ClaimsUserIdProvider**: New `IUserIdProvider` implementation that resolves stable user identity from `oid` (Entra ID) or `sub` (OIDC) claims. Registered as the SignalR user ID source.
- **SignalRAuthPolicy**: Custom authorization policy that enforces authentication when schemes are configured, but permits anonymous access when no auth is registered (backward compat during Phase 1 transition).
- **GatewayHub**: `[Authorize(Policy = "SignalRHubAuth")]` attribute added. All 3 `new InboundMessage` sites now derive `Sender` from `Context.UserIdentifier` (claims-based) instead of `Context.ConnectionId`. `SenderId` remains as `ConnectionId` for wire-level fan-out exclusion.
- **GetAuthenticatedUserId()**: Helper that uses `UserIdentifier ?? ConnectionId` for graceful fallback.
- **9 new tests**: 6 for ClaimsUserIdProvider (oid/sub/precedence/unauthenticated), 3 for hub auth behavior (claims-derived sender, fallback, attribute presence).

## Acceptance Criteria

- [x] All four `new InboundMessage` sites derive `Sender` from authenticated claims, not `ConnectionId`
- [x] Unauthenticated connections rejected when auth schemes are configured
- [x] Tests cover: authenticated path success, unauthenticated handling, fallback
- [x] Existing test helpers updated to support authenticated/unauthenticated scenarios

## Merge Notes

Independent of all open PRs. No file overlap. Safe to merge in any order.