### PR TITLE
feat(providers): add dynamic model discovery at startup with built-in fallback

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Copilot/CopilotModelDiscoveryProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/CopilotModelDiscoveryProvider.cs
@@ -1,0 +1,228 @@
+using BotNexus.Agent.Providers.Copilot.Discovery;
+using BotNexus.Agent.Providers.Core.Compatibility;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Agent.Providers.Copilot;
+
+/// <summary>
+/// Discovers available models from the GitHub Copilot API at startup.
+/// Maps <see cref="CopilotModelInfo"/> responses into <see cref="LlmModel"/>
+/// entries using vendor/family heuristics to determine the correct API format.
+/// </summary>
+public sealed class CopilotModelDiscoveryProvider : IModelDiscoveryProvider
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "github-copilot";
+
+    private static readonly IReadOnlyDictionary<string, string> CopilotHeaders = new Dictionary<string, string>
+    {
+        ["User-Agent"] = "GitHubCopilotChat/0.35.0",
+        ["Editor-Version"] = "vscode/1.107.0",
+        ["Editor-Plugin-Version"] = "copilot-chat/0.35.0",
+        ["Copilot-Integration-Id"] = "vscode-chat"
+    };
+
+    private static readonly OpenAICompletionsCompat CopilotCompletionsCompat = new()
+    {
+        SupportsStore = false,
+        SupportsDeveloperRole = false,
+        SupportsReasoningEffort = false
+    };
+
+    private static readonly ModelCost FreeCost = new(0, 0, 0, 0);
+
+    private readonly CopilotDiscoveryClient _discoveryClient;
+    private readonly Func<CancellationToken, Task<(string? SessionToken, string? Endpoint)>> _credentialResolver;
+    private readonly ILogger<CopilotModelDiscoveryProvider> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="CopilotModelDiscoveryProvider"/>.
+    /// </summary>
+    /// <param name="discoveryClient">The Copilot discovery HTTP client.</param>
+    /// <param name="credentialResolver">
+    /// Resolves a valid Copilot session token and API endpoint.
+    /// Returns (null, null) if credentials are unavailable.
+    /// </param>
+    /// <param name="logger">Logger.</param>
+    public CopilotModelDiscoveryProvider(
+        CopilotDiscoveryClient discoveryClient,
+        Func<CancellationToken, Task<(string? SessionToken, string? Endpoint)>> credentialResolver,
+        ILogger<CopilotModelDiscoveryProvider> logger)
+    {
+        _discoveryClient = discoveryClient ?? throw new ArgumentNullException(nameof(discoveryClient));
+        _credentialResolver = credentialResolver ?? throw new ArgumentNullException(nameof(credentialResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<LlmModel>?> DiscoverModelsAsync(CancellationToken cancellationToken = default)
+    {
+        var (sessionToken, endpoint) = await _credentialResolver(cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(sessionToken) || string.IsNullOrWhiteSpace(endpoint))
+        {
+            _logger.LogDebug("Copilot model discovery skipped: no valid credentials available.");
+            return null;
+        }
+
+        var response = await _discoveryClient.GetModelsAsync(endpoint, sessionToken, cancellationToken).ConfigureAwait(false);
+
+        if (response.Data is null || response.Data.Count == 0)
+        {
+            _logger.LogDebug("Copilot model discovery returned no models.");
+            return null;
+        }
+
+        var models = new List<LlmModel>(response.Data.Count);
+
+        foreach (var info in response.Data)
+        {
+            if (string.IsNullOrWhiteSpace(info.Id))
+                continue;
+
+            var model = MapToLlmModel(info);
+            if (model is not null)
+                models.Add(model);
+        }
+
+        return models;
+    }
+
+    /// <summary>
+    /// Maps a <see cref="CopilotModelInfo"/> to an <see cref="LlmModel"/>.
+    /// Uses vendor + family heuristics to determine API format, reasoning support,
+    /// and input modalities.
+    /// </summary>
+    public static LlmModel? MapToLlmModel(CopilotModelInfo info)
+    {
+        if (string.IsNullOrWhiteSpace(info.Id))
+            return null;
+
+        var id = info.Id;
+        var name = info.Name ?? info.Id;
+        var family = info.Capabilities?.Family ?? string.Empty;
+        var vendor = info.Vendor ?? string.Empty;
+
+        var api = ResolveApiFormat(id, family, vendor);
+        var reasoning = IsReasoningModel(id, family);
+        var supportsExtraHigh = SupportsExtraHighThinking(id, family);
+        var input = ResolveInputModalities(info);
+        var (contextWindow, maxTokens) = ResolveLimits(info);
+        var compat = api == "github-copilot-completions" ? CopilotCompletionsCompat : null;
+
+        return new LlmModel(
+            Id: id,
+            Name: name,
+            Api: api,
+            Provider: "github-copilot",
+            BaseUrl: "https://api.individual.githubcopilot.com",
+            Reasoning: reasoning,
+            Input: input,
+            Cost: FreeCost,
+            ContextWindow: contextWindow,
+            MaxTokens: maxTokens,
+            SupportsExtraHighThinking: supportsExtraHigh,
+            Headers: CopilotHeaders,
+            Compat: compat);
+    }
+
+    /// <summary>
+    /// Resolves the API format based on model family/vendor/id heuristics.
+    /// </summary>
+    public static string ResolveApiFormat(string id, string family, string vendor)
+    {
+        // Claude models use the messages API
+        if (family.StartsWith("claude", StringComparison.OrdinalIgnoreCase) ||
+            id.StartsWith("claude", StringComparison.OrdinalIgnoreCase))
+            return "github-copilot-messages";
+
+        // GPT-5+ and o-series use the responses API
+        if (id.StartsWith("gpt-5", StringComparison.OrdinalIgnoreCase) ||
+            id.StartsWith("o3", StringComparison.OrdinalIgnoreCase) ||
+            id.StartsWith("o4", StringComparison.OrdinalIgnoreCase))
+            return "github-copilot-responses";
+
+        // Everything else (GPT-4, Gemini, Grok, etc.) uses completions
+        return "github-copilot-completions";
+    }
+
+    /// <summary>
+    /// Determines if a model supports reasoning/thinking based on family and id.
+    /// </summary>
+    public static bool IsReasoningModel(string id, string family)
+    {
+        // Claude 4+ and Sonnet 4.5+ support thinking
+        if (id.StartsWith("claude-opus-4", StringComparison.OrdinalIgnoreCase) ||
+            id.StartsWith("claude-sonnet-4", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // GPT-5+ supports reasoning
+        if (id.StartsWith("gpt-5", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // o-series models
+        if (id.StartsWith("o3", StringComparison.OrdinalIgnoreCase) ||
+            id.StartsWith("o4", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Gemini 3+
+        if (id.StartsWith("gemini-3", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Grok code
+        if (id.StartsWith("grok-code", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines if a model supports extra-high thinking budget.
+    /// </summary>
+    public static bool SupportsExtraHighThinking(string id, string family)
+    {
+        // Claude Opus 4.6+ supports extra high
+        if (id.StartsWith("claude-opus-4.", StringComparison.OrdinalIgnoreCase))
+        {
+            var versionPart = id.AsSpan()["claude-opus-4.".Length..];
+            if (versionPart.Length > 0 && char.IsDigit(versionPart[0]) && versionPart[0] >= '6')
+                return true;
+        }
+
+        // GPT 5.2+
+        if (id.StartsWith("gpt-5.", StringComparison.OrdinalIgnoreCase))
+        {
+            var versionPart = id.AsSpan()["gpt-5.".Length..];
+            if (versionPart.Length > 0 && char.IsDigit(versionPart[0]) && versionPart[0] >= '2')
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<string> ResolveInputModalities(CopilotModelInfo info)
+    {
+        var supportsVision = info.Capabilities?.Supports?.Vision ?? false;
+        return supportsVision ? ["text", "image"] : ["text"];
+    }
+
+    private static (int ContextWindow, int MaxTokens) ResolveLimits(CopilotModelInfo info)
+    {
+        var limits = info.Capabilities?.Limits;
+        int contextWindow = 128000; // default
+        int maxTokens = 32000; // default
+
+        if (limits is null)
+            return (contextWindow, maxTokens);
+
+        if (limits.TryGetValue("max_prompt_tokens", out var promptEl) && promptEl.TryGetInt32(out var promptTokens))
+            contextWindow = promptTokens;
+
+        if (limits.TryGetValue("max_output_tokens", out var outputEl) && outputEl.TryGetInt32(out var outputTokens))
+            maxTokens = outputTokens;
+
+        return (contextWindow, maxTokens);
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Core/Registry/IModelDiscoveryProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Registry/IModelDiscoveryProvider.cs
@@ -1,0 +1,28 @@
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Providers.Core.Registry;
+
+/// <summary>
+/// Discovers available models from a provider's API at runtime.
+/// Implementations are registered in DI and invoked at startup to overlay
+/// dynamic models onto the built-in model registry.
+/// </summary>
+public interface IModelDiscoveryProvider
+{
+    /// <summary>
+    /// Provider key this discovery handles (e.g. "github-copilot", "anthropic").
+    /// </summary>
+    string ProviderKey { get; }
+
+    /// <summary>
+    /// Discover available models from the provider API. Returns null if discovery
+    /// is unavailable (no credentials, network error, provider unsupported) —
+    /// caller falls back to built-in models.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A list of discovered models to register, or null if discovery failed or
+    /// is not available for this provider.
+    /// </returns>
+    Task<IReadOnlyList<LlmModel>?> DiscoverModelsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -16,8 +16,11 @@ using BotNexus.Agent.Providers.Core.Registry;
 using Microsoft.Extensions.Options;
 using BotNexus.Agent.Providers.OpenAI;
 using BotNexus.Agent.Providers.OpenAICompat;
+using BotNexus.Agent.Providers.Copilot;
+using BotNexus.Agent.Providers.Copilot.Discovery;
 using BotNexus.Agent.Providers.GitHubModels;
 using BotNexus.Agent.Providers.IntegrationMock;
+using BotNexus.Gateway.Models;
 using BotNexus.Cron;
 using BotNexus.Cron.Extensions;
 using BotNexus.Domain.World;
@@ -252,6 +255,26 @@ builder.Services.AddSingleton<LlmClient>(serviceProvider =>
     serviceProvider.GetRequiredService<BuiltInModels>().RegisterAll(models);
     new IntegrationMockModels().RegisterAll(models);
     GitHubModelsProvider.RegisterModels(models);
+
+    // Dynamic model discovery: overlay live API models onto built-in registry.
+    // Discovery is best-effort — failures fall back to built-in models.
+    var authManager = serviceProvider.GetRequiredService<GatewayAuthManager>();
+    var discoveryClient = new CopilotDiscoveryClient(httpClient);
+    var copilotDiscovery = new CopilotModelDiscoveryProvider(
+        discoveryClient,
+        async ct =>
+        {
+            var apiKey = await authManager.GetApiKeyAsync("github-copilot", ct);
+            var endpoint = authManager.GetApiEndpoint("github-copilot");
+            return (apiKey, endpoint);
+        },
+        loggerFactory.CreateLogger<CopilotModelDiscoveryProvider>());
+
+    var discoveryService = new ModelDiscoveryService(
+        models,
+        [copilotDiscovery],
+        loggerFactory.CreateLogger<ModelDiscoveryService>());
+    discoveryService.DiscoverAndRegisterAsync().GetAwaiter().GetResult();
 
     // Register models from openai-compat providers in config (e.g. Ollama, LM Studio),
     // or any provider with an explicit Api override (e.g. integration-mock).

--- a/src/gateway/BotNexus.Gateway/Models/ModelDiscoveryService.cs
+++ b/src/gateway/BotNexus.Gateway/Models/ModelDiscoveryService.cs
@@ -1,0 +1,87 @@
+using BotNexus.Agent.Providers.Core.Registry;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Models;
+
+/// <summary>
+/// Runs model discovery at startup by invoking all registered
+/// <see cref="IModelDiscoveryProvider"/> instances and merging results
+/// into the <see cref="ModelRegistry"/>. Discovery is best-effort:
+/// failures are logged and the built-in registry remains as fallback.
+/// </summary>
+public sealed class ModelDiscoveryService
+{
+    private readonly ModelRegistry _modelRegistry;
+    private readonly IEnumerable<IModelDiscoveryProvider> _discoveryProviders;
+    private readonly ILogger<ModelDiscoveryService> _logger;
+
+    /// <summary>Default timeout for each provider's discovery call.</summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    public ModelDiscoveryService(
+        ModelRegistry modelRegistry,
+        IEnumerable<IModelDiscoveryProvider> discoveryProviders,
+        ILogger<ModelDiscoveryService> logger)
+    {
+        _modelRegistry = modelRegistry ?? throw new ArgumentNullException(nameof(modelRegistry));
+        _discoveryProviders = discoveryProviders ?? throw new ArgumentNullException(nameof(discoveryProviders));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Runs discovery for all registered providers and merges results into the registry.
+    /// Dynamic models overwrite matching built-in entries (same provider + modelId).
+    /// New models not in built-in are added. Discovery failures do not remove existing entries.
+    /// </summary>
+    public async Task DiscoverAndRegisterAsync(CancellationToken cancellationToken = default)
+    {
+        foreach (var provider in _discoveryProviders)
+        {
+            await DiscoverFromProviderAsync(provider, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DiscoverFromProviderAsync(IModelDiscoveryProvider provider, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(DefaultTimeout);
+
+            var models = await provider.DiscoverModelsAsync(timeoutCts.Token).ConfigureAwait(false);
+
+            if (models is null)
+            {
+                _logger.LogDebug("Model discovery for provider {ProviderKey} returned null (unavailable). Using built-in models.", provider.ProviderKey);
+                return;
+            }
+
+            var added = 0;
+            var overwritten = 0;
+
+            foreach (var model in models)
+            {
+                var existing = _modelRegistry.GetModel(provider.ProviderKey, model.Id);
+                _modelRegistry.Register(provider.ProviderKey, model);
+
+                if (existing is not null)
+                    overwritten++;
+                else
+                    added++;
+            }
+
+            _logger.LogInformation(
+                "Model discovery for provider {ProviderKey}: {Added} new, {Overwritten} updated (total {Total} discovered).",
+                provider.ProviderKey, added, overwritten, models.Count);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("Model discovery for provider {ProviderKey} timed out after {Timeout}s. Using built-in models.",
+                provider.ProviderKey, DefaultTimeout.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Model discovery for provider {ProviderKey} failed. Using built-in models.", provider.ProviderKey);
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Models/CopilotModelDiscoveryProviderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Models/CopilotModelDiscoveryProviderTests.cs
@@ -1,0 +1,200 @@
+using BotNexus.Agent.Providers.Copilot;
+using BotNexus.Agent.Providers.Copilot.Discovery;
+
+namespace BotNexus.Gateway.Tests.Models;
+
+public sealed class CopilotModelDiscoveryProviderTests
+{
+    [Theory]
+    [InlineData("claude-sonnet-4.6", "claude", "Anthropic", "github-copilot-messages")]
+    [InlineData("claude-opus-4.8", "claude", "Anthropic", "github-copilot-messages")]
+    [InlineData("claude-haiku-4.5", "claude", "Anthropic", "github-copilot-messages")]
+    [InlineData("gpt-5", "gpt", "OpenAI", "github-copilot-responses")]
+    [InlineData("gpt-5.2", "gpt", "OpenAI", "github-copilot-responses")]
+    [InlineData("gpt-5.4-mini", "gpt", "OpenAI", "github-copilot-responses")]
+    [InlineData("gpt-4.1", "gpt", "OpenAI", "github-copilot-completions")]
+    [InlineData("gpt-4o", "gpt", "OpenAI", "github-copilot-completions")]
+    [InlineData("gemini-2.5-pro", "gemini", "Google", "github-copilot-completions")]
+    [InlineData("gemini-3-flash-preview", "gemini", "Google", "github-copilot-completions")]
+    [InlineData("o3", "o3", "OpenAI", "github-copilot-responses")]
+    [InlineData("o4-mini", "o4", "OpenAI", "github-copilot-responses")]
+    [InlineData("grok-code-fast-1", "grok", "xAI", "github-copilot-completions")]
+    public void ResolveApiFormat_MapsCorrectly(string modelId, string family, string vendor, string expectedApi)
+    {
+        var result = CopilotModelDiscoveryProvider.ResolveApiFormat(modelId, family, vendor);
+        result.ShouldBe(expectedApi);
+    }
+
+    [Theory]
+    [InlineData("claude-opus-4.6", "claude", true)]
+    [InlineData("claude-sonnet-4.6", "claude", true)]
+    [InlineData("claude-haiku-4.5", "claude", false)]
+    [InlineData("gpt-5", "gpt", true)]
+    [InlineData("gpt-5.2", "gpt", true)]
+    [InlineData("gpt-4.1", "gpt", false)]
+    [InlineData("gpt-4o", "gpt", false)]
+    [InlineData("gemini-3-flash-preview", "gemini", true)]
+    [InlineData("gemini-2.5-pro", "gemini", false)]
+    [InlineData("o3", "o3", true)]
+    [InlineData("o4-mini", "o4", true)]
+    [InlineData("grok-code-fast-1", "grok", true)]
+    public void IsReasoningModel_CorrectlyIdentifies(string modelId, string family, bool expected)
+    {
+        var result = CopilotModelDiscoveryProvider.IsReasoningModel(modelId, family);
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("claude-opus-4.6", "claude", true)]
+    [InlineData("claude-opus-4.8", "claude", true)]
+    [InlineData("claude-opus-4.5", "claude", false)]
+    [InlineData("claude-sonnet-4.6", "claude", false)]
+    [InlineData("gpt-5.2", "gpt", true)]
+    [InlineData("gpt-5.4", "gpt", true)]
+    [InlineData("gpt-5.1", "gpt", false)]
+    [InlineData("gpt-5", "gpt", false)]
+    [InlineData("gpt-4.1", "gpt", false)]
+    public void SupportsExtraHighThinking_CorrectlyIdentifies(string modelId, string family, bool expected)
+    {
+        var result = CopilotModelDiscoveryProvider.SupportsExtraHighThinking(modelId, family);
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void MapToLlmModel_MapsAllFields()
+    {
+        // Arrange
+        var info = new CopilotModelInfo
+        {
+            Id = "claude-sonnet-4.6",
+            Name = "Claude Sonnet 4.6",
+            Vendor = "Anthropic",
+            Capabilities = new CopilotModelCapabilities
+            {
+                Family = "claude",
+                Supports = new CopilotModelSupports { Vision = true, ToolCalls = true, Streaming = true },
+                Limits = new Dictionary<string, System.Text.Json.JsonElement>
+                {
+                    ["max_prompt_tokens"] = System.Text.Json.JsonDocument.Parse("1000000").RootElement,
+                    ["max_output_tokens"] = System.Text.Json.JsonDocument.Parse("32000").RootElement
+                }
+            }
+        };
+
+        // Act
+        var model = CopilotModelDiscoveryProvider.MapToLlmModel(info);
+
+        // Assert
+        model.ShouldNotBeNull();
+        model.Id.ShouldBe("claude-sonnet-4.6");
+        model.Name.ShouldBe("Claude Sonnet 4.6");
+        model.Api.ShouldBe("github-copilot-messages");
+        model.Provider.ShouldBe("github-copilot");
+        model.Reasoning.ShouldBeTrue();
+        model.Input.ShouldContain("text");
+        model.Input.ShouldContain("image");
+        model.ContextWindow.ShouldBe(1000000);
+        model.MaxTokens.ShouldBe(32000);
+        model.SupportsExtraHighThinking.ShouldBe(false);
+        model.Headers.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void MapToLlmModel_NoVision_TextOnly()
+    {
+        // Arrange
+        var info = new CopilotModelInfo
+        {
+            Id = "gpt-4.1",
+            Name = "GPT-4.1",
+            Vendor = "OpenAI",
+            Capabilities = new CopilotModelCapabilities
+            {
+                Family = "gpt",
+                Supports = new CopilotModelSupports { Vision = false }
+            }
+        };
+
+        // Act
+        var model = CopilotModelDiscoveryProvider.MapToLlmModel(info);
+
+        // Assert
+        model.ShouldNotBeNull();
+        model.Input.ShouldBe(new[] { "text" });
+    }
+
+    [Fact]
+    public void MapToLlmModel_NullCapabilities_UsesDefaults()
+    {
+        // Arrange
+        var info = new CopilotModelInfo
+        {
+            Id = "unknown-model",
+            Name = "Unknown"
+        };
+
+        // Act
+        var model = CopilotModelDiscoveryProvider.MapToLlmModel(info);
+
+        // Assert
+        model.ShouldNotBeNull();
+        model.ContextWindow.ShouldBe(128000); // default
+        model.MaxTokens.ShouldBe(32000); // default
+        model.Input.ShouldBe(new[] { "text" });
+    }
+
+    [Fact]
+    public void MapToLlmModel_NullId_ReturnsNull()
+    {
+        var info = new CopilotModelInfo { Id = null };
+        CopilotModelDiscoveryProvider.MapToLlmModel(info).ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapToLlmModel_EmptyId_ReturnsNull()
+    {
+        var info = new CopilotModelInfo { Id = "   " };
+        CopilotModelDiscoveryProvider.MapToLlmModel(info).ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapToLlmModel_CompletionsApi_SetsCompat()
+    {
+        // Arrange
+        var info = new CopilotModelInfo
+        {
+            Id = "gpt-4o",
+            Name = "GPT-4o",
+            Vendor = "OpenAI",
+            Capabilities = new CopilotModelCapabilities { Family = "gpt" }
+        };
+
+        // Act
+        var model = CopilotModelDiscoveryProvider.MapToLlmModel(info);
+
+        // Assert
+        model.ShouldNotBeNull();
+        model.Api.ShouldBe("github-copilot-completions");
+        model.Compat.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void MapToLlmModel_MessagesApi_NoCompat()
+    {
+        // Arrange
+        var info = new CopilotModelInfo
+        {
+            Id = "claude-sonnet-4.6",
+            Vendor = "Anthropic",
+            Capabilities = new CopilotModelCapabilities { Family = "claude" }
+        };
+
+        // Act
+        var model = CopilotModelDiscoveryProvider.MapToLlmModel(info);
+
+        // Assert
+        model.ShouldNotBeNull();
+        model.Api.ShouldBe("github-copilot-messages");
+        model.Compat.ShouldBeNull();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Models/ModelDiscoveryServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Models/ModelDiscoveryServiceTests.cs
@@ -1,0 +1,209 @@
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Gateway.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Models;
+
+public sealed class ModelDiscoveryServiceTests
+{
+    private readonly ModelRegistry _registry = new();
+    private readonly NullLogger<ModelDiscoveryService> _logger = NullLogger<ModelDiscoveryService>.Instance;
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_RegistersNewModels()
+    {
+        // Arrange
+        var discoveredModels = new List<LlmModel>
+        {
+            CreateModel("new-model-1", "New Model 1"),
+            CreateModel("new-model-2", "New Model 2")
+        };
+
+        var provider = new FakeDiscoveryProvider("test-provider", discoveredModels);
+        var service = new ModelDiscoveryService(_registry, [provider], _logger);
+
+        // Act
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert
+        _registry.GetModel("test-provider", "new-model-1").ShouldNotBeNull();
+        _registry.GetModel("test-provider", "new-model-2").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_OverwritesExistingModels()
+    {
+        // Arrange: register a built-in model first
+        var builtIn = CreateModel("existing-model", "Built-In Name", contextWindow: 64000);
+        _registry.Register("test-provider", builtIn);
+
+        var dynamic = CreateModel("existing-model", "Dynamic Name", contextWindow: 200000);
+        var provider = new FakeDiscoveryProvider("test-provider", [dynamic]);
+        var service = new ModelDiscoveryService(_registry, [provider], _logger);
+
+        // Act
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert
+        var resolved = _registry.GetModel("test-provider", "existing-model")!;
+        resolved.Name.ShouldBe("Dynamic Name");
+        resolved.ContextWindow.ShouldBe(200000);
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_NullResult_PreservesExistingModels()
+    {
+        // Arrange: register a built-in model first
+        var builtIn = CreateModel("existing-model", "Built-In Name");
+        _registry.Register("test-provider", builtIn);
+
+        var provider = new FakeDiscoveryProvider("test-provider", result: null);
+        var service = new ModelDiscoveryService(_registry, [provider], _logger);
+
+        // Act
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert: built-in still present
+        _registry.GetModel("test-provider", "existing-model").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_ExceptionInProvider_DoesNotThrow()
+    {
+        // Arrange
+        var builtIn = CreateModel("existing-model", "Built-In Name");
+        _registry.Register("test-provider", builtIn);
+
+        var provider = new ThrowingDiscoveryProvider("test-provider");
+        var service = new ModelDiscoveryService(_registry, [provider], _logger);
+
+        // Act — should not throw
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert: built-in still present
+        _registry.GetModel("test-provider", "existing-model").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_Timeout_SkipsGracefully()
+    {
+        // Arrange
+        var builtIn = CreateModel("existing-model", "Built-In Name");
+        _registry.Register("slow-provider", builtIn);
+
+        var provider = new SlowDiscoveryProvider("slow-provider", delay: TimeSpan.FromSeconds(30));
+        var service = new ModelDiscoveryService(_registry, [provider], _logger);
+
+        // Act — should complete quickly (10s timeout is internal)
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await service.DiscoverAndRegisterAsync(cts.Token);
+
+        // Assert: built-in still present, no dynamic models added
+        _registry.GetModel("slow-provider", "existing-model").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_MultipleProviders_IndependentlyProcessed()
+    {
+        // Arrange
+        var provider1 = new FakeDiscoveryProvider("provider-a", [CreateModel("model-a", "Model A")]);
+        var provider2 = new FakeDiscoveryProvider("provider-b", [CreateModel("model-b", "Model B")]);
+        var service = new ModelDiscoveryService(_registry, [provider1, provider2], _logger);
+
+        // Act
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert
+        _registry.GetModel("provider-a", "model-a").ShouldNotBeNull();
+        _registry.GetModel("provider-b", "model-b").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_FailingProvider_DoesNotAffectOthers()
+    {
+        // Arrange
+        var failingProvider = new ThrowingDiscoveryProvider("bad-provider");
+        var goodProvider = new FakeDiscoveryProvider("good-provider", [CreateModel("good-model", "Good")]);
+        var service = new ModelDiscoveryService(_registry, [failingProvider, goodProvider], _logger);
+
+        // Act
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert: good provider's model is registered despite the other failing
+        _registry.GetModel("good-provider", "good-model").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task DiscoverAndRegisterAsync_DoesNotRemoveBuiltInModelsNotInDiscovery()
+    {
+        // Arrange: register two built-in models
+        _registry.Register("test-provider", CreateModel("model-a", "A"));
+        _registry.Register("test-provider", CreateModel("model-b", "B"));
+
+        // Discovery only returns model-a (not model-b)
+        var provider = new FakeDiscoveryProvider("test-provider", [CreateModel("model-a", "Updated A")]);
+        var service = new ModelDiscoveryService(_registry, [provider], _logger);
+
+        // Act
+        await service.DiscoverAndRegisterAsync();
+
+        // Assert: model-b is still present (not removed)
+        _registry.GetModel("test-provider", "model-a")!.Name.ShouldBe("Updated A");
+        _registry.GetModel("test-provider", "model-b").ShouldNotBeNull();
+    }
+
+    private static LlmModel CreateModel(string id, string name, int contextWindow = 128000) => new(
+        Id: id,
+        Name: name,
+        Api: "test-api",
+        Provider: "test-provider",
+        BaseUrl: "https://test.example.com",
+        Reasoning: false,
+        Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: contextWindow,
+        MaxTokens: 32000);
+
+    private sealed class FakeDiscoveryProvider : IModelDiscoveryProvider
+    {
+        public string ProviderKey { get; }
+        private readonly IReadOnlyList<LlmModel>? _result;
+
+        public FakeDiscoveryProvider(string providerKey, IReadOnlyList<LlmModel>? result)
+        {
+            ProviderKey = providerKey;
+            _result = result;
+        }
+
+        public Task<IReadOnlyList<LlmModel>?> DiscoverModelsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_result);
+    }
+
+    private sealed class ThrowingDiscoveryProvider : IModelDiscoveryProvider
+    {
+        public string ProviderKey { get; }
+        public ThrowingDiscoveryProvider(string providerKey) => ProviderKey = providerKey;
+
+        public Task<IReadOnlyList<LlmModel>?> DiscoverModelsAsync(CancellationToken cancellationToken = default)
+            => throw new HttpRequestException("Network error");
+    }
+
+    private sealed class SlowDiscoveryProvider : IModelDiscoveryProvider
+    {
+        public string ProviderKey { get; }
+        private readonly TimeSpan _delay;
+
+        public SlowDiscoveryProvider(string providerKey, TimeSpan delay)
+        {
+            ProviderKey = providerKey;
+            _delay = delay;
+        }
+
+        public async Task<IReadOnlyList<LlmModel>?> DiscoverModelsAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(_delay, cancellationToken);
+            return [new LlmModel("slow-model", "Slow", "test", "slow-provider", "", false, ["text"], new ModelCost(0,0,0,0), 128000, 32000)];
+        }
+    }
+}


### PR DESCRIPTION
Closes #1091

## Changes

### New interface: IModelDiscoveryProvider (Providers.Core)
- Contract for providers to discover models from their live API
- Returns \IReadOnlyList<LlmModel>?\ — null means unavailable (fallback to built-in)

### ModelDiscoveryService (Gateway)
- Iterates all registered \IModelDiscoveryProvider\ instances at startup
- Per-provider 10s timeout with graceful fallback on failure
- Dynamic models overwrite matching built-in entries (same provider + modelId)
- New models not in built-in are added; built-in models absent from discovery are preserved
- All exceptions caught and logged — never blocks startup

### CopilotModelDiscoveryProvider (Providers.Copilot)
- Calls \GET {endpoints.api}/models\ using existing auth infrastructure
- Maps \CopilotModelInfo\ → \LlmModel\ using vendor/family heuristics:
  - \claude-*\ → \github-copilot-messages\
  - \gpt-5*\, \o3\, \o4\ → \github-copilot-responses\
  - Everything else → \github-copilot-completions\
- Resolves context window, max tokens, vision, reasoning, extra-high from API response
- Returns null if no credentials available

### Program.cs integration
- Discovery runs after \BuiltInModels.RegisterAll()\ + \GitHubModelsProvider.RegisterModels()\
- Runs before config-based model registration (user overrides still win)
- Uses \GatewayAuthManager\ for credential resolution

### Tests
- 8 ModelDiscoveryService tests: register new, overwrite existing, null fallback, exception handling, timeout, multi-provider independence, non-removal of missing models
- 14+ CopilotModelDiscoveryProvider tests: API format resolution, reasoning detection, extra-high thinking, full field mapping, null/empty handling, compat object wiring

## Merge Notes
This PR touches \Program.cs\ (additive — 20 lines in the LlmClient factory) and adds 4 new files. No overlap with open PRs #1123, #1127, #1128, #1130. Safe to merge in any order.