### PR TITLE
feat(agents): add built-in internal agents for common sub-agent roles

### DIFF
--- a/src/gateway/BotNexus.Gateway/Agents/BuiltInAgentRegistrationService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/BuiltInAgentRegistrationService.cs
@@ -1,0 +1,47 @@
+using BotNexus.Gateway.Abstractions.Agents;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Agents;
+
+/// <summary>
+/// Registers built-in internal agents at startup before configuration-based agents load.
+/// This ensures they appear in <see cref="AgentConfigurationHostedService"/>'s
+/// <c>_codeBasedAgentIds</c> set and cannot be overridden by user configuration.
+/// </summary>
+/// <remarks>
+/// Must be registered before <see cref="AgentConfigurationHostedService"/> in the hosted
+/// service pipeline so that <see cref="IAgentRegistry.GetAll"/> returns these agents
+/// when the configuration service snapshots code-based IDs.
+/// </remarks>
+internal sealed class BuiltInAgentRegistrationService(
+    IAgentRegistry registry,
+    ILogger<BuiltInAgentRegistrationService> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var registered = 0;
+        foreach (var descriptor in BuiltInAgents.All)
+        {
+            if (registry.Contains(descriptor.AgentId))
+            {
+                logger.LogDebug(
+                    "Built-in agent '{AgentId}' already registered, skipping.",
+                    descriptor.AgentId);
+                continue;
+            }
+
+            registry.Register(descriptor);
+            registered++;
+        }
+
+        logger.LogInformation(
+            "Registered {Count} built-in agents: {AgentIds}",
+            registered,
+            string.Join(", ", BuiltInAgents.All.Select(a => a.AgentId.Value)));
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/gateway/BotNexus.Gateway/Agents/BuiltInAgents.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/BuiltInAgents.cs
@@ -1,0 +1,114 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Agents;
+
+/// <summary>
+/// Defines the built-in internal agents that are always available on every BotNexus instance.
+/// These agents serve common roles and can be used as sub-agent targets via
+/// <c>spawn_subagent(targetAgentId: ...)</c> or <c>agent_converse</c>.
+/// </summary>
+/// <remarks>
+/// Built-in agents are registered before config-based sources load, so they appear in
+/// <see cref="AgentConfigurationHostedService"/>'s <c>_codeBasedAgentIds</c> set and
+/// cannot be overridden by user configuration files.
+/// </remarks>
+public static class BuiltInAgents
+{
+    /// <summary>Web search, URL fetch, summarization. Read-only. No code execution.</summary>
+    public static AgentDescriptor Researcher { get; } = new()
+    {
+        AgentId = AgentId.From("researcher"),
+        DisplayName = "Researcher",
+        Emoji = "🔍",
+        Description = "Web search, URL fetch, and summarization. Read-only — no code execution.",
+        ModelId = "",
+        ApiProvider = "",
+        SystemPrompt = "You are a research assistant. Find information, summarize content, and answer questions using web search and document reading. You do not execute code or modify files.",
+        ToolIds = ["web_search", "web_fetch", "memory_search", "memory_get", "read", "glob", "grep"],
+        Metadata = new Dictionary<string, object?> { ["role"] = "researcher", ["builtin"] = true },
+    };
+
+    /// <summary>Code writing, editing, building, testing. Full file and shell access.</summary>
+    public static AgentDescriptor Coder { get; } = new()
+    {
+        AgentId = AgentId.From("coder"),
+        DisplayName = "Coder",
+        Emoji = "💻",
+        Description = "Code writing, editing, building, and testing. Full file and shell access.",
+        ModelId = "",
+        ApiProvider = "",
+        SystemPrompt = "You are a coding assistant. Write, edit, build, and test code. You have full file system and shell access within your workspace.",
+        ToolIds = ["read", "write", "edit", "glob", "grep", "shell", "exec", "process", "watch_file"],
+        Metadata = new Dictionary<string, object?> { ["role"] = "coder", ["builtin"] = true },
+    };
+
+    /// <summary>Issue decomposition, spec writing, task breakdown. Memory and web access.</summary>
+    public static AgentDescriptor Planner { get; } = new()
+    {
+        AgentId = AgentId.From("planner"),
+        DisplayName = "Planner",
+        Emoji = "📋",
+        Description = "Issue decomposition, spec writing, and task breakdown. Memory and web access.",
+        ModelId = "",
+        ApiProvider = "",
+        SystemPrompt = "You are a planning assistant. Break down complex tasks, write specifications, decompose issues, and organize work. You have memory and web search access for research.",
+        ToolIds = ["memory_search", "memory_save", "memory_get", "web_search", "read", "write"],
+        Metadata = new Dictionary<string, object?> { ["role"] = "planner", ["builtin"] = true },
+    };
+
+    /// <summary>Code review, PR analysis, quality checks. Read-only file and shell access.</summary>
+    public static AgentDescriptor Reviewer { get; } = new()
+    {
+        AgentId = AgentId.From("reviewer"),
+        DisplayName = "Reviewer",
+        Emoji = "🔎",
+        Description = "Code review, PR analysis, and quality checks. Read-only file and shell access.",
+        ModelId = "",
+        ApiProvider = "",
+        SystemPrompt = "You are a code review assistant. Analyze code quality, review pull requests, check for bugs and improvements. You have read-only access to files and can run diagnostic commands.",
+        ToolIds = ["read", "glob", "grep", "shell", "web_fetch", "memory_search"],
+        Metadata = new Dictionary<string, object?> { ["role"] = "reviewer", ["builtin"] = true },
+    };
+
+    /// <summary>Documentation, changelogs, summaries, content. File write access.</summary>
+    public static AgentDescriptor Writer { get; } = new()
+    {
+        AgentId = AgentId.From("writer"),
+        DisplayName = "Writer",
+        Emoji = "✍️",
+        Description = "Documentation, changelogs, summaries, and content creation. File write access.",
+        ModelId = "",
+        ApiProvider = "",
+        SystemPrompt = "You are a writing assistant. Create documentation, changelogs, summaries, and other content. You can read and write files, search the web for reference material.",
+        ToolIds = ["read", "write", "edit", "glob", "grep", "web_search", "web_fetch", "memory_search"],
+        Metadata = new Dictionary<string, object?> { ["role"] = "writer", ["builtin"] = true },
+    };
+
+    /// <summary>Data analysis, log triage, metrics. Read and shell access.</summary>
+    public static AgentDescriptor Analyst { get; } = new()
+    {
+        AgentId = AgentId.From("analyst"),
+        DisplayName = "Analyst",
+        Emoji = "📊",
+        Description = "Data analysis, log triage, and metrics. Read and shell access.",
+        ModelId = "",
+        ApiProvider = "",
+        SystemPrompt = "You are a data analysis assistant. Analyze logs, metrics, and data. You have read access to files and can run commands to process data.",
+        ToolIds = ["read", "glob", "grep", "shell", "exec", "web_fetch"],
+        Metadata = new Dictionary<string, object?> { ["role"] = "analyst", ["builtin"] = true },
+    };
+
+    /// <summary>
+    /// All built-in agent descriptors. Registered at startup via DI.
+    /// </summary>
+    public static IReadOnlyList<AgentDescriptor> All { get; } =
+    [
+        Researcher,
+        Coder,
+        Planner,
+        Reviewer,
+        Writer,
+        Analyst,
+    ];
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -319,6 +319,7 @@ public static class GatewayServiceCollectionExtensions
             var writer = serviceProvider.GetRequiredService<PlatformConfigWriter>();
             return new PlatformConfigAgentWriter(writer, home);
         }));
