### PR TITLE
fix(gateway): add threadpool watchdog, lock timeout logging, and health endpoint hardening

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -90,6 +90,7 @@ builder.Services.AddOpenTelemetry()
     });
 
 builder.Services.AddBotNexusGateway(builder.Configuration);
+builder.Services.AddDiagnosticsHardening();
 builder.Services.AddBotNexusCron();
 builder.Services.AddPlatformConfiguration(resolvedConfigPath, builder.Configuration);
 builder.Services.Configure<CronOptions>(options =>
@@ -373,22 +374,43 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapControllers();
-app.MapGet("/health", (IServiceProvider sp) =>
+app.MapGet("/health", async (IServiceProvider sp) =>
 {
-    var tracker = sp.GetService<BotNexus.Gateway.Diagnostics.IActivityTracker>();
-    var lastActivity = tracker?.LastActivityUtc;
-    var elapsed = tracker?.TimeSinceLastActivity;
-    var status = elapsed switch
+    // Health endpoint hardening: if the handler cannot execute within 5 seconds,
+    // it means the threadpool is exhausted or a deadlock is preventing work scheduling.
+    // Return 503 in that case rather than holding the connection open indefinitely.
+    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+    var response = await BotNexus.Gateway.Diagnostics.HealthEndpointHelper.ExecuteWithTimeoutAsync(
+        () =>
+        {
+            var tracker = sp.GetService<BotNexus.Gateway.Diagnostics.IActivityTracker>();
+            var lastActivity = tracker?.LastActivityUtc;
+            var elapsed = tracker?.TimeSinceLastActivity;
+            var status = elapsed switch
+            {
+                { TotalMinutes: >= 10 } => "degraded",
+                { TotalMinutes: >= 5 } => "warning",
+                _ => "ok"
+            };
+            return Task.FromResult(new BotNexus.Gateway.Diagnostics.HealthResponse(
+                status,
+                lastActivity?.ToString("o"),
+                elapsed?.TotalSeconds));
+        },
+        cts.Token);
+
+    if (response.Status == "timeout")
     {
-        { TotalMinutes: >= 10 } => "degraded",
-        { TotalMinutes: >= 5 } => "warning",
-        _ => "ok"
-    };
+        return Results.Json(
+            new { status = "timeout", message = "Health check timed out — possible threadpool exhaustion or deadlock" },
+            statusCode: 503);
+    }
+
     return Results.Ok(new
     {
-        status,
-        lastActivity = lastActivity?.ToString("o"),
-        inactivitySeconds = elapsed?.TotalSeconds
+        status = response.Status,
+        lastActivity = response.LastActivity,
+        inactivitySeconds = response.InactivitySeconds
     });
 });
 app.MapGet("/api/version", () =>

--- a/src/gateway/BotNexus.Gateway/Diagnostics/HealthEndpointHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/HealthEndpointHelper.cs
@@ -1,0 +1,44 @@
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Response model for the /health endpoint with timeout awareness.
+/// </summary>
+public sealed record HealthResponse(string Status, string? LastActivity, double? InactivitySeconds);
+
+/// <summary>
+/// Helper for executing the health endpoint logic with a timeout.
+/// If the health handler cannot complete within the timeout, the endpoint returns a 
+/// "timeout" status — indicating the process is alive but unable to schedule work.
+/// </summary>
+public static class HealthEndpointHelper
+{
+    /// <summary>
+    /// Executes the health check factory with a timeout. If the cancellation token fires
+    /// before the factory completes, returns a timeout response.
+    /// </summary>
+    /// <param name="factory">Factory that produces the health response.</param>
+    /// <param name="cancellationToken">Cancellation token with timeout applied.</param>
+    /// <returns>The health response, or a timeout response if execution took too long.</returns>
+    public static async Task<HealthResponse> ExecuteWithTimeoutAsync(
+        Func<Task<HealthResponse>> factory,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var task = factory();
+            var completed = await Task.WhenAny(task, Task.Delay(Timeout.Infinite, cancellationToken));
+
+            if (completed == task)
+            {
+                return await task;
+            }
+
+            // Timeout: cancellation fired before the factory completed
+            return new HealthResponse("timeout", null, null);
+        }
+        catch (OperationCanceledException)
+        {
+            return new HealthResponse("timeout", null, null);
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/LockTimeoutLogger.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/LockTimeoutLogger.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Wraps semaphore acquisition with timeout-based warning logging.
+/// If acquiring a lock takes longer than the configured threshold, a warning is emitted
+/// with the lock name and elapsed time — helping identify lock contention and deadlock sources.
+/// </summary>
+public sealed class LockTimeoutLogger(
+    ILogger<LockTimeoutLogger> logger,
+    TimeSpan warningThreshold)
+{
+    private readonly ILogger<LockTimeoutLogger> _logger = logger;
+    private readonly TimeSpan _warningThreshold = warningThreshold;
+
+    /// <summary>
+    /// Creates a LockTimeoutLogger with the default 5-second warning threshold.
+    /// </summary>
+    public LockTimeoutLogger(ILogger<LockTimeoutLogger> logger)
+        : this(logger, TimeSpan.FromSeconds(5))
+    {
+    }
+
+    /// <summary>
+    /// Acquires the semaphore and returns a disposable handle. If acquisition takes longer
+    /// than the warning threshold, a WARNING log is emitted with the lock name and elapsed time.
+    /// </summary>
+    /// <param name="semaphore">The semaphore to acquire.</param>
+    /// <param name="lockName">A descriptive name for the lock (for logging).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A disposable that releases the semaphore on dispose.</returns>
+    public async Task<IDisposable> AcquireAsync(SemaphoreSlim semaphore, string lockName, CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+
+        // Try to acquire immediately
+        if (semaphore.Wait(0))
+        {
+            return new SemaphoreReleaser(semaphore);
+        }
+
+        // Start monitoring for slow acquisition
+        using var warningCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var warningTask = EmitWarningAfterDelay(lockName, sw, warningCts.Token);
+
+        await semaphore.WaitAsync(cancellationToken);
+
+        // Cancel the warning task if we acquired in time
+        await warningCts.CancelAsync();
+
+        sw.Stop();
+        if (sw.Elapsed >= _warningThreshold)
+        {
+            _logger.LogWarning(
+                "Lock acquisition for '{LockName}' took {Elapsed}ms (threshold: {Threshold}ms). " +
+                "Possible contention or deadlock.",
+                lockName,
+                sw.ElapsedMilliseconds,
+                _warningThreshold.TotalMilliseconds);
+        }
+
+        return new SemaphoreReleaser(semaphore);
+    }
+
+    private async Task EmitWarningAfterDelay(string lockName, Stopwatch sw, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(_warningThreshold, ct);
+
+            // If we get here, the threshold was exceeded while still waiting
+            _logger.LogWarning(
+                "Lock acquisition for '{LockName}' is taking longer than {Threshold}ms (still waiting after {Elapsed}ms).",
+                lockName,
+                _warningThreshold.TotalMilliseconds,
+                sw.ElapsedMilliseconds);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: either acquired or outer cancellation
+        }
+    }
+
+    private sealed class SemaphoreReleaser(SemaphoreSlim semaphore) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            {
+                semaphore.Release();
+            }
+        }
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/ThreadPoolWatchdogService.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/ThreadPoolWatchdogService.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Configuration for the threadpool watchdog service.
+/// </summary>
+public sealed class ThreadPoolWatchdogOptions
+{
+    /// <summary>
+    /// How often to check threadpool health. Default: 30 seconds.
+    /// </summary>
+    public TimeSpan CheckInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Pending work item count above which a warning is emitted. Default: 100.
+    /// A sustained queue depth above this threshold indicates threadpool starvation
+    /// or deadlock conditions.
+    /// </summary>
+    public int QueueDepthThreshold { get; set; } = 100;
+}
+
+/// <summary>
+/// Abstraction for querying threadpool metrics to support testability.
+/// </summary>
+public interface IThreadPoolMetrics
+{
+    /// <summary>Gets the number of pending work items in the threadpool.</summary>
+    long PendingWorkItemCount { get; }
+
+    /// <summary>Gets available worker and IO threads.</summary>
+    (int WorkerAvailable, int WorkerMax, int WorkerMin, int IoAvailable, int IoMax, int IoMin) GetThreadCounts();
+}
+
+/// <summary>
+/// Default implementation that reads from the real .NET ThreadPool.
+/// </summary>
+public sealed class SystemThreadPoolMetrics : IThreadPoolMetrics
+{
+    public long PendingWorkItemCount => ThreadPool.PendingWorkItemCount;
+
+    public (int WorkerAvailable, int WorkerMax, int WorkerMin, int IoAvailable, int IoMax, int IoMin) GetThreadCounts()
+    {
+        ThreadPool.GetAvailableThreads(out var workerAvailable, out var ioAvailable);
+        ThreadPool.GetMaxThreads(out var workerMax, out var ioMax);
+        ThreadPool.GetMinThreads(out var workerMin, out var ioMin);
+        return (workerAvailable, workerMax, workerMin, ioAvailable, ioMax, ioMin);
+    }
+}
+
+/// <summary>
+/// Background service that monitors the .NET ThreadPool queue depth and logs diagnostic
+/// snapshots when pending work exceeds the configured threshold. Helps detect threadpool
+/// exhaustion scenarios where the gateway is alive but unable to schedule new work.
+/// </summary>
+public sealed class ThreadPoolWatchdogService : BackgroundService
+{
+    private readonly ThreadPoolWatchdogOptions _options;
+    private readonly ILogger<ThreadPoolWatchdogService> _logger;
+    private readonly IThreadPoolMetrics _metrics;
+    private bool _warningEmitted;
+
+    public ThreadPoolWatchdogService(
+        IOptions<ThreadPoolWatchdogOptions> options,
+        ILogger<ThreadPoolWatchdogService> logger,
+        IThreadPoolMetrics? metrics = null)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _metrics = metrics ?? new SystemThreadPoolMetrics();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Give the gateway time to start up before monitoring
+        await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                CheckThreadPool();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "ThreadPool watchdog check failed unexpectedly.");
+            }
+
+            await Task.Delay(_options.CheckInterval, stoppingToken);
+        }
+    }
+
+    /// <summary>
+    /// Checks threadpool queue depth and emits a diagnostic snapshot if above threshold.
+    /// Exposed as internal for testability.
+    /// </summary>
+    internal void CheckThreadPool()
+    {
+        var pendingWorkItems = _metrics.PendingWorkItemCount;
+
+        if (pendingWorkItems > _options.QueueDepthThreshold)
+        {
+            if (!_warningEmitted)
+            {
+                var counts = _metrics.GetThreadCounts();
+
+                _logger.LogWarning(
+                    "ThreadPool queue depth {PendingCount} exceeds threshold {Threshold}. " +
+                    "Workers: available={WorkerAvailable}/{WorkerMax} (min={WorkerMin}), " +
+                    "IO: available={IoAvailable}/{IoMax} (min={IoMin}). " +
+                    "Possible threadpool starvation or deadlock.",
+                    pendingWorkItems,
+                    _options.QueueDepthThreshold,
+                    counts.WorkerAvailable, counts.WorkerMax, counts.WorkerMin,
+                    counts.IoAvailable, counts.IoMax, counts.IoMin);
+
+                _warningEmitted = true;
+            }
+        }
+        else
+        {
+            // Queue depth recovered
+            _warningEmitted = false;
+        }
+    }
+
+    /// <summary>
+    /// Resets internal state for testing purposes only.
+    /// </summary>
+    internal void ResetForTesting() => _warningEmitted = false;
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/DiagnosticsServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/DiagnosticsServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BotNexus.Gateway.Extensions;
+
+/// <summary>
+/// Registers additional diagnostics services for liveness hardening:
+/// threadpool queue monitoring and lock timeout logging.
+/// </summary>
+public static class DiagnosticsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the threadpool watchdog and lock timeout logger to the service collection.
+    /// </summary>
+    public static IServiceCollection AddDiagnosticsHardening(this IServiceCollection services)
+    {
+        services.AddSingleton<IThreadPoolMetrics, SystemThreadPoolMetrics>();
+        services.Configure<ThreadPoolWatchdogOptions>(_ => { });
+        services.AddHostedService<ThreadPoolWatchdogService>();
+        services.AddSingleton<LockTimeoutLogger>();
+        return services;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/LivenessHardeningTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/LivenessHardeningTests.cs
@@ -1,0 +1,252 @@
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Diagnostics;
+
+public sealed class ThreadPoolWatchdogServiceTests
+{
+    private static IOptions<ThreadPoolWatchdogOptions> DefaultOptions(Action<ThreadPoolWatchdogOptions>? configure = null)
+    {
+        var options = new ThreadPoolWatchdogOptions();
+        configure?.Invoke(options);
+        return Options.Create(options);
+    }
+
+    [Fact]
+    public void CheckThreadPool_BelowThreshold_NoWarning()
+    {
+        // Arrange
+        var logger = new FakeLogger<ThreadPoolWatchdogService>();
+        var metrics = new FakeThreadPoolMetrics { PendingWorkItemCount = 5 };
+        var service = new ThreadPoolWatchdogService(DefaultOptions(), logger, metrics);
+
+        // Act
+        service.CheckThreadPool();
+
+        // Assert
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+    }
+
+    [Fact]
+    public void CheckThreadPool_AboveThreshold_EmitsWarning()
+    {
+        // Arrange
+        var logger = new FakeLogger<ThreadPoolWatchdogService>();
+        var metrics = new FakeThreadPoolMetrics { PendingWorkItemCount = 200 };
+        var service = new ThreadPoolWatchdogService(DefaultOptions(), logger, metrics);
+
+        // Act
+        service.CheckThreadPool();
+
+        // Assert
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void CheckThreadPool_RepeatedAboveThreshold_OnlyEmitsOnce()
+    {
+        // Arrange
+        var logger = new FakeLogger<ThreadPoolWatchdogService>();
+        var metrics = new FakeThreadPoolMetrics { PendingWorkItemCount = 200 };
+        var service = new ThreadPoolWatchdogService(DefaultOptions(), logger, metrics);
+
+        // Act
+        service.CheckThreadPool();
+        service.CheckThreadPool();
+        service.CheckThreadPool();
+
+        // Assert: only one warning, not three
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void CheckThreadPool_RecoveryThenExceedAgain_EmitsSecondWarning()
+    {
+        // Arrange
+        var logger = new FakeLogger<ThreadPoolWatchdogService>();
+        var metrics = new FakeThreadPoolMetrics { PendingWorkItemCount = 200 };
+        var service = new ThreadPoolWatchdogService(DefaultOptions(), logger, metrics);
+
+        // Act: exceed threshold
+        service.CheckThreadPool();
+        Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+
+        // Recover below threshold
+        metrics.PendingWorkItemCount = 5;
+        service.CheckThreadPool();
+
+        // Exceed again
+        metrics.PendingWorkItemCount = 200;
+        service.CheckThreadPool();
+
+        // Assert: two warnings total (one per exceedance cycle)
+        Assert.Equal(2, logger.Entries.Count(e => e.Level == LogLevel.Warning));
+    }
+
+    [Fact]
+    public void CheckThreadPool_WarningIncludesThreadCounts()
+    {
+        // Arrange
+        var logger = new FakeLogger<ThreadPoolWatchdogService>();
+        var metrics = new FakeThreadPoolMetrics { PendingWorkItemCount = 200 };
+        var service = new ThreadPoolWatchdogService(DefaultOptions(), logger, metrics);
+
+        // Act
+        service.CheckThreadPool();
+
+        // Assert: message contains threadpool diagnostic info
+        var warning = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains("200", warning.Message);
+        Assert.Contains("100", warning.Message); // threshold
+    }
+}
+
+public sealed class HealthEndpointTimeoutTests
+{
+    [Fact]
+    public async Task HealthCheck_WhenNotTimedOut_ReturnsStatus()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = await HealthEndpointHelper.ExecuteWithTimeoutAsync(
+            () => Task.FromResult(new HealthResponse("ok", null, null)),
+            cts.Token);
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public async Task HealthCheck_WhenTimedOut_ReturnsTimeoutStatus()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = await HealthEndpointHelper.ExecuteWithTimeoutAsync(
+            () => Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(_ => new HealthResponse("ok", null, null)),
+            cts.Token);
+
+        Assert.Equal("timeout", result.Status);
+    }
+
+    [Fact]
+    public async Task HealthCheck_WhenTimedOut_ReturnsNullFields()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = await HealthEndpointHelper.ExecuteWithTimeoutAsync(
+            () => Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(_ => new HealthResponse("ok", "2026-01-01", 42.0)),
+            cts.Token);
+
+        Assert.Null(result.LastActivity);
+        Assert.Null(result.InactivitySeconds);
+    }
+
+    [Fact]
+    public async Task HealthCheck_PreservesResponseFields()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = await HealthEndpointHelper.ExecuteWithTimeoutAsync(
+            () => Task.FromResult(new HealthResponse("degraded", "2026-06-09T12:00:00Z", 600.5)),
+            cts.Token);
+
+        Assert.Equal("degraded", result.Status);
+        Assert.Equal("2026-06-09T12:00:00Z", result.LastActivity);
+        Assert.Equal(600.5, result.InactivitySeconds);
+    }
+}
+
+public sealed class LockTimeoutLoggerTests
+{
+    [Fact]
+    public async Task AcquireAsync_WhenFast_NoWarning()
+    {
+        // Arrange
+        var logger = new FakeLogger<LockTimeoutLogger>();
+        var semaphore = new SemaphoreSlim(1, 1);
+        var lockLogger = new LockTimeoutLogger(logger, TimeSpan.FromSeconds(5));
+
+        // Act
+        using (await lockLogger.AcquireAsync(semaphore, "TestLock", CancellationToken.None))
+        {
+            // hold briefly
+        }
+
+        // Assert: no warning logged
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenSlow_EmitsWarning()
+    {
+        // Arrange
+        var logger = new FakeLogger<LockTimeoutLogger>();
+        var semaphore = new SemaphoreSlim(1, 1);
+        var lockLogger = new LockTimeoutLogger(logger, TimeSpan.FromMilliseconds(50));
+
+        // Hold the semaphore to force contention
+        await semaphore.WaitAsync();
+
+        // Act: try to acquire with very short threshold — will log warning
+        var acquireTask = lockLogger.AcquireAsync(semaphore, "TestLock", CancellationToken.None);
+
+        // Wait for the warning threshold to fire
+        await Task.Delay(200);
+
+        // Release so the acquire completes
+        semaphore.Release();
+        using (await acquireTask)
+        {
+            // acquired after delay
+        }
+
+        // Assert: warning was logged about slow acquisition
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Warning &&
+            e.Message.Contains("TestLock"));
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ReleasesOnDispose()
+    {
+        // Arrange
+        var logger = new FakeLogger<LockTimeoutLogger>();
+        var semaphore = new SemaphoreSlim(1, 1);
+        var lockLogger = new LockTimeoutLogger(logger, TimeSpan.FromSeconds(5));
+
+        // Act: acquire and dispose
+        using (await lockLogger.AcquireAsync(semaphore, "TestLock", CancellationToken.None))
+        {
+            Assert.Equal(0, semaphore.CurrentCount);
+        }
+
+        // Assert: semaphore released after dispose
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+}
+
+/// <summary>Fake threadpool metrics for deterministic testing.</summary>
+internal sealed class FakeThreadPoolMetrics : IThreadPoolMetrics
+{
+    public long PendingWorkItemCount { get; set; }
+
+    public (int WorkerAvailable, int WorkerMax, int WorkerMin, int IoAvailable, int IoMax, int IoMin) GetThreadCounts()
+        => (8, 16, 4, 8, 16, 4);
+}
+
+/// <summary>Simple in-memory logger for testing.</summary>
+public sealed class FakeLogger<T> : ILogger<T>
+{
+    public List<LogEntry> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+    }
+
+    public record LogEntry(LogLevel Level, string Message);
+}


### PR DESCRIPTION
Closes #1075

## Changes

Implements the remaining acceptance criteria for gateway liveness hardening:

### ThreadPool Watchdog (AC3: Deadlock detection)
- `IThreadPoolMetrics` abstraction for testability
- `ThreadPoolWatchdogService`: monitors `ThreadPool.PendingWorkItemCount` against configurable threshold (default 100)
- Logs WARNING with full diagnostic snapshot (pending items, worker/IO thread counts) when threshold exceeded
- Single-fire per exceedance cycle (resets on recovery)

### Lock Timeout Logger (AC2: Lock timeout logging)
- `LockTimeoutLogger`: wraps semaphore acquisition with configurable warning threshold (default 5s)
- Emits WARNING with lock name and elapsed time when acquisition exceeds threshold
- Also emits a proactive warning while still waiting (before acquisition completes)
- Disposable handle pattern for clean semaphore release

### Health Endpoint Hardening (AC4: /health timeout)
- /health endpoint now executes with a 5-second CancellationTokenSource timeout
- If the handler cannot execute within 5s (threadpool exhausted, deadlock), returns HTTP 503 with `{"status":"timeout"}`
- `HealthEndpointHelper.ExecuteWithTimeoutAsync` for testable timeout logic

### DI Registration
- New `DiagnosticsServiceCollectionExtensions.AddDiagnosticsHardening()` method
- Registered in Program.cs alongside existing gateway services
- Avoids modifying `GatewayServiceCollectionExtensions.cs` (open in PR #1120)

## Tests
- 12 new tests covering all three components
- Architecture 178 ✅, Gateway 2506 ✅, Scenarios 29 ✅

## Merge Notes
Independent of all 6 open PRs. Only touches Program.cs /health endpoint (no overlap with PR #1120 satellite auth or PR #1121 canvas notifications). Safe to merge in any order.