### PR TITLE
feat(gateway): add threadpool and activity diagnostics REST endpoints

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
@@ -1,5 +1,6 @@
 using BotNexus.Gateway.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Api.Controllers;
 
@@ -12,11 +13,19 @@ namespace BotNexus.Gateway.Api.Controllers;
 public sealed class DiagnosticsController(
     ILogger<DiagnosticsController> logger,
     LogDiagnosticsRingBuffer? logBuffer = null,
-    MemoryPressureMonitor? memoryMonitor = null) : ControllerBase
+    MemoryPressureMonitor? memoryMonitor = null,
+    IThreadPoolMetrics? threadPoolMetrics = null,
+    IOptions<ThreadPoolWatchdogOptions>? threadPoolOptions = null,
+    IActivityTracker? activityTracker = null,
+    IOptions<LivenessWatchdogOptions>? livenessOptions = null) : ControllerBase
 {
     private readonly ILogger<DiagnosticsController> _logger = logger;
     private readonly LogDiagnosticsRingBuffer? _logBuffer = logBuffer;
     private readonly MemoryPressureMonitor? _memoryMonitor = memoryMonitor;
+    private readonly IThreadPoolMetrics? _threadPoolMetrics = threadPoolMetrics;
+    private readonly ThreadPoolWatchdogOptions? _threadPoolOptions = threadPoolOptions?.Value;
+    private readonly IActivityTracker? _activityTracker = activityTracker;
+    private readonly LivenessWatchdogOptions? _livenessOptions = livenessOptions?.Value;
 
     /// <summary>
     /// Accepts an error report from any channel adapter and logs it at Error level.
@@ -160,6 +169,54 @@ public sealed class DiagnosticsController(
     private static string? Sanitise(string? value) =>
         value?.Replace("\r", string.Empty, StringComparison.Ordinal)
               .Replace("\n", " ", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Returns a point-in-time threadpool snapshot with health assessment.
+    /// </summary>
+    [HttpGet("threadpool")]
+    public IActionResult GetThreadpool()
+    {
+        if (_threadPoolMetrics is null)
+            return NotFound("Threadpool diagnostics not enabled.");
+
+        var counts = _threadPoolMetrics.GetThreadCounts();
+        var pending = _threadPoolMetrics.PendingWorkItemCount;
+        var threshold = _threadPoolOptions?.QueueDepthThreshold ?? 100;
+
+        return Ok(new ThreadPoolSnapshotDto
+        {
+            PendingWorkItems = pending,
+            WorkerAvailable = counts.WorkerAvailable,
+            WorkerMax = counts.WorkerMax,
+            WorkerMin = counts.WorkerMin,
+            IoAvailable = counts.IoAvailable,
+            IoMax = counts.IoMax,
+            IoMin = counts.IoMin,
+            IsHealthy = pending < threshold,
+            QueueDepthThreshold = threshold
+        });
+    }
+
+    /// <summary>
+    /// Returns gateway activity tracking snapshot with health assessment.
+    /// </summary>
+    [HttpGet("activity")]
+    public IActionResult GetActivity()
+    {
+        if (_activityTracker is null)
+            return NotFound("Activity tracking not enabled.");
+
+        var inactivity = _activityTracker.TimeSinceLastActivity;
+        var threshold = _livenessOptions?.WarningThreshold ?? TimeSpan.FromMinutes(5);
+
+        return Ok(new ActivitySnapshotDto
+        {
+            LastActivityUtc = _activityTracker.LastActivityUtc,
+            InactivitySeconds = (long)inactivity.TotalSeconds,
+            IsHealthy = inactivity < threshold,
+            WarningThresholdSeconds = (long)threshold.TotalSeconds
+        });
+    }
 }
 
 /// <summary>
@@ -268,4 +325,55 @@ public sealed class MemoryPressureHistoryResponse
 
     /// <summary>Total snapshots retained in the ring buffer.</summary>
     public required int SnapshotsRetained { get; init; }
+}
+
+/// <summary>
+/// Point-in-time threadpool snapshot including health assessment.
+/// </summary>
+public sealed class ThreadPoolSnapshotDto
+{
+    /// <summary>Number of pending work items in the threadpool queue.</summary>
+    public required long PendingWorkItems { get; init; }
+
+    /// <summary>Available worker threads.</summary>
+    public required int WorkerAvailable { get; init; }
+
+    /// <summary>Maximum worker threads.</summary>
+    public required int WorkerMax { get; init; }
+
+    /// <summary>Minimum worker threads.</summary>
+    public required int WorkerMin { get; init; }
+
+    /// <summary>Available IO completion port threads.</summary>
+    public required int IoAvailable { get; init; }
+
+    /// <summary>Maximum IO completion port threads.</summary>
+    public required int IoMax { get; init; }
+
+    /// <summary>Minimum IO completion port threads.</summary>
+    public required int IoMin { get; init; }
+
+    /// <summary>True when pending work items are below the configured threshold.</summary>
+    public required bool IsHealthy { get; init; }
+
+    /// <summary>Configured queue depth threshold above which the pool is considered unhealthy.</summary>
+    public required int QueueDepthThreshold { get; init; }
+}
+
+/// <summary>
+/// Gateway activity tracking snapshot with health assessment.
+/// </summary>
+public sealed class ActivitySnapshotDto
+{
+    /// <summary>UTC timestamp of the last recorded gateway activity.</summary>
+    public required DateTimeOffset LastActivityUtc { get; init; }
+
+    /// <summary>Seconds since last activity.</summary>
+    public required long InactivitySeconds { get; init; }
+
+    /// <summary>True when inactivity is below the configured warning threshold.</summary>
+    public required bool IsHealthy { get; init; }
+
+    /// <summary>Configured warning threshold in seconds.</summary>
+    public required long WarningThresholdSeconds { get; init; }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/DiagnosticsEndpointTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/DiagnosticsEndpointTests.cs
@@ -1,0 +1,122 @@
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace BotNexus.Gateway.Tests.Diagnostics;
+
+public sealed class DiagnosticsEndpointTests
+{
+    // --- Threadpool endpoint ---
+
+    [Fact]
+    public void GetThreadpool_WithMetricsRegistered_ReturnsOkWithSnapshot()
+    {
+        var metrics = Substitute.For<IThreadPoolMetrics>();
+        metrics.PendingWorkItemCount.Returns(5L);
+        metrics.GetThreadCounts().Returns((90, 100, 4, 95, 100, 4));
+
+        var options = Options.Create(new ThreadPoolWatchdogOptions { QueueDepthThreshold = 100 });
+        var logger = Substitute.For<ILogger<DiagnosticsController>>();
+        var controller = new DiagnosticsController(logger, threadPoolMetrics: metrics, threadPoolOptions: options);
+
+        var result = controller.GetThreadpool();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var dto = ok.Value.ShouldBeOfType<ThreadPoolSnapshotDto>();
+        dto.PendingWorkItems.ShouldBe(5);
+        dto.WorkerAvailable.ShouldBe(90);
+        dto.WorkerMax.ShouldBe(100);
+        dto.WorkerMin.ShouldBe(4);
+        dto.IoAvailable.ShouldBe(95);
+        dto.IoMax.ShouldBe(100);
+        dto.IoMin.ShouldBe(4);
+        dto.IsHealthy.ShouldBeTrue();
+        dto.QueueDepthThreshold.ShouldBe(100);
+    }
+
+    [Fact]
+    public void GetThreadpool_WhenPendingExceedsThreshold_ReportsUnhealthy()
+    {
+        var metrics = Substitute.For<IThreadPoolMetrics>();
+        metrics.PendingWorkItemCount.Returns(150L);
+        metrics.GetThreadCounts().Returns((10, 100, 4, 50, 100, 4));
+
+        var options = Options.Create(new ThreadPoolWatchdogOptions { QueueDepthThreshold = 100 });
+        var logger = Substitute.For<ILogger<DiagnosticsController>>();
+        var controller = new DiagnosticsController(logger, threadPoolMetrics: metrics, threadPoolOptions: options);
+
+        var result = controller.GetThreadpool();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var dto = ok.Value.ShouldBeOfType<ThreadPoolSnapshotDto>();
+        dto.PendingWorkItems.ShouldBe(150);
+        dto.IsHealthy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetThreadpool_WhenNotRegistered_ReturnsNotFound()
+    {
+        var logger = Substitute.For<ILogger<DiagnosticsController>>();
+        var controller = new DiagnosticsController(logger);
+
+        var result = controller.GetThreadpool();
+
+        var notFound = result.ShouldBeOfType<NotFoundObjectResult>();
+        notFound.Value.ShouldBe("Threadpool diagnostics not enabled.");
+    }
+
+    // --- Activity endpoint ---
+
+    [Fact]
+    public void GetActivity_WithTrackerRegistered_ReturnsOkWithSnapshot()
+    {
+        var tracker = Substitute.For<IActivityTracker>();
+        tracker.LastActivityUtc.Returns(DateTimeOffset.UtcNow.AddSeconds(-30));
+        tracker.TimeSinceLastActivity.Returns(TimeSpan.FromSeconds(30));
+
+        var options = Options.Create(new LivenessWatchdogOptions { WarningThreshold = TimeSpan.FromMinutes(5) });
+        var logger = Substitute.For<ILogger<DiagnosticsController>>();
+        var controller = new DiagnosticsController(logger, activityTracker: tracker, livenessOptions: options);
+
+        var result = controller.GetActivity();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var dto = ok.Value.ShouldBeOfType<ActivitySnapshotDto>();
+        dto.InactivitySeconds.ShouldBeInRange(29, 31);
+        dto.IsHealthy.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetActivity_WhenInactivityExceedsThreshold_ReportsUnhealthy()
+    {
+        var tracker = Substitute.For<IActivityTracker>();
+        tracker.LastActivityUtc.Returns(DateTimeOffset.UtcNow.AddMinutes(-10));
+        tracker.TimeSinceLastActivity.Returns(TimeSpan.FromMinutes(10));
+
+        var options = Options.Create(new LivenessWatchdogOptions { WarningThreshold = TimeSpan.FromMinutes(5) });
+        var logger = Substitute.For<ILogger<DiagnosticsController>>();
+        var controller = new DiagnosticsController(logger, activityTracker: tracker, livenessOptions: options);
+
+        var result = controller.GetActivity();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var dto = ok.Value.ShouldBeOfType<ActivitySnapshotDto>();
+        dto.IsHealthy.ShouldBeFalse();
+        dto.InactivitySeconds.ShouldBeGreaterThanOrEqualTo(600);
+    }
+
+    [Fact]
+    public void GetActivity_WhenNotRegistered_ReturnsNotFound()
+    {
+        var logger = Substitute.For<ILogger<DiagnosticsController>>();
+        var controller = new DiagnosticsController(logger);
+
+        var result = controller.GetActivity();
+
+        var notFound = result.ShouldBeOfType<NotFoundObjectResult>();
+        notFound.Value.ShouldBe("Activity tracking not enabled.");
+    }
+}


### PR DESCRIPTION
Closes #1139

## Changes

Adds two new endpoints to `DiagnosticsController`:

- **`GET /api/diagnostics/threadpool`** — Returns threadpool snapshot: pending work items, worker/IO thread counts, health assessment based on configured queue depth threshold
- **`GET /api/diagnostics/activity`** — Returns gateway activity snapshot: last activity timestamp, inactivity duration, health assessment based on liveness watchdog threshold

Both endpoints:
- Return 404 when their backing service is not registered (graceful degradation)
- Use existing `GatewayAuthMiddleware` authentication automatically
- Compare against configured thresholds for health assessment

New DTOs: `ThreadPoolSnapshotDto`, `ActivitySnapshotDto`

6 new tests covering happy paths and service-not-registered cases.

## Test Results
- Gateway: 2549 ✅
- Architecture: 178 ✅

## Merge Notes

Only touches `DiagnosticsController.cs` and a new test file. No overlap with any open PR. Safe to merge in any order.