### PR TITLE
feat(memory): add IAgentMemory abstraction with DTOs and factory interface

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemoryConsolidateRequest.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemoryConsolidateRequest.cs
@@ -1,0 +1,23 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Request to perform memory consolidation (dreaming). The provider merges,
+/// summarises, or archives older entries to maintain long-term coherence.
+/// </summary>
+/// <param name="AgentId">The agent whose memory to consolidate.</param>
+/// <param name="LookbackDays">
+/// Number of days of daily notes to consider for consolidation. Defaults to 14.
+/// </param>
+/// <param name="MaxContentChars">
+/// Maximum characters of source content to feed into the consolidation process.
+/// Defaults to 50,000.
+/// </param>
+/// <param name="DryRun">
+/// When true, the provider should return what it would consolidate without
+/// actually modifying any stored state.
+/// </param>
+public sealed record AgentMemoryConsolidateRequest(
+    string AgentId,
+    int LookbackDays = 14,
+    int MaxContentChars = 50_000,
+    bool DryRun = false);

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemoryPromptRequest.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemoryPromptRequest.cs
@@ -1,0 +1,50 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Request parameters for retrieving memory context to include in an agent's prompt.
+/// </summary>
+/// <param name="AgentId">The agent whose memory to query.</param>
+/// <param name="SessionId">The current session identifier for relevance scoping.</param>
+/// <param name="ConversationId">Optional conversation identifier for topic filtering.</param>
+/// <param name="MaxTokenBudget">
+/// Maximum approximate token budget for the returned context.
+/// The provider should respect this limit when assembling content.
+/// </param>
+public sealed record AgentMemoryPromptRequest(
+    string AgentId,
+    string? SessionId = null,
+    string? ConversationId = null,
+    int MaxTokenBudget = 4000);
+
+/// <summary>
+/// Memory context assembled by the provider for prompt inclusion.
+/// Contains structured sections that the prompt pipeline can arrange.
+/// </summary>
+/// <param name="LongTermMemory">
+/// Consolidated long-term memory content (e.g. MEMORY.md equivalent).
+/// </param>
+/// <param name="DailyNotes">
+/// Recent daily notes relevant to the current context, ordered newest first.
+/// </param>
+/// <param name="ApproximateTokenCount">
+/// Estimated token count of the assembled context for budget tracking.
+/// </param>
+public sealed record AgentMemoryContext(
+    string? LongTermMemory,
+    IReadOnlyList<AgentMemoryDailyNote> DailyNotes,
+    int ApproximateTokenCount)
+{
+    /// <summary>
+    /// An empty context with no memory content.
+    /// </summary>
+    public static AgentMemoryContext Empty { get; } = new(null, Array.Empty<AgentMemoryDailyNote>(), 0);
+}
+
+/// <summary>
+/// A single daily note entry within the memory context.
+/// </summary>
+/// <param name="Date">The date this note covers.</param>
+/// <param name="Content">The markdown content of the daily note.</param>
+public sealed record AgentMemoryDailyNote(
+    DateOnly Date,
+    string Content);

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySaveRequest.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySaveRequest.cs
@@ -1,0 +1,22 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Request to persist a memory entry. The provider determines storage format and indexing.
+/// </summary>
+/// <param name="AgentId">The agent this memory belongs to.</param>
+/// <param name="Content">The content to persist.</param>
+/// <param name="SourceType">
+/// Origin of the memory entry: "conversation", "manual", "compaction", "dreaming", "tool".
+/// </param>
+/// <param name="SessionId">Optional session that produced this memory.</param>
+/// <param name="TurnIndex">Optional turn index within the session.</param>
+/// <param name="Tags">Optional tags for categorisation and filtering.</param>
+/// <param name="ExpiresAt">Optional expiry time after which the entry may be purged.</param>
+public sealed record AgentMemorySaveRequest(
+    string AgentId,
+    string Content,
+    string SourceType,
+    string? SessionId = null,
+    int? TurnIndex = null,
+    IReadOnlyList<string>? Tags = null,
+    DateTimeOffset? ExpiresAt = null);

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySearchFilter.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySearchFilter.cs
@@ -1,0 +1,33 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Optional filter for narrowing memory search results by source type,
+/// date range, session, or tags.
+/// </summary>
+public sealed record AgentMemorySearchFilter
+{
+    /// <summary>
+    /// Filter to entries from a specific source type (e.g. "conversation", "dreaming").
+    /// </summary>
+    public string? SourceType { get; init; }
+
+    /// <summary>
+    /// Filter to entries from a specific session.
+    /// </summary>
+    public string? SessionId { get; init; }
+
+    /// <summary>
+    /// Only include entries created after this date.
+    /// </summary>
+    public DateTimeOffset? AfterDate { get; init; }
+
+    /// <summary>
+    /// Only include entries created before this date.
+    /// </summary>
+    public DateTimeOffset? BeforeDate { get; init; }
+
+    /// <summary>
+    /// Only include entries that have at least one of these tags.
+    /// </summary>
+    public IReadOnlyList<string>? Tags { get; init; }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySearchRequest.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySearchRequest.cs
@@ -1,0 +1,36 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Request to search memory entries with natural language and optional filters.
+/// </summary>
+/// <param name="AgentId">The agent whose memory to search.</param>
+/// <param name="Query">Natural language search query.</param>
+/// <param name="TopK">Maximum number of results to return. Defaults to 10.</param>
+/// <param name="Filter">Optional filter to narrow results by source, date, or tags.</param>
+public sealed record AgentMemorySearchRequest(
+    string AgentId,
+    string Query,
+    int TopK = 10,
+    AgentMemorySearchFilter? Filter = null);
+
+/// <summary>
+/// A single search result from a memory query.
+/// </summary>
+/// <param name="Id">Unique identifier of the memory entry.</param>
+/// <param name="Content">The full content of the entry.</param>
+/// <param name="SourceType">Origin type of the entry.</param>
+/// <param name="SessionId">Session that produced this entry, if any.</param>
+/// <param name="CreatedAt">When the entry was created.</param>
+/// <param name="RelevanceScore">
+/// Provider-specific relevance score. Higher is more relevant.
+/// Not comparable across different providers.
+/// </param>
+/// <param name="Tags">Tags associated with this entry.</param>
+public sealed record AgentMemorySearchResult(
+    string Id,
+    string Content,
+    string SourceType,
+    string? SessionId,
+    DateTimeOffset CreatedAt,
+    double RelevanceScore = 0.0,
+    IReadOnlyList<string>? Tags = null);

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySessionEvent.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySessionEvent.cs
@@ -1,0 +1,17 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Event raised when a session completes, allowing memory providers to
+/// flush pending writes or perform session-scoped bookkeeping.
+/// </summary>
+/// <param name="AgentId">The agent that owned the session.</param>
+/// <param name="SessionId">The session that completed.</param>
+/// <param name="ConversationId">The conversation the session belonged to, if any.</param>
+/// <param name="EndedAt">When the session ended.</param>
+/// <param name="TurnCount">Total number of turns in the session.</param>
+public sealed record AgentMemorySessionEvent(
+    string AgentId,
+    string SessionId,
+    string? ConversationId = null,
+    DateTimeOffset? EndedAt = null,
+    int TurnCount = 0);

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/IAgentMemory.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/IAgentMemory.cs
@@ -1,0 +1,45 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Unified memory provider interface for agent memory operations.
+/// Abstracts the underlying storage mechanism (SQLite, file-based, QMD, hybrid)
+/// behind a consistent API that the gateway pipeline consumes.
+/// </summary>
+public interface IAgentMemory
+{
+    /// <summary>
+    /// Retrieves memory context suitable for inclusion in the agent's system prompt.
+    /// The provider decides what is relevant based on the request parameters.
+    /// </summary>
+    Task<AgentMemoryContext> GetPromptContextAsync(AgentMemoryPromptRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists a memory entry from a session interaction, compaction summary,
+    /// manual save, or dreaming consolidation.
+    /// </summary>
+    Task SaveAsync(AgentMemorySaveRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Searches memory entries using a natural language query with optional filters.
+    /// Returns ranked results ordered by relevance.
+    /// </summary>
+    Task<IReadOnlyList<AgentMemorySearchResult>> SearchAsync(AgentMemorySearchRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves a specific memory entry by its unique identifier.
+    /// Returns null if the entry does not exist or has been archived.
+    /// </summary>
+    Task<AgentMemorySearchResult?> GetAsync(string entryId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Called when a session ends to allow the provider to flush pending writes,
+    /// update indexes, or perform session-scoped bookkeeping.
+    /// </summary>
+    Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs periodic memory consolidation (dreaming). The provider merges,
+    /// summarises, or archives older entries to maintain long-term coherence.
+    /// </summary>
+    Task ConsolidateAsync(AgentMemoryConsolidateRequest request, CancellationToken ct = default);
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/IAgentMemoryFactory.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/IAgentMemoryFactory.cs
@@ -1,0 +1,25 @@
+namespace BotNexus.Gateway.Contracts.Memory;
+
+/// <summary>
+/// Creates <see cref="IAgentMemory"/> instances for a given agent, resolving the
+/// appropriate provider based on agent configuration.
+/// </summary>
+public interface IAgentMemoryFactory
+{
+    /// <summary>
+    /// Creates or retrieves a memory provider instance for the specified agent.
+    /// The provider type is resolved from the agent's memory configuration
+    /// (e.g. "markdown", "qmd", "hybrid").
+    /// </summary>
+    /// <param name="agentId">The agent identifier to create memory for.</param>
+    /// <param name="providerName">
+    /// Optional provider name override. When null, uses the agent's configured provider.
+    /// </param>
+    /// <returns>A configured <see cref="IAgentMemory"/> instance.</returns>
+    IAgentMemory Create(string agentId, string? providerName = null);
+
+    /// <summary>
+    /// Returns the names of all registered memory providers.
+    /// </summary>
+    IReadOnlyList<string> GetRegisteredProviders();
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Memory/AgentMemoryDtoTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Memory/AgentMemoryDtoTests.cs
@@ -1,0 +1,201 @@
+using BotNexus.Gateway.Contracts.Memory;
+
+namespace BotNexus.Gateway.Tests.Memory;
+
+public sealed class AgentMemoryDtoTests
+{
+    [Fact]
+    public void AgentMemoryPromptRequest_DefaultValues()
+    {
+        var request = new AgentMemoryPromptRequest("agent-1");
+
+        Assert.Equal("agent-1", request.AgentId);
+        Assert.Null(request.SessionId);
+        Assert.Null(request.ConversationId);
+        Assert.Equal(4000, request.MaxTokenBudget);
+    }
+
+    [Fact]
+    public void AgentMemoryPromptRequest_WithAllParameters()
+    {
+        var request = new AgentMemoryPromptRequest(
+            "agent-1",
+            SessionId: "session-1",
+            ConversationId: "conv-1",
+            MaxTokenBudget: 8000);
+
+        Assert.Equal("agent-1", request.AgentId);
+        Assert.Equal("session-1", request.SessionId);
+        Assert.Equal("conv-1", request.ConversationId);
+        Assert.Equal(8000, request.MaxTokenBudget);
+    }
+
+    [Fact]
+    public void AgentMemoryContext_Empty_HasNoContent()
+    {
+        var context = AgentMemoryContext.Empty;
+
+        Assert.Null(context.LongTermMemory);
+        Assert.Empty(context.DailyNotes);
+        Assert.Equal(0, context.ApproximateTokenCount);
+    }
+
+    [Fact]
+    public void AgentMemoryContext_WithContent()
+    {
+        var notes = new[]
+        {
+            new AgentMemoryDailyNote(new DateOnly(2026, 6, 10), "Today's note"),
+            new AgentMemoryDailyNote(new DateOnly(2026, 6, 9), "Yesterday's note")
+        };
+
+        var context = new AgentMemoryContext("Long-term memory content", notes, 150);
+
+        Assert.Equal("Long-term memory content", context.LongTermMemory);
+        Assert.Equal(2, context.DailyNotes.Count);
+        Assert.Equal(150, context.ApproximateTokenCount);
+    }
+
+    [Fact]
+    public void AgentMemoryDailyNote_RecordEquality()
+    {
+        var note1 = new AgentMemoryDailyNote(new DateOnly(2026, 6, 10), "Content");
+        var note2 = new AgentMemoryDailyNote(new DateOnly(2026, 6, 10), "Content");
+
+        Assert.Equal(note1, note2);
+        Assert.Equal(note1.GetHashCode(), note2.GetHashCode());
+    }
+
+    [Fact]
+    public void AgentMemorySaveRequest_DefaultValues()
+    {
+        var request = new AgentMemorySaveRequest("agent-1", "Some content", "conversation");
+
+        Assert.Equal("agent-1", request.AgentId);
+        Assert.Equal("Some content", request.Content);
+        Assert.Equal("conversation", request.SourceType);
+        Assert.Null(request.SessionId);
+        Assert.Null(request.TurnIndex);
+        Assert.Null(request.Tags);
+        Assert.Null(request.ExpiresAt);
+    }
+
+    [Fact]
+    public void AgentMemorySaveRequest_WithAllParameters()
+    {
+        var expires = DateTimeOffset.UtcNow.AddDays(7);
+        var tags = new[] { "important", "architecture" };
+
+        var request = new AgentMemorySaveRequest(
+            "agent-1",
+            "Content",
+            "manual",
+            SessionId: "session-1",
+            TurnIndex: 5,
+            Tags: tags,
+            ExpiresAt: expires);
+
+        Assert.Equal("session-1", request.SessionId);
+        Assert.Equal(5, request.TurnIndex);
+        Assert.Equal(tags, request.Tags);
+        Assert.Equal(expires, request.ExpiresAt);
+    }
+
+    [Fact]
+    public void AgentMemorySearchRequest_DefaultValues()
+    {
+        var request = new AgentMemorySearchRequest("agent-1", "find something");
+
+        Assert.Equal("agent-1", request.AgentId);
+        Assert.Equal("find something", request.Query);
+        Assert.Equal(10, request.TopK);
+        Assert.Null(request.Filter);
+    }
+
+    [Fact]
+    public void AgentMemorySearchResult_RecordEquality()
+    {
+        var created = DateTimeOffset.UtcNow;
+        var result1 = new AgentMemorySearchResult("id-1", "Content", "conversation", "session-1", created, 0.95);
+        var result2 = new AgentMemorySearchResult("id-1", "Content", "conversation", "session-1", created, 0.95);
+
+        Assert.Equal(result1, result2);
+    }
+
+    [Fact]
+    public void AgentMemorySearchResult_DefaultRelevanceScore()
+    {
+        var result = new AgentMemorySearchResult("id-1", "Content", "manual", null, DateTimeOffset.UtcNow);
+
+        Assert.Equal(0.0, result.RelevanceScore);
+        Assert.Null(result.Tags);
+    }
+
+    [Fact]
+    public void AgentMemorySessionEvent_DefaultValues()
+    {
+        var evt = new AgentMemorySessionEvent("agent-1", "session-1");
+
+        Assert.Equal("agent-1", evt.AgentId);
+        Assert.Equal("session-1", evt.SessionId);
+        Assert.Null(evt.ConversationId);
+        Assert.Null(evt.EndedAt);
+        Assert.Equal(0, evt.TurnCount);
+    }
+
+    [Fact]
+    public void AgentMemoryConsolidateRequest_DefaultValues()
+    {
+        var request = new AgentMemoryConsolidateRequest("agent-1");
+
+        Assert.Equal("agent-1", request.AgentId);
+        Assert.Equal(14, request.LookbackDays);
+        Assert.Equal(50_000, request.MaxContentChars);
+        Assert.False(request.DryRun);
+    }
+
+    [Fact]
+    public void AgentMemoryConsolidateRequest_WithDryRun()
+    {
+        var request = new AgentMemoryConsolidateRequest("agent-1", LookbackDays: 7, MaxContentChars: 25_000, DryRun: true);
+
+        Assert.Equal(7, request.LookbackDays);
+        Assert.Equal(25_000, request.MaxContentChars);
+        Assert.True(request.DryRun);
+    }
+
+    [Fact]
+    public void AgentMemorySearchFilter_DefaultValues()
+    {
+        var filter = new AgentMemorySearchFilter();
+
+        Assert.Null(filter.SourceType);
+        Assert.Null(filter.SessionId);
+        Assert.Null(filter.AfterDate);
+        Assert.Null(filter.BeforeDate);
+        Assert.Null(filter.Tags);
+    }
+
+    [Fact]
+    public void AgentMemorySearchFilter_WithAllProperties()
+    {
+        var after = DateTimeOffset.UtcNow.AddDays(-7);
+        var before = DateTimeOffset.UtcNow;
+        var tags = new[] { "tag1" };
+
+        var filter = new AgentMemorySearchFilter
+        {
+            SourceType = "conversation",
+            SessionId = "session-1",
+            AfterDate = after,
+            BeforeDate = before,
+            Tags = tags
+        };
+
+        Assert.Equal("conversation", filter.SourceType);
+        Assert.Equal("session-1", filter.SessionId);
+        Assert.Equal(after, filter.AfterDate);
+        Assert.Equal(before, filter.BeforeDate);
+        Assert.Equal(tags, filter.Tags);
+    }
+}


### PR DESCRIPTION
Closes #1186

## Changes

- `IAgentMemory` interface with 6 operations: GetPromptContextAsync, SaveAsync, SearchAsync, GetAsync, OnSessionCompleteAsync, ConsolidateAsync
- All request/response DTOs: AgentMemoryPromptRequest, AgentMemoryContext, AgentMemoryDailyNote, AgentMemorySaveRequest, AgentMemorySearchRequest, AgentMemorySearchResult, AgentMemorySessionEvent, AgentMemoryConsolidateRequest
- `AgentMemorySearchFilter` for narrowing search results
- `IAgentMemoryFactory` with provider name resolution and registry listing
- 15 unit tests covering record equality, defaults, and all parameter combinations

All new files in `src/gateway/BotNexus.Gateway.Contracts/Memory/` — no existing code modified.

## Merge Notes

Pure additive — new files only in Gateway.Contracts. No overlap with any open PR. Safe to merge in any order.