### PR TITLE
feat(extensions): add update action to DataStoreTool for modifying existing rows

### DIFF
--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreTool.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreTool.cs
@@ -18,7 +18,7 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
     // Actions the tool supports.
     internal static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
     {
-        "ingest", "query", "insert", "delete", "schema", "tables", "drop"
+        "ingest", "query", "insert", "update", "delete", "schema", "tables", "drop"
     };
 
     public string Name => "data_store";
@@ -26,23 +26,27 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
 
     public Tool Definition => new(
         Name,
-        "Manage a per-agent structured SQLite data store. Ingest JSON arrays, run SELECT queries, insert rows, delete rows, inspect schema, list tables, or drop tables.",
+        "Manage a per-agent structured SQLite data store. Ingest JSON arrays, run SELECT queries, insert rows, update rows, delete rows, inspect schema, list tables, or drop tables.",
         JsonDocument.Parse("""
             {
               "type": "object",
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["ingest", "query", "insert", "delete", "schema", "tables", "drop"],
-                  "description": "Action to perform: 'ingest' - bulk load a JSON array; 'query' - run a SELECT; 'insert' - add a single JSON object row; 'delete' - remove rows matching a WHERE clause; 'schema' - show column names and types; 'tables' - list all tables; 'drop' - drop a table."
+                  "enum": ["ingest", "query", "insert", "update", "delete", "schema", "tables", "drop"],
+                  "description": "Action to perform: 'ingest' - bulk load a JSON array; 'query' - run a SELECT; 'insert' - add a single JSON object row; 'update' - modify rows matching a WHERE clause; 'delete' - remove rows matching a WHERE clause; 'schema' - show column names and types; 'tables' - list all tables; 'drop' - drop a table."
                 },
                 "table": {
                   "type": "string",
-                  "description": "Table name (required for ingest, insert, delete, schema, drop). Lowercase alphanumeric + underscores only."
+                  "description": "Table name (required for ingest, insert, update, delete, schema, drop). Lowercase alphanumeric + underscores only."
                 },
                 "data": {
                   "type": "string",
                   "description": "JSON array of objects for 'ingest', or single JSON object for 'insert'."
+                },
+                "set": {
+                  "type": "string",
+                  "description": "JSON object of column=value pairs for 'update' action (e.g. {\"status\":\"done\",\"count\":5})."
                 },
                 "sql": {
                   "type": "string",
@@ -50,7 +54,7 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
                 },
                 "where": {
                   "type": "string",
-                  "description": "WHERE clause for 'delete' action (e.g. \"status = 'done'\"). Required for delete to prevent accidental full-table wipe."
+                  "description": "WHERE clause for 'update' and 'delete' actions (e.g. \"status = 'done'\"). Required to prevent accidental full-table operations."
                 }
               },
               "required": ["action"]
@@ -81,6 +85,7 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
             "ingest"  => await IngestAsync(arguments, cancellationToken),
             "query"   => await QueryAsync(arguments, cancellationToken),
             "insert"  => await InsertAsync(arguments, cancellationToken),
+            "update"  => await UpdateAsync(arguments, cancellationToken),
             "delete"  => await DeleteAsync(arguments, cancellationToken),
             "schema"  => await SchemaAsync(arguments, cancellationToken),
             "tables"  => await backend.TablesAsync(cancellationToken),
@@ -123,6 +128,18 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
         if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'. Use lowercase letters, digits, and underscores only.");
         if (string.IsNullOrWhiteSpace(data))  return DataStoreResult.Fail("'data' (JSON object) is required for insert.");
         return await backend.InsertAsync(table, data, ct);
+    }
+
+    private async Task<DataStoreResult> UpdateAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        var set   = GetString(args, "set");
+        var where = GetString(args, "where");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for update.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'. Use lowercase letters, digits, and underscores only.");
+        if (string.IsNullOrWhiteSpace(set))   return DataStoreResult.Fail("'set' (JSON object of column=value pairs) is required for update.");
+        if (string.IsNullOrWhiteSpace(where)) return DataStoreResult.Fail("'where' clause is required for update to prevent accidental full-table updates.");
+        return await backend.UpdateAsync(table, set, where, ct);
     }
 
     private async Task<DataStoreResult> DeleteAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)

--- a/src/extensions/BotNexus.Extensions.DataStore/IDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/IDataStoreBackend.cs
@@ -22,6 +22,9 @@ public interface IDataStoreBackend : IDisposable
     /// <summary>Delete rows matching a WHERE clause.</summary>
     Task<DataStoreResult> DeleteAsync(string table, string where, CancellationToken ct = default);
 
+    /// <summary>Update rows matching a WHERE clause with the provided column values.</summary>
+    Task<DataStoreResult> UpdateAsync(string table, string set, string where, CancellationToken ct = default);
+
     /// <summary>Return the schema (column names and types) for a table.</summary>
     Task<DataStoreResult> SchemaAsync(string table, CancellationToken ct = default);
 

--- a/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
@@ -162,6 +162,43 @@ internal sealed class SqliteDataStoreBackend : IDataStoreBackend
         catch (Exception ex) { return DataStoreResult.Fail($"Delete failed: {ex.Message}"); }
     }
 
+    public async Task<DataStoreResult> UpdateAsync(string table, string set, string where, CancellationToken ct = default)
+    {
+        try
+        {
+            await _lock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                using var doc = JsonDocument.Parse(set);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                    return DataStoreResult.Fail("'set' must be a JSON object of column=value pairs.");
+
+                var properties = doc.RootElement.EnumerateObject().ToList();
+                if (properties.Count == 0)
+                    return DataStoreResult.Fail("'set' must contain at least one column=value pair.");
+
+                var conn = await GetConnectionAsync(ct).ConfigureAwait(false);
+
+                // Build parameterized SET clause
+                var setClauses = new List<string>();
+                using var cmd = conn.CreateCommand();
+                for (int i = 0; i < properties.Count; i++)
+                {
+                    setClauses.Add($"\"{properties[i].Name}\" = @s{i}");
+                    cmd.Parameters.AddWithValue($"@s{i}", JsonElementToSqlite(properties[i].Value));
+                }
+
+                cmd.CommandText = $"UPDATE \"{table}\" SET {string.Join(", ", setClauses)} WHERE {where}";
+                int affected = await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                return DataStoreResult.Ok($"{affected} row{(affected == 1 ? "" : "s")} updated.", affected);
+            }
+            finally { _lock.Release(); }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (JsonException ex) { return DataStoreResult.Fail($"Update failed: invalid JSON in 'set' — {ex.Message}"); }
+        catch (Exception ex) { return DataStoreResult.Fail($"Update failed: {ex.Message}"); }
+    }
+
     public async Task<DataStoreResult> SchemaAsync(string table, CancellationToken ct = default)
     {
         try

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
@@ -31,7 +31,7 @@ public sealed class DataStoreToolTests
     [Fact]
     public void ValidActions_ContainsAllExpectedActions()
     {
-        var expected = new[] { "ingest", "query", "insert", "delete", "schema", "tables", "drop" };
+        var expected = new[] { "ingest", "query", "insert", "update", "delete", "schema", "tables", "drop" };
         foreach (var a in expected)
             DataStoreTool.ValidActions.Contains(a).ShouldBeTrue($"'{a}' missing from ValidActions");
     }
@@ -39,8 +39,8 @@ public sealed class DataStoreToolTests
     // ── Unknown action ────────────────────────────────────────────────────────
 
     [Theory]
-    [InlineData("update")]
     [InlineData("upsert")]
+    [InlineData("merge")]
     [InlineData("")]
     [InlineData(null)]
     public async Task ExecuteAsync_UnknownAction_ReturnsError(string? action)
@@ -181,6 +181,55 @@ public sealed class DataStoreToolTests
         var result  = await tool.ExecuteAsync("tc1", Args("delete", ("table", "events"), ("where", "id = 1")));
         IsError(result).ShouldBeFalse();
         backend.LastAction.ShouldBe("delete");
+    }
+
+    // ── update ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Update_MissingTable_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("update", ("set", "{\"x\":1}"), ("where", "id = 1")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("table");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Update_MissingSet_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("update", ("table", "events"), ("where", "id = 1")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("set");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Update_MissingWhere_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("update", ("table", "events"), ("set", "{\"x\":1}")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("where");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Update_InvalidTableName_ReturnsError()
+    {
+        var tool   = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("update", ("table", "Bad-Table"), ("set", "{\"x\":1}"), ("where", "id = 1")));
+        IsError(result).ShouldBeTrue();
+        TextOf(result).ShouldContain("Invalid table name");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Update_HappyPath_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool    = CreateTool(backend);
+        var result  = await tool.ExecuteAsync("tc1", Args("update", ("table", "events"), ("set", "{\"status\":\"done\"}"), ("where", "id = 1")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("update");
+        backend.LastTable.ShouldBe("events");
     }
 
     // ── schema ────────────────────────────────────────────────────────────────
@@ -335,6 +384,9 @@ internal sealed class FakeDataStoreBackend : IDataStoreBackend
 
     public Task<DataStoreResult> DeleteAsync(string table, string where, CancellationToken ct = default)
     { LastAction = "delete"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("1 deleted", 1)); }
+
+    public Task<DataStoreResult> UpdateAsync(string table, string set, string where, CancellationToken ct = default)
+    { LastAction = "update"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("1 row updated.", 1)); }
 
     public Task<DataStoreResult> SchemaAsync(string table, CancellationToken ct = default)
     { LastAction = "schema"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("id INTEGER", 0)); }

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/SqliteDataStoreBackendTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/SqliteDataStoreBackendTests.cs
@@ -267,6 +267,89 @@ public sealed class SqliteDataStoreBackendTests : IDisposable
         doc.RootElement[0].GetProperty("cnt").GetInt64().ShouldBe(1);
     }
 
+    // ── Update ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_ModifiesMatchingRows()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("tasks", """[{"id":1,"status":"open"},{"id":2,"status":"open"}]""");
+
+        var result = await backend.UpdateAsync("tasks", """{"status":"done"}""", "id = 1");
+
+        result.Success.ShouldBeTrue(result.Error);
+        result.RowCount.ShouldBe(1);
+
+        var query = await backend.QueryAsync("SELECT status FROM tasks WHERE id = 1");
+        using var doc = JsonDocument.Parse(query.Payload ?? "[]");
+        doc.RootElement[0].GetProperty("status").GetString().ShouldBe("done");
+    }
+
+    [Fact]
+    public async Task Update_MultipleColumns_AllUpdated()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("items", """[{"id":1,"name":"old","count":0}]""");
+
+        var result = await backend.UpdateAsync("items", """{"name":"new","count":5}""", "id = 1");
+
+        result.Success.ShouldBeTrue(result.Error);
+        result.RowCount.ShouldBe(1);
+
+        var query = await backend.QueryAsync("SELECT name, count FROM items WHERE id = 1");
+        using var doc = JsonDocument.Parse(query.Payload ?? "[]");
+        doc.RootElement[0].GetProperty("name").GetString().ShouldBe("new");
+        doc.RootElement[0].GetProperty("count").GetInt64().ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task Update_NoMatchingRows_Returns0()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("tasks", """[{"id":1,"status":"open"}]""");
+
+        var result = await backend.UpdateAsync("tasks", """{"status":"done"}""", "id = 999");
+
+        result.Success.ShouldBeTrue(result.Error);
+        result.RowCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Update_InvalidJson_ReturnsError()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("tasks", """[{"id":1,"status":"open"}]""");
+
+        var result = await backend.UpdateAsync("tasks", "not-json", "id = 1");
+
+        result.Success.ShouldBeFalse();
+        (result.Error ?? string.Empty).ShouldContain("Update failed");
+    }
+
+    [Fact]
+    public async Task Update_EmptySetObject_ReturnsError()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("tasks", """[{"id":1,"status":"open"}]""");
+
+        var result = await backend.UpdateAsync("tasks", "{}", "id = 1");
+
+        result.Success.ShouldBeFalse();
+        (result.Error ?? string.Empty).ShouldContain("at least one");
+    }
+
+    [Fact]
+    public async Task Update_NonObjectJson_ReturnsError()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("tasks", """[{"id":1,"status":"open"}]""");
+
+        var result = await backend.UpdateAsync("tasks", "[1,2,3]", "id = 1");
+
+        result.Success.ShouldBeFalse();
+        (result.Error ?? string.Empty).ShouldContain("JSON object");
+    }
+
     // ── Schema not found ─────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #1161

## Changes

- Added `update` action to `DataStoreTool` — agents can now modify existing rows in-place using a JSON object of column=value pairs and a mandatory WHERE clause
- Added `IDataStoreBackend.UpdateAsync(table, set, where)` interface method
- Implemented `SqliteDataStoreBackend.UpdateAsync` with parameterized SET values (safe from SQL injection on values)
- Updated tool definition JSON schema: `update` in action enum, new `set` parameter, `where` description covers both update and delete
- Updated `ValidActions` set
- 5 new tool-level tests (missing table, missing set, missing where, invalid table name, happy path)
- 6 new SQLite backend integration tests (modify matching rows, multi-column update, zero rows matched, invalid JSON, empty set object, non-object JSON)

## Merge Notes

This PR is fully independent — no file overlap with any open PR. Safe to merge in any order.