### PR TITLE
feat(cron): detect and log missed cron runs on gateway startup

### DIFF
--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -30,6 +30,7 @@
     <Compile Include="Tools\CronTool.cs" />
     <Compile Include="CronRunRetentionOptions.cs" />
     <Compile Include="CronRunRetentionHostedService.cs" />
+    <Compile Include="MissedRunDetectionService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class CronServiceCollectionExtensions
         services.TryAddSingleton<IPromptTemplateResolver, CronOptionsPromptTemplateResolver>();
         services.AddOptions<CronRunRetentionOptions>();
         services.AddSingleton<IHostedService, CronRunRetentionHostedService>();
+        services.AddSingleton<IHostedService, MissedRunDetectionService>();
         return services;
     }
 

--- a/src/gateway/BotNexus.Cron/MissedRunDetectionService.cs
+++ b/src/gateway/BotNexus.Cron/MissedRunDetectionService.cs
@@ -1,0 +1,137 @@
+using BotNexus.Cron.Actions;
+using Cronos;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Cron;
+
+/// <summary>
+/// Runs once on startup to detect cron jobs that missed their scheduled execution window
+/// during gateway downtime. Records missed runs and optionally triggers catch-up execution
+/// for jobs configured with <c>catchUp: true</c> in metadata.
+/// </summary>
+public sealed class MissedRunDetectionService(
+    ICronStore cronStore,
+    CronScheduler scheduler,
+    ILogger<MissedRunDetectionService> logger) : IHostedService
+{
+    internal const string CatchUpMetadataKey = "catchUp";
+    internal const string MissedStatus = "missed";
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await cronStore.InitializeAsync(cancellationToken).ConfigureAwait(false);
+
+        var jobs = await cronStore.ListAsync(ct: cancellationToken).ConfigureAwait(false);
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var job in jobs)
+        {
+            if (!job.Enabled || string.IsNullOrWhiteSpace(job.Schedule))
+            {
+                continue;
+            }
+
+            if (job.LastRunAt is null)
+            {
+                // Never ran — no baseline to detect missed runs from.
+                continue;
+            }
+
+            var missedRuns = GetMissedRuns(job, now);
+
+            foreach (var missedTime in missedRuns)
+            {
+                logger.LogWarning(
+                    "Cron job '{JobName}' ({JobId}) missed scheduled run at {MissedTime:u}",
+                    job.Name, job.Id, missedTime);
+
+                var run = await cronStore.RecordRunStartAsync(job.Id, cancellationToken).ConfigureAwait(false);
+                await cronStore.RecordRunCompleteAsync(run.Id, MissedStatus, ct: cancellationToken).ConfigureAwait(false);
+            }
+
+            if (missedRuns.Count > 0 && HasCatchUp(job))
+            {
+                logger.LogInformation(
+                    "Triggering catch-up execution for cron job '{JobName}' ({JobId}) — {Count} missed run(s)",
+                    job.Name, job.Id, missedRuns.Count);
+
+                try
+                {
+                    await scheduler.RunNowAsync(job.Id, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Catch-up execution failed for cron job '{JobName}' ({JobId})", job.Name, job.Id);
+                }
+            }
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Calculates the scheduled run times that were missed between the job's last run and now.
+    /// </summary>
+    internal static IReadOnlyList<DateTimeOffset> GetMissedRuns(CronJob job, DateTimeOffset now)
+    {
+        if (job.LastRunAt is null || string.IsNullOrWhiteSpace(job.Schedule))
+        {
+            return [];
+        }
+
+        CronExpression expression;
+        try
+        {
+            expression = CronExpression.Parse(job.Schedule, CronFormat.Standard);
+        }
+        catch
+        {
+            return [];
+        }
+
+        var tz = TimeZoneHelper.Resolve(job.TimeZone);
+        var missedRuns = new List<DateTimeOffset>();
+
+        // Start scanning from lastRunAt; find all occurrences between then and now.
+        var cursor = job.LastRunAt.Value.UtcDateTime;
+        var limit = now.UtcDateTime;
+
+        // Cap at 100 missed runs to avoid runaway iteration for very frequent schedules after long downtime.
+        const int maxMissed = 100;
+
+        while (missedRuns.Count < maxMissed)
+        {
+            var next = expression.GetNextOccurrence(cursor, tz);
+            if (next is null || next.Value >= limit)
+            {
+                break;
+            }
+
+            missedRuns.Add(new DateTimeOffset(next.Value, TimeSpan.Zero));
+            cursor = next.Value;
+        }
+
+        return missedRuns;
+    }
+
+    private static bool HasCatchUp(CronJob job)
+    {
+        if (job.Metadata is null)
+        {
+            return false;
+        }
+
+        if (!job.Metadata.TryGetValue(CatchUpMetadataKey, out var value))
+        {
+            return false;
+        }
+
+        return value switch
+        {
+            bool b => b,
+            string s => s.Equals("true", StringComparison.OrdinalIgnoreCase),
+            _ => false
+        };
+    }
+}

--- a/tests/gateway/BotNexus.Cron.Tests/MissedRunDetectionServiceTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/MissedRunDetectionServiceTests.cs
@@ -1,0 +1,176 @@
+using BotNexus.Cron.Tests.TestInfrastructure;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging.Abstractions;
+
+
+namespace BotNexus.Cron.Tests;
+
+public sealed class MissedRunDetectionServiceTests
+{
+    [Fact]
+    public void GetMissedRuns_NoLastRun_ReturnsEmpty()
+    {
+        var job = CreateJob("j1") with { LastRunAt = null };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, DateTimeOffset.UtcNow);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetMissedRuns_NoMissedRuns_ReturnsEmpty()
+    {
+        // Last ran 30 seconds ago, schedule is every minute — next run hasn't been missed yet
+        var now = DateTimeOffset.UtcNow;
+        var job = CreateJob("j1") with
+        {
+            Schedule = "*/5 * * * *",
+            LastRunAt = now.AddSeconds(-30)
+        };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, now);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetMissedRuns_SingleMissedRun_ReturnsOne()
+    {
+        // Schedule every 5 minutes, last ran 10 minutes ago — should have one missed run
+        var now = new DateTimeOffset(2026, 6, 11, 12, 10, 0, TimeSpan.Zero);
+        var job = CreateJob("j1") with
+        {
+            Schedule = "*/5 * * * *",
+            LastRunAt = now.AddMinutes(-10) // 12:00
+        };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, now);
+
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(new DateTimeOffset(2026, 6, 11, 12, 5, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void GetMissedRuns_MultipleMissedRuns_ReturnsAll()
+    {
+        // Schedule every 5 minutes, last ran 20 minutes ago — should have 3 missed runs (at :05, :10, :15 — but not :20 which is "now")
+        var now = new DateTimeOffset(2026, 6, 11, 12, 20, 0, TimeSpan.Zero);
+        var job = CreateJob("j1") with
+        {
+            Schedule = "*/5 * * * *",
+            LastRunAt = new DateTimeOffset(2026, 6, 11, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, now);
+
+        result.Count.ShouldBe(3);
+        result[0].ShouldBe(new DateTimeOffset(2026, 6, 11, 12, 5, 0, TimeSpan.Zero));
+        result[1].ShouldBe(new DateTimeOffset(2026, 6, 11, 12, 10, 0, TimeSpan.Zero));
+        result[2].ShouldBe(new DateTimeOffset(2026, 6, 11, 12, 15, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void GetMissedRuns_InvalidSchedule_ReturnsEmpty()
+    {
+        var job = CreateJob("j1") with
+        {
+            Schedule = "not-a-cron-expression",
+            LastRunAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, DateTimeOffset.UtcNow);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetMissedRuns_CapsAtMaximum()
+    {
+        // Schedule every minute, last ran 200 minutes ago — capped at 100
+        var now = new DateTimeOffset(2026, 6, 11, 15, 0, 0, TimeSpan.Zero);
+        var job = CreateJob("j1") with
+        {
+            Schedule = "* * * * *",
+            LastRunAt = now.AddMinutes(-200)
+        };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, now);
+
+        result.Count.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task StartAsync_RecordsMissedRuns()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var now = DateTimeOffset.UtcNow;
+
+        // Create a job that last ran 10 minutes ago with 5-minute schedule
+        var job = CronStoreTestContext.CreateJob("missed-job") with
+        {
+            Schedule = "*/5 * * * *",
+            LastRunAt = now.AddMinutes(-12)
+        };
+        await context.Store.CreateAsync(job);
+
+        var service = new MissedRunDetectionService(
+            context.Store, null!, NullLogger<MissedRunDetectionService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("missed-job"), limit: 50);
+        history.ShouldContain(r => r.Status == MissedRunDetectionService.MissedStatus);
+    }
+
+    [Fact]
+    public async Task StartAsync_SkipsDisabledJobs()
+    {
+        await using var context = await CronStoreTestContext.CreateAsync();
+        var now = DateTimeOffset.UtcNow;
+
+        var job = CronStoreTestContext.CreateJob("disabled-job", enabled: false) with
+        {
+            Schedule = "*/5 * * * *",
+            LastRunAt = now.AddMinutes(-30)
+        };
+        await context.Store.CreateAsync(job);
+
+        var service = new MissedRunDetectionService(
+            context.Store, null!, NullLogger<MissedRunDetectionService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var history = await context.Store.GetRunHistoryAsync(JobId.From("disabled-job"), limit: 50);
+        history.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetMissedRuns_WithTimezone_CalculatesCorrectly()
+    {
+        // Job in America/Los_Angeles, schedule at top of hour
+        var now = new DateTimeOffset(2026, 6, 11, 20, 30, 0, TimeSpan.Zero); // 1:30 PM PDT
+        var job = CreateJob("tz-job") with
+        {
+            Schedule = "0 * * * *", // every hour
+            LastRunAt = new DateTimeOffset(2026, 6, 11, 18, 0, 0, TimeSpan.Zero), // 11:00 AM PDT
+            TimeZone = "America/Los_Angeles"
+        };
+
+        var result = MissedRunDetectionService.GetMissedRuns(job, now);
+
+        // Should have missed :00 at 19:00 UTC (12:00 PM PDT) and 20:00 UTC (1:00 PM PDT)
+        result.Count.ShouldBe(2);
+    }
+
+    private static CronJob CreateJob(string id) => new()
+    {
+        Id = JobId.From(id),
+        Name = $"Job {id}",
+        Schedule = "*/5 * * * *",
+        ActionType = "agent-prompt",
+        AgentId = AgentId.From("test-agent"),
+        Enabled = true,
+        CreatedBy = "test",
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+}


### PR DESCRIPTION
Closes #1223

## Changes
- New \MissedRunDetectionService\ (IHostedService, runs once on startup)
- Scans all enabled cron jobs, compares \LastRunAt\ against expected schedule occurrences
- Records each missed run as a \CronRun\ with status \missed\
- Logs missed runs at WARNING level
- Jobs with \catchUp: true\ in metadata trigger one catch-up execution via \CronScheduler.RunNowAsync\
- Capped at 100 missed runs per job to prevent runaway iteration after long downtime
- 9 new tests covering: no missed runs, single/multiple missed runs, invalid schedules, cap enforcement, timezone handling, disabled job skipping, integration with SQLite store

## Merge Notes
Safe to merge in any order — touches only \BotNexus.Cron\ (\MissedRunDetectionService.cs\, \BotNexus.Cron.csproj\, \CronServiceCollectionExtensions.cs\) and its test file. No overlap with any open PR.