### PR TITLE
feat(cli): add debug db subcommand for raw database introspection

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
@@ -7,11 +7,13 @@ namespace BotNexus.Cli.Commands;
 /// </summary>
 internal sealed class DebugCommand
 {
+    private readonly DebugDbCommand _db = new();
     private readonly DebugLogsCommand _logs = new();
     private readonly DebugSessionsCommand _sessions = new();
     public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("debug", "Platform diagnostics - inspect sessions, logs, and databases offline.");
+        command.AddCommand(_db.Build(targetOption));
         command.AddCommand(_logs.Build(targetOption));
         command.AddCommand(_sessions.Build(targetOption));
         return command;

--- a/src/gateway/BotNexus.Cli/Commands/DebugDbCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugDbCommand.cs
@@ -1,0 +1,309 @@
+using System.CommandLine;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// CLI subcommands for raw database introspection of BotNexus SQLite stores.
+/// Provides tables, schema, and size operations for offline diagnostics
+/// without requiring a running gateway instance.
+/// </summary>
+internal sealed class DebugDbCommand
+{
+    internal static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public Command Build(Option<string?> targetOption)
+    {
+        var command = new Command("db", "Raw database introspection (offline, no gateway required).");
+
+        var formatOption = new Option<string>("--format", () => "table", "Output format: table or json.");
+        command.AddOption(formatOption);
+
+        var dbOption = new Option<string?>("--db", "Target database: sessions, cron, or memory.");
+
+        // ── tables ──
+        var tablesCommand = new Command("tables", "List tables with row counts.") { dbOption };
+        tablesCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var db = context.ParseResult.GetValueForOption(dbOption);
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = ExecuteTables(home, db, format);
+            return Task.CompletedTask;
+        });
+
+        // ── schema ──
+        var schemaCommand = new Command("schema", "Show CREATE TABLE statements.") { dbOption };
+        schemaCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var db = context.ParseResult.GetValueForOption(dbOption);
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = ExecuteSchema(home, db, format);
+            return Task.CompletedTask;
+        });
+
+        // ── size ──
+        var sizeCommand = new Command("size", "Show file sizes for all .db files.");
+        sizeCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var home = CliPaths.ResolveTarget(target);
+            context.ExitCode = ExecuteSize(home, format);
+            return Task.CompletedTask;
+        });
+
+        command.AddCommand(tablesCommand);
+        command.AddCommand(schemaCommand);
+        command.AddCommand(sizeCommand);
+        return command;
+    }
+
+    internal static int ExecuteTables(string home, string? db, string format)
+    {
+        var dbFiles = ResolveDbFiles(home, db);
+        if (dbFiles.Length == 0)
+        {
+            AnsiConsole.MarkupLine("[red]No database files found.[/]");
+            return 1;
+        }
+
+        var allTables = new List<TableEntry>();
+
+        foreach (var dbFile in dbFiles)
+        {
+            if (!File.Exists(dbFile.Path))
+            {
+                AnsiConsole.MarkupLine($"[yellow]Skipping {Markup.Escape(dbFile.Name)}: file not found.[/]");
+                continue;
+            }
+
+            using var connection = OpenReadOnly(dbFile.Path);
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;";
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                var tableName = reader.GetString(0);
+                var rowCount = GetRowCount(connection, tableName);
+                allTables.Add(new TableEntry { Database = dbFile.Name, Table = tableName, RowCount = rowCount });
+            }
+        }
+
+        if (format == "json")
+        {
+            AnsiConsole.WriteLine(JsonSerializer.Serialize(allTables, JsonOpts));
+        }
+        else
+        {
+            var table = new Table();
+            table.AddColumn("Database");
+            table.AddColumn("Table");
+            table.AddColumn(new TableColumn("Rows").RightAligned());
+
+            foreach (var entry in allTables)
+                table.AddRow(entry.Database, entry.Table, entry.RowCount.ToString("N0"));
+
+            AnsiConsole.Write(table);
+        }
+
+        return 0;
+    }
+
+    internal static int ExecuteSchema(string home, string? db, string format)
+    {
+        var dbFiles = ResolveDbFiles(home, db);
+        if (dbFiles.Length == 0)
+        {
+            AnsiConsole.MarkupLine("[red]No database files found.[/]");
+            return 1;
+        }
+
+        var schemas = new List<SchemaEntry>();
+
+        foreach (var dbFile in dbFiles)
+        {
+            if (!File.Exists(dbFile.Path))
+            {
+                AnsiConsole.MarkupLine($"[yellow]Skipping {Markup.Escape(dbFile.Name)}: file not found.[/]");
+                continue;
+            }
+
+            using var connection = OpenReadOnly(dbFile.Path);
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;";
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                schemas.Add(new SchemaEntry
+                {
+                    Database = dbFile.Name,
+                    Table = reader.GetString(0),
+                    Ddl = reader.IsDBNull(1) ? string.Empty : reader.GetString(1)
+                });
+            }
+        }
+
+        if (format == "json")
+        {
+            AnsiConsole.WriteLine(JsonSerializer.Serialize(schemas, JsonOpts));
+        }
+        else
+        {
+            foreach (var entry in schemas)
+            {
+                AnsiConsole.MarkupLine($"[bold]{Markup.Escape(entry.Database)}[/] → [cyan]{Markup.Escape(entry.Table)}[/]");
+                AnsiConsole.WriteLine(entry.Ddl);
+                AnsiConsole.WriteLine();
+            }
+        }
+
+        return 0;
+    }
+
+    internal static int ExecuteSize(string home, string format)
+    {
+        if (!Directory.Exists(home))
+        {
+            AnsiConsole.MarkupLine("[red]BotNexus home directory not found:[/] " + Markup.Escape(home));
+            return 1;
+        }
+
+        var dbFiles = Directory.GetFiles(home, "*.db", SearchOption.TopDirectoryOnly)
+            .Select(p => new FileInfo(p))
+            .OrderBy(f => f.Name)
+            .ToList();
+
+        // Also check for WAL and journal files
+        var walFiles = Directory.GetFiles(home, "*.db-wal", SearchOption.TopDirectoryOnly)
+            .Concat(Directory.GetFiles(home, "*.db-shm", SearchOption.TopDirectoryOnly))
+            .Select(p => new FileInfo(p))
+            .OrderBy(f => f.Name)
+            .ToList();
+
+        if (dbFiles.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No .db files found in:[/] " + Markup.Escape(home));
+            return 0;
+        }
+
+        var entries = dbFiles.Select(f => new SizeEntry
+        {
+            File = f.Name,
+            SizeBytes = f.Length,
+            SizeFormatted = FormatSize(f.Length)
+        }).ToList();
+
+        foreach (var wal in walFiles)
+        {
+            entries.Add(new SizeEntry
+            {
+                File = wal.Name,
+                SizeBytes = wal.Length,
+                SizeFormatted = FormatSize(wal.Length)
+            });
+        }
+
+        entries = entries.OrderBy(e => e.File).ToList();
+
+        if (format == "json")
+        {
+            AnsiConsole.WriteLine(JsonSerializer.Serialize(entries, JsonOpts));
+        }
+        else
+        {
+            var table = new Table();
+            table.AddColumn("File");
+            table.AddColumn(new TableColumn("Size").RightAligned());
+
+            foreach (var entry in entries)
+                table.AddRow(entry.File, entry.SizeFormatted);
+
+            var totalBytes = entries.Sum(e => e.SizeBytes);
+            table.AddRow("[bold]Total[/]", $"[bold]{FormatSize(totalBytes)}[/]");
+            AnsiConsole.Write(table);
+        }
+
+        return 0;
+    }
+
+    internal static DbFileInfo[] ResolveDbFiles(string home, string? db)
+    {
+        if (!string.IsNullOrEmpty(db))
+        {
+            var fileName = db.EndsWith(".db", StringComparison.OrdinalIgnoreCase) ? db : $"{db}.db";
+            var path = Path.Combine(home, fileName);
+            return [new DbFileInfo(db, path)];
+        }
+
+        if (!Directory.Exists(home))
+            return [];
+
+        return Directory.GetFiles(home, "*.db", SearchOption.TopDirectoryOnly)
+            .Select(p => new DbFileInfo(Path.GetFileNameWithoutExtension(p), p))
+            .OrderBy(f => f.Name)
+            .ToArray();
+    }
+
+    private static long GetRowCount(SqliteConnection connection, string tableName)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM [{tableName}];";
+        return (long)(cmd.ExecuteScalar() ?? 0);
+    }
+
+    private static SqliteConnection OpenReadOnly(string dbPath)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadOnly
+        }.ToString();
+
+        var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        return connection;
+    }
+
+    internal static string FormatSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        < 1024 * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
+        _ => $"{bytes / (1024.0 * 1024 * 1024):F2} GB"
+    };
+
+    internal sealed record DbFileInfo(string Name, string Path);
+
+    private sealed class TableEntry
+    {
+        public string Database { get; init; } = string.Empty;
+        public string Table { get; init; } = string.Empty;
+        public long RowCount { get; init; }
+    }
+
+    private sealed class SchemaEntry
+    {
+        public string Database { get; init; } = string.Empty;
+        public string Table { get; init; } = string.Empty;
+        public string Ddl { get; init; } = string.Empty;
+    }
+
+    private sealed class SizeEntry
+    {
+        public string File { get; init; } = string.Empty;
+        public long SizeBytes { get; init; }
+        public string SizeFormatted { get; init; } = string.Empty;
+    }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/DebugDbCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/DebugDbCommandTests.cs
@@ -1,0 +1,190 @@
+using BotNexus.Cli.Commands;
+using Microsoft.Data.Sqlite;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class DebugDbCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DebugDbCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"botnexus-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        CreateTestDatabases();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private void CreateTestDatabases()
+    {
+        // sessions.db
+        using (var connection = new SqliteConnection($"Data Source={Path.Combine(_tempDir, "sessions.db")}"))
+        {
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE sessions (id TEXT PRIMARY KEY, status TEXT);
+                INSERT INTO sessions VALUES ('s1', 'active');
+                INSERT INTO sessions VALUES ('s2', 'sealed');
+                CREATE TABLE session_history (id INTEGER PRIMARY KEY, session_id TEXT, content TEXT);
+                INSERT INTO session_history VALUES (1, 's1', 'hello');
+                INSERT INTO session_history VALUES (2, 's1', 'world');
+                INSERT INTO session_history VALUES (3, 's2', 'done');
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        // cron.db
+        using (var connection = new SqliteConnection($"Data Source={Path.Combine(_tempDir, "cron.db")}"))
+        {
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE jobs (id TEXT PRIMARY KEY, name TEXT, schedule TEXT);
+                INSERT INTO jobs VALUES ('j1', 'maintenance', '0 * * * *');
+                CREATE TABLE run_history (id INTEGER PRIMARY KEY, job_id TEXT, status TEXT);
+                INSERT INTO run_history VALUES (1, 'j1', 'success');
+                """;
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    // ─── tables ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteTables_returns_tables_for_all_databases()
+    {
+        var result = DebugDbCommand.ExecuteTables(_tempDir, null, "json");
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteTables_filters_by_db_name()
+    {
+        var result = DebugDbCommand.ExecuteTables(_tempDir, "sessions", "json");
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteTables_returns_error_for_missing_directory()
+    {
+        var result = DebugDbCommand.ExecuteTables(Path.Combine(_tempDir, "nonexistent"), null, "table");
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void ExecuteTables_returns_error_when_specific_db_missing()
+    {
+        var result = DebugDbCommand.ExecuteTables(_tempDir, "memory", "table");
+        // memory.db doesn't exist, but we should still get table format (skipped warning)
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteTables_table_format_succeeds()
+    {
+        var result = DebugDbCommand.ExecuteTables(_tempDir, "cron", "table");
+        Assert.Equal(0, result);
+    }
+
+    // ─── schema ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteSchema_returns_ddl_for_all_databases()
+    {
+        var result = DebugDbCommand.ExecuteSchema(_tempDir, null, "json");
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteSchema_filters_by_db_name()
+    {
+        var result = DebugDbCommand.ExecuteSchema(_tempDir, "cron", "json");
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteSchema_returns_error_for_missing_directory()
+    {
+        var result = DebugDbCommand.ExecuteSchema(Path.Combine(_tempDir, "nonexistent"), null, "table");
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void ExecuteSchema_table_format_succeeds()
+    {
+        var result = DebugDbCommand.ExecuteSchema(_tempDir, "sessions", "table");
+        Assert.Equal(0, result);
+    }
+
+    // ─── size ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteSize_returns_sizes_for_all_db_files()
+    {
+        var result = DebugDbCommand.ExecuteSize(_tempDir, "json");
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteSize_table_format_succeeds()
+    {
+        var result = DebugDbCommand.ExecuteSize(_tempDir, "table");
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ExecuteSize_returns_error_for_missing_directory()
+    {
+        var result = DebugDbCommand.ExecuteSize(Path.Combine(_tempDir, "nonexistent"), "table");
+        Assert.Equal(1, result);
+    }
+
+    // ─── utility methods ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveDbFiles_returns_all_dbs_when_no_filter()
+    {
+        var files = DebugDbCommand.ResolveDbFiles(_tempDir, null);
+        Assert.Equal(2, files.Length); // sessions.db + cron.db
+    }
+
+    [Fact]
+    public void ResolveDbFiles_filters_to_single_db()
+    {
+        var files = DebugDbCommand.ResolveDbFiles(_tempDir, "sessions");
+        Assert.Single(files);
+        Assert.Equal("sessions", files[0].Name);
+    }
+
+    [Fact]
+    public void ResolveDbFiles_handles_db_extension_in_name()
+    {
+        var files = DebugDbCommand.ResolveDbFiles(_tempDir, "cron.db");
+        Assert.Single(files);
+        Assert.Equal("cron.db", files[0].Name);
+    }
+
+    [Fact]
+    public void ResolveDbFiles_returns_empty_for_nonexistent_home()
+    {
+        var files = DebugDbCommand.ResolveDbFiles(Path.Combine(_tempDir, "nonexistent"), null);
+        Assert.Empty(files);
+    }
+
+    [Theory]
+    [InlineData(0, "0 B")]
+    [InlineData(512, "512 B")]
+    [InlineData(1024, "1.0 KB")]
+    [InlineData(1536, "1.5 KB")]
+    [InlineData(1048576, "1.0 MB")]
+    [InlineData(1073741824, "1.00 GB")]
+    public void FormatSize_returns_expected_string(long bytes, string expected)
+    {
+        Assert.Equal(expected, DebugDbCommand.FormatSize(bytes));
+    }
+}


### PR DESCRIPTION
Closes #1177

## Changes
- `DebugDbCommand` with three subcommands:
  - `tables [--db name]` — lists all tables with row counts
  - `schema [--db name]` — shows CREATE TABLE DDL statements
  - `size` — shows file sizes for all .db and .db-wal/.db-shm files
- Wired into `DebugCommand` as `botnexus debug db`
- Direct SQLite read (Microsoft.Data.Sqlite) — works offline, no gateway required
- `--format table|json` output modes on all subcommands
- `--db` filter accepts name with or without `.db` extension
- Graceful handling of missing databases and directories
- `FormatSize` utility for human-readable byte sizes
- 22 unit tests covering all operations, edge cases, and utilities

## Merge Notes
Modifies `DebugCommand.cs` (adds 2 lines) — conflicts with PR #1136 (already merged) resolved by branching from current main.
Safe to merge in parallel with all other open PRs except if another PR also adds to DebugCommand.cs.