### PR TITLE
feat(cron): add history action to CronTool for inspecting run outcomes

### DIFF
--- a/src/gateway/BotNexus.Cron/Tools/CronTool.cs
+++ b/src/gateway/BotNexus.Cron/Tools/CronTool.cs
@@ -26,7 +26,7 @@ public sealed class CronTool(
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["list", "create", "update", "delete", "run"]
+                  "enum": ["list", "create", "update", "delete", "run", "history"]
                 },
                 "jobId": { "type": "string", "description": "Optional - for update/delete/run." },
                 "includeSystem": { "type": "boolean", "description": "When true, include system-provisioned jobs (e.g., heartbeat) in list output. Default: false." },
@@ -42,7 +42,8 @@ public sealed class CronTool(
                   "additionalProperties": { "type": "string" }
                 },
                 "model": { "type": "string", "description": "Optional model override for agent-prompt jobs. Supports model-id or provider/model-id." },
-                "enabled": { "type": "boolean", "description": "Whether the job is enabled." }
+                "enabled": { "type": "boolean", "description": "Whether the job is enabled." },
+                "limit": { "type": "integer", "description": "Maximum number of history entries to return (for history action). Default: 20, max: 100." }
               },
               "required": ["action"]
             }
@@ -76,6 +77,9 @@ public sealed class CronTool(
         if (arguments.TryGetValue("enabled", out var enabled) && enabled is not null)
             prepared["enabled"] = ReadBool(enabled, "enabled");
 
+        if (arguments.TryGetValue("limit", out var limitVal) && limitVal is not null)
+            prepared["limit"] = limitVal;
+
         return Task.FromResult<IReadOnlyDictionary<string, object?>>(prepared);
     }
 
@@ -93,6 +97,7 @@ public sealed class CronTool(
             "update" => await UpdateAsync(arguments, cancellationToken).ConfigureAwait(false),
             "delete" => await DeleteAsync(arguments, cancellationToken).ConfigureAwait(false),
             "run" => await RunAsync(arguments, cancellationToken).ConfigureAwait(false),
+            "history" => await HistoryAsync(arguments, cancellationToken).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unsupported cron action '{action}'.")
         };
     }
@@ -234,6 +239,22 @@ public sealed class CronTool(
         return TextResult(JsonSerializer.Serialize(run, JsonOptions));
     }
 
