### PR TITLE
feat(memory): add shared memory store configuration and registry with access control

### DIFF
--- a/src/gateway/BotNexus.Memory/ISharedMemoryStoreRegistry.cs
+++ b/src/gateway/BotNexus.Memory/ISharedMemoryStoreRegistry.cs
@@ -1,0 +1,26 @@
+namespace BotNexus.Memory;
+
+/// <summary>
+/// Registry for shared memory stores with access control enforcement.
+/// Resolves stores by name and validates reader/writer permissions per agent.
+/// </summary>
+public interface ISharedMemoryStoreRegistry : IAsyncDisposable
+{
+    /// <summary>Gets a shared store by name. Returns null if not configured.</summary>
+    IMemoryStore? GetStore(string storeName);
+
+    /// <summary>Gets all store names readable by the specified agent.</summary>
+    IReadOnlyList<string> GetReadableStores(string agentId);
+
+    /// <summary>Gets all store names writable by the specified agent.</summary>
+    IReadOnlyList<string> GetWritableStores(string agentId);
+
+    /// <summary>Returns true if the agent can read from the named store.</summary>
+    bool CanRead(string agentId, string storeName);
+
+    /// <summary>Returns true if the agent can write to the named store.</summary>
+    bool CanWrite(string agentId, string storeName);
+
+    /// <summary>Gets all configured shared store configs.</summary>
+    IReadOnlyList<SharedMemoryStoreConfig> GetAllConfigs();
+}

--- a/src/gateway/BotNexus.Memory/SharedMemoryStoreConfig.cs
+++ b/src/gateway/BotNexus.Memory/SharedMemoryStoreConfig.cs
@@ -1,0 +1,29 @@
+namespace BotNexus.Memory;
+
+/// <summary>
+/// Configuration for a named shared memory store that multiple agents can read/write.
+/// Parsed from Gateway.Memory.SharedStores[] in config.json.
+/// </summary>
+public sealed record SharedMemoryStoreConfig
+{
+    /// <summary>Unique store name (e.g. "platform-knowledge").</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Human-readable description of what this store is for.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Agent IDs allowed to write to this store. Use "*" for all agents.
+    /// </summary>
+    public IReadOnlyList<string> Writers { get; init; } = [];
+
+    /// <summary>
+    /// Agent IDs allowed to read from this store. Use "*" for all agents.
+    /// </summary>
+    public IReadOnlyList<string> Readers { get; init; } = [];
+
+    /// <summary>
+    /// Number of days to retain entries. Null means no retention limit.
+    /// </summary>
+    public int? RetentionDays { get; init; }
+}

