### PR TITLE
fix(compaction): add configurable timeout and circuit-breaker for hung LLM summarization calls

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Sessions/CompactionOptions.cs
@@ -25,6 +25,14 @@ public sealed record CompactionOptions
     /// <summary>Provider to use for summarization (e.g., "github-copilot"). If null, auto-detected from registered providers.</summary>
     public string? SummarizationProvider { get; init; }
 
+    /// <summary>
+    /// Maximum seconds to wait for the LLM summarization call to complete before
+    /// aborting compaction (default: 90). Prevents hung provider calls from blocking
+    /// the session indefinitely. The timeout is enforced via a linked CancellationToken
+    /// that cancels the wait on the provider response.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 90;
+
     /// <summary>Pre-compaction memory flush configuration.</summary>
     public MemoryFlushOptions MemoryFlush { get; init; } = new();
 }

--- a/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
+++ b/src/gateway/BotNexus.Gateway/Sessions/LlmSessionCompactor.cs
@@ -155,7 +155,36 @@ public sealed class LlmSessionCompactor : ISessionCompactor
         var priorSummary = ExtractPriorSummary(toSummarize);
         var summaryPrompt = BuildSummarizationPrompt(toSummarize, options.MaxSummaryChars, priorSummary);
         var effectiveOptions = ResolveEffectiveOptions(options);
-        var summary = await CallLlmForSummaryAsync(summaryPrompt, effectiveOptions, cancellationToken).ConfigureAwait(false);
+
+        string summary;
+        try
+        {
+            summary = await CallLlmForSummaryAsync(summaryPrompt, effectiveOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Timeout fired (not caller cancellation) — treat as a provider stall.
+            _consecutiveFailures.AddOrUpdate(sessionKey, 1, (_, count) => count + 1);
+            _logger.LogWarning(
+                "Compaction timed out for session {SessionId} after {Timeout}s. " +
+                "History is unchanged. Consecutive failures: {Failures}/{Max}",
+                session.SessionId,
+                effectiveOptions.TimeoutSeconds,
+                _consecutiveFailures.GetValueOrDefault(sessionKey, 1),
+                MaxConsecutiveFailures);
+
+            return new CompactionResult
+            {
+                Summary = string.Empty,
+                Succeeded = false,
+                EntriesSummarized = 0,
+                EntriesPreserved = history.Count,
+                TokensBefore = tokensBefore,
+                TokensAfter = tokensBefore,
+                SnapshotDestructiveVersion = snap.DestructiveVersion,
+                SnapshotHistoryCount = snap.Count
+            };
+        }
 
         // Bug 1 / Bug 5 guard: if the LLM returned nothing, abort — do NOT mutate history.
         if (string.IsNullOrWhiteSpace(summary))
@@ -432,9 +461,15 @@ public sealed class LlmSessionCompactor : ISessionCompactor
                 new UserMessage(new UserMessageContent(summaryPrompt), DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
             ]);
 
+        // Create a timeout-linked token so hung provider calls are cancelled after
+        // CompactionOptions.TimeoutSeconds. The linked token fires on whichever
+        // triggers first: the caller's cancellation or the configured timeout.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(options.TimeoutSeconds));
+
         var completion = await _llmClient
             .CompleteSimpleAsync(model, context)
-            .WaitAsync(cancellationToken)
+            .WaitAsync(timeoutCts.Token)
             .ConfigureAwait(false);
 
         // Bug 3: log what actually came back before filtering.

