### PR TITLE
feat(portal): expose participant roster and agent attribution for multi-agent conversations

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateModels.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateModels.cs
@@ -65,6 +65,9 @@ public sealed record ChatMessage(string Role, string Content, DateTimeOffset Tim
     /// <summary>Stable identity for markdown caching and tool-call linking.</summary>
     public string Id { get; init; } = Guid.NewGuid().ToString("N");
 
+    /// <summary>Agent that produced this message (for multi-agent conversations).</summary>
+    public string? AgentId { get; init; }
+
     /// <summary>Tool name if this is a tool-related message.</summary>
     public string? ToolName { get; init; }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ConversationContracts.cs
@@ -16,7 +16,13 @@ public sealed record ConversationSummaryDto(
     [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt,
     [property: JsonPropertyName("kind")] string Kind = "HumanAgent",
     [property: JsonPropertyName("isPinned")] bool IsPinned = false,
-    [property: JsonPropertyName("pinnedAt")] DateTimeOffset? PinnedAt = null);
+    [property: JsonPropertyName("pinnedAt")] DateTimeOffset? PinnedAt = null,
+    [property: JsonPropertyName("participants")] IReadOnlyList<ParticipantDto>? Participants = null);
+
+public sealed record ParticipantDto(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("role")] string? Role = null);
 
 public sealed record CreateConversationRequestDto(
     [property: JsonPropertyName("agentId")] string AgentId,
@@ -59,6 +65,9 @@ public sealed class ConversationHistoryEntryDto
 
     [JsonPropertyName("sessionId")]
     public required string SessionId { get; init; }
+
+    [JsonPropertyName("agentId")]
+    public string? AgentId { get; init; }
 
     [JsonPropertyName("timestamp")]
     public required DateTimeOffset Timestamp { get; init; }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
@@ -71,6 +71,9 @@ public sealed class ConversationHistoryEntry
     /// <summary>The session this entry belongs to.</summary>
     public required string SessionId { get; init; }
 
+    /// <summary>The agent that owns the session this entry belongs to.</summary>
+    public string? AgentId { get; init; }
+
     /// <summary>Entry timestamp.</summary>
     public required DateTimeOffset Timestamp { get; init; }
 

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -123,7 +123,11 @@ public sealed class ConversationsController : ControllerBase
             c.Purpose,
             c.Kind.ToString(),
             c.IsPinned,
-            c.PinnedAt);
+            c.PinnedAt,
+            c.Participants.Select(p => new ParticipantSummary(
+                p.CitizenId.Kind.ToString(),
+                p.CitizenId.Value,
+                p.Role)).ToList());
 
     /// <summary>
     /// Gets a specific conversation by ID, including all channel bindings.
@@ -389,6 +393,7 @@ public sealed class ConversationsController : ControllerBase
                 {
                     Kind = "boundary",
                     SessionId = previousSession.SessionId.Value,
+                    AgentId = previousSession.AgentId.Value,
                     Timestamp = previousSession.UpdatedAt,
                     Reason = "session_end"
                 });
