### PR TITLE
feat(ci): add maintenance automation scripts for PR status, logs, and branch sync

### DIFF
--- a/scripts/ci-pr-get-logs.ps1
+++ b/scripts/ci-pr-get-logs.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+    Retrieves failing CI workflow run logs for a given PR.
+
+.DESCRIPTION
+    Finds the most recent failing workflow run(s) on the given PR and downloads
+    their logs. Outputs log text for each failing job to stdout.
+
+.PARAMETER PR
+    The PR number to inspect.
+
+.EXAMPLE
+    pwsh -NoProfile -File scripts/ci-pr-get-logs.ps1 -PR 1127
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [int]$PR
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = 'Sytone/botnexus'
+
+# Get the head branch for this PR
+$prData = gh pr view $PR --repo $repo --json headRefName | ConvertFrom-Json
+if (-not $prData) {
+    Write-Error "PR #$PR not found."
+    return
+}
+
+$branch = $prData.headRefName
+
+# Get workflow runs for this branch
+$runs = gh run list --repo $repo --branch $branch --limit 5 --json databaseId,status,conclusion,name,headBranch |
+    ConvertFrom-Json |
+    Where-Object { $_.conclusion -eq 'failure' }
+
+if (-not $runs -or $runs.Count -eq 0) {
+    Write-Output "No failing workflow runs found for PR #$PR (branch: $branch)."
+    return
+}
+
+foreach ($run in $runs | Select-Object -First 2) {
+    Write-Output "=== Run $($run.databaseId) ($($run.name)) ==="
+    Write-Output ""
+
+    # Get failed jobs for this run
+    $jobs = gh run view $run.databaseId --repo $repo --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>$null
+    if ($jobs) {
+        Write-Output "Failed jobs: $($jobs -join ', ')"
+        Write-Output ""
+    }
+
+    # Download and output logs (truncated to last 200 lines per run)
+    $logOutput = gh run view $run.databaseId --repo $repo --log-failed 2>$null
+    if ($logOutput) {
+        $lines = $logOutput -split "`n"
+        if ($lines.Count -gt 200) {
+            Write-Output "... (truncated, showing last 200 lines) ..."
+            $lines | Select-Object -Last 200 | ForEach-Object { Write-Output $_ }
+        } else {
+            $logOutput | ForEach-Object { Write-Output $_ }
+        }
+    } else {
+        Write-Output "(No log output available for this run)"
+    }
+
+    Write-Output ""
+}

--- a/scripts/ci-pr-status.ps1
+++ b/scripts/ci-pr-status.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    Returns CI status for all open PRs in Sytone/botnexus as a JSON array.
+
+.DESCRIPTION
+    Queries GitHub for all open PRs, their check statuses, and how far behind
+    main they are. Outputs a JSON array suitable for consumption by maintenance
+    automation scripts.
+
+.OUTPUTS
+    JSON array of objects with: number, title, branch, ciStatus, behindBy,
+    failingChecks, pendingChecks, mergeable.
+
+.EXAMPLE
+    pwsh -NoProfile -File scripts/ci-pr-status.ps1
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repo = 'Sytone/botnexus'
+
+$prs = gh pr list --repo $repo --state open --json number,title,headRefName,mergeable | ConvertFrom-Json
+
+if (-not $prs -or $prs.Count -eq 0) {
+    Write-Output '[]'
+    return
+}
+
+$results = @()
+foreach ($pr in $prs) {
+    $checks = gh pr checks $pr.number --repo $repo --json name,state 2>$null | ConvertFrom-Json
+    if (-not $checks) { $checks = @() }
+
+    $behind = 0
+    try {
+        $behind = [int](gh api "repos/$repo/compare/main...$($pr.headRefName)" --jq '.behind_by' 2>$null)
+    } catch {
+        $behind = 0
+    }
+
+    $failing = @($checks | Where-Object { $_.state -eq 'FAILURE' })
+    $pending = @($checks | Where-Object { $_.state -eq 'PENDING' })
+
+    $ciStatus = if ($failing.Count -gt 0) {
+        'failing'
+    } elseif ($pending.Count -gt 0) {
+        'pending'
+    } elseif ($checks.Count -eq 0) {
+        'unknown'
+    } else {
+        'passing'
+    }
+
+    $results += [pscustomobject]@{
+        number        = $pr.number
+        title         = $pr.title
+        branch        = $pr.headRefName
+        ciStatus      = $ciStatus
+        behindBy      = $behind
+        failingChecks = @($failing | ForEach-Object { $_.name })
+        pendingChecks = @($pending | ForEach-Object { $_.name })
+        mergeable     = $pr.mergeable
+    }
+}
+
+$results | ConvertTo-Json -Depth 5

