### PR TITLE
feat(portal): persist thinking content in session history for reload

### DIFF
--- a/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/GatewaySession.cs
@@ -353,6 +353,12 @@ public sealed record SessionEntry
     /// turns; ignored by the LLM context builder.
     /// </summary>
     public string? TurnIdempotencyKey { get; init; }
+
+    /// <summary>
+    /// Accumulated thinking/reasoning content from the model response.
+    /// Null when the model did not produce reasoning blocks.
+    /// </summary>
+    public string? ThinkingContent { get; init; }
 }
 
 /// <summary>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/AgentInteractionService.cs
@@ -481,6 +481,7 @@ public sealed class AgentInteractionService : IAgentInteractionService
                             ToolCallId = entry.ToolCallId,
                             ToolArgs = entry.ToolArgs,
                             ToolIsError = entry.ToolIsError,
+                            ThinkingContent = entry.ThinkingContent,
                             IsToolCall = entry.ToolName is not null,
                             ToolResult = entry.ToolName is not null ? AnsiStripper.Strip(entry.Content) : null
                         });
@@ -533,7 +534,8 @@ public sealed class AgentInteractionService : IAgentInteractionService
                             IsToolCall = isToolCall,
                             ToolResult = isToolCall ? AnsiStripper.Strip(entry.Content) : null,
                             ToolArgs = entry.ToolArgs,
-                            ToolIsError = entry.ToolIsError
+                            ToolIsError = entry.ToolIsError,
+                            ThinkingContent = entry.ThinkingContent
                         });
                     }
                 }
@@ -632,7 +634,8 @@ public sealed class AgentInteractionService : IAgentInteractionService
                         ToolName = entry.ToolName,
                         ToolCallId = entry.ToolCallId,
                         ToolArgs = entry.ToolArgs,
-                        ToolIsError = entry.ToolIsError,
+                            ToolIsError = entry.ToolIsError,
+                            ThinkingContent = entry.ThinkingContent,
                         ToolResult = entry.ToolName is not null ? AnsiStripper.Strip(entry.Content) : null,
                         IsToolCall = entry.ToolName is not null
                     });

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ConversationContracts.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/ConversationContracts.cs
@@ -92,6 +92,9 @@ public sealed class ConversationHistoryEntryDto
 
     [JsonPropertyName("reason")]
     public string? Reason { get; init; }
+
+    [JsonPropertyName("thinkingContent")]
+    public string? ThinkingContent { get; init; }
 }
 
 public sealed record SessionHistoryResponseDto(
@@ -122,4 +125,7 @@ public sealed class SessionHistoryEntryDto
 
     [JsonPropertyName("toolIsError")]
     public bool ToolIsError { get; init; }
+
+    [JsonPropertyName("thinkingContent")]
+    public string? ThinkingContent { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationDtos.cs
@@ -97,4 +97,7 @@ public sealed class ConversationHistoryEntry
 
     /// <summary>Reason for the boundary (for kind = "boundary").</summary>
     public string? Reason { get; init; }
+
+    /// <summary>Thinking/reasoning content from the model (for assistant messages).</summary>
+    public string? ThinkingContent { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -441,7 +441,8 @@ public sealed class ConversationsController : ControllerBase
                     ToolName = entry.ToolName,
                     ToolCallId = entry.ToolCallId,
                     ToolArgs = entry.ToolArgs,
-                    ToolIsError = entry.ToolIsError
+                    ToolIsError = entry.ToolIsError,
+                    ThinkingContent = entry.ThinkingContent
                 });
             }
         }

--- a/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/SqliteSessionStore.cs
@@ -559,7 +559,9 @@ public sealed class SqliteSessionStore : SessionStoreBase
                      // P9-E (#645): trigger_type captures the proxy origin of a turn
                      // (Cron/Soul/Heartbeat/Memory). Idempotent ALTER guarantees existing
                      // pre-P9-E DBs gain the column on the first post-upgrade open.