@@ -417,6 +422,7 @@ public sealed class ConversationsController : ControllerBase
                     {
                         Kind = "compaction",
                         SessionId = session.SessionId.Value,
+                        AgentId = session.AgentId.Value,
                         Timestamp = entry.Timestamp,
                         Reason = "compaction",
                         Content = entry.Content
@@ -428,6 +434,7 @@ public sealed class ConversationsController : ControllerBase
                 {
                     Kind = "message",
                     SessionId = session.SessionId.Value,
+                    AgentId = session.AgentId.Value,
                     Role = entry.Role.ToString().ToLowerInvariant(),
                     Content = entry.Content,
                     Timestamp = entry.Timestamp,

--- a/src/gateway/BotNexus.Gateway.Contracts/Conversations/ConversationSummary.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Conversations/ConversationSummary.cs
@@ -18,6 +18,10 @@ namespace BotNexus.Gateway.Abstractions.Conversations;
 /// like the portal can hide internal agent-to-agent transcripts from the user-facing conversation
 /// list. Defaults to <c>HumanAgent</c> for back-compat with pre-Phase-4 stores.
 /// </param>
+/// <param name="Participants">
+/// Citizen participants in this conversation — enables the portal to render a participant
+/// roster (avatar chips) in the conversation header for multi-agent sessions.
+/// </param>
 public sealed record ConversationSummary(
     string ConversationId,
     string AgentId,
@@ -31,4 +35,13 @@ public sealed record ConversationSummary(
     string? Purpose = null,
     string Kind = "HumanAgent",
     bool IsPinned = false,
-    DateTimeOffset? PinnedAt = null);
+    DateTimeOffset? PinnedAt = null,
+    IReadOnlyList<ParticipantSummary>? Participants = null);
+
+/// <summary>
+/// Lightweight participant identity for conversation summary rendering.
+/// </summary>
+/// <param name="Kind">Citizen kind: "User" or "Agent".</param>
+/// <param name="Id">The citizen identifier (agent id or user id).</param>
+/// <param name="Role">Optional role label (e.g., "initiator", "peer").</param>
+public sealed record ParticipantSummary(string Kind, string Id, string? Role = null);

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -246,7 +246,11 @@ public sealed class InMemoryConversationStore : IConversationStore
             c.Purpose,
             c.Kind.ToString(),
             c.IsPinned,
-            c.PinnedAt);
+            c.PinnedAt,
+            c.Participants.Select(p => new ParticipantSummary(
+                p.CitizenId.Kind.ToString(),
+                p.CitizenId.Value,
+                p.Role)).ToList());
 
     // ── Canvas State ───────────────────────────────────────────────────────
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Conversations/MultiAgentPortalRenderingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Conversations/MultiAgentPortalRenderingTests.cs
@@ -1,0 +1,200 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+/// <summary>
+/// Tests for multi-agent portal rendering support (#415):
+/// - Participant roster exposed in conversation summary
+/// - Agent attribution on conversation history entries
+/// </summary>
+public sealed class MultiAgentPortalRenderingTests
+{
+    private static readonly AgentId HostAgent = AgentId.From("host-agent");
+    private static readonly AgentId PeerAgent = AgentId.From("peer-agent");
+
+    // ── Participant roster in conversation summaries ──────────────────────
+
+    [Fact]
+    public async Task List_Conversation_IncludesParticipantRoster()
+    {
+        var conversations = new InMemoryConversationStore();
+        var conversation = await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = ConversationId.From("c_multiagent_1"),
+            AgentId = HostAgent,
+            Title = "Multi-agent test",
+            Kind = ConversationKind.AgentAgent
+        });
+
+        await conversations.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant { CitizenId = CitizenId.Of(HostAgent), Role = "initiator" },
+                new SessionParticipant { CitizenId = CitizenId.Of(PeerAgent), Role = "peer" }
+            ]);
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+        var result = await controller.List(HostAgent.Value, CancellationToken.None);
+
+        var summaries = ((result as OkObjectResult)?.Value as IEnumerable<ConversationSummary>)?.ToList();
+        summaries.ShouldNotBeNull();
+        summaries!.Count.ShouldBe(1);
+        summaries[0].Participants.ShouldNotBeNull();
+        summaries[0].Participants!.Count.ShouldBe(2);
+        summaries[0].Participants!.ShouldContain(p => p.Id == HostAgent.Value && p.Role == "initiator");
+        summaries[0].Participants!.ShouldContain(p => p.Id == PeerAgent.Value && p.Role == "peer");
+    }
+
+    [Fact]
+    public async Task List_HumanAgentConversation_ParticipantsIncludesHumanUser()
+    {
+        var conversations = new InMemoryConversationStore();
+        var conversation = await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = ConversationId.From("c_human_agent_1"),
+            AgentId = HostAgent,
+            Title = "Human-agent test",
+            Kind = ConversationKind.HumanAgent
+        });
+
+        await conversations.AddParticipantsAsync(
+            conversation.ConversationId,
+            [
+                new SessionParticipant { CitizenId = CitizenId.Of(UserId.From("user-123")), Role = "initiator" },
+                new SessionParticipant { CitizenId = CitizenId.Of(HostAgent), Role = "responder" }
+            ]);
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+        var result = await controller.List(HostAgent.Value, CancellationToken.None);
+
+        var summaries = ((result as OkObjectResult)?.Value as IEnumerable<ConversationSummary>)?.ToList();
+        summaries.ShouldNotBeNull();
+        summaries![0].Participants.ShouldNotBeNull();
+        summaries[0].Participants!.Count.ShouldBe(2);
+        summaries[0].Participants!.ShouldContain(p => p.Kind == "User" && p.Id == "user-123");
+    }
+
+    [Fact]
+    public async Task List_ConversationWithNoParticipants_ReturnsEmptyList()
+    {
+        var conversations = new InMemoryConversationStore();
+        await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = ConversationId.From("c_empty_participants"),
+            AgentId = HostAgent,
+            Title = "No participants",
+            Kind = ConversationKind.HumanAgent
+        });
+
+        var controller = new ConversationsController(conversations, new InMemorySessionStore());
+        var result = await controller.List(HostAgent.Value, CancellationToken.None);
+
+        var summaries = ((result as OkObjectResult)?.Value as IEnumerable<ConversationSummary>)?.ToList();
+        summaries.ShouldNotBeNull();
+        summaries![0].Participants.ShouldNotBeNull();
+        summaries[0].Participants!.Count.ShouldBe(0);
+    }
+
+    // ── Agent attribution on history entries ──────────────────────────────
+
+    [Fact]
+    public async Task GetHistory_MultiAgentConversation_EntriesIncludeAgentId()
+    {
+        var conversationId = ConversationId.From("c_multiagent_history");
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+
+        // Host agent session
+        var hostSession = await sessions.GetOrCreateAsync(SessionId.From("s-host-1"), HostAgent);
+        hostSession.Session.ConversationId = conversationId;
+        hostSession.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "Hello from host",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-2)
+        });
+        await sessions.SaveAsync(hostSession);
+
+        // Peer agent session
+        var peerSession = await sessions.GetOrCreateAsync(SessionId.From("s-peer-1"), PeerAgent);
+        peerSession.Session.ConversationId = conversationId;
+        peerSession.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "Hello from peer",
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(-1)
+        });
+        await sessions.SaveAsync(peerSession);
+
+        // Conversation with ActiveSessionId set for fallback path
+        await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = HostAgent,
+            Title = "Multi-agent history",
+            Kind = ConversationKind.AgentAgent,
+            ActiveSessionId = SessionId.From("s-host-1")
+        });
+
+        var controller = new ConversationsController(conversations, sessions);
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 50, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+        response!.Entries.Count.ShouldBeGreaterThanOrEqualTo(2);
+
+        var hostEntry = response.Entries.First(e => e.Content == "Hello from host");
+        hostEntry.AgentId.ShouldBe(HostAgent.Value);
+
+        var peerEntry = response.Entries.First(e => e.Content == "Hello from peer");
+        peerEntry.AgentId.ShouldBe(PeerAgent.Value);
+    }
+
+    [Fact]
+    public async Task GetHistory_SingleAgentConversation_EntriesStillIncludeAgentId()
+    {
+        var conversationId = ConversationId.From("c_single_agent_history");
+        var sessions = new InMemorySessionStore();
+        var conversations = new InMemoryConversationStore();
+        await conversations.CreateAsync(new Conversation
+        {
+            ConversationId = conversationId,
+            AgentId = HostAgent,
+            Title = "Single agent",
+            Kind = ConversationKind.HumanAgent
+        });
+
+        var session = await sessions.GetOrCreateAsync(SessionId.From("s-single-1"), HostAgent);
+        session.Session.ConversationId = conversationId;
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.User,
+            Content = "User message"
+        });
+        session.AddEntry(new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "Agent reply"
+        });
+        await sessions.SaveAsync(session);
+
+        var controller = new ConversationsController(conversations, sessions);
+        var actionResult = await controller.GetHistory(conversationId.Value, limit: 50, offset: 0, CancellationToken.None);
+
+        var response = (actionResult as OkObjectResult)?.Value as ConversationHistoryResponse;
+        response.ShouldNotBeNull();
+
+        // All entries in a single-agent conversation carry the same AgentId
+        foreach (var entry in response!.Entries.Where(e => e.Kind == "message"))
+        {
+            entry.AgentId.ShouldBe(HostAgent.Value);
+        }
+    }
+}


