### PR TITLE
feat(cli): add debug logs subcommand for direct log file inspection

### DIFF
--- a/src/gateway/BotNexus.Cli/CliApp.cs
+++ b/src/gateway/BotNexus.Cli/CliApp.cs
@@ -105,6 +105,7 @@ internal static class CliApp
             .AddSingleton<ProviderCommand>()
             .AddSingleton<CronCommands>()
             .AddSingleton<SatelliteCommand>()
+            .AddSingleton<DebugCommand>()
             .BuildServiceProvider();
     }
 
@@ -132,6 +133,7 @@ internal static class CliApp
         root.AddCommand(serviceProvider.GetRequiredService<ProviderCommand>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<CronCommands>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<SatelliteCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<DebugCommand>().Build(verboseOption, targetOption));
 
         return root;
     }

--- a/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
@@ -1,0 +1,22 @@
+using System.CommandLine;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// Top-level <c>botnexus debug</c> command that groups diagnostic subcommands
+/// for offline platform inspection. All debug subcommands operate directly on
+/// local files (SQLite databases, log files) without requiring a running gateway.
+/// </summary>
+internal sealed class DebugCommand
+{
+    private readonly DebugLogsCommand _logs = new();
+
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
+    {
+        var command = new Command("debug", "Platform diagnostics — inspect sessions, logs, and databases offline.");
+
+        command.AddCommand(_logs.Build(targetOption));
+
+        return command;
+    }
+}

