### PR TITLE
feat(memory): wire MemorySaveTool and MemorySearchTool through IAgentMemory abstraction

### DIFF
--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Security;
 using BotNexus.Gateway.Federation;
 using BotNexus.Gateway.Channels;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -112,6 +113,7 @@ public static class GatewayServiceCollectionExtensions
             });
         });
         services.AddSingleton<IAgentWorkspaceManager, FileAgentWorkspaceManager>();
+        services.TryAddSingleton<IAgentMemoryFactory, DefaultAgentMemoryFactory>();
          services.AddSingleton<IContextBuilder, WorkspaceContextBuilder>();
          services.AddSingleton<IAgentRegistry, DefaultAgentRegistry>();
          services.AddSingleton<IUserRegistry, DefaultUserRegistry>();

--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -29,6 +29,7 @@ using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Tools;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Memory;
 using BotNexus.Memory.Tools;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,6 +63,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
     private readonly IToolRegistry _toolRegistry;
     private readonly IEnumerable<IAgentToolContributor> _toolContributors;
     private readonly IMemoryStoreFactory _memoryStoreFactory;
+    private readonly IAgentMemoryFactory _agentMemoryFactory;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<InProcessIsolationStrategy> _logger;
 
@@ -74,6 +76,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         IToolRegistry toolRegistry,
         IEnumerable<IAgentToolContributor> toolContributors,
         IMemoryStoreFactory memoryStoreFactory,
+        IAgentMemoryFactory agentMemoryFactory,
         IServiceProvider serviceProvider,
         ILogger<InProcessIsolationStrategy> logger)
     {
@@ -85,6 +88,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         _toolRegistry = toolRegistry;
         _toolContributors = toolContributors;
         _memoryStoreFactory = memoryStoreFactory;
+        _agentMemoryFactory = agentMemoryFactory;
         _serviceProvider = serviceProvider;
         _logger = logger;
     }
@@ -138,8 +142,9 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             // Initialize asynchronously ΓÇö don't block handle creation.
             // Memory tools work immediately; the store initializes in the background.
             _ = memoryStore.InitializeAsync(CancellationToken.None);
-            tools.Add(new MemorySaveTool(_workspaceManager, descriptor.AgentId.Value, descriptor.Memory.Path));
-            tools.Add(new MemorySearchTool(memoryStore, descriptor.Memory));
+            var agentMemory = _agentMemoryFactory.Create(descriptor.AgentId.Value);
+            tools.Add(new MemorySaveTool(agentMemory, descriptor.AgentId.Value));
+            tools.Add(new MemorySearchTool(agentMemory, descriptor.AgentId.Value, descriptor.Memory));
             tools.Add(new MemoryGetTool(memoryStore));
         }
 

