### PR TITLE
docs: daily documentation grooming 2026-06-11

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -145,6 +145,7 @@ export default defineConfig({
         text: 'Features',
         items: [
           { text: 'Sub-Agent Spawning', link: '/features/sub-agent-spawning' },
+          { text: 'Built-in Agents', link: '/features/built-in-agents' },
           { text: 'Shell Execution', link: '/features/shell-execution' },
           { text: 'Canvas', link: '/features/canvas' },
           { text: 'Skills', link: '/skills' },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1266,6 +1266,161 @@ X-Api-Key: your-api-key
 
 ---
 
+### Diagnostics: Thread Pool
+
+**Endpoint:** `GET /api/diagnostics/threadpool`
+
+**Description:** Returns thread pool health metrics including pending work items, thread counts, and a health assessment.
+
+**Request:**
+```http
+GET /api/diagnostics/threadpool
+X-Api-Key: your-api-key
+```
+
+**Response:** 200 OK
+```json
+{
+  "pendingWorkItems": 3,
+  "workerThreads": { "available": 28, "max": 32 },
+  "completionPortThreads": { "available": 8, "max": 8 },
+  "health": "healthy"
+}
+```
+
+Returns `404` if the threadpool watchdog service is not registered.
+
+---
+
+### Diagnostics: Activity
+
+**Endpoint:** `GET /api/diagnostics/activity`
+
+**Description:** Returns the gateway's last activity timestamp and inactivity duration.
+
+**Request:**
+```http
+GET /api/diagnostics/activity
+X-Api-Key: your-api-key
+```
+
+**Response:** 200 OK
+```json
+{
+  "lastActivityUtc": "2026-06-10T14:30:00Z",
+  "inactivitySeconds": 120,
+  "health": "healthy"
+}
+```
+
+Returns `404` if the activity tracking service is not registered.
+
+---
+
+### Memory Statistics
+
+**Endpoint:** `GET /api/memory`
+
+**Description:** Returns memory store statistics for all agents.
+
+**Request:**
+```http
+GET /api/memory
+X-Api-Key: your-api-key
+```
+
+**Response:** 200 OK
+```json
+[
+  {
+    "agentId": "assistant",
+    "entryCount": 42,
+    "totalSizeBytes": 128000
+  }
+]
+```
+
+---
+
+### Memory Statistics (Per Agent)
+
+**Endpoint:** `GET /api/memory/{agentId}`
+
+**Description:** Returns memory store statistics for a specific agent.
+
+**Parameters:**
+- `agentId` (string, path) — Agent ID
+
+**Response:** 200 OK
+```json
+{
+  "agentId": "assistant",
+  "entryCount": 42,
+  "totalSizeBytes": 128000
+}
+```
+
+---
+
+### Memory Search (Per Agent)
+
+**Endpoint:** `GET /api/memory/{agentId}/entries?query=`
+
+**Description:** Search memory entries for an agent.
+
+**Parameters:**
+- `agentId` (string, path) — Agent ID
+- `query` (string, query) — Search text
+
+**Response:** 200 OK — Returns matching memory entries.
+
+---
+
+### Satellites
+
+**Endpoint:** `GET /api/satellites`
+
+**Description:** List all registered satellite nodes with their connection status.
+
+**Request:**
+```http
+GET /api/satellites
+X-Api-Key: your-api-key
+```
+
+**Response:** 200 OK
+```json
+[
+  {
+    "id": "sat_desktop_home",
+    "displayName": "Home Desktop",
+    "owner": "jon",
+    "platform": "windows",
+    "capabilities": ["notify", "canvas"],
+    "status": "online",
+    "lastSeenUtc": "2026-06-10T14:30:00Z"
+  }
+]
+```
+
+---
+
+### Get Satellite
+
+**Endpoint:** `GET /api/satellites/{id}`
+
+**Description:** Get details for a specific satellite.
+
+**Parameters:**
+- `id` (string, path) — Satellite ID
+
+**Response:** 200 OK — Returns the satellite details.
+
+**Error Responses:**
+- `404 Not Found` — Satellite does not exist
+
+---
+
 ## Error Handling
 
 ### Error Response Format

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -74,7 +74,15 @@ You should see the root command help listing all available subcommands.
 22. [prompt render](#prompt-render) — Render a prompt template
 23. [prompt run](#prompt-run) — Render and execute a prompt template
 24. [satellite](#satellite) — Manage satellite nodes
-25. [Examples](#examples)
+25. [doctor](#doctor) — Diagnose configuration issues
+26. [locations](#locations) — Show resolved file paths
+27. [update](#update) — Check for and apply updates
+28. [memory](#memory) — Manage agent memory
+29. [cron](#cron-command) — Manage cron jobs from the CLI
+30. [debug sessions](#debug-sessions) — Inspect session SQLite database
+31. [debug logs](#debug-logs) — Inspect log files
+32. [debug db](#debug-db) — Inspect raw databases
+33. [Examples](#examples)
 
 ---
 
@@ -1431,6 +1439,321 @@ Remove a satellite registration. The satellite's API key is immediately invalida
 
 ```powershell
 botnexus satellite remove <NAME>
+```
+
+---
+
+## doctor
+
+Run diagnostic checks against your BotNexus configuration, providers, and environment. Reports issues with actionable fix suggestions.
+
+### Usage
+
+```powershell
+botnexus doctor [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--target <DIR>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+| `--verbose` | Show detailed check output. |
+
+### Examples
+
+```powershell
+# Run all diagnostics
+botnexus doctor
+
+# Check a specific instance
+botnexus doctor --target /opt/botnexus-prod
+```
+
+Checks include: config validity, provider reachability, directory permissions, extension loading, and port availability.
+
+---
+
+## locations
+
+Show resolved paths for all BotNexus directories and files (config, logs, sessions, agents, extensions).
+
+### Usage
+
+```powershell
+botnexus locations [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--target <DIR>` | BotNexus home directory. Defaults to `~/.botnexus`. |
+
+### Examples
+
+```powershell
+botnexus locations
+```
+
+Example output:
+
+```text
+Home:       C:\Users\you\.botnexus
+Config:     C:\Users\you\.botnexus\config.json
+Logs:       C:\Users\you\.botnexus\logs
+Sessions:   C:\Users\you\.botnexus\sessions
+Agents:     C:\Users\you\.botnexus\agents
+Extensions: C:\Users\you\.botnexus\extensions
+```
+
+---
+
+## update
+
+Check for available updates and optionally apply them.
+
+### Usage
+
+```powershell
+botnexus update [COMMAND] [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `check` | Check if updates are available (default) |
+| `apply` | Pull latest changes and rebuild |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--path <DIR>` | Repository root. Defaults to install location. |
+| `--verbose` | Show detailed update output. |
+
+### Exit Codes (for `update check`)
+
+| Code | Meaning |
+|------|--------|
+| `0` | Up to date |
+| `1` | Updates available |
+| `2` | Check failed |
+
+### Examples
+
+```powershell
+# Check for updates
+botnexus update check
+
+# Apply updates
+botnexus update apply
+```
+
+---
+
+## memory
+
+Manage agent memory files from the CLI.
+
+### Usage
+
+```powershell
+botnexus memory <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `list` | List memory entries for an agent |
+| `search` | Search memory content |
+| `consolidate` | Trigger memory consolidation |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--agent <ID>` | Target agent ID. |
+| `--target <DIR>` | BotNexus home directory. |
+
+### Examples
+
+```powershell
+# List memory files for an agent
+botnexus memory list --agent assistant
+
+# Search memory content
+botnexus memory search --agent assistant --query "deployment"
+```
+
+---
+
+## cron (command) {#cron-command}
+
+Manage cron jobs from the CLI.
+
+### Usage
+
+```powershell
+botnexus cron <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all configured cron jobs |
+| `status` | Show job status and last run time |
+| `run` | Manually trigger a job |
+| `enable` | Enable a disabled job |
+| `disable` | Disable a job |
+
+### Examples
+
+```powershell
+# List all cron jobs
+botnexus cron list
+
+# Check status
+botnexus cron status
+
+# Trigger a job manually
+botnexus cron run morning-briefing
+```
+
+---
+
+## debug sessions
+
+Directly inspect the sessions SQLite database without requiring a running gateway. Useful for offline diagnostics.
+
+### Usage
+
+```powershell
+botnexus debug sessions <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all sessions with summary info |
+| `get` | Show details for a specific session |
+| `compaction` | Show compaction history for a session |
+| `stats` | Database-wide statistics |
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--target <DIR>` | `~/.botnexus` | BotNexus home directory |
+| `--format` | `table` | Output format: `table` or `json` |
+
+### Examples
+
+```powershell
+# List sessions
+botnexus debug sessions list
+
+# Get session details
+botnexus debug sessions get --id "session-abc123"
+
+# Show compaction history
+botnexus debug sessions compaction --id "session-abc123"
+
+# Database statistics
+botnexus debug sessions stats
+
+# JSON output for scripting
+botnexus debug sessions list --format json
+```
+
+---
+
+## debug logs
+
+Directly inspect log files without requiring a running gateway. Reads the hourly Serilog structured log files.
+
+### Usage
+
+```powershell
+botnexus debug logs <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `tail` | Show the most recent log entries |
+| `errors` | Filter to ERROR and FATAL entries |
+| `search` | Search log content by text |
+| `session` | Filter logs for a specific session |
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--target <DIR>` | `~/.botnexus` | BotNexus home directory |
+| `--format` | `table` | Output format: `table` or `json` |
+| `--lines <N>` | `50` | Number of entries to show |
+
+### Examples
+
+```powershell
+# Tail recent logs
+botnexus debug logs tail
+
+# Show recent errors
+botnexus debug logs errors
+
+# Search for a pattern
+botnexus debug logs search --query "timeout"
+
+# Filter by session
+botnexus debug logs session --id "session-abc123"
+```
+
+---
+
+## debug db
+
+Directly inspect raw SQLite databases in the BotNexus home directory. Useful for understanding schema and diagnosing storage issues.
+
+### Usage
+
+```powershell
+botnexus debug db <COMMAND> [OPTIONS]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `tables` | List tables in a database |
+| `schema` | Show column definitions for a table |
+| `size` | Show database file sizes |
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--target <DIR>` | `~/.botnexus` | BotNexus home directory |
+| `--db <NAME>` | (all) | Filter to a specific database file |
+| `--format` | `table` | Output format: `table` or `json` |
+
+### Examples
+
+```powershell
+# List all databases and their sizes
+botnexus debug db size
+
+# Show tables in sessions database
+botnexus debug db tables --db sessions
+
+# Inspect table schema
+botnexus debug db schema --db sessions --table SessionEntries
 ```
 
 ---

--- a/docs/cron-and-scheduling.md
+++ b/docs/cron-and-scheduling.md
@@ -618,6 +618,39 @@ Unlike `consolidate-memory` (which merges files mechanically), memory dreaming u
 
 **Use case:** Keep an agent's long-term memory fresh and relevant without manual curation. Schedule weekly during off-hours.
 
+### 8.5 `cron-run-retention`
+
+**Name:** `cron-run-retention`  
+**Description:** Purges old completed cron run history records to prevent unbounded database growth.
+
+Periodically sweeps the cron run store and deletes records with status `Completed`, `Failed`, or `Timeout` that are older than the configured retention period.
+
+**Configuration Properties:**
+- `Action`: `"cron-run-retention"`
+- `RetentionDays`: Number of days to keep run records (default: 30)
+- `CheckIntervalMinutes`: How often the service checks for expired records (default: 60)
+
+**Configuration:**
+```json
+{
+  "Type": "maintenance",
+  "Action": "cron-run-retention",
+  "Schedule": "0 4 * * *",
+  "Metadata": {
+    "RetentionDays": 30,
+    "CheckIntervalMinutes": 60
+  },
+  "Enabled": true
+}
+```
+
+**Output:**
+```text
+Purged 156 cron run records older than 30 days.
+```
+
+**Use case:** Prevent the cron SQLite database from growing indefinitely on long-running instances.
+
 ---
 
 ## 9. CronTool — Runtime Job Management
@@ -627,9 +660,37 @@ Agents can schedule, remove, or list cron jobs at runtime using the **`cron` too
 ### 9.1 Tool Definition
 
 **Name:** `cron`  
-**Description:** Schedule or manage cron jobs. Actions: schedule, remove, list.
+**Description:** Schedule or manage cron jobs. Actions: list, create, update, delete, run, history.
 
 ### 9.2 Actions
+
+#### `history`
+
+Retrieves execution history for a specific job.
+
+**Arguments:**
+- `action` = `"history"`
+- `jobId`: Job identifier (required)
+- `limit`: Maximum entries to return (1–100, default: 20)
+
+**Example:**
+```json
+{
+  "action": "history",
+  "jobId": "morning-briefing",
+  "limit": 10
+}
+```
+
+**Response:**
+```text
+Run History for 'morning-briefing' (last 10 runs):
+
+| # | Started | Duration | Status | Result |
+|---|---------|----------|--------|--------|
+| 1 | 2026-06-10 09:00:05Z | 12.3s | Completed | Success |
+| 2 | 2026-06-09 09:00:03Z | 8.1s | Completed | Success |
+```
 
 #### `list`
 

--- a/docs/extensions/data-store.md
+++ b/docs/extensions/data-store.md
@@ -15,6 +15,7 @@ The Data Store extension provides agents with a per-agent structured SQLite data
 - Bulk ingest JSON arrays with automatic schema inference
 - Run SELECT queries against stored data
 - Insert individual rows
+- Update existing rows matching conditions
 - Delete rows matching conditions
 - Inspect table schemas
 - List all tables
@@ -24,11 +25,12 @@ The Data Store extension provides agents with a per-agent structured SQLite data
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | Action: `ingest`, `query`, `insert`, `delete`, `schema`, `tables`, or `drop`. |
+| `action` | string | Yes | Action: `ingest`, `query`, `insert`, `update`, `delete`, `schema`, `tables`, or `drop`. |
 | `table` | string | Conditional | Table name. Required for `ingest`, `insert`, `delete`, `schema`, `drop`. Lowercase alphanumeric + underscores only. |
 | `data` | string | Conditional | JSON array of objects for `ingest`, or single JSON object for `insert`. |
 | `sql` | string | Conditional | SELECT statement for `query` action. Only SELECT is permitted. |
-| `where` | string | Conditional | WHERE clause for `delete` action (required to prevent accidental full-table wipe). |
+| `set` | string | Conditional | JSON object of column=value pairs for `update` action (e.g. `{"status": "done"}`). |
+| `where` | string | Conditional | WHERE clause for `update` and `delete` actions (required to prevent accidental full-table wipe). |
 
 ## Configuration
 
@@ -86,6 +88,21 @@ Add a single row to a table.
   "data": "{\"name\": \"Charlie\", \"email\": \"charlie@example.com\"}"
 }
 ```
+
+### `update`
+
+Modify existing rows matching a WHERE clause. Both `set` and `where` are required.
+
+```json
+{
+  "action": "update",
+  "table": "contacts",
+  "set": "{\"email\": \"alice@newdomain.com\"}",
+  "where": "name = 'Alice'"
+}
+```
+
+The `set` parameter is a JSON object where keys are column names and values are the new values. The `where` clause prevents accidental full-table updates.
 
 ### `delete`
 

--- a/docs/features/built-in-agents.md
+++ b/docs/features/built-in-agents.md
@@ -1,0 +1,88 @@
+# Built-in Agents
+
+BotNexus ships with six built-in agent archetypes that are always available on every instance. These agents serve common roles and can be used as sub-agent targets without any configuration.
+
+## Overview
+
+Built-in agents are registered at startup before user-configured agents load. They:
+
+- Inherit the spawning agent's model and provider (empty `ModelId` and `ApiProvider`)
+- Have restricted tool sets appropriate to their role
+- Can be targeted via `spawn_subagent(targetAgentId: "...")` or `agent_converse`
+- Cannot be overridden by user configuration
+- Appear at the bottom of agent dropdowns in the portal
+
+## Available Archetypes
+
+| ID | Emoji | Role | Description |
+|----|-------|------|-------------|
+| `researcher` | 🔍 | Research | Web search, URL fetch, and summarization. Read-only. |
+| `coder` | 💻 | Code | Code writing, editing, building, and testing. Full file and shell access. |
+| `planner` | 📋 | Planning | Issue decomposition, spec writing, and task breakdown. |
+| `reviewer` | 🔎 | Review | Code review, PR analysis, and quality checks. Read-only shell access. |
+| `writer` | ✍️ | Writing | Documentation, changelogs, summaries, and content creation. |
+| `analyst` | 📊 | Analysis | Data analysis, log triage, and metrics. |
+
+## Tool Access by Archetype
+
+| Agent | Tools |
+|-------|-------|
+| `researcher` | `web_search`, `web_fetch`, `memory_search`, `memory_get`, `read`, `glob`, `grep` |
+| `coder` | `read`, `write`, `edit`, `glob`, `grep`, `shell`, `exec`, `process`, `watch_file` |
+| `planner` | `memory_search`, `memory_save`, `memory_get`, `web_search`, `read`, `write` |
+| `reviewer` | `read`, `glob`, `grep`, `shell`, `web_fetch`, `memory_search` |
+| `writer` | `read`, `write`, `edit`, `glob`, `grep`, `web_search`, `web_fetch`, `memory_search` |
+| `analyst` | `read`, `glob`, `grep`, `shell`, `exec`, `web_fetch` |
+
+## Usage Examples
+
+### Spawning a sub-agent
+
+```json
+{
+  "tool": "spawn_subagent",
+  "parameters": {
+    "targetAgentId": "researcher",
+    "task": "Find the latest release notes for .NET 10"
+  }
+}
+```
+
+### Conversing with a built-in agent
+
+```json
+{
+  "tool": "agent_converse",
+  "parameters": {
+    "agentId": "reviewer",
+    "message": "Review the changes in PR #1234 for potential issues"
+  }
+}
+```
+
+### Using the archetype parameter
+
+When spawning sub-agents, you can also use the `archetype` parameter to hint at behavior without targeting a specific agent:
+
+```json
+{
+  "tool": "spawn_subagent",
+  "parameters": {
+    "archetype": "coder",
+    "task": "Implement the FooBar interface"
+  }
+}
+```
+
+## Model Inheritance
+
+Built-in agents have empty `ModelId` and `ApiProvider` fields. When spawned as sub-agents, they inherit the calling agent's model and provider context. This means:
+
+- A sub-agent spawned by an agent using `claude-sonnet-4.5` will also use `claude-sonnet-4.5`
+- No additional provider configuration is needed
+- The cost is attributed to the spawning agent's provider account
+
+## Related
+
+- [Sub-Agent Spawning](/features/sub-agent-spawning) — How sub-agents work
+- [Agents User Guide](/user-guide/agents) — Configuring custom agents


### PR DESCRIPTION
## Changes

- **DataStore extension**: Added `update` action documentation (set + where parameters)
- **CronTool**: Added `history` action documentation, updated tool definition to list all 6 actions
- **Cron maintenance**: Added §8.5 `cron-run-retention` maintenance action
- **CLI reference**: Added 8 missing command sections (doctor, locations, update, memory, cron, debug sessions, debug logs, debug db)
- **API reference**: Added diagnostics endpoints (threadpool, activity), memory statistics endpoints, satellite endpoints
- **Built-in agents**: New feature page documenting all 6 archetypes with tool access tables
- **VitePress sidebar**: Added Built-in Agents to Features section

## New pages

- `docs/features/built-in-agents.md` — Built-in agent archetypes reference

## Content fixes

- CronTool definition said "schedule, remove, list" — updated to "list, create, update, delete, run, history"
- DataStore tool parameters table was missing `set` and `update` action

---
Automated by the daily documentation groomer.