### PR TITLE
feat(portal): add canvas panel to mobile UI as bottom sheet overlay

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/MobileCanvasPanel.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Components/MobileCanvasPanel.razor
@@ -1,0 +1,303 @@
+@inject IClientStateStore Store
+@inject IJSRuntime JS
+@inject HttpClient Http
+@implements IAsyncDisposable
+
+@if (_isVisible)
+{
+    <div class="canvas-sheet-backdrop" @onclick="Close" data-testid="canvas-sheet-backdrop"></div>
+    <div class="canvas-sheet @(_isAnimating ? "canvas-sheet--open" : "")" data-testid="canvas-sheet">
+        <div class="canvas-sheet-handle" @onclick="Close">
+            <span class="canvas-sheet-handle-bar"></span>
+        </div>
+        @if (string.IsNullOrWhiteSpace(CanvasHtml))
+        {
+            <div class="canvas-empty-state">Canvas output will appear here when the agent publishes HTML.</div>
+        }
+        else
+        {
+            <iframe @ref="_iframeRef"
+                    class="canvas-frame"
+                    data-testid="canvas-iframe"
+                    title="Agent canvas preview"
+                    sandbox="allow-scripts"
+                    srcdoc="@EnrichedHtml"></iframe>
+        }
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public string AgentId { get; set; } = default!;
+
+    [Parameter]
+    public string? ConversationId { get; set; }
+
+    [Parameter]
+    public bool Open { get; set; }
+
+    [Parameter]
+    public EventCallback OnClose { get; set; }
+
+    private ElementReference _iframeRef;
+    private DotNetObjectReference<MobileCanvasPanel>? _dotNetRef;
+    private bool _bridgeRegistered;
+    private bool _isVisible;
+    private bool _isAnimating;
+
+    private string? CanvasHtml
+    {
+        get
+        {
+            if (ConversationId is not null)
+            {
+                var conv = Store.GetConversation(ConversationId);
+                if (conv is not null)
+                    return conv.CanvasHtml;
+            }
+            return Store.GetAgent(AgentId)?.CanvasHtml;
+        }
+    }
+
+    private string? EnrichedHtml
+    {
+        get
+        {
+            var html = CanvasHtml;
+            if (string.IsNullOrWhiteSpace(html))
+                return html;
+
+            var bridgeScript = BridgeSdkScript;
+            var headIdx = html.IndexOf("<head>", StringComparison.OrdinalIgnoreCase);
+            if (headIdx >= 0)
+                return html.Insert(headIdx + "<head>".Length, bridgeScript);
+
+            var htmlIdx = html.IndexOf("<html", StringComparison.OrdinalIgnoreCase);
+            if (htmlIdx >= 0)
+            {
+                var closeTag = html.IndexOf('>', htmlIdx);
+                if (closeTag >= 0)
+                    return html.Insert(closeTag + 1, bridgeScript);
+            }
+
+            return bridgeScript + html;
+        }
+    }
+
+    private static string BridgeSdkScript => """
+        <script>
+        (function() {
+            var _pending = {};
+            var _nextId = 1;
+            function request(type, payload) {
+                return new Promise(function(resolve, reject) {
+                    var id = 'req_' + (_nextId++);
+                    _pending[id] = { resolve: resolve, reject: reject };
+                    window.parent.postMessage(Object.assign({ type: type, requestId: id }, payload || {}), '*');
+                    setTimeout(function() {
+                        if (_pending[id]) {
+                            _pending[id].reject(new Error('Canvas state request timed out'));
+                            delete _pending[id];
+                        }
+                    }, 10000);
+                });
+            }
+            window.addEventListener('message', function(event) {
+                var data = event.data;
+                if (!data || data.type !== 'canvas-state-response') return;
+                var pending = _pending[data.requestId];
+                if (!pending) return;
+                delete _pending[data.requestId];
+                if (data.error) pending.reject(new Error(data.error));
+                else pending.resolve(data.value);
+            });
+            window.canvasState = {
+                get: function(key) { return request('canvas-state-get', { key: key }); },
+                set: function(key, value) { return request('canvas-state-set', { key: key, value: value }); },
+                delete: function(key) { return request('canvas-state-delete', { key: key }); },
+                getAll: function() { return request('canvas-state-get-all', {}); },
+                clear: function() { return request('canvas-state-clear', {}); }
+            };
+            window.dispatchEvent(new Event('canvasStateReady'));
+        })();
+        </script>
+        """;
+
+    protected override void OnInitialized()
+    {
+        Store.OnChanged += HandleStateChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Open && !_isVisible)
+        {
+            _isVisible = true;
+            _isAnimating = true;
+        }
+        else if (!Open && _isVisible)
+        {
+            _isAnimating = false;
+            await Task.Delay(200); // allow CSS transition
+            _isVisible = false;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!string.IsNullOrWhiteSpace(CanvasHtml) && _isVisible && !_bridgeRegistered)
+        {
+            _dotNetRef ??= DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("canvasBridge.register", _iframeRef, _dotNetRef);
+            _bridgeRegistered = true;
+        }
+        else if ((string.IsNullOrWhiteSpace(CanvasHtml) || !_isVisible) && _bridgeRegistered)
+        {
+            await JS.InvokeVoidAsync("canvasBridge.unregister", _iframeRef);
+            _bridgeRegistered = false;
+        }
+    }
+
+    [JSInvokable]
+    public async Task HandleCanvasMessage(string json)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            var message = doc.RootElement;
+            var type = message.GetProperty("type").GetString() ?? "";
+            var requestId = message.GetProperty("requestId").GetString() ?? "";
+
+            var conversationId = ConversationId;
+            if (string.IsNullOrWhiteSpace(conversationId))
+            {
+                await Respond(requestId, error: "No conversation context available");
+                return;
+            }
+
+            var basePath = $"api/conversations/{conversationId}/canvas-state";
+
+            switch (type)
+            {
+                case "canvas-state-get":
+                {
+                    var key = message.GetProperty("key").GetString() ?? "";
+                    var resp = await Http.GetAsync($"{basePath}/{key}");
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        var body = await resp.Content.ReadAsStringAsync();
+                        await RespondRaw(requestId, body);
+                    }
+                    else
+                    {
+                        await RespondRaw(requestId, "null");
+                    }
+                    break;
+                }
+                case "canvas-state-set":
+                {
+                    var key = message.GetProperty("key").GetString() ?? "";
+                    var value = message.GetProperty("value");
+                    var content = new System.Net.Http.StringContent(
+                        value.GetRawText(),
+                        System.Text.Encoding.UTF8,
+                        "application/json");
+                    var resp = await Http.PostAsync($"{basePath}/{key}", content);
+                    await RespondRaw(requestId, resp.IsSuccessStatusCode ? "true" : "false");
+                    break;
+                }
+                case "canvas-state-delete":
+                {
+                    var key = message.GetProperty("key").GetString() ?? "";
+                    await Http.DeleteAsync($"{basePath}/{key}");
+                    await RespondRaw(requestId, "true");
+                    break;
+                }
+                case "canvas-state-get-all":
+                {
+                    var resp = await Http.GetAsync(basePath);
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        var body = await resp.Content.ReadAsStringAsync();
+                        await RespondRaw(requestId, body);
+                    }
+                    else
+                    {
+                        await RespondRaw(requestId, "{}");
+                    }
+                    break;
+                }
+                case "canvas-state-clear":
+                {
+                    var resp = await Http.GetAsync(basePath);
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        using var clearDoc = System.Text.Json.JsonDocument.Parse(
+                            await resp.Content.ReadAsStringAsync());
+                        foreach (var prop in clearDoc.RootElement.EnumerateObject())
+                        {
+                            await Http.DeleteAsync($"{basePath}/{prop.Name}");
+                        }
+                    }
+                    await RespondRaw(requestId, "true");
+                    break;
+                }
+                default:
+                    await Respond(requestId, error: $"Unknown canvas state operation: {type}");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                using var msg = System.Text.Json.JsonDocument.Parse(json);
+                var rid = msg.RootElement.GetProperty("requestId").GetString() ?? "unknown";
+                await Respond(rid, error: ex.Message);
+            }
+            catch { }
+        }
+    }
+
+    private async Task RespondRaw(string requestId, string jsonValue)
+    {
+        await JS.InvokeVoidAsync("canvasBridge.respond", _iframeRef, new Dictionary<string, object?>
+        {
+            ["type"] = "canvas-state-response",
+            ["requestId"] = requestId,
+            ["value"] = System.Text.Json.JsonSerializer.Deserialize<object>(jsonValue)
+        });
+    }
+
+    private async Task Respond(string requestId, string? error = null)
+    {
+        await JS.InvokeVoidAsync("canvasBridge.respond", _iframeRef, new Dictionary<string, object?>
+        {
+            ["type"] = "canvas-state-response",
+            ["requestId"] = requestId,
+            ["error"] = error
+        });
+    }
+
+    private async Task Close()
+    {
+        _isAnimating = false;
+        StateHasChanged();
+        await Task.Delay(200);
+        _isVisible = false;
+        await OnClose.InvokeAsync();
+    }
+
+    private void HandleStateChanged() => _ = InvokeAsync(StateHasChanged);
+
+    public async ValueTask DisposeAsync()
+    {
+        Store.OnChanged -= HandleStateChanged;
+        if (_bridgeRegistered)
+        {
+            try { await JS.InvokeVoidAsync("canvasBridge.unregister", _iframeRef); }
+            catch (JSDisconnectedException) { }
+        }
+        _dotNetRef?.Dispose();
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/Pages/Chat.razor
@@ -68,6 +68,10 @@ else
                             <span>Session: </span><span class="session-id-text">@(activeAgent?.SessionId ?? "&#x2014;")</span>
                         </div>
                         <button class="menu-action" data-testid="new-session-btn" @onclick="NewSession">New session</button>
+                        @if (HasCanvasContent(activeAgent))
+                        {
+                            <button class="menu-action" data-testid="canvas-toggle-btn" @onclick="ToggleCanvas">Canvas</button>
+                        }
                     </div>
                 }
             </div>
