### PR TITLE
fix(security): extract SSRF validator as shared utility for reuse across tools

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/WebFetchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebFetchTool.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Gateway.Abstractions.Security;
 
 namespace BotNexus.Extensions.WebTools;
 
@@ -89,11 +90,17 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
 
         // SSRF guard: block private/loopback/IMDS addresses and additional blocked hosts
         if (!_config.AllowPrivateNetworks)
-            AssertNotPrivateOrImds(uri);
-
-        // Always check additional blocked hosts (even when AllowPrivateNetworks = true)
-        if (_config.AdditionalBlockedHosts.Count > 0)
-            AssertNotAdditionalBlocked(uri);
+            SsrfValidator.AssertSafe(uri, _config.AdditionalBlockedHosts);
+        else if (_config.AdditionalBlockedHosts.Count > 0)
+        {
+            // Even when AllowPrivateNetworks = true, check additional blocked hosts
+            foreach (var blocked in _config.AdditionalBlockedHosts)
+            {
+                if (uri.Host.Equals(blocked, StringComparison.OrdinalIgnoreCase))
+                    throw new ArgumentException(
+                        $"URL host '{uri.Host}' is blocked by configuration (SSRF prevention).");
+            }
+        }
 
         var maxLength = ReadOptionalInt(arguments, "max_length") ?? 5000;
         if (maxLength < 1 || maxLength > _config.MaxLengthChars)
@@ -120,83 +127,13 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
     /// <summary>
     /// Throws <see cref="ArgumentException"/> when <paramref name="uri"/> resolves to a
     /// private, loopback, link-local, IMDS, or otherwise reserved address.
+    /// Delegates to <see cref="SsrfValidator"/> for the actual validation logic.
     /// </summary>
-    /// <remarks>
-    /// Checked ranges (IPv4):
-    /// <list type="bullet">
-    ///   <item>Loopback: 127.0.0.0/8</item>
-    ///   <item>Any: 0.0.0.0/8</item>
-    ///   <item>Link-local / IMDS: 169.254.0.0/16</item>
-    ///   <item>RFC-1918 class A: 10.0.0.0/8</item>
-    ///   <item>RFC-1918 class B: 172.16.0.0/12</item>
-    ///   <item>RFC-1918 class C: 192.168.0.0/16</item>
-    ///   <item>Carrier-grade NAT: 100.64.0.0/10</item>
-    /// </list>
-    /// IPv6 loopback (::1) and hostnames <c>localhost</c> /
-    /// <c>metadata.google.internal</c> are also blocked.
-    /// </remarks>
     internal static void AssertNotPrivateOrImds(Uri uri)
     {
-        var host = uri.Host;
-
-        // Blocked hostnames (exact, case-insensitive)
-        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
-            host.Equals("metadata.google.internal", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new ArgumentException(
-                $"URL host '{host}' is blocked for security reasons (SSRF prevention).");
-        }
-
-        // Try to parse as an IP address (handles both bare IPv4 and [IPv6] bracket notation)
-        var hostToParse = host.StartsWith('[') && host.EndsWith(']')
-            ? host[1..^1]   // strip IPv6 brackets
-            : host;
-
-        if (!System.Net.IPAddress.TryParse(hostToParse, out var ip))
-            return; // hostname — DNS resolution not performed at prep time
-
-        // IPv6 loopback ::1
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
-        {
-            if (ip.Equals(System.Net.IPAddress.IPv6Loopback))
-                throw new ArgumentException(
-                    $"URL host '{host}' is blocked for security reasons (SSRF prevention).");
-            return; // other IPv6 addresses: allow (no private-range filtering for IPv6 beyond ::1)
-        }
-
-        // IPv4 range checks
-        var bytes = ip.GetAddressBytes(); // big-endian: bytes[0] is most-significant
-        var b0 = bytes[0];
-        var b1 = bytes[1];
-
-        bool isBlocked =
-            b0 == 127 ||                                    // 127.0.0.0/8   loopback
-            b0 == 0 ||                                      // 0.0.0.0/8     any
-            b0 == 10 ||                                     // 10.0.0.0/8    RFC-1918
-            (b0 == 169 && b1 == 254) ||                     // 169.254.0.0/16 link-local / IMDS
-            (b0 == 172 && b1 >= 16 && b1 <= 31) ||         // 172.16.0.0/12 RFC-1918
-            (b0 == 192 && b1 == 168) ||                     // 192.168.0.0/16 RFC-1918
-            (b0 == 100 && (b1 & 0xC0) == 64);              // 100.64.0.0/10 CGN
-
-        if (isBlocked)
-            throw new ArgumentException(
-                $"URL host '{host}' is blocked for security reasons (SSRF prevention).");
+        SsrfValidator.AssertSafe(uri);
     }
 
