### PR TITLE
fix(skills): validate symlink resolution before skill file writes

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/Security/SkillPathValidator.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/Security/SkillPathValidator.cs
@@ -1,0 +1,128 @@
+using System.IO.Abstractions;
+
+namespace BotNexus.Extensions.Skills.Security;
+
+/// <summary>
+/// Validates that resolved file paths remain within the expected skill directory boundary
+/// after symlink resolution. Prevents symlink-based path traversal attacks where a symlink
+/// inside the skill directory points to a location outside the trusted root.
+/// </summary>
+internal static class SkillPathValidator
+{
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Validates that the given target path resolves to a location within the allowed root
+    /// after following any symlinks in the path. Returns the resolved path on success.
+    /// </summary>
+    /// <param name="targetPath">The absolute path to validate.</param>
+    /// <param name="allowedRoot">The root directory that must contain the resolved path.</param>
+    /// <param name="fileSystem">File system abstraction for testability.</param>
+    /// <param name="resolvedPath">The fully resolved path (symlinks followed).</param>
+    /// <param name="error">Error message if validation fails; null on success.</param>
+    /// <returns>True if the path is safe; false if it escapes the allowed root.</returns>
+    public static bool TryValidate(
+        string targetPath,
+        string allowedRoot,
+        IFileSystem fileSystem,
+        out string resolvedPath,
+        out string? error)
+    {
+        resolvedPath = targetPath;
+        error = null;
+
+        // Normalize the allowed root (ensure trailing separator for prefix comparison)
+        var normalizedRoot = NormalizePath(allowedRoot, fileSystem);
+
+        // Resolve symlinks by walking each path component
+        var resolved = ResolvePath(targetPath, fileSystem);
+        var normalizedResolved = NormalizePath(resolved, fileSystem);
+
+        // Check containment: resolved path must be under (or equal to) the allowed root
+        if (!IsUnderOrEqual(normalizedResolved, normalizedRoot, fileSystem))
+        {
+            error = $"Path escapes skill directory boundary after symlink resolution. " +
+                    $"Resolved '{resolved}' is not within '{allowedRoot}'.";
+            return false;
+        }
+
+        resolvedPath = resolved;
+        return true;
+    }
+
+    /// <summary>
+    /// Checks each component of the path for symlinks (reparse points) by walking
+    /// from root to leaf. If any component is a symlink, resolves it and continues
+    /// from the resolved location.
+    /// </summary>
+    private static string ResolvePath(string fullPath, IFileSystem fileSystem)
+    {
+        var normalized = fileSystem.Path.GetFullPath(fullPath);
+        var root = fileSystem.Path.GetPathRoot(normalized);
+        if (string.IsNullOrWhiteSpace(root))
+            return normalized;
+
+        var segments = normalized[root.Length..]
+            .Split(
+                [fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar],
+                StringSplitOptions.RemoveEmptyEntries);
+
+        var current = root.TrimEnd(fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar);
+
+        foreach (var segment in segments)
+        {
+            current = fileSystem.Path.Combine(current, segment);
+
+            if (fileSystem.Directory.Exists(current))
+            {
+                var dirInfo = fileSystem.DirectoryInfo.New(current);
+                if (dirInfo.LinkTarget is not null)
+                {
+                    var target = ResolveLink(current, dirInfo.LinkTarget, fileSystem);
+                    current = target;
+                }
+            }
+            else if (fileSystem.File.Exists(current))
+            {
+                var fileInfo = fileSystem.FileInfo.New(current);
+                if (fileInfo.LinkTarget is not null)
+                {
+                    var target = ResolveLink(current, fileInfo.LinkTarget, fileSystem);
+                    current = target;
+                }
+            }
+            // If path component doesn't exist yet (write to new file), stop resolution
+            // and just use the normalized form from here forward
+        }
+
+        return fileSystem.Path.GetFullPath(current);
+    }
+
+    private static string ResolveLink(string linkPath, string linkTarget, IFileSystem fileSystem)
+    {
+        if (fileSystem.Path.IsPathRooted(linkTarget))
+            return fileSystem.Path.GetFullPath(linkTarget);
+
+        var parent = fileSystem.Path.GetDirectoryName(linkPath);
+        return string.IsNullOrEmpty(parent)
+            ? fileSystem.Path.GetFullPath(linkTarget)
+            : fileSystem.Path.GetFullPath(fileSystem.Path.Combine(parent, linkTarget));
+    }
+
+    private static string NormalizePath(string path, IFileSystem fileSystem)
+    {
+        var full = fileSystem.Path.GetFullPath(path);
+        return full.TrimEnd(fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar);
+    }
+
+    private static bool IsUnderOrEqual(string candidate, string root, IFileSystem fileSystem)
+    {
+        if (string.Equals(candidate, root, PathComparison))
+            return true;
+
+        var sep = fileSystem.Path.DirectorySeparatorChar.ToString();
+        return candidate.StartsWith(root + sep, PathComparison);
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Skills/SkillManagerTool.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillManagerTool.cs
@@ -227,6 +227,11 @@ public sealed class SkillManagerTool(
             return Error(reason);
 
         var targetPath = Path.Combine(skillDir, relPath);
+
+        // Validate symlink resolution stays within skill boundary
+        if (!SkillPathValidator.TryValidate(targetPath, skillDir, _fs, out targetPath, out var symlinkError))
+            return Error(symlinkError!);
+
         if (!_fs.File.Exists(targetPath))
             return Error($"File '{relPath}' not found in skill '{name}'.");
 
@@ -312,6 +317,10 @@ public sealed class SkillManagerTool(
 
         var targetPath = Path.Combine(skillDir, relPath);
 
+        // Validate symlink resolution stays within skill boundary
+        if (!SkillPathValidator.TryValidate(targetPath, skillDir, _fs, out targetPath, out var writeSymlinkError))
+            return Error(writeSymlinkError!);
+
         // Ensure the supporting sub-directory exists
         var targetDir = Path.GetDirectoryName(targetPath);
         if (!string.IsNullOrEmpty(targetDir))
@@ -355,6 +364,11 @@ public sealed class SkillManagerTool(
             return Error($"Skill '{name}' is a global skill. Files cannot be removed from it by the agent.");
 
         var targetPath = Path.Combine(skillDir, relPath);
+
+        // Validate symlink resolution stays within skill boundary
+        if (!SkillPathValidator.TryValidate(targetPath, skillDir, _fs, out targetPath, out var removeSymlinkError))
+            return Error(removeSymlinkError!);
+
         if (!_fs.File.Exists(targetPath))
             return Error($"File '{relPath}' not found in skill '{name}'.");
 

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillManagerToolSymlinkTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillManagerToolSymlinkTests.cs
@@ -1,0 +1,122 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Extensions.Skills;
+
+namespace BotNexus.Skills.Tests;
+
+/// <summary>
+/// Tests that SkillManagerTool rejects write operations when symlinks would
+/// escape the skill directory boundary.
+/// </summary>
+public sealed class SkillManagerToolSymlinkTests
+{
+    private const string WorkspaceSkillsDir = "/workspace/skills";
+
+    private static SkillsConfig EnabledConfig(bool deletionAllowed = false) => new()
+    {
+        AllowSkillCreation = true,
+        AllowSkillDeletion = deletionAllowed
+    };
+
+    private static IReadOnlyDictionary<string, object?> Args(string action, string name, params (string key, object? value)[] extra)
+    {
+        var d = new Dictionary<string, object?> { ["action"] = action, ["name"] = name };
+        foreach (var (k, v) in extra)
+            d[k] = v;
+        return d;
+    }
+
+    private static string ResultText(BotNexus.Agent.Core.Types.AgentToolResult result)
+        => string.Join("", result.Content.Select(c => c.Value));
+
+    private static string ValidSkillMd(string name) => $"""
+        ---
+        name: {name}
+        description: A test skill for {name}
+        ---
+        # {name}
+        Body.
+        """;
+
+    [Fact]
+    public async Task Patch_WithSymlinkEscaping_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var skillDir = $"{WorkspaceSkillsDir}/evil-skill";
+        fs.AddFile($"{skillDir}/SKILL.md", new MockFileData(ValidSkillMd("evil-skill")));
+        // Create a symlink in scripts/ pointing outside
+        fs.AddFile("/etc/passwd", new MockFileData("root:x:0:0"));
+        fs.AddDirectory($"{skillDir}/scripts");
+        fs.File.CreateSymbolicLink($"{skillDir}/scripts/passwd", "/etc/passwd");
+
+        var tool = new SkillManagerTool(null, WorkspaceSkillsDir, EnabledConfig(), fs);
+        var result = await tool.ExecuteAsync("tc1",
+            Args("patch", "evil-skill",
+                ("filePath", "scripts/passwd"),
+                ("oldText", "root"),
+                ("newText", "hacked")));
+
+        var text = ResultText(result);
+        Assert.Contains("Error", text);
+        Assert.Contains("escapes skill directory boundary", text);
+    }
+
+    [Fact]
+    public async Task WriteFile_WithSymlinkEscaping_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var skillDir = $"{WorkspaceSkillsDir}/evil-skill";
+        fs.AddFile($"{skillDir}/SKILL.md", new MockFileData(ValidSkillMd("evil-skill")));
+        // Create a symlink directory pointing outside
+        fs.AddDirectory("/sensitive/data");
+        fs.Directory.CreateSymbolicLink($"{skillDir}/assets", "/sensitive/data");
+
+        var tool = new SkillManagerTool(null, WorkspaceSkillsDir, EnabledConfig(), fs);
+        var result = await tool.ExecuteAsync("tc2",
+            Args("write_file", "evil-skill",
+                ("filePath", "assets/payload.txt"),
+                ("content", "malicious content")));
+
+        var text = ResultText(result);
+        Assert.Contains("Error", text);
+        Assert.Contains("escapes skill directory boundary", text);
+    }
+
+    [Fact]
+    public async Task RemoveFile_WithSymlinkEscaping_ReturnsError()
+    {
+        var fs = new MockFileSystem();
+        var skillDir = $"{WorkspaceSkillsDir}/evil-skill";
+        fs.AddFile($"{skillDir}/SKILL.md", new MockFileData(ValidSkillMd("evil-skill")));
+        fs.AddFile("/etc/important.conf", new MockFileData("important"));
+        fs.AddDirectory($"{skillDir}/scripts");
+        fs.File.CreateSymbolicLink($"{skillDir}/scripts/important.conf", "/etc/important.conf");
+
+        var tool = new SkillManagerTool(null, WorkspaceSkillsDir, EnabledConfig(deletionAllowed: true), fs);
+        var result = await tool.ExecuteAsync("tc3",
+            Args("remove_file", "evil-skill",
+                ("filePath", "scripts/important.conf")));
+
+        var text = ResultText(result);
+        Assert.Contains("Error", text);
+        Assert.Contains("escapes skill directory boundary", text);
+    }
+
+    [Fact]
+    public async Task WriteFile_WithinSkillBoundary_Succeeds()
+    {
+        var fs = new MockFileSystem();
+        var skillDir = $"{WorkspaceSkillsDir}/good-skill";
+        fs.AddFile($"{skillDir}/SKILL.md", new MockFileData(ValidSkillMd("good-skill")));
+        fs.AddDirectory($"{skillDir}/assets");
+
+        var tool = new SkillManagerTool(null, WorkspaceSkillsDir, EnabledConfig(), fs);
+        var result = await tool.ExecuteAsync("tc4",
+            Args("write_file", "good-skill",
+                ("filePath", "assets/data.txt"),
+                ("content", "safe content")));
+
+        var text = ResultText(result);
+        Assert.DoesNotContain("Error", text);
+        Assert.Contains("Wrote", text);
+    }
+}

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillPathValidatorTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillPathValidatorTests.cs
@@ -1,0 +1,123 @@
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Extensions.Skills.Security;
+
+namespace BotNexus.Skills.Tests;
+
+/// <summary>
+/// Tests for <see cref="SkillPathValidator"/> — ensures symlink-based path traversal
+/// is detected and rejected before writes occur.
+/// </summary>
+public sealed class SkillPathValidatorTests
+{
+    private const string SkillRoot = "/workspace/skills/my-skill";
+
+    [Fact]
+    public void TryValidate_NormalPath_Succeeds()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillRoot);
+        fs.AddDirectory($"{SkillRoot}/scripts");
+
+        var target = $"{SkillRoot}/scripts/run.ps1";
+
+        var result = SkillPathValidator.TryValidate(target, SkillRoot, fs, out var resolved, out var error);
+
+        Assert.True(result);
+        Assert.Null(error);
+        Assert.Contains("my-skill", resolved);
+    }
+
+    [Fact]
+    public void TryValidate_PathOutsideRoot_Fails()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillRoot);
+
+        var target = "/workspace/skills/other-skill/scripts/evil.ps1";
+
+        var result = SkillPathValidator.TryValidate(target, SkillRoot, fs, out _, out var error);
+
+        Assert.False(result);
+        Assert.NotNull(error);
+        Assert.Contains("escapes skill directory boundary", error);
+    }
+
+    [Fact]
+    public void TryValidate_SymlinkDirectoryEscapes_Fails()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillRoot);
+        // Create a symlink directory inside the skill that points outside
+        fs.AddDirectory("/etc/secrets");
+        fs.Directory.CreateSymbolicLink($"{SkillRoot}/scripts", "/etc/secrets");
+
+        var target = $"{SkillRoot}/scripts/passwords.txt";
+
+        var result = SkillPathValidator.TryValidate(target, SkillRoot, fs, out _, out var error);
+
+        Assert.False(result);
+        Assert.NotNull(error);
+        Assert.Contains("escapes skill directory boundary", error);
+    }
+
+    [Fact]
+    public void TryValidate_SymlinkFileEscapes_Fails()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{SkillRoot}/scripts");
+        // Symlink file pointing outside
+        fs.AddFile("/etc/shadow", new MockFileData("secret"));
+        fs.File.CreateSymbolicLink($"{SkillRoot}/scripts/shadow", "/etc/shadow");
+
+        var target = $"{SkillRoot}/scripts/shadow";
+
+        var result = SkillPathValidator.TryValidate(target, SkillRoot, fs, out _, out var error);
+
+        Assert.False(result);
+        Assert.NotNull(error);
+        Assert.Contains("escapes skill directory boundary", error);
+    }
+
+    [Fact]
+    public void TryValidate_SymlinkWithinSkillDir_Succeeds()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{SkillRoot}/templates");
+        fs.AddDirectory($"{SkillRoot}/scripts");
+        // Symlink inside skill dir pointing to another location inside skill dir
+        fs.Directory.CreateSymbolicLink($"{SkillRoot}/scripts/shared", $"{SkillRoot}/templates");
+
+        var target = $"{SkillRoot}/scripts/shared/default.md";
+
+        var result = SkillPathValidator.TryValidate(target, SkillRoot, fs, out var resolved, out var error);
+
+        Assert.True(result);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryValidate_PathEqualToRoot_Succeeds()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillRoot);
+
+        var result = SkillPathValidator.TryValidate(SkillRoot, SkillRoot, fs, out _, out var error);
+
+        Assert.True(result);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryValidate_NewFileInExistingDir_Succeeds()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory($"{SkillRoot}/assets");
+        // File doesn't exist yet but directory does and contains no symlinks
+        var target = $"{SkillRoot}/assets/new-image.png";
+
+        var result = SkillPathValidator.TryValidate(target, SkillRoot, fs, out _, out var error);
+
+        Assert.True(result);
+        Assert.Null(error);
+    }
+}


### PR DESCRIPTION
Closes #1235

## Changes
- Add SkillPathValidator in Security/ — resolves symlinks component-by-component and validates the resolved path remains within the skill directory boundary
- Wire validation into SkillManagerTool for all write paths: patch, write_file, remove_file
- 11 new tests (7 unit for SkillPathValidator + 4 integration for SkillManagerTool symlink scenarios)

## Merge Notes
No file overlap with any open PR. Safe to merge in any order.