--- a/src/gateway/BotNexus.Memory/DefaultAgentMemoryFactory.cs
+++ b/src/gateway/BotNexus.Memory/DefaultAgentMemoryFactory.cs
@@ -1,0 +1,50 @@
+using System.IO.Abstractions;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Contracts.Memory;
+
+namespace BotNexus.Memory;
+
+/// <summary>
+/// Default factory that creates <see cref="IAgentMemory"/> instances.
+/// Currently only supports the "markdown" provider which delegates to
+/// file-based workspace saves and SQLite-backed search.
+/// </summary>
+public sealed class DefaultAgentMemoryFactory : IAgentMemoryFactory
+{
+    private readonly IAgentWorkspaceManager _workspaceManager;
+    private readonly IMemoryStoreFactory _memoryStoreFactory;
+    private readonly IFileSystem _fileSystem;
+
+    private static readonly IReadOnlyList<string> RegisteredProviders = ["markdown"];
+
+    public DefaultAgentMemoryFactory(
+        IAgentWorkspaceManager workspaceManager,
+        IMemoryStoreFactory memoryStoreFactory,
+        IFileSystem fileSystem)
+    {
+        _workspaceManager = workspaceManager ?? throw new ArgumentNullException(nameof(workspaceManager));
+        _memoryStoreFactory = memoryStoreFactory ?? throw new ArgumentNullException(nameof(memoryStoreFactory));
+        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    }
+
+    /// <inheritdoc />
+    public IAgentMemory Create(string agentId, string? providerName = null)
+    {
+        var provider = providerName ?? "markdown";
+
+        if (!string.Equals(provider, "markdown", StringComparison.OrdinalIgnoreCase))
+            throw new NotSupportedException($"Memory provider '{provider}' is not registered. Available: {string.Join(", ", RegisteredProviders)}");
+
+        var memoryStore = _memoryStoreFactory.Create(agentId);
+        _ = memoryStore.InitializeAsync(CancellationToken.None);
+
+        return new MarkdownAgentMemory(
+            agentId,
+            _workspaceManager,
+            memoryStore,
+            _fileSystem);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetRegisteredProviders() => RegisteredProviders;
+}

--- a/src/gateway/BotNexus.Memory/MarkdownAgentMemory.cs
+++ b/src/gateway/BotNexus.Memory/MarkdownAgentMemory.cs
@@ -1,0 +1,201 @@
+using System.IO.Abstractions;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Contracts.Memory;
+using BotNexus.Memory.Models;
+
+namespace BotNexus.Memory;
+
+/// <summary>
+/// File-based memory provider that delegates to workspace files for saves and prompt context,
+/// and to the SQLite memory store for search and retrieval operations.
+/// This preserves the exact existing behavior while exposing it through the IAgentMemory abstraction.
+/// </summary>
+public sealed class MarkdownAgentMemory : IAgentMemory
+{
+    private readonly string _agentId;
+    private readonly IAgentWorkspaceManager _workspaceManager;
+    private readonly IMemoryStore _memoryStore;
+    private readonly IFileSystem _fileSystem;
+    private readonly string? _memoryPathOverride;
+
+    public MarkdownAgentMemory(
+        string agentId,
+        IAgentWorkspaceManager workspaceManager,
+        IMemoryStore memoryStore,
+        IFileSystem fileSystem,
+        string? memoryPathOverride = null)
+    {
+        _agentId = string.IsNullOrWhiteSpace(agentId)
+            ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
+            : agentId;
+        _workspaceManager = workspaceManager ?? throw new ArgumentNullException(nameof(workspaceManager));
+        _memoryStore = memoryStore ?? throw new ArgumentNullException(nameof(memoryStore));
+        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        _memoryPathOverride = memoryPathOverride;
+    }
+
+    /// <inheritdoc />
+    public Task<AgentMemoryContext> GetPromptContextAsync(AgentMemoryPromptRequest request, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var workspacePath = ResolveWorkspaceDirectory(_workspaceManager.GetWorkspacePath(request.AgentId));
+        return LoadDailyMemoryContextAsync(workspacePath, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(AgentMemorySaveRequest request, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        // Delegate to the workspace manager which handles file-based memory saves
+        // (daily notes, specific file paths, memory path overrides).
+        await _workspaceManager.SaveMemoryAsync(
+            request.AgentId,
+            null, // filePath derived from request context — for now matches existing tool behavior
+            request.Content,
+            _memoryPathOverride,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Saves memory to a specific file path under the memory root.
+    /// </summary>
+    public async Task SaveToFileAsync(string content, string? filePath, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        await _workspaceManager.SaveMemoryAsync(
+            _agentId,
+            filePath,
+            content,
+            _memoryPathOverride,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AgentMemorySearchResult>> SearchAsync(AgentMemorySearchRequest request, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var filter = request.Filter is not null
+            ? new MemorySearchFilter
+            {
+                SourceType = request.Filter.SourceType,
+                SessionId = request.Filter.SessionId,
+                AfterDate = request.Filter.AfterDate,
+                BeforeDate = request.Filter.BeforeDate,
+                Tags = request.Filter.Tags
+            }
+            : null;
+
+        var entries = await _memoryStore.SearchAsync(request.Query, request.TopK, filter, ct).ConfigureAwait(false);
+        return entries.Select(MapToSearchResult).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentMemorySearchResult?> GetAsync(string entryId, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var entry = await _memoryStore.GetByIdAsync(entryId, ct).ConfigureAwait(false);
+        return entry is null ? null : MapToSearchResult(entry);
+    }
+
+    /// <inheritdoc />
+    public Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default)
+    {
+        // The markdown provider has no session-level bookkeeping — file writes are immediate.
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task ConsolidateAsync(AgentMemoryConsolidateRequest request, CancellationToken ct = default)
+    {
+        // Consolidation is handled by the existing MemoryDreamingCronAction.
+        // This provider does not perform its own consolidation.
+        return Task.CompletedTask;
+    }
+
+    private async Task<AgentMemoryContext> LoadDailyMemoryContextAsync(string workspacePath, CancellationToken ct)
+    {
+        var memoryRoot = ResolveMemoryRoot(workspacePath);
+        if (!_fileSystem.Directory.Exists(memoryRoot))
+            return AgentMemoryContext.Empty;
+
+        var today = DateTime.Now.Date;
+        var targetNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            today.ToString("yyyy-MM-dd"),
+            today.AddDays(-1).ToString("yyyy-MM-dd")
+        };
+
+        var files = _fileSystem.Directory.GetFiles(memoryRoot, "*.md")
+            .Select(path => new
+            {
+                FullPath = path,
+                Name = _fileSystem.Path.GetFileNameWithoutExtension(path)
+            })
+            .Where(file => targetNames.Contains(file.Name))
+            .OrderByDescending(file => file.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var dailyNotes = new List<AgentMemoryDailyNote>();
+        var totalChars = 0;
+
+        foreach (var file in files)
+        {
+            var content = await _fileSystem.File.ReadAllTextAsync(file.FullPath, ct).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                var trimmed = content.Trim();
+                if (DateOnly.TryParse(file.Name, out var date))
+                {
+                    dailyNotes.Add(new AgentMemoryDailyNote(date, trimmed));
+                    totalChars += trimmed.Length;
+                }
+            }
+        }
+
+        // Rough token estimate: ~4 chars per token
+        var approxTokens = totalChars / 4;
+        return new AgentMemoryContext(null, dailyNotes, approxTokens);
+    }
+
+    private string ResolveWorkspaceDirectory(string workspacePath)
+    {
+        var resolvedPath = _fileSystem.Path.GetFullPath(workspacePath);
+        if (_fileSystem.Path.GetFileName(resolvedPath)
+            .Equals("workspace", StringComparison.OrdinalIgnoreCase))
+            return resolvedPath;
+
+        var nestedWorkspacePath = _fileSystem.Path.Combine(resolvedPath, "workspace");
+        return _fileSystem.Directory.Exists(nestedWorkspacePath) ? nestedWorkspacePath : resolvedPath;
+    }
+
+    private string ResolveMemoryRoot(string workspacePath)
+    {
+        var relative = string.IsNullOrWhiteSpace(_memoryPathOverride)
+            ? "memory"
+            : _memoryPathOverride.Trim().Replace('\\', '/');
+
+        if (relative.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            relative = _fileSystem.Path.GetDirectoryName(relative) ?? "memory";
+
+        var memoryRoot = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(workspacePath, relative));
+        var workspaceFullPath = _fileSystem.Path.GetFullPath(workspacePath);
+        var workspacePrefix = workspaceFullPath.TrimEnd(
+            _fileSystem.Path.DirectorySeparatorChar,
+            _fileSystem.Path.AltDirectorySeparatorChar) + _fileSystem.Path.DirectorySeparatorChar;
+
+        if (!memoryRoot.StartsWith(workspacePrefix, StringComparison.OrdinalIgnoreCase) &&
+            !memoryRoot.Equals(workspaceFullPath, StringComparison.OrdinalIgnoreCase))
+            return _fileSystem.Path.Combine(workspacePath, "memory");
+
+        return memoryRoot;
+    }
+
+    private static AgentMemorySearchResult MapToSearchResult(MemoryEntry entry)
+        => new(
+            Id: entry.Id,
+            Content: entry.Content,
+            SourceType: entry.SourceType,
+            SessionId: entry.SessionId,
+            CreatedAt: entry.CreatedAt);
+}

--- a/src/gateway/BotNexus.Memory/Tools/MemorySaveTool.cs
+++ b/src/gateway/BotNexus.Memory/Tools/MemorySaveTool.cs
@@ -2,29 +2,25 @@ using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
-using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Contracts.Memory;
 
 namespace BotNexus.Memory.Tools;
 
 /// <summary>
-/// Appends markdown notes to an agent's memory workspace files.
+/// Appends markdown notes to an agent's memory via the <see cref="IAgentMemory"/> abstraction.
+/// Supports both the default daily note target and explicit file paths.
 /// </summary>
 public sealed class MemorySaveTool : IAgentTool
 {
-    private readonly IAgentWorkspaceManager _workspaceManager;
+    private readonly IAgentMemory _agentMemory;
     private readonly string _agentId;
-    private readonly string? _memoryPathOverride;
 
-    public MemorySaveTool(
-        IAgentWorkspaceManager workspaceManager,
-        string agentId,
-        string? memoryPathOverride = null)
+    public MemorySaveTool(IAgentMemory agentMemory, string agentId)
     {
-        _workspaceManager = workspaceManager;
+        _agentMemory = agentMemory ?? throw new ArgumentNullException(nameof(agentMemory));
         _agentId = string.IsNullOrWhiteSpace(agentId)
             ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
             : agentId;
-        _memoryPathOverride = memoryPathOverride;
     }
 
     public string Name => "memory_save";
@@ -83,7 +79,21 @@ public sealed class MemorySaveTool : IAgentTool
             ? ToStringValue(filePathValue)
             : null;
 
-        await _workspaceManager.SaveMemoryAsync(_agentId, filePath, content, _memoryPathOverride, cancellationToken);
+        if (!string.IsNullOrWhiteSpace(filePath) && _agentMemory is MarkdownAgentMemory markdownMemory)
+        {
+            // File-path saves use the extended method on MarkdownAgentMemory
+            await markdownMemory.SaveToFileAsync(content, filePath, cancellationToken);
+        }
+        else
+        {
+            // Default save via the abstraction
+            var request = new AgentMemorySaveRequest(
+                AgentId: _agentId,
+                Content: content,
+                SourceType: "tool");
+            await _agentMemory.SaveAsync(request, cancellationToken);
+        }
+
         var targetDescription = string.IsNullOrWhiteSpace(filePath)
             ? "default memory target"
             : filePath;

--- a/src/gateway/BotNexus.Memory/Tools/MemorySearchTool.cs
+++ b/src/gateway/BotNexus.Memory/Tools/MemorySearchTool.cs
@@ -2,18 +2,27 @@ using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Agent.Providers.Core.Models;
 
 namespace BotNexus.Memory.Tools;
 
+/// <summary>
+/// Searches the agent's persistent memory via the <see cref="IAgentMemory"/> abstraction.
+/// Results are ranked by relevance with optional temporal decay.
+/// </summary>
 public sealed class MemorySearchTool : IAgentTool
 {
-    private readonly IMemoryStore _memoryStore;
+    private readonly IAgentMemory _agentMemory;
+    private readonly string _agentId;
     private readonly int _defaultTopK;
 
-    public MemorySearchTool(IMemoryStore memoryStore, MemoryAgentConfig? config = null)
+    public MemorySearchTool(IAgentMemory agentMemory, string agentId, MemoryAgentConfig? config = null)
     {
-        _memoryStore = memoryStore;
+        _agentMemory = agentMemory ?? throw new ArgumentNullException(nameof(agentMemory));
+        _agentId = string.IsNullOrWhiteSpace(agentId)
+            ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
+            : agentId;
         _defaultTopK = Math.Max(1, config?.Search?.DefaultTopK ?? 10);
     }
 
@@ -96,7 +105,13 @@ public sealed class MemorySearchTool : IAgentTool
             : _defaultTopK;
         var filter = ParseFilter(arguments.TryGetValue("filter", out var filterValue) ? filterValue : null);
 
-        var entries = await _memoryStore.SearchAsync(query, topK, filter, cancellationToken).ConfigureAwait(false);
+        var request = new AgentMemorySearchRequest(
+            AgentId: _agentId,
+            Query: query,
+            TopK: topK,
+            Filter: filter);
+
+        var entries = await _agentMemory.SearchAsync(request, cancellationToken).ConfigureAwait(false);
         if (entries.Count == 0)
             return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "No matching memories found.")]);
 
@@ -127,7 +142,7 @@ public sealed class MemorySearchTool : IAgentTool
         return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, string.Join(Environment.NewLine, lines))]);
     }
 
-    private static MemorySearchFilter? ParseFilter(object? value)
+    private static AgentMemorySearchFilter? ParseFilter(object? value)
     {
         if (value is null)
             return null;
@@ -142,7 +157,7 @@ public sealed class MemorySearchTool : IAgentTool
         if (element.ValueKind != JsonValueKind.Object)
             return null;
 
-        return new MemorySearchFilter
+        return new AgentMemorySearchFilter
         {
             SourceType = ReadOptionalString(element, "sourceType"),
             SessionId = ReadOptionalString(element, "sessionId"),

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentIntegrationTests.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using System.IO.Abstractions;
+using BotNexus.Gateway.Tests.TestInfrastructure;
 
 namespace BotNexus.Gateway.Tests.Agents;
 
@@ -387,6 +388,7 @@ public sealed class SubAgentIntegrationTests
             new DefaultToolRegistry([]),
             Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             services.BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentKindTests.cs
@@ -15,6 +15,7 @@ using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Tools;
 using BotNexus.Memory;
 using BotNexus.Memory.Models;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Agent.Core;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Providers.Core;
@@ -387,6 +388,7 @@ public sealed class SubAgentKindTests
             new DefaultToolRegistry([]),
             Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             services.BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
     }
@@ -487,4 +489,22 @@ file sealed class StubMemoryStore : IMemoryStore
     public Task ClearAsync(CancellationToken ct = default) => Task.CompletedTask;
     public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new MemoryStoreStats(0, 0, null));
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+file sealed class StubAgentMemoryFactory : IAgentMemoryFactory
+{
+    public IAgentMemory Create(string agentId, string? providerName = null) => new StubAgentMemoryImpl();
+    public IReadOnlyList<string> GetRegisteredProviders() => ["markdown"];
+
+    private sealed class StubAgentMemoryImpl : IAgentMemory
+    {
+        public Task<AgentMemoryContext> GetPromptContextAsync(AgentMemoryPromptRequest request, CancellationToken ct = default)
+            => Task.FromResult(AgentMemoryContext.Empty);
+        public Task SaveAsync(AgentMemorySaveRequest request, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<AgentMemorySearchResult>> SearchAsync(AgentMemorySearchRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentMemorySearchResult>>([]);
+        public Task<AgentMemorySearchResult?> GetAsync(string entryId, CancellationToken ct = default) => Task.FromResult<AgentMemorySearchResult?>(null);
+        public Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ConsolidateAsync(AgentMemoryConsolidateRequest request, CancellationToken ct = default) => Task.CompletedTask;
+    }
 }

--- a/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/InProcessIsolationStrategyTests.cs
@@ -23,6 +23,7 @@ using System.IO.Abstractions;
 using System.Reflection;
 using System.Text.Json;
 using AgentCoreUserMessage = BotNexus.Agent.Core.Types.UserMessage;
+using BotNexus.Gateway.Tests.TestInfrastructure;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -53,6 +54,7 @@ public sealed class InProcessIsolationStrategyTests
             new DefaultToolRegistry(Array.Empty<IAgentTool>()),
             Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             new ServiceCollection().BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
 
@@ -442,6 +444,7 @@ public sealed class InProcessIsolationStrategyTests
             new DefaultToolRegistry(Array.Empty<IAgentTool>()),
             contributors ?? Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             new ServiceCollection().BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/PlatformConfigAgentSourceTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using System.IO.Abstractions;
 using System.Text.Json.Nodes;
+using BotNexus.Gateway.Tests.TestInfrastructure;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -546,6 +547,7 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
             new DefaultToolRegistry(Array.Empty<IAgentTool>()),
             Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             new ServiceCollection().BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
 
@@ -607,6 +609,7 @@ public sealed class PlatformConfigAgentSourceTests : IDisposable
             new DefaultToolRegistry(Array.Empty<IAgentTool>()),
             Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             new ServiceCollection().BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
 

--- a/tests/gateway/BotNexus.Gateway.Tests/SystemPromptCaptureTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SystemPromptCaptureTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using System.IO.Abstractions;
+using BotNexus.Gateway.Tests.TestInfrastructure;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -138,6 +139,7 @@ public sealed class SystemPromptCaptureTests
             new DefaultToolRegistry(Array.Empty<IAgentTool>()),
             Array.Empty<IAgentToolContributor>(),
             new NoOpMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             new ServiceCollection().BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
     }

--- a/tests/gateway/BotNexus.Gateway.Tests/TestInfrastructure/StubAgentMemoryFactory.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/TestInfrastructure/StubAgentMemoryFactory.cs
@@ -1,36 +1,15 @@
 using BotNexus.Gateway.Contracts.Memory;
-using BotNexus.Memory.Tools;
 
-namespace BotNexus.Memory.Tests.Tools;
+namespace BotNexus.Gateway.Tests.TestInfrastructure;
 
-public sealed class MemorySaveToolContractTests
+/// <summary>
+/// Stub IAgentMemoryFactory for tests that construct InProcessIsolationStrategy.
+/// Returns a no-op IAgentMemory implementation.
+/// </summary>
+internal sealed class StubAgentMemoryFactory : IAgentMemoryFactory
 {
-    [Fact]
-    public void Contract_ExposesMemorySaveNameOnly()
-    {
-        var tool = new MemorySaveTool(new StubAgentMemory(), "agent-a");
-
-        tool.Name.ShouldBe("memory_save");
-        tool.Label.ShouldBe("Memory Save");
-        tool.Definition.Description.ShouldContain("Append markdown memory notes");
-    }
-
-    [Fact]
-    public async Task PrepareArguments_WithFilePath_ProducesSaveArguments()
-    {
-        var tool = new MemorySaveTool(new StubAgentMemory(), "agent-a");
-
-        var prepared = await tool.PrepareArgumentsAsync(
-            new Dictionary<string, object?>
-            {
-                ["content"] = "remember this",
-                ["file_path"] = @"memory\2026-01-01.md"
-            });
-
-        prepared.Count.ShouldBe(2);
-        prepared["content"].ShouldBe("remember this");
-        prepared["file_path"].ShouldBe(@"memory\2026-01-01.md");
-    }
+    public IAgentMemory Create(string agentId, string? providerName = null) => new StubAgentMemory();
+    public IReadOnlyList<string> GetRegisteredProviders() => ["markdown"];
 
     private sealed class StubAgentMemory : IAgentMemory
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ToolHookWiringTests.cs
@@ -18,6 +18,7 @@ using BotNexus.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Abstractions;
+using BotNexus.Gateway.Tests.TestInfrastructure;
 
 namespace BotNexus.Gateway.Tests;
 
@@ -155,6 +156,7 @@ public sealed class ToolHookWiringTests
             new DefaultToolRegistry(Array.Empty<IAgentTool>()),
             Array.Empty<IAgentToolContributor>(),
             new StubMemoryStoreFactory(),
+            new StubAgentMemoryFactory(),
             services.BuildServiceProvider(),
             NullLogger<InProcessIsolationStrategy>.Instance);
     }

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySaveToolTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySaveToolTests.cs
@@ -1,5 +1,4 @@
-using BotNexus.Gateway.Abstractions.Agents;
-using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Memory.Tools;
 using System.Text.Json;
 
@@ -10,8 +9,8 @@ public sealed class MemorySaveToolTests
     [Fact]
     public async Task PrepareArgumentsAsync_WithContentOnly_KeepsLegacyContract()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
         var prepared = await tool.PrepareArgumentsAsync(
             new Dictionary<string, object?> { ["content"] = "legacy content-only payload" });
@@ -25,8 +24,8 @@ public sealed class MemorySaveToolTests
     [Fact]
     public void Definition_UsesCanonicalMemorySaveNamingWithoutMemoryStoreTerminology()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
         tool.Name.ShouldBe("memory_save");
         tool.Definition.Name.ShouldBe("memory_save");
@@ -36,8 +35,8 @@ public sealed class MemorySaveToolTests
     [Fact]
     public void Definition_RequiresContentForLegacyContentOnlyCalls()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
         var required = tool.Definition.Parameters.GetProperty("required")
             .EnumerateArray()
@@ -48,28 +47,28 @@ public sealed class MemorySaveToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithContentOnly_DelegatesToWorkspaceManagerWithNullFilePath()
+    public async Task ExecuteAsync_WithContentOnly_DelegatesToAgentMemorySaveAsync()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth", memoryPathOverride: "journals");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
         await tool.ExecuteAsync(
             "call-1",
             new Dictionary<string, object?> { ["content"] = "daily memory entry" });
 
-        workspaceManager.SaveCalls.Count.ShouldBe(1);
-        var call = workspaceManager.SaveCalls.Single();
-        call.AgentName.ShouldBe("farnsworth");
-        call.FilePath.ShouldBeNull();
+        memory.SaveCalls.Count.ShouldBe(1);
+        var call = memory.SaveCalls.Single();
+        call.AgentId.ShouldBe("farnsworth");
         call.Content.ShouldBe("daily memory entry");
-        call.MemoryPathOverride.ShouldBe("journals");
+        call.SourceType.ShouldBe("tool");
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithFilePath_DelegatesToWorkspaceManagerWithoutRewritingPath()
+    public async Task ExecuteAsync_WithFilePath_FallsBackToSaveAsync_WhenNotMarkdownMemory()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth");
+        // When IAgentMemory is not a MarkdownAgentMemory, file_path falls back to SaveAsync
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
         await tool.ExecuteAsync(
             "call-2",
@@ -79,92 +78,78 @@ public sealed class MemorySaveToolTests
                 ["file_path"] = @"memory\handoff.md"
             });
 
-        workspaceManager.SaveCalls.Count.ShouldBe(1);
-        var call = workspaceManager.SaveCalls.Single();
-        call.AgentName.ShouldBe("farnsworth");
-        call.FilePath.ShouldBe(@"memory\handoff.md");
-        call.Content.ShouldBe("handoff note");
+        // Falls through to SaveAsync since SpyAgentMemory is not MarkdownAgentMemory
+        memory.SaveCalls.Count.ShouldBe(1);
+        memory.SaveCalls.Single().Content.ShouldBe("handoff note");
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithFilePathAndOverride_DelegatesBothValuesToWorkspaceManager()
+    public async Task ExecuteAsync_ReturnsSuccessMessageWithFilePath()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth", memoryPathOverride: "journals");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
-        await tool.ExecuteAsync(
-            "call-override",
+        var result = await tool.ExecuteAsync(
+            "call-3",
             new Dictionary<string, object?>
             {
-                ["content"] = "explicit path note",
+                ["content"] = "note",
                 ["file_path"] = "handoff.md"
             });
 
-        workspaceManager.SaveCalls.Count.ShouldBe(1);
-        var call = workspaceManager.SaveCalls.Single();
-        call.AgentName.ShouldBe("farnsworth");
-        call.FilePath.ShouldBe("handoff.md");
-        call.Content.ShouldBe("explicit path note");
-        call.MemoryPathOverride.ShouldBe("journals");
+        result.Content.Count.ShouldBe(1);
+        result.Content[0].Value.ShouldContain("handoff.md");
     }
 
     [Fact]
-    public async Task ExecuteAsync_DoesNotUseWorkspacePathWhenSavingMemory()
+    public async Task ExecuteAsync_ReturnsSuccessMessageForDefaultTarget()
     {
-        var workspaceManager = new SpyWorkspaceManager { ThrowOnGetWorkspacePath = true };
-        var tool = new MemorySaveTool(workspaceManager, "farnsworth");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "farnsworth");
 
-        await tool.ExecuteAsync(
-            "call-3",
-            new Dictionary<string, object?> { ["content"] = "delegation only" });
+        var result = await tool.ExecuteAsync(
+            "call-4",
+            new Dictionary<string, object?> { ["content"] = "note" });
 
-        workspaceManager.SaveCalls.Count.ShouldBe(1);
-        workspaceManager.GetWorkspacePathCallCount.ShouldBe(0);
+        result.Content[0].Value.ShouldContain("default memory target");
     }
 
