### PR TITLE
fix(providers): honor Retry-After header for short rate-limit windows

### DIFF
--- a/src/agent/BotNexus.Agent.Core/Loop/AgentLoopRunner.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/AgentLoopRunner.cs
@@ -317,9 +317,12 @@ public static class AgentLoopRunner
             catch (Exception ex) when (IsTransientError(ex) && attempt < maxAttempts - 1)
             {
                 RestoreMessagesAfterFailedStream(messages, messageCountBeforeStream);
-                var delayMs = config.MaxRetryDelayMs is > 0
-                    ? Math.Min(backoffMs, config.MaxRetryDelayMs.Value)
-                    : backoffMs;
+                var retryAfterDelay = (ex as ProviderRateLimitException)?.RetryAfter;
+                var delayMs = retryAfterDelay is not null
+                    ? (int)retryAfterDelay.Value.TotalMilliseconds
+                    : config.MaxRetryDelayMs is > 0
+                        ? Math.Min(backoffMs, config.MaxRetryDelayMs.Value)
+                        : backoffMs;
                 await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
                 attempt++;
                 backoffMs *= 2;
@@ -356,6 +359,9 @@ public static class AgentLoopRunner
 
     private static bool IsTransientError(Exception exception)
     {
+        if (exception is ProviderRateLimitException)
+            return true;
+
         var message = exception.Message;
         if (string.IsNullOrWhiteSpace(message))
         {

--- a/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Anthropic/AnthropicProvider.cs
@@ -202,8 +202,7 @@ public sealed partial class AnthropicProvider(HttpClient httpClient) : IApiProvi
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(effectiveCt);
-            throw new HttpRequestException(
-                $"Anthropic API returned {(int)response.StatusCode}: {errorBody}");
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, errorBody, "Anthropic");
         }
 
         using var responseStream = await response.Content.ReadAsStreamAsync(effectiveCt);

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Completions/CopilotCompletionsProvider.cs
@@ -199,7 +199,7 @@ public sealed class CopilotCompletionsProvider(
         {
             var errorBody = await response.Content.ReadAsStringAsync(ct);
             var providerError = ExtractProviderErrorMessage(errorBody, model);
-            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {providerError}");
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, providerError, "Copilot Completions");
         }
 
         using var responseStream = await response.Content.ReadAsStreamAsync(ct);

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Messages/CopilotMessagesProvider.cs
@@ -202,8 +202,7 @@ public sealed partial class CopilotMessagesProvider(HttpClient httpClient) : IAp
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(effectiveCt);
-            throw new HttpRequestException(
-                $"Copilot Messages API returned {(int)response.StatusCode}: {errorBody}");
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, errorBody, "Copilot Messages");
         }
 
         using var responseStream = await response.Content.ReadAsStreamAsync(effectiveCt);

--- a/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
+++ b/src/agent/BotNexus.Agent.Providers.Copilot/Responses/CopilotResponsesProvider.cs
@@ -138,7 +138,7 @@ public sealed class CopilotResponsesProvider(
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(ct);
-            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {errorBody}");
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, errorBody, "Copilot Responses");
         }
 
         using var responseStream = await response.Content.ReadAsStreamAsync(ct);

--- a/src/agent/BotNexus.Agent.Providers.Core/ProviderHttpErrorHelper.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/ProviderHttpErrorHelper.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace BotNexus.Agent.Providers.Core;
+
+/// <summary>
+/// Shared utility for provider HTTP error handling.
+/// Converts rate-limit responses into <see cref="ProviderRateLimitException"/> with parsed Retry-After.
+/// </summary>
+public static class ProviderHttpErrorHelper
+{
+    /// <summary>
+    /// Throws the appropriate exception for a failed HTTP response.
+    /// For 429 responses, throws <see cref="ProviderRateLimitException"/> with the parsed Retry-After delay.
+    /// For all other failures, throws <see cref="HttpRequestException"/> with the status code and body.
+    /// </summary>
+    public static void ThrowForFailedResponse(
+        HttpResponseMessage response,
+        string errorBody,
+        string providerName)
+    {
+        var statusCode = (int)response.StatusCode;
+
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            var retryAfter = ParseRetryAfterHeader(response.Headers);
+            throw new ProviderRateLimitException(
+                $"{providerName} returned {statusCode}: {errorBody}",
+                statusCode,
+                retryAfter);
+        }
+
+        throw new HttpRequestException($"HTTP {statusCode}: {errorBody}");
+    }
+
+    private static TimeSpan? ParseRetryAfterHeader(HttpResponseHeaders headers)
+    {
+        if (headers.RetryAfter is null)
+            return null;
+
+        // RetryConditionHeaderValue has either Delta (TimeSpan) or Date
+        if (headers.RetryAfter.Delta is { } delta && delta > TimeSpan.Zero)
+            return delta <= TimeSpan.FromMinutes(2) ? delta : TimeSpan.FromMinutes(2);
+
+        if (headers.RetryAfter.Date is { } date)
+        {
+            var delay = date - DateTimeOffset.UtcNow;
+            if (delay > TimeSpan.Zero && delay <= TimeSpan.FromMinutes(2))
+                return delay;
+        }
+
+        return null;
+    }
+}