-                     ("trigger_type", "TEXT")
+                     ("trigger_type", "TEXT"),
+                     // #1191: thinking content persistence for portal reload
+                     ("thinking_content", "TEXT")
                  })
         {
             try
@@ -900,7 +902,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
 
         await using var historyCommand = connection.CreateCommand();
         historyCommand.CommandText = """
-            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history, trigger_type
+            SELECT role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history, trigger_type, thinking_content
             FROM session_history
             WHERE session_id = $sessionId
             ORDER BY id ASC
@@ -925,6 +927,9 @@ public sealed class SqliteSessionStore : SessionStoreBase
                 IsHistory = historyReader.FieldCount > 9 && !historyReader.IsDBNull(9) && historyReader.GetInt64(9) != 0,
                 Trigger = historyReader.FieldCount > 10 && !historyReader.IsDBNull(10)
                     ? TriggerType.FromString(historyReader.GetString(10))
+                    : null,
+                ThinkingContent = historyReader.FieldCount > 11 && !historyReader.IsDBNull(11)
+                    ? historyReader.GetString(11)
                     : null
             });
         }
@@ -1012,8 +1017,8 @@ public sealed class SqliteSessionStore : SessionStoreBase
             await using var insertCommand = connection.CreateCommand();
             insertCommand.Transaction = transaction;
             insertCommand.CommandText = """
-                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history, trigger_type)
-                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError, $isCrashSentinel, $isHistory, $triggerType)
+                INSERT INTO session_history (session_id, role, content, timestamp, tool_name, tool_call_id, is_compaction_summary, tool_args, tool_is_error, is_crash_sentinel, is_history, trigger_type, thinking_content)
+                VALUES ($sessionId, $role, $content, $timestamp, $toolName, $toolCallId, $isCompactionSummary, $toolArgs, $toolIsError, $isCrashSentinel, $isHistory, $triggerType, $thinkingContent)
                 """;
             insertCommand.Parameters.AddWithValue("$sessionId", session.SessionId.Value);
             insertCommand.Parameters.AddWithValue("$role", entry.Role.Value);
@@ -1027,6 +1032,7 @@ public sealed class SqliteSessionStore : SessionStoreBase
             insertCommand.Parameters.AddWithValue("$isCrashSentinel", entry.IsCrashSentinel ? 1 : 0);
             insertCommand.Parameters.AddWithValue("$isHistory", entry.IsHistory ? 1 : 0);
             insertCommand.Parameters.AddWithValue("$triggerType", (object?)entry.Trigger?.Value ?? DBNull.Value);
+            insertCommand.Parameters.AddWithValue("$thinkingContent", (object?)entry.ThinkingContent ?? DBNull.Value);
             await insertCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -34,6 +34,7 @@ public static class StreamingSessionHelper
         var streamedHistory = new List<SessionEntry>();
         var allHistoryEntries = new List<SessionEntry>();
         var hadThinkingContent = false;
+        var thinkingBuffer = new StringBuilder();
         var hadMessageEnd = false;
         var toolStartIds = new HashSet<string>(StringComparer.Ordinal);
         var toolEndIds = new HashSet<string>(StringComparer.Ordinal);
@@ -53,6 +54,7 @@ public static class StreamingSessionHelper
                     break;
                 case AgentStreamEventType.ThinkingDelta when evt.ThinkingContent is not null:
                     hadThinkingContent = true;
+                    thinkingBuffer.Append(evt.ThinkingContent);
                     break;
                 case AgentStreamEventType.MessageEnd:
                     hadMessageEnd = true;
@@ -122,7 +124,8 @@ public static class StreamingSessionHelper
                     streamedHistory.Clear();
                     if (streamedContent.Length > 0)
                     {
-                        turnSnapshot.Add(new SessionEntry { Role = MessageRole.Assistant, Content = streamedContent.ToString() });
+                        turnSnapshot.Add(new SessionEntry { Role = MessageRole.Assistant, Content = streamedContent.ToString(), ThinkingContent = thinkingBuffer.Length > 0 ? thinkingBuffer.ToString() : null });
+                        thinkingBuffer.Clear();
                         streamedContent.Clear();
                     }
                     session.AddEntries(turnSnapshot);
@@ -174,7 +177,7 @@ public static class StreamingSessionHelper
         var finalContent = streamedContent.ToString();
         if (!string.IsNullOrWhiteSpace(finalContent))
         {
-            session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = finalContent });
+            session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = finalContent, ThinkingContent = thinkingBuffer.Length > 0 ? thinkingBuffer.ToString() : null });
         }
         else if (streamedHistory.Count == 0 && hadThinkingContent && hadMessageEnd)
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
@@ -38,7 +38,7 @@ public sealed class StreamingSessionHelperTests
     }
 
     [Fact]
-    public async Task ProcessAndSaveAsync_DoesNotPersistThinkingContent()
+    public async Task ProcessAndSaveAsync_PersistsThinkingContentOnAssistantEntry()
     {
         var callbackTypes = new List<AgentStreamEventType>();
         var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-2"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
@@ -61,7 +61,47 @@ public sealed class StreamingSessionHelperTests
         session.History.ShouldHaveSingleItem();
         session.History[0].Role.ShouldBe(MessageRole.Assistant);
         session.History[0].Content.ShouldBe("Final answer.");
+        session.History[0].ThinkingContent.ShouldBe("Let me think...");
         callbackTypes.ShouldContain(AgentStreamEventType.ThinkingDelta);
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_NoThinking_ThinkingContentIsNull()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-2b"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Hello" }
+            ]),
+            session,
+            store.Object);
+
+        session.History.ShouldHaveSingleItem();
+        session.History[0].ThinkingContent.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ProcessAndSaveAsync_MultipleThinkingDeltas_Accumulated()
+    {
+        var session = new GatewaySession { SessionId = BotNexus.Domain.Primitives.SessionId.From("session-2c"), AgentId = BotNexus.Domain.Primitives.AgentId.From("agent-1") };
+        var store = new Mock<ISessionStore>();
+
+        await StreamingSessionHelper.ProcessAndSaveAsync(
+            ToAsyncEnumerable(
+            [
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "First " },
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "second " },
+                new AgentStreamEvent { Type = AgentStreamEventType.ThinkingDelta, ThinkingContent = "third" },
+                new AgentStreamEvent { Type = AgentStreamEventType.ContentDelta, ContentDelta = "Answer" }
+            ]),
+            session,
+            store.Object);
+
+        session.History.ShouldHaveSingleItem();
+        session.History[0].ThinkingContent.ShouldBe("First second third");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/ThinkingContentPersistenceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ThinkingContentPersistenceTests.cs
@@ -1,0 +1,38 @@
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class ThinkingContentPersistenceTests
+{
+    [Fact]
+    public void SessionEntry_ThinkingContent_defaults_to_null()
+    {
+        var entry = new SessionEntry { Role = MessageRole.Assistant, Content = "Hello" };
+        Assert.Null(entry.ThinkingContent);
+    }
+
+    [Fact]
+    public void SessionEntry_ThinkingContent_round_trips()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "Response",
+            ThinkingContent = "I should think about this carefully."
+        };
+        Assert.Equal("I should think about this carefully.", entry.ThinkingContent);
+    }
+
+    [Fact]
+    public void SessionEntry_with_record_copies_ThinkingContent()
+    {
+        var original = new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = "Hello",
+            ThinkingContent = "Reasoning here"
+        };
+        var copy = original with { Content = "Updated" };
+        Assert.Equal("Reasoning here", copy.ThinkingContent);
+    }
+}


### PR DESCRIPTION
Closes #1191

## Changes

- **Domain**: Add `string? ThinkingContent` property to `SessionEntry`
- **StreamingSessionHelper**: Accumulate `ThinkingDelta` events into a `StringBuilder`, attach to assistant `SessionEntry` on flush/final write
- **SQLite**: Add `thinking_content` TEXT column migration (idempotent); update INSERT/SELECT queries
- **ConversationsController**: Map `entry.ThinkingContent` to `ConversationHistoryEntry` DTO
- **Client DTOs**: Add `ThinkingContent` to both `ConversationHistoryEntryDto` and `SessionHistoryEntryDto`
- **AgentInteractionService**: Wire `ThinkingContent` from history entries to `ChatMessage.ThinkingContent`

## Testing

- 3 new tests in `ThinkingContentPersistenceTests` (domain property behavior)
- 3 updated/new tests in `StreamingSessionHelperTests` (accumulation, null when absent, multi-delta)
- All 2695 Gateway tests pass, Architecture 178, Scenarios 29

## Merge Notes

Independent of all 13 open PRs. No file overlap detected. Safe to merge in any order.