### PR TITLE
refactor(gateway): eliminate repeated .From() conversions in AgentsController

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/AgentsController.cs
@@ -52,7 +52,8 @@ public sealed class AgentsController : ControllerBase
     [HttpGet("{agentId}")]
     public ActionResult<AgentDescriptor> Get(string agentId)
     {
-        var descriptor = _registry.Get(AgentId.From(agentId));
+        var typedAgentId = AgentId.From(agentId);
+        var descriptor = _registry.Get(typedAgentId);
         return descriptor is not null ? Ok(descriptor) : NotFound();
     }
 
@@ -110,9 +111,10 @@ public sealed class AgentsController : ControllerBase
             });
         }
 
+        var typedAgentId = AgentId.From(agentId);
         var updatedDescriptor = descriptor;
 
-        var wasUpdated = _registry.Update(AgentId.From(agentId), updatedDescriptor);
+        var wasUpdated = _registry.Update(typedAgentId, updatedDescriptor);
         if (!wasUpdated)
             return NotFound();
 
@@ -145,7 +147,9 @@ public sealed class AgentsController : ControllerBase
     [HttpGet("{agentId}/sessions/{sessionId}/status")]
     public ActionResult<AgentInstance> GetInstanceStatus(string agentId, string sessionId)
     {
-        var instance = _supervisor.GetInstance(AgentId.From(agentId), SessionId.From(sessionId));
+        var typedAgentId = AgentId.From(agentId);
+        var typedSessionId = SessionId.From(sessionId);
+        var instance = _supervisor.GetInstance(typedAgentId, typedSessionId);
         return instance is not null ? Ok(instance) : NotFound();
     }
 
@@ -157,7 +161,9 @@ public sealed class AgentsController : ControllerBase
     [HttpGet("{agentId}/health")]
     public async Task<ActionResult<AgentHealthResponse>> GetHealth(string agentId, CancellationToken cancellationToken)
     {
-        if (_registry.Get(AgentId.From(agentId)) is null)
+        var typedAgentId = AgentId.From(agentId);
+
+        if (_registry.Get(typedAgentId) is null)
             return NotFound();
 
         var instances = (_supervisor.GetAllInstances() ?? [])
@@ -165,10 +171,10 @@ public sealed class AgentsController : ControllerBase
             .ToList();
 
         if (instances.Count == 0)
-            return Ok(new AgentHealthResponse("unknown", AgentId.From(agentId), 0));
+            return Ok(new AgentHealthResponse("unknown", typedAgentId, 0));
 
         if (_supervisor is not IAgentHandleInspector inspector)
-            return Ok(new AgentHealthResponse("unknown", AgentId.From(agentId), instances.Count));
+            return Ok(new AgentHealthResponse("unknown", typedAgentId, instances.Count));
 
         var evaluatedCount = 0;
         foreach (var instance in instances)
@@ -179,18 +185,20 @@ public sealed class AgentsController : ControllerBase
 
             evaluatedCount++;
             if (!await healthCheckable.PingAsync(cancellationToken))
-                return Ok(new AgentHealthResponse("unhealthy", AgentId.From(agentId), instances.Count));
+                return Ok(new AgentHealthResponse("unhealthy", typedAgentId, instances.Count));
         }
 
         var status = evaluatedCount > 0 ? "healthy" : "unknown";
-        return Ok(new AgentHealthResponse(status, AgentId.From(agentId), instances.Count));
+        return Ok(new AgentHealthResponse(status, typedAgentId, instances.Count));
     }
 
     /// <summary>Stops a specific agent instance.</summary>
     [HttpPost("{agentId}/sessions/{sessionId}/stop")]
     public async Task<ActionResult> StopInstance(string agentId, string sessionId, CancellationToken cancellationToken)
     {
-        await _supervisor.StopAsync(AgentId.From(agentId), SessionId.From(sessionId), cancellationToken);
+        var typedAgentId = AgentId.From(agentId);
+        var typedSessionId = SessionId.From(sessionId);
+        await _supervisor.StopAsync(typedAgentId, typedSessionId, cancellationToken);
         return NoContent();
     }
 
@@ -277,8 +285,10 @@ public sealed class AgentsController : ControllerBase
 
     private IAgentHandle? GetAgentHandle(string agentId, string sessionId)
     {
+        var typedAgentId = AgentId.From(agentId);
+        var typedSessionId = SessionId.From(sessionId);
         var supervisorImpl = _supervisor as BotNexus.Gateway.Agents.DefaultAgentSupervisor;
-        return supervisorImpl?.GetHandle(AgentId.From(agentId), SessionId.From(sessionId));
+        return supervisorImpl?.GetHandle(typedAgentId, typedSessionId);
     }
 
     private async Task NotifyAgentsChangedBestEffortAsync(string changeType, string? agentId, CancellationToken cancellationToken)


### PR DESCRIPTION
Part of #603

## Changes

Eliminates 11 inline `.From()` conversion calls in `AgentsController.cs` by converting route-bound string parameters to typed `AgentId`/`SessionId` primitives **once** at method entry and flowing the typed values through all downstream calls.

### Pattern applied (consistent with existing `Unregister` method):
```csharp
// Before: repeated inline conversions
var descriptor = _registry.Get(AgentId.From(agentId));
// ...
return Ok(new AgentHealthResponse("unknown", AgentId.From(agentId), 0));

// After: convert once, use typed local throughout  
var typedAgentId = AgentId.From(agentId);
var descriptor = _registry.Get(typedAgentId);
// ...
return Ok(new AgentHealthResponse("unknown", typedAgentId, 0));
```

### Methods refactored:
- `Get` — 1 conversion eliminated
- `Update` — 1 conversion eliminated
- `GetInstanceStatus` — 2 conversions eliminated
- `GetHealth` — 5 conversions eliminated
- `StopInstance` — 2 conversions eliminated
- `GetAgentHandle` (private) — 2 conversions eliminated

### Not touched (already correct):
- `Unregister` — already uses typed local pattern
- `Register` — receives typed `AgentDescriptor` directly

## GatewayHost.cs — deferred

The GatewayHost.cs portion of #603 (23 `.From()` calls) is significantly more complex due to:
- `sessionId` being reassigned 3 times mid-loop during conversation resolution
- Telemetry tags needing raw string values
- 1367-line critical hot path requiring careful testing

This will be addressed in a dedicated follow-up PR with more extensive test coverage.

## Tests
- Architecture 178 ✅
- AgentsController tests 28 ✅  
- Scenarios 29 ✅

## Merge Notes
Independent of all open PRs. Only touches `AgentsController.cs` (no overlap with any open PR). Safe to merge in any order. GatewayHost.cs follow-up PR will be opened separately.