### PR TITLE
feat(cron): add run history retention service to purge old completed records

### DIFF
--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -28,6 +28,8 @@
     <Compile Include="ActionStubs\WebhookActionStub.cs" />
     <Compile Include="Extensions\CronServiceCollectionExtensions.cs" />
     <Compile Include="Tools\CronTool.cs" />
+    <Compile Include="CronRunRetentionOptions.cs" />
+    <Compile Include="CronRunRetentionHostedService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gateway/BotNexus.Cron/CronRunRetentionHostedService.cs
+++ b/src/gateway/BotNexus.Cron/CronRunRetentionHostedService.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Cron;
+
+/// <summary>
+/// Background service that periodically purges completed/failed cron run records older than
+/// the configured retention threshold. Prevents unbounded SQLite growth from frequent cron jobs.
+/// </summary>
+public sealed class CronRunRetentionHostedService(
+    ICronStore cronStore,
+    IOptions<CronRunRetentionOptions> optionsAccessor,
+    ILogger<CronRunRetentionHostedService> logger) : BackgroundService
+{
+    private CronRunRetentionOptions Options => optionsAccessor.Value;
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var purged = await RunRetentionOnceAsync(stoppingToken).ConfigureAwait(false);
+                if (purged > 0)
+                {
+                    logger.LogInformation(
+                        "Cron run retention: purged {Count} run(s) older than {Days} days.",
+                        purged, Options.RetentionDays);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Cron run retention iteration failed.");
+            }
+
+            var delay = Options.CheckInterval > TimeSpan.Zero
+                ? Options.CheckInterval
+                : TimeSpan.FromHours(1);
+
+            await Task.Delay(delay, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Executes a single retention pass. Exposed for testing.
+    /// </summary>
+    internal async Task<int> RunRetentionOnceAsync(CancellationToken ct = default)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-Options.RetentionDays);
+        return await cronStore.PurgeRunsOlderThanAsync(cutoff, ct).ConfigureAwait(false);
+    }
+}

--- a/src/gateway/BotNexus.Cron/CronRunRetentionOptions.cs
+++ b/src/gateway/BotNexus.Cron/CronRunRetentionOptions.cs
@@ -1,0 +1,18 @@
+namespace BotNexus.Cron;
+
+/// <summary>
+/// Configuration for automatic purging of old completed cron run records.
+/// Prevents unbounded growth of the cron_runs table in SQLite.
+/// </summary>
+public sealed class CronRunRetentionOptions
+{
+    /// <summary>
+    /// Number of days to retain completed/failed run records. Default: 30.
+    /// </summary>
+    public int RetentionDays { get; set; } = 30;
+
+    /// <summary>
+    /// How often the retention service checks for expired runs. Default: 1 hour.
+    /// </summary>
+    public TimeSpan CheckInterval { get; set; } = TimeSpan.FromHours(1);
+}

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ public static class CronServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, CommandCronAction>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, MemoryDreamingCronAction>());
         services.TryAddSingleton<IPromptTemplateResolver, CronOptionsPromptTemplateResolver>();
+        services.AddOptions<CronRunRetentionOptions>();
+        services.AddSingleton<IHostedService, CronRunRetentionHostedService>();
         return services;
     }
 

--- a/src/gateway/BotNexus.Cron/ICronStore.cs
+++ b/src/gateway/BotNexus.Cron/ICronStore.cs
@@ -26,4 +26,11 @@ public interface ICronStore
     /// a cron job to its conversation under P9-D — this CAS guarantees only one stamp wins.
     /// </remarks>
     Task<ConversationId?> TrySetConversationIdAsync(JobId jobId, ConversationId conversationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Purges completed and failed run records older than <paramref name="cutoff"/>.
+    /// Never deletes runs with status "running" to avoid removing in-progress work.
+    /// Returns the number of rows deleted.
+    /// </summary>
+    Task<int> PurgeRunsOlderThanAsync(DateTimeOffset cutoff, CancellationToken ct = default);
 }

--- a/src/gateway/BotNexus.Cron/SqliteCronStore.cs
+++ b/src/gateway/BotNexus.Cron/SqliteCronStore.cs
@@ -583,4 +583,23 @@ public sealed class SqliteCronStore(string dbPath, IFileSystem? fileSystem = nul
 
         return JsonSerializer.Deserialize<Dictionary<string, string?>>(parametersJson, JsonOptions);
     }