--- a/src/agent/BotNexus.Agent.Providers.Core/ProviderRateLimitException.cs
+++ b/src/agent/BotNexus.Agent.Providers.Core/ProviderRateLimitException.cs
@@ -1,0 +1,45 @@
+namespace BotNexus.Agent.Providers.Core;
+
+/// <summary>
+/// Thrown when a provider returns HTTP 429 (Too Many Requests) with an optional Retry-After header.
+/// The agent loop can use <see cref="RetryAfter"/> to wait the server-specified duration
+/// instead of using generic exponential backoff.
+/// </summary>
+public sealed class ProviderRateLimitException : HttpRequestException
+{
+    /// <summary>
+    /// The server-suggested delay before retrying, parsed from the Retry-After header.
+    /// Null if the header was absent or unparseable.
+    /// </summary>
+    public TimeSpan? RetryAfter { get; }
+
+    public ProviderRateLimitException(string message, int statusCode, TimeSpan? retryAfter)
+        : base(message, null, (System.Net.HttpStatusCode)statusCode)
+    {
+        RetryAfter = retryAfter;
+    }
+
+    /// <summary>
+    /// Parses the Retry-After header value. Supports both delta-seconds and HTTP-date formats.
+    /// Returns null if the value is absent, empty, or unparseable.
+    /// </summary>
+    public static TimeSpan? ParseRetryAfterHeader(string? headerValue)
+    {
+        if (string.IsNullOrWhiteSpace(headerValue))
+            return null;
+
+        // Try delta-seconds first (most common for rate limits)
+        if (int.TryParse(headerValue.Trim(), out var seconds) && seconds > 0)
+            return TimeSpan.FromSeconds(Math.Min(seconds, 120)); // Cap at 2 minutes
+
+        // Try HTTP-date format
+        if (DateTimeOffset.TryParse(headerValue.Trim(), out var date))
+        {
+            var delay = date - DateTimeOffset.UtcNow;
+            if (delay > TimeSpan.Zero && delay <= TimeSpan.FromMinutes(2))
+                return delay;
+        }
+
+        return null;
+    }
+}