--- a/src/gateway/BotNexus.Memory/SharedMemoryStoreRegistry.cs
+++ b/src/gateway/BotNexus.Memory/SharedMemoryStoreRegistry.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.IO.Abstractions;
+
+namespace BotNexus.Memory;
+
+/// <summary>
+/// In-memory registry of shared memory stores backed by SQLite.
+/// Stores are located at {basePath}/shared/{store-name}.db.
+/// </summary>
+public sealed class SharedMemoryStoreRegistry : ISharedMemoryStoreRegistry
+{
+    private readonly IReadOnlyList<SharedMemoryStoreConfig> _configs;
+    private readonly string _basePath;
+    private readonly IFileSystem _fileSystem;
+    private readonly ConcurrentDictionary<string, IMemoryStore> _stores = new(StringComparer.OrdinalIgnoreCase);
+
+    public SharedMemoryStoreRegistry(
+        IReadOnlyList<SharedMemoryStoreConfig> configs,
+        string basePath,
+        IFileSystem? fileSystem = null)
+    {
+        _configs = configs ?? throw new ArgumentNullException(nameof(configs));
+        _basePath = basePath ?? throw new ArgumentNullException(nameof(basePath));
+        _fileSystem = fileSystem ?? new FileSystem();
+    }
+
+    public IMemoryStore? GetStore(string storeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storeName);
+
+        var config = FindConfig(storeName);
+        if (config is null)
+            return null;
+
+        return _stores.GetOrAdd(storeName, name =>
+        {
+            var dbPath = Path.Combine(_basePath, "shared", $"{name}.db");
+            return new SqliteMemoryStore(dbPath, _fileSystem);
+        });
+    }
+
+    public IReadOnlyList<string> GetReadableStores(string agentId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        return _configs
+            .Where(c => HasAccess(c.Readers, agentId))
+            .Select(c => c.Name)
+            .ToList();
+    }
+
+    public IReadOnlyList<string> GetWritableStores(string agentId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        return _configs
+            .Where(c => HasAccess(c.Writers, agentId))
+            .Select(c => c.Name)
+            .ToList();
+    }
+
+    public bool CanRead(string agentId, string storeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(storeName);
+
+        var config = FindConfig(storeName);
+        return config is not null && HasAccess(config.Readers, agentId);
+    }
+
+    public bool CanWrite(string agentId, string storeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(storeName);
+
+        var config = FindConfig(storeName);
+        return config is not null && HasAccess(config.Writers, agentId);
+    }
+
+    public IReadOnlyList<SharedMemoryStoreConfig> GetAllConfigs() => _configs;
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var pair in _stores)
+            await pair.Value.DisposeAsync();
+
+        _stores.Clear();
+    }
+
+    private SharedMemoryStoreConfig? FindConfig(string storeName)
+        => _configs.FirstOrDefault(c => string.Equals(c.Name, storeName, StringComparison.OrdinalIgnoreCase));
+
+    private static bool HasAccess(IReadOnlyList<string> accessList, string agentId)
+    {
+        if (accessList.Count == 0)
+            return false;
+
+        return accessList.Any(entry =>
+            string.Equals(entry, "*", StringComparison.Ordinal) ||
+            string.Equals(entry, agentId, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/SharedMemoryStoreConfigTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/SharedMemoryStoreConfigTests.cs
@@ -1,0 +1,58 @@
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace BotNexus.Memory.Tests;
+
+public sealed class SharedMemoryStoreConfigTests
+{
+    [Fact]
+    public void Config_RequiresName()
+    {
+        var config = new SharedMemoryStoreConfig
+        {
+            Name = "platform-knowledge",
+            Description = "Platform decisions and patterns",
+            Writers = ["farnsworth", "nova"],
+            Readers = ["*"],
+            RetentionDays = 365
+        };
+
+        Assert.Equal("platform-knowledge", config.Name);
+        Assert.Equal("Platform decisions and patterns", config.Description);
+        Assert.Equal(2, config.Writers.Count);
+        Assert.Single(config.Readers);
+        Assert.Equal(365, config.RetentionDays);
+    }
+
+    [Fact]
+    public void Config_DefaultsToEmptyLists()
+    {
+        var config = new SharedMemoryStoreConfig { Name = "test" };
+
+        Assert.Empty(config.Writers);
+        Assert.Empty(config.Readers);
+        Assert.Null(config.Description);
+        Assert.Null(config.RetentionDays);
+    }
+
+    [Fact]
+    public void Config_RecordEquality()
+    {
+        var a = new SharedMemoryStoreConfig
+        {
+            Name = "test",
+            Writers = ["agent1"],
+            Readers = ["*"]
+        };
+        var b = new SharedMemoryStoreConfig
+        {
+            Name = "test",
+            Writers = ["agent1"],
+            Readers = ["*"]
+        };
+
+        // Records use reference equality for collections
+        Assert.NotEqual(a, b);
+        Assert.Equal(a.Name, b.Name);
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/SharedMemoryStoreRegistryTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/SharedMemoryStoreRegistryTests.cs
@@ -1,0 +1,186 @@
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace BotNexus.Memory.Tests;
+
+public sealed class SharedMemoryStoreRegistryTests : IAsyncDisposable
+{
+    private readonly MockFileSystem _fileSystem = new();
+    private readonly List<SharedMemoryStoreConfig> _configs;
+    private readonly SharedMemoryStoreRegistry _registry;
+
+    public SharedMemoryStoreRegistryTests()
+    {
+        _configs =
+        [
+            new SharedMemoryStoreConfig
+            {
+                Name = "platform-knowledge",
+                Description = "Platform decisions",
+                Writers = ["farnsworth", "nova"],
+                Readers = ["*"],
+                RetentionDays = null
+            },
+            new SharedMemoryStoreConfig
+            {
+                Name = "team-procedures",
+                Description = "SOPs",
+                Writers = ["*"],
+                Readers = ["*"],
+                RetentionDays = 365
+            },
+            new SharedMemoryStoreConfig
+            {
+                Name = "restricted",
+                Description = "Admin only",
+                Writers = ["admin"],
+                Readers = ["admin", "farnsworth"]
+            }
+        ];
+
+        _registry = new SharedMemoryStoreRegistry(_configs, "/memory", _fileSystem);
+    }
+
+    public ValueTask DisposeAsync() => _registry.DisposeAsync();
+
+    [Fact]
+    public void GetStore_ReturnsStoreForConfiguredName()
+    {
+        var store = _registry.GetStore("platform-knowledge");
+        Assert.NotNull(store);
+    }
+
+    [Fact]
+    public void GetStore_ReturnsNullForUnknownName()
+    {
+        var store = _registry.GetStore("nonexistent");
+        Assert.Null(store);
+    }
+
+    [Fact]
+    public void GetStore_CaseInsensitive()
+    {
+        var store = _registry.GetStore("Platform-Knowledge");
+        Assert.NotNull(store);
+    }
+
+    [Fact]
+    public void GetStore_ReturnsSameInstanceOnRepeatedCalls()
+    {
+        var store1 = _registry.GetStore("platform-knowledge");
+        var store2 = _registry.GetStore("platform-knowledge");
+        Assert.Same(store1, store2);
+    }
+
+    [Fact]
+    public void CanRead_WildcardAllowsAnyAgent()
+    {
+        Assert.True(_registry.CanRead("random-agent", "platform-knowledge"));
+        Assert.True(_registry.CanRead("random-agent", "team-procedures"));
+    }
+
+    [Fact]
+    public void CanRead_ExplicitListEnforced()
+    {
+        Assert.True(_registry.CanRead("admin", "restricted"));
+        Assert.True(_registry.CanRead("farnsworth", "restricted"));
+        Assert.False(_registry.CanRead("nova", "restricted"));
+    }
+
+    [Fact]
+    public void CanRead_ReturnsFalseForUnknownStore()
+    {
+        Assert.False(_registry.CanRead("farnsworth", "nonexistent"));
+    }
+
+    [Fact]
+    public void CanWrite_WildcardAllowsAnyAgent()
+    {
+        Assert.True(_registry.CanWrite("random-agent", "team-procedures"));
+    }
+
+    [Fact]
+    public void CanWrite_ExplicitListEnforced()
+    {
+        Assert.True(_registry.CanWrite("farnsworth", "platform-knowledge"));
+        Assert.True(_registry.CanWrite("nova", "platform-knowledge"));
+        Assert.False(_registry.CanWrite("random-agent", "platform-knowledge"));
+    }
+
+    [Fact]
+    public void CanWrite_ReturnsFalseForUnknownStore()
+    {
+        Assert.False(_registry.CanWrite("farnsworth", "nonexistent"));
+    }
+
+    [Fact]
+    public void CanWrite_AdminOnlyStore()
+    {
+        Assert.True(_registry.CanWrite("admin", "restricted"));
+        Assert.False(_registry.CanWrite("farnsworth", "restricted"));
+        Assert.False(_registry.CanWrite("nova", "restricted"));
+    }
+
+    [Fact]
+    public void GetReadableStores_WildcardReturnsAll()
+    {
+        var stores = _registry.GetReadableStores("random-agent");
+        // platform-knowledge and team-procedures have Readers=["*"]
+        Assert.Contains("platform-knowledge", stores);
+        Assert.Contains("team-procedures", stores);
+        Assert.DoesNotContain("restricted", stores);
+    }
+
+    [Fact]
+    public void GetReadableStores_ExplicitAgent()
+    {
+        var stores = _registry.GetReadableStores("farnsworth");
+        Assert.Contains("platform-knowledge", stores);
+        Assert.Contains("team-procedures", stores);
+        Assert.Contains("restricted", stores);
+    }
+
+    [Fact]
+    public void GetWritableStores_ExplicitAgent()
+    {
+        var stores = _registry.GetWritableStores("farnsworth");
+        Assert.Contains("platform-knowledge", stores);
+        Assert.Contains("team-procedures", stores);
+        Assert.DoesNotContain("restricted", stores);
+    }
+
+    [Fact]
+    public void GetWritableStores_AdminAgent()
+    {
+        var stores = _registry.GetWritableStores("admin");
+        Assert.DoesNotContain("platform-knowledge", stores); // admin not in Writers
+        Assert.Contains("team-procedures", stores); // wildcard
+        Assert.Contains("restricted", stores); // explicit
+    }
+
+    [Fact]
+    public void GetAllConfigs_ReturnsAllConfigured()
+    {
+        var configs = _registry.GetAllConfigs();
+        Assert.Equal(3, configs.Count);
+    }
+
+    [Fact]
+    public void CanRead_CaseInsensitiveAgentId()
+    {
+        Assert.True(_registry.CanRead("FARNSWORTH", "restricted"));
+        Assert.True(_registry.CanWrite("NOVA", "platform-knowledge"));
+    }
+
+    [Fact]
+    public async Task EmptyAccessList_DeniesAll()
+    {
+        var configs = new List<SharedMemoryStoreConfig>
+        {
+            new() { Name = "empty", Writers = [], Readers = [] }
+        };
+        await using var registry = new SharedMemoryStoreRegistry(configs, "/memory", _fileSystem);
+        Assert.False(registry.CanRead("anyone", "empty"));
+        Assert.False(registry.CanWrite("anyone", "empty"));
+    }
+}


### PR DESCRIPTION
Closes #1202

## Changes
- `SharedMemoryStoreConfig`: configuration model for named shared stores (Name, Description, Writers, Readers, RetentionDays)
- `ISharedMemoryStoreRegistry`: interface for resolving shared stores with reader/writer access control
- `SharedMemoryStoreRegistry`: implementation backed by SQLite stores at `~/.botnexus/memory/shared/{name}.db`
  - Wildcard `"*"` support for open-access stores
  - Case-insensitive agent ID and store name matching
  - Thread-safe ConcurrentDictionary store caching
- 20 unit tests covering access control, wildcard, case sensitivity, empty lists

Part of #1180 (collective learning) — first sub-issue (1/5).

## Merge Notes
Targets only `src/gateway/BotNexus.Memory` and `tests/gateway/BotNexus.Memory.Tests`. No overlap with any open PR. Safe to merge in any order.