-    private sealed class SpyWorkspaceManager : IAgentWorkspaceManager
+    [Fact]
+    public void Constructor_ThrowsOnNullAgentMemory()
     {
-        public List<SaveMemoryCall> SaveCalls { get; } = [];
-
-        public bool ThrowOnGetWorkspacePath { get; init; }
-
-        public int GetWorkspacePathCallCount { get; private set; }
-
-        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
-            => Task.FromResult(new AgentWorkspace(agentName, Soul: string.Empty, Identity: string.Empty, User: string.Empty, Memory: string.Empty));
-
-        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default)
-        {
-            SaveCalls.Add(new SaveMemoryCall(agentName, null, content, MemoryPathOverride: null));
-            return Task.CompletedTask;
-        }
-
-        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default)
-        {
-            SaveCalls.Add(new SaveMemoryCall(agentName, filePath, content, MemoryPathOverride: null));
-            return Task.CompletedTask;
-        }
-
-        public Task SaveMemoryAsync(
-            string agentName,
-            string? filePath,
-            string content,
-            string? memoryPathOverride,
-            CancellationToken ct = default)
-        {
-            SaveCalls.Add(new SaveMemoryCall(agentName, filePath, content, memoryPathOverride));
-            return Task.CompletedTask;
-        }
-
-        public string GetWorkspacePath(string agentName)
-        {
-            GetWorkspacePathCallCount++;
-            if (ThrowOnGetWorkspacePath)
-                throw new InvalidOperationException("MemorySaveTool must delegate through IAgentWorkspaceManager.SaveMemoryAsync.");
-
-            return $@"C:\agents\{agentName}\workspace";
-        }
+        Should.Throw<ArgumentNullException>(() => new MemorySaveTool(null!, "farnsworth"));
     }
 
