### PR TITLE
feat(gateway): hydrate config.json with default values from schema contributors on startup

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/BuiltInSchemaContributors.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/BuiltInSchemaContributors.cs
@@ -1,0 +1,99 @@
+using BotNexus.Gateway.Abstractions.Sessions;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Contributes default values for the <c>gateway</c> section of config.json.
+/// Only includes settings that live directly under the gateway key (not nested sub-sections
+/// which have their own contributors).
+/// </summary>
+public sealed class GatewaySchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "gateway";
+
+    public object GetDefaults() => new
+    {
+        listenUrl = "http://localhost:5005",
+        logLevel = "Information",
+        enableProviderRequestLogging = false,
+        shellPreference = "auto"
+    };
+}
+
+/// <summary>
+/// Contributes default values for the <c>gateway.compaction</c> section.
+/// </summary>
+public sealed class CompactionSchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "gateway.compaction";
+
+    public object GetDefaults() => new CompactionOptions();
+}
+
+/// <summary>
+/// Contributes default values for the <c>gateway.auxiliary</c> section.
+/// </summary>
+public sealed class AuxiliarySchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "gateway.auxiliary";
+
+    public object GetDefaults() => new
+    {
+        titling = new
+        {
+            model = (string?)null,
+            timeoutSeconds = 30
+        }
+    };
+}
+
+/// <summary>
+/// Contributes default values for the <c>gateway.autoUpdate</c> section.
+/// </summary>
+public sealed class AutoUpdateSchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "gateway.autoUpdate";
+
+    public object GetDefaults() => new AutoUpdateConfig();
+}
+
+/// <summary>
+/// Contributes default values for the <c>cron</c> section.
+/// </summary>
+public sealed class CronSchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "cron";
+
+    public object GetDefaults() => new
+    {
+        tickIntervalSeconds = 60
+    };
+}
+
+/// <summary>
+/// Contributes default values for the <c>gateway.sessionStore</c> section.
+/// </summary>
+public sealed class SessionStoreSchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "gateway.sessionStore";
+
+    public object GetDefaults() => new
+    {
+        type = "Sqlite"
+    };
+}
+
+/// <summary>
+/// Contributes default values for the <c>gateway.rateLimit</c> section.
+/// </summary>
+public sealed class RateLimitSchemaContributor : IConfigSchemaContributor
+{
+    public string SectionPath => "gateway.rateLimit";
+
+    public object GetDefaults() => new
+    {
+        enabled = false,
+        requestsPerMinute = 300,
+        windowSeconds = 60
+    };
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/ConfigHydrationService.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/ConfigHydrationService.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Hosted service that hydrates config.json with default values from all registered
+/// <see cref="IConfigSchemaContributor"/> implementations on startup. Existing user
+/// values are never overwritten — only missing keys are populated.
+/// </summary>
+public sealed class ConfigHydrationService : IHostedService
+{
+    private readonly PlatformConfigWriter _writer;
+    private readonly IEnumerable<IConfigSchemaContributor> _contributors;
+    private readonly ILogger<ConfigHydrationService> _logger;
+
+    private static readonly JsonSerializerOptions SerializeOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public ConfigHydrationService(
+        PlatformConfigWriter writer,
+        IEnumerable<IConfigSchemaContributor> contributors,
+        ILogger<ConfigHydrationService> logger)
+    {
+        _writer = writer;
+        _contributors = contributors;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var contributorList = _contributors.ToList();
+        if (contributorList.Count == 0)
+            return;
+
+        int addedKeys = 0;
+
+        await _writer.MutateAsync(root =>
+        {
+            foreach (var contributor in contributorList)
+            {
+                var defaults = contributor.GetDefaults();
+                if (defaults is null)
+                    continue;
+
+                var defaultsJson = JsonSerializer.SerializeToNode(defaults, SerializeOptions);
+                if (defaultsJson is not JsonObject defaultsObj)
+                    continue;
+
+                addedKeys += MergeAtPath(root, contributor.SectionPath, defaultsObj);
+            }
+        }, "config-hydration", cancellationToken);
+
+        if (addedKeys > 0)
+            _logger.LogInformation("Configuration hydrated: {Count} new keys added", addedKeys);
+        else
+            _logger.LogDebug("Configuration hydration complete — no new keys needed");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Navigates to the target path in the root object, creating intermediate objects as needed,
+    /// then deep-merges the defaults. Returns the count of keys added.
+    /// </summary>
+    internal static int MergeAtPath(JsonObject root, string sectionPath, JsonObject defaults)
+    {
+        var segments = sectionPath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var target = root;
+
+        foreach (var segment in segments)
+        {
+            if (target[segment] is JsonObject existing)
+            {
+                target = existing;
+            }
+            else if (target[segment] is null)
+            {
+                var newObj = new JsonObject();
+                target[segment] = newObj;
+                target = newObj;
+            }
+            else
+            {
+                // Target path exists but is not an object (scalar or array) — do not overwrite
+                return 0;
+            }
+        }
+
+        return DeepMergeDefaults(target, defaults);
+    }
+
+    /// <summary>
+    /// Deep-merges <paramref name="defaults"/> into <paramref name="target"/>.
+    /// Only adds keys that are missing in target. Never overwrites existing values.
+    /// Returns count of keys added.
+    /// </summary>
+    internal static int DeepMergeDefaults(JsonObject target, JsonObject defaults)
+    {
+        int added = 0;
+
+        foreach (var kvp in defaults)
+        {
+            var key = kvp.Key;
+            var defaultValue = kvp.Value;
+
+            if (target[key] is null)
+            {
+                // Key missing entirely — add the default
+                target[key] = defaultValue?.DeepClone();
+                added += CountKeys(defaultValue);
+            }
+            else if (target[key] is JsonObject targetChild && defaultValue is JsonObject defaultChild)
+            {
+                // Both are objects — recurse
+                added += DeepMergeDefaults(targetChild, defaultChild);
+            }
+            // Else: key exists with a value (scalar, array, or null set by user) — preserve it
+        }
+
+        return added;
+    }
+
+    /// <summary>
+    /// Counts the total number of leaf keys in a JSON node tree.
+    /// </summary>
+    private static int CountKeys(JsonNode? node)
+    {
+        if (node is null)
+            return 1; // null is a valid value, counts as one key
+
+        if (node is JsonObject obj)
+        {
+            int count = 0;
+            foreach (var kvp in obj)
+                count += CountKeys(kvp.Value);
+            return count == 0 ? 1 : count;
+        }
+
+        return 1; // scalar or array = 1 key
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Configuration/IConfigSchemaContributor.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/IConfigSchemaContributor.cs
@@ -1,0 +1,20 @@
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Contributes a default configuration section for config hydration.
+/// Implementations declare which JSON path they own and provide a default
+/// object that will be deep-merged into config.json on startup when keys are missing.
+/// </summary>
+public interface IConfigSchemaContributor
+{
+    /// <summary>
+    /// Dot-separated JSON path for this section (e.g. "gateway", "gateway.compaction", "cron").
+    /// </summary>
+    string SectionPath { get; }
+
+    /// <summary>
+    /// Returns an object representing the default values for this section.
+    /// Serialized to JSON and deep-merged with existing config — existing keys are never overwritten.
+    /// </summary>
+    object GetDefaults();
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -319,6 +319,16 @@ public static class GatewayServiceCollectionExtensions
             var writer = serviceProvider.GetRequiredService<PlatformConfigWriter>();
             return new PlatformConfigAgentWriter(writer, home);
         }));
+        // Config hydration — populate missing keys with defaults on startup
+        services.AddSingleton<IConfigSchemaContributor, GatewaySchemaContributor>();
+        services.AddSingleton<IConfigSchemaContributor, CompactionSchemaContributor>();
+        services.AddSingleton<IConfigSchemaContributor, AuxiliarySchemaContributor>();
+        services.AddSingleton<IConfigSchemaContributor, AutoUpdateSchemaContributor>();
+        services.AddSingleton<IConfigSchemaContributor, CronSchemaContributor>();
+        services.AddSingleton<IConfigSchemaContributor, SessionStoreSchemaContributor>();
+        services.AddSingleton<IConfigSchemaContributor, RateLimitSchemaContributor>();
+        services.AddHostedService<ConfigHydrationService>();
+
         services.AddHostedService<BuiltInAgentRegistrationService>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AgentConfigurationHostedService>());
 

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/ConfigHydrationServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/ConfigHydrationServiceTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json.Nodes;
+using BotNexus.Gateway.Configuration;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public class ConfigHydrationServiceTests
+{
+    [Fact]
+    public void MergeAtPath_AddsTopLevelSection_WhenMissing()
+    {
+        var root = new JsonObject();
+        var defaults = new JsonObject { ["enabled"] = true, ["interval"] = 60 };
+
+        var added = ConfigHydrationService.MergeAtPath(root, "cron", defaults);
+
+        Assert.Equal(2, added);
+        Assert.True(root["cron"]!["enabled"]!.GetValue<bool>());
+        Assert.Equal(60, root["cron"]!["interval"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void MergeAtPath_AddsNestedSection_WhenMissing()
+    {
+        var root = new JsonObject { ["gateway"] = new JsonObject() };
+        var defaults = new JsonObject { ["timeoutSeconds"] = 90 };
+
+        var added = ConfigHydrationService.MergeAtPath(root, "gateway.compaction", defaults);
+
+        Assert.Equal(1, added);
+        Assert.Equal(90, root["gateway"]!["compaction"]!["timeoutSeconds"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void MergeAtPath_CreatesIntermediateObjects_WhenPathDoesNotExist()
+    {
+        var root = new JsonObject();
+        var defaults = new JsonObject { ["model"] = "gpt-4.1" };
+
+        var added = ConfigHydrationService.MergeAtPath(root, "gateway.auxiliary.titling", defaults);
+
+        Assert.Equal(1, added);
+        Assert.Equal("gpt-4.1", root["gateway"]!["auxiliary"]!["titling"]!["model"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void MergeAtPath_DoesNotOverwrite_WhenPathIsScalar()
+    {
+        var root = new JsonObject { ["gateway"] = JsonValue.Create("custom-value") };
+        var defaults = new JsonObject { ["listenUrl"] = "http://localhost:5005" };
+
+        var added = ConfigHydrationService.MergeAtPath(root, "gateway", defaults);
+
+        Assert.Equal(0, added);
+        Assert.Equal("custom-value", root["gateway"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void DeepMergeDefaults_PreservesExistingValues()
+    {
+        var target = new JsonObject
+        {
+            ["enabled"] = true,
+            ["requestsPerMinute"] = 100
+        };
+        var defaults = new JsonObject
+        {
+            ["enabled"] = false,
+            ["requestsPerMinute"] = 300,
+            ["windowSeconds"] = 60
+        };
+
+        var added = ConfigHydrationService.DeepMergeDefaults(target, defaults);
+
+        Assert.Equal(1, added);
+        Assert.True(target["enabled"]!.GetValue<bool>());
+        Assert.Equal(100, target["requestsPerMinute"]!.GetValue<int>());
+        Assert.Equal(60, target["windowSeconds"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void DeepMergeDefaults_AddsKey_WhenTargetHasNullAssignment()
+    {
+        // JsonObject["key"] = null removes the key, so it's treated as missing
+        var target = new JsonObject { ["timeout"] = 30 };
+        var defaults = new JsonObject { ["model"] = "gpt-4.1", ["timeout"] = 60 };
+
+        var added = ConfigHydrationService.DeepMergeDefaults(target, defaults);
+
+        Assert.Equal(1, added); // model added
+        Assert.Equal("gpt-4.1", target["model"]!.GetValue<string>());
+        Assert.Equal(30, target["timeout"]!.GetValue<int>()); // preserved
+    }
+
+    [Fact]
+    public void DeepMergeDefaults_RecursesIntoNestedObjects()
+    {
+        var target = new JsonObject
+        {
+            ["compaction"] = new JsonObject { ["preservedTurns"] = 5 }
+        };
+        var defaults = new JsonObject
+        {
+            ["compaction"] = new JsonObject
+            {
+                ["preservedTurns"] = 3,
+                ["timeoutSeconds"] = 90
+            }
+        };
+
+        var added = ConfigHydrationService.DeepMergeDefaults(target, defaults);
+
+        Assert.Equal(1, added);
+        Assert.Equal(5, target["compaction"]!["preservedTurns"]!.GetValue<int>());
+        Assert.Equal(90, target["compaction"]!["timeoutSeconds"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void DeepMergeDefaults_PreservesArrayValues_DoesNotMergeElements()
+    {
+        var target = new JsonObject
+        {
+            ["allowedOrigins"] = new JsonArray("http://custom:3000")
+        };
+        var defaults = new JsonObject
+        {
+            ["allowedOrigins"] = new JsonArray("http://localhost:5005"),
+            ["enabled"] = true
+        };
+
+        var added = ConfigHydrationService.DeepMergeDefaults(target, defaults);
+
+        Assert.Equal(1, added); // only "enabled" added
+        var origins = target["allowedOrigins"]!.AsArray();
+        Assert.Single(origins);
+        Assert.Equal("http://custom:3000", origins[0]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void DeepMergeDefaults_EmptyTarget_GetsAllDefaults()
+    {
+        var target = new JsonObject();
+        var defaults = new JsonObject
+        {
+            ["a"] = 1,
+            ["b"] = "two",
+            ["c"] = new JsonObject { ["nested"] = true }
+        };
+
+        var added = ConfigHydrationService.DeepMergeDefaults(target, defaults);
+
+        Assert.Equal(3, added);
+        Assert.Equal(1, target["a"]!.GetValue<int>());
+        Assert.Equal("two", target["b"]!.GetValue<string>());
+        Assert.True(target["c"]!["nested"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void GatewaySchemaContributor_ReturnsExpectedDefaults()
+    {
+        var contributor = new GatewaySchemaContributor();
+
+        Assert.Equal("gateway", contributor.SectionPath);
+        Assert.NotNull(contributor.GetDefaults());
+    }
+
+    [Fact]
+    public void CompactionSchemaContributor_ReturnsExpectedDefaults()
+    {
+        var contributor = new CompactionSchemaContributor();
+
+        Assert.Equal("gateway.compaction", contributor.SectionPath);
+        Assert.NotNull(contributor.GetDefaults());
+    }
+
+    [Fact]
+    public void CronSchemaContributor_ReturnsExpectedDefaults()
+    {
+        var contributor = new CronSchemaContributor();
+
+        Assert.Equal("cron", contributor.SectionPath);
+        Assert.NotNull(contributor.GetDefaults());
+    }
+}


### PR DESCRIPTION
Closes #1210

## Changes

- **IConfigSchemaContributor** interface: contributors declare a section path and provide default values
- **ConfigHydrationService** (IHostedService): on startup, deep-merges defaults into config.json — existing user values are never overwritten
- **7 built-in contributors**: gateway, compaction, auxiliary, autoUpdate, cron, sessionStore, rateLimit
- **Deep-merge logic**: navigates dot-separated paths, creates intermediate objects, recursively merges nested objects, preserves arrays and scalars
- **12 unit tests** covering merge logic, path navigation, preservation rules, and contributor contracts

## Design

Option A from the issue (IConfigSchemaContributor registry). Extensions can contribute their own config sections by registering additional implementations.

Key rules implemented:
| Scenario | Behavior |
|----------|----------|
| Key exists with user value | **Preserve** |
| Key missing entirely | **Add** with default |
| New section missing entirely | **Add** full section with all defaults |
| Nested objects | Deep-merge at key level |
| Arrays | Treated as atomic (not merged element-by-element) |

## Merge Notes

Safe to merge in any order with all other open PRs — only touches Configuration/ files and GatewayServiceCollectionExtensions.cs (additive registration lines only).