### PR TITLE
fix(channels): evict stale streaming and error-reply state in Telegram adapter

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
@@ -3,6 +3,9 @@
     <RootNamespace>BotNexus.Extensions.Channels.Telegram</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Gateway.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="botnexus-extension.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -272,6 +272,8 @@ public sealed class TelegramChannelAdapter(
                 case AgentStreamEventType.MessageEnd:
                     await FlushStreamingStateAsync(runtime, state, force: true, cancellationToken);
                     state.Reset();
+                    // Remove the entry to prevent unbounded dictionary growth over time.
+                    runtime.StreamingStates.TryRemove(stateKey, out _);
                     return;
             }
 
@@ -287,6 +289,7 @@ public sealed class TelegramChannelAdapter(
     private async Task RunPollingLoopAsync(BotRuntime runtime, int pollingTimeoutSeconds, CancellationToken cancellationToken)
     {
         long? offset = null;
+        var lastEvictionUtc = DateTimeOffset.UtcNow;
         while (!cancellationToken.IsCancellationRequested)
         {
             try
@@ -296,6 +299,13 @@ public sealed class TelegramChannelAdapter(
                 {
                     offset = update.UpdateId + 1;
                     await HandleUpdateAsync(runtime, update, cancellationToken);
+                }
+
+                // Periodically evict stale error-reply tracking entries (every 5 minutes).
+                if (DateTimeOffset.UtcNow - lastEvictionUtc > TimeSpan.FromMinutes(5))
+                {
+                    EvictStaleErrorStateForRuntime(runtime, TimeSpan.FromMinutes(30));
+                    lastEvictionUtc = DateTimeOffset.UtcNow;
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -593,6 +603,41 @@ public sealed class TelegramChannelAdapter(
     {
         if (builder.Length > 0)
             builder.AppendLine();
+    }
+
+    /// <summary>
+    /// Returns the total number of streaming state entries across all bot runtimes.
+    /// Used for diagnostics and testing to verify state is properly evicted.
+    /// </summary>
+    internal int GetStreamingStateCount()
+        => _bots.Values.Sum(r => r.StreamingStates.Count);
+
+    /// <summary>
+    /// Returns the total number of error reply tracking entries across all bot runtimes.
+    /// Used for diagnostics and testing to verify state is properly evicted.
+    /// </summary>
+    internal int GetErrorReplyStateCount()
+        => _bots.Values.Sum(r => r.LastErrorReplyUtcByChat.Count);
+
+    /// <summary>
+    /// Removes error reply tracking entries older than <paramref name="maxAge"/>.
+    /// Prevents unbounded growth of the per-chat error cooldown dictionary.
+    /// </summary>
+    /// <param name="maxAge">Maximum age for retained entries. Entries older than this are removed.</param>
+    internal void EvictStaleErrorState(TimeSpan maxAge)
+    {
+        foreach (var runtime in _bots.Values)
+            EvictStaleErrorStateForRuntime(runtime, maxAge);
+    }
+
+    private static void EvictStaleErrorStateForRuntime(BotRuntime runtime, TimeSpan maxAge)
+    {
+        var cutoff = DateTimeOffset.UtcNow - maxAge;
+        foreach (var kvp in runtime.LastErrorReplyUtcByChat)
+        {
+            if (kvp.Value < cutoff)
+                runtime.LastErrorReplyUtcByChat.TryRemove(kvp.Key, out _);
+        }
     }
 
     private sealed class BotRuntime(string botName, TelegramBotConfig config, TelegramBotApiClient apiClient)

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramStateEvictionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramStateEvictionTests.cs
@@ -1,0 +1,219 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Extensions.Channels.Telegram;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net;
+using System.Text.Json;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+/// <summary>
+/// Tests for streaming state and error reply state eviction in the Telegram channel adapter.
+/// Verifies that in-memory collections do not grow unbounded over time.
+/// </summary>
+public sealed class TelegramStateEvictionTests
+{
+    private static TelegramChannelAdapter CreateAdapter(HttpMessageHandler handler, int errorCooldownMs = 5000)
+    {
+        var options = Options.Create(new TelegramGatewayOptions
+        {
+            BotToken = "123:ABC",
+            ErrorCooldownMs = errorCooldownMs,
+            AllowedChatIds = { 41, 42, 43, 44, 45, 46 }
+        });
+        var factory = new StubHttpClientFactory(_ => new HttpClient(handler));
+        return new TelegramChannelAdapter(
+            NullLogger<TelegramChannelAdapter>.Instance,
+            options,
+            factory);
+    }
+
+    private static StubHttpMessageHandler CreateOkHandler()
+    {
+        return new StubHttpMessageHandler((request, _) =>
+        {
+            // Determine which Telegram API method is being called from the URL path
+            var path = request.RequestUri?.AbsolutePath ?? "";
+            string json;
+
+            if (path.Contains("/sendMessage") || path.Contains("/editMessageText"))
+            {
+                // Return a valid TelegramMessage-shaped response
+                json = JsonSerializer.Serialize(new
+                {
+                    ok = true,
+                    result = new
+                    {
+                        message_id = 1,
+                        chat = new { id = 42 },
+                        date = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                        text = "ok"
+                    }
+                });
+            }
+            else
+            {
+                json = JsonSerializer.Serialize(new { ok = true, result = true });
+            }
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        });
+    }
+
+    private static async Task StartAdapterAsync(TelegramChannelAdapter adapter)
+    {
+        var dispatcher = new Mock<IChannelDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+    }
+
+    private static ChannelStreamTarget MakeTarget(int chatId)
+    {
+        return new ChannelStreamTarget(
+            ConversationId.From($"conv-{chatId}"),
+            SessionId.From($"session-{chatId}"),
+            ChannelAddress.From($"{chatId}"));
+    }
+
+    [Fact]
+    public async Task StreamingState_RemovedAfterMessageEnd()
+    {
+        var handler = CreateOkHandler();
+        var adapter = CreateAdapter(handler);
+        await StartAdapterAsync(adapter);
+
+        var target = MakeTarget(42);
+
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hello" }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }, CancellationToken.None);
+
+        Assert.Equal(0, adapter.GetStreamingStateCount());
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StreamingState_RetainedDuringActiveStream()
+    {
+        var handler = CreateOkHandler();
+        var adapter = CreateAdapter(handler);
+        await StartAdapterAsync(adapter);
+
+        var target = MakeTarget(42);
+
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "hello" }, CancellationToken.None);
+
+        Assert.Equal(1, adapter.GetStreamingStateCount());
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StreamingState_MultipleSessionsAllEvictedAfterEnd()
+    {
+        var handler = CreateOkHandler();
+        var adapter = CreateAdapter(handler);
+        await StartAdapterAsync(adapter);
+
+        for (int i = 1; i <= 5; i++)
+        {
+            var target = MakeTarget(40 + i);
+
+            await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+            await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = $"msg-{i}" }, CancellationToken.None);
+            await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }, CancellationToken.None);
+        }
+
+        Assert.Equal(0, adapter.GetStreamingStateCount());
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task LastErrorReplyState_EvictsStaleEntries()
+    {
+        var handler = CreateOkHandler();
+        var adapter = CreateAdapter(handler, errorCooldownMs: 100);
+        await StartAdapterAsync(adapter);
+
+        for (int i = 1; i <= 3; i++)
+        {
+            var target = MakeTarget(40 + i);
+
+            await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+            await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "test error" }, CancellationToken.None);
+            await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }, CancellationToken.None);
+        }
+
+        // Force eviction of all entries (maxAge=Zero means everything is stale)
+        adapter.EvictStaleErrorState(TimeSpan.Zero);
+
+        Assert.Equal(0, adapter.GetErrorReplyStateCount());
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task LastErrorReplyState_RetainsRecentEntries()
+    {
+        var handler = CreateOkHandler();
+        var adapter = CreateAdapter(handler, errorCooldownMs: 100);
+        await StartAdapterAsync(adapter);
+
+        var target = MakeTarget(42);
+
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.Error, ErrorMessage = "test" }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }, CancellationToken.None);
+
+        // Evict only entries older than 1 hour (recent should survive)
+        adapter.EvictStaleErrorState(TimeSpan.FromHours(1));
+
+        Assert.Equal(1, adapter.GetErrorReplyStateCount());
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StreamingState_NewStreamOnSameChannelAfterEviction_Works()
+    {
+        var handler = CreateOkHandler();
+        var adapter = CreateAdapter(handler);
+        await StartAdapterAsync(adapter);
+
+        var target = MakeTarget(42);
+
+        // First stream
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "first" }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }, CancellationToken.None);
+        Assert.Equal(0, adapter.GetStreamingStateCount());
+
+        // Second stream on same address
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageStart }, CancellationToken.None);
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "second" }, CancellationToken.None);
+        Assert.Equal(1, adapter.GetStreamingStateCount());
+
+        await adapter.SendStreamEventAsync(target, new AgentStreamEvent { Type = AgentStreamEventType.MessageEnd }, CancellationToken.None);
+        Assert.Equal(0, adapter.GetStreamingStateCount());
+
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    private sealed class StubHttpClientFactory(Func<string, HttpClient> factory) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => factory(name);
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
Closes #1151

## Changes

- **StreamingStates**: entries are now `TryRemove`d from the dictionary on `MessageEnd` instead of only being reset in-place. Previously, completed streaming sessions left orphan dictionary entries that accumulated indefinitely over the adapter's lifetime.

- **LastErrorReplyUtcByChat**: added periodic eviction (every 5 minutes during polling, removing entries older than 30 minutes). This prevents unbounded growth proportional to the number of unique chat IDs that have ever triggered an error.

- **InternalsVisibleTo**: added to the Telegram extension csproj so Gateway.Tests can verify eviction behavior.

- **6 new tests**: covering state removal on MessageEnd, retention during active streams, multi-session eviction, stale/recent error state differentiation, and same-channel stream reuse after eviction.

## Merge Notes

No file overlap with any open PR. Safe to merge in any order.