### PR TITLE
fix(tools): reject unknown properties when additionalProperties is false

### DIFF
--- a/src/agent/BotNexus.Agent.Providers.Core/Validation/ToolCallValidator.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/Validation/ToolCallValidator.cs
@@ -29,6 +29,7 @@ public static class ToolCallValidator
 
         ValidateRequired(arguments, parameterSchema, errors);
         ValidateTopLevelProperties(arguments, parameterSchema, errors);
+        ValidateAdditionalProperties(arguments, parameterSchema, errors);
 
         return errors.Count == 0
             ? (true, [])
@@ -90,6 +91,42 @@ public static class ToolCallValidator
 
             ValidateType(argumentProperty, propertySchema, errors);
             ValidateEnum(argumentProperty, propertySchema, errors);
+        }
+    }
+
+    private static void ValidateAdditionalProperties(JsonElement arguments, JsonElement schema, ICollection<string> errors)
+    {
+        if (arguments.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        if (!schema.TryGetProperty("additionalProperties", out var additionalProps))
+        {
+            return;
+        }
+
+        if (additionalProps.ValueKind != JsonValueKind.False)
+        {
+            return;
+        }
+
+        if (!schema.TryGetProperty("properties", out var propertiesElement) || propertiesElement.ValueKind != JsonValueKind.Object)
+        {
+            // No properties defined but additionalProperties is false — all properties are unknown
+            foreach (var argumentProperty in arguments.EnumerateObject())
+            {
+                errors.Add($"Property '{argumentProperty.Name}' is not defined in the schema.");
+            }
+            return;
+        }
+
+        foreach (var argumentProperty in arguments.EnumerateObject())
+        {
+            if (!propertiesElement.TryGetProperty(argumentProperty.Name, out _))
+            {
+                errors.Add($"Property '{argumentProperty.Name}' is not defined in the schema.");
+            }
         }
     }
 

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/Validation/ToolCallValidatorTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/Validation/ToolCallValidatorTests.cs
@@ -134,4 +134,91 @@ public class ToolCallValidatorTests
         result.IsValid.ShouldBeTrue();
         result.Errors.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void Validate_WhenAdditionalPropertiesFalse_RejectsUnknownProperties()
+    {
+        var arguments = JsonDocument.Parse("""{ "query": "hello", "verbose": true }""").RootElement.Clone();
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "query": { "type": "string" }
+              },
+              "required": ["query"],
+              "additionalProperties": false
+            }
+            """).RootElement.Clone();
+
+        var result = ToolCallValidator.Validate(arguments, schema);
+
+        result.IsValid.ShouldBeFalse();
+        var error = result.Errors.ShouldHaveSingleItem();
+        error.ShouldContain("verbose");
+        error.ShouldContain("not defined");
+    }
+
+    [Fact]
+    public void Validate_WhenAdditionalPropertiesFalse_AllowsDefinedProperties()
+    {
+        var arguments = JsonDocument.Parse("""{ "query": "hello", "limit": 10 }""").RootElement.Clone();
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "query": { "type": "string" },
+                "limit": { "type": "integer" }
+              },
+              "required": ["query"],
+              "additionalProperties": false
+            }
+            """).RootElement.Clone();
+
+        var result = ToolCallValidator.Validate(arguments, schema);
+
+        result.IsValid.ShouldBeTrue();
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenAdditionalPropertiesTrue_AllowsUnknownProperties()
+    {
+        var arguments = JsonDocument.Parse("""{ "query": "hello", "extra": "stuff" }""").RootElement.Clone();
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "query": { "type": "string" }
+              },
+              "additionalProperties": true
+            }
+            """).RootElement.Clone();
+
+        var result = ToolCallValidator.Validate(arguments, schema);
+
+        result.IsValid.ShouldBeTrue();
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenAdditionalPropertiesFalse_ReportsMultipleUnknownProperties()
+    {
+        var arguments = JsonDocument.Parse("""{ "query": "hello", "timeout": 30, "format": "json" }""").RootElement.Clone();
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "query": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+            """).RootElement.Clone();
+
+        var result = ToolCallValidator.Validate(arguments, schema);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.Length.ShouldBe(2);
+        result.Errors.ShouldContain(e => e.Contains("timeout"));
+        result.Errors.ShouldContain(e => e.Contains("format"));
+    }
 }


### PR DESCRIPTION
Closes #1222

## Changes
- Added \ValidateAdditionalProperties\ method to \ToolCallValidator\
- When schema declares \dditionalProperties: false\, unknown properties produce a validation error naming the offending property
- When \dditionalProperties\ is true or absent, behavior is unchanged (permissive)
- 4 new tests covering: rejection of unknown props, acceptance of defined props, explicit true allows extras, multiple unknown props reported

## Merge Notes
Safe to merge in any order — only touches \ToolCallValidator.cs\ in Providers.Core and its test file. No overlap with any open PR.