+        services.AddHostedService<BuiltInAgentRegistrationService>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
 
         return services;

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/BuiltInAgentRegistrationServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/BuiltInAgentRegistrationServiceTests.cs
@@ -1,0 +1,114 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class BuiltInAgentRegistrationServiceTests
+{
+    private readonly DefaultAgentRegistry _registry = new(NullLogger<DefaultAgentRegistry>.Instance);
+    private readonly BuiltInAgentRegistrationService _service;
+
+    public BuiltInAgentRegistrationServiceTests()
+    {
+        _service = new BuiltInAgentRegistrationService(
+            _registry,
+            NullLogger<BuiltInAgentRegistrationService>.Instance);
+    }
+
+    [Fact]
+    public async Task StartAsync_registers_all_builtin_agents()
+    {
+        await _service.StartAsync(CancellationToken.None);
+
+        var registered = _registry.GetAll();
+        Assert.Equal(BuiltInAgents.All.Count, registered.Count);
+    }
+
+    [Fact]
+    public async Task StartAsync_agents_are_discoverable_by_id()
+    {
+        await _service.StartAsync(CancellationToken.None);
+
+        foreach (var expected in BuiltInAgents.All)
+        {
+            var actual = _registry.Get(expected.AgentId);
+            Assert.NotNull(actual);
+            Assert.Equal(expected.DisplayName, actual.DisplayName);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_skips_already_registered_agents()
+    {
+        // Pre-register one agent
+        _registry.Register(BuiltInAgents.Researcher);
+
+        await _service.StartAsync(CancellationToken.None);
+
+        // Should still have exactly 6 agents (not 7)
+        var registered = _registry.GetAll();
+        Assert.Equal(BuiltInAgents.All.Count, registered.Count);
+    }
+
+    [Fact]
+    public async Task StartAsync_does_not_overwrite_preexisting_agent()
+    {
+        // Register a custom agent with the same ID
+        var custom = new AgentDescriptor
+        {
+            AgentId = AgentId.From("researcher"),
+            DisplayName = "Custom Researcher",
+            ModelId = "custom-model",
+            ApiProvider = "custom-provider",
+        };
+        _registry.Register(custom);
+
+        await _service.StartAsync(CancellationToken.None);
+
+        var actual = _registry.Get(AgentId.From("researcher"));
+        Assert.NotNull(actual);
+        Assert.Equal("Custom Researcher", actual.DisplayName);
+    }
+
+    [Fact]
+    public async Task StopAsync_is_noop()
+    {
+        await _service.StartAsync(CancellationToken.None);
+        await _service.StopAsync(CancellationToken.None);
+
+        // Agents remain registered after stop
+        Assert.Equal(BuiltInAgents.All.Count, _registry.GetAll().Count);
+    }
+
+    [Fact]
+    public async Task StartAsync_agents_have_correct_role_metadata()
+    {
+        await _service.StartAsync(CancellationToken.None);
+
+        var coder = _registry.Get(AgentId.From("coder"));
+        Assert.NotNull(coder);
+        Assert.True(coder.Metadata.ContainsKey("role"));
+        Assert.Equal("coder", coder.Metadata["role"]);
+    }
+
+    [Fact]
+    public async Task StartAsync_agents_appear_as_code_based_in_config_service()
+    {
+        // This simulates the scenario where AgentConfigurationHostedService
+        // captures code-based IDs after built-in registration
+        await _service.StartAsync(CancellationToken.None);
+
+        var codeBasedIds = _registry.GetAll()
+            .Select(d => d.AgentId.Value)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.Contains(agent.AgentId.Value, codeBasedIds);
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/BuiltInAgentsTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/BuiltInAgentsTests.cs
@@ -1,0 +1,241 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class BuiltInAgentsTests
+{
+    [Fact]
+    public void All_contains_six_agents()
+    {
+        Assert.Equal(6, BuiltInAgents.All.Count);
+    }
+
+    [Theory]
+    [InlineData("researcher")]
+    [InlineData("coder")]
+    [InlineData("planner")]
+    [InlineData("reviewer")]
+    [InlineData("writer")]
+    [InlineData("analyst")]
+    public void All_contains_expected_agent_id(string expectedId)
+    {
+        Assert.Contains(BuiltInAgents.All, a => a.AgentId.Value == expectedId);
+    }
+
+    [Fact]
+    public void All_agent_ids_are_unique()
+    {
+        var ids = BuiltInAgents.All.Select(a => a.AgentId.Value).ToList();
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void All_agents_have_display_name()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(agent.DisplayName),
+                $"Agent '{agent.AgentId}' has no display name.");
+        }
+    }
+
+    [Fact]
+    public void All_agents_have_emoji()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(agent.Emoji),
+                $"Agent '{agent.AgentId}' has no emoji.");
+        }
+    }
+
+    [Fact]
+    public void All_agents_have_description()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(agent.Description),
+                $"Agent '{agent.AgentId}' has no description.");
+        }
+    }
+
+    [Fact]
+    public void All_agents_have_system_prompt()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(agent.SystemPrompt),
+                $"Agent '{agent.AgentId}' has no system prompt.");
+        }
+    }
+
+    [Fact]
+    public void All_agents_have_non_empty_tool_ids()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.True(agent.ToolIds.Count > 0,
+                $"Agent '{agent.AgentId}' has no tool IDs.");
+        }
+    }
+
+    [Fact]
+    public void All_agents_have_role_metadata()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.True(agent.Metadata.ContainsKey("role"),
+                $"Agent '{agent.AgentId}' is missing 'role' metadata.");
+            Assert.NotNull(agent.Metadata["role"]);
+        }
+    }
+
+    [Fact]
+    public void All_agents_have_builtin_metadata_flag()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.True(agent.Metadata.ContainsKey("builtin"),
+                $"Agent '{agent.AgentId}' is missing 'builtin' metadata flag.");
+            Assert.Equal(true, agent.Metadata["builtin"]);
+        }
+    }
+
+    [Fact]
+    public void Researcher_cannot_execute_code()
+    {
+        var tools = BuiltInAgents.Researcher.ToolIds;
+        Assert.DoesNotContain("shell", tools);
+        Assert.DoesNotContain("exec", tools);
+        Assert.DoesNotContain("write", tools);
+        Assert.DoesNotContain("edit", tools);
+    }
+
+    [Fact]
+    public void Researcher_has_read_and_search_tools()
+    {
+        var tools = BuiltInAgents.Researcher.ToolIds;
+        Assert.Contains("web_search", tools);
+        Assert.Contains("web_fetch", tools);
+        Assert.Contains("read", tools);
+        Assert.Contains("glob", tools);
+        Assert.Contains("grep", tools);
+    }
+
+    [Fact]
+    public void Coder_has_full_file_and_shell_access()
+    {
+        var tools = BuiltInAgents.Coder.ToolIds;
+        Assert.Contains("read", tools);
+        Assert.Contains("write", tools);
+        Assert.Contains("edit", tools);
+        Assert.Contains("shell", tools);
+        Assert.Contains("exec", tools);
+        Assert.Contains("process", tools);
+    }
+
+    [Fact]
+    public void Coder_cannot_search_web()
+    {
+        var tools = BuiltInAgents.Coder.ToolIds;
+        Assert.DoesNotContain("web_search", tools);
+    }
+
+    [Fact]
+    public void Reviewer_is_read_only_with_shell()
+    {
+        var tools = BuiltInAgents.Reviewer.ToolIds;
+        Assert.Contains("read", tools);
+        Assert.Contains("glob", tools);
+        Assert.Contains("grep", tools);
+        Assert.Contains("shell", tools);
+        Assert.DoesNotContain("write", tools);
+        Assert.DoesNotContain("edit", tools);
+        Assert.DoesNotContain("exec", tools);
+    }
+
+    [Fact]
+    public void Planner_has_memory_and_web_tools()
+    {
+        var tools = BuiltInAgents.Planner.ToolIds;
+        Assert.Contains("memory_search", tools);
+        Assert.Contains("memory_save", tools);
+        Assert.Contains("memory_get", tools);
+        Assert.Contains("web_search", tools);
+        Assert.Contains("read", tools);
+        Assert.Contains("write", tools);
+    }
+
+    [Fact]
+    public void Planner_cannot_execute_shell()
+    {
+        var tools = BuiltInAgents.Planner.ToolIds;
+        Assert.DoesNotContain("shell", tools);
+        Assert.DoesNotContain("exec", tools);
+    }
+
+    [Fact]
+    public void Writer_has_file_write_and_search()
+    {
+        var tools = BuiltInAgents.Writer.ToolIds;
+        Assert.Contains("read", tools);
+        Assert.Contains("write", tools);
+        Assert.Contains("edit", tools);
+        Assert.Contains("web_search", tools);
+        Assert.Contains("web_fetch", tools);
+    }
+
+    [Fact]
+    public void Writer_cannot_execute_shell()
+    {
+        var tools = BuiltInAgents.Writer.ToolIds;
+        Assert.DoesNotContain("shell", tools);
+        Assert.DoesNotContain("exec", tools);
+    }
+
+    [Fact]
+    public void Analyst_has_read_and_shell_access()
+    {
+        var tools = BuiltInAgents.Analyst.ToolIds;
+        Assert.Contains("read", tools);
+        Assert.Contains("glob", tools);
+        Assert.Contains("grep", tools);
+        Assert.Contains("shell", tools);
+        Assert.Contains("exec", tools);
+        Assert.Contains("web_fetch", tools);
+    }
+
+    [Fact]
+    public void Analyst_cannot_write_files()
+    {
+        var tools = BuiltInAgents.Analyst.ToolIds;
+        Assert.DoesNotContain("write", tools);
+        Assert.DoesNotContain("edit", tools);
+    }
+
+    [Fact]
+    public void All_agents_have_empty_model_and_provider()
+    {
+        // Built-in agents inherit model/provider from the spawning context
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.Equal("", agent.ModelId);
+            Assert.Equal("", agent.ApiProvider);
+        }
+    }
+
+    [Fact]
+    public void All_agents_are_named_kind()
+    {
+        foreach (var agent in BuiltInAgents.All)
+        {
+            Assert.Equal(AgentKind.Named, agent.Kind);
+        }
+    }
+}


