### PR TITLE
feat(extensions): add QMD CLI backend and knowledge_search tool

### DIFF
--- a/src/extensions/BotNexus.Extensions.Qmd/BotNexus.Extensions.Qmd.csproj
+++ b/src/extensions/BotNexus.Extensions.Qmd/BotNexus.Extensions.Qmd.csproj
@@ -11,6 +11,9 @@
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
   <!-- Copy extension output + manifest to artifacts/extensions/ for dev-time discovery -->
   <Target Name="CopyExtensionToArtifacts" AfterTargets="Build">
     <PropertyGroup>

--- a/src/extensions/BotNexus.Extensions.Qmd/KnowledgeSearchTool.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/KnowledgeSearchTool.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Agent-facing tool for searching the QMD knowledge base.
+/// Supports keyword, semantic, and hybrid search modes.
+/// </summary>
+public sealed class KnowledgeSearchTool(IQmdBackend backend, QmdConfig config) : IAgentTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public string Name => "knowledge_search";
+
+    /// <inheritdoc />
+    public string Label => "Knowledge Search";
+
+    /// <inheritdoc />
+    public Tool Definition => new(
+        Name,
+        "Search the knowledge base using keyword, semantic, or hybrid search.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "description": "Search query (natural language or keywords)."
+                },
+                "store": {
+                  "type": "string",
+                  "description": "Target store name. Omit to search all stores."
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": ["keyword", "semantic", "hybrid"],
+                  "description": "Search mode. Default from config."
+                },
+                "limit": {
+                  "type": "integer",
+                  "description": "Maximum results to return (1-50). Default from config."
+                }
+              },
+              "required": ["query"]
+            }
+            """).RootElement.Clone());
+
+    /// <inheritdoc />
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyDictionary<string, object?>>(
+            new Dictionary<string, object?>(arguments, StringComparer.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        var query = GetString(arguments, "query");
+        if (string.IsNullOrWhiteSpace(query))
+            return TextResult("Error: The 'query' parameter is required.");
+
+        var store = GetString(arguments, "store");
+        var modeStr = GetString(arguments, "mode") ?? config.DefaultSearchMode;
+        var limit = GetInt(arguments, "limit") ?? config.MaxResults;
+
+        if (limit < 1) limit = 1;
+        if (limit > 50) limit = 50;
+
+        var mode = modeStr?.ToLowerInvariant() switch
+        {
+            "keyword" => QmdSearchMode.Keyword,
+            "semantic" => QmdSearchMode.Semantic,
+            "hybrid" => QmdSearchMode.Hybrid,
+            _ => QmdSearchMode.Hybrid
+        };
+
+        try
+        {
+            var results = await backend.SearchAsync(query, store, mode, limit, cancellationToken);
+            var json = JsonSerializer.Serialize(results, JsonOptions);
+            return TextResult(json);
+        }
+        catch (QmdBinaryNotFoundException ex)
+        {
+            return TextResult($"Error: {ex.Message}");
+        }
+        catch (QmdCliException ex)
+        {
+            return TextResult($"Error: Search failed: {ex.Message}");
+        }
+        catch (TimeoutException ex)
+        {
+            return TextResult($"Error: {ex.Message}");
+        }
+    }
+
+    private static AgentToolResult TextResult(string text) =>
+        new([new AgentToolContent(AgentToolContentType.Text, text)]);
+
+    private static string? GetString(IReadOnlyDictionary<string, object?> args, string key) =>
+        args.TryGetValue(key, out var val) ? val?.ToString() : null;
+
+    private static int? GetInt(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var val) || val is null) return null;
+        if (val is int i) return i;
+        if (val is long l) return (int)l;
+        if (val is JsonElement je && je.ValueKind == JsonValueKind.Number) return je.GetInt32();
+        if (int.TryParse(val.ToString(), out var parsed)) return parsed;
+        return null;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Qmd/QmdCliBackend.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdCliBackend.cs
@@ -1,0 +1,171 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Implements <see cref="IQmdBackend"/> by shelling out to the <c>qmd</c> CLI binary.
+/// Each method maps to a specific <c>qmd</c> subcommand with <c>--json</c> output.
+/// </summary>
+public sealed class QmdCliBackend : IQmdBackend
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly string _qmdPath;
+    private readonly TimeSpan _timeout;
+    private readonly ILogger? _logger;
+
+    /// <summary>
+    /// Creates a new QMD CLI backend.
+    /// </summary>
+    /// <param name="qmdPath">Path to the qmd binary (or just "qmd" for PATH resolution).</param>
+    /// <param name="timeout">Maximum time to wait for a CLI call.</param>
+    /// <param name="logger">Optional logger.</param>
+    public QmdCliBackend(string? qmdPath = null, TimeSpan? timeout = null, ILogger? logger = null)
+    {
+        _qmdPath = string.IsNullOrWhiteSpace(qmdPath) ? "qmd" : qmdPath;
+        _timeout = timeout ?? TimeSpan.FromSeconds(30);
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<QmdSearchResult[]> SearchAsync(string query, string? store, QmdSearchMode mode, int limit, CancellationToken ct = default)
+    {
+        var command = mode switch
+        {
+            QmdSearchMode.Keyword => "search",
+            QmdSearchMode.Semantic => "vsearch",
+            QmdSearchMode.Hybrid => "query",
+            _ => "query"
+        };
+
+        var args = new List<string> { command, query };
+        if (!string.IsNullOrEmpty(store)) { args.Add("-c"); args.Add(store); }
+        args.Add("-n"); args.Add(limit.ToString());
+        args.Add("--json");
+
+        var output = await RunAsync(args, ct);
+        return JsonSerializer.Deserialize<QmdSearchResult[]>(output, JsonOptions) ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<QmdDocument?> GetDocumentAsync(string id, CancellationToken ct = default)
+    {
+        var output = await RunAsync(["get", id, "--json"], ct);
+        return JsonSerializer.Deserialize<QmdDocument>(output, JsonOptions);
+    }
+
+    /// <inheritdoc />
+    public async Task<QmdStoreInfo[]> GetStoresAsync(CancellationToken ct = default)
+    {
+        var output = await RunAsync(["status", "--json"], ct);
+        return JsonSerializer.Deserialize<QmdStoreInfo[]>(output, JsonOptions) ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateIndexAsync(string? store, CancellationToken ct = default)
+    {
+        var args = new List<string> { "update" };
+        if (!string.IsNullOrEmpty(store)) { args.Add("-c"); args.Add(store); }
+        await RunAsync(args, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task EmbedAsync(string? store, CancellationToken ct = default)
+    {
+        var args = new List<string> { "embed" };
+        if (!string.IsNullOrEmpty(store)) { args.Add("-c"); args.Add(store); }
+        await RunAsync(args, ct);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    internal async Task<string> RunAsync(IReadOnlyList<string> arguments, CancellationToken ct)
+    {
+        _logger?.LogDebug("Executing: {QmdPath} {Args}", _qmdPath, string.Join(' ', arguments));
+
+        var psi = new ProcessStartInfo(_qmdPath)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var arg in arguments) psi.ArgumentList.Add(arg);
+
+        using var process = new Process { StartInfo = psi };
+
+        try
+        {
+            process.Start();
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            throw new QmdBinaryNotFoundException(_qmdPath, ex);
+        }
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        var stdoutTask = ReadStreamAsync(process.StandardOutput, stdout, ct);
+        var stderrTask = ReadStreamAsync(process.StandardError, stderr, ct);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_timeout);
+
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new TimeoutException($"qmd CLI call timed out after {_timeout.TotalSeconds}s. Args: {string.Join(' ', arguments)}");
+        }
+
+        await Task.WhenAll(stdoutTask, stderrTask);
+
+        if (process.ExitCode != 0)
+        {
+            var error = stderr.ToString().Trim();
+            _logger?.LogWarning("qmd exited with code {ExitCode}: {Error}", process.ExitCode, error);
+            throw new QmdCliException(process.ExitCode, error, arguments);
+        }
+
+        return stdout.ToString();
+    }
+
+    private static async Task ReadStreamAsync(System.IO.StreamReader reader, StringBuilder buffer, CancellationToken ct)
+    {
+        var buf = new char[4096];
+        int read;
+        while ((read = await reader.ReadAsync(buf, ct)) > 0)
+            buffer.Append(buf, 0, read);
+    }
+}
+
+/// <summary>Thrown when the qmd binary cannot be found at the configured path.</summary>
+public sealed class QmdBinaryNotFoundException : Exception
+{
+    public QmdBinaryNotFoundException(string path, Exception? inner = null)
+        : base($"The qmd binary was not found at '{path}'. Ensure qmd is installed and available on PATH, or configure QmdPath in the extension config.", inner) { }
+}
+
+/// <summary>Thrown when the qmd CLI returns a non-zero exit code.</summary>
+public sealed class QmdCliException : Exception
+{
+    public int ExitCode { get; }
+    public string StdErr { get; }
+    public IReadOnlyList<string> Arguments { get; }
+
+    public QmdCliException(int exitCode, string stderr, IReadOnlyList<string> arguments)
+        : base($"qmd exited with code {exitCode}: {stderr}")
+    {
+        ExitCode = exitCode;
+        StdErr = stderr;
+        Arguments = arguments;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Qmd/QmdToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdToolContributor.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Contributes the <see cref="KnowledgeSearchTool"/> when
+/// the QMD extension is enabled for the agent.
+/// </summary>
+public sealed class QmdToolContributor(ILoggerFactory? loggerFactory = null) : IAgentToolContributor
+{
+    /// <inheritdoc />
+    public Task<AgentToolContribution> ContributeAsync(
+        AgentToolContributionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var config = ResolveConfig(context.Descriptor);
+
+        if (!config.Enabled)
+            return Task.FromResult(new AgentToolContribution(Array.Empty<IAgentTool>()));
+
+        var logger = loggerFactory?.CreateLogger<QmdCliBackend>();
+        var backend = new QmdCliBackend(config.QmdPath, TimeSpan.FromSeconds(30), logger);
+        IReadOnlyList<IAgentTool> tools = [new KnowledgeSearchTool(backend, config)];
+
+        return Task.FromResult(new AgentToolContribution(tools, [backend]));
+    }
+
+    internal static QmdConfig ResolveConfig(AgentDescriptor descriptor)
+    {
+        if (descriptor.ExtensionConfig.TryGetValue("botnexus-qmd", out var element))
+        {
+            try
+            {
+                var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+                return JsonSerializer.Deserialize<QmdConfig>(element.GetRawText(), options)
+                       ?? new QmdConfig();
+            }
+            catch
+            {
+                return new QmdConfig();
+            }
+        }
+
+        return new QmdConfig();
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/BotNexus.Extensions.Qmd.Tests.csproj
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/BotNexus.Extensions.Qmd.Tests.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\extensions\BotNexus.Extensions.Qmd\BotNexus.Extensions.Qmd.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\agent\BotNexus.Agent.Core\BotNexus.Agent.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/KnowledgeSearchToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/KnowledgeSearchToolTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public sealed class KnowledgeSearchToolTests
+{
+    private readonly InMemoryQmdBackend _backend = new();
+    private readonly QmdConfig _config = new() { DefaultSearchMode = "hybrid", MaxResults = 10 };
+
+    private KnowledgeSearchTool CreateTool() => new(_backend, _config);
+
+    private static string GetText(AgentToolResult result) =>
+        result.Content[0].Value;
+
+    [Fact]
+    public void Name_IsKnowledgeSearch()
+    {
+        var tool = CreateTool();
+        Assert.Equal("knowledge_search", tool.Name);
+    }
+
+    [Fact]
+    public void Definition_HasRequiredQueryParameter()
+    {
+        var tool = CreateTool();
+        var schema = tool.Definition.Parameters;
+        Assert.Equal(JsonValueKind.Array, schema.GetProperty("required").ValueKind);
+        var required = schema.GetProperty("required").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains("query", required);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyQuery_ReturnsError()
+    {
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?> { ["query"] = "" };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.Contains("required", GetText(result));
+        Assert.StartsWith("Error:", GetText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNullQuery_ReturnsError()
+    {
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?> { ["query"] = null };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.StartsWith("Error:", GetText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidQuery_ReturnsJsonResults()
+    {
+        _backend.Documents.Add(
+            new QmdDocument("doc1", "test-store", "/path/doc1.md", "Hello World", "hello this is content"));
+
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?> { ["query"] = "hello", ["store"] = "test-store" };
+        var result = await tool.ExecuteAsync("tc1", args);
+
+        var text = GetText(result);
+        Assert.DoesNotContain("Error:", text);
+        var parsed = JsonSerializer.Deserialize<QmdSearchResult[]>(text, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.NotNull(parsed);
+        Assert.Single(parsed);
+        Assert.Equal("doc1", parsed[0].Id);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithModeOverride_UsesSpecifiedMode()
+    {
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["mode"] = "keyword"
+        };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.DoesNotContain("Error:", GetText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLimitOverride_ClampsToRange()
+    {
+        var tool = CreateTool();
+        var args = new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["limit"] = 100 // exceeds 50 max
+        };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.DoesNotContain("Error:", GetText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenBinaryNotFound_ReturnsErrorMessage()
+    {
+        var failingBackend = new FailingQmdBackend(new QmdBinaryNotFoundException("/bad/path"));
+        var tool = new KnowledgeSearchTool(failingBackend, _config);
+        var args = new Dictionary<string, object?> { ["query"] = "test" };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.Contains("not found", GetText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCliError_ReturnsErrorMessage()
+    {
+        var failingBackend = new FailingQmdBackend(new QmdCliException(1, "store not found", ["search"]));
+        var tool = new KnowledgeSearchTool(failingBackend, _config);
+        var args = new Dictionary<string, object?> { ["query"] = "test" };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.Contains("Search failed", GetText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTimeout_ReturnsErrorMessage()
+    {
+        var failingBackend = new FailingQmdBackend(new TimeoutException("timed out"));
+        var tool = new KnowledgeSearchTool(failingBackend, _config);
+        var args = new Dictionary<string, object?> { ["query"] = "test" };
+        var result = await tool.ExecuteAsync("tc1", args);
+        Assert.Contains("timed out", GetText(result));
+    }
+
+    /// <summary>Backend that always throws the configured exception on SearchAsync.</summary>
+    private sealed class FailingQmdBackend(Exception ex) : IQmdBackend
+    {
+        public Task<QmdSearchResult[]> SearchAsync(string query, string? store, QmdSearchMode mode, int limit, CancellationToken ct) =>
+            throw ex;
+        public Task<QmdDocument?> GetDocumentAsync(string id, CancellationToken ct) => throw ex;
+        public Task<QmdStoreInfo[]> GetStoresAsync(CancellationToken ct) => throw ex;
+        public Task UpdateIndexAsync(string? store, CancellationToken ct) => throw ex;
+        public Task EmbedAsync(string? store, CancellationToken ct) => throw ex;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdCliBackendTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdCliBackendTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public sealed class QmdCliBackendTests
+{
+    [Fact]
+    public void Constructor_WithNullPath_DefaultsToQmd()
+    {
+        var backend = new QmdCliBackend(null);
+        // Can't easily test the path without running, but we can verify it doesn't throw
+        Assert.NotNull(backend);
+    }
+
+    [Fact]
+    public void Constructor_WithExplicitPath_UsesProvidedPath()
+    {
+        var backend = new QmdCliBackend("/usr/local/bin/qmd");
+        Assert.NotNull(backend);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenBinaryNotFound_ThrowsQmdBinaryNotFoundException()
+    {
+        var backend = new QmdCliBackend("/nonexistent/path/to/qmd-fake-binary-xyz");
+        await Assert.ThrowsAsync<QmdBinaryNotFoundException>(
+            () => backend.RunAsync(["status", "--json"], CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCancelled_ThrowsOperationCancelled()
+    {
+        var backend = new QmdCliBackend("/nonexistent/path/to/qmd-fake-binary-xyz");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        // Either throws OperationCanceled or QmdBinaryNotFound depending on platform timing
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => backend.RunAsync(["status"], cts.Token));
+    }
+
+    [Fact]
+    public void QmdBinaryNotFoundException_ContainsPath()
+    {
+        var ex = new QmdBinaryNotFoundException("/some/path");
+        Assert.Contains("/some/path", ex.Message);
+    }
+
+    [Fact]
+    public void QmdCliException_ContainsExitCodeAndStderr()
+    {
+        var ex = new QmdCliException(1, "error detail", ["search", "test"]);
+        Assert.Equal(1, ex.ExitCode);
+        Assert.Equal("error detail", ex.StdErr);
+        Assert.Contains("error detail", ex.Message);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DoesNotThrow()
+    {
+        var backend = new QmdCliBackend();
+        await backend.DisposeAsync();
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdToolContributorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdToolContributorTests.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public sealed class QmdToolContributorTests
+{
+    [Fact]
+    public void ResolveConfig_WithValidExtensionConfig_ReturnsConfig()
+    {
+        var configJson = JsonSerializer.SerializeToElement(new { enabled = true, qmdPath = "/usr/bin/qmd", maxResults = 20 });
+        var descriptor = CreateDescriptor(new Dictionary<string, JsonElement> { ["botnexus-qmd"] = configJson });
+
+        var config = QmdToolContributor.ResolveConfig(descriptor);
+
+        Assert.True(config.Enabled);
+        Assert.Equal("/usr/bin/qmd", config.QmdPath);
+        Assert.Equal(20, config.MaxResults);
+    }
+
+    [Fact]
+    public void ResolveConfig_WithNoExtensionConfig_ReturnsDefaults()
+    {
+        var descriptor = CreateDescriptor(new Dictionary<string, JsonElement>());
+        var config = QmdToolContributor.ResolveConfig(descriptor);
+
+        Assert.True(config.Enabled);
+        Assert.Null(config.QmdPath);
+        Assert.Equal(10, config.MaxResults);
+        Assert.Equal("hybrid", config.DefaultSearchMode);
+    }
+
+    [Fact]
+    public void ResolveConfig_WithDisabledConfig_ReturnsDisabled()
+    {
+        var configJson = JsonSerializer.SerializeToElement(new { enabled = false });
+        var descriptor = CreateDescriptor(new Dictionary<string, JsonElement> { ["botnexus-qmd"] = configJson });
+
+        var config = QmdToolContributor.ResolveConfig(descriptor);
+        Assert.False(config.Enabled);
+    }
+
+    [Fact]
+    public void ResolveConfig_WithMalformedJson_ReturnsDefaults()
+    {
+        var malformed = JsonSerializer.SerializeToElement("not an object");
+        var descriptor = CreateDescriptor(new Dictionary<string, JsonElement> { ["botnexus-qmd"] = malformed });
+
+        var config = QmdToolContributor.ResolveConfig(descriptor);
+        Assert.True(config.Enabled); // Falls back to defaults
+    }
+
+    private static AgentDescriptor CreateDescriptor(Dictionary<string, JsonElement> extensionConfig)
+    {
+        return new AgentDescriptor
+        {
+            AgentId = AgentId.From("test-agent"),
+            DisplayName = "Test Agent",
+            ModelId = "test-model",
+            ApiProvider = "test-provider",
+            ExtensionConfig = extensionConfig
+        };
+    }
+}


### PR DESCRIPTION
Closes #1173

## Changes
- **QmdCliBackend**: wraps the \qmd\ CLI binary with \--json\ output, timeout handling (30s), graceful binary-not-found errors
- **KnowledgeSearchTool**: agent-facing \knowledge_search\ tool with keyword/semantic/hybrid mode selection, store filtering, limit clamping
- **QmdToolContributor**: \IAgentToolContributor\ that reads \otnexus-qmd\ extension config and contributes the tool when enabled
- **Custom exceptions**: \QmdBinaryNotFoundException\, \QmdCliException\ with structured error data
- **21 new tests**: 7 CLI backend, 10 tool, 4 contributor config resolution

Part of #1171 QMD extension chain (2/5).

## Merge Notes
No file overlap with any open PR. Depends on merged #1178 (QMD scaffold). Safe to merge in any order with existing open PRs.