### PR DESCRIPTION
Closes #415

## Changes

- **ConversationSummary** (Contracts): added \Participants\ field (\IReadOnlyList<ParticipantSummary>?\) with \ParticipantSummary(Kind, Id, Role)\ DTO
- **ConversationHistoryEntry** (API DTOs): added \AgentId\ property so each history entry carries the producing agent's identity
- **ConversationSummaryDto** (BlazorClient): added \Participants\ field with \ParticipantDto\ DTO
- **ConversationHistoryEntryDto** (BlazorClient): added \AgentId\ field
- **ChatMessage** (BlazorClient state): added \AgentId\ property for client-side multi-agent message attribution
- **ConversationsController.ToSummary**: populates participants from \Conversation.Participants\
- **ConversationsController.GetHistory**: populates \AgentId\ on all entry types (message, boundary, compaction)
- **InMemoryConversationStore.ToSummary**: populates participants for test parity
- **5 new tests** covering participant roster in summaries (multi-agent, human-agent, empty) and agent attribution on history entries (multi-agent, single-agent)

## Scope

This PR delivers the **API + data model layer** for #415. The portal UI rendering (participant chips in header, per-agent message coloring with CSS) can be a follow-up PR consuming this data.

## Merge Notes

Independent of all 7 open PRs. No file overlap. Safe to merge in any order.