-    /// <summary>
-    /// Throws <see cref="ArgumentException"/> when the URI host exactly matches one of the
-    /// <see cref="WebFetchConfig.AdditionalBlockedHosts"/>.
-    /// </summary>
-    private void AssertNotAdditionalBlocked(Uri uri)
-    {
-        var host = uri.Host;
-        foreach (var blocked in _config.AdditionalBlockedHosts)
-        {
-            if (host.Equals(blocked, StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException(
-                    $"URL host '{host}' is blocked by configuration (SSRF prevention).");
-        }
-    }
 
     /// <inheritdoc />
     public async Task<AgentToolResult> ExecuteAsync(

--- a/src/gateway/BotNexus.Gateway.Contracts/Security/SsrfValidator.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Security/SsrfValidator.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace BotNexus.Gateway.Abstractions.Security;
+
+/// <summary>
+/// Shared SSRF (Server-Side Request Forgery) validation utility.
+/// Validates URLs against private network ranges, cloud metadata endpoints,
+/// and configurable blocked hosts before opening outbound connections.
+/// <para>
+/// Use this for ANY URL that will be used to open a new connection —
+/// not just user-provided URLs but also dynamically-discovered URLs from
+/// intermediary services (CDP /json/list, proxy headers, redirect targets, etc.).
+/// </para>
+/// </summary>
+public static class SsrfValidator
+{
+    /// <summary>
+    /// Validates that a URI does not target private, loopback, link-local,
+    /// cloud metadata, or otherwise reserved network addresses.
+    /// </summary>
+    /// <param name="uri">The URI to validate.</param>
+    /// <param name="additionalBlockedHosts">
+    /// Optional additional hostnames to block (exact match, case-insensitive).
+    /// </param>
+    /// <returns>
+    /// An <see cref="SsrfValidationResult"/> indicating whether the URL is safe
+    /// or the reason it was blocked.
+    /// </returns>
+    public static SsrfValidationResult Validate(Uri uri, IReadOnlyList<string>? additionalBlockedHosts = null)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+
+        // Only HTTP(S) schemes are valid for outbound connections
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return SsrfValidationResult.Blocked(
+                $"URL scheme '{uri.Scheme}' is not allowed. Only HTTP and HTTPS are permitted.");
+        }
+
+        var host = uri.Host;
+
+        // Check additional blocked hosts first (cheapest comparison)
+        if (additionalBlockedHosts is { Count: > 0 })
+        {
+            foreach (var blocked in additionalBlockedHosts)
+            {
+                if (host.Equals(blocked, StringComparison.OrdinalIgnoreCase))
+                {
+                    return SsrfValidationResult.Blocked(
+                        $"URL host '{host}' is blocked by configuration (SSRF prevention).");
+                }
+            }
+        }
+
+        // Blocked hostnames (exact, case-insensitive)
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+            host.Equals("metadata.google.internal", StringComparison.OrdinalIgnoreCase))
+        {
+            return SsrfValidationResult.Blocked(
+                $"URL host '{host}' is blocked for security reasons (SSRF prevention).");
+        }
+
+        // Try to parse as an IP address (handles both bare IPv4 and [IPv6] bracket notation)
+        var hostToParse = host.StartsWith('[') && host.EndsWith(']')
+            ? host[1..^1]   // strip IPv6 brackets
+            : host;
+
+        if (!IPAddress.TryParse(hostToParse, out var ip))
+        {
+            // Hostname — DNS resolution not performed at validation time.
+            // Safe to proceed (DNS rebinding attacks require additional mitigations).
+            return SsrfValidationResult.Allowed;
+        }
+
+        // IPv6 loopback ::1
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (ip.Equals(IPAddress.IPv6Loopback))
+            {
+                return SsrfValidationResult.Blocked(
+                    $"URL host '{host}' is blocked for security reasons (SSRF prevention).");
+            }
+
+            // Other IPv6 addresses: allow (no private-range filtering beyond ::1)
+            return SsrfValidationResult.Allowed;
+        }
+
+        // IPv4 range checks
+        var bytes = ip.GetAddressBytes(); // big-endian: bytes[0] is most-significant
+        var b0 = bytes[0];
+        var b1 = bytes[1];
+
+        bool isBlocked =
+            b0 == 127 ||                                    // 127.0.0.0/8   loopback
+            b0 == 0 ||                                      // 0.0.0.0/8     any
+            b0 == 10 ||                                     // 10.0.0.0/8    RFC-1918
+            (b0 == 169 && b1 == 254) ||                     // 169.254.0.0/16 link-local / IMDS
+            (b0 == 172 && b1 >= 16 && b1 <= 31) ||         // 172.16.0.0/12 RFC-1918
+            (b0 == 192 && b1 == 168) ||                     // 192.168.0.0/16 RFC-1918
+            (b0 == 100 && (b1 & 0xC0) == 64);              // 100.64.0.0/10 CGN
+
+        if (isBlocked)
+        {
+            return SsrfValidationResult.Blocked(
+                $"URL host '{host}' is blocked for security reasons (SSRF prevention).");
+        }
+
+        return SsrfValidationResult.Allowed;
+    }
+
+    /// <summary>
+    /// Throws <see cref="ArgumentException"/> if the URI targets a blocked address.
+    /// Convenience method for use in tool argument validation where an exception
+    /// is the expected failure path.
+    /// </summary>
+    /// <param name="uri">The URI to validate.</param>
+    /// <param name="additionalBlockedHosts">
+    /// Optional additional hostnames to block (exact match, case-insensitive).
+    /// </param>
+    /// <exception cref="ArgumentException">Thrown when the URL is blocked.</exception>
+    public static void AssertSafe(Uri uri, IReadOnlyList<string>? additionalBlockedHosts = null)
+    {
+        var result = Validate(uri, additionalBlockedHosts);
+        if (!result.IsSafe)
+        {
+            throw new ArgumentException(result.Reason);
+        }
+    }
+}
+
+/// <summary>
+/// Result of an SSRF validation check.
+/// </summary>
+public readonly struct SsrfValidationResult
+{
+    /// <summary>Whether the URL is safe to connect to.</summary>
+    public bool IsSafe { get; }
+
+    /// <summary>Human-readable reason the URL was blocked (null when safe).</summary>
+    public string? Reason { get; }
+
+    private SsrfValidationResult(bool isSafe, string? reason)
+    {
+        IsSafe = isSafe;
+        Reason = reason;
+    }
+
+    /// <summary>The URL passed validation.</summary>
+    public static SsrfValidationResult Allowed => new(true, null);
+
+    /// <summary>The URL was blocked for the given reason.</summary>
+    public static SsrfValidationResult Blocked(string reason) => new(false, reason);
+}

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/SsrfValidatorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/SsrfValidatorTests.cs
@@ -1,0 +1,177 @@
+using BotNexus.Gateway.Abstractions.Security;
+
+namespace BotNexus.Extensions.WebTools.Tests;
+
+public sealed class SsrfValidatorTests
+{
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("https://api.github.com/repos")]
+    [InlineData("http://8.8.8.8/health")]
+    [InlineData("https://203.0.113.1/api")]
+    public void Validate_PublicUrls_ReturnsAllowed(string url)
+    {
+        var result = SsrfValidator.Validate(new Uri(url));
+        result.IsSafe.ShouldBeTrue();
+        result.Reason.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1")]
+    [InlineData("http://127.0.0.1:8080/api")]
+    [InlineData("http://127.255.0.1")]
+    public void Validate_LoopbackIPv4_ReturnsBlocked(string url)
+    {
+        var result = SsrfValidator.Validate(new Uri(url));
+        result.IsSafe.ShouldBeFalse();
+        result.Reason!.ShouldContain("SSRF prevention");
+    }
+
+    [Fact]
+    public void Validate_LoopbackIPv6_ReturnsBlocked()
+    {
+        var result = SsrfValidator.Validate(new Uri("http://[::1]/api"));
+        result.IsSafe.ShouldBeFalse();
+        result.Reason!.ShouldContain("SSRF prevention");
+    }
+
+    [Fact]
+    public void Validate_Localhost_ReturnsBlocked()
+    {
+        var result = SsrfValidator.Validate(new Uri("http://localhost/api"));
+        result.IsSafe.ShouldBeFalse();
+        result.Reason!.ShouldContain("SSRF prevention");
+    }
+
+    [Fact]
+    public void Validate_LocalhostCaseInsensitive_ReturnsBlocked()
+    {
+        var result = SsrfValidator.Validate(new Uri("http://LOCALHOST:3000/"));
+        result.IsSafe.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_GoogleMetadata_ReturnsBlocked()
+    {
+        var result = SsrfValidator.Validate(new Uri("http://metadata.google.internal/computeMetadata"));
+        result.IsSafe.ShouldBeFalse();
+        result.Reason!.ShouldContain("SSRF prevention");
+    }
+
+    [Theory]
+    [InlineData("http://169.254.169.254/latest/meta-data")] // AWS IMDS
+    [InlineData("http://169.254.0.1")]                       // link-local
+    public void Validate_LinkLocalImds_ReturnsBlocked(string url)
+    {
+        var result = SsrfValidator.Validate(new Uri(url));
+        result.IsSafe.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("http://10.0.0.1")]
+    [InlineData("http://10.255.255.255")]
+    [InlineData("http://172.16.0.1")]
+    [InlineData("http://172.31.255.255")]
+    [InlineData("http://192.168.0.1")]
+    [InlineData("http://192.168.255.255")]
+    public void Validate_Rfc1918_ReturnsBlocked(string url)
+    {
+        var result = SsrfValidator.Validate(new Uri(url));
+        result.IsSafe.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("http://100.64.0.1")]   // CGN start
+    [InlineData("http://100.127.255.255")] // CGN end
+    public void Validate_CarrierGradeNat_ReturnsBlocked(string url)
+    {
+        var result = SsrfValidator.Validate(new Uri(url));
+        result.IsSafe.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_ZeroNetwork_ReturnsBlocked()
+    {
+        var result = SsrfValidator.Validate(new Uri("http://0.0.0.0/"));
+        result.IsSafe.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("http://172.15.255.255")] // just below 172.16.0.0
+    [InlineData("http://172.32.0.0")]     // just above 172.31.255.255
+    public void Validate_NearRfc1918Boundary_ReturnsAllowed(string url)
+    {
+        var result = SsrfValidator.Validate(new Uri(url));
+        result.IsSafe.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_AdditionalBlockedHosts_ReturnsBlocked()
+    {
+        var blocked = new[] { "evil.internal", "attacker.local" };
+        var result = SsrfValidator.Validate(new Uri("https://evil.internal/api"), blocked);
+        result.IsSafe.ShouldBeFalse();
+        result.Reason!.ShouldContain("blocked by configuration");
+    }
+
+    [Fact]
+    public void Validate_AdditionalBlockedHosts_CaseInsensitive()
+    {
+        var blocked = new[] { "EVIL.INTERNAL" };
+        var result = SsrfValidator.Validate(new Uri("https://evil.internal/api"), blocked);
+        result.IsSafe.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_NonBlockedHost_ReturnsAllowed()
+    {
+        var blocked = new[] { "evil.internal" };
+        var result = SsrfValidator.Validate(new Uri("https://safe.example.com/api"), blocked);
+        result.IsSafe.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_NonHttpScheme_ReturnsBlocked()
+    {
+        var result = SsrfValidator.Validate(new Uri("ftp://files.example.com/data"));
+        result.IsSafe.ShouldBeFalse();
+        result.Reason!.ShouldContain("Only HTTP and HTTPS are permitted");
+    }
+
+    [Fact]
+    public void AssertSafe_BlockedUrl_ThrowsArgumentException()
+    {
+        Should.Throw<ArgumentException>(() =>
+            SsrfValidator.AssertSafe(new Uri("http://169.254.169.254/latest")));
+    }
+
+    [Fact]
+    public void AssertSafe_SafeUrl_DoesNotThrow()
+    {
+        Should.NotThrow(() =>
+            SsrfValidator.AssertSafe(new Uri("https://api.example.com/data")));
+    }
+
+    [Fact]
+    public void Validate_NullUri_ThrowsArgumentNull()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            SsrfValidator.Validate(null!));
+    }
+
+    [Fact]
+    public void Validate_PublicIPv6_ReturnsAllowed()
+    {
+        // 2001:db8::1 is documentation range but not loopback
+        var result = SsrfValidator.Validate(new Uri("http://[2001:db8::1]/api"));
+        result.IsSafe.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_HostnameNotResolved_ReturnsAllowed()
+    {
+        // Non-IP hostnames are allowed (DNS not resolved at validation time)
+        var result = SsrfValidator.Validate(new Uri("https://internal.corp.example.com/api"));
+        result.IsSafe.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Closes #1147

## Changes
- Create `SsrfValidator` in `Gateway.Contracts/Security/` as a shared SSRF validation utility
- Provides `Validate(Uri, IReadOnlyList<string>?)` returning `SsrfValidationResult` (safe/blocked with reason)
- Provides `AssertSafe(Uri, IReadOnlyList<string>?)` convenience method that throws `ArgumentException`
- Validates: scheme (HTTP/HTTPS only), hostnames (localhost, metadata.google.internal), IPv4 ranges (loopback, RFC-1918, IMDS/link-local, CGN, 0.0.0.0/8), IPv6 loopback, and configurable additional blocked hosts
- `WebFetchTool` now delegates to `SsrfValidator.AssertSafe()` instead of inline logic
- Removed redundant `AssertNotAdditionalBlocked` private method (logic now in shared validator)
- Retained `AssertNotPrivateOrImds` as a thin wrapper for test compatibility

## Why
Any URL discovered from a third-party service (CDP `/json/list`, proxy headers, sandbox callbacks) and used to open a new connection is an SSRF vector. The deny list was previously locked inside WebFetchTool. Docker sandbox tool routing (#1072), future browser tools, and any extension opening outbound connections can now use the same shared validator.

## Tests
22 new tests covering:
- Public URLs allowed (IPv4, hostnames)
- Loopback IPv4/IPv6 blocked
- Localhost blocked (case-insensitive)
- Google metadata blocked
- Link-local/IMDS blocked
- All RFC-1918 ranges blocked
- CGN blocked
- 0.0.0.0/8 blocked
- Boundary cases (172.15.x allowed, 172.32.x allowed)
- Additional blocked hosts (configurable, case-insensitive)
- Non-HTTP schemes blocked
- Null URI throws ArgumentNullException
- Hostnames not DNS-resolved (allowed)
- AssertSafe convenience method throws/doesn't throw

## Merge Notes
Independent of all open PRs. Touches `WebFetchTool.cs` (no overlap) and adds `SsrfValidator.cs` to Gateway.Contracts.