--- a/tests/agent/BotNexus.Agent.Core.Tests/Loop/ProviderRetryAfterTests.cs
+++ b/tests/agent/BotNexus.Agent.Core.Tests/Loop/ProviderRetryAfterTests.cs
@@ -1,0 +1,157 @@
+using BotNexus.Agent.Core.Configuration;
+using BotNexus.Agent.Core.Loop;
+using BotNexus.Agent.Core.Tests.TestUtils;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Core.Tests.Loop;
+
+using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
+
+/// <summary>
+/// Tests for ProviderRateLimitException and Retry-After header handling in the agent loop.
+/// </summary>
+public class ProviderRetryAfterTests
+{
+    [Fact]
+    public async Task RunAsync_ProviderRateLimitException_IsRetried()
+    {
+        var attempts = 0;
+        using var _ = RegisterProvider("ratelimit-test", (_, _, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+                throw new ProviderRateLimitException("429: rate limited", 429, TimeSpan.FromMilliseconds(10));
+
+            return TestStreamFactory.CreateTextResponse("recovered");
+        });
+
+        var config = CreateConfig("ratelimit-test");
+        var context = new AgentContext(null, [], []);
+
+        var result = await AgentLoopRunner.RunAsync(
+            [new AgentUserMessage("test")],
+            context,
+            config,
+            _ => Task.CompletedTask,
+            CancellationToken.None);
+
+        attempts.ShouldBeGreaterThan(1, "ProviderRateLimitException should trigger retry");
+        result.OfType<AssistantAgentMessage>().ShouldContain(m => m.Content == "recovered");
+    }
+
+    [Fact]
+    public async Task RunAsync_ProviderRateLimitWithRetryAfter_UsesSpecifiedDelay()
+    {
+        var attempts = 0;
+        var timestamps = new List<DateTimeOffset>();
+        using var _ = RegisterProvider("delay-test", (_, _, _) =>
+        {
+            timestamps.Add(DateTimeOffset.UtcNow);
+            if (Interlocked.Increment(ref attempts) == 1)
+                throw new ProviderRateLimitException("429: rate limited", 429, TimeSpan.FromMilliseconds(50));
+
+            return TestStreamFactory.CreateTextResponse("ok");
+        });
+
+        // Don't cap retry delay -- let the RetryAfter value be used
+        var config = CreateConfig("delay-test", maxRetryDelayMs: null);
+
+        var result = await AgentLoopRunner.RunAsync(
+            [new AgentUserMessage("test")],
+            new AgentContext(null, [], []),
+            config,
+            _ => Task.CompletedTask,
+            CancellationToken.None);
+
+        attempts.ShouldBe(2);
+        result.OfType<AssistantAgentMessage>().ShouldContain(m => m.Content == "ok");
+        // The gap between attempts should be at least ~50ms (the RetryAfter value)
+        var gap = timestamps[1] - timestamps[0];
+        gap.TotalMilliseconds.ShouldBeGreaterThan(40); // Allow some timing slack
+    }
+
+    [Fact]
+    public async Task RunAsync_ProviderRateLimitWithNullRetryAfter_FallsBackToExponentialBackoff()
+    {
+        var attempts = 0;
+        using var _ = RegisterProvider("null-retry-test", (_, _, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) <= 2)
+                throw new ProviderRateLimitException("429: rate limited", 429, retryAfter: null);
+
+            return TestStreamFactory.CreateTextResponse("recovered");
+        });
+
+        var config = CreateConfig("null-retry-test");
+
+        var result = await AgentLoopRunner.RunAsync(
+            [new AgentUserMessage("test")],
+            new AgentContext(null, [], []),
+            config,
+            _ => Task.CompletedTask,
+            CancellationToken.None);
+
+        attempts.ShouldBe(3);
+        result.OfType<AssistantAgentMessage>().ShouldContain(m => m.Content == "recovered");
+    }
+
+    [Fact]
+    public void ProviderRateLimitException_InheritsFromHttpRequestException()
+    {
+        var ex = new ProviderRateLimitException("test", 429, TimeSpan.FromSeconds(5));
+        ex.ShouldBeAssignableTo<HttpRequestException>();
+        ex.StatusCode.ShouldBe(System.Net.HttpStatusCode.TooManyRequests);
+        ex.RetryAfter.ShouldBe(TimeSpan.FromSeconds(5));
+    }
+
+    [Theory]
+    [InlineData("5", 5000)]
+    [InlineData("30", 30000)]
+    [InlineData("0", null)]
+    [InlineData("-1", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    [InlineData("999", 120000)] // Capped at 2 minutes
+    public void ParseRetryAfterHeader_DeltaSeconds_ReturnsExpected(string? headerValue, int? expectedMs)
+    {
+        var result = ProviderRateLimitException.ParseRetryAfterHeader(headerValue);
+        if (expectedMs is null)
+            result.ShouldBeNull();
+        else
+            result!.Value.TotalMilliseconds.ShouldBe(expectedMs.Value);
+    }
+
+    #region Helpers
+
+    private static AgentLoopConfig CreateConfig(string apiId, int? maxRetryDelayMs = 1)
+    {
+        return new AgentLoopConfig(
+            Model: TestHelpers.CreateTestModel(apiId),
+            LlmClient: TestHelpers.CreateLlmClient(),
+            ConvertToLlm: (messages, _) => Task.FromResult<IReadOnlyList<Message>>(
+                messages.OfType<AgentUserMessage>()
+                    .Select(m => (Message)new BotNexus.Agent.Providers.Core.Models.UserMessage(
+                        new UserMessageContent(m.Content),
+                        DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()))
+                    .ToList()),
+            TransformContext: (messages, _) => Task.FromResult(messages),
+            GetApiKey: (_, _) => Task.FromResult<string?>(null),
+            GetSteeringMessages: null,
+            GetFollowUpMessages: null,
+            ToolExecutionMode: ToolExecutionMode.Sequential,
+            BeforeToolCall: null,
+            AfterToolCall: null,
+            GenerationSettings: new SimpleStreamOptions(),
+            MaxRetryDelayMs: maxRetryDelayMs);
+    }
+
+    private static IDisposable RegisterProvider(string apiId,
+        Func<LlmModel, Context, SimpleStreamOptions?, BotNexus.Agent.Providers.Core.Streaming.LlmStream> factory)
+    {
+        var provider = new TestApiProvider(apiId, simpleStreamFactory: factory);
+        return TestHelpers.RegisterProvider(provider);
+    }
+
+    #endregion
+}

--- a/tests/agent/BotNexus.Agent.Providers.Core.Tests/ProviderHttpErrorHelperTests.cs
+++ b/tests/agent/BotNexus.Agent.Providers.Core.Tests/ProviderHttpErrorHelperTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace BotNexus.Agent.Providers.Core.Tests;
+
+public sealed class ProviderHttpErrorHelperTests
+{
+    [Fact]
+    public void ThrowForFailedResponse_429WithRetryAfterSeconds_ThrowsProviderRateLimitException()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(10));
+
+        var ex = Assert.Throws<ProviderRateLimitException>(() =>
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, "rate limited", "TestProvider"));
+
+        Assert.Equal(System.Net.HttpStatusCode.TooManyRequests, ex.StatusCode);
+        Assert.NotNull(ex.RetryAfter);
+        Assert.Equal(TimeSpan.FromSeconds(10), ex.RetryAfter);
+        Assert.Contains("TestProvider", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowForFailedResponse_429WithoutRetryAfter_ThrowsProviderRateLimitExceptionNullDelay()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+
+        var ex = Assert.Throws<ProviderRateLimitException>(() =>
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, "rate limited", "TestProvider"));
+
+        Assert.Equal(System.Net.HttpStatusCode.TooManyRequests, ex.StatusCode);
+        Assert.Null(ex.RetryAfter);
+    }
+
+    [Fact]
+    public void ThrowForFailedResponse_429WithLargeRetryAfter_CapsAt2Minutes()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(300));
+
+        var ex = Assert.Throws<ProviderRateLimitException>(() =>
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, "rate limited", "TestProvider"));
+
+        Assert.NotNull(ex.RetryAfter);
+        Assert.Equal(TimeSpan.FromMinutes(2), ex.RetryAfter);
+    }
+
+    [Fact]
+    public void ThrowForFailedResponse_500Error_ThrowsHttpRequestException()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var ex = Assert.Throws<HttpRequestException>(() =>
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, "server error", "TestProvider"));
+
+        Assert.IsNotType<ProviderRateLimitException>(ex);
+        Assert.Contains("500", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowForFailedResponse_401Error_ThrowsHttpRequestException()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+        var ex = Assert.Throws<HttpRequestException>(() =>
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, "unauthorized", "TestProvider"));
+
+        Assert.IsNotType<ProviderRateLimitException>(ex);
+    }
+
+    [Fact]
+    public void ThrowForFailedResponse_429WithDateRetryAfter_ParsesFutureDate()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        var futureDate = DateTimeOffset.UtcNow.AddSeconds(15);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(futureDate);
+
+        var ex = Assert.Throws<ProviderRateLimitException>(() =>
+            ProviderHttpErrorHelper.ThrowForFailedResponse(response, "rate limited", "TestProvider"));
+
+        Assert.NotNull(ex.RetryAfter);
+        // Should be approximately 15 seconds (within timing tolerance)
+        Assert.InRange(ex.RetryAfter.Value.TotalSeconds, 10, 20);
+    }
+}


### PR DESCRIPTION
Closes #1238

## Changes
- Add \ProviderRateLimitException\ (extends HttpRequestException) with \RetryAfter\ property
- Add \ProviderHttpErrorHelper.ThrowForFailedResponse\ — shared utility that throws \ProviderRateLimitException\ on 429 with parsed Retry-After header, plain HttpRequestException otherwise
- Update Copilot (Completions, Messages, Responses) and Anthropic providers to use the helper
- Update \AgentLoopRunner.ExecuteWithRetryAsync\ to prefer server-specified RetryAfter delay over exponential backoff
- Add explicit \ProviderRateLimitException\ check in \IsTransientError\
- Retry-After caps at 2 minutes (prevents unbounded waits)
- 17 new tests (11 agent loop retry, 6 HTTP error helper)

## Merge Notes
Safe to merge in any order with all other open PRs. Touches Agent.Core (loop), Providers.Core, Providers.Copilot, and Providers.Anthropic — no overlap with open PRs.