### PR TITLE
feat(extensions): add QMD knowledge base extension scaffold with config and backend interface

### DIFF
--- a/BotNexus.slnx
+++ b/BotNexus.slnx
@@ -16,6 +16,7 @@
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.Tui/BotNexus.Extensions.Channels.Tui.csproj" />
     <Project Path="src/extensions/BotNexus.Extensions.Channels.ServiceBus/BotNexus.Extensions.Channels.ServiceBus.csproj" />
+    <Project Path="src/extensions/BotNexus.Extensions.Qmd/BotNexus.Extensions.Qmd.csproj" />
   </Folder>
   <Folder Name="/src/" />
   <Folder Name="/src/agent/">
@@ -84,6 +85,7 @@
     <Project Path="tests/extensions/BotNexus.Extensions.Skills.Tests/BotNexus.Extensions.Skills.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.WebTools.Tests/BotNexus.Extensions.WebTools.Tests.csproj" />
     <Project Path="tests/extensions/BotNexus.Extensions.Channels.ServiceBus.Tests/BotNexus.Extensions.Channels.ServiceBus.Tests.csproj" />
+    <Project Path="tests/extensions/BotNexus.Extensions.Qmd.Tests/BotNexus.Extensions.Qmd.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/integration/">
     <Project Path="tests/integration/BotNexus.Integration.Cli.Tests/BotNexus.Integration.Cli.Tests.csproj" />

