### PR TITLE
fix(tests): add 'you' to GenericWindowsAccounts allowlist for docs placeholder

### DIFF
--- a/tests/architecture/BotNexus.Architecture.Tests/PersonalPathLeakArchitectureTests.cs
+++ b/tests/architecture/BotNexus.Architecture.Tests/PersonalPathLeakArchitectureTests.cs
@@ -61,6 +61,7 @@ public sealed class PersonalPathLeakArchitectureTests
     {
         "username",   // generic docs placeholder (docs/development/workspace-and-memory.md)
         "test",       // generic test fixture (tests/gateway/BotNexus.Cron.Tests/CronOptionsPromptTemplateResolverTests.cs)
+        "you",        // generic docs placeholder for the reader (docs/cli-reference.md)
     };
 
     // Built from fragments so the test source doesn't itself match the


### PR DESCRIPTION
The docs grooming PR (#1226) added \C:\Users\you\.botnexus\ as an example path in cli-reference.md. The PersonalPathLeakArchitectureTests allowlist had \you\ in CiHomeAccounts (Linux paths) but not in GenericWindowsAccounts (Windows paths), causing all PRs to fail on the \impacted-tests\ check.

Adds \you\ to GenericWindowsAccounts with a comment citing the file.

Fixes build failures on PRs #1168, #1170, #1233, #1234.