--- a/scripts/ci-pr-sync-main.ps1
+++ b/scripts/ci-pr-sync-main.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Merges main into a PR branch and pushes the result.
+
+.DESCRIPTION
+    Fetches latest main, merges it into the specified branch using a temporary
+    local checkout, and pushes. Outputs JSON with success status and message.
+
+.PARAMETER Branch
+    The head branch name to sync with main.
+
+.OUTPUTS
+    JSON object: { success: bool, message: string }
+
+.EXAMPLE
+    pwsh -NoProfile -File scripts/ci-pr-sync-main.ps1 -Branch feat/my-feature
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Branch
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = 'Sytone/botnexus'
+
+function Output-Result {
+    param([bool]$Success, [string]$Message)
+    [pscustomobject]@{ success = $Success; message = $Message } | ConvertTo-Json -Compress
+}
+
+# Fetch latest from remote
+$fetchResult = git fetch origin main $Branch 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Output-Result -Success $false -Message "Fetch failed: $fetchResult"
+    return
+}
+
+# Check if branch exists locally or needs to be checked out
+$localBranches = git branch --list $Branch 2>$null
+$worktreePath = $null
+
+# Find worktree for this branch
+$worktrees = git worktree list --porcelain 2>$null
+$currentWorktree = $null
+foreach ($line in $worktrees -split "`n") {
+    if ($line -match '^worktree (.+)$') {
+        $currentWorktree = $Matches[1]
+    }
+    if ($line -match "^branch refs/heads/$([regex]::Escape($Branch))$") {
+        $worktreePath = $currentWorktree
+        break
+    }
+}
+
+if ($worktreePath) {
+    # Use existing worktree
+    $mergeResult = git -C $worktreePath merge origin/main -m "chore: merge main into $Branch" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        # Abort the merge so we don't leave the worktree dirty
+        git -C $worktreePath merge --abort 2>$null
+        Output-Result -Success $false -Message "Merge conflict: $mergeResult"
+        return
+    }
+
+    $pushResult = git -C $worktreePath push origin $Branch 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Output-Result -Success $false -Message "Push failed: $pushResult"
+        return
+    }
+
+    Output-Result -Success $true -Message "Merged main into $Branch and pushed successfully."
+} else {
+    # No worktree — use detached merge via remote refs
+    # Create a temporary local branch tracking the remote
+    git branch -f "__sync-temp-$Branch" "origin/$Branch" 2>$null
+    $tempBranch = "__sync-temp-$Branch"
+
+    # Try merge using a temporary worktree
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "botnexus-sync-$(Get-Random)"
+    try {
+        git worktree add $tempDir $tempBranch 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Output-Result -Success $false -Message "Failed to create temporary worktree for sync."
+            return
+        }
+
+        $mergeResult = git -C $tempDir merge origin/main -m "chore: merge main into $Branch" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            git -C $tempDir merge --abort 2>$null
+            Output-Result -Success $false -Message "Merge conflict: $mergeResult"
+            return
+        }
+
+        $pushResult = git -C $tempDir push origin "${tempBranch}:${Branch}" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Output-Result -Success $false -Message "Push failed: $pushResult"
+            return
+        }
+
+        Output-Result -Success $true -Message "Merged main into $Branch and pushed successfully."
+    } finally {
+        if (Test-Path $tempDir) {
+            git worktree remove $tempDir --force 2>$null
+        }
+        git branch -D $tempBranch 2>$null
+    }
+}


### PR DESCRIPTION
Closes #1138

## Changes

Adds three PowerShell scripts referenced by the autonomous maintenance playbook:

- **`scripts/ci-pr-status.ps1`** — Queries all open PRs and outputs JSON array with CI status, behindBy count, failing/pending checks, and mergeable state
- **`scripts/ci-pr-get-logs.ps1 -PR <N>`** — Retrieves failing workflow run logs for a given PR (last 200 lines per run)
- **`scripts/ci-pr-sync-main.ps1 -Branch <name>`** — Merges main into a branch via existing worktree or temporary checkout, outputs JSON success/failure

All scripts:
- Use `gh` CLI with explicit `--repo Sytone/botnexus`
- Work from any working directory
- Have comment headers with synopsis, description, parameters, and examples

## Merge Notes

Scripts-only change, no overlap with any open PR. Safe to merge in any order.