### PR TITLE
feat(gateway): add configurable access policy for agent-to-agent exchanges

### DIFF
--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -28,6 +28,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
     private readonly IOptions<Gateway.Configuration.GatewayOptions> _options;
     private readonly ILogger<AgentExchangeService> _logger;
     private readonly IOptions<PlatformConfig> _platformConfigOptions;
+    private readonly IOptions<AgentExchangeOptions> _exchangeOptions;
     private readonly CrossWorldChannelAdapter _crossWorldChannelAdapter;
     private readonly string _sourceWorldId;
 
@@ -39,7 +40,8 @@ public sealed class AgentExchangeService : IAgentExchangeService
         IOptions<Gateway.Configuration.GatewayOptions> options,
         ILogger<AgentExchangeService> logger,
         IOptions<PlatformConfig>? platformConfigOptions = null,
-        CrossWorldChannelAdapter? crossWorldChannelAdapter = null)
+        CrossWorldChannelAdapter? crossWorldChannelAdapter = null,
+        IOptions<AgentExchangeOptions>? exchangeOptions = null)
     {
         _registry = registry;
         _supervisor = supervisor;
@@ -48,6 +50,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
         _options = options;
         _logger = logger;
         _platformConfigOptions = platformConfigOptions ?? Options.Create(new PlatformConfig());
+        _exchangeOptions = exchangeOptions ?? Options.Create(new AgentExchangeOptions());
         _crossWorldChannelAdapter = crossWorldChannelAdapter ?? new CrossWorldChannelAdapter(
             NullLogger<CrossWorldChannelAdapter>.Instance,
             new HttpClient());
@@ -71,10 +74,17 @@ public sealed class AgentExchangeService : IAgentExchangeService
             throw new KeyNotFoundException($"Target agent '{request.TargetId}' is not registered.");
         var targetDescriptor = isLocalTarget ? _registry.Get(request.TargetId) : null;
 
-        if (!initiatorDescriptor.SubAgentIds.Contains(request.TargetId.Value, StringComparer.OrdinalIgnoreCase)
-            && !IsRoleGranted(initiatorDescriptor, targetDescriptor))
-            throw new UnauthorizedAccessException(
-                $"Agent '{request.InitiatorId}' is not allowed to converse with '{request.TargetId}'.");
+        if (!_exchangeOptions.Value.IsOpen)
+        {
+            if (!initiatorDescriptor.SubAgentIds.Contains(request.TargetId.Value, StringComparer.OrdinalIgnoreCase)
+                && !IsRoleGranted(initiatorDescriptor, targetDescriptor))
+                throw new UnauthorizedAccessException(
+                    $"Agent '{request.InitiatorId}' is not allowed to converse with '{request.TargetId}'.");
+        }
+
+        _logger.LogInformation(
+            "Agent exchange initiated: {Initiator} -> {Target} (policy={Policy})",
+            request.InitiatorId.Value, request.TargetId.Value, _exchangeOptions.Value.AccessPolicy);
 
         var normalizedChain = NormalizeChain(request.CallChain, request.InitiatorId);
         EnsureCallChainAllowed(normalizedChain, request.TargetId);

--- a/src/gateway/BotNexus.Gateway/Configuration/AgentExchangeOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/AgentExchangeOptions.cs
@@ -1,0 +1,23 @@
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Configuration for the agent-to-agent exchange system.
+/// Bound from <c>gateway:agentExchange</c> in config.json.
+/// </summary>
+public sealed class AgentExchangeOptions
+{
+    /// <summary>
+    /// Controls which agents are allowed to initiate conversations with other agents.
+    /// <list type="bullet">
+    /// <item><c>open</c> (default): any registered agent can converse with any other registered agent.</item>
+    /// <item><c>whitelist</c>: the initiator must have the target in its <c>SubAgentIds</c> list
+    /// or have a matching <c>SubAgentRoles</c> grant.</item>
+    /// </list>
+    /// </summary>
+    public string AccessPolicy { get; set; } = "open";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <see cref="AccessPolicy"/> is <c>open</c> (case-insensitive).
+    /// </summary>
+    public bool IsOpen => string.Equals(AccessPolicy, "open", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ public static class GatewayServiceCollectionExtensions
             services.Configure<SubAgentOptions>(config.GetSection("gateway:subAgents"));
             services.Configure<DelayToolOptions>(config.GetSection("gateway:delayTool"));
             services.Configure<FileWatcherToolOptions>(config.GetSection("gateway:fileWatcherTool"));
+            services.Configure<AgentExchangeOptions>(config.GetSection("gateway:agentExchange"));
             services.Configure<ConversationRetentionOptions>(config.GetSection("gateway:conversations"));
 
             var compactionSection = config.GetSection("gateway:compaction");

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeAccessPolicyTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeAccessPolicyTests.cs
@@ -1,0 +1,250 @@
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Configuration;
+using BotNexus.Gateway.Conversations;
+using BotNexus.Gateway.Sessions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class AgentExchangeAccessPolicyTests
+{
+    [Fact]
+    public async Task OpenPolicy_AllowsUnlistedAgentPair()
+    {
+        // Initiator does NOT list target in SubAgentIds
+        var initiator = AgentId.From("agent-a");
+        var target = AgentId.From("agent-b");
+        var registry = CreateRegistry(initiator, target, subAgentIds: []);
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore(redactor: null, conversationStore: conversationStore);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "Hello back" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "open" }));
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+        result.FinalResponse.ShouldBe("Hello back");
+    }
+
+    [Fact]
+    public async Task WhitelistPolicy_RejectsUnlistedAgentPair()
+    {
+        var initiator = AgentId.From("agent-a");
+        var target = AgentId.From("agent-b");
+        var registry = CreateRegistry(initiator, target, subAgentIds: []);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            Mock.Of<IAgentSupervisor>(),
+            new InMemorySessionStore(),
+            new InMemoryConversationStore(),
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
+
+        Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello"
+        });
+
+        await action.ShouldThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task WhitelistPolicy_AllowsListedAgentPair()
+    {
+        var initiator = AgentId.From("agent-a");
+        var target = AgentId.From("agent-b");
+        var registry = CreateRegistry(initiator, target, subAgentIds: ["agent-b"]);
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore(redactor: null, conversationStore: conversationStore);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "Allowed" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public async Task DefaultPolicy_IsOpen()
+    {
+        // No explicit exchangeOptions — default should be "open"
+        var initiator = AgentId.From("agent-a");
+        var target = AgentId.From("agent-b");
+        var registry = CreateRegistry(initiator, target, subAgentIds: []);
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore(redactor: null, conversationStore: conversationStore);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "Default open" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance);
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public async Task WhitelistPolicy_AllowsRoleGrantedPair()
+    {
+        var initiator = AgentId.From("agent-a");
+        var target = AgentId.From("agent-b");
+        var registry = CreateRegistryWithRole(initiator, target, subAgentIds: [], subAgentRoles: ["researcher"], targetRole: "researcher");
+
+        var conversationStore = new InMemoryConversationStore();
+        var sessionStore = new InMemorySessionStore(redactor: null, conversationStore: conversationStore);
+
+        var handle = new Mock<IAgentHandle>();
+        handle.Setup(h => h.PromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentResponse { Content = "Role granted" });
+        var supervisor = new Mock<IAgentSupervisor>();
+        supervisor.Setup(s => s.GetOrCreateAsync(target, It.IsAny<SessionId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle.Object);
+
+        var service = new AgentExchangeService(
+            registry.Object,
+            supervisor.Object,
+            sessionStore,
+            conversationStore,
+            Options.Create(new GatewayOptions()),
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
+
+        var result = await service.ConverseAsync(new AgentExchangeRequest
+        {
+            InitiatorId = initiator,
+            TargetId = target,
+            Message = "Hello",
+            MaxTurns = 1
+        });
+
+        result.Status.ShouldBe("sealed");
+    }
+
+    [Fact]
+    public void IsOpen_CaseInsensitive()
+    {
+        new AgentExchangeOptions { AccessPolicy = "OPEN" }.IsOpen.ShouldBeTrue();
+        new AgentExchangeOptions { AccessPolicy = "Open" }.IsOpen.ShouldBeTrue();
+        new AgentExchangeOptions { AccessPolicy = "whitelist" }.IsOpen.ShouldBeFalse();
+        new AgentExchangeOptions { AccessPolicy = "" }.IsOpen.ShouldBeFalse();
+    }
+
+    private static Mock<IAgentRegistry> CreateRegistry(AgentId initiator, AgentId target, IReadOnlyList<string> subAgentIds)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Initiator",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentIds = subAgentIds
+        });
+        registry.Setup(r => r.Get(target)).Returns(new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Target",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentIds = []
+        });
+        registry.Setup(r => r.Contains(target)).Returns(true);
+        return registry;
+    }
+
+    private static Mock<IAgentRegistry> CreateRegistryWithRole(
+        AgentId initiator, AgentId target,
+        IReadOnlyList<string> subAgentIds, IReadOnlyList<string> subAgentRoles,
+        string targetRole)
+    {
+        var registry = new Mock<IAgentRegistry>();
+        registry.Setup(r => r.Get(initiator)).Returns(new AgentDescriptor
+        {
+            AgentId = initiator,
+            DisplayName = "Initiator",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentIds = subAgentIds,
+            SubAgentRoles = subAgentRoles
+        });
+        registry.Setup(r => r.Get(target)).Returns(new AgentDescriptor
+        {
+            AgentId = target,
+            DisplayName = "Target",
+            ModelId = "gpt-5-mini",
+            ApiProvider = "copilot",
+            SubAgentIds = [],
+            Metadata = new Dictionary<string, object?> { ["role"] = targetRole }
+        });
+        registry.Setup(r => r.Contains(target)).Returns(true);
+        return registry;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeServiceTests.cs
@@ -87,7 +87,8 @@ public sealed class AgentExchangeServiceTests
             new InMemorySessionStore(),
             new InMemoryConversationStore(),
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentExchangeService>.Instance);
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
 
         Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {
@@ -858,7 +859,8 @@ public sealed class AgentExchangeServiceTests
             new InMemorySessionStore(),
             new InMemoryConversationStore(),
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentExchangeService>.Instance);
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
 
         Func<Task> action = () => service.ConverseAsync(new AgentExchangeRequest
         {

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentRolesTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentRolesTests.cs
@@ -110,7 +110,8 @@ public sealed class SubAgentRolesTests
             new InMemorySessionStore(),
             new InMemoryConversationStore(),
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentExchangeService>.Instance);
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
 
         await Should.ThrowAsync<UnauthorizedAccessException>(() =>
             service.ConverseAsync(new AgentExchangeRequest
@@ -208,7 +209,8 @@ public sealed class SubAgentRolesTests
             new InMemorySessionStore(),
             new InMemoryConversationStore(),
             Options.Create(new GatewayOptions()),
-            NullLogger<AgentExchangeService>.Instance);
+            NullLogger<AgentExchangeService>.Instance,
+            exchangeOptions: Options.Create(new AgentExchangeOptions { AccessPolicy = "whitelist" }));
 
         await Should.ThrowAsync<UnauthorizedAccessException>(() =>
             service.ConverseAsync(new AgentExchangeRequest


### PR DESCRIPTION
## Summary

Default policy is now **open** — any registered agent can converse with any other without being listed in `SubAgentIds`. The legacy `whitelist` mode preserves the previous behavior for environments that need explicit control.

## Changes

- **New**: `AgentExchangeOptions` config class with `AccessPolicy` (string: `open`|`whitelist`) and `IsOpen` helper
- **Modified**: `AgentExchangeService.ConverseAsync` — access check gated by policy instead of unconditional
- **Modified**: `GatewayServiceCollectionExtensions` — binds `gateway:agentExchange` config section
- **New**: 6 dedicated access policy tests covering open/whitelist/default/role-grant scenarios
- **Updated**: 2 existing tests that assumed whitelist behavior now explicitly opt-in to whitelist

## Configuration

```json
{
  "gateway": {
    "agentExchange": {
      "accessPolicy": "open"
    }
  }
}
```

No configuration needed for the new default (open). Set to `whitelist` to restore legacy behavior.

## Auditability

All exchange initiations are now logged at INFO:
```
Agent exchange initiated: farnsworth -> nova (policy=open)
```

Closes #1247
Part of #1246 (Autonomous Agent Collaboration — Phase 1)