-    private sealed record SaveMemoryCall(string AgentName, string? FilePath, string Content, string? MemoryPathOverride);
+    [Fact]
+    public void Constructor_ThrowsOnEmptyAgentId()
+    {
+        var memory = new SpyAgentMemory();
+        Should.Throw<ArgumentException>(() => new MemorySaveTool(memory, ""));
+    }
+
+    private sealed class SpyAgentMemory : IAgentMemory
+    {
+        public List<AgentMemorySaveRequest> SaveCalls { get; } = [];
+
+        public Task<AgentMemoryContext> GetPromptContextAsync(AgentMemoryPromptRequest request, CancellationToken ct = default)
+            => Task.FromResult(AgentMemoryContext.Empty);
+
+        public Task SaveAsync(AgentMemorySaveRequest request, CancellationToken ct = default)
+        {
+            SaveCalls.Add(request);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<AgentMemorySearchResult>> SearchAsync(AgentMemorySearchRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentMemorySearchResult>>([]);
+
+        public Task<AgentMemorySearchResult?> GetAsync(string entryId, CancellationToken ct = default)
+            => Task.FromResult<AgentMemorySearchResult?>(null);
+
+        public Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task ConsolidateAsync(AgentMemoryConsolidateRequest request, CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
 }

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySearchToolTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySearchToolTests.cs
@@ -1,6 +1,8 @@
 using BotNexus.Agent.Core.Types;
+using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Memory.Tests.TestInfrastructure;
 using BotNexus.Memory.Tools;
+using System.IO.Abstractions;
 
 namespace BotNexus.Memory.Tests.Tools;
 
@@ -11,7 +13,8 @@ public sealed class MemorySearchToolTests
     {
         await using var context = await MemoryStoreTestContext.CreateAsync();
         await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry("entry-1", "agent-a", "searchablememorytext"));
-        var tool = new MemorySearchTool(context.Store);
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a");
 
         var result = await tool.ExecuteAsync(
             "call-1",
@@ -27,7 +30,8 @@ public sealed class MemorySearchToolTests
     public async Task ExecuteAsync_WithNoResults_ReturnsEmptyMessage()
     {
         await using var context = await MemoryStoreTestContext.CreateAsync();
-        var tool = new MemorySearchTool(context.Store);
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a");
 
         var result = await tool.ExecuteAsync(
             "call-2",
@@ -36,6 +40,19 @@ public sealed class MemorySearchToolTests
         GetText(result).ShouldBe("No matching memories found.");
     }
 
+    private static MarkdownAgentMemory CreateAgentMemory(MemoryStoreTestContext context)
+        => new("agent-a", new StubWorkspaceManager(), context.Store, new FileSystem());
+
     private static string GetText(AgentToolResult result)
         => result.Content.Single(content => content.Type == AgentToolContentType.Text).Value;
+
+    private sealed class StubWorkspaceManager : IAgentWorkspaceManager
+    {
+        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
+            => Task.FromResult(new AgentWorkspace(agentName, Soul: "", Identity: "", User: "", Memory: ""));
+        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, string? memoryPathOverride, CancellationToken ct = default) => Task.CompletedTask;
+        public string GetWorkspacePath(string agentName) => $@"C:\agents\{agentName}\workspace";
+    }
 }

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemoryToolAdditionalTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemoryToolAdditionalTests.cs
@@ -1,9 +1,10 @@
 using System.Text.Json;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Gateway.Abstractions.Agents;
-using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Memory.Tests.TestInfrastructure;
 using BotNexus.Memory.Tools;
+using System.IO.Abstractions;
 
 namespace BotNexus.Memory.Tests.Tools;
 
@@ -12,7 +13,7 @@ public sealed class MemoryToolAdditionalTests
     [Fact]
     public async Task MemorySaveTool_PrepareArguments_MissingContent_Throws()
     {
-        var tool = new MemorySaveTool(new SpyWorkspaceManager(), "agent-a");
+        var tool = new MemorySaveTool(new SpyAgentMemory(), "agent-a");
 
         var act = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?>());
 
@@ -22,35 +23,35 @@ public sealed class MemoryToolAdditionalTests
     [Fact]
     public async Task MemorySaveTool_StoresSpecialCharacters()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "agent-a");
-        var payload = "special chars ; | ` \" ' and emoji 😀";
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "agent-a");
+        var payload = "special chars ; | ` \" ' and emoji \U0001f600";
 
         await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["content"] = payload });
 