+
+    /// <inheritdoc />
+    public async Task<int> PurgeRunsOlderThanAsync(DateTimeOffset cutoff, CancellationToken ct = default)
+    {
+        await using var connection = CreateConnection();
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            DELETE FROM cron_runs
+            WHERE completed_at IS NOT NULL
+              AND completed_at < $cutoff
+              AND status IN ('completed', 'failed')
+            """;
+        command.Parameters.AddWithValue("$cutoff", cutoff.ToString("O"));
+        var deleted = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        if (deleted > 0)
+            _logger.LogDebug("Purged {Count} cron run record(s) older than {Cutoff}.", deleted, cutoff);
+        return deleted;
+    }
 }

--- a/tests/gateway/BotNexus.Cron.Tests/CronRunRetentionHostedServiceTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronRunRetentionHostedServiceTests.cs
@@ -1,0 +1,89 @@
+using BotNexus.Cron.Tests.TestInfrastructure;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Cron.Tests;
+
+public sealed class CronRunRetentionHostedServiceTests
+{
+    [Fact]
+    public async Task RunRetentionOnceAsync_PurgesExpiredRuns()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
+
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run.Id, "completed");
+
+        // Backdate the run to 45 days ago
+        await BackdateRunCompletedAt(context.DbPath, run.Id, DateTimeOffset.UtcNow.AddDays(-45));
+
+        var options = Options.Create(new CronRunRetentionOptions { RetentionDays = 30 });
+        var service = new CronRunRetentionHostedService(
+            context.Store, options, NullLogger<CronRunRetentionHostedService>.Instance);
+
+        var purged = await service.RunRetentionOnceAsync();
+
+        purged.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_PreservesRecentRuns()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
+
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run.Id, "completed");
+
+        var options = Options.Create(new CronRunRetentionOptions { RetentionDays = 30 });
+        var service = new CronRunRetentionHostedService(
+            context.Store, options, NullLogger<CronRunRetentionHostedService>.Instance);
+
+        var purged = await service.RunRetentionOnceAsync();
+
+        purged.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Options_DefaultValues_AreCorrect()
+    {
+        var options = new CronRunRetentionOptions();
+
+        options.RetentionDays.ShouldBe(30);
+        options.CheckInterval.ShouldBe(TimeSpan.FromHours(1));
+    }
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_UsesConfiguredRetentionDays()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
+
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run.Id, "completed");
+
+        // Backdate to 10 days ago
+        await BackdateRunCompletedAt(context.DbPath, run.Id, DateTimeOffset.UtcNow.AddDays(-10));
+
+        // With 7 day retention, this should be purged
+        var options = Options.Create(new CronRunRetentionOptions { RetentionDays = 7 });
+        var service = new CronRunRetentionHostedService(
+            context.Store, options, NullLogger<CronRunRetentionHostedService>.Instance);
+
+        var purged = await service.RunRetentionOnceAsync();
+        purged.ShouldBe(1);
+    }
+
+    private static async Task BackdateRunCompletedAt(string dbPath, RunId runId, DateTimeOffset backdatedTime)
+    {
+        await using var connection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE cron_runs SET completed_at = $completedAt WHERE id = $runId";
+        command.Parameters.AddWithValue("$completedAt", backdatedTime.ToString("O"));
+        command.Parameters.AddWithValue("$runId", runId.Value);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/gateway/BotNexus.Cron.Tests/CronRunRetentionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/CronRunRetentionTests.cs
@@ -1,0 +1,139 @@
+using BotNexus.Cron.Tests.TestInfrastructure;
+using BotNexus.Domain.Primitives;
+
+namespace BotNexus.Cron.Tests;
+
+public sealed class CronRunRetentionTests
+{
+    [Fact]
+    public async Task PurgeRunsOlderThanAsync_DeletesCompletedRunsOlderThanCutoff()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1");
+        await context.Store.CreateAsync(job);
+
+        // Record a run that completed 60 days ago
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run.Id, "completed");
+
+        // Manually backdate the completed_at to 60 days ago
+        await BackdateRunCompletedAt(context.DbPath, run.Id, DateTimeOffset.UtcNow.AddDays(-60));
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-30);
+        var purged = await context.Store.PurgeRunsOlderThanAsync(cutoff);
+
+        purged.ShouldBe(1);
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
+        history.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PurgeRunsOlderThanAsync_PreservesRecentCompletedRuns()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1");
+        await context.Store.CreateAsync(job);
+
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run.Id, "completed");
+
+        // Cutoff is 30 days ago -- run completed just now, should be preserved
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-30);
+        var purged = await context.Store.PurgeRunsOlderThanAsync(cutoff);
+
+        purged.ShouldBe(0);
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
+        history.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task PurgeRunsOlderThanAsync_DeletesFailedRunsOlderThanCutoff()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1");
+        await context.Store.CreateAsync(job);
+
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run.Id, "failed", "timeout");
+
+        await BackdateRunCompletedAt(context.DbPath, run.Id, DateTimeOffset.UtcNow.AddDays(-45));
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-30);
+        var purged = await context.Store.PurgeRunsOlderThanAsync(cutoff);
+
+        purged.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task PurgeRunsOlderThanAsync_NeverDeletesRunningRuns()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1");
+        await context.Store.CreateAsync(job);
+
+        // Start a run but don't complete it -- stays in "running" status
+        var run = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+
+        // Try to purge with very aggressive cutoff (1 day ago)
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+        var purged = await context.Store.PurgeRunsOlderThanAsync(cutoff);
+
+        purged.ShouldBe(0);
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
+        history.Count.ShouldBe(1);
+        history[0].Status.ShouldBe("running");
+    }
+
+    [Fact]
+    public async Task PurgeRunsOlderThanAsync_ReturnsZeroWhenNothingToPurge()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var job = CronStoreTestContext.CreateJob("job-1");
+        await context.Store.CreateAsync(job);
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-30);
+        var purged = await context.Store.PurgeRunsOlderThanAsync(cutoff);
+
+        purged.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task PurgeRunsOlderThanAsync_HandlesMultipleJobsCorrectly()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-1"));
+        await context.Store.CreateAsync(CronStoreTestContext.CreateJob("job-2"));
+
+        var run1 = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run1.Id, "completed");
+        await BackdateRunCompletedAt(context.DbPath, run1.Id, DateTimeOffset.UtcNow.AddDays(-40));
+
+        var run2 = await context.Store.RecordRunStartAsync(JobId.From("job-2"));
+        await context.Store.RecordRunCompleteAsync(run2.Id, "completed");
+        await BackdateRunCompletedAt(context.DbPath, run2.Id, DateTimeOffset.UtcNow.AddDays(-40));
+
+        // Recent run that should be preserved
+        var run3 = await context.Store.RecordRunStartAsync(JobId.From("job-1"));
+        await context.Store.RecordRunCompleteAsync(run3.Id, "completed");
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-30);
+        var purged = await context.Store.PurgeRunsOlderThanAsync(cutoff);
+
+        purged.ShouldBe(2);
+        var history1 = await context.Store.GetRunHistoryAsync(JobId.From("job-1"));
+        history1.Count.ShouldBe(1); // Only the recent one
+        var history2 = await context.Store.GetRunHistoryAsync(JobId.From("job-2"));
+        history2.ShouldBeEmpty();
+    }
+
+    private static async Task BackdateRunCompletedAt(string dbPath, RunId runId, DateTimeOffset backdatedTime)
+    {
+        await using var connection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE cron_runs SET completed_at = $completedAt WHERE id = $runId";
+        command.Parameters.AddWithValue("$completedAt", backdatedTime.ToString("O"));
+        command.Parameters.AddWithValue("$runId", runId.Value);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/CronControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/CronControllerTests.cs
@@ -341,6 +341,17 @@ public sealed class CronControllerTests
                 .ToList();
             return Task.FromResult<IReadOnlyList<CronRun>>(runs);
         }
+
+        public Task<int> PurgeRunsOlderThanAsync(DateTimeOffset cutoff, CancellationToken ct = default)
+        {
+            var toRemove = _runs.Values
+                .Where(r => r.CompletedAt.HasValue && r.CompletedAt.Value < cutoff && r.Status is "completed" or "failed")
+                .Select(r => r.Id.Value)
+                .ToList();
+            foreach (var id in toRemove)
+                _runs.Remove(id);
+            return Task.FromResult(toRemove.Count);
+        }
     }
 
     private sealed class StaticOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>


### PR DESCRIPTION
Closes #1181

## Changes

- Added \ICronStore.PurgeRunsOlderThanAsync(DateTimeOffset cutoff)\ — deletes completed/failed runs older than cutoff, never touches running runs
- Added \SqliteCronStore\ implementation with parameterized DELETE
- Added \CronRunRetentionHostedService\ (BackgroundService): periodic sweep with configurable interval
- Added \CronRunRetentionOptions\: RetentionDays (default 30), CheckInterval (default 1h)
- Registered in \CronServiceCollectionExtensions.AddBotNexusCron()\
- Updated \FakeCronStore\ in CronControllerTests for interface compliance
- 10 new tests (6 purge logic + 4 hosted service lifecycle)

## Merge Notes

Independent of all open PRs. Only additive overlap: CronTool.cs is in PR #1164 but this PR does not touch that file. Safe to merge in any order.