### PR TITLE
fix(portal): expand thinking block by default instead of collapsed

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ChatPanel.razor
@@ -229,7 +229,7 @@
                 {
                     <div class="thinking-block @(!ShowThinking ? "visibility-hidden" : "")"
                          style="@(!ShowThinking ? "display:none" : "")">
-                        <details>
+                        <details open>
                             <summary class="thinking-summary">💭 Thinking…</summary>
                             <div class="thinking-content">@msg.ThinkingContent</div>
                         </details>

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ChatPanelTests.cs
@@ -742,6 +742,23 @@ public sealed class ChatPanelTests : IDisposable
     }
 
     [Fact]
+    public void ThinkingBlock_Details_Element_Has_Open_Attribute_By_Default()
+    {
+        CreateAndSeedAgent("agent-1", isConnected: true);
+        _store.SeedConversations("agent-1", [MakeConvDto("conv-1", "agent-1")]);
+        _store.SetActiveConversation("agent-1", "conv-1");
+        _store.AppendMessage("conv-1", new ChatMessage("Assistant", "Answer", DateTimeOffset.UtcNow)
+        {
+            ThinkingContent = "Some reasoning..."
+        });
+
+        var cut = _ctx.Render<ChatPanel>(p => p.Add(c => c.AgentId, "agent-1"));
+
+        var details = cut.Find(".thinking-block details");
+        Assert.True(details.HasAttribute("open"), "Thinking <details> should have the 'open' attribute by default.");
+    }
+
+    [Fact]
     public void Normal_Assistant_Message_Without_Thinking_Renders_MessageBubble()
     {
         CreateAndSeedAgent("agent-1", isConnected: true);


### PR DESCRIPTION
Closes #1192

## Changes
- Add \open\ attribute to \<details>\ element in ChatPanel.razor for completed thinking blocks
- Streaming thinking blocks already had \open\ — this aligns the completed message rendering
- 1 new test verifying the \open\ attribute is present by default

## Merge Notes
No file overlap with any open PR. Safe to merge in any order.