### PR TITLE
fix(tests): make GitHub Models integration tests resilient to API degradation

### DIFF
--- a/tests/integration/BotNexus.Integration.ProviderTests/BotNexus.Integration.ProviderTests.csproj
+++ b/tests/integration/BotNexus.Integration.ProviderTests/BotNexus.Integration.ProviderTests.csproj
@@ -11,6 +11,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
+    <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/tests/integration/BotNexus.Integration.ProviderTests/GitHubModelsIntegrationTests.cs
+++ b/tests/integration/BotNexus.Integration.ProviderTests/GitHubModelsIntegrationTests.cs
@@ -11,7 +11,9 @@ namespace BotNexus.Integration.ProviderTests;
 /// These tests make real HTTP calls to https://models.inference.ai.azure.com
 /// and require a valid GITHUB_TOKEN environment variable.
 /// <para>
-/// Tests are skipped gracefully when GITHUB_TOKEN is not present (local dev runs).
+/// Tests are skipped gracefully when:
+/// - GITHUB_TOKEN is not present (local dev runs)
+/// - The external API is degraded (returning empty responses / HTTP errors)
 /// Rate limiting: tests use Task.Delay between calls to stay under 15 RPM.
 /// </para>
 /// </summary>
@@ -20,16 +22,20 @@ namespace BotNexus.Integration.ProviderTests;
 [Collection("GitHubModels")]
 public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
 {
+    private const string ApiDegradedReason =
+        "GitHub Models API is degraded (returning empty responses). Skipping integration test.";
+
     private readonly HttpClient _httpClient = new();
     private OpenAICompatProvider _provider = null!;
     private LlmModel _model = null!;
+    private bool _apiAvailable;
     private static readonly long Ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
         var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
         if (string.IsNullOrEmpty(token))
-            return Task.CompletedTask;
+            return;
 
         _httpClient.DefaultRequestHeaders.Authorization =
             new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
@@ -40,7 +46,9 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         GitHubModelsProvider.RegisterModels(registry);
         _model = registry.GetModel("github-models", "gpt-4o-mini")!;
 
-        return Task.CompletedTask;
+        // Probe the API with a minimal request to detect outages early.
+        // If the probe fails or returns empty, all tests will skip gracefully.
+        _apiAvailable = await ProbeApiAvailabilityAsync();
     }
 
     public Task DisposeAsync()
@@ -53,6 +61,8 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
     public async Task BasicCompletion_ReturnsNonEmptyResponse()
     {
         // Arrange
+        Skip.If(!_apiAvailable, ApiDegradedReason);
+
         var context = new Context(
             SystemPrompt: "You are a helpful assistant. Reply in one sentence.",
             Messages: [new UserMessage(new UserMessageContent("What is 2+2?"), Ts)]);
@@ -61,6 +71,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         var result = await CollectStreamAsync(_provider.Stream(_model, context));
 
         // Assert
+        SkipIfDegraded(result);
         result.Text.ShouldNotBeNullOrWhiteSpace();
         result.StopReason.ShouldBe(StopReason.Stop);
     }