--- a/src/gateway/BotNexus.Cli/Commands/DebugLogsCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugLogsCommand.cs
@@ -1,0 +1,357 @@
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// CLI subcommands for inspecting BotNexus log files directly without
+/// requiring a running gateway instance. Reads hourly-rotated log files
+/// from ~/.botnexus/logs/ with pattern botnexus-YYYYMMDDH.log.
+/// </summary>
+internal sealed class DebugLogsCommand
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Regex to parse Serilog structured log lines.
+    /// Format: 2026-06-10 14:30:15.123 +00:00 [INF] Message text
+    /// </summary>
+    internal static readonly Regex LogLinePattern = new(
+        @"^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3})\s*([+-]\d{2}:\d{2})?\s*\[(\w{3})\]\s*(.*)",
+        RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(100));
+
+    public Command Build(Option<string?> targetOption)
+    {
+        var command = new Command("logs", "Inspect log files directly (offline, no gateway required).");
+
+        var formatOption = new Option<string>("--format", () => "table", "Output format: table or json.");
+        command.AddOption(formatOption);
+
+        // ── tail ──
+        var limitOption = new Option<int>("--limit", () => 50, "Maximum lines to return.");
+        var levelOption = new Option<string?>("--level", "Filter by log level: debug, info, warn, error.");
+
+        var tailCommand = new Command("tail", "Show most recent log lines.")
+        {
+            limitOption, levelOption
+        };
+        tailCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var limit = context.ParseResult.GetValueForOption(limitOption);
+            var level = context.ParseResult.GetValueForOption(levelOption);
+            var logsDir = ResolveLogsDir(target);
+            context.ExitCode = ExecuteTail(logsDir, limit, level, format);
+            return Task.CompletedTask;
+        });
+
+        // ── errors ──
+        var errorsLimitOption = new Option<int>("--limit", () => 20, "Maximum error lines to return.");
+        var errorsCommand = new Command("errors", "Show recent error log lines (shorthand for tail --level error).")
+        {
+            errorsLimitOption
+        };
+        errorsCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var limit = context.ParseResult.GetValueForOption(errorsLimitOption);
+            var logsDir = ResolveLogsDir(target);
+            context.ExitCode = ExecuteTail(logsDir, limit, "error", format);
+            return Task.CompletedTask;
+        });
+
+        // ── search ──
+        var termOption = new Option<string>("--term", "Keyword to search for.") { IsRequired = true };
+        var sinceOption = new Option<string?>("--since", "Only search log files after this datetime (ISO format).");
+        var searchLimitOption = new Option<int>("--limit", () => 50, "Maximum matching lines to return.");
+
+        var searchCommand = new Command("search", "Search across log files for a keyword.")
+        {
+            termOption, sinceOption, searchLimitOption
+        };
+        searchCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var term = context.ParseResult.GetValueForOption(termOption)!;
+            var since = context.ParseResult.GetValueForOption(sinceOption);
+            var limit = context.ParseResult.GetValueForOption(searchLimitOption);
+            var logsDir = ResolveLogsDir(target);
+            context.ExitCode = ExecuteSearch(logsDir, term, since, limit, format);
+            return Task.CompletedTask;
+        });
+
+        // ── session ──
+        var sessionIdArg = new Argument<string>("session-id", "Session ID to search for in logs.");
+        var sessionLimitOption = new Option<int>("--limit", () => 100, "Maximum matching lines to return.");
+
+        var sessionCommand = new Command("session", "Find all log lines mentioning a session ID.")
+        {
+            sessionIdArg, sessionLimitOption
+        };
+        sessionCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var sessionId = context.ParseResult.GetValueForArgument(sessionIdArg);
+            var limit = context.ParseResult.GetValueForOption(sessionLimitOption);
+            var logsDir = ResolveLogsDir(target);
+            context.ExitCode = ExecuteSearch(logsDir, sessionId, null, limit, format);
+            return Task.CompletedTask;
+        });
+
+        command.AddCommand(tailCommand);
+        command.AddCommand(errorsCommand);
+        command.AddCommand(searchCommand);
+        command.AddCommand(sessionCommand);
+        return command;
+    }
+
+    internal static string ResolveLogsDir(string? target)
+    {
+        var home = CliPaths.ResolveTarget(target);
+        return Path.Combine(home, "logs");
+    }
+
+    internal static int ExecuteTail(string logsDir, int limit, string? level, string format)
+    {
+        if (!Directory.Exists(logsDir))
+        {
+            AnsiConsole.MarkupLine("[red]Logs directory not found:[/] " + Markup.Escape(logsDir));
+            return 1;
+        }
+
+        var lines = TailLines(logsDir, limit, level);
+
+        if (lines.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No log lines found matching criteria.[/]");
+            return 0;
+        }
+
+        OutputLines(lines, format);
+        return 0;
+    }
+
+    internal static int ExecuteSearch(string logsDir, string term, string? since, int limit, string format)
+    {
+        if (!Directory.Exists(logsDir))
+        {
+            AnsiConsole.MarkupLine("[red]Logs directory not found:[/] " + Markup.Escape(logsDir));
+            return 1;
+        }
+
+        DateTime? sinceDate = null;
+        if (since is not null)
+        {
+            if (!DateTime.TryParse(since, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
+            {
+                AnsiConsole.MarkupLine($"[red]Invalid --since datetime:[/] {Markup.Escape(since)}");
+                return 1;
+            }
+            sinceDate = parsed.ToLocalTime();
+        }
+
+        var lines = SearchLines(logsDir, term, sinceDate, limit);
+
+        if (lines.Count == 0)
+        {
+            AnsiConsole.MarkupLine($"[yellow]No log lines found containing:[/] {Markup.Escape(term)}");
+            return 0;
+        }
+
+        OutputLines(lines, format);
+        return 0;
+    }
+
+    // ── Core log reading logic ──
+
+    internal static List<LogEntry> TailLines(string logsDir, int limit, string? level)
+    {
+        var files = GetLogFilesSorted(logsDir);
+        if (files.Count == 0) return [];
+
+        var result = new List<LogEntry>();
+        var normalizedLevel = NormalizeLevel(level);
+
+        // Read files from most recent backwards until we have enough lines
+        for (var i = files.Count - 1; i >= 0 && result.Count < limit; i--)
+        {
+            var fileLines = File.ReadAllLines(files[i]);
+            for (var j = fileLines.Length - 1; j >= 0 && result.Count < limit; j--)
+            {
+                var entry = ParseLogLine(fileLines[j], files[i]);
+                if (entry is null) continue;
+                if (normalizedLevel is not null && !string.Equals(entry.Level, normalizedLevel, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                result.Add(entry);
+            }
+        }
+
+        // Reverse to chronological order
+        result.Reverse();
+        return result;
+    }
+
+    internal static List<LogEntry> SearchLines(string logsDir, string term, DateTime? sinceLocal, int limit)
+    {
+        var files = GetLogFilesSorted(logsDir);
+        if (files.Count == 0) return [];
+
+        var result = new List<LogEntry>();
+
+        foreach (var file in files)
+        {
+            // Skip files before the 'since' date based on filename
+            if (sinceLocal is not null)
+            {
+                var fileTime = ParseFileTimestamp(file);
+                if (fileTime is not null && fileTime.Value.AddHours(1) <= sinceLocal.Value)
+                    continue;
+            }
+
+            foreach (var line in File.ReadLines(file))
+            {
+                if (result.Count >= limit) break;
+                if (line.Contains(term, StringComparison.OrdinalIgnoreCase))
+                {
+                    var entry = ParseLogLine(line, file) ?? new LogEntry { Message = line, SourceFile = Path.GetFileName(file) };
+                    result.Add(entry);
+                }
+            }
+
+            if (result.Count >= limit) break;
+        }
+
+        return result;
+    }
+
+    internal static List<string> GetLogFilesSorted(string logsDir)
+    {
+        if (!Directory.Exists(logsDir)) return [];
+
+        return Directory.GetFiles(logsDir, "botnexus-*.log")
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    internal static LogEntry? ParseLogLine(string line, string? sourceFile = null)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return null;
+
+        var match = LogLinePattern.Match(line);
+        if (!match.Success)
+        {
+            // Non-structured line (continuation, stack trace, etc.)
+            return new LogEntry
+            {
+                Message = line,
+                SourceFile = sourceFile is not null ? Path.GetFileName(sourceFile) : null
+            };
+        }
+
+        return new LogEntry
+        {
+            Timestamp = match.Groups[1].Value,
+            Offset = match.Groups[2].Value,
+            Level = NormalizeLevelAbbrev(match.Groups[3].Value),
+            Message = match.Groups[4].Value,
+            SourceFile = sourceFile is not null ? Path.GetFileName(sourceFile) : null
+        };
+    }
+
+    internal static DateTime? ParseFileTimestamp(string filePath)
+    {
+        // Pattern: botnexus-YYYYMMDDH.log or botnexus-YYYYMMDDHH.log
+        var fileName = Path.GetFileNameWithoutExtension(filePath);
+        if (!fileName.StartsWith("botnexus-", StringComparison.Ordinal)) return null;
+
+        var datePart = fileName["botnexus-".Length..];
+        // Try YYYYMMDDHH (10 chars) then YYYYMMDDH (9 chars)
+        if (datePart.Length >= 10 &&
+            DateTime.TryParseExact(datePart[..10], "yyyyMMddHH", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt10))
+            return dt10;
+        if (datePart.Length >= 9 &&
+            int.TryParse(datePart[..8], out _) &&
+            int.TryParse(datePart[8..9], out var hour9) && hour9 is >= 0 and <= 9)
+        {
+            if (DateTime.TryParseExact(datePart[..8], "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt8))
+                return dt8.AddHours(hour9);
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeLevel(string? level) => level?.ToLowerInvariant() switch
+    {
+        "debug" or "dbg" or "verbose" or "vrb" => "DBG",
+        "info" or "information" or "inf" => "INF",
+        "warn" or "warning" or "wrn" => "WRN",
+        "error" or "err" or "fatal" or "ftl" => "ERR",
+        null => null,
+        _ => level.ToUpperInvariant()
+    };
+
+    private static string NormalizeLevelAbbrev(string abbrev) => abbrev.ToUpperInvariant() switch
+    {
+        "DBG" or "VRB" => "DBG",
+        "INF" => "INF",
+        "WRN" => "WRN",
+        "ERR" or "FTL" => "ERR",
+        _ => abbrev.ToUpperInvariant()
+    };
+
+    private static void OutputLines(List<LogEntry> lines, string format)
+    {
+        if (format == "json")
+        {
+            AnsiConsole.Write(new Text(JsonSerializer.Serialize(lines, JsonOpts)));
+            AnsiConsole.WriteLine();
+            return;
+        }
+
+        foreach (var entry in lines)
+        {
+            var levelMarkup = entry.Level switch
+            {
+                "ERR" => "[red]ERR[/]",
+                "WRN" => "[yellow]WRN[/]",
+                "INF" => "[green]INF[/]",
+                "DBG" => "[dim]DBG[/]",
+                _ => Markup.Escape(entry.Level ?? "???")
+            };
+
+            if (entry.Timestamp is not null)
+            {
+                AnsiConsole.MarkupLine($"[dim]{Markup.Escape(entry.Timestamp)}[/] {levelMarkup} {Markup.Escape(entry.Message ?? "")}");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"  {Markup.Escape(entry.Message ?? "")}");
+            }
+        }
+
+        AnsiConsole.MarkupLine($"\n[dim]{lines.Count} line(s) shown.[/]");
+    }
+
+    // ── DTO ──
+
+    internal sealed class LogEntry
+    {
+        public string? Timestamp { get; set; }
+        public string? Offset { get; set; }
+        public string? Level { get; set; }
+        public string? Message { get; set; }
+        public string? SourceFile { get; set; }
+    }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/DebugLogsCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/DebugLogsCommandTests.cs
@@ -1,0 +1,220 @@
+using BotNexus.Cli.Commands;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class DebugLogsCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _logsDir;
+
+    public DebugLogsCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"botnexus-logtest-{Guid.NewGuid():N}");
+        _logsDir = Path.Combine(_tempDir, "logs");
+        Directory.CreateDirectory(_logsDir);
+        CreateTestLogFiles();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private void CreateTestLogFiles()
+    {
+        // Create a log file for 2026-06-10 hour 14
+        var file1 = Path.Combine(_logsDir, "botnexus-2026061014.log");
+        File.WriteAllLines(file1, [
+            "2026-06-10 14:00:01.123 +00:00 [INF] Gateway started on port 5005",
+            "2026-06-10 14:00:02.456 +00:00 [DBG] Loading agent configuration for farnsworth",
+            "2026-06-10 14:01:00.789 +00:00 [INF] Session sess-abc-123 created for agent nova",
+            "2026-06-10 14:02:30.100 +00:00 [WRN] Compaction for sess-abc-123 took 45s (threshold: 30s)",
+            "2026-06-10 14:05:00.000 +00:00 [ERR] Provider timeout: Copilot returned 503"
+        ]);
+
+        // Create a log file for 2026-06-10 hour 15
+        var file2 = Path.Combine(_logsDir, "botnexus-2026061015.log");
+        File.WriteAllLines(file2, [
+            "2026-06-10 15:00:00.000 +00:00 [INF] Cron job heartbeat:farnsworth fired",
+            "2026-06-10 15:00:01.000 +00:00 [INF] Session sess-def-456 created for agent farnsworth",
+            "2026-06-10 15:01:00.000 +00:00 [ERR] Tool execution failed: read returned empty",
+            "2026-06-10 15:01:00.001 +00:00 [ERR]   at BotNexus.Gateway.Tools.ReadTool.Execute()",
+            "2026-06-10 15:02:00.000 +00:00 [INF] Session sess-abc-123 sealed (compaction complete)"
+        ]);
+    }
+
+    [Fact]
+    public void ResolveLogsDir_WithTarget_ReturnsLogsSubdir()
+    {
+        var dir = DebugLogsCommand.ResolveLogsDir(_tempDir);
+        dir.ShouldBe(_logsDir);
+    }
+
+    [Fact]
+    public void ResolveLogsDir_DefaultTarget_EndsWithLogs()
+    {
+        var dir = DebugLogsCommand.ResolveLogsDir(null);
+        dir.ShouldEndWith("logs");
+    }
+
+    [Fact]
+    public void GetLogFilesSorted_ReturnsFilesInOrder()
+    {
+        var files = DebugLogsCommand.GetLogFilesSorted(_logsDir);
+        files.Count.ShouldBe(2);
+        Path.GetFileName(files[0]).ShouldBe("botnexus-2026061014.log");
+        Path.GetFileName(files[1]).ShouldBe("botnexus-2026061015.log");
+    }
+
+    [Fact]
+    public void GetLogFilesSorted_NonexistentDir_ReturnsEmpty()
+    {
+        var files = DebugLogsCommand.GetLogFilesSorted("/nonexistent/path");
+        files.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TailLines_ReturnsLastNLines()
+    {
+        var lines = DebugLogsCommand.TailLines(_logsDir, 3, null);
+        lines.Count.ShouldBe(3);
+        // Last 3 lines from file2 (most recent)
+        lines[2].Message!.ShouldContain("sess-abc-123 sealed");
+    }
+
+    [Fact]
+    public void TailLines_WithLevelFilter_ReturnsOnlyMatchingLevel()
+    {
+        var lines = DebugLogsCommand.TailLines(_logsDir, 50, "error");
+        lines.Count.ShouldBe(3); // 1 ERR from file1, 2 ERR from file2
+        foreach (var line in lines)
+        {
+            line.Level.ShouldBe("ERR");
+        }
+    }
+
+    [Fact]
+    public void TailLines_EmptyDir_ReturnsEmpty()
+    {
+        var emptyDir = Path.Combine(_tempDir, "empty-logs");
+        Directory.CreateDirectory(emptyDir);
+        var lines = DebugLogsCommand.TailLines(emptyDir, 10, null);
+        lines.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SearchLines_FindsTerm()
+    {
+        var lines = DebugLogsCommand.SearchLines(_logsDir, "sess-abc-123", null, 50);
+        lines.Count.ShouldBe(3); // appears in file1 (2 lines) and file2 (1 line)
+    }
+
+    [Fact]
+    public void SearchLines_CaseInsensitive()
+    {
+        var lines = DebugLogsCommand.SearchLines(_logsDir, "GATEWAY STARTED", null, 50);
+        lines.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void SearchLines_WithSince_SkipsOlderFiles()
+    {
+        // Since 2026-06-10 16:00 should skip both files (file2 covers hour 15)
+        var since = new DateTime(2026, 6, 10, 16, 0, 0);
+        var lines = DebugLogsCommand.SearchLines(_logsDir, "sess-abc-123", since, 50);
+        lines.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SearchLines_RespectsLimit()
+    {
+        var lines = DebugLogsCommand.SearchLines(_logsDir, "2026", null, 2);
+        lines.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ParseLogLine_ValidLine_ParsesCorrectly()
+    {
+        var entry = DebugLogsCommand.ParseLogLine("2026-06-10 14:00:01.123 +00:00 [INF] Gateway started");
+        entry.ShouldNotBeNull();
+        entry.Timestamp.ShouldBe("2026-06-10 14:00:01.123");
+        entry.Offset.ShouldBe("+00:00");
+        entry.Level.ShouldBe("INF");
+        entry.Message.ShouldBe("Gateway started");
+    }
+
+    [Fact]
+    public void ParseLogLine_EmptyLine_ReturnsNull()
+    {
+        var entry = DebugLogsCommand.ParseLogLine("");
+        entry.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseLogLine_NonStructuredLine_ReturnsRawMessage()
+    {
+        var entry = DebugLogsCommand.ParseLogLine("  at System.Runtime.Something.Method()");
+        entry.ShouldNotBeNull();
+        entry.Timestamp.ShouldBeNull();
+        entry.Level.ShouldBeNull();
+        entry.Message!.ShouldContain("System.Runtime");
+    }
+
+    [Fact]
+    public void ParseFileTimestamp_ValidTenDigit_ParsesCorrectly()
+    {
+        var dt = DebugLogsCommand.ParseFileTimestamp("/logs/botnexus-2026061014.log");
+        dt.ShouldNotBeNull();
+        dt.Value.ShouldBe(new DateTime(2026, 6, 10, 14, 0, 0));
+    }
+
+    [Fact]
+    public void ParseFileTimestamp_ValidNineDigit_ParsesCorrectly()
+    {
+        var dt = DebugLogsCommand.ParseFileTimestamp("/logs/botnexus-202606109.log");
+        dt.ShouldNotBeNull();
+        dt.Value.ShouldBe(new DateTime(2026, 6, 10, 9, 0, 0));
+    }
+
+    [Fact]
+    public void ParseFileTimestamp_InvalidFile_ReturnsNull()
+    {
+        var dt = DebugLogsCommand.ParseFileTimestamp("/logs/other-file.log");
+        dt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExecuteTail_MissingDir_ReturnsError()
+    {
+        var result = DebugLogsCommand.ExecuteTail("/nonexistent/logs", 10, null, "table");
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ExecuteTail_ValidDir_ReturnsSuccess()
+    {
+        var result = DebugLogsCommand.ExecuteTail(_logsDir, 5, null, "json");
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteSearch_MissingDir_ReturnsError()
+    {
+        var result = DebugLogsCommand.ExecuteSearch("/nonexistent/logs", "test", null, 10, "table");
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ExecuteSearch_ValidDir_ReturnsSuccess()
+    {
+        var result = DebugLogsCommand.ExecuteSearch(_logsDir, "Gateway", null, 10, "json");
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteSearch_InvalidSince_ReturnsError()
+    {
+        var result = DebugLogsCommand.ExecuteSearch(_logsDir, "test", "not-a-date", 10, "table");
+        result.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
Closes #1134

## Changes
- New `botnexus debug logs` subcommand with `tail`, `errors`, `search`, and `session` operations
- Direct file I/O reading `~/.botnexus/logs/botnexus-YYYYMMDDHH.log` (no running gateway required)
- Hourly file boundary crossing for tail operations
- File-level since filtering for efficient search
- Serilog structured log line parsing (timestamp, offset, level, message)
- Level filtering (debug/info/warn/error)
- `--format table|json` output support
- `--target` convention for non-default BotNexus home directories
- 22 unit tests covering all paths

## Subcommands
```
botnexus debug logs tail [--limit N] [--level debug|info|warn|error]
botnexus debug logs errors [--limit N]
botnexus debug logs search --term <keyword> [--since <datetime>] [--limit N]
botnexus debug logs session <session-id> [--limit N]
```

## Merge Notes
Both this PR and #1135 (debug sessions) create `DebugCommand.cs` — they CANNOT merge in parallel. **Merge #1135 first**, then rebase this PR to add `_logs` to the existing `DebugCommand`. Or merge this first and rebase #1135.

Only touches CLI files (CliApp.cs registration + new command files). No conflicts with other open PRs (#1123, #1127, #1128, #1130, #1131, #1132).