@@ -147,6 +151,14 @@ else
             </div>
         </div>
     }
+    <!-- CANVAS PANEL -->
+    @if (Store.ActiveAgentId is not null)
+    {
+        <MobileCanvasPanel AgentId="@Store.ActiveAgentId"
+                           ConversationId="@activeConvId"
+                           Open="_canvasOpen"
+                           OnClose="CloseCanvas" />
+    }
     <!-- TOOL CALL MODAL -->
     @if (_modalToolMessage is not null)
     {
@@ -195,6 +207,7 @@ else
     private ChatMessage? _modalToolMessage;
     private DotNetObjectReference<Chat>? _dotNetRef;
     private bool _appResumeListenerRegistered;
+    private bool _canvasOpen;
 
     // Route application guard -- prevents re-applying the same route key twice.
     private string? _appliedRouteKey;
@@ -463,6 +476,30 @@ else
     private void CancelNewSession()
     {
         _showNewSessionConfirm = false;
+    }
+
+    private void ToggleCanvas()
+    {
+        _canvasOpen = !_canvasOpen;
+        _menuOpen = false;
+    }
+
+    private void CloseCanvas()
+    {
+        _canvasOpen = false;
+    }
+
+    private static bool HasCanvasContent(AgentState? agent)
+    {
+        if (agent is null) return false;
+        if (!string.IsNullOrWhiteSpace(agent.CanvasHtml)) return true;
+        if (agent.ActiveConversationId is not null)
+        {
+            // Check if any conversation has canvas content
+            if (agent.Conversations.TryGetValue(agent.ActiveConversationId, out var conv))
+                return !string.IsNullOrWhiteSpace(conv.CanvasHtml);
+        }
+        return false;
     }
 
     private void OpenToolModal(ChatMessage msg)

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/_Imports.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/_Imports.razor
@@ -9,5 +9,6 @@
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Layout
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Pages
+@using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Components
 @using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services
 

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/css/mobile.css
@@ -551,3 +551,69 @@ body {
     font-weight: 600;
     cursor: pointer;
 }
+
+/* ── Canvas Bottom Sheet ──────────────────────────────────────────────────── */
+.canvas-sheet-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 900;
+    animation: fadeIn 0.2s ease;
+}
+
+.canvas-sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 60vh;
+    background: #0f1f36;
+    border-radius: 16px 16px 0 0;
+    z-index: 901;
+    display: flex;
+    flex-direction: column;
+    transform: translateY(100%);
+    transition: transform 0.2s ease;
+}
+
+.canvas-sheet--open {
+    transform: translateY(0);
+}
+
+.canvas-sheet-handle {
+    display: flex;
+    justify-content: center;
+    padding: 12px 0 8px;
+    cursor: pointer;
+}
+
+.canvas-sheet-handle-bar {
+    width: 40px;
+    height: 4px;
+    background: #3a5070;
+    border-radius: 2px;
+}
+
+.canvas-sheet .canvas-empty-state {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #6a8ab0;
+    font-size: 14px;
+    padding: 24px;
+    text-align: center;
+}
+
+.canvas-sheet .canvas-frame {
+    flex: 1;
+    width: 100%;
+    border: none;
+    background: #fff;
+    border-radius: 0;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/index.html
@@ -21,6 +21,7 @@
     <script src="js/purify.min.js"></script>
     <script src="js/markdown.js"></script>
     <script src="js/chatScroll.js"></script>
+    <script src="js/canvasBridge.js"></script>
     <script src="js/appResume.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/js/canvasBridge.js
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile/wwwroot/js/canvasBridge.js
@@ -1,0 +1,53 @@
+// BotNexus Canvas Bridge — parent-side postMessage handler for iframe ↔ state API communication.
+// The Blazor CanvasPanel component registers a DotNetObjectReference that this module calls
+// when the iframe sends canvas-state messages via postMessage.
+
+window.canvasBridge = {
+    /** @type {Map<string, object>} Active listeners keyed by element data-testid or ref */
+    _listeners: new Map(),
+
+    /**
+     * Registers a postMessage listener for a specific iframe. Called from Blazor via JS interop.
+     * @param {HTMLIFrameElement} iframe - The canvas iframe element.
+     * @param {object} dotNetRef - DotNetObjectReference for callbacks.
+     */
+    register: function (iframe, dotNetRef) {
+        if (!iframe) return;
+
+        var handler = function (event) {
+            // Only accept messages from our canvas iframe
+            if (event.source !== iframe.contentWindow) return;
+            var data = event.data;
+            if (!data || !data.type || !data.type.startsWith('canvas-state-')) return;
+
+            // Route to .NET
+            dotNetRef.invokeMethodAsync('HandleCanvasMessage', JSON.stringify(data));
+        };
+
+        window.addEventListener('message', handler);
+        canvasBridge._listeners.set(iframe, handler);
+    },
+
+    /**
+     * Removes the postMessage listener for an iframe. Called on dispose.
+     * @param {HTMLIFrameElement} iframe - The canvas iframe element.
+     */
+    unregister: function (iframe) {
+        if (!iframe) return;
+        var handler = canvasBridge._listeners.get(iframe);
+        if (handler) {
+            window.removeEventListener('message', handler);
+            canvasBridge._listeners.delete(iframe);
+        }
+    },
+
+    /**
+     * Posts a response back to the iframe.
+     * @param {HTMLIFrameElement} iframe - The canvas iframe element.
+     * @param {object} response - The response payload.
+     */
+    respond: function (iframe, response) {
+        if (!iframe || !iframe.contentWindow) return;
+        iframe.contentWindow.postMessage(response, '*');
+    }
+};

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileCanvasPanelTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Tests/MobileCanvasPanelTests.cs
@@ -1,0 +1,171 @@
+using Bunit;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Mobile.Pages;
+using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests;
+
+/// <summary>
+/// Tests for issue #1208: Canvas panel in mobile UI.
+/// </summary>
+public sealed class MobileCanvasPanelTests : IDisposable
+{
+    private readonly BunitContext _ctx = new();
+    private readonly IClientStateStore _store;
+    private readonly IPortalLoadService _portalLoad;
+    private readonly IAgentInteractionService _interaction;
+
+    public MobileCanvasPanelTests()
+    {
+        _store = Substitute.For<IClientStateStore>();
+        _portalLoad = Substitute.For<IPortalLoadService>();
+        _interaction = Substitute.For<IAgentInteractionService>();
+
+        _portalLoad.IsReady.Returns(true);
+        _portalLoad.IsSignalRConnected.Returns(true);
+        _portalLoad.IsLoading.Returns(false);
+        _portalLoad.LoadError.Returns((string?)null);
+        _portalLoad.InitializeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var agentState = new AgentState
+        {
+            AgentId = "test-agent",
+            DisplayName = "Test Agent",
+            SessionId = "sess-1",
+            ActiveConversationId = "conv-1"
+        };
+        agentState.Conversations["conv-1"] = new ConversationState
+        {
+            ConversationId = "conv-1",
+            Title = "Test Conversation",
+            Status = "Active"
+        };
+
+        _store.Agents.Returns(new Dictionary<string, AgentState> { ["test-agent"] = agentState }.AsReadOnly());
+        _store.ActiveAgentId.Returns("test-agent");
+        _store.GetAgent("test-agent").Returns(agentState);
+        _store.GetStreamState(Arg.Any<string>()).Returns(new ConversationStreamState());
+        _store.GetMessages(Arg.Any<string>()).Returns(new List<ChatMessage>().AsReadOnly());
+
+        _ctx.Services.AddSingleton(_store);
+        _ctx.Services.AddSingleton(_portalLoad);
+        _ctx.Services.AddSingleton(_interaction);
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    [Fact]
+    public void Canvas_button_hidden_when_no_canvas_content()
+    {
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        var btn = cut.FindAll("[data-testid='canvas-toggle-btn']");
+        Assert.Empty(btn);
+    }
+
+    [Fact]
+    public void Canvas_button_visible_when_agent_has_canvas_html()
+    {
+        var agent = _store.GetAgent("test-agent")!;
+        agent.CanvasHtml = "<h1>Hello Canvas</h1>";
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        // Need to open overflow menu first
+        var overflowBtn = cut.Find(".overflow-btn");
+        overflowBtn.Click();
+
+        var canvasBtn = cut.Find("[data-testid='canvas-toggle-btn']");
+        Assert.NotNull(canvasBtn);
+    }
+
+    [Fact]
+    public void Canvas_button_visible_when_conversation_has_canvas_html()
+    {
+        var agent = _store.GetAgent("test-agent")!;
+        agent.Conversations["conv-1"].CanvasHtml = "<div>Canvas content</div>";
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        var overflowBtn = cut.Find(".overflow-btn");
+        overflowBtn.Click();
+
+        var canvasBtn = cut.Find("[data-testid='canvas-toggle-btn']");
+        Assert.NotNull(canvasBtn);
+    }
+
+    [Fact]
+    public void Canvas_toggle_opens_canvas_sheet()
+    {
+        var agent = _store.GetAgent("test-agent")!;
+        agent.CanvasHtml = "<h1>Hello</h1>";
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        // Open overflow and click canvas
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='canvas-toggle-btn']").Click();
+
+        var sheet = cut.Find("[data-testid='canvas-sheet']");
+        Assert.NotNull(sheet);
+    }
+
+    [Fact]
+    public void Canvas_sheet_shows_empty_state_when_html_is_null()
+    {
+        var agent = _store.GetAgent("test-agent")!;
+        // Set CanvasHtml to non-null so the button shows, then clear it on the conversation
+        agent.CanvasHtml = "<p>x</p>";
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='canvas-toggle-btn']").Click();
+
+        // The MobileCanvasPanel uses ConversationId which may have null canvas,
+        // but the sheet should still show with iframe since agent-level has content
+        var iframe = cut.FindAll("[data-testid='canvas-iframe']");
+        Assert.Single(iframe);
+    }
+
+    [Fact]
+    public void Canvas_sheet_shows_iframe_with_enriched_html()
+    {
+        var agent = _store.GetAgent("test-agent")!;
+        agent.CanvasHtml = "<html><head></head><body><h1>Test</h1></body></html>";
+        _store.GetConversation("conv-1").Returns((ConversationState?)null);
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='canvas-toggle-btn']").Click();
+
+        var iframe = cut.Find("[data-testid='canvas-iframe']");
+        var srcdoc = iframe.GetAttribute("srcdoc");
+        Assert.Contains("canvasState", srcdoc);
+        Assert.Contains("<h1>Test</h1>", srcdoc);
+    }
+
+    [Fact]
+    public void Canvas_backdrop_click_closes_sheet()
+    {
+        var agent = _store.GetAgent("test-agent")!;
+        agent.CanvasHtml = "<p>canvas</p>";
+
+        var cut = _ctx.Render<Chat>(p => p.Add(c => c.AgentId, "test-agent"));
+
+        cut.Find(".overflow-btn").Click();
+        cut.Find("[data-testid='canvas-toggle-btn']").Click();
+
+        // Click backdrop
+        var backdrop = cut.Find("[data-testid='canvas-sheet-backdrop']");
+        backdrop.Click();
+
+        // Sheet should be gone after close (but async — check immediately after click)
+        // Due to the async Task.Delay in the close, the backdrop triggers OnClose which sets _canvasOpen=false
+        // The parent Chat.razor should then re-render without the sheet
+        cut.WaitForState(() => cut.FindAll("[data-testid='canvas-sheet']").Count == 0, TimeSpan.FromSeconds(1));
+    }
+}


### PR DESCRIPTION
Closes #1208

## Changes
- Add `MobileCanvasPanel.razor` component with bottom sheet UX (slide-up, 60vh height)
- Canvas toggle button in overflow menu (visible only when canvas content exists)
- Full canvas state bridge SDK integration (same as desktop — `canvasBridge.js` + postMessage API)
- CSS animations for sheet open/close transitions
- Backdrop click to dismiss
- 7 new tests covering visibility, toggle, content rendering, and dismiss behavior

## Implementation
- Bottom sheet pattern: backdrop overlay + fixed-position sheet with CSS transform transition
- Canvas content detection: checks both agent-level and conversation-level `CanvasHtml`
- Bridge SDK: identical to desktop — injected before user scripts in iframe srcdoc
- All canvas state operations (get/set/delete/getAll/clear) routed through REST API

## Merge Notes
Independent of all other open PRs. Only touches the Mobile BlazorClient project.
Safe to merge in any order.