+    private async Task<AgentToolResult> HistoryAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken cancellationToken)
+    {
+        var jobId = JobId.From(ReadRequired(arguments, "jobId"));
+        var existing = await cronStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
+            ?? throw new KeyNotFoundException($"Cron job '{jobId.Value}' was not found.");
+
+        EnsureCanManage(existing);
+
+        var limit = ReadInt(arguments, "limit", defaultValue: 20);
+        if (limit < 1) limit = 1;
+        if (limit > 100) limit = 100;
+
+        var runs = await cronStore.GetRunHistoryAsync(jobId, limit, cancellationToken).ConfigureAwait(false);
+        return TextResult(JsonSerializer.Serialize(runs, JsonOptions));
+    }
+
     private void EnsureCanManage(CronJob job)
     {
         if (allowCrossAgentCron)
@@ -268,7 +289,8 @@ public sealed class CronTool(
            || action.Equals("create", StringComparison.OrdinalIgnoreCase)
            || action.Equals("update", StringComparison.OrdinalIgnoreCase)
            || action.Equals("delete", StringComparison.OrdinalIgnoreCase)
-           || action.Equals("run", StringComparison.OrdinalIgnoreCase);
+           || action.Equals("run", StringComparison.OrdinalIgnoreCase)
+           || action.Equals("history", StringComparison.OrdinalIgnoreCase);
 
     private static void CopyString(IReadOnlyDictionary<string, object?> source, Dictionary<string, object?> destination, string key)
     {
@@ -357,6 +379,23 @@ public sealed class CronTool(
             string text when bool.TryParse(text, out var parsed) => parsed,
             _ => throw new ArgumentException($"Argument '{argumentName}' must be a boolean.")
         };
+
+    private static int ReadInt(IReadOnlyDictionary<string, object?> arguments, string key, int defaultValue)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+            return defaultValue;
+
+        return value switch
+        {
+            int i => i,
+            long l => (int)l,
+            double d => (int)d,
+            JsonElement { ValueKind: JsonValueKind.Number } element => element.GetInt32(),
+            JsonElement { ValueKind: JsonValueKind.String } element when int.TryParse(element.GetString(), out var parsed) => parsed,
+            string text when int.TryParse(text, out var parsed) => parsed,
+            _ => defaultValue
+        };
+    }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/tests/gateway/BotNexus.Cron.Tests/CronToolTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronToolTests.cs
@@ -512,6 +512,114 @@ public sealed class CronToolTests
         var ex = await Record.ExceptionAsync(act);
         ex.ShouldNotBeOfType<UnauthorizedAccessException>();
     }
+
+    // ── History ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_History_ReturnsRunHistory()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateJob("job-1", createdBy: "agent-a"));
+        store.Setup(value => value.GetRunHistoryAsync(JobId.From("job-1"), 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new CronRun { Id = RunId.From("run-1"), JobId = JobId.From("job-1"), Status = "completed", StartedAt = DateTimeOffset.UtcNow },
+                new CronRun { Id = RunId.From("run-2"), JobId = JobId.From("job-1"), Status = "failed", Error = "timeout", StartedAt = DateTimeOffset.UtcNow }
+            ]);
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
+
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = "history",
+            ["jobId"] = "job-1"
+        });
+
+        var text = ReadText(result);
+        text.ShouldContain("run-1");
+        text.ShouldContain("completed");
+        text.ShouldContain("run-2");
+        text.ShouldContain("failed");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_History_JobNotFound_Throws()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        store.Setup(value => value.GetAsync(JobId.From("nope"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CronJob?)null);
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
+
+        var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = "history",
+            ["jobId"] = "nope"
+        });
+
+        await act.ShouldThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_History_AccessDenied_Throws()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateJob("job-1", createdBy: "other-agent"));
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-b"));
+
+        var act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = "history",
+            ["jobId"] = "job-1"
+        });
+
+        await act.ShouldThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_History_RespectsLimitParameter()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateJob("job-1", createdBy: "agent-a"));
+        store.Setup(value => value.GetRunHistoryAsync(JobId.From("job-1"), 5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
+
+        await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = "history",
+            ["jobId"] = "job-1",
+            ["limit"] = 5
+        });
+
+        store.Verify(s => s.GetRunHistoryAsync(JobId.From("job-1"), 5, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_History_ClampsLimitToMax100()
+    {
+        var store = new Mock<ICronStore>();
+        var scheduler = CreateScheduler();
+        store.Setup(value => value.GetAsync(JobId.From("job-1"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateJob("job-1", createdBy: "agent-a"));
+        store.Setup(value => value.GetRunHistoryAsync(JobId.From("job-1"), 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        var tool = new CronTool(store.Object, scheduler, AgentId.From("agent-a"));
+
+        await tool.ExecuteAsync("call-1", new Dictionary<string, object?>
+        {
+            ["action"] = "history",
+            ["jobId"] = "job-1",
+            ["limit"] = 500
+        });
+
+        store.Verify(s => s.GetRunHistoryAsync(JobId.From("job-1"), 100, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
     private static CronScheduler CreateScheduler()
     {
         var store = new Mock<ICronStore>().Object;


### PR DESCRIPTION
Closes #1162

## Changes

- Added `history` action to `CronTool` — agents can now inspect their cron job run history (status, errors, timing, session IDs)
- Same access control as other actions: only job creator or target agent can view history
- `limit` parameter (default 20, clamped to 1-100) controls how many records are returned
- `ICronStore.GetRunHistoryAsync` was already implemented but not exposed through the tool; this wires it through
- Tool definition schema updated: `history` in action enum, `limit` parameter added
- `ReadInt` helper method added for parsing integer parameters from various source types
- 5 new tests: happy path, job not found, access denied, limit respected, limit clamped to max

## Merge Notes

This PR is fully independent — touches only `CronTool.cs` and its test file. No file overlap with any open PR. Safe to merge in any order.