@@ -69,6 +80,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
     public async Task ToolCall_RoundTrip_ReturnsToolUseAndFinalResponse()
     {
         // Arrange: give the model a tool and ask it something that requires the tool
+        Skip.If(!_apiAvailable, ApiDegradedReason);
         await Task.Delay(4000); // rate limit spacing
 
         var weatherTool = new Tool(
@@ -93,6 +105,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         var result = await CollectStreamAsync(_provider.Stream(_model, context));
 
         // Assert
+        SkipIfDegraded(result);
         result.ToolCalls.ShouldNotBeEmpty("Model should call the get_weather tool");
         var toolCall = result.ToolCalls[0];
         toolCall.Name.ShouldBe("get_weather");
@@ -103,6 +116,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
     public async Task Streaming_EmitsTextDeltas()
     {
         // Arrange
+        Skip.If(!_apiAvailable, ApiDegradedReason);
         await Task.Delay(4000); // rate limit spacing
 
         var context = new Context(
@@ -131,6 +145,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         }
 
         // Assert
+        Skip.If(deltaCount == 0 && string.IsNullOrEmpty(finalText), ApiDegradedReason);
         deltaCount.ShouldBeGreaterThan(1, "Streaming should emit multiple text deltas");
         finalText.ShouldNotBeNullOrWhiteSpace();
     }
@@ -139,6 +154,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
     public async Task SystemPrompt_IsRespected()
     {
         // Arrange: use a very specific system prompt constraint
+        Skip.If(!_apiAvailable, ApiDegradedReason);
         await Task.Delay(4000); // rate limit spacing
 
         var context = new Context(
@@ -148,7 +164,8 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         // Act
         var result = await CollectStreamAsync(_provider.Stream(_model, context));
 
-        // Assert: the response should contain PINEAPPLE (model may add punctuation)
+        // Assert
+        SkipIfDegraded(result);
         result.Text.ToUpperInvariant().ShouldContain("PINEAPPLE");
     }
 
@@ -156,6 +173,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
     public async Task MultiTurn_MaintainsContext()
     {
         // Arrange: multi-turn conversation where second message references first
+        Skip.If(!_apiAvailable, ApiDegradedReason);
         await Task.Delay(4000); // rate limit spacing
 
         var messages = new Message[]
@@ -182,6 +200,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         var result = await CollectStreamAsync(_provider.Stream(_model, context));
 
         // Assert
+        SkipIfDegraded(result);
         result.Text.ShouldContain("Farnsworth", Case.Insensitive);
     }
 
@@ -189,6 +208,7 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
     public async Task AgentLoop_SmokeTool_CompletesCycle()
     {
         // Arrange: simulate one agent loop iteration with tool call + result
+        Skip.If(!_apiAvailable, ApiDegradedReason);
         await Task.Delay(4000); // rate limit spacing
 
         var calculatorTool = new Tool(
@@ -211,6 +231,8 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
             Tools: [calculatorTool]);
 
         var turn1 = await CollectStreamAsync(_provider.Stream(_model, context1));
+
+        SkipIfDegraded(turn1);
 
         if (turn1.ToolCalls.Count == 0)
         {
@@ -250,8 +272,49 @@ public sealed class GitHubModelsIntegrationTests : IAsyncLifetime
         var turn2 = await CollectStreamAsync(_provider.Stream(_model, context2));
 
         // Assert
+        SkipIfDegraded(turn2);
         turn2.Text.ShouldContain("56");
         turn2.StopReason.ShouldBe(StopReason.Stop);
+    }
+
+    /// <summary>
+    /// Probes the GitHub Models API with a minimal completion request to detect
+    /// whether the service is operational. Returns false if the API returns empty
+    /// responses, errors, or is unreachable.
+    /// </summary>
+    private async Task<bool> ProbeApiAvailabilityAsync()
+    {
+        if (_provider is null || _model is null)
+            return false;
+
+        try
+        {
+            var context = new Context(
+                SystemPrompt: "Reply with OK.",
+                Messages: [new UserMessage(new UserMessageContent("ping"), Ts - 1)]);
+
+            var result = await CollectStreamAsync(_provider.Stream(_model, context));
+            return !string.IsNullOrWhiteSpace(result.Text);
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (TaskCanceledException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Skips the current test if the API returned an empty response, indicating
+    /// the provider is degraded (returning 200 with no content).
+    /// </summary>
+    private static void SkipIfDegraded(StreamResult result)
+    {
+        Skip.If(
+            string.IsNullOrWhiteSpace(result.Text) && result.ToolCalls.Count == 0,
+            ApiDegradedReason);
     }
 
     /// <summary>Collects a stream into a simple result for assertions.</summary>

--- a/tests/integration/BotNexus.Integration.ProviderTests/RequiresGitHubTokenFact.cs
+++ b/tests/integration/BotNexus.Integration.ProviderTests/RequiresGitHubTokenFact.cs
@@ -1,10 +1,14 @@
+using Xunit;
+
 namespace BotNexus.Integration.ProviderTests;
 
 /// <summary>
 /// Skip guard for integration tests that require a GITHUB_TOKEN.
 /// Tests are gracefully skipped when the token is not present (local dev runs).
+/// Inherits from <see cref="SkippableFactAttribute"/> so tests can also skip
+/// at runtime via <c>Skip.If(...)</c> when the external API is degraded.
 /// </summary>
-public class RequiresGitHubTokenFactAttribute : FactAttribute
+public class RequiresGitHubTokenFactAttribute : SkippableFactAttribute
 {
     public RequiresGitHubTokenFactAttribute()
     {


### PR DESCRIPTION
Closes #1129

## Changes
- **RequiresGitHubTokenFact** now inherits from \SkippableFactAttribute\ (from Xunit.SkippableFact) enabling runtime skip via \Skip.If(...)\
- **API availability probe**: \ProbeApiAvailabilityAsync()\ runs once in \InitializeAsync\ — sends a minimal completion request and marks the API as unavailable if it returns empty
- **Per-test degradation guard**: \SkipIfDegraded(result)\ checks each response and skips if text is empty AND no tool calls returned
- **All 6 tests** now skip gracefully when the API is degraded instead of failing assertions

## Root Cause
The GitHub Models API (\models.inference.ai.azure.com\) periodically returns HTTP 200 with empty response bodies. This causes all integration tests to fail with null/empty assertion errors, making main branch CI red even though there is no code regression.

## Merge Notes
This PR only touches files under \	ests/integration/BotNexus.Integration.ProviderTests/\. No overlap with any other open PR. Safe to merge in any order.