### PR TITLE
fix(canvas): inject bridge SDK before user scripts to eliminate async timing race

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/CanvasPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/CanvasPanel.razor
@@ -51,8 +51,8 @@
     }
 
     /// <summary>
-    /// Returns the canvas HTML with the bridge SDK script injected before the closing body tag
-    /// (or appended if no body tag exists). This gives iframe code access to window.canvasState.
+    /// Returns the canvas HTML with the bridge SDK script prepended so window.canvasState
+    /// is available synchronously before any user scripts execute.
     /// </summary>
     private string? EnrichedHtml
     {
@@ -63,11 +63,23 @@
                 return html;
 
             var bridgeScript = BridgeSdkScript;
-            var bodyCloseIdx = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
-            if (bodyCloseIdx >= 0)
-                return html.Insert(bodyCloseIdx, bridgeScript);
 
-            return html + bridgeScript;
+            // Insert after <head> if present so the bridge is first to execute
+            var headIdx = html.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
+            if (headIdx >= 0)
+                return html.Insert(headIdx + "<head>".Length, bridgeScript);
+
+            // Insert after <html> if no head tag
+            var htmlIdx = html.IndexOf("<html", StringComparison.OrdinalIgnoreCase);
+            if (htmlIdx >= 0)
+            {
+                var closeTag = html.IndexOf('>', htmlIdx);
+                if (closeTag >= 0)
+                    return html.Insert(closeTag + 1, bridgeScript);
+            }
+
+            // No structural HTML — prepend the bridge script
+            return bridgeScript + html;
         }
     }
 

--- a/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/CanvasTool.cs
@@ -54,7 +54,7 @@ public sealed class CanvasTool(
 
     public Tool Definition => new(
         Name,
-        "Publish Canvas tab HTML for the current agent scope. Use action='render' with html content to replace output, or action='clear' to clear output. Use set_state/get_state/clear_state for persistent key-value state. Rendered HTML has access to a 'window.canvasState' JavaScript API (get/set/delete/getAll/clear) that persists state server-side; the iframe can read and write the same state keys the agent uses via set_state/get_state.",
+        "Publish Canvas tab HTML for the current agent scope. Use action='render' with html content to replace output, or action='clear' to clear output. Use set_state/get_state/clear_state for persistent key-value state. Rendered HTML has access to a 'window.canvasState' JavaScript API (get/set/delete/getAll/clear) that persists state server-side; the iframe can read and write the same state keys the agent uses via set_state/get_state. The canvasState bridge is injected synchronously before user scripts execute, so it is safe to use immediately without polling or ready-event checks.",
         ToolSchema);
 
     public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/CanvasPanelTests.cs
@@ -69,36 +69,58 @@ public sealed class CanvasPanelTests : IDisposable
     }
 
     [Fact]
-    public void Bridge_sdk_injected_before_closing_body_tag()
+    public void Bridge_sdk_injected_after_head_tag_before_user_scripts()
     {
         var agent = _store.GetAgent("agent-1")!;
-        agent.CanvasHtml = "<html><body><p>Content</p></body></html>";
+        agent.CanvasHtml = "<html><head><script>var user = 1;</script></head><body><p>Content</p></body></html>";
 
         var cut = _ctx.Render<CanvasPanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
 
         var frame = cut.Find("iframe[data-testid='canvas-iframe']");
         var srcdoc = frame.GetAttribute("srcdoc")!;
 
-        // The bridge script should appear before </body>
-        var scriptIdx = srcdoc.IndexOf("window.canvasState", StringComparison.Ordinal);
-        var bodyCloseIdx = srcdoc.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
-        scriptIdx.ShouldBeGreaterThan(0);
-        bodyCloseIdx.ShouldBeGreaterThan(scriptIdx);
+        // The bridge script should appear after <head> but before user script
+        var bridgeIdx = srcdoc.IndexOf("window.canvasState", StringComparison.Ordinal);
+        var userScriptIdx = srcdoc.IndexOf("var user = 1", StringComparison.Ordinal);
+        bridgeIdx.ShouldBeGreaterThan(0);
+        userScriptIdx.ShouldBeGreaterThan(bridgeIdx);
     }
 
     [Fact]
-    public void Bridge_sdk_appended_when_no_body_tag()
+    public void Bridge_sdk_prepended_when_no_head_or_html_tag()
     {
         var agent = _store.GetAgent("agent-1")!;
-        agent.CanvasHtml = "<h1>No body tag</h1>";
+        agent.CanvasHtml = "<h1>No structural tags</h1><script>var x = 1;</script>";
 
         var cut = _ctx.Render<CanvasPanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
 
         var frame = cut.Find("iframe[data-testid='canvas-iframe']");
         var srcdoc = frame.GetAttribute("srcdoc")!;
 
-        srcdoc.ShouldContain("<h1>No body tag</h1>");
-        srcdoc.ShouldContain("window.canvasState");
+        // Bridge script should be at the very beginning
+        var bridgeIdx = srcdoc.IndexOf("window.canvasState", StringComparison.Ordinal);
+        var userIdx = srcdoc.IndexOf("<h1>No structural tags</h1>", StringComparison.Ordinal);
+        bridgeIdx.ShouldBeGreaterThan(0);
+        userIdx.ShouldBeGreaterThan(bridgeIdx);
+    }
+
+    [Fact]
+    public void Bridge_sdk_injected_after_html_tag_when_no_head_tag()
+    {
+        var agent = _store.GetAgent("agent-1")!;
+        agent.CanvasHtml = "<html><body><script>var x = 1;</script></body></html>";
+
+        var cut = _ctx.Render<CanvasPanel>(parameters => parameters.Add(x => x.AgentId, "agent-1"));
+
+        var frame = cut.Find("iframe[data-testid='canvas-iframe']");
+        var srcdoc = frame.GetAttribute("srcdoc")!;
+
+        // Bridge should be after <html> but before <body> content
+        var bridgeIdx = srcdoc.IndexOf("window.canvasState", StringComparison.Ordinal);
+        var htmlIdx = srcdoc.IndexOf("<html>", StringComparison.Ordinal);
+        var userScriptIdx = srcdoc.IndexOf("var x = 1", StringComparison.Ordinal);
+        bridgeIdx.ShouldBeGreaterThan(htmlIdx);
+        userScriptIdx.ShouldBeGreaterThan(bridgeIdx);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1189

## Changes
- Bridge SDK script is now injected at the TOP of the HTML (after `<head>` or `<html>` tag, or prepended if neither exists) instead of before `</body>`
- This ensures `window.canvasState` is defined synchronously before any user scripts execute
- Eliminates the race condition where agents checking canvasState synchronously got undefined
- Tool description updated to document that the bridge is available immediately without polling
- canvasStateReady event still fires for backwards compatibility

## Tests Updated
- Replaced old injection-position tests with:
  - Bridge_sdk_injected_after_head_tag_before_user_scripts
  - Bridge_sdk_prepended_when_no_head_or_html_tag
  - Bridge_sdk_injected_after_html_tag_when_no_head_tag

## Merge Notes
No file overlap with any open PR. Safe to merge in any order.