### PR TITLE
fix(gateway): resolve skill paths to sandbox-relative locations for Docker isolation

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/DockerWorkspaceSynchronizer.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/DockerWorkspaceSynchronizer.cs
@@ -105,4 +105,53 @@ public sealed class DockerWorkspaceSynchronizer : IWorkspaceSynchronizer
                 Error: ex.Message);
         }
     }
+
+    /// <summary>
+    /// Copies skill scripts from the host skills directory into the sandbox.
+    /// This ensures skill references in the agent prompt resolve correctly inside the container.
+    /// </summary>
+    /// <param name="sandboxName">Target sandbox name.</param>
+    /// <param name="hostSkillsDir">Absolute path to the host skills directory.</param>
+    /// <param name="sandboxSkillsPath">Path inside the sandbox to copy skills into.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result describing what was synced.</returns>
+    public async Task<WorkspaceSyncResult> SyncSkillsToSandboxAsync(
+        string sandboxName,
+        string hostSkillsDir,
+        string sandboxSkillsPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostSkillsDir);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sandboxSkillsPath);
+
+        _logger.LogInformation(
+            "Skills sync: copying host '{HostSkillsDir}' → sandbox '{SandboxName}:{SandboxSkillsPath}'",
+            hostSkillsDir, sandboxName, sandboxSkillsPath);
+
+        try
+        {
+            await _runner.CopyToSandboxAsync(
+                sandboxName, hostSkillsDir, sandboxSkillsPath, cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Skills sync: host → sandbox complete for '{SandboxName}'",
+                sandboxName);
+
+            return new WorkspaceSyncResult(Success: true, Direction: SyncDirection.ToSandbox);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Skills sync: host → sandbox FAILED for '{SandboxName}': {Message}",
+                sandboxName, ex.Message);
+
+            return new WorkspaceSyncResult(
+                Success: false,
+                Direction: SyncDirection.ToSandbox,
+                Error: ex.Message);
+        }
+    }
 }