--- a/tests/gateway/BotNexus.Gateway.Tests/Sessions/CompactionTimeoutTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Sessions/CompactionTimeoutTests.cs
@@ -1,0 +1,219 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Sessions;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core.Streaming;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Sessions;
+
+public sealed class CompactionTimeoutTests
+{
+    private static readonly LlmModel TestModel = new(
+        Id: "test-model",
+        Name: "Test Model",
+        Api: "test-api",
+        Provider: "test-provider",
+        BaseUrl: "https://example.com",
+        Reasoning: false,
+        Input: ["text"],
+        Cost: new ModelCost(0, 0, 0, 0),
+        ContextWindow: 32000,
+        MaxTokens: 4096);
+
+    [Fact]
+    public void CompactionOptions_TimeoutSeconds_DefaultIs90()
+    {
+        var options = new CompactionOptions();
+        options.TimeoutSeconds.ShouldBe(90);
+    }
+
+    [Fact]
+    public void CompactionOptions_TimeoutSeconds_CanBeCustomized()
+    {
+        var options = new CompactionOptions { TimeoutSeconds = 30 };
+        options.TimeoutSeconds.ShouldBe(30);
+    }
+
+    [Fact]
+    public async Task CompactAsync_HungLlmCall_TimesOutAndFails()
+    {
+        // Simulate an LLM call that never completes
+        var session = CreateLargeSession(100);
+        var compactor = CreateHungCompactor();
+        var options = new CompactionOptions
+        {
+            TimeoutSeconds = 1, // 1 second timeout for test speed
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        };
+
+        var result = await compactor.CompactAsync(session, options);
+
+        // Should fail gracefully rather than hang forever
+        result.Succeeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CompactAsync_CallerCancellation_ThrowsOperationCanceled()
+    {
+        var session = CreateLargeSession(100);
+        var compactor = CreateHungCompactor();
+        var options = new CompactionOptions
+        {
+            TimeoutSeconds = 300, // Long timeout — cancellation comes from caller
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        // Caller cancellation should propagate as OperationCanceledException
+        // (the coordinator layer catches this and returns a failed outcome)
+        await Should.ThrowAsync<TaskCanceledException>(
+            () => compactor.CompactAsync(session, options, cts.Token));
+    }
+
+    [Fact]
+    public async Task CompactAsync_NormalCompletion_NotAffectedByTimeout()
+    {
+        var session = CreateLargeSession(100);
+        var compactor = CreateCompactor("Good summary");
+        var options = new CompactionOptions
+        {
+            TimeoutSeconds = 90,
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        };
+
+        var result = await compactor.CompactAsync(session, options);
+
+        result.Succeeded.ShouldBeTrue();
+        result.Summary.ShouldContain("Good summary");
+    }
+
+    [Fact]
+    public async Task CompactAsync_TimeoutIncrementsCircuitBreaker()
+    {
+        var session = CreateLargeSession(100);
+        var compactor = CreateHungCompactor();
+        var options = new CompactionOptions
+        {
+            TimeoutSeconds = 1,
+            ContextWindowTokens = 100,
+            TokenThresholdRatio = 0.01,
+            PreservedTurns = 1,
+            SummarizationModel = TestModel.Id
+        };
+
+        // Each timeout increments the failure counter
+        for (var i = 0; i < LlmSessionCompactor.MaxConsecutiveFailures; i++)
+        {
+            var r = await compactor.CompactAsync(session, options);
+            r.Succeeded.ShouldBeFalse();
+        }
+
+        // Circuit breaker should now be open
+        var result = await compactor.CompactAsync(session, options);
+        result.Succeeded.ShouldBeFalse();
+        result.EntriesPreserved.ShouldBe(0); // short-circuits without snapshotting
+    }
+
+    private static GatewaySession CreateLargeSession(int entryCount)
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From(Guid.NewGuid().ToString("N")),
+            AgentId = AgentId.From("agent")
+        };
+
+        var entries = new List<SessionEntry>();
+        for (var i = 0; i < entryCount; i++)
+        {
+            entries.Add(new SessionEntry
+            {
+                Role = i % 2 == 0 ? "user" : "assistant",
+                Content = $"message {i} " + new string('x', 50)
+            });
+        }
+
+        session.AddEntries(entries);
+        return session;
+    }
+
+    private static LlmSessionCompactor CreateCompactor(string summary)
+    {
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        models.Register(TestModel.Provider, TestModel);
+
+        var provider = new Mock<IApiProvider>();
+        provider.SetupGet(item => item.Api).Returns(TestModel.Api);
+        provider.Setup(item => item.StreamSimple(
+                It.IsAny<LlmModel>(),
+                It.IsAny<Context>(),
+                It.IsAny<SimpleStreamOptions?>()))
+            .Returns(() => CreateStream(summary));
+
+        providers.Register(provider.Object);
+
+        var llmClient = new LlmClient(providers, models);
+        return new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
+    }
+
+    /// <summary>
+    /// Creates a compactor that simulates a hung LLM call (never completes).
+    /// The stream's GetResultAsync() will never resolve.
+    /// </summary>
+    private static LlmSessionCompactor CreateHungCompactor()
+    {
+        var providers = new ApiProviderRegistry();
+        var models = new ModelRegistry();
+        models.Register(TestModel.Provider, TestModel);
+
+        var provider = new Mock<IApiProvider>();
+        provider.SetupGet(item => item.Api).Returns(TestModel.Api);
+        provider.Setup(item => item.StreamSimple(
+                It.IsAny<LlmModel>(),
+                It.IsAny<Context>(),
+                It.IsAny<SimpleStreamOptions?>()))
+            .Returns(() =>
+            {
+                // Return a stream that never pushes a result — simulates hung provider
+                return new LlmStream();
+            });
+
+        providers.Register(provider.Object);
+
+        var llmClient = new LlmClient(providers, models);
+        return new LlmSessionCompactor(llmClient, NullLogger<LlmSessionCompactor>.Instance);
+    }
+
+    private static LlmStream CreateStream(string summary)
+    {
+        var stream = new LlmStream();
+        var completion = new AssistantMessage(
+            Content: [new TextContent(summary)],
+            Api: TestModel.Api,
+            Provider: TestModel.Provider,
+            ModelId: TestModel.Id,
+            Usage: Usage.Empty(),
+            StopReason: StopReason.Stop,
+            ErrorMessage: null,
+            ResponseId: null,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        stream.Push(new DoneEvent(StopReason.Stop, completion));
+        stream.End(completion);
+        return stream;
+    }
+}


### PR DESCRIPTION
Closes #1149

## Changes
- Add `CompactionOptions.TimeoutSeconds` (default 90s) for compaction LLM call timeout enforcement
- Create a linked `CancellationTokenSource` in `CallLlmForSummaryAsync` that fires on whichever triggers first: caller cancellation or the configured timeout
- Timeout failures now increment the circuit breaker counter (same path as empty-summary failures) and log a specific warning with the configured timeout value
- Caller cancellation (gateway shutdown, explicit abort) correctly propagates as `OperationCanceledException` for the coordinator to handle

## Root Cause
The compaction LLM call used `.WaitAsync(cancellationToken)` which only respected the caller's token. A hung provider (no response, stalled connection) would block the compaction task indefinitely since `CompleteSimpleAsync` does not accept a `CancellationToken` internally. The issue claimed a 60s timeout existed (`CompactionOptions.TimeoutSeconds`) but that property was only on `MemoryFlushOptions` — no compaction-level timeout existed.

## Tests
6 new tests covering:
- Default timeout value is 90s
- Custom timeout configuration
- Hung LLM call times out and returns failed result
- Caller cancellation propagates correctly (not absorbed)
- Normal completion unaffected by timeout
- Timeout increments circuit breaker counter

## Merge Notes
Independent of all open PRs. Touches only `CompactionOptions.cs` and `LlmSessionCompactor.cs` which have no overlap with the current queue.