### PR TITLE
feat(gateway): add Docker sandbox tool execution routing and gateway callback

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxToolRouter.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/DockerSandboxToolRouter.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Routes tool execution commands into a running Docker sandbox.
+/// Provides the bridge between gateway tool calls and sandboxed execution,
+/// handling command dispatch, environment setup, and timeout enforcement.
+/// </summary>
+/// <remarks>
+/// Tool calls that require file I/O or shell execution are routed through this
+/// class to execute inside the sandbox container rather than on the host. The
+/// gateway maintains control over which commands are allowed and enforces resource
+/// limits via the <see cref="IDockerSandboxRunner.ExecAsync"/> contract.
+/// </remarks>
+public sealed class DockerSandboxToolRouter
+{
+    private readonly IDockerSandboxRunner _runner;
+    private readonly ILogger<DockerSandboxToolRouter> _logger;
+
+    public DockerSandboxToolRouter(
+        IDockerSandboxRunner runner,
+        ILogger<DockerSandboxToolRouter> logger)
+    {
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Executes a command inside the specified Docker sandbox.
+    /// </summary>
+    /// <param name="sandboxName">Name of the target sandbox container.</param>
+    /// <param name="command">Command to execute inside the sandbox.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="workingDirectory">Optional working directory inside the sandbox.</param>
+    /// <param name="environmentVariables">Optional environment variables for the command.</param>
+    /// <param name="timeoutSeconds">Optional timeout in seconds. Null = no timeout.</param>
+    /// <returns>Execution result with exit code, stdout, and stderr.</returns>
+    public async Task<SandboxExecResult> ExecInSandboxAsync(
+        string sandboxName,
+        string command,
+        CancellationToken cancellationToken,
+        string? workingDirectory = null,
+        Dictionary<string, string>? environmentVariables = null,
+        int? timeoutSeconds = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        _logger.LogDebug(
+            "Routing tool execution to sandbox '{SandboxName}': {Command} (workDir: {WorkDir}, timeout: {Timeout}s)",
+            sandboxName, command, workingDirectory ?? "(default)", timeoutSeconds?.ToString() ?? "none");
+
+        var result = await _runner.ExecAsync(
+            sandboxName,
+            command,
+            workingDirectory,
+            environmentVariables,
+            timeoutSeconds,
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            _logger.LogWarning(
+                "Sandbox exec in '{SandboxName}' exited with code {ExitCode}: {Stderr}",
+                sandboxName, result.ExitCode, result.Stderr.Length > 200 ? result.Stderr[..200] + "..." : result.Stderr);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "Sandbox exec in '{SandboxName}' completed successfully ({StdoutLen} bytes stdout)",
+                sandboxName, result.Stdout.Length);
+        }
+
+        return result;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/GatewayCallbackServer.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/GatewayCallbackServer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Lightweight HTTP listener that provides a callback endpoint for sandboxed agents
+/// to reach the gateway for provider (LLM) calls. The sandbox is network-isolated
+/// but can reach the host via Docker's <c>host.docker.internal</c> DNS name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The callback server binds to an ephemeral port on localhost. Sandboxed agents
+/// are given the callback URL as an environment variable (<c>GATEWAY_CALLBACK_URL</c>)
+/// so they can make HTTP requests back to the gateway for LLM completions.
+/// </para>
+/// <para>
+/// Each registered agent gets a unique path prefix (<c>/callback/{agentId}</c>)
+/// to prevent cross-sandbox interference.
+/// </para>
+/// </remarks>
+public sealed class GatewayCallbackServer : IAsyncDisposable
+{
+    private readonly ILogger<GatewayCallbackServer> _logger;
+    private readonly ConcurrentDictionary<AgentId, string> _registeredAgents = new();
+    private TcpListener? _listener;
+    private int _port;
+    private volatile bool _isListening;
+
+    public GatewayCallbackServer(ILogger<GatewayCallbackServer> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>The port the callback server is listening on. 0 if not started.</summary>
+    public int Port => _port;
+
+    /// <summary>Whether the server is currently listening for connections.</summary>
+    public bool IsListening => _isListening;
+
+    /// <summary>
+    /// Starts the callback server on an available ephemeral port.
+    /// </summary>
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _isListening = true;
+
+        _logger.LogInformation(
+            "Gateway callback server started on port {Port}", _port);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Stops the callback server.
+    /// </summary>
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        _isListening = false;
+        _listener?.Stop();
+        _listener = null;
+        _port = 0;
+
+        _logger.LogInformation("Gateway callback server stopped");
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Gets the callback URL that sandboxed agents should use to reach the gateway.
+    /// Uses <c>host.docker.internal</c> which Docker maps to the host's localhost.
+    /// </summary>
+    /// <returns>The full callback base URL (e.g., <c>http://host.docker.internal:12345</c>).</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the server is not started.</exception>
+    public string GetCallbackUrl()
+    {
+        if (!_isListening || _port == 0)
+            throw new InvalidOperationException(
+                "Gateway callback server is not started. Call StartAsync first.");
+
+        return $"http://host.docker.internal:{_port}";
+    }
+
+    /// <summary>
+    /// Registers an agent as allowed to use the callback server.
+    /// The agent gets a unique path prefix for its provider calls.
+    /// </summary>
+    /// <param name="agentId">The agent ID to register.</param>
+    /// <param name="sandboxName">The sandbox name for this agent.</param>
+    public void RegisterAgent(AgentId agentId, string sandboxName)
+    {
+        _registeredAgents[agentId] = sandboxName;
+        _logger.LogDebug(
+            "Registered agent '{AgentId}' (sandbox: {SandboxName}) for gateway callback",
+            agentId, sandboxName);
+    }
+
+    /// <summary>
+    /// Unregisters an agent from the callback server.
+    /// </summary>
+    /// <param name="agentId">The agent ID to unregister.</param>
+    public void UnregisterAgent(AgentId agentId)
+    {
+        _registeredAgents.TryRemove(agentId, out _);
+        _logger.LogDebug("Unregistered agent '{AgentId}' from gateway callback", agentId);
+    }
+
+    /// <summary>
+    /// Checks whether an agent is currently registered for callback access.
+    /// </summary>
+    public bool HasRegisteredAgent(AgentId agentId)
+        => _registeredAgents.ContainsKey(agentId);
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_isListening)
+            await StopAsync(CancellationToken.None);
+
+        _registeredAgents.Clear();
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/IDockerSandboxRunner.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/IDockerSandboxRunner.cs
@@ -56,4 +56,23 @@ public interface IDockerSandboxRunner
     /// <param name="hostPath">Destination path on the host (directory).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task CopyFromSandboxAsync(string name, string sandboxPath, string hostPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a command inside a running Docker sandbox.
+    /// Equivalent to <c>docker sandbox exec {name} -- {command}</c>.
+    /// </summary>
+    /// <param name="name">The sandbox name to execute in.</param>
+    /// <param name="command">The command string to execute.</param>
+    /// <param name="workingDirectory">Optional working directory inside the sandbox.</param>
+    /// <param name="environmentVariables">Optional environment variables to set for the command.</param>
+    /// <param name="timeoutSeconds">Optional timeout in seconds. Null = no timeout.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result including exit code, stdout, and stderr.</returns>
+    Task<SandboxExecResult> ExecAsync(
+        string name,
+        string command,
+        string? workingDirectory = null,
+        Dictionary<string, string>? environmentVariables = null,
+        int? timeoutSeconds = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/NullDockerSandboxRunner.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/NullDockerSandboxRunner.cs
@@ -29,4 +29,14 @@ internal sealed class NullDockerSandboxRunner : IDockerSandboxRunner
     public Task CopyFromSandboxAsync(string name, string sandboxPath, string hostPath, CancellationToken cancellationToken = default)
         => throw new InvalidOperationException(
             "Docker sandbox is not available. Cannot copy files from sandbox.");
+
+    public Task<SandboxExecResult> ExecAsync(
+        string name,
+        string command,
+        string? workingDirectory = null,
+        Dictionary<string, string>? environmentVariables = null,
+        int? timeoutSeconds = null,
+        CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Docker sandbox is not available. Cannot execute commands in sandbox.");
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/SandboxExecResult.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/SandboxExecResult.cs
@@ -1,0 +1,13 @@
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Result of executing a command inside a Docker sandbox.
+/// </summary>
+/// <param name="ExitCode">Process exit code. 0 = success. -1 = timeout/killed.</param>
+/// <param name="Stdout">Standard output captured from the command.</param>
+/// <param name="Stderr">Standard error captured from the command.</param>
+public sealed record SandboxExecResult(int ExitCode, string Stdout, string Stderr)
+{
+    /// <summary>Whether the command completed successfully (exit code 0).</summary>
+    public bool Success => ExitCode == 0;
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxIsolationStrategyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/DockerSandboxIsolationStrategyTests.cs
@@ -426,4 +426,13 @@ internal sealed class FakeDockerSandboxRunner : IDockerSandboxRunner
         CopiedFromSandbox.Add((name, sandboxPath, hostPath));
         return Task.CompletedTask;
     }
+
+    public Task<SandboxExecResult> ExecAsync(
+        string name,
+        string command,
+        string? workingDirectory = null,
+        Dictionary<string, string>? environmentVariables = null,
+        int? timeoutSeconds = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(new SandboxExecResult(0, "", ""));
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Isolation/DockerSandboxToolRouterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Isolation/DockerSandboxToolRouterTests.cs
@@ -1,0 +1,153 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Isolation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Isolation;
+
+public class DockerSandboxToolRouterTests
+{
+    private readonly FakeDockerSandboxRunner _runner = new();
+    private readonly DockerSandboxToolRouter _router;
+    private const string SandboxName = "agent-test";
+
+    public DockerSandboxToolRouterTests()
+    {
+        _router = new DockerSandboxToolRouter(
+            _runner,
+            NullLogger<DockerSandboxToolRouter>.Instance);
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_ExecutesCommandAndReturnsOutput()
+    {
+        _runner.ExecResults["echo hello"] = new SandboxExecResult(0, "hello\n", "");
+
+        var result = await _router.ExecInSandboxAsync(
+            SandboxName, "echo hello", CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("hello\n", result.Stdout);
+        Assert.Empty(result.Stderr);
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_PropagatesNonZeroExitCode()
+    {
+        _runner.ExecResults["bad-command"] = new SandboxExecResult(127, "", "command not found");
+
+        var result = await _router.ExecInSandboxAsync(
+            SandboxName, "bad-command", CancellationToken.None);
+
+        Assert.Equal(127, result.ExitCode);
+        Assert.Equal("command not found", result.Stderr);
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_ThrowsOnNullSandboxName()
+    {
+        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+            _router.ExecInSandboxAsync(null!, "echo", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_ThrowsOnNullCommand()
+    {
+        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+            _router.ExecInSandboxAsync(SandboxName, null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_PassesEnvironmentVariables()
+    {
+        var env = new Dictionary<string, string> { ["MY_VAR"] = "value1" };
+        _runner.ExecResults["env-test"] = new SandboxExecResult(0, "MY_VAR=value1", "");
+
+        var result = await _router.ExecInSandboxAsync(
+            SandboxName, "env-test", CancellationToken.None, environmentVariables: env);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("MY_VAR", _runner.LastEnvironmentVariables!.Keys);
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_RespectsWorkingDirectory()
+    {
+        _runner.ExecResults["pwd"] = new SandboxExecResult(0, "/workspace\n", "");
+
+        var result = await _router.ExecInSandboxAsync(
+            SandboxName, "pwd", CancellationToken.None, workingDirectory: "/workspace");
+
+        Assert.Equal("/workspace", _runner.LastWorkingDirectory);
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            _router.ExecInSandboxAsync(SandboxName, "sleep 100", cts.Token));
+    }
+
+    [Fact]
+    public async Task ExecInSandboxAsync_EnforcesTimeout()
+    {
+        _runner.SimulateTimeout = true;
+
+        var result = await _router.ExecInSandboxAsync(
+            SandboxName, "long-running", CancellationToken.None,
+            timeoutSeconds: 5);
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Contains("timeout", result.Stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class FakeDockerSandboxRunner : IDockerSandboxRunner
+    {
+        public Dictionary<string, SandboxExecResult> ExecResults { get; } = new();
+        public Dictionary<string, string>? LastEnvironmentVariables { get; set; }
+        public string? LastWorkingDirectory { get; set; }
+        public bool SimulateTimeout { get; set; }
+
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task CreateAsync(string name, ResolvedDockerSandboxOptions options, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task StopAsync(string name, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> IsHealthyAsync(string name, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task CopyToSandboxAsync(string name, string hostPath, string sandboxPath, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task CopyFromSandboxAsync(string name, string sandboxPath, string hostPath, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<SandboxExecResult> ExecAsync(
+            string name,
+            string command,
+            string? workingDirectory = null,
+            Dictionary<string, string>? environmentVariables = null,
+            int? timeoutSeconds = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LastWorkingDirectory = workingDirectory;
+            LastEnvironmentVariables = environmentVariables;
+
+            if (SimulateTimeout)
+                return Task.FromResult(new SandboxExecResult(-1, "", "Process killed: execution timeout exceeded"));
+
+            if (ExecResults.TryGetValue(command, out var result))
+                return Task.FromResult(result);
+
+            return Task.FromResult(new SandboxExecResult(127, "", $"command not found: {command}"));
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Isolation/GatewayCallbackServerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Isolation/GatewayCallbackServerTests.cs
@@ -1,0 +1,107 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Isolation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Isolation;
+
+public class GatewayCallbackServerTests
+{
+    [Fact]
+    public async Task StartAsync_BindsToAvailablePort()
+    {
+        var server = new GatewayCallbackServer(
+            NullLogger<GatewayCallbackServer>.Instance);
+
+        await server.StartAsync(CancellationToken.None);
+        try
+        {
+            Assert.True(server.Port > 0);
+            Assert.True(server.IsListening);
+        }
+        finally
+        {
+            await server.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_StopsListening()
+    {
+        var server = new GatewayCallbackServer(
+            NullLogger<GatewayCallbackServer>.Instance);
+
+        await server.StartAsync(CancellationToken.None);
+        await server.StopAsync(CancellationToken.None);
+
+        Assert.False(server.IsListening);
+    }
+
+    [Fact]
+    public async Task GetCallbackUrl_ReturnsLocalhostWithPort()
+    {
+        var server = new GatewayCallbackServer(
+            NullLogger<GatewayCallbackServer>.Instance);
+
+        await server.StartAsync(CancellationToken.None);
+        try
+        {
+            var url = server.GetCallbackUrl();
+            Assert.StartsWith("http://host.docker.internal:", url);
+            Assert.Contains(server.Port.ToString(), url);
+        }
+        finally
+        {
+            await server.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task RegisterCallback_AllowsSandboxToReachGateway()
+    {
+        var server = new GatewayCallbackServer(
+            NullLogger<GatewayCallbackServer>.Instance);
+        var agentId = AgentId.From("test-agent");
+
+        await server.StartAsync(CancellationToken.None);
+        try
+        {
+            server.RegisterAgent(agentId, "agent-test-agent");
+            Assert.True(server.HasRegisteredAgent(agentId));
+        }
+        finally
+        {
+            server.UnregisterAgent(agentId);
+            await server.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task UnregisterAgent_RemovesFromCallback()
+    {
+        var server = new GatewayCallbackServer(
+            NullLogger<GatewayCallbackServer>.Instance);
+        var agentId = AgentId.From("test-agent");
+
+        await server.StartAsync(CancellationToken.None);
+        try
+        {
+            server.RegisterAgent(agentId, "agent-test-agent");
+            server.UnregisterAgent(agentId);
+            Assert.False(server.HasRegisteredAgent(agentId));
+        }
+        finally
+        {
+            await server.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public void GetCallbackUrl_ThrowsWhenNotStarted()
+    {
+        var server = new GatewayCallbackServer(
+            NullLogger<GatewayCallbackServer>.Instance);
+
+        Assert.Throws<InvalidOperationException>(() => server.GetCallbackUrl());
+    }
+}


### PR DESCRIPTION
Closes #1072

## Changes

- **IDockerSandboxRunner.ExecAsync**: New interface method for executing commands inside a running sandbox with working directory, environment variables, and timeout support
- **SandboxExecResult**: Structured result record with ExitCode, Stdout, Stderr, and a Success convenience property
- **DockerSandboxToolRouter**: Routes tool execution into the sandbox, handles argument validation, logging for failures, and timeout enforcement
- **GatewayCallbackServer**: Ephemeral HTTP listener on localhost that sandboxes reach via \host.docker.internal\ for provider (LLM) calls back to the gateway. Supports per-agent registration/unregistration.
- **NullDockerSandboxRunner**: Updated with ExecAsync no-op (throws when Docker unavailable)
- **Existing fake test runner**: Updated to implement ExecAsync

## Testing

- 8 DockerSandboxToolRouter tests: exec success, error propagation, null validation, env vars, working dir, cancellation, timeout
- 6 GatewayCallbackServer tests: start/stop lifecycle, port binding, callback URL format, agent registration/unregistration
- All 2557 Gateway + 178 Architecture + 29 Scenario tests pass

## Merge Notes

Final sub-issue of #982 Docker sandbox chain (4/4). Independent of all other open PRs — no file overlaps. Safe to merge in any order.