### PR DESCRIPTION
Closes #467

## Changes

- **BuiltInAgents.cs**: Defines 6 static agent descriptors (researcher, coder, planner, reviewer, writer, analyst) with role-appropriate tool restrictions and metadata
- **BuiltInAgentRegistrationService.cs**: Hosted service that registers all built-in agents before config-based sources load, ensuring they appear as code-based agents in AgentConfigurationHostedService
- **GatewayServiceCollectionExtensions.cs**: Registers the BuiltInAgentRegistrationService before AgentConfigurationHostedService

## Design

- Built-in agents use empty `ModelId`/`ApiProvider` — they inherit model and provider from the spawning agent context when used as sub-agents
- Each agent has a `role` metadata key matching its role name, compatible with `SubAgentRoles` grants
- Each agent has a `builtin` metadata flag for identification
- Tool restrictions are enforced by the existing `InProcessIsolationStrategy` via `ToolIds`
- Registration runs before `AgentConfigurationHostedService.StartAsync`, so these agents appear in `_codeBasedAgentIds` and cannot be overridden by user config files

## Tests

- 50 new tests covering: agent definitions, tool restrictions per role, metadata, registration behavior, skip-if-preexisting logic, code-based ID visibility

## Merge Notes

Independent of all open PRs. Touches only `GatewayServiceCollectionExtensions.cs` (1 additive line) which overlaps with nothing in the current queue.