### PR TITLE
feat(cli): add debug cron subcommand for scheduler diagnostics

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
@@ -7,12 +7,14 @@ namespace BotNexus.Cli.Commands;
 /// </summary>
 internal sealed class DebugCommand
 {
+    private readonly DebugCronCommand _cron = new();
     private readonly DebugDbCommand _db = new();
     private readonly DebugLogsCommand _logs = new();
     private readonly DebugSessionsCommand _sessions = new();
     public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
         var command = new Command("debug", "Platform diagnostics - inspect sessions, logs, and databases offline.");
+        command.AddCommand(_cron.Build(targetOption));
         command.AddCommand(_db.Build(targetOption));
         command.AddCommand(_logs.Build(targetOption));
         command.AddCommand(_sessions.Build(targetOption));

--- a/src/gateway/BotNexus.Cli/Commands/DebugCronCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugCronCommand.cs
@@ -1,0 +1,386 @@
+using System.CommandLine;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// CLI subcommands for inspecting the cron SQLite database directly
+/// without requiring a running gateway instance. Provides status, history,
+/// and missed-job detection for offline scheduler diagnostics.
+/// </summary>
+internal sealed class DebugCronCommand
+{
+    public Command Build(Option<string?> targetOption)
+    {
+        var command = new Command("cron", "Inspect cron scheduler state directly (offline, no gateway required).");
+
+        var formatOption = new Option<string>("--format", () => "table", "Output format: table or json.");
+        command.AddOption(formatOption);
+
+        // ── status ──
+        var statusCommand = new Command("status", "Show scheduler health: enabled jobs, last/next tick.");
+        statusCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var dbPath = ResolveCronDb(target);
+            context.ExitCode = ExecuteStatus(dbPath, format);
+            return Task.CompletedTask;
+        });
+
+        // ── history ──
+        var limitOption = new Option<int>("--limit", () => 20, "Maximum run records to return.");
+        var jobIdOption = new Option<string?>("--job", "Filter by job ID.");
+        var historyCommand = new Command("history", "Show recent run outcomes from cron.sqlite.")
+        {
+            limitOption, jobIdOption
+        };
+        historyCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var limit = context.ParseResult.GetValueForOption(limitOption);
+            var jobId = context.ParseResult.GetValueForOption(jobIdOption);
+            var dbPath = ResolveCronDb(target);
+            context.ExitCode = ExecuteHistory(dbPath, jobId, limit, format);
+            return Task.CompletedTask;
+        });
+
+        // ── missed ──
+        var missedCommand = new Command("missed", "Identify jobs that should have fired but did not.");
+        missedCommand.SetHandler(context =>
+        {
+            var target = context.ParseResult.GetValueForOption(targetOption);
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var dbPath = ResolveCronDb(target);
+            context.ExitCode = ExecuteMissed(dbPath, format);
+            return Task.CompletedTask;
+        });
+
+        command.AddCommand(statusCommand);
+        command.AddCommand(historyCommand);
+        command.AddCommand(missedCommand);
+        return command;
+    }
+
+    internal static string ResolveCronDb(string? target)
+    {
+        var home = CliPaths.ResolveTarget(target);
+        return Path.Combine(home, "cron.sqlite");
+    }
+
+    internal static int ExecuteStatus(string dbPath, string format)
+    {
+        if (!File.Exists(dbPath))
+        {
+            AnsiConsole.MarkupLine("[red]cron.sqlite not found at:[/] " + Markup.Escape(dbPath));
+            return 1;
+        }
+
+        using var connection = OpenReadOnly(dbPath);
+        var status = new CronStatus();
+
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT COUNT(*) FROM cron_jobs";
+            status.TotalJobs = Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT COUNT(*) FROM cron_jobs WHERE enabled = 1";
+            status.EnabledJobs = Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT COUNT(*) FROM cron_jobs WHERE enabled = 0";
+            status.DisabledJobs = Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT MAX(last_run_at) FROM cron_jobs WHERE last_run_at IS NOT NULL";
+            var result = cmd.ExecuteScalar();
+            status.LastRunAt = result is DBNull or null ? null : result.ToString();
+        }
+
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT MIN(next_run_at) FROM cron_jobs WHERE enabled = 1 AND next_run_at IS NOT NULL";
+            var result = cmd.ExecuteScalar();
+            status.NextRunAt = result is DBNull or null ? null : result.ToString();
+        }
+
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT COUNT(*) FROM cron_runs WHERE status = 'running'";
+            status.RunningNow = Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        var fileInfo = new FileInfo(dbPath);
+        status.DbSizeBytes = fileInfo.Length;
+
+        if (format == "json")
+        {
+            AnsiConsole.Write(new Text(JsonSerializer.Serialize(status, DebugSessionsCommand.JsonOpts)));
+            AnsiConsole.WriteLine();
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine("[bold]Cron Scheduler Status[/]");
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"  Total jobs:      [bold]{status.TotalJobs}[/]");
+        AnsiConsole.MarkupLine($"  Enabled:         [green]{status.EnabledJobs}[/]");
+        AnsiConsole.MarkupLine($"  Disabled:        [dim]{status.DisabledJobs}[/]");
+        AnsiConsole.MarkupLine($"  Currently running: [bold]{status.RunningNow}[/]");
+        AnsiConsole.MarkupLine($"  Last run at:     {Markup.Escape(FormatDate(status.LastRunAt))}");
+        AnsiConsole.MarkupLine($"  Next scheduled:  {Markup.Escape(FormatDate(status.NextRunAt))}");
+        AnsiConsole.MarkupLine($"  DB size:         {Math.Round(status.DbSizeBytes / 1024.0, 1)} KB");
+        return 0;
+    }
+
+    internal static int ExecuteHistory(string dbPath, string? jobId, int limit, string format)
+    {
+        if (!File.Exists(dbPath))
+        {
+            AnsiConsole.MarkupLine("[red]cron.sqlite not found at:[/] " + Markup.Escape(dbPath));
+            return 1;
+        }
+
+        using var connection = OpenReadOnly(dbPath);
+        using var cmd = connection.CreateCommand();
+
+        if (jobId is not null)
+        {
+            cmd.CommandText = """
+                SELECT r.id, r.job_id, j.name, r.started_at, r.completed_at, r.status, r.error
+                FROM cron_runs r
+                LEFT JOIN cron_jobs j ON j.id = r.job_id
+                WHERE r.job_id = @jobId
+                ORDER BY r.started_at DESC
+                LIMIT @limit
+                """;
+            cmd.Parameters.AddWithValue("@jobId", jobId);
+        }
+        else
+        {
+            cmd.CommandText = """
+                SELECT r.id, r.job_id, j.name, r.started_at, r.completed_at, r.status, r.error
+                FROM cron_runs r
+                LEFT JOIN cron_jobs j ON j.id = r.job_id
+                ORDER BY r.started_at DESC
+                LIMIT @limit
+                """;
+        }
+        cmd.Parameters.AddWithValue("@limit", limit);
+
+        var runs = new List<CronRunEntry>();
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            var startedAt = reader.IsDBNull(3) ? null : reader.GetString(3);
+            var completedAt = reader.IsDBNull(4) ? null : reader.GetString(4);
+            long? durationMs = null;
+            if (startedAt is not null && completedAt is not null &&
+                DateTimeOffset.TryParse(startedAt, out var start) &&
+                DateTimeOffset.TryParse(completedAt, out var end))
+            {
+                durationMs = (long)(end - start).TotalMilliseconds;
+            }
+
+            runs.Add(new CronRunEntry
+            {
+                RunId = reader.GetString(0),
+                JobId = reader.GetString(1),
+                JobName = reader.IsDBNull(2) ? null : reader.GetString(2),
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                Status = reader.GetString(5),
+                Error = reader.IsDBNull(6) ? null : reader.GetString(6),
+                DurationMs = durationMs
+            });
+        }
+
+        if (format == "json")
+        {
+            AnsiConsole.Write(new Text(JsonSerializer.Serialize(runs, DebugSessionsCommand.JsonOpts)));
+            AnsiConsole.WriteLine();
+            return 0;
+        }
+
+        if (runs.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No run history found.[/]");
+            return 0;
+        }
+
+        var table = new Table()
+            .AddColumn("Job")
+            .AddColumn("Started")
+            .AddColumn("Duration")
+            .AddColumn("Status")
+            .AddColumn("Error");
+
+        foreach (var r in runs)
+        {
+            table.AddRow(
+                Markup.Escape(Truncate(r.JobName ?? r.JobId, 28)),
+                Markup.Escape(FormatDate(r.StartedAt)),
+                r.DurationMs.HasValue ? $"{r.DurationMs}ms" : "[dim]—[/]",
+                FormatRunStatus(r.Status),
+                Markup.Escape(Truncate(r.Error ?? "", 40)));
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine($"\n[dim]{runs.Count} run(s) shown.[/]");
+        return 0;
+    }
+
+    internal static int ExecuteMissed(string dbPath, string format)
+    {
+        if (!File.Exists(dbPath))
+        {
+            AnsiConsole.MarkupLine("[red]cron.sqlite not found at:[/] " + Markup.Escape(dbPath));
+            return 1;
+        }
+
+        using var connection = OpenReadOnly(dbPath);
+        using var cmd = connection.CreateCommand();
+
+        // A job is "missed" if it's enabled, has a next_run_at in the past, and isn't currently running
+        var now = DateTimeOffset.UtcNow.ToString("o");
+        cmd.CommandText = """
+            SELECT j.id, j.name, j.schedule, j.last_run_at, j.next_run_at
+            FROM cron_jobs j
+            WHERE j.enabled = 1
+              AND j.next_run_at IS NOT NULL
+              AND j.next_run_at < @now
+              AND j.id NOT IN (SELECT job_id FROM cron_runs WHERE status = 'running')
+            ORDER BY j.next_run_at ASC
+            """;
+        cmd.Parameters.AddWithValue("@now", now);
+
+        var missed = new List<CronMissedEntry>();
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            var nextRunAt = reader.IsDBNull(4) ? null : reader.GetString(4);
+            TimeSpan? overdue = null;
+            if (nextRunAt is not null && DateTimeOffset.TryParse(nextRunAt, out var next))
+            {
+                overdue = DateTimeOffset.UtcNow - next;
+            }
+
+            missed.Add(new CronMissedEntry
+            {
+                JobId = reader.GetString(0),
+                Name = reader.IsDBNull(1) ? null : reader.GetString(1),
+                Schedule = reader.GetString(2),
+                LastRunAt = reader.IsDBNull(3) ? null : reader.GetString(3),
+                NextRunAt = nextRunAt,
+                OverdueMinutes = overdue.HasValue ? (long)overdue.Value.TotalMinutes : null
+            });
+        }
+
+        if (format == "json")
+        {
+            AnsiConsole.Write(new Text(JsonSerializer.Serialize(missed, DebugSessionsCommand.JsonOpts)));
+            AnsiConsole.WriteLine();
+            return 0;
+        }
+
+        if (missed.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]No missed jobs — scheduler appears healthy.[/]");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine($"[red]⚠ {missed.Count} job(s) appear to have missed their scheduled run:[/]");
+        AnsiConsole.WriteLine();
+
+        var table = new Table()
+            .AddColumn("Job")
+            .AddColumn("Schedule")
+            .AddColumn("Expected At")
+            .AddColumn("Overdue");
+
+        foreach (var m in missed)
+        {
+            table.AddRow(
+                Markup.Escape(Truncate(m.Name ?? m.JobId, 28)),
+                Markup.Escape(m.Schedule),
+                Markup.Escape(FormatDate(m.NextRunAt)),
+                m.OverdueMinutes.HasValue ? $"[red]{m.OverdueMinutes} min[/]" : "[dim]—[/]");
+        }
+
+        AnsiConsole.Write(table);
+        return 0;
+    }
+
+    // ── Helpers ──
+
+    private static SqliteConnection OpenReadOnly(string dbPath)
+    {
+        var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+        connection.Open();
+        return connection;
+    }
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength ? value : value[..maxLength] + "…";
+
+    private static string FormatDate(string? isoDate)
+    {
+        if (isoDate is null) return "(none)";
+        if (DateTimeOffset.TryParse(isoDate, out var dto))
+            return dto.ToString("yyyy-MM-dd HH:mm:ss");
+        return isoDate;
+    }
+
+    private static string FormatRunStatus(string status) => status.ToLowerInvariant() switch
+    {
+        "completed" => "[green]completed[/]",
+        "running" => "[blue]running[/]",
+        "failed" => "[red]failed[/]",
+        "timeout" => "[yellow]timeout[/]",
+        _ => Markup.Escape(status)
+    };
+
+    // ── DTOs ──
+
+    internal sealed class CronStatus
+    {
+        public int TotalJobs { get; set; }
+        public int EnabledJobs { get; set; }
+        public int DisabledJobs { get; set; }
+        public int RunningNow { get; set; }
+        public string? LastRunAt { get; set; }
+        public string? NextRunAt { get; set; }
+        public long DbSizeBytes { get; set; }
+    }
+
+    internal sealed class CronRunEntry
+    {
+        public string RunId { get; set; } = "";
+        public string JobId { get; set; } = "";
+        public string? JobName { get; set; }
+        public string? StartedAt { get; set; }
+        public string? CompletedAt { get; set; }
+        public string Status { get; set; } = "";
+        public string? Error { get; set; }
+        public long? DurationMs { get; set; }
+    }
+
+    internal sealed class CronMissedEntry
+    {
+        public string JobId { get; set; } = "";
+        public string? Name { get; set; }
+        public string Schedule { get; set; } = "";
+        public string? LastRunAt { get; set; }
+        public string? NextRunAt { get; set; }
+        public long? OverdueMinutes { get; set; }
+    }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/DebugCronCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/DebugCronCommandTests.cs
@@ -1,0 +1,215 @@
+using BotNexus.Cli.Commands;
+using Microsoft.Data.Sqlite;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class DebugCronCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _dbPath;
+
+    public DebugCronCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"botnexus-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _dbPath = Path.Combine(_tempDir, "cron.sqlite");
+        CreateTestDatabase();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private void CreateTestDatabase()
+    {
+        using var connection = new SqliteConnection($"Data Source={_dbPath}");
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE cron_jobs (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                agent_id TEXT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                last_run_at TEXT NULL,
+                next_run_at TEXT NULL,
+                last_run_status TEXT NULL,
+                last_run_error TEXT NULL
+            );
+            CREATE TABLE cron_runs (
+                id TEXT PRIMARY KEY,
+                job_id TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                completed_at TEXT NULL,
+                status TEXT NOT NULL,
+                error TEXT NULL,
+                session_id TEXT NULL,
+                FOREIGN KEY(job_id) REFERENCES cron_jobs(id) ON DELETE CASCADE
+            );
+            CREATE INDEX idx_cron_runs_job_id_started_at ON cron_runs(job_id, started_at DESC);
+
+            INSERT INTO cron_jobs VALUES ('j1', 'heartbeat', '*/5 * * * *', 'agent-prompt', 'farnsworth', 1, '2026-06-10T12:00:00Z', '2026-06-10T12:05:00Z', 'completed', NULL);
+            INSERT INTO cron_jobs VALUES ('j2', 'maintenance', '0 0 * * *', 'agent-prompt', 'farnsworth', 1, '2026-06-09T00:00:00Z', '2026-06-01T00:00:00Z', 'completed', NULL);
+            INSERT INTO cron_jobs VALUES ('j3', 'disabled-job', '0 12 * * *', 'agent-prompt', 'nova', 0, NULL, NULL, NULL, NULL);
+
+            INSERT INTO cron_runs VALUES ('r1', 'j1', '2026-06-10T12:00:00Z', '2026-06-10T12:00:05Z', 'completed', NULL, 's1');
+            INSERT INTO cron_runs VALUES ('r2', 'j1', '2026-06-10T11:55:00Z', '2026-06-10T11:55:03Z', 'completed', NULL, 's2');
+            INSERT INTO cron_runs VALUES ('r3', 'j2', '2026-06-09T00:00:00Z', '2026-06-09T00:01:30Z', 'completed', NULL, 's3');
+            INSERT INTO cron_runs VALUES ('r4', 'j1', '2026-06-10T11:50:00Z', NULL, 'running', NULL, 's4');
+            INSERT INTO cron_runs VALUES ('r5', 'j2', '2026-06-08T00:00:00Z', '2026-06-08T00:00:10Z', 'failed', 'timeout after 90s', NULL);
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    // ─── ResolveCronDb ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveCronDb_uses_target_path()
+    {
+        var result = DebugCronCommand.ResolveCronDb("/custom/path");
+        result.ShouldBe(Path.Combine("/custom/path", "cron.sqlite"));
+    }
+
+    [Fact]
+    public void ResolveCronDb_uses_default_when_null()
+    {
+        var result = DebugCronCommand.ResolveCronDb(null);
+        result.ShouldContain("cron.sqlite");
+    }
+
+    // ─── status ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteStatus_returns_zero_with_valid_db()
+    {
+        var exitCode = DebugCronCommand.ExecuteStatus(_dbPath, "json");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteStatus_returns_one_when_db_missing()
+    {
+        var exitCode = DebugCronCommand.ExecuteStatus(Path.Combine(_tempDir, "nonexistent.sqlite"), "table");
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ExecuteStatus_table_format_returns_zero()
+    {
+        var exitCode = DebugCronCommand.ExecuteStatus(_dbPath, "table");
+        exitCode.ShouldBe(0);
+    }
+
+    // ─── history ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteHistory_returns_zero_with_valid_db()
+    {
+        var exitCode = DebugCronCommand.ExecuteHistory(_dbPath, null, 20, "json");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteHistory_filters_by_job_id()
+    {
+        var exitCode = DebugCronCommand.ExecuteHistory(_dbPath, "j1", 10, "json");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteHistory_returns_one_when_db_missing()
+    {
+        var exitCode = DebugCronCommand.ExecuteHistory(Path.Combine(_tempDir, "nonexistent.sqlite"), null, 20, "table");
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ExecuteHistory_table_format_returns_zero()
+    {
+        var exitCode = DebugCronCommand.ExecuteHistory(_dbPath, null, 20, "table");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteHistory_respects_limit()
+    {
+        var exitCode = DebugCronCommand.ExecuteHistory(_dbPath, null, 2, "json");
+        exitCode.ShouldBe(0);
+    }
+
+    // ─── missed ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteMissed_returns_zero_with_valid_db()
+    {
+        // j2 has next_run_at in the past (2026-06-01) so it should appear as missed
+        var exitCode = DebugCronCommand.ExecuteMissed(_dbPath, "json");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteMissed_returns_one_when_db_missing()
+    {
+        var exitCode = DebugCronCommand.ExecuteMissed(Path.Combine(_tempDir, "nonexistent.sqlite"), "table");
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ExecuteMissed_table_format_returns_zero()
+    {
+        var exitCode = DebugCronCommand.ExecuteMissed(_dbPath, "table");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteMissed_excludes_currently_running_jobs()
+    {
+        // j1 has a 'running' entry in cron_runs (r4) — but j1's next_run_at is in the future
+        // so it shouldn't appear as missed regardless. This verifies the exclusion logic doesn't crash.
+        var exitCode = DebugCronCommand.ExecuteMissed(_dbPath, "json");
+        exitCode.ShouldBe(0);
+    }
+
+    // ─── empty db ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExecuteHistory_handles_empty_runs_table()
+    {
+        var emptyDb = Path.Combine(_tempDir, "empty-cron.sqlite");
+        using (var conn = new SqliteConnection($"Data Source={emptyDb}"))
+        {
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, name TEXT, schedule TEXT, action_type TEXT, enabled INTEGER DEFAULT 1, last_run_at TEXT, next_run_at TEXT, last_run_status TEXT, last_run_error TEXT);
+                CREATE TABLE cron_runs (id TEXT PRIMARY KEY, job_id TEXT, started_at TEXT, completed_at TEXT, status TEXT, error TEXT, session_id TEXT);
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        var exitCode = DebugCronCommand.ExecuteHistory(emptyDb, null, 20, "table");
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ExecuteStatus_handles_empty_tables()
+    {
+        var emptyDb = Path.Combine(_tempDir, "empty-cron2.sqlite");
+        using (var conn = new SqliteConnection($"Data Source={emptyDb}"))
+        {
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, name TEXT, schedule TEXT, action_type TEXT, enabled INTEGER DEFAULT 1, last_run_at TEXT, next_run_at TEXT, last_run_status TEXT, last_run_error TEXT);
+                CREATE TABLE cron_runs (id TEXT PRIMARY KEY, job_id TEXT, started_at TEXT, completed_at TEXT, status TEXT, error TEXT, session_id TEXT);
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        var exitCode = DebugCronCommand.ExecuteStatus(emptyDb, "json");
+        exitCode.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
Closes #1218

## Changes
- Add \DebugCronCommand\ with three subcommands: \status\, \history\, \missed\
- \status\: shows enabled/disabled job counts, last run time, next scheduled, currently running, DB size
- \history\: shows recent run outcomes with job name, start time, duration, status, error (filterable by --job)
- \missed\: identifies enabled jobs whose next_run_at is in the past and not currently running
- All subcommands support \--format table|json\ and \--target\ convention
- 16 unit tests covering all operations, missing DB, empty tables, and filtering
- Registered under existing \DebugCommand\ in CliApp

## Merge Notes
Safe to merge in any order with other open PRs — only touches CLI commands (DebugCommand.cs additive, new DebugCronCommand.cs).
