### PR TITLE
docs(domain): fix HIGH and MED stale XML doc comments from post-579 audit

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/Session.cs
@@ -78,9 +78,9 @@ public sealed record Session
     /// <summary>
     /// Gets or sets the conversation this session belongs to. Conversation is the
     /// durable parent container; sessions are bounded transcripts inside a conversation.
-    /// The unset sentinel is <c>default(ConversationId)</c> — store implementations are
-    /// responsible for backfilling unset values to the agent's legacy conversation
-    /// before returning a session to callers (Phase 9 / P9-B; issues #615, #627).
+    /// Always set — store implementations backfill any legacy unset values to the agent's
+    /// default conversation before returning a session to callers (completed in Phase 9 /
+    /// P9-B; issues #615, #627).
     /// </summary>
     public ConversationId ConversationId { get; set; }
 

--- a/src/domain/BotNexus.Domain/World/ICitizen.cs
+++ b/src/domain/BotNexus.Domain/World/ICitizen.cs
@@ -17,7 +17,8 @@ namespace BotNexus.Domain.World;
 /// timestamp — are intentionally deferred. Agents do not yet carry a back-reference to
 /// their <see cref="WorldDescriptor"/> (world membership is denormalised through
 /// <see cref="WorldDescriptor.HostedAgents"/>); the interface stays minimal so adoption
-/// is mechanical. Lifting <c>World</c> to the interface was deferred.
+/// is mechanical. Lifting <c>World</c> to the interface was considered in Phase 7 but
+/// deliberately deferred.
 /// </para>
 /// </remarks>
 public interface ICitizen

--- a/src/domain/BotNexus.Domain/World/User.cs
+++ b/src/domain/BotNexus.Domain/World/User.cs
@@ -15,9 +15,10 @@ namespace BotNexus.Domain.World;
 /// separate <c>UserProfile</c> aggregate that joins by <see cref="Id"/>.
 /// </para>
 /// <para>
-/// <see cref="World"/> appears here even though <see cref="ICitizen"/> does not yet expose
-/// it. Lifting <c>World</c> to the interface was deferred — currently only User
-/// carries it.
+/// <see cref="World"/> appears here even though <see cref="ICitizen"/> does not expose
+/// it. Lifting <c>World</c> to the interface was considered during Phase 7 but
+/// deliberately deferred — agents do not yet carry a back-reference to their world,
+/// so the interface stays minimal. Currently only User carries it.
 /// </para>
 /// </remarks>
 public sealed record User : ICitizen
@@ -30,8 +31,8 @@ public sealed record User : ICitizen
 
     /// <summary>
     /// The world this user is a citizen of. Mirrors the implicit world membership
-    /// agents have today via <see cref="WorldDescriptor.HostedAgents"/>; lifts to
-    /// <see cref="ICitizen"/> in Phase 7.
+    /// agents have today via <see cref="WorldDescriptor.HostedAgents"/>. Lifting to
+    /// <see cref="ICitizen"/> was considered in Phase 7 but deliberately deferred.
     /// </summary>
     public required WorldIdentity World { get; init; }
 

--- a/src/gateway/BotNexus.Gateway.Contracts/Security/IGatewayAuthHandler.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/IGatewayAuthHandler.cs
@@ -11,12 +11,15 @@ namespace BotNexus.Gateway.Abstractions.Security;
 /// <para>Built into the Gateway API middleware pipeline. Every request passes
 /// through authentication before reaching REST controllers or extension-hosted
 /// endpoints.</para>
-/// <para>Built-in implementations (planned):</para>
+/// <para>Built-in implementations:</para>
 /// <list type="bullet">
 ///   <item><b>ApiKeyAuthHandler</b> — Static API key validation. Suitable for development
 ///   and simple single-tenant deployments.</item>
-///   <item><b>JwtAuthHandler</b> — JWT bearer token validation. For production multi-tenant
-///   scenarios. Not yet implemented (see #567).</item>
+///   <item><b>SatelliteKeyAuthHandler</b> — Satellite node authentication using
+///   <c>sat_</c>-prefixed API keys.</item>
+///   <item><b>JWT (claims-based)</b> — Bearer token validation via ASP.NET JwtBearer
+///   middleware and <c>ClaimsUserIdProvider</c>. Resolves stable user identity from
+///   <c>oid</c>/<c>sub</c> claims (see #567, implemented in PR #1123).</item>
 /// </list>
 /// </remarks>
 public interface IGatewayAuthHandler


### PR DESCRIPTION
Closes #1143

Part of #612 (W-2 scope)

## Changes

Fixes 4 stale XML doc comments identified as HIGH/MED severity in #612:

| File | Fix |
|------|-----|
| `IGatewayAuthHandler.cs` | Updated "planned" implementations list — JWT auth is now implemented via ClaimsUserIdProvider + SignalRAuthPolicy (#1123), added SatelliteKeyAuthHandler |
| `User.cs` | Changed Phase 7 future-tense ("will lift World") to past-tense noting deliberate deferral |
| `ICitizen.cs` | Same Phase 7 future-tense fix — lifting World was considered and deliberately deferred |
| `Session.cs` | Updated ConversationId comment — P9-B backfill is complete (#615, #627 closed), field is now always set |

## Scope

- Comments only — zero functional code changes
- `GatewayHub.cs:29` (MED) skipped — file overlap with PR #1123
- LOW items deferred to follow-up

## Merge Notes

Independent of all other open PRs. Safe to merge in any order.