--- a/src/gateway/BotNexus.Gateway/Isolation/SandboxSkillPathRewriter.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/SandboxSkillPathRewriter.cs
@@ -1,0 +1,131 @@
+namespace BotNexus.Gateway.Isolation;
+
+/// <summary>
+/// Rewrites host-absolute skill paths to sandbox-relative paths in skill content.
+/// When an agent runs inside a Docker sandbox, skill script references in the system
+/// prompt must point to sandbox-local paths rather than host paths that don't exist
+/// inside the container.
+/// </summary>
+public static class SandboxSkillPathRewriter
+{
+    /// <summary>
+    /// Default sandbox skills mount point (Linux path inside the container).
+    /// </summary>
+    public const string DefaultSandboxSkillsPath = "/workspace/skills";
+
+    /// <summary>
+    /// Rewrites all occurrences of the host skills directory path in the given content
+    /// to the sandbox-relative path.
+    /// </summary>
+    /// <param name="content">Skill content (markdown) that may contain host paths.</param>
+    /// <param name="hostSkillsDir">
+    /// The host-absolute skills directory path (e.g., "C:\Users\jobullen\.botnexus\skills").
+    /// Both forward-slash and backslash variants are replaced.
+    /// </param>
+    /// <param name="sandboxSkillsPath">
+    /// The sandbox-relative path to use (e.g., "/workspace/skills").
+    /// </param>
+    /// <returns>Content with host paths replaced by sandbox paths.</returns>
+    public static string RewritePaths(
+        string content,
+        string hostSkillsDir,
+        string sandboxSkillsPath = DefaultSandboxSkillsPath)
+    {
+        if (string.IsNullOrEmpty(content) || string.IsNullOrEmpty(hostSkillsDir))
+            return content;
+
+        // Normalize: replace both backslash and forward-slash variants
+        var backslashPath = hostSkillsDir.Replace('/', '\\');
+        var forwardSlashPath = hostSkillsDir.Replace('\\', '/');
+
+        var result = content;
+
+        // Replace backslash variant first (Windows paths)
+        if (result.Contains(backslashPath, StringComparison.OrdinalIgnoreCase))
+            result = result.Replace(backslashPath, sandboxSkillsPath, StringComparison.OrdinalIgnoreCase);
+
+        // Replace forward-slash variant
+        if (result.Contains(forwardSlashPath, StringComparison.OrdinalIgnoreCase))
+            result = result.Replace(forwardSlashPath, sandboxSkillsPath, StringComparison.OrdinalIgnoreCase);
+
+        // Normalize remaining backslashes to forward slashes in paths that follow
+        // the sandbox prefix (Linux containers use forward slashes)
+        result = NormalizePathSeparatorsAfterPrefix(result, sandboxSkillsPath);
+
+        return result;
+    }
+
+    /// <summary>
+    /// After path prefix replacement, normalizes any remaining backslashes that
+    /// immediately follow the sandbox prefix into forward slashes. This handles
+    /// cases where Windows sub-paths (\teams\scripts\Tool.ps1) remain after
+    /// the prefix is rewritten to a Linux path.
+    /// </summary>
+    private static string NormalizePathSeparatorsAfterPrefix(string content, string prefix)
+    {
+        var sb = new System.Text.StringBuilder(content.Length);
+        int searchFrom = 0;
+
+        while (true)
+        {
+            var idx = content.IndexOf(prefix, searchFrom, StringComparison.Ordinal);
+            if (idx < 0)
+            {
+                sb.Append(content, searchFrom, content.Length - searchFrom);
+                break;
+            }
+
+            // Append everything up to and including the prefix
+            sb.Append(content, searchFrom, idx + prefix.Length - searchFrom);
+            searchFrom = idx + prefix.Length;
+
+            // Normalize backslashes in the path segment that follows the prefix
+            while (searchFrom < content.Length)
+            {
+                var ch = content[searchFrom];
+                if (ch == '\\')
+                {
+                    sb.Append('/');
+                    searchFrom++;
+                }
+                else if (ch == '/' || char.IsLetterOrDigit(ch) || ch == '.' || ch == '-' || ch == '_')
+                {
+                    sb.Append(ch);
+                    searchFrom++;
+                }
+                else
+                {
+                    // Non-path character — stop normalizing
+                    break;
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Rewrites skill paths in the content by trying multiple common host skill directory patterns.
+    /// This handles the case where skills reference the global skills dir, agent skills dir,
+    /// or workspace skills dir.
+    /// </summary>
+    /// <param name="content">Skill content that may contain host paths.</param>
+    /// <param name="hostSkillsDirs">
+    /// Collection of host skill directory paths to search for and replace.
+    /// </param>
+    /// <param name="sandboxSkillsPath">Sandbox-relative base path.</param>
+    /// <returns>Content with all recognized host paths replaced.</returns>
+    public static string RewriteMultiplePaths(
+        string content,
+        IEnumerable<string> hostSkillsDirs,
+        string sandboxSkillsPath = DefaultSandboxSkillsPath)
+    {
+        var result = content;
+        foreach (var hostDir in hostSkillsDirs)
+        {
+            if (!string.IsNullOrWhiteSpace(hostDir))
+                result = RewritePaths(result, hostDir, sandboxSkillsPath);
+        }
+        return result;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Isolation/SandboxSkillPathRewriter.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/SandboxSkillPathRewriter.cs
@@ -19,7 +19,7 @@ public static class SandboxSkillPathRewriter
     /// </summary>
     /// <param name="content">Skill content (markdown) that may contain host paths.</param>
     /// <param name="hostSkillsDir">
-    /// The host-absolute skills directory path (e.g., "C:\Users\jobullen\.botnexus\skills").
+    /// The host-absolute skills directory path (e.g., "%USERPROFILE%\.botnexus\skills").
     /// Both forward-slash and backslash variants are replaced.
     /// </param>
     /// <param name="sandboxSkillsPath">

--- a/tests/gateway/BotNexus.Gateway.Tests/Isolation/DockerWorkspaceSynchronizerSkillSyncTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Isolation/DockerWorkspaceSynchronizerSkillSyncTests.cs
@@ -1,0 +1,68 @@
+using BotNexus.Gateway.Isolation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Isolation;
+
+/// <summary>
+/// Tests for <see cref="DockerWorkspaceSynchronizer.SyncSkillsToSandboxAsync"/>.
+/// </summary>
+public sealed class DockerWorkspaceSynchronizerSkillSyncTests
+{
+    [Fact]
+    public async Task SyncSkillsToSandbox_CallsCopyToSandboxWithCorrectPaths()
+    {
+        var runner = new Mock<IDockerSandboxRunner>();
+        runner.Setup(r => r.CopyToSandboxAsync(
+            "agent-farnsworth", "/host/skills", "/workspace/skills", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var synchronizer = new DockerWorkspaceSynchronizer(
+            runner.Object,
+            NullLogger<DockerWorkspaceSynchronizer>.Instance);
+
+        var result = await synchronizer.SyncSkillsToSandboxAsync(
+            "agent-farnsworth", "/host/skills", "/workspace/skills");
+
+        Assert.True(result.Success);
+        Assert.Equal(SyncDirection.ToSandbox, result.Direction);
+        runner.Verify(r => r.CopyToSandboxAsync(
+            "agent-farnsworth", "/host/skills", "/workspace/skills", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncSkillsToSandbox_ReturnsFailureOnException()
+    {
+        var runner = new Mock<IDockerSandboxRunner>();
+        runner.Setup(r => r.CopyToSandboxAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Docker not running"));
+
+        var synchronizer = new DockerWorkspaceSynchronizer(
+            runner.Object,
+            NullLogger<DockerWorkspaceSynchronizer>.Instance);
+
+        var result = await synchronizer.SyncSkillsToSandboxAsync(
+            "agent-test", "/host/skills", "/workspace/skills");
+
+        Assert.False(result.Success);
+        Assert.Equal(SyncDirection.ToSandbox, result.Direction);
+        Assert.Contains("Docker not running", result.Error);
+    }
+
+    [Theory]
+    [InlineData("", "/host/skills", "/sandbox/skills")]
+    [InlineData("sandbox", "", "/sandbox/skills")]
+    [InlineData("sandbox", "/host/skills", "")]
+    public async Task SyncSkillsToSandbox_ThrowsOnNullOrWhitespaceArguments(
+        string sandboxName, string hostDir, string sandboxPath)
+    {
+        var runner = new Mock<IDockerSandboxRunner>();
+        var synchronizer = new DockerWorkspaceSynchronizer(
+            runner.Object,
+            NullLogger<DockerWorkspaceSynchronizer>.Instance);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => synchronizer.SyncSkillsToSandboxAsync(sandboxName, hostDir, sandboxPath));
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Isolation/SandboxSkillPathRewriterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Isolation/SandboxSkillPathRewriterTests.cs
@@ -11,8 +11,8 @@ public sealed class SandboxSkillPathRewriterTests
     [Fact]
     public void RewritePaths_ReplacesBackslashWindowsPath()
     {
-        var content = @"Use skill at C:\Users\jobullen\.botnexus\skills\teams\scripts\SendMessageToChat.ps1";
-        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+        var content = @"Use skill at C:\Users\test\.botnexus\skills\teams\scripts\SendMessageToChat.ps1";
+        var hostDir = @"C:\Users\test\.botnexus\skills";
 
         var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
 
@@ -22,8 +22,8 @@ public sealed class SandboxSkillPathRewriterTests
     [Fact]
     public void RewritePaths_ReplacesForwardSlashPath()
     {
-        var content = "Use skill at C:/Users/jobullen/.botnexus/skills/teams/scripts/SendMessageToChat.ps1";
-        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+        var content = "Use skill at C:/Users/test/.botnexus/skills/teams/scripts/SendMessageToChat.ps1";
+        var hostDir = @"C:\Users\test\.botnexus\skills";
 
         var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
 
@@ -33,8 +33,8 @@ public sealed class SandboxSkillPathRewriterTests
     [Fact]
     public void RewritePaths_IsCaseInsensitive()
     {
-        var content = @"Use skill at c:\users\JOBULLEN\.botnexus\skills\teams\scripts\Tool.ps1";
-        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+        var content = @"Use skill at c:\users\TEST\.botnexus\skills\teams\scripts\Tool.ps1";
+        var hostDir = @"C:\Users\test\.botnexus\skills";
 
         var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
 
@@ -44,8 +44,8 @@ public sealed class SandboxSkillPathRewriterTests
     [Fact]
     public void RewritePaths_ReplacesMultipleOccurrences()
     {
-        var content = @"Call C:\Users\jobullen\.botnexus\skills\teams\scripts\Send.ps1 or C:\Users\jobullen\.botnexus\skills\mail\scripts\Read.ps1";
-        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+        var content = @"Call C:\Users\test\.botnexus\skills\teams\scripts\Send.ps1 or C:\Users\test\.botnexus\skills\mail\scripts\Read.ps1";
+        var hostDir = @"C:\Users\test\.botnexus\skills";
 
         var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
 
@@ -55,8 +55,8 @@ public sealed class SandboxSkillPathRewriterTests
     [Fact]
     public void RewritePaths_WithCustomSandboxPath()
     {
-        var content = @"Script: C:\Users\jobullen\.botnexus\skills\calendar\scripts\List.ps1";
-        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+        var content = @"Script: C:\Users\test\.botnexus\skills\calendar\scripts\List.ps1";
+        var hostDir = @"C:\Users\test\.botnexus\skills";
 
         var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir, "/app/skills");
 
@@ -67,7 +67,7 @@ public sealed class SandboxSkillPathRewriterTests
     public void RewritePaths_PreservesContentWithoutHostPaths()
     {
         var content = "This content has no paths to rewrite.";
-        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+        var hostDir = @"C:\Users\test\.botnexus\skills";
 
         var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
 
@@ -95,15 +95,15 @@ public sealed class SandboxSkillPathRewriterTests
     [Fact]
     public void RewriteMultiplePaths_RewritesAllKnownDirs()
     {
-        var content = @"Global: C:\Users\jobullen\.botnexus\skills\teams\scripts\Send.ps1
-Agent: C:\Users\jobullen\.botnexus\agents\farnsworth\skills\custom\scripts\Run.ps1
-Workspace: C:\Users\jobullen\.botnexus\agents\farnsworth\workspace\skills\local\Tool.ps1";
+        var content = @"Global: C:\Users\test\.botnexus\skills\teams\scripts\Send.ps1
+Agent: C:\Users\test\.botnexus\agents\farnsworth\skills\custom\scripts\Run.ps1
+Workspace: C:\Users\test\.botnexus\agents\farnsworth\workspace\skills\local\Tool.ps1";
 
         var hostDirs = new[]
         {
-            @"C:\Users\jobullen\.botnexus\skills",
-            @"C:\Users\jobullen\.botnexus\agents\farnsworth\skills",
-            @"C:\Users\jobullen\.botnexus\agents\farnsworth\workspace\skills"
+            @"C:\Users\test\.botnexus\skills",
+            @"C:\Users\test\.botnexus\agents\farnsworth\skills",
+            @"C:\Users\test\.botnexus\agents\farnsworth\workspace\skills"
         };
 
         var result = SandboxSkillPathRewriter.RewriteMultiplePaths(content, hostDirs);
@@ -117,8 +117,8 @@ Workspace: C:\Users\jobullen\.botnexus\agents\farnsworth\workspace\skills\local\
     [Fact]
     public void RewriteMultiplePaths_SkipsNullAndEmptyDirs()
     {
-        var content = @"Path: C:\Users\jobullen\.botnexus\skills\teams\Send.ps1";
-        var hostDirs = new[] { "", null!, @"C:\Users\jobullen\.botnexus\skills" };
+        var content = @"Path: C:\Users\test\.botnexus\skills\teams\Send.ps1";
+        var hostDirs = new[] { "", null!, @"C:\Users\test\.botnexus\skills" };
 
         var result = SandboxSkillPathRewriter.RewriteMultiplePaths(content, hostDirs);
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Isolation/SandboxSkillPathRewriterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Isolation/SandboxSkillPathRewriterTests.cs
@@ -1,0 +1,133 @@
+using BotNexus.Gateway.Isolation;
+
+namespace BotNexus.Gateway.Tests.Isolation;
+
+/// <summary>
+/// Tests for <see cref="SandboxSkillPathRewriter"/> which rewrites host-absolute
+/// skill paths to sandbox-relative paths when agents run in Docker containers.
+/// </summary>
+public sealed class SandboxSkillPathRewriterTests
+{
+    [Fact]
+    public void RewritePaths_ReplacesBackslashWindowsPath()
+    {
+        var content = @"Use skill at C:\Users\jobullen\.botnexus\skills\teams\scripts\SendMessageToChat.ps1";
+        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
+
+        Assert.Equal("Use skill at /workspace/skills/teams/scripts/SendMessageToChat.ps1", result);
+    }
+
+    [Fact]
+    public void RewritePaths_ReplacesForwardSlashPath()
+    {
+        var content = "Use skill at C:/Users/jobullen/.botnexus/skills/teams/scripts/SendMessageToChat.ps1";
+        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
+
+        Assert.Equal("Use skill at /workspace/skills/teams/scripts/SendMessageToChat.ps1", result);
+    }
+
+    [Fact]
+    public void RewritePaths_IsCaseInsensitive()
+    {
+        var content = @"Use skill at c:\users\JOBULLEN\.botnexus\skills\teams\scripts\Tool.ps1";
+        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
+
+        Assert.Equal("Use skill at /workspace/skills/teams/scripts/Tool.ps1", result);
+    }
+
+    [Fact]
+    public void RewritePaths_ReplacesMultipleOccurrences()
+    {
+        var content = @"Call C:\Users\jobullen\.botnexus\skills\teams\scripts\Send.ps1 or C:\Users\jobullen\.botnexus\skills\mail\scripts\Read.ps1";
+        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
+
+        Assert.Equal("Call /workspace/skills/teams/scripts/Send.ps1 or /workspace/skills/mail/scripts/Read.ps1", result);
+    }
+
+    [Fact]
+    public void RewritePaths_WithCustomSandboxPath()
+    {
+        var content = @"Script: C:\Users\jobullen\.botnexus\skills\calendar\scripts\List.ps1";
+        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir, "/app/skills");
+
+        Assert.Equal("Script: /app/skills/calendar/scripts/List.ps1", result);
+    }
+
+    [Fact]
+    public void RewritePaths_PreservesContentWithoutHostPaths()
+    {
+        var content = "This content has no paths to rewrite.";
+        var hostDir = @"C:\Users\jobullen\.botnexus\skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
+
+        Assert.Equal("This content has no paths to rewrite.", result);
+    }
+
+    [Fact]
+    public void RewritePaths_HandlesNullOrEmptyContent()
+    {
+        Assert.Equal("", SandboxSkillPathRewriter.RewritePaths("", @"C:\skills"));
+        Assert.Equal("some text", SandboxSkillPathRewriter.RewritePaths("some text", ""));
+    }
+
+    [Fact]
+    public void RewritePaths_HandlesLinuxHostPath()
+    {
+        var content = "Use /home/user/.botnexus/skills/teams/scripts/Send.ps1";
+        var hostDir = "/home/user/.botnexus/skills";
+
+        var result = SandboxSkillPathRewriter.RewritePaths(content, hostDir);
+
+        Assert.Equal("Use /workspace/skills/teams/scripts/Send.ps1", result);
+    }
+
+    [Fact]
+    public void RewriteMultiplePaths_RewritesAllKnownDirs()
+    {
+        var content = @"Global: C:\Users\jobullen\.botnexus\skills\teams\scripts\Send.ps1
+Agent: C:\Users\jobullen\.botnexus\agents\farnsworth\skills\custom\scripts\Run.ps1
+Workspace: C:\Users\jobullen\.botnexus\agents\farnsworth\workspace\skills\local\Tool.ps1";
+
+        var hostDirs = new[]
+        {
+            @"C:\Users\jobullen\.botnexus\skills",
+            @"C:\Users\jobullen\.botnexus\agents\farnsworth\skills",
+            @"C:\Users\jobullen\.botnexus\agents\farnsworth\workspace\skills"
+        };
+
+        var result = SandboxSkillPathRewriter.RewriteMultiplePaths(content, hostDirs);
+
+        Assert.Contains("/workspace/skills/teams/scripts/Send.ps1", result);
+        Assert.Contains("/workspace/skills/custom/scripts/Run.ps1", result);
+        Assert.Contains("/workspace/skills/local/Tool.ps1", result);
+        Assert.DoesNotContain(@"C:\Users", result);
+    }
+
+    [Fact]
+    public void RewriteMultiplePaths_SkipsNullAndEmptyDirs()
+    {
+        var content = @"Path: C:\Users\jobullen\.botnexus\skills\teams\Send.ps1";
+        var hostDirs = new[] { "", null!, @"C:\Users\jobullen\.botnexus\skills" };
+
+        var result = SandboxSkillPathRewriter.RewriteMultiplePaths(content, hostDirs);
+
+        Assert.Equal("Path: /workspace/skills/teams/Send.ps1", result);
+    }
+
+    [Fact]
+    public void DefaultSandboxSkillsPath_IsLinuxWorkspaceSkills()
+    {
+        Assert.Equal("/workspace/skills", SandboxSkillPathRewriter.DefaultSandboxSkillsPath);
+    }
+}


### PR DESCRIPTION
Closes #1150

## Changes

### SandboxSkillPathRewriter (new)
- Transforms host-absolute skill paths to sandbox-relative Linux paths
- Handles both backslash (`C:\...`) and forward-slash (`C:/...`) path variants
- Case-insensitive host path matching
- Normalizes remaining backslashes after prefix replacement (for Windows → Linux)
- `RewriteMultiplePaths()` handles global, agent, and workspace skill directories simultaneously

### DockerWorkspaceSynchronizer
- New `SyncSkillsToSandboxAsync()` method copies skill scripts into sandbox before agent dispatch
- Ensures skill script files exist at the rewritten sandbox paths

### Tests (16 new)
- 11 tests for SandboxSkillPathRewriter (backslash, forward-slash, case-insensitive, multiple dirs, Linux host, null handling)
- 5 tests for DockerWorkspaceSynchronizer skill sync (success, failure, arg validation)

## Merge Notes
Part of #982 Docker sandbox chain. No file overlap with PR #1128 (which touches DockerSandboxToolRouter and IDockerSandboxRunner). Safe to merge in any order.