### PR TITLE
fix(portal): sort built-in agents to bottom of agent dropdown

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/AgentDescriptor.cs
@@ -128,6 +128,12 @@ public sealed record AgentDescriptor : ICitizen
         new Dictionary<string, object?>();
 
     /// <summary>
+    /// Whether this agent is a built-in platform agent (determined by <c>metadata.builtin</c>).
+    /// Built-in agents sort after user-configured agents in portal UI.
+    /// </summary>
+    public bool IsBuiltIn => Metadata.TryGetValue("builtin", out var v) && v is true;
+
+    /// <summary>
     /// Strategy-specific isolation configuration for <see cref="IsolationStrategy" />.
     /// </summary>
     public IReadOnlyDictionary<string, object?> IsolationOptions { get; init; } =

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/Abstractions/IClientStateStore.cs
@@ -145,6 +145,9 @@ public sealed class AgentState
     /// <summary>Short description of this agent's purpose.</summary>
     public string? Description { get; set; }
 
+    /// <summary>Whether this is a platform built-in agent (sorts after user agents in UI).</summary>
+    public bool IsBuiltIn { get; set; }
+
     /// <summary>Active session ID (last established).</summary>
     public string? SessionId { get; set; }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ClientStateStore.cs
@@ -34,6 +34,7 @@ public sealed class ClientStateStore : IClientStateStore
                     DisplayName = a.DisplayName,
                     Emoji = a.Emoji,
                     Description = a.Description,
+                    IsBuiltIn = a.IsBuiltIn,
                     IsConnected = true
                 };
             }
@@ -42,6 +43,7 @@ public sealed class ClientStateStore : IClientStateStore
                 existing.DisplayName = a.DisplayName;
                 existing.Emoji = a.Emoji;
                 existing.Description = a.Description;
+                existing.IsBuiltIn = a.IsBuiltIn;
             }
         }
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/HubContracts.cs
@@ -19,7 +19,8 @@ public sealed record AgentSummary(
     [property: JsonPropertyName("agentId")] string AgentId,
     [property: JsonPropertyName("displayName")] string DisplayName,
     [property: JsonPropertyName("emoji")] string? Emoji = null,
-    [property: JsonPropertyName("description")] string? Description = null);
+    [property: JsonPropertyName("description")] string? Description = null,
+    [property: JsonPropertyName("isBuiltIn")] bool IsBuiltIn = false);
 
 /// <summary>Hub capabilities advertised on connect.</summary>
 public sealed record HubCapabilities(

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalLoadService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/PortalLoadService.cs
@@ -1,4 +1,4 @@
-﻿namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 
 /// <summary>
 /// Owns the portal startup sequence: REST first, SignalR second.
@@ -57,6 +57,7 @@ public sealed class PortalLoadService : IPortalLoadService
                     AgentId = agent.AgentId,
                     DisplayName = agent.DisplayName,
                     Emoji = agent.Emoji,
+                    IsBuiltIn = agent.IsBuiltIn,
                     IsConnected = true
                 });
             }
@@ -234,6 +235,7 @@ public sealed class PortalLoadService : IPortalLoadService
                     AgentId = agent.AgentId,
                     DisplayName = agent.DisplayName,
                     Emoji = agent.Emoji,
+                    IsBuiltIn = agent.IsBuiltIn,
                     IsConnected = true
                 });
             }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -74,7 +74,7 @@
                                 value="@Store.ActiveAgentId"
                                 @onchange="OnAgentSelected">
                             <option value="">— select agent —</option>
-                            @foreach (var (agentId, agent) in Store.Agents.Where(kv => !kv.Value.IsReadOnly))
+                            @foreach (var (agentId, agent) in Store.Agents.Where(kv => !kv.Value.IsReadOnly).OrderBy(kv => kv.Value.IsBuiltIn).ThenBy(kv => kv.Value.DisplayName))
                             {
                                 <option value="@agentId">
                                     @FormatAgentName(agent)


### PR DESCRIPTION
Closes #1193

Built-in agents (researcher, coder, planner, reviewer, writer, analyst) were mixed in with user-configured agents in the sidebar dropdown. Now user agents sort first (alphabetical), built-in agents sort last (alphabetical).

## Changes

- **AgentDescriptor**: Added `IsBuiltIn` computed property (checks `Metadata["builtin"] == true`)
- **AgentSummary** (client DTO): Added `isBuiltIn` JSON field
- **AgentState**: Added `IsBuiltIn` property
- **PortalLoadService + ClientStateStore**: Flow `IsBuiltIn` through seeding
- **MainLayout.razor**: Sort dropdown `.OrderBy(kv => kv.Value.IsBuiltIn).ThenBy(kv => kv.Value.DisplayName)`

## Testing

- All impacted tests pass (Gateway 2690, Architecture, Scenarios 29)
- E2E skipped (no running gateway, expected)