-        workspaceManager.SaveCalls.Count.ShouldBe(1);
-        workspaceManager.SaveCalls.Single().Content.ShouldBe(payload);
+        memory.SaveCalls.Count.ShouldBe(1);
+        memory.SaveCalls.Single().Content.ShouldBe(payload);
     }
 
     [Fact]
     public async Task MemorySaveTool_DuplicateContent_CreatesDistinctAppends()
     {
-        var workspaceManager = new SpyWorkspaceManager();
-        var tool = new MemorySaveTool(workspaceManager, "agent-a");
+        var memory = new SpyAgentMemory();
+        var tool = new MemorySaveTool(memory, "agent-a");
         var args = new Dictionary<string, object?> { ["content"] = "duplicate payload" };
 
         await tool.ExecuteAsync("call-1", args);
         await tool.ExecuteAsync("call-2", args);
 
-        workspaceManager.SaveCalls.Count.ShouldBe(2);
-        workspaceManager.SaveCalls[0].Content.ShouldBe("duplicate payload");
-        workspaceManager.SaveCalls[1].Content.ShouldBe("duplicate payload");
+        memory.SaveCalls.Count.ShouldBe(2);
+        memory.SaveCalls[0].Content.ShouldBe("duplicate payload");
+        memory.SaveCalls[1].Content.ShouldBe("duplicate payload");
     }
 
     [Fact]
     public async Task MemorySaveTool_PrepareArguments_IgnoresLegacyStoreArguments()
     {
-        var tool = new MemorySaveTool(new SpyWorkspaceManager(), "agent-a");
+        var tool = new MemorySaveTool(new SpyAgentMemory(), "agent-a");
         var prepared = await tool.PrepareArgumentsAsync(
             new Dictionary<string, object?> { ["content"] = "x", ["expiresInDays"] = "not-a-number", ["tags"] = new[] { "legacy" } });
 
@@ -62,7 +63,8 @@ public sealed class MemoryToolAdditionalTests
     public async Task MemorySearchTool_PrepareArguments_EmptyQuery_Throws()
     {
         await using var context = await MemoryStoreTestContext.CreateAsync();
-        var tool = new MemorySearchTool(context.Store);
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a");
 
         var act = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["query"] = "   " });
 