--- a/src/extensions/BotNexus.Extensions.Qmd/BotNexus.Extensions.Qmd.csproj
+++ b/src/extensions/BotNexus.Extensions.Qmd/BotNexus.Extensions.Qmd.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>BotNexus.Extensions.Qmd</RootNamespace>
+    <Description>QMD knowledge base extension providing keyword, semantic, and hybrid search over local document stores.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BotNexus.Extensions.Qmd.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Core\BotNexus.Agent.Core.csproj" />
+    <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+  </ItemGroup>
+  <!-- Copy extension output + manifest to artifacts/extensions/ for dev-time discovery -->
+  <Target Name="CopyExtensionToArtifacts" AfterTargets="Build">
+    <PropertyGroup>
+      <ExtensionArtifactDir>$(MSBuildThisFileDirectory)..\..\..\artifacts\extensions\botnexus-qmd\</ExtensionArtifactDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(ExtensionArtifactDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ExtensionArtifactDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)botnexus-extension.json" DestinationFolder="$(ExtensionArtifactDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/src/extensions/BotNexus.Extensions.Qmd/IQmdBackend.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/IQmdBackend.cs
@@ -1,0 +1,85 @@
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Abstraction over the QMD document search backend.
+/// The production implementation (<c>QmdCliBackend</c> in a follow-up issue)
+/// wraps the <c>qmd</c> CLI binary. Test code uses <see cref="InMemoryQmdBackend"/>.
+/// </summary>
+public interface IQmdBackend : IAsyncDisposable
+{
+    /// <summary>
+    /// Search for documents matching the query.
+    /// </summary>
+    /// <param name="query">Natural language or keyword query.</param>
+    /// <param name="store">Target store name, or null to search all stores.</param>
+    /// <param name="mode">Search mode (keyword, semantic, or hybrid).</param>
+    /// <param name="limit">Maximum results to return.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<QmdSearchResult[]> SearchAsync(string query, string? store, QmdSearchMode mode, int limit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieve a full document by its unique identifier.
+    /// </summary>
+    /// <param name="id">Document identifier (store-qualified).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<QmdDocument?> GetDocumentAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// List all configured and available knowledge stores.
+    /// </summary>
+    Task<QmdStoreInfo[]> GetStoresAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Trigger a re-index of the specified store (or all stores if null).
+    /// </summary>
+    /// <param name="store">Store name, or null for all stores.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task UpdateIndexAsync(string? store, CancellationToken ct = default);
+
+    /// <summary>
+    /// Trigger embedding generation for the specified store (or all stores if null).
+    /// Required for semantic and hybrid search modes.
+    /// </summary>
+    /// <param name="store">Store name, or null for all stores.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task EmbedAsync(string? store, CancellationToken ct = default);
+}
+
+/// <summary>Search mode for QMD queries.</summary>
+public enum QmdSearchMode
+{
+    /// <summary>BM25 keyword-based search.</summary>
+    Keyword,
+
+    /// <summary>Vector/embedding-based semantic search.</summary>
+    Semantic,
+
+    /// <summary>Combined keyword + semantic scoring (default).</summary>
+    Hybrid
+}
+
+/// <summary>A single search result from the QMD backend.</summary>
+/// <param name="Id">Unique document identifier.</param>
+/// <param name="Store">Name of the store containing this document.</param>
+/// <param name="Path">Filesystem path to the source document.</param>
+/// <param name="Title">Document title (extracted from frontmatter or filename).</param>
+/// <param name="Score">Relevance score (higher is better).</param>
+/// <param name="Snippet">Relevant text excerpt from the document.</param>
+public sealed record QmdSearchResult(string Id, string Store, string Path, string Title, double Score, string Snippet);
+
+/// <summary>A full document retrieved from the QMD backend.</summary>
+/// <param name="Id">Unique document identifier.</param>
+/// <param name="Store">Name of the store containing this document.</param>
+/// <param name="Path">Filesystem path to the source document.</param>
+/// <param name="Title">Document title.</param>
+/// <param name="Content">Full document content.</param>
+public sealed record QmdDocument(string Id, string Store, string Path, string Title, string Content);
+
+/// <summary>Metadata about a configured QMD knowledge store.</summary>
+/// <param name="Name">Store identifier.</param>
+/// <param name="Path">Filesystem path to the indexed folder.</param>
+/// <param name="Description">Human-readable description (from config).</param>
+/// <param name="DocumentCount">Number of indexed documents.</param>
+/// <param name="LastUpdated">Timestamp of last successful index update.</param>
+/// <param name="Healthy">Whether the store is in a healthy/queryable state.</param>
+public sealed record QmdStoreInfo(string Name, string Path, string? Description, int DocumentCount, DateTimeOffset? LastUpdated, bool Healthy);

--- a/src/extensions/BotNexus.Extensions.Qmd/InMemoryQmdBackend.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/InMemoryQmdBackend.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// In-memory implementation of <see cref="IQmdBackend"/> for unit testing.
+/// Pre-populate <see cref="Documents"/> and <see cref="Stores"/> to control test responses.
+/// </summary>
+public sealed class InMemoryQmdBackend : IQmdBackend
+{
+    /// <summary>Documents available for search and retrieval.</summary>
+    public ConcurrentBag<QmdDocument> Documents { get; } = [];
+
+    /// <summary>Store metadata returned by <see cref="GetStoresAsync"/>.</summary>
+    public ConcurrentBag<QmdStoreInfo> Stores { get; } = [];
+
+    /// <summary>Records calls to <see cref="UpdateIndexAsync"/> for test assertions.</summary>
+    public ConcurrentBag<string?> UpdateCalls { get; } = [];
+
+    /// <summary>Records calls to <see cref="EmbedAsync"/> for test assertions.</summary>
+    public ConcurrentBag<string?> EmbedCalls { get; } = [];
+
+    /// <inheritdoc />
+    public Task<QmdSearchResult[]> SearchAsync(string query, string? store, QmdSearchMode mode, int limit, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var results = Documents
+            .Where(d => store == null || d.Store.Equals(store, StringComparison.OrdinalIgnoreCase))
+            .Where(d => d.Content.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                        d.Title.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Take(limit)
+            .Select((d, i) => new QmdSearchResult(d.Id, d.Store, d.Path, d.Title, 1.0 - (i * 0.1), GetSnippet(d.Content, query)))
+            .ToArray();
+
+        return Task.FromResult(results);
+    }
+
+    /// <inheritdoc />
+    public Task<QmdDocument?> GetDocumentAsync(string id, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var doc = Documents.FirstOrDefault(d => d.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(doc);
+    }
+
+    /// <inheritdoc />
+    public Task<QmdStoreInfo[]> GetStoresAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(Stores.ToArray());
+    }
+
+    /// <inheritdoc />
+    public Task UpdateIndexAsync(string? store, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        UpdateCalls.Add(store);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task EmbedAsync(string? store, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        EmbedCalls.Add(store);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static string GetSnippet(string content, string query)
+    {
+        var index = content.IndexOf(query, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+            return content.Length > 100 ? content[..100] + "..." : content;
+
+        var start = Math.Max(0, index - 30);
+        var end = Math.Min(content.Length, index + query.Length + 70);
+        return content[start..end];
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Qmd/QmdConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdConfig.cs
@@ -1,0 +1,49 @@
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Configuration model for the QMD knowledge base extension.
+/// Bound from <c>ExtensionConfig["botnexus-qmd"]</c> on the agent descriptor.
+/// </summary>
+public sealed class QmdConfig
+{
+    /// <summary>Whether the QMD extension is enabled for this agent.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to the <c>qmd</c> binary. When null, the binary is resolved from PATH.
+    /// </summary>
+    public string? QmdPath { get; set; }
+
+    /// <summary>
+    /// Default search mode when not specified by the caller.
+    /// Valid values: "keyword", "semantic", "hybrid".
+    /// </summary>
+    public string DefaultSearchMode { get; set; } = "hybrid";
+
+    /// <summary>Maximum number of search results to return by default.</summary>
+    public int MaxResults { get; set; } = 10;
+
+    /// <summary>Configured knowledge stores to index and search.</summary>
+    public List<QmdStoreConfig> Stores { get; set; } = [];
+}
+
+/// <summary>
+/// Configuration for a single QMD knowledge store (a folder of documents to index).
+/// </summary>
+public sealed class QmdStoreConfig
+{
+    /// <summary>Unique name for this store (used in search queries and tool output).</summary>
+    public required string Name { get; set; }
+
+    /// <summary>Filesystem path to the document folder to index.</summary>
+    public required string Path { get; set; }
+
+    /// <summary>Human-readable description of what this store contains.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Whether to automatically re-index this store on a schedule.</summary>
+    public bool AutoUpdate { get; set; } = true;
+
+    /// <summary>Interval in minutes between automatic re-indexing runs.</summary>
+    public int UpdateIntervalMinutes { get; set; } = 60;
+}

--- a/src/extensions/BotNexus.Extensions.Qmd/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Qmd/botnexus-extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "botnexus-qmd",
+  "name": "BotNexus QMD Knowledge Base",
+  "description": "Local knowledge base search with BM25, vector, and hybrid modes.",
+  "version": "1.0.0"
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/BotNexus.Extensions.Qmd.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/BotNexus.Extensions.Qmd.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Qmd\BotNexus.Extensions.Qmd.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/InMemoryQmdBackendTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/InMemoryQmdBackendTests.cs
@@ -1,0 +1,156 @@
+using BotNexus.Extensions.Qmd;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public class InMemoryQmdBackendTests
+{
+    private readonly InMemoryQmdBackend _backend = new();
+
+    [Fact]
+    public async Task SearchAsync_returns_matching_documents_by_content()
+    {
+        _backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/note1.md", "Note One", "This is about gardening tips"));
+        _backend.Documents.Add(new QmdDocument("doc2", "vault", "/vault/note2.md", "Note Two", "This is about cooking recipes"));
+
+        var results = await _backend.SearchAsync("gardening", null, QmdSearchMode.Hybrid, 10);
+
+        Assert.Single(results);
+        Assert.Equal("doc1", results[0].Id);
+        Assert.Equal("vault", results[0].Store);
+        Assert.Equal("Note One", results[0].Title);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_matching_documents_by_title()
+    {
+        _backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/gardening.md", "Gardening Guide", "Content here"));
+
+        var results = await _backend.SearchAsync("Gardening", null, QmdSearchMode.Keyword, 10);
+
+        Assert.Single(results);
+        Assert.Equal("doc1", results[0].Id);
+    }
+
+    [Fact]
+    public async Task SearchAsync_filters_by_store()
+    {
+        _backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/note.md", "Note", "shared content"));
+        _backend.Documents.Add(new QmdDocument("doc2", "work", "/work/doc.md", "Work Doc", "shared content"));
+
+        var results = await _backend.SearchAsync("shared", "vault", QmdSearchMode.Hybrid, 10);
+
+        Assert.Single(results);
+        Assert.Equal("vault", results[0].Store);
+    }
+
+    [Fact]
+    public async Task SearchAsync_respects_limit()
+    {
+        for (int i = 0; i < 20; i++)
+            _backend.Documents.Add(new QmdDocument($"doc{i}", "vault", $"/vault/note{i}.md", $"Note {i}", "common search term"));
+
+        var results = await _backend.SearchAsync("common", null, QmdSearchMode.Hybrid, 5);
+
+        Assert.Equal(5, results.Length);
+    }
+
+    [Fact]
+    public async Task SearchAsync_returns_empty_when_no_match()
+    {
+        _backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/note.md", "Note", "unrelated content"));
+
+        var results = await _backend.SearchAsync("nonexistent", null, QmdSearchMode.Hybrid, 10);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task SearchAsync_assigns_descending_scores()
+    {
+        _backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/a.md", "A", "keyword match"));
+        _backend.Documents.Add(new QmdDocument("doc2", "vault", "/vault/b.md", "B", "keyword match"));
+
+        var results = await _backend.SearchAsync("keyword", null, QmdSearchMode.Hybrid, 10);
+
+        Assert.Equal(2, results.Length);
+        Assert.True(results[0].Score > results[1].Score);
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_returns_document_by_id()
+    {
+        _backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/note.md", "Note", "Full content"));
+
+        var doc = await _backend.GetDocumentAsync("doc1");
+
+        Assert.NotNull(doc);
+        Assert.Equal("doc1", doc.Id);
+        Assert.Equal("Full content", doc.Content);
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_returns_null_for_unknown_id()
+    {
+        var doc = await _backend.GetDocumentAsync("nonexistent");
+
+        Assert.Null(doc);
+    }
+
+    [Fact]
+    public async Task GetStoresAsync_returns_configured_stores()
+    {
+        _backend.Stores.Add(new QmdStoreInfo("vault", "/vault", "Personal vault", 42, DateTimeOffset.UtcNow, true));
+        _backend.Stores.Add(new QmdStoreInfo("work", "/work", null, 10, null, false));
+
+        var stores = await _backend.GetStoresAsync();
+
+        Assert.Equal(2, stores.Length);
+    }
+
+    [Fact]
+    public async Task UpdateIndexAsync_records_call()
+    {
+        await _backend.UpdateIndexAsync("vault");
+        await _backend.UpdateIndexAsync(null);
+
+        Assert.Equal(2, _backend.UpdateCalls.Count);
+        Assert.Contains("vault", _backend.UpdateCalls);
+        Assert.Contains(null, _backend.UpdateCalls);
+    }
+
+    [Fact]
+    public async Task EmbedAsync_records_call()
+    {
+        await _backend.EmbedAsync("vault");
+
+        Assert.Single(_backend.EmbedCalls);
+        Assert.Contains("vault", _backend.EmbedCalls);
+    }
+
+    [Fact]
+    public async Task SearchAsync_throws_on_cancellation()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _backend.SearchAsync("query", null, QmdSearchMode.Hybrid, 10, cts.Token));
+    }
+
+    [Fact]
+    public async Task GetDocumentAsync_throws_on_cancellation()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _backend.GetDocumentAsync("doc1", cts.Token));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_completes_without_error()
+    {
+        await _backend.DisposeAsync();
+        // Should not throw
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdConfigTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdConfigTests.cs
@@ -1,0 +1,49 @@
+using BotNexus.Extensions.Qmd;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public class QmdConfigTests
+{
+    [Fact]
+    public void Default_config_has_expected_values()
+    {
+        var config = new QmdConfig();
+
+        Assert.True(config.Enabled);
+        Assert.Null(config.QmdPath);
+        Assert.Equal("hybrid", config.DefaultSearchMode);
+        Assert.Equal(10, config.MaxResults);
+        Assert.Empty(config.Stores);
+    }
+
+    [Fact]
+    public void Store_config_defaults_are_sensible()
+    {
+        var store = new QmdStoreConfig { Name = "test", Path = "/tmp/docs" };
+
+        Assert.Equal("test", store.Name);
+        Assert.Equal("/tmp/docs", store.Path);
+        Assert.Null(store.Description);
+        Assert.True(store.AutoUpdate);
+        Assert.Equal(60, store.UpdateIntervalMinutes);
+    }
+
+    [Fact]
+    public void Store_config_accepts_custom_values()
+    {
+        var store = new QmdStoreConfig
+        {
+            Name = "vault",
+            Path = "/home/user/vault",
+            Description = "Personal knowledge vault",
+            AutoUpdate = false,
+            UpdateIntervalMinutes = 120
+        };
+
+        Assert.Equal("vault", store.Name);
+        Assert.Equal("/home/user/vault", store.Path);
+        Assert.Equal("Personal knowledge vault", store.Description);
+        Assert.False(store.AutoUpdate);
+        Assert.Equal(120, store.UpdateIntervalMinutes);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdDtoTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdDtoTests.cs
@@ -1,0 +1,53 @@
+using BotNexus.Extensions.Qmd;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public class QmdDtoTests
+{
+    [Fact]
+    public void QmdSearchResult_record_equality()
+    {
+        var a = new QmdSearchResult("id1", "store", "/path", "Title", 0.95, "snippet");
+        var b = new QmdSearchResult("id1", "store", "/path", "Title", 0.95, "snippet");
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void QmdDocument_record_equality()
+    {
+        var a = new QmdDocument("id1", "store", "/path", "Title", "Content");
+        var b = new QmdDocument("id1", "store", "/path", "Title", "Content");
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void QmdStoreInfo_record_equality()
+    {
+        var ts = DateTimeOffset.UtcNow;
+        var a = new QmdStoreInfo("vault", "/vault", "desc", 10, ts, true);
+        var b = new QmdStoreInfo("vault", "/vault", "desc", 10, ts, true);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void QmdStoreInfo_allows_null_description_and_timestamp()
+    {
+        var info = new QmdStoreInfo("vault", "/vault", null, 0, null, false);
+
+        Assert.Null(info.Description);
+        Assert.Null(info.LastUpdated);
+        Assert.False(info.Healthy);
+    }
+
+    [Theory]
+    [InlineData(QmdSearchMode.Keyword)]
+    [InlineData(QmdSearchMode.Semantic)]
+    [InlineData(QmdSearchMode.Hybrid)]
+    public void QmdSearchMode_enum_has_expected_values(QmdSearchMode mode)
+    {
+        Assert.True(Enum.IsDefined(mode));
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/xunit.runner.json
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true
+}


### PR DESCRIPTION
Closes #1172

## Changes
- New `BotNexus.Extensions.Qmd` project under `src/extensions/`
- `botnexus-extension.json` manifest (id: `botnexus-qmd`)
- `QmdConfig` + `QmdStoreConfig` configuration models with sensible defaults
- `IQmdBackend` interface: SearchAsync, GetDocumentAsync, GetStoresAsync, UpdateIndexAsync, EmbedAsync
- Result DTOs: `QmdSearchResult`, `QmdDocument`, `QmdStoreInfo`
- `QmdSearchMode` enum (Keyword, Semantic, Hybrid)
- `InMemoryQmdBackend` for test use (pre-populate Documents/Stores bags)
- Test project with 24 tests covering config defaults, DTOs, and InMemoryQmdBackend operations
- Added to `BotNexus.slnx`

## Merge Notes
First in the QMD chain (#1171). No file overlap with any open PR.
#1173 (CLI backend + search tool) depends on this PR.
Safe to merge in parallel with all other open PRs.