### PR TITLE
feat(extensions): add count action to DataStoreTool for row counting

### DIFF
--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreTool.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreTool.cs
@@ -18,7 +18,7 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
     // Actions the tool supports.
     internal static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
     {
-        "ingest", "query", "insert", "update", "delete", "schema", "tables", "drop"
+        "ingest", "query", "insert", "update", "delete", "count", "schema", "tables", "drop"
     };
 
     public string Name => "data_store";
@@ -26,15 +26,15 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
 
     public Tool Definition => new(
         Name,
-        "Manage a per-agent structured SQLite data store. Ingest JSON arrays, run SELECT queries, insert rows, update rows, delete rows, inspect schema, list tables, or drop tables.",
+        "Manage a per-agent structured SQLite data store. Ingest JSON arrays, run SELECT queries, insert rows, update rows, delete rows, count rows, inspect schema, list tables, or drop tables.",
         JsonDocument.Parse("""
             {
               "type": "object",
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["ingest", "query", "insert", "update", "delete", "schema", "tables", "drop"],
-                  "description": "Action to perform: 'ingest' - bulk load a JSON array; 'query' - run a SELECT; 'insert' - add a single JSON object row; 'update' - modify rows matching a WHERE clause; 'delete' - remove rows matching a WHERE clause; 'schema' - show column names and types; 'tables' - list all tables; 'drop' - drop a table."
+                  "enum": ["ingest", "query", "insert", "update", "delete", "count", "schema", "tables", "drop"],
+                  "description": "Action to perform: 'ingest' - bulk load a JSON array; 'query' - run a SELECT; 'insert' - add a single JSON object row; 'update' - modify rows matching a WHERE clause; 'delete' - remove rows matching a WHERE clause; 'count' - count rows with optional WHERE filter; 'schema' - show column names and types; 'tables' - list all tables; 'drop' - drop a table."
                 },
                 "table": {
                   "type": "string",
@@ -87,6 +87,7 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
             "insert"  => await InsertAsync(arguments, cancellationToken),
             "update"  => await UpdateAsync(arguments, cancellationToken),
             "delete"  => await DeleteAsync(arguments, cancellationToken),
+            "count"   => await CountAsync(arguments, cancellationToken),
             "schema"  => await SchemaAsync(arguments, cancellationToken),
             "tables"  => await backend.TablesAsync(cancellationToken),
             "drop"    => await DropAsync(arguments, cancellationToken),
@@ -150,6 +151,15 @@ public sealed class DataStoreTool(IDataStoreBackend backend) : IAgentTool
         if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'. Use lowercase letters, digits, and underscores only.");
         if (string.IsNullOrWhiteSpace(where)) return DataStoreResult.Fail("'where' clause is required for delete to prevent accidental full-table wipe.");
         return await backend.DeleteAsync(table, where, ct);
+    }
+
+    private async Task<DataStoreResult> CountAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)
+    {
+        var table = GetString(args, "table");
+        if (string.IsNullOrWhiteSpace(table)) return DataStoreResult.Fail("'table' is required for count.");
+        if (!IsValidTableName(table)) return DataStoreResult.Fail($"Invalid table name '{table}'.");
+        var where = GetString(args, "where");
+        return await backend.CountAsync(table, where, ct);
     }
 
     private async Task<DataStoreResult> SchemaAsync(IReadOnlyDictionary<string, object?> args, CancellationToken ct)

--- a/src/extensions/BotNexus.Extensions.DataStore/IDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/IDataStoreBackend.cs
@@ -31,6 +31,9 @@ public interface IDataStoreBackend : IDisposable
     /// <summary>List all tables in the data store.</summary>
     Task<DataStoreResult> TablesAsync(CancellationToken ct = default);
 
+    /// <summary>Count rows in a table, optionally filtered by a WHERE clause.</summary>
+    Task<DataStoreResult> CountAsync(string table, string? where = null, CancellationToken ct = default);
+
     /// <summary>Drop a table entirely.</summary>
     Task<DataStoreResult> DropAsync(string table, CancellationToken ct = default);
 }

--- a/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
@@ -252,6 +252,28 @@ internal sealed class SqliteDataStoreBackend : IDataStoreBackend
         catch (Exception ex) { return DataStoreResult.Fail($"Tables failed: {ex.Message}"); }
     }
 
+    public async Task<DataStoreResult> CountAsync(string table, string? where = null, CancellationToken ct = default)
+    {
+        try
+        {
+            await _lock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var conn = await GetConnectionAsync(ct).ConfigureAwait(false);
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = string.IsNullOrWhiteSpace(where)
+                    ? $"SELECT COUNT(*) FROM \"{table}\""
+                    : $"SELECT COUNT(*) FROM \"{table}\" WHERE {where}";
+                var result = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                var count = Convert.ToInt64(result);
+                var json = System.Text.Json.JsonSerializer.Serialize(new { table, count });
+                return DataStoreResult.Ok(json, (int)count);
+            }
+            finally { _lock.Release(); }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex) { return DataStoreResult.Fail($"Count failed: {ex.Message}"); }
+    }
     public async Task<DataStoreResult> DropAsync(string table, CancellationToken ct = default)
     {
         try

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/DataStoreToolTests.cs
@@ -31,7 +31,7 @@ public sealed class DataStoreToolTests
     [Fact]
     public void ValidActions_ContainsAllExpectedActions()
     {
-        var expected = new[] { "ingest", "query", "insert", "update", "delete", "schema", "tables", "drop" };
+        var expected = new[] { "ingest", "query", "insert", "update", "delete", "count", "schema", "tables", "drop" };
         foreach (var a in expected)
             DataStoreTool.ValidActions.Contains(a).ShouldBeTrue($"'{a}' missing from ValidActions");
     }
@@ -232,6 +232,46 @@ public sealed class DataStoreToolTests
         backend.LastTable.ShouldBe("events");
     }
 
+    // ── count ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_Count_MissingTable_ReturnsError()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("count"));
+        IsError(result).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_InvalidTableName_ReturnsError()
+    {
+        var tool = CreateTool();
+        var result = await tool.ExecuteAsync("tc1", Args("count", ("table", "My-Table")));
+        IsError(result).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_FullTable_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool = CreateTool(backend);
+        var result = await tool.ExecuteAsync("tc1", Args("count", ("table", "events")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("count");
+        backend.LastTable.ShouldBe("events");
+        TextOf(result).ShouldContain("42");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_WithWhere_DelegatesToBackend()
+    {
+        var backend = new FakeDataStoreBackend();
+        var tool = CreateTool(backend);
+        var result = await tool.ExecuteAsync("tc1", Args("count", ("table", "events"), ("where", "status = 'done'")));
+        IsError(result).ShouldBeFalse();
+        backend.LastAction.ShouldBe("count");
+    }
+
     // ── schema ────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -394,6 +434,8 @@ internal sealed class FakeDataStoreBackend : IDataStoreBackend
     public Task<DataStoreResult> TablesAsync(CancellationToken ct = default)
     { LastAction = "tables"; return Task.FromResult(DataStoreResult.Ok("events", 0)); }
 
+    public Task<DataStoreResult> CountAsync(string table, string? where = null, CancellationToken ct = default)
+    { LastAction = "count"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("{\"table\":\"" + table + "\",\"count\":42}", 42)); }
     public Task<DataStoreResult> DropAsync(string table, CancellationToken ct = default)
     { LastAction = "drop"; LastTable = table; return Task.FromResult(DataStoreResult.Ok("dropped", 0)); }
 

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/SqliteDataStoreBackendTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/SqliteDataStoreBackendTests.cs
@@ -360,4 +360,36 @@ public sealed class SqliteDataStoreBackendTests : IDisposable
         result.Success.ShouldBeFalse();
         (result.Error ?? string.Empty).ShouldContain("does not exist");
     }
+
+    // ── Count ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Count_FullTable_ReturnsCorrectCount()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("items", """[{"id":1},{"id":2},{"id":3}]""");
+        var result = await backend.CountAsync("items");
+        result.Success.ShouldBeTrue();
+        result.RowCount.ShouldBe(3);
+        result.Payload!.ShouldContain("3");
+    }
+
+    [Fact]
+    public async Task Count_WithWhere_ReturnsFilteredCount()
+    {
+        var backend = CreateBackend();
+        await backend.IngestAsync("items", """[{"id":1,"status":"done"},{"id":2,"status":"open"},{"id":3,"status":"done"}]""");
+        var result = await backend.CountAsync("items", "status = 'done'");
+        result.Success.ShouldBeTrue();
+        result.RowCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Count_NonExistentTable_ReturnsError()
+    {
+        var backend = CreateBackend();
+        var result = await backend.CountAsync("nonexistent");
+        result.Success.ShouldBeFalse();
+        (result.Error ?? string.Empty).ShouldContain("Count failed");
+    }
 }


### PR DESCRIPTION
Closes #1227

## Changes
- Added `CountAsync` to `IDataStoreBackend` interface
- Implemented in `SqliteDataStoreBackend` with optional WHERE filtering
- Added `count` action to `DataStoreTool` (ValidActions, schema enum, tool description)
- Returns structured JSON: `{"table":"...","count":N}`
- 7 new tests (4 tool-level + 3 SQLite integration)

## Merge Notes
No file overlap with any open PR. Safe to merge in any order.
