### PR TITLE
fix(gateway): silently drop thinking-only responses instead of showing confusing stall notice

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -646,9 +646,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                     {
                         // Detect thinking-only responses: when the model returns only a
                         // reasoning/thinking block with no user-visible content, StripThinkingTags
-                        // produces an empty string. Delivering an empty message would leave the
-                        // user with no reply and the conversation apparently stuck (#849).
-                        // Fall back to a stall notice so the turn completes gracefully.
+                        // produces an empty string. Silently skip delivery (#1198).
                         var outboundContent = ch.SupportsThinkingDisplay
                             ? response.Content
                             : AssistantTextSanitizer.StripThinkingTags(response.Content);
@@ -657,26 +655,29 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                             string.IsNullOrWhiteSpace(outboundContent) &&
                             AssistantTextSanitizer.IsThinkingOnlyResponse(response.Content))
                         {
-                            _logger.LogWarning(
+                            _logger.LogInformation(
                                 "Agent '{AgentId}' session '{SessionId}' returned a thinking-only response " +
                                 "(no user-visible content after stripping reasoning blocks). " +
-                                "Sending stall notice to prevent stuck conversation.",
+                                "Closing turn silently.",
                                 agentId, sessionId);
-                            outboundContent = "[I wasn't able to generate a response. Please try again.]"; // #849
+                            // Don't send anything to the user — thinking-only responses are
+                            // normal model behaviour, not an error (#1198).
                         }
-
-                        await ch.SendAsync(new OutboundMessage
+                        else
                         {
-                            ChannelType = message.ChannelType,
-                            ChannelAddress = message.ChannelAddress,
-                            Content = outboundContent,
-                            SessionId = sessionId,
-                            // Binding-aware fields from originating binding fix #126:
-                            // ensure replies carry the binding's decoration. Native sub-addresses
-                            // (e.g. Telegram forum topics) are already encoded in ChannelAddress.
-                            BindingId = resolvedSource.BindingId,
-                            DisplayPrefix = resolvedSource.DisplayPrefix
-                        }, cancellationToken);
+                            await ch.SendAsync(new OutboundMessage
+                            {
+                                ChannelType = message.ChannelType,
+                                ChannelAddress = message.ChannelAddress,
+                                Content = outboundContent,
+                                SessionId = sessionId,
+                                // Binding-aware fields from originating binding fix #126:
+                                // ensure replies carry the binding's decoration. Native sub-addresses
+                                // (e.g. Telegram forum topics) are already encoded in ChannelAddress.
+                                BindingId = resolvedSource.BindingId,
+                                DisplayPrefix = resolvedSource.DisplayPrefix
+                            }, cancellationToken);
+                        }
                     }
 
                     session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = response.Content });

--- a/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
+++ b/src/gateway/BotNexus.Gateway/Streaming/StreamingSessionHelper.cs
@@ -179,14 +179,13 @@ public static class StreamingSessionHelper
         else if (streamedHistory.Count == 0 && hadThinkingContent && hadMessageEnd)
         {
             // The model produced only reasoning/thinking blocks and no visible text or tool calls.
-            // Without this sentinel the session transcript ends with the user message and no
-            // assistant reply, so the next turn replays the abandoned user prompt, causing
-            // duplicate-message confusion and skipped tool calls (same pattern as #656).
-            // Surface a system entry so the conversation is in a known good state.
+            // Add an empty assistant entry so the transcript is in a valid state (prevents the
+            // duplicate-message replay bug from #656). Do NOT surface any user-visible message —
+            // thinking-only responses are a normal model behaviour, not an error (#1198).
             session.AddEntry(new SessionEntry
             {
-                Role = MessageRole.System,
-                Content = "Agent produced only reasoning content and could not generate a visible response. Please try again or rephrase your message."
+                Role = MessageRole.Assistant,
+                Content = string.Empty
             });
         }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostTests.cs
@@ -2151,11 +2151,11 @@ public sealed class GatewayHostTests
     // #849 -- thinking-only response stall detection
 
     [Fact]
-    public async Task DispatchAsync_WhenAgentReturnsThinkingOnlyResponse_SendsStallNotice()
+    public async Task DispatchAsync_WhenAgentReturnsThinkingOnlyResponse_DoesNotSendMessage()
     {
         // Arrange: agent returns a response that consists solely of a thinking block.
         // The channel does NOT support thinking display (most channels).
-        // Expected: stall notice delivered instead of empty message.
+        // Expected: no message delivered — thinking-only is silently dropped (#1198).
         var router = new Mock<IMessageRouter>();
         router.Setup(r => r.ResolveAsync(It.IsAny<InboundMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(["agent-a"]);
@@ -2177,12 +2177,10 @@ public sealed class GatewayHostTests
 
         await host.DispatchAsync(CreateMessage("hello", sessionId: "session-1"));
 
-        // Assert: channel received the stall notice, NOT the raw thinking block.
+        // Assert: channel received NO message — thinking-only responses are silently dropped.
         channel.Verify(c => c.SendAsync(
-            It.Is<OutboundMessage>(m =>
-                m.Content.Contains("wasn't able to generate",
-                    StringComparison.OrdinalIgnoreCase)),
-            It.IsAny<CancellationToken>()), Times.Once);
+            It.IsAny<OutboundMessage>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/StreamingSessionHelperTests.cs
@@ -235,7 +235,7 @@ public sealed class StreamingSessionHelperTests
     }
 
     [Fact]
-    public async Task ProcessAndSaveAsync_ThinkingOnlyWithMessageEnd_AddsSystemStallEntry()
+    public async Task ProcessAndSaveAsync_ThinkingOnlyWithMessageEnd_AddsEmptyAssistantEntry()
     {
         // Arrange: provider returned only thinking blocks, no visible text, no tools.
         // MessageEnd signals a clean turn completion — but no user-visible content was produced.
@@ -252,10 +252,10 @@ public sealed class StreamingSessionHelperTests
             session,
             store.Object);
 
-        // Assert: exactly one system entry with the stall message.
+        // Assert: exactly one empty assistant entry to close the turn (no user-visible message).
         session.History.ShouldHaveSingleItem();
-        session.History[0].Role.ShouldBe(MessageRole.System);
-        session.History[0].Content.ShouldContain("only reasoning content");
+        session.History[0].Role.ShouldBe(MessageRole.Assistant);
+        session.History[0].Content.ShouldBe(string.Empty);
         store.Verify(s => s.SaveAsync(session, It.IsAny<CancellationToken>()), Times.Once);
     }
 


### PR DESCRIPTION
Closes #1198

When the model returns only reasoning/thinking blocks with no visible text, the gateway previously surfaced a confusing message ("Agent produced only reasoning content and could not generate a visible response..."). This is normal model behaviour, not an error.

## Changes

**Streaming path** (`StreamingSessionHelper.cs`):
- Changed from System role entry with stall message → empty Assistant entry
- Maintains transcript integrity (prevents duplicate-message replay bug #656)
- No user-visible message surfaced

**Non-streaming path** (`GatewayHost.cs`):
- Changed from sending stall notice text → silently skipping delivery
- Session still records the assistant entry normally
- Log level downgraded from Warning to Information

## Tests updated
- `StreamingSessionHelperTests.ProcessAndSaveAsync_ThinkingOnlyWithMessageEnd_AddsEmptyAssistantEntry` (renamed, asserts empty assistant)
- `GatewayHostTests.DispatchAsync_WhenAgentReturnsThinkingOnlyResponse_DoesNotSendMessage` (renamed, asserts Times.Never)