### PR TITLE
docs: daily documentation grooming 2026-06-10

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,6 +93,7 @@ export default defineConfig({
           { text: 'OpenAI', link: '/providers/openai' },
           { text: 'OpenAI-Compatible', link: '/providers/openai-compatible' },
           { text: 'GitHub Copilot', link: '/providers/github-copilot' },
+          { text: 'Ollama', link: '/providers/ollama' },
         ],
       },
       {
@@ -103,6 +104,7 @@ export default defineConfig({
           { text: 'Process Tool', link: '/extensions/process-tool' },
           { text: 'Web Tools', link: '/extensions/web-tools' },
           { text: 'Data Store', link: '/extensions/data-store' },
+          { text: 'Skills', link: '/extensions/skills' },
           { text: 'MCP', link: '/extensions/mcp' },
           { text: 'MCP Invoke', link: '/extensions/mcp-invoke' },
           { text: 'Debug Tool', link: '/extensions/debug-tool' },
@@ -144,6 +146,7 @@ export default defineConfig({
         items: [
           { text: 'Sub-Agent Spawning', link: '/features/sub-agent-spawning' },
           { text: 'Shell Execution', link: '/features/shell-execution' },
+          { text: 'Canvas', link: '/features/canvas' },
           { text: 'Skills', link: '/skills' },
           { text: 'Cron & Scheduling', link: '/cron-and-scheduling' },
         ],

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,16 +62,19 @@ You should see the root command help listing all available subcommands.
 10. [config get](#config-get) — Read a config value
 11. [config set](#config-set) — Set a config value
 12. [config schema](#config-schema) — Generate JSON schema
-13. [provider](#provider) — Show or set up providers
-14. [provider setup](#provider-setup) — Interactive provider setup wizard
-15. [provider list](#provider-list) — List configured providers
-16. [provider add](#provider-add) — Add or update a provider non-interactively (scripts and CI)
-17. [provider remove](#provider-remove) — Remove a provider non-interactively
-16. [prompt](#prompt) — Manage prompt templates
-17. [prompt list](#prompt-list) — List available prompt templates
-18. [prompt render](#prompt-render) — Render a prompt template
-19. [prompt run](#prompt-run) — Render and execute a prompt template
-20. [Examples](#examples)
+13. [gateway](#gateway) — Manage the gateway lifecycle
+14. [provider](#provider) — Show or set up providers
+15. [provider setup](#provider-setup) — Interactive provider setup wizard
+16. [provider list](#provider-list) — List configured providers
+17. [provider add](#provider-add) — Add or update a provider non-interactively (scripts and CI)
+18. [provider remove](#provider-remove) — Remove a provider non-interactively
+19. [provider ollama](#provider-ollama) — Ollama local model diagnostics
+20. [prompt](#prompt) — Manage prompt templates
+21. [prompt list](#prompt-list) — List available prompt templates
+22. [prompt render](#prompt-render) — Render a prompt template
+23. [prompt run](#prompt-run) — Render and execute a prompt template
+24. [satellite](#satellite) — Manage satellite nodes
+25. [Examples](#examples)
 
 ---
 
@@ -756,6 +759,112 @@ botnexus config schema --output my-schema.json
 
 ---
 
+## gateway
+
+Manage the BotNexus Gateway lifecycle: start, stop, status, restart. For foreground/development mode, use `serve` or `serve gateway` instead.
+
+### Usage
+
+```powershell
+botnexus gateway <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `start` | Start the gateway process (detached by default) |
+| `stop` | Stop the gateway process |
+| `status` | Check gateway process status |
+| `restart` | Restart the gateway process |
+| `install` | Install the gateway as an OS service |
+| `uninstall` | Remove the OS service registration |
+
+### gateway start
+
+Start the gateway process in detached (background) mode. Builds the solution first unless `--skip-build` is passed.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--port <PORT>` | `5005` | Port to listen on |
+| `--source <DIR>` | `~/botnexus` | Path to the BotNexus repository root |
+| `--attached` | off | Run in foreground instead of detached mode |
+| `--skip-build` | off | Skip the implicit solution rebuild before starting |
+
+```powershell
+# Start detached on default port
+botnexus gateway start
+
+# Start on custom port, skip build
+botnexus gateway start --port 8080 --skip-build
+
+# Start in foreground (like serve)
+botnexus gateway start --attached
+```
+
+### gateway stop
+
+Stop the running gateway process.
+
+```powershell
+botnexus gateway stop
+```
+
+### gateway status
+
+Check whether the gateway process is running.
+
+```powershell
+botnexus gateway status
+```
+
+### gateway restart
+
+Stop and restart the gateway process.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--port <PORT>` | `5005` | Port to listen on |
+| `--source <DIR>` | `~/botnexus` | Path to the BotNexus repository root |
+
+```powershell
+botnexus gateway restart
+botnexus gateway restart --port 8080
+```
+
+### gateway install
+
+Install the gateway as an OS-managed service for automatic startup. Supports:
+
+- **Windows** — Windows Service (via `sc.exe`)
+- **Linux** — systemd unit file
+- **macOS** — launchd plist
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--port <PORT>` | `5005` | Port for the service to listen on |
+| `--source <DIR>` | `~/botnexus` | Path to the BotNexus repository root |
+
+```powershell
+# Install as Windows Service
+botnexus gateway install
+
+# Install with custom port
+botnexus gateway install --port 8080
+```
+
+After installation, manage the service with standard OS tools (`sc`, `systemctl`, `launchctl`).
+
+### gateway uninstall
+
+Remove the OS service registration.
+
+```powershell
+botnexus gateway uninstall
+```
+
+---
+
 ## provider
 
 Show provider status or start the setup wizard. When run without a subcommand, shows configured providers if any exist, otherwise launches the setup wizard.
@@ -969,6 +1078,62 @@ botnexus provider remove --name <NAME> [OPTIONS]
 ```powershell
 botnexus provider remove --name integration-mock
 ```
+
+---
+
+## provider ollama
+
+Diagnostic subcommands for local Ollama instances. Verifies connectivity, lists pulled models, and tests inference without requiring a running gateway.
+
+### Usage
+
+```powershell
+botnexus provider ollama <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `status` | Check Ollama server connectivity and version |
+| `models` | List models available on the local instance |
+| `test` | Send a test prompt to verify model inference |
+
+### provider ollama status
+
+```powershell
+botnexus provider ollama status
+botnexus provider ollama status --url http://192.168.1.100:11434
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--url <URL>` | `http://localhost:11434` | Ollama server URL |
+
+### provider ollama models
+
+```powershell
+botnexus provider ollama models
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--url <URL>` | `http://localhost:11434` | Ollama server URL |
+
+### provider ollama test
+
+Send a simple chat completion request to verify end-to-end inference.
+
+```powershell
+botnexus provider ollama test --model llama3
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--url <URL>` | `http://localhost:11434` | Ollama server URL |
+| `--model <ID>` | (required) | Model to test |
+
+See [Ollama Provider](providers/ollama.md) for full setup and configuration details.
 
 ---
 
@@ -1204,6 +1369,68 @@ Output includes:
 [dim]Rendering template 'code-review-summary' with agent 'assistant'...[/]
 [dim]Rendered template and invoked http://localhost:5005/api/chat[/]
 [Agent response...]
+```
+
+---
+
+## satellite
+
+Manage satellite nodes — remote presence points that extend BotNexus to additional machines (desktop notifications, canvas windows, remote command execution).
+
+### Usage
+
+```powershell
+botnexus satellite <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all registered satellites |
+| `register` | Register a new satellite and generate its API key |
+| `remove` | Remove a satellite registration |
+
+### satellite list
+
+List all registered satellites with their status and capabilities.
+
+```powershell
+botnexus satellite list
+```
+
+### satellite register
+
+Register a new satellite and generate a unique API key (prefixed `sat_`).
+
+```powershell
+botnexus satellite register <NAME> --owner <USER_ID> [OPTIONS]
+```
+
+| Argument/Option | Required | Description |
+|-----------------|----------|-------------|
+| `<NAME>` | Yes | Satellite ID (e.g., `sat_desktop_home`) |
+| `--owner <ID>` | Yes | Owner user ID |
+| `--display-name <NAME>` | No | Human-readable display name |
+| `--platform <OS>` | No | Platform: `windows`, `macos`, `linux` (default: `windows`) |
+| `--capabilities <LIST>` | No | Comma-separated capabilities: `notify`, `canvas`, `exec` (default: `notify,canvas`) |
+
+```powershell
+# Register a Windows desktop satellite
+botnexus satellite register sat_desktop_home --owner jon --display-name "Home Desktop"
+
+# Register with exec capability
+botnexus satellite register sat_workstation --owner jon --capabilities notify,canvas,exec
+```
+
+The generated API key is displayed once after registration. Store it securely — it cannot be retrieved later.
+
+### satellite remove
+
+Remove a satellite registration. The satellite's API key is immediately invalidated.
+
+```powershell
+botnexus satellite remove <NAME>
 ```
 
 ---

--- a/docs/cron-and-scheduling.md
+++ b/docs/cron-and-scheduling.md
@@ -583,6 +583,41 @@ Archived 8 log files older than 30 days.
 }
 ```
 
+### 8.4 `memory-dreaming`
+
+**Name:** `memory-dreaming`  
+**Description:** Periodic memory consolidation via LLM — reads recent daily notes, builds a consolidation prompt, and dispatches a session to update `MEMORY.md` with distilled insights.
+
+Unlike `consolidate-memory` (which merges files mechanically), memory dreaming uses an LLM to extract patterns, decisions, and knowledge from daily notes and weave them into the agent's long-term memory.
+
+**Configuration Properties:**
+- `Action`: `"memory-dreaming"`
+- `lookbackDays` (in job metadata): Number of days of daily notes to read (default: 14)
+- `maxContentChars` (in job metadata): Maximum characters of source material (default: 50000)
+
+**Configuration:**
+```json
+{
+  "Type": "maintenance",
+  "Action": "memory-dreaming",
+  "Schedule": "0 3 * * 0",
+  "Agent": "my-agent",
+  "Metadata": {
+    "lookbackDays": 14,
+    "maxContentChars": 50000
+  },
+  "Enabled": true
+}
+```
+
+**Behavior:**
+- Reads `memory/YYYY-MM-DD.md` files from the last N days in the agent's workspace
+- Builds a consolidation prompt with the collected daily notes as context
+- Dispatches a cron-triggered session that writes distilled insights back to `MEMORY.md`
+- Skips execution if no daily notes exist in the lookback window
+
+**Use case:** Keep an agent's long-term memory fresh and relevant without manual curation. Schedule weekly during off-hours.
+
 ---
 
 ## 9. CronTool — Runtime Job Management

--- a/docs/extensions/skills.md
+++ b/docs/extensions/skills.md
@@ -1,0 +1,105 @@
+# Skills Extension
+
+The Skills extension provides the runtime infrastructure for loading, managing, and injecting skill knowledge into agent prompts. It powers the `skills` tool that agents use to discover and activate domain-specific knowledge packages.
+
+## What It Does
+
+- **Discovers skills** from the global skills directory (`~/.botnexus/skills/`) and per-agent workspace skills
+- **Injects skill context** into agent system prompts via the prompt pipeline hook system
+- **Provides the `skills` tool** with `list` and `load` actions for on-demand skill activation
+- **Manages skill lifecycle** — loading, caching, and unloading skill content
+
+## Enabling
+
+The Skills extension is built-in and enabled by default. No explicit configuration is required.
+
+Skills are discovered from:
+
+1. **Global directory**: `~/.botnexus/skills/<skill-name>/SKILL.md`
+2. **Agent workspace**: `~/.botnexus/agents/<agent-id>/workspace/skills/<skill-name>/SKILL.md`
+
+## Tools Provided
+
+### `skills`
+
+The primary tool agents use to interact with the skill system.
+
+#### `list` — Discover available skills
+
+Returns all skills available to the current agent, with descriptions.
+
+```json
+{
+  "action": "list"
+}
+```
+
+#### `load` — Activate a skill
+
+Loads a skill's content into the current conversation context.
+
+```json
+{
+  "action": "load",
+  "skillName": "my-skill"
+}
+```
+
+### `skill_manage`
+
+Administrative tool for creating and maintaining skills at runtime.
+
+| Action | Description |
+|--------|-------------|
+| `create` | Create a new skill with SKILL.md content |
+| `edit` | Full rewrite of a skill's SKILL.md |
+| `patch` | Targeted find-replace within a skill file |
+| `delete` | Remove a skill |
+| `write_file` | Write a supporting file (references/, templates/, scripts/, assets/) |
+| `remove_file` | Delete a supporting file |
+
+## Prompt Integration
+
+Skills integrate with the prompt pipeline through the `SkillPromptHookHandler`:
+
+1. **Auto-loaded skills** — Skills marked in agent config are injected into every prompt
+2. **On-demand skills** — Skills loaded via the `skills` tool are added to the current session context
+3. **Skill context section** — Appears as a `<!-- SKILLS_CONTEXT -->` block in the system prompt
+
+## Configuration
+
+### Agent-Level Skill Configuration
+
+Agents can auto-load specific skills via their configuration:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "skills": ["github", "teams", "calendar"]
+    }
+  }
+}
+```
+
+Auto-loaded skills are always available without the agent needing to call `skills load`.
+
+## Skill Directory Structure
+
+Each skill follows the [Agent Skills specification](https://agentskills.io/specification):
+
+```text
+skills/
+└── my-skill/
+    ├── SKILL.md           # Required — skill definition with YAML frontmatter
+    ├── references/        # Domain knowledge files
+    ├── templates/         # Reusable templates
+    ├── scripts/           # Executable scripts (tool wrappers)
+    └── assets/            # Static assets
+```
+
+## See Also
+
+- [Skills Guide](/skills) — comprehensive guide to writing and using skills
+- [Extension Development](../extension-development.md) — building custom extensions
+- [Prompt Pipeline](../development/prompt-pipeline.md) — how skills integrate with the prompt system

--- a/docs/features/canvas.md
+++ b/docs/features/canvas.md
@@ -1,0 +1,139 @@
+# Canvas
+
+The canvas system gives agents the ability to render rich HTML content and maintain persistent key-value state scoped to conversations. Canvas output appears in a dedicated panel in the web portal.
+
+## Overview
+
+Canvas provides two complementary capabilities:
+
+1. **HTML Rendering** — Agents can push arbitrary HTML to a visual panel (dashboards, charts, interactive UIs)
+2. **State Management** — Persistent key-value store scoped to each conversation, accessible from both agent-side tools and client-side JavaScript
+
+## Canvas Tool
+
+Agents interact with canvas through the built-in `canvas` tool.
+
+### Actions
+
+| Action | Description |
+|--------|-------------|
+| `render` | Replace the canvas panel HTML content |
+| `clear` | Clear all canvas panel content |
+| `set_state` | Store a key-value pair in conversation state |
+| `get_state` | Retrieve state (single key or all keys) |
+| `clear_state` | Remove a state key, or clear all state |
+
+### Rendering HTML
+
+```json
+{
+  "action": "render",
+  "html": "<h1>Dashboard</h1><p>Active agents: 3</p>"
+}
+```
+
+The HTML is rendered inside a sandboxed iframe in the web portal. Use `action: "clear"` to reset the panel.
+
+### State Management
+
+State is persisted in the conversation store (SQLite) and survives session restarts.
+
+**Set a value:**
+```json
+{
+  "action": "set_state",
+  "key": "theme",
+  "value": "dark"
+}
+```
+
+**Get a single key:**
+```json
+{
+  "action": "get_state",
+  "key": "theme"
+}
+```
+
+**Get all state:**
+```json
+{
+  "action": "get_state"
+}
+```
+
+**Clear a single key:**
+```json
+{
+  "action": "clear_state",
+  "key": "theme"
+}
+```
+
+**Clear all state:**
+```json
+{
+  "action": "clear_state"
+}
+```
+
+## REST API
+
+Canvas state is also accessible via the conversations REST API:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/conversations/{id}/canvas-state` | Get all canvas state for a conversation |
+| `GET` | `/api/conversations/{id}/canvas-state/{key}` | Get a specific state key |
+| `POST` | `/api/conversations/{id}/canvas-state/{key}` | Set a state key (body is the JSON value) |
+| `DELETE` | `/api/conversations/{id}/canvas-state/{key}` | Delete a specific state key |
+
+## SignalR Notifications
+
+When canvas state changes (via tool or REST API), a `CanvasStateChanged` event is broadcast to connected clients over SignalR. This enables real-time reactive UIs:
+
+```typescript
+// Client-side SignalR handler
+connection.on("CanvasStateChanged", (conversationId, key, value) => {
+  // Update local state reactively
+});
+```
+
+## postMessage Bridge
+
+Canvas HTML rendered in the iframe can communicate back to the server via `window.postMessage`. The portal's `canvasBridge.js` intercepts messages and forwards state updates through the SignalR connection:
+
+```javascript
+// Inside canvas iframe
+window.parent.postMessage({
+  type: 'canvas-state',
+  action: 'set',
+  key: 'counter',
+  value: 42
+}, '*');
+```
+
+## Configuration
+
+Canvas is a built-in tool — no additional configuration is required. The canvas panel appears automatically in the web portal when an agent uses the `canvas` tool.
+
+### State Persistence
+
+Canvas state is stored in the conversation store:
+- **SQLite**: `canvas_state` side-table with composite primary key `(conversation_id, key)`
+- **In-Memory**: `ConcurrentDictionary` per conversation (development/testing)
+- **File**: Persisted as `CanvasState` property in conversation JSON files
+
+## Use Cases
+
+- **Dashboards** — Render live metrics, charts, and status panels
+- **Interactive forms** — Collect structured input from users via HTML forms
+- **Configuration UIs** — Visual editors that persist settings via state
+- **Progress tracking** — Multi-step workflows with visual progress indicators
+- **Agent memory** — Agents can read state from previous sessions to maintain context
+
+## See Also
+
+- [Extensions](../user-guide/extensions.md) — how extensions integrate with the platform
+- [SignalR Hub Contract](../signalr-hub-contract.md) — real-time event protocol
+- [Sub-Agent Spawning](sub-agent-spawning.md) — sub-agents can inherit parent canvas context

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1,0 +1,146 @@
+# Ollama Provider
+
+Ollama runs large language models locally on your machine. BotNexus connects to Ollama through its OpenAI-compatible API endpoint, giving you fully offline agent execution with no API keys required.
+
+## Prerequisites
+
+- [Ollama](https://ollama.com/) installed and running locally
+- At least one model pulled (e.g. `ollama pull llama3`)
+
+## Quick Start
+
+Use the built-in CLI diagnostics to verify connectivity and list available models:
+
+```powershell
+# Check server status
+botnexus provider ollama status
+
+# List pulled models
+botnexus provider ollama models
+
+# Test a model with a simple prompt
+botnexus provider ollama test --model llama3
+```
+
+## Configuration
+
+Ollama uses the OpenAI-compatible provider under the hood. Configure it in `config.json`:
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "api": "openai-completions",
+      "baseUrl": "http://localhost:11434/v1",
+      "defaultModel": "llama3"
+    }
+  },
+  "agents": {
+    "my-agent": {
+      "apiProvider": "ollama",
+      "modelId": "llama3"
+    }
+  }
+}
+```
+
+No API key is required — Ollama does not authenticate local requests.
+
+### Configuration Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `api` | Yes | Must be `"openai-completions"` |
+| `baseUrl` | Yes | Ollama's OpenAI-compatible endpoint (default: `http://localhost:11434/v1`) |
+| `defaultModel` | No | Default model ID for agents using this provider |
+
+## CLI Diagnostics
+
+The `botnexus provider ollama` command group provides operator diagnostics without requiring a running gateway:
+
+### `ollama status`
+
+Check server connectivity and version:
+
+```powershell
+botnexus provider ollama status
+```
+
+```text
+✓ Ollama is running (version 0.5.4)
+  URL: http://localhost:11434
+```
+
+### `ollama models`
+
+List all models pulled on the local instance:
+
+```powershell
+botnexus provider ollama models
+```
+
+```text
+┌───────────────────┬─────────┬────────────┐
+│ Model             │ Size    │ Modified   │
+├───────────────────┼─────────┼────────────┤
+│ llama3:latest     │ 4.7 GB  │ 2 days ago │
+│ codellama:13b     │ 7.4 GB  │ 5 days ago │
+│ mistral:latest    │ 4.1 GB  │ 1 week ago │
+└───────────────────┴─────────┴────────────┘
+```
+
+### `ollama test`
+
+Send a test prompt to verify end-to-end model inference:
+
+```powershell
+botnexus provider ollama test --model llama3
+```
+
+Uses the Ollama OpenAI-compatible chat completions endpoint to confirm the model responds correctly.
+
+## Features
+
+### Streaming
+
+Fully supported via the standard SSE protocol.
+
+### Tool Use (Function Calling)
+
+Depends on the specific model. Models like `llama3` and `mistral` support function calling when configured with `--tool-call` in Ollama. Smaller or older models may not support tools.
+
+### Custom Server URL
+
+If Ollama runs on a remote machine or non-default port:
+
+```powershell
+botnexus provider ollama status --url http://192.168.1.100:11434
+botnexus provider ollama models --url http://192.168.1.100:11434
+```
+
+Update `baseUrl` in config accordingly:
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "api": "openai-completions",
+      "baseUrl": "http://192.168.1.100:11434/v1"
+    }
+  }
+}
+```
+
+## Known Limitations
+
+- **No authentication** — Ollama does not support API keys; secure your network if exposing remotely
+- **Model availability** — models must be pulled before use (`ollama pull <model>`)
+- **Context window** — varies by model; BotNexus cannot auto-detect limits for all models
+- **Token counting** — uses tiktoken-compatible estimates which may be inaccurate for non-OpenAI architectures
+- **Structured outputs** — JSON mode support depends on the specific model
+
+## See Also
+
+- [OpenAI-Compatible Provider](openai-compatible.md) — the underlying protocol Ollama uses
+- [Provider Setup](../cli-reference.md#provider-setup) — interactive provider setup wizard
+- [Configuration Guide](../configuration.md) — full configuration reference

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -45,7 +45,7 @@ This provider works with any service implementing the OpenAI Chat Completions pr
 - **DeepSeek** — `https://api.deepseek.com/v1`
 - **Groq** — `https://api.groq.com/openai/v1`
 - **Together AI** — `https://api.together.xyz/v1`
-- **Ollama** — `http://localhost:11434/v1` (local)
+- **Ollama** — `http://localhost:11434/v1` (local) — see [dedicated Ollama page](ollama.md) for CLI diagnostics
 - **vLLM** — `http://localhost:8000/v1` (local)
 - **LM Studio** — `http://localhost:1234/v1` (local)
 - **OpenRouter** — `https://openrouter.ai/api/v1`


### PR DESCRIPTION
## Changes

### New pages (3)
- `docs/providers/ollama.md` — dedicated Ollama provider page with CLI diagnostics reference
- `docs/extensions/skills.md` — Skills extension page (tools, prompt integration, directory structure)
- `docs/features/canvas.md` — Canvas feature page (tool actions, REST API, SignalR notifications, postMessage bridge)

### CLI reference updates
- Added `gateway` command section (start/stop/status/restart/install/uninstall)
- Added `provider ollama` subcommand section (status/models/test)
- Added `satellite` command section (list/register/remove)
- Fixed TOC numbering (was duplicated at 16/17)

### Content updates
- `cron-and-scheduling.md` — added §8.4 `memory-dreaming` maintenance action (PR #1124)
- `providers/openai-compatible.md` — cross-reference to new Ollama page

### Sidebar (config.mts)
- Added Ollama to Providers section
- Added Skills to Extensions section
- Added Canvas to Features section

## Gaps identified for next run
- `doctor` CLI command (locations + config checks) — undocumented
- `cron` CLI command — undocumented
- `memory` CLI command — undocumented
- `update` CLI command — undocumented
- `locations` CLI command — undocumented
- Docker sandbox isolation — no user-facing docs yet
- Satellite system architecture page — only CLI documented so far
- Dynamic model discovery — no user-facing docs yet
- Built-in agents (archetypes) — referenced in sub-agent docs but no dedicated section

---
Automated by the daily documentation groomer.