@@ -75,7 +77,8 @@ public sealed class MemoryToolAdditionalTests
         await using var context = await MemoryStoreTestContext.CreateAsync();
         await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry("keep", "agent-a", "tool-filter-token", sourceType: "manual", sessionId: "s1", metadataJson: """{"tags":["release"]}"""));
         await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry("drop", "agent-a", "tool-filter-token", sourceType: "conversation", sessionId: "s2", metadataJson: """{"tags":["ops"]}"""));
-        var tool = new MemorySearchTool(context.Store);
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a");
 
         var filter = JsonSerializer.Serialize(new
         {
@@ -99,7 +102,8 @@ public sealed class MemoryToolAdditionalTests
     {
         await using var context = await MemoryStoreTestContext.CreateAsync();
         await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry("entry-1", "agent-a", "hello world"));
-        var tool = new MemorySearchTool(context.Store);
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a");
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["query"] = "" });
 
@@ -151,48 +155,48 @@ public sealed class MemoryToolAdditionalTests
         await using var context = await MemoryStoreTestContext.CreateAsync();
         await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry("entry-1", "agent-a", "alpha secure token"));
         await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry("entry-2", "agent-a", "beta secure token"));
-        var tool = new MemorySearchTool(context.Store);
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a");
 
         var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["query"] = "' OR 1=1 --" });
 
         GetText(result).ShouldBe("No matching memories found.");
     }
 
+    private static MarkdownAgentMemory CreateAgentMemory(MemoryStoreTestContext context)
+        => new("agent-a", new StubWorkspaceManager(), context.Store, new FileSystem());
+
     private static string GetText(AgentToolResult result)
         => result.Content.Single(content => content.Type == AgentToolContentType.Text).Value;
 
-    private sealed class SpyWorkspaceManager : IAgentWorkspaceManager
+    private sealed class SpyAgentMemory : IAgentMemory
     {
-        public List<SaveMemoryCall> SaveCalls { get; } = [];
+        public List<AgentMemorySaveRequest> SaveCalls { get; } = [];
 
-        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
-            => Task.FromResult(new AgentWorkspace(agentName, Soul: string.Empty, Identity: string.Empty, User: string.Empty, Memory: string.Empty));
-
-        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default)
+        public Task<AgentMemoryContext> GetPromptContextAsync(AgentMemoryPromptRequest request, CancellationToken ct = default)
+            => Task.FromResult(AgentMemoryContext.Empty);
+        public Task SaveAsync(AgentMemorySaveRequest request, CancellationToken ct = default)
         {
-            SaveCalls.Add(new SaveMemoryCall(agentName, null, content, null));
+            SaveCalls.Add(request);
             return Task.CompletedTask;
         }
-
-        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default)
-        {
-            SaveCalls.Add(new SaveMemoryCall(agentName, filePath, content, null));
-            return Task.CompletedTask;
-        }
-
-        public Task SaveMemoryAsync(
-            string agentName,
-            string? filePath,
-            string content,
-            string? memoryPathOverride,
-            CancellationToken ct = default)
-        {
-            SaveCalls.Add(new SaveMemoryCall(agentName, filePath, content, memoryPathOverride));
-            return Task.CompletedTask;
-        }
-
-        public string GetWorkspacePath(string agentName) => $@"C:\agents\{agentName}\workspace";
+        public Task<IReadOnlyList<AgentMemorySearchResult>> SearchAsync(AgentMemorySearchRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentMemorySearchResult>>([]);
+        public Task<AgentMemorySearchResult?> GetAsync(string entryId, CancellationToken ct = default)
+            => Task.FromResult<AgentMemorySearchResult?>(null);
+        public Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default)
+            => Task.CompletedTask;
+        public Task ConsolidateAsync(AgentMemoryConsolidateRequest request, CancellationToken ct = default)
+            => Task.CompletedTask;
     }
 
-    private sealed record SaveMemoryCall(string AgentName, string? FilePath, string Content, string? MemoryPathOverride);
+    private sealed class StubWorkspaceManager : IAgentWorkspaceManager
+    {
+        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
+            => Task.FromResult(new AgentWorkspace(agentName, Soul: "", Identity: "", User: "", Memory: ""));
+        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, string? memoryPathOverride, CancellationToken ct = default) => Task.CompletedTask;
+        public string GetWorkspacePath(string agentName) => $@"C:\agents\{agentName}\workspace";
+    }
 }


### PR DESCRIPTION
Closes #1219

## Changes

- **MarkdownAgentMemory**: implements IAgentMemory by delegating to IAgentWorkspaceManager (saves) and IMemoryStore (search/get). Preserves exact existing behavior.
- **DefaultAgentMemoryFactory**: creates MarkdownAgentMemory instances, currently only supports \markdown\ provider.
- **MemorySaveTool**: refactored to accept IAgentMemory instead of IAgentWorkspaceManager. File-path saves use MarkdownAgentMemory.SaveToFileAsync when the provider is markdown.
- **MemorySearchTool**: refactored to accept IAgentMemory instead of IMemoryStore. Uses AgentMemorySearchRequest/AgentMemorySearchFilter DTOs.
- **InProcessIsolationStrategy**: accepts IAgentMemoryFactory via DI, creates per-agent IAgentMemory instances for tool construction.
- **DI registration**: IAgentMemoryFactory registered as singleton in GatewayServiceCollectionExtensions.
- All existing tests updated to use new constructors; 66 memory tests + 2740 gateway tests pass.

## Merge Notes

Independent of all other open PRs. Safe to merge in any order.