### PR TITLE
fix(webhooks): validate callback URLs against SSRF and use IHttpClientFactory

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/WebhookInboundController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/WebhookInboundController.cs
@@ -24,6 +24,7 @@ public sealed class WebhookInboundController(
     IInboundMessageOrchestrator orchestrator,
     IConversationStore conversationStore,
     ISessionStore sessionStore,
+    IHttpClientFactory httpClientFactory,
     ILogger<WebhookInboundController> logger) : ControllerBase
 {
     private const string SignatureHeader = "X-BotNexus-Signature-256";
@@ -324,12 +325,23 @@ public sealed class WebhookInboundController(
 
     private async Task DeliverCallbackAsync(WebhookRunId runId, string callbackUrl, CancellationToken ct)
     {
+        // Validate callback URL against SSRF before making any outbound request
+        var validation = WebhookCallbackValidator.IsCallbackUrlSafe(callbackUrl);
+        if (!validation.IsSafe)
+        {
+            logger.LogWarning(
+                "Webhook run '{RunId}' callback to '{CallbackUrl}' blocked: {Reason}",
+                runId, callbackUrl, validation.Reason);
+            return;
+        }
+
         var run = await runStore.GetAsync(runId, ct);
         if (run is null) return;
 
         try
         {
-            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+            using var http = httpClientFactory.CreateClient("WebhookCallback");
+            http.Timeout = TimeSpan.FromSeconds(30);
             var payload = System.Text.Json.JsonSerializer.Serialize(new
             {
                 runId = run.Id.Value,

--- a/src/gateway/BotNexus.Gateway.Webhooks/BotNexus.Gateway.Webhooks.csproj
+++ b/src/gateway/BotNexus.Gateway.Webhooks/BotNexus.Gateway.Webhooks.csproj
@@ -17,6 +17,7 @@
     <Compile Include="SqliteWebhookRegistrationStore.cs" />
     <Compile Include="SqliteWebhookRunStore.cs" />
     <Compile Include="WebhookServiceCollectionExtensions.cs" />
+    <Compile Include="WebhookCallbackValidator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gateway/BotNexus.Gateway.Webhooks/WebhookCallbackValidator.cs
+++ b/src/gateway/BotNexus.Gateway.Webhooks/WebhookCallbackValidator.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace BotNexus.Gateway.Webhooks;
+
+/// <summary>
+/// Validates webhook callback URLs against SSRF attack vectors.
+/// Prevents the gateway from being used as a proxy to reach internal services
+/// via attacker-controlled callback URLs.
+/// </summary>
+public static class WebhookCallbackValidator
+{
+    /// <summary>
+    /// Validates that a callback URL does not target private, loopback, link-local,
+    /// or cloud metadata network addresses.
+    /// </summary>
+    /// <param name="url">The callback URL to validate.</param>
+    /// <returns>A result indicating whether the URL is safe for outbound delivery.</returns>
+    public static CallbackValidationResult IsCallbackUrlSafe(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return CallbackValidationResult.Rejected("Callback URL is null or empty.");
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return CallbackValidationResult.Rejected($"Callback URL '{url}' is not a valid absolute URI.");
+
+        // Only HTTP(S) schemes are allowed
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            return CallbackValidationResult.Rejected(
+                $"Callback URL scheme '{uri.Scheme}' is not allowed. Only HTTP and HTTPS are permitted.");
+
+        var host = uri.Host;
+
+        // Block well-known dangerous hostnames
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+            host.Equals("metadata.google.internal", StringComparison.OrdinalIgnoreCase))
+        {
+            return CallbackValidationResult.Rejected(
+                $"Callback URL host '{host}' is blocked (SSRF prevention).");
+        }
+
+        // Parse IP addresses and check ranges
+        if (IPAddress.TryParse(host, out var ip))
+        {
+            if (IsBlockedAddress(ip))
+            {
+                return CallbackValidationResult.Rejected(
+                    $"Callback URL targets a private/reserved IP address '{host}' (SSRF prevention).");
+            }
+        }
+
+        // Check for IPv6 bracket notation ([::1])
+        if (host.StartsWith('[') && host.EndsWith(']'))
+        {
+            var innerIp = host[1..^1];
+            if (IPAddress.TryParse(innerIp, out var bracketIp) && IsBlockedAddress(bracketIp))
+            {
+                return CallbackValidationResult.Rejected(
+                    $"Callback URL targets a private/reserved IP address '{host}' (SSRF prevention).");
+            }
+        }
+
+        return CallbackValidationResult.Safe();
+    }
+
+    private static bool IsBlockedAddress(IPAddress address)
+    {
+        // Loopback (127.0.0.0/8, ::1)
+        if (IPAddress.IsLoopback(address))
+            return true;
+
+        // IPv6 link-local (fe80::/10)
+        if (address.AddressFamily == AddressFamily.InterNetworkV6 && address.IsIPv6LinkLocal)
+            return true;
+
+        // IPv4 checks
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var bytes = address.GetAddressBytes();
+
+            // 10.0.0.0/8
+            if (bytes[0] == 10)
+                return true;
+
+            // 172.16.0.0/12
+            if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+                return true;
+
+            // 192.168.0.0/16
+            if (bytes[0] == 192 && bytes[1] == 168)
+                return true;
+
+            // 169.254.0.0/16 (link-local / cloud metadata)
+            if (bytes[0] == 169 && bytes[1] == 254)
+                return true;
+
+            // 0.0.0.0/8
+            if (bytes[0] == 0)
+                return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Result of a webhook callback URL validation check.
+/// </summary>
+public readonly record struct CallbackValidationResult
+{
+    /// <summary>Whether the URL is safe for outbound delivery.</summary>
+    public bool IsSafe { get; init; }
+
+    /// <summary>Reason the URL was rejected. Null when safe.</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>Creates a safe result.</summary>
+    public static CallbackValidationResult Safe() => new() { IsSafe = true, Reason = null };
+
+    /// <summary>Creates a rejected result with reason.</summary>
+    public static CallbackValidationResult Rejected(string reason) => new() { IsSafe = false, Reason = reason };
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Controllers/WebhookCallbackSecurityTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Controllers/WebhookCallbackSecurityTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Gateway.Dispatching;
+using BotNexus.Gateway.Webhooks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace BotNexus.Gateway.Tests.Controllers;
+
+public sealed class WebhookCallbackSecurityTests
+{
+    private readonly IWebhookRegistrationStore _registrations = Substitute.For<IWebhookRegistrationStore>();
+    private readonly IWebhookRunStore _runs = Substitute.For<IWebhookRunStore>();
+    private readonly IInboundMessageOrchestrator _orchestrator = Substitute.For<IInboundMessageOrchestrator>();
+    private readonly IConversationStore _conversations = Substitute.For<IConversationStore>();
+    private readonly ISessionStore _sessions = Substitute.For<ISessionStore>();
+    private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+
+    [Theory]
+    [InlineData("http://127.0.0.1/evil")]
+    [InlineData("http://localhost/evil")]
+    [InlineData("http://[::1]/evil")]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://10.0.0.1/internal")]
+    [InlineData("http://172.16.0.1/internal")]
+    [InlineData("http://192.168.1.1/internal")]
+    [InlineData("http://metadata.google.internal/computeMetadata/v1/")]
+    [InlineData("ftp://example.com/file")]
+    public void IsCallbackUrlSafe_RejectsUnsafeUrls(string url)
+    {
+        var result = WebhookCallbackValidator.IsCallbackUrlSafe(url);
+
+        Assert.False(result.IsSafe);
+        Assert.NotNull(result.Reason);
+    }
+
+    [Theory]
+    [InlineData("https://api.example.com/webhook/callback")]
+    [InlineData("https://hooks.slack.com/services/123")]
+    [InlineData("http://external.company.net:8080/callback")]
+    public void IsCallbackUrlSafe_AcceptsPublicUrls(string url)
+    {
+        var result = WebhookCallbackValidator.IsCallbackUrlSafe(url);
+
+        Assert.True(result.IsSafe);
+        Assert.Null(result.Reason);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-url")]
+    public void IsCallbackUrlSafe_RejectsInvalidUrls(string url)
+    {
+        var result = WebhookCallbackValidator.IsCallbackUrlSafe(url);
+
+        Assert.False(result.IsSafe);
+    }
+
+    [Fact]
+    public void IsCallbackUrlSafe_RejectsNullUrl()
+    {
+        var result = WebhookCallbackValidator.IsCallbackUrlSafe(null!);
+
+        Assert.False(result.IsSafe);
+    }
+}


### PR DESCRIPTION
Closes #1165

## Changes

- **SSRF validation**: Added `WebhookCallbackValidator` to reject callback URLs targeting private IPs, loopback, link-local, and cloud metadata endpoints before any outbound request is made
- **HttpClient anti-pattern**: Replaced `new HttpClient()` with `IHttpClientFactory.CreateClient("WebhookCallback")` to prevent socket exhaustion under load
- **Logging**: Blocked callback attempts logged at WARNING with the rejection reason

## Files Changed
- `WebhookInboundController.cs`: injected `IHttpClientFactory`, call SSRF validator before delivery
- `WebhookCallbackValidator.cs` (new): standalone SSRF validation for callback URLs
- `BotNexus.Gateway.Webhooks.csproj`: added new file to compile items
- `WebhookCallbackSecurityTests.cs` (new): 16 tests covering blocked/allowed URL patterns

## Test Results
- Gateway: 2559 pass, 1 skip
- Webhooks: 38 pass
- Architecture: 178 pass
- Scenarios: 29 pass

## Merge Notes
Independent of all other open PRs. No file overlap. Safe to merge in any order.
