### PR TITLE
feat(gateway): add memory statistics REST endpoint for per-agent store diagnostics

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/MemoryController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/MemoryController.cs
@@ -1,0 +1,136 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Memory;
+using BotNexus.Memory.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+/// <summary>
+/// REST endpoints for inspecting per-agent memory store statistics.
+/// </summary>
+[ApiController]
+[Route("api/memory")]
+public sealed class MemoryController(
+    IAgentRegistry agentRegistry,
+    IMemoryStoreFactory memoryStoreFactory,
+    ILogger<MemoryController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Lists all agents that have memory enabled along with their store statistics.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> ListMemoryStores(CancellationToken ct)
+    {
+        var agents = agentRegistry.GetAll()
+            .Where(a => a.Memory is { Enabled: true })
+            .OrderBy(a => a.AgentId.ToString(), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var results = new List<MemoryStoreDto>(agents.Count);
+        foreach (var agent in agents)
+        {
+            var dto = await GetStatsForAgentAsync(agent.AgentId.Value, ct).ConfigureAwait(false);
+            if (dto is not null)
+                results.Add(dto);
+        }
+
+        return Ok(results);
+    }
+
+    /// <summary>
+    /// Gets memory store statistics for a specific agent.
+    /// </summary>
+    [HttpGet("{agentId}")]
+    public async Task<IActionResult> GetMemoryStore(string agentId, CancellationToken ct)
+    {
+        var descriptor = agentRegistry.Get(AgentId.From(agentId));
+        if (descriptor is null)
+            return NotFound(new { error = $"Agent '{agentId}' not found." });
+
+        if (descriptor.Memory is not { Enabled: true })
+            return NotFound(new { error = $"Agent '{agentId}' does not have memory enabled." });
+
+        var dto = await GetStatsForAgentAsync(agentId, ct).ConfigureAwait(false);
+        return dto is not null ? Ok(dto) : NotFound(new { error = $"Memory store for agent '{agentId}' is not available." });
+    }
+
+    /// <summary>
+    /// Searches memory entries for a specific agent. Requires a query parameter.
+    /// </summary>
+    [HttpGet("{agentId}/entries")]
+    public async Task<IActionResult> SearchEntries(
+        string agentId,
+        [FromQuery] string? query = null,
+        [FromQuery] int limit = 20,
+        CancellationToken ct = default)
+    {
+        var descriptor = agentRegistry.Get(AgentId.From(agentId));
+        if (descriptor is null)
+            return NotFound(new { error = $"Agent '{agentId}' not found." });
+
+        if (descriptor.Memory is not { Enabled: true })
+            return NotFound(new { error = $"Agent '{agentId}' does not have memory enabled." });
+
+        if (string.IsNullOrWhiteSpace(query))
+            return BadRequest(new { error = "Query parameter is required for entry search." });
+
+        limit = Math.Clamp(limit, 1, 100);
+
+        try
+        {
+            var store = memoryStoreFactory.Create(agentId);
+            await store.InitializeAsync(ct).ConfigureAwait(false);
+
+            var entries = await store.SearchAsync(query, limit, ct: ct).ConfigureAwait(false);
+
+            var dtos = entries.Select(e => new MemoryEntryDto(
+                Id: e.Id,
+                CreatedAt: e.CreatedAt,
+                SourceType: e.SourceType,
+                SessionId: e.SessionId,
+                ContentPreview: e.Content.Length > 200 ? e.Content[..200] + "..." : e.Content
+            )).ToList();
+
+            return Ok(new { agentId, query, entries = dtos, count = dtos.Count });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to search memory entries for agent '{AgentId}'.", agentId);
+            return StatusCode(500, new { error = "Failed to access memory store." });
+        }
+    }
+
+    private async Task<MemoryStoreDto?> GetStatsForAgentAsync(string agentId, CancellationToken ct)
+    {
+        try
+        {
+            var store = memoryStoreFactory.Create(agentId);
+            await store.InitializeAsync(ct).ConfigureAwait(false);
+            var stats = await store.GetStatsAsync(ct).ConfigureAwait(false);
+            return new MemoryStoreDto(
+                AgentId: agentId,
+                EntryCount: stats.EntryCount,
+                DatabaseSizeBytes: stats.DatabaseSizeBytes,
+                LastIndexedAt: stats.LastIndexedAt);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to get memory stats for agent '{AgentId}'.", agentId);
+            return null;
+        }
+    }
+}
+
+internal sealed record MemoryStoreDto(
+    string AgentId,
+    int EntryCount,
+    long DatabaseSizeBytes,
+    DateTimeOffset? LastIndexedAt);
+
+internal sealed record MemoryEntryDto(
+    string Id,
+    DateTimeOffset CreatedAt,
+    string SourceType,
+    string? SessionId,
+    string ContentPreview);

--- a/tests/gateway/BotNexus.Gateway.Tests/Controllers/MemoryControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Controllers/MemoryControllerTests.cs
@@ -1,0 +1,179 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Api.Controllers;
+using BotNexus.Memory;
+using BotNexus.Memory.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Controllers;
+
+public sealed class MemoryControllerTests
+{
+    private static readonly AgentDescriptor AgentWithMemory = new()
+    {
+        AgentId = AgentId.From("test-agent"),
+        DisplayName = "Test Agent",
+        ApiProvider = "test",
+        ModelId = "test-model",
+        Memory = new MemoryAgentConfig { Enabled = true }
+    };
+
+    private static readonly AgentDescriptor AgentWithoutMemory = new()
+    {
+        AgentId = AgentId.From("no-memory"),
+        DisplayName = "No Memory",
+        ApiProvider = "test",
+        ModelId = "test-model",
+        Memory = new MemoryAgentConfig { Enabled = false }
+    };
+
+    [Fact]
+    public async Task ListMemoryStores_ReturnsStatsForEnabledAgents()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.GetAll()).Returns([AgentWithMemory, AgentWithoutMemory]);
+
+        var store = new Mock<IMemoryStore>();
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStoreStats(42, 1024, DateTimeOffset.UtcNow));
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        factory.Setup(f => f.Create("test-agent")).Returns(store.Object);
+
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.ListMemoryStores(CancellationToken.None);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var list = ok.Value as IEnumerable<object>;
+        list.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GetMemoryStore_ReturnsStatsForValidAgent()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("test-agent"))).Returns(AgentWithMemory);
+
+        var store = new Mock<IMemoryStore>();
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStoreStats(10, 512, null));
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        factory.Setup(f => f.Create("test-agent")).Returns(store.Object);
+
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.GetMemoryStore("test-agent", CancellationToken.None);
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetMemoryStore_Returns404ForUnknownAgent()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.GetMemoryStore("unknown", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetMemoryStore_Returns404WhenMemoryDisabled()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("no-memory"))).Returns(AgentWithoutMemory);
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.GetMemoryStore("no-memory", CancellationToken.None);
+
+        result.ShouldBeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task SearchEntries_ReturnsBadRequestWhenQueryMissing()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("test-agent"))).Returns(AgentWithMemory);
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.SearchEntries("test-agent", query: null);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task SearchEntries_ReturnsMatchingEntries()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("test-agent"))).Returns(AgentWithMemory);
+
+        var entries = new List<MemoryEntry>
+        {
+            new()
+            {
+                Id = "entry-1",
+                AgentId = "test-agent",
+                SourceType = "conversation",
+                Content = "Found something relevant about BotNexus architecture",
+                CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+            }
+        };
+
+        var store = new Mock<IMemoryStore>();
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.SearchAsync("architecture", 20, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        factory.Setup(f => f.Create("test-agent")).Returns(store.Object);
+
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.SearchEntries("test-agent", query: "architecture");
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task SearchEntries_Returns404ForUnknownAgent()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(It.IsAny<AgentId>())).Returns((AgentDescriptor?)null);
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.SearchEntries("unknown", query: "test");
+
+        result.ShouldBeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task SearchEntries_ClampsLimitTo100()
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(AgentId.From("test-agent"))).Returns(AgentWithMemory);
+
+        var store = new Mock<IMemoryStore>();
+        store.Setup(s => s.InitializeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        store.Setup(s => s.SearchAsync("test", 100, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>());
+
+        var factory = new Mock<IMemoryStoreFactory>();
+        factory.Setup(f => f.Create("test-agent")).Returns(store.Object);
+
+        var controller = new MemoryController(registry.Object, factory.Object, NullLogger<MemoryController>.Instance);
+        var result = await controller.SearchEntries("test-agent", query: "test", limit: 500);
+
+        result.ShouldBeOfType<OkObjectResult>();
+        store.Verify(s => s.SearchAsync("test", 100, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #1182

## Changes

- Added \MemoryController\ with 3 endpoints:
  - \GET /api/memory\ — lists all agents with memory enabled and their store stats
  - \GET /api/memory/{agentId}\ — detailed stats for a specific agent's memory store
  - \GET /api/memory/{agentId}/entries?query=...\ — search memory entries (FTS5)
- DTOs: \MemoryStoreDto\ (agentId, entryCount, databaseSizeBytes, lastIndexedAt) and \MemoryEntryDto\ (id, createdAt, sourceType, sessionId, contentPreview)
- 8 new tests covering: list stores, get single store, 404 for unknown agent, 404 for disabled memory, search entries, bad request without query, limit clamping

## Design Decisions

- Uses existing \IMemoryStoreFactory.Create(agentId)\ — no new factory methods needed
- Filters agents to those with \Memory.Enabled = true\ via \IAgentRegistry.GetAll()\
- Entry search requires a query parameter (FTS5 does not support listing all entries)
- Content preview truncated to 200 chars to keep responses lightweight
- Graceful degradation: stores that throw are logged and skipped in list view

## Merge Notes

Independent of all open PRs. Only touches Gateway.Api (new controller) and Gateway.Tests (new test file). Safe to merge in any order.