### PR TITLE
feat(gateway): add conversation budget system with daily caps, loop detection, and cooldown

### DIFF
--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeBudgetOptions.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeBudgetOptions.cs
@@ -1,0 +1,30 @@
+namespace BotNexus.Gateway.Agents;
+
+/// <summary>
+/// Configuration for agent exchange budget limits and loop detection.
+/// Bound from <c>gateway:agentExchange</c> in config.json.
+/// </summary>
+public sealed class AgentExchangeBudgetOptions
+{
+    /// <summary>
+    /// Maximum total turns per agent pair per calendar day (UTC). Default 200.
+    /// </summary>
+    public int DailyTurnCap { get; set; } = 200;
+
+    /// <summary>
+    /// Window in seconds for loop detection. If the same pair re-engages within
+    /// this window, the loop counter increments. Default 60.
+    /// </summary>
+    public int LoopDetectionWindowSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Number of rapid re-engagements within the detection window before
+    /// cooldown is triggered. Default 3.
+    /// </summary>
+    public int LoopThreshold { get; set; } = 3;
+
+    /// <summary>
+    /// Cooldown duration in seconds when a loop is detected. Default 300 (5 minutes).
+    /// </summary>
+    public int CooldownOnLoopDetectSeconds { get; set; } = 300;
+}

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeBudgetTracker.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeBudgetTracker.cs
@@ -1,0 +1,180 @@
+using System.Collections.Concurrent;
+using BotNexus.Domain.Primitives;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Agents;
+
+/// <summary>
+/// Tracks per-pair turn budgets, daily caps, and loop detection for agent-to-agent exchanges.
+/// All state is in-memory and resets on process restart.
+/// </summary>
+public sealed class AgentExchangeBudgetTracker
+{
+    private readonly IOptions<AgentExchangeBudgetOptions> _options;
+    private readonly ILogger<AgentExchangeBudgetTracker> _logger;
+    private readonly ConcurrentDictionary<string, PairState> _pairStates = new();
+    private readonly TimeProvider _timeProvider;
+
+    public AgentExchangeBudgetTracker(
+        IOptions<AgentExchangeBudgetOptions> options,
+        ILogger<AgentExchangeBudgetTracker> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _options = options;
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Validates that the given agent pair is within budget. Throws if budget is exhausted or cooldown active.
+    /// </summary>
+    public void EnsureWithinBudget(AgentId initiator, AgentId target)
+    {
+        var key = MakePairKey(initiator, target);
+        var state = _pairStates.GetOrAdd(key, _ => new PairState(_timeProvider.GetUtcNow()));
+        var now = _timeProvider.GetUtcNow();
+        var opts = _options.Value;
+
+        lock (state)
+        {
+            // Reset daily counters if day changed
+            if (state.DayStart.Date != now.Date)
+            {
+                state.DailyTurns = 0;
+                state.DayStart = now;
+            }
+
+            // Check cooldown
+            if (state.CooldownUntil.HasValue && now < state.CooldownUntil.Value)
+            {
+                var remaining = state.CooldownUntil.Value - now;
+                _logger.LogWarning(
+                    "Agent exchange {Initiator} -> {Target} blocked: cooldown active ({Remaining}s remaining)",
+                    initiator.Value, target.Value, (int)remaining.TotalSeconds);
+                throw new InvalidOperationException(
+                    $"Agent pair '{initiator.Value}' -> '{target.Value}' is in cooldown for {(int)remaining.TotalSeconds}s due to loop detection.");
+            }
+
+            // Check daily cap
+            if (state.DailyTurns >= opts.DailyTurnCap)
+            {
+                _logger.LogWarning(
+                    "Agent exchange {Initiator} -> {Target} blocked: daily turn cap exhausted ({Cap})",
+                    initiator.Value, target.Value, opts.DailyTurnCap);
+                throw new InvalidOperationException(
+                    $"Daily conversation budget exhausted for pair '{initiator.Value}' -> '{target.Value}' (cap: {opts.DailyTurnCap}).");
+            }
+
+            // Loop detection: if same pair re-engages within window
+            if (state.LastExchangeEnd.HasValue)
+            {
+                var elapsed = (now - state.LastExchangeEnd.Value).TotalSeconds;
+                if (elapsed < opts.LoopDetectionWindowSeconds)
+                {
+                    state.LoopCounter++;
+                    if (state.LoopCounter >= opts.LoopThreshold)
+                    {
+                        state.CooldownUntil = now.AddSeconds(opts.CooldownOnLoopDetectSeconds);
+                        state.LoopCounter = 0;
+                        _logger.LogWarning(
+                            "Loop detected for {Initiator} -> {Target}: {Count} rapid re-engagements. Cooldown {Seconds}s applied.",
+                            initiator.Value, target.Value, opts.LoopThreshold, opts.CooldownOnLoopDetectSeconds);
+                        throw new InvalidOperationException(
+                            $"Loop detected for pair '{initiator.Value}' -> '{target.Value}'. Cooldown of {opts.CooldownOnLoopDetectSeconds}s applied.");
+                    }
+                }
+                else
+                {
+                    // Outside window — reset loop counter
+                    state.LoopCounter = 0;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Records that an exchange completed, incrementing the daily turn count and marking the timestamp.
+    /// </summary>
+    public void RecordExchangeComplete(AgentId initiator, AgentId target, int turnsUsed)
+    {
+        var key = MakePairKey(initiator, target);
+        var state = _pairStates.GetOrAdd(key, _ => new PairState(_timeProvider.GetUtcNow()));
+        var now = _timeProvider.GetUtcNow();
+
+        lock (state)
+        {
+            if (state.DayStart.Date != now.Date)
+            {
+                state.DailyTurns = 0;
+                state.DayStart = now;
+            }
+
+            state.DailyTurns += turnsUsed;
+            state.LastExchangeEnd = now;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current budget state for a pair (for diagnostics).
+    /// </summary>
+    public PairBudgetInfo? GetPairInfo(AgentId initiator, AgentId target)
+    {
+        var key = MakePairKey(initiator, target);
+        if (!_pairStates.TryGetValue(key, out var state))
+            return null;
+
+        lock (state)
+        {
+            return new PairBudgetInfo(
+                DailyTurnsUsed: state.DailyTurns,
+                DailyTurnCap: _options.Value.DailyTurnCap,
+                LoopCounter: state.LoopCounter,
+                CooldownUntil: state.CooldownUntil,
+                LastExchangeEnd: state.LastExchangeEnd);
+        }
+    }
+
+    /// <summary>
+    /// Returns all tracked pairs and their budget state (for diagnostics endpoint).
+    /// </summary>
+    public IReadOnlyDictionary<string, PairBudgetInfo> GetAllPairInfo()
+    {
+        var result = new Dictionary<string, PairBudgetInfo>();
+        foreach (var (key, state) in _pairStates)
+        {
+            lock (state)
+            {
+                result[key] = new PairBudgetInfo(
+                    DailyTurnsUsed: state.DailyTurns,
+                    DailyTurnCap: _options.Value.DailyTurnCap,
+                    LoopCounter: state.LoopCounter,
+                    CooldownUntil: state.CooldownUntil,
+                    LastExchangeEnd: state.LastExchangeEnd);
+            }
+        }
+        return result;
+    }
+
+    private static string MakePairKey(AgentId initiator, AgentId target) =>
+        $"{initiator.Value}:{target.Value}";
+
+    private sealed class PairState(DateTimeOffset dayStart)
+    {
+        public int DailyTurns;
+        public DateTimeOffset DayStart = dayStart;
+        public int LoopCounter;
+        public DateTimeOffset? CooldownUntil;
+        public DateTimeOffset? LastExchangeEnd;
+    }
+}
+
+/// <summary>
+/// Diagnostic snapshot of budget state for an agent pair.
+/// </summary>
+public sealed record PairBudgetInfo(
+    int DailyTurnsUsed,
+    int DailyTurnCap,
+    int LoopCounter,
+    DateTimeOffset? CooldownUntil,
+    DateTimeOffset? LastExchangeEnd);

--- a/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/AgentExchangeService.cs
@@ -29,6 +29,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
     private readonly ILogger<AgentExchangeService> _logger;
     private readonly IOptions<PlatformConfig> _platformConfigOptions;
     private readonly CrossWorldChannelAdapter _crossWorldChannelAdapter;
+    private readonly AgentExchangeBudgetTracker? _budgetTracker;
     private readonly string _sourceWorldId;
 
     public AgentExchangeService(
@@ -39,7 +40,8 @@ public sealed class AgentExchangeService : IAgentExchangeService
         IOptions<Gateway.Configuration.GatewayOptions> options,
         ILogger<AgentExchangeService> logger,
         IOptions<PlatformConfig>? platformConfigOptions = null,
-        CrossWorldChannelAdapter? crossWorldChannelAdapter = null)
+        CrossWorldChannelAdapter? crossWorldChannelAdapter = null,
+        AgentExchangeBudgetTracker? budgetTracker = null)
     {
         _registry = registry;
         _supervisor = supervisor;
@@ -48,6 +50,7 @@ public sealed class AgentExchangeService : IAgentExchangeService
         _options = options;
         _logger = logger;
         _platformConfigOptions = platformConfigOptions ?? Options.Create(new PlatformConfig());
+        _budgetTracker = budgetTracker;
         _crossWorldChannelAdapter = crossWorldChannelAdapter ?? new CrossWorldChannelAdapter(
             NullLogger<CrossWorldChannelAdapter>.Instance,
             new HttpClient());
@@ -78,6 +81,9 @@ public sealed class AgentExchangeService : IAgentExchangeService
 
         var normalizedChain = NormalizeChain(request.CallChain, request.InitiatorId);
         EnsureCallChainAllowed(normalizedChain, request.TargetId);
+
+        // Budget enforcement: daily cap, loop detection, cooldown
+        _budgetTracker?.EnsureWithinBudget(request.InitiatorId, request.TargetId);
 
         if (!isLocalTarget && parsedCrossWorldTarget is not null)
             return await ConverseCrossWorldAsync(request, parsedCrossWorldTarget, normalizedChain, cancellationToken).ConfigureAwait(false);
@@ -224,6 +230,9 @@ public sealed class AgentExchangeService : IAgentExchangeService
             throw;
         }
 
+
+        // Record budget usage after successful exchange
+        _budgetTracker?.RecordExchangeComplete(request.InitiatorId, request.TargetId, transcript.Count);
         return new AgentExchangeResult
         {
             SessionId = sessionId,
@@ -410,6 +419,9 @@ public sealed class AgentExchangeService : IAgentExchangeService
             throw;
         }
 
+
+        // Record budget usage after successful exchange
+        _budgetTracker?.RecordExchangeComplete(request.InitiatorId, request.TargetId, transcript.Count);
         return new AgentExchangeResult
         {
             SessionId = sessionId,

--- a/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/GatewayServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ public static class GatewayServiceCollectionExtensions
             services.Configure<SubAgentOptions>(config.GetSection("gateway:subAgents"));
             services.Configure<DelayToolOptions>(config.GetSection("gateway:delayTool"));
             services.Configure<FileWatcherToolOptions>(config.GetSection("gateway:fileWatcherTool"));
+            services.Configure<AgentExchangeBudgetOptions>(config.GetSection("gateway:agentExchange"));
             services.Configure<ConversationRetentionOptions>(config.GetSection("gateway:conversations"));
 
             var compactionSection = config.GetSection("gateway:compaction");
@@ -120,6 +121,7 @@ public static class GatewayServiceCollectionExtensions
          services.AddSingleton<ICitizenRegistry, DefaultCitizenRegistry>();
          services.TryAddSingleton<IAgentConfigurationWriter, NoOpAgentConfigurationWriter>();
         services.AddSingleton<IAgentSupervisor, DefaultAgentSupervisor>();
+        services.AddSingleton<AgentExchangeBudgetTracker>();
         services.AddSingleton<IAgentExchangeService, AgentExchangeService>();
         services.AddSingleton<CrossWorldInboundAuthService>();
         services.TryAddSingleton<IWorldContext, PlatformWorldContext>();

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeBudgetTrackerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/AgentExchangeBudgetTrackerTests.cs
@@ -1,0 +1,199 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Tests.Agents;
+
+public sealed class AgentExchangeBudgetTrackerTests
+{
+    private static AgentExchangeBudgetTracker CreateTracker(
+        AgentExchangeBudgetOptions? options = null,
+        TestTimeProvider? timeProvider = null)
+    {
+        return new AgentExchangeBudgetTracker(
+            Options.Create(options ?? new AgentExchangeBudgetOptions()),
+            NullLogger<AgentExchangeBudgetTracker>.Instance,
+            timeProvider);
+    }
+
+    [Fact]
+    public void EnsureWithinBudget_FirstCall_DoesNotThrow()
+    {
+        var tracker = CreateTracker();
+        tracker.EnsureWithinBudget(AgentId.From("agent-a"), AgentId.From("agent-b"));
+    }
+
+    [Fact]
+    public void EnsureWithinBudget_DailyCapExhausted_Throws()
+    {
+        var tracker = CreateTracker(new AgentExchangeBudgetOptions { DailyTurnCap = 5 });
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+
+        tracker.RecordExchangeComplete(a, b, 5);
+
+        var ex = Should.Throw<InvalidOperationException>(() => tracker.EnsureWithinBudget(a, b));
+        ex.Message.ShouldContain("Daily conversation budget exhausted");
+    }
+
+    [Fact]
+    public void EnsureWithinBudget_DailyCapResetsNextDay()
+    {
+        var time = new TestTimeProvider(new DateTimeOffset(2026, 6, 11, 10, 0, 0, TimeSpan.Zero));
+        var tracker = CreateTracker(new AgentExchangeBudgetOptions { DailyTurnCap = 5 }, time);
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+
+        tracker.RecordExchangeComplete(a, b, 5);
+        time.Advance(TimeSpan.FromHours(24));
+
+        tracker.EnsureWithinBudget(a, b); // new day — should not throw
+    }
+
+    [Fact]
+    public void EnsureWithinBudget_LoopDetected_EnforcesCooldown()
+    {
+        var time = new TestTimeProvider(new DateTimeOffset(2026, 6, 11, 10, 0, 0, TimeSpan.Zero));
+        var tracker = CreateTracker(
+            new AgentExchangeBudgetOptions
+            {
+                LoopDetectionWindowSeconds = 60,
+                LoopThreshold = 3,
+                CooldownOnLoopDetectSeconds = 300,
+                DailyTurnCap = 1000
+            }, time);
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+
+        for (int i = 0; i < 3; i++)
+        {
+            tracker.EnsureWithinBudget(a, b);
+            tracker.RecordExchangeComplete(a, b, 1);
+            time.Advance(TimeSpan.FromSeconds(5));
+        }
+
+        // 4th triggers loop detection (counter > threshold)
+        var ex = Should.Throw<InvalidOperationException>(() => tracker.EnsureWithinBudget(a, b));
+        ex.Message.ShouldContain("Loop detected");
+    }
+
+    [Fact]
+    public void EnsureWithinBudget_CooldownExpires_Resumes()
+    {
+        var time = new TestTimeProvider(new DateTimeOffset(2026, 6, 11, 10, 0, 0, TimeSpan.Zero));
+        var tracker = CreateTracker(
+            new AgentExchangeBudgetOptions
+            {
+                LoopDetectionWindowSeconds = 60,
+                LoopThreshold = 2,
+                CooldownOnLoopDetectSeconds = 300,
+                DailyTurnCap = 1000
+            }, time);
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+
+        // Trigger cooldown: 2 within-window re-engagements triggers at threshold
+        tracker.EnsureWithinBudget(a, b);
+        tracker.RecordExchangeComplete(a, b, 1);
+        time.Advance(TimeSpan.FromSeconds(5));
+        tracker.EnsureWithinBudget(a, b); // counter -> 1
+        tracker.RecordExchangeComplete(a, b, 1);
+        time.Advance(TimeSpan.FromSeconds(5));
+        // 3rd call: counter -> 2 >= threshold(2), triggers cooldown
+        Should.Throw<InvalidOperationException>(() => tracker.EnsureWithinBudget(a, b));
+
+        // After cooldown
+        time.Advance(TimeSpan.FromSeconds(300));
+        tracker.EnsureWithinBudget(a, b); // should not throw
+    }
+
+    [Fact]
+    public void EnsureWithinBudget_OutsideWindow_ResetsLoopCounter()
+    {
+        var time = new TestTimeProvider(new DateTimeOffset(2026, 6, 11, 10, 0, 0, TimeSpan.Zero));
+        var tracker = CreateTracker(
+            new AgentExchangeBudgetOptions
+            {
+                LoopDetectionWindowSeconds = 60,
+                LoopThreshold = 3,
+                CooldownOnLoopDetectSeconds = 300,
+                DailyTurnCap = 1000
+            }, time);
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+
+        tracker.EnsureWithinBudget(a, b);
+        tracker.RecordExchangeComplete(a, b, 1);
+        time.Advance(TimeSpan.FromSeconds(5));
+        tracker.EnsureWithinBudget(a, b);
+        tracker.RecordExchangeComplete(a, b, 1);
+
+        // Wait beyond window
+        time.Advance(TimeSpan.FromSeconds(120));
+        tracker.EnsureWithinBudget(a, b); // resets counter, no exception
+    }
+
+    [Fact]
+    public void DifferentPairs_IndependentBudgets()
+    {
+        var tracker = CreateTracker(new AgentExchangeBudgetOptions { DailyTurnCap = 5 });
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+        var c = AgentId.From("agent-c");
+
+        tracker.RecordExchangeComplete(a, b, 5);
+        Should.Throw<InvalidOperationException>(() => tracker.EnsureWithinBudget(a, b));
+        tracker.EnsureWithinBudget(a, c); // independent pair — should not throw
+    }
+
+    [Fact]
+    public void GetPairInfo_ReturnsNull_ForUnknownPair()
+    {
+        var tracker = CreateTracker();
+        tracker.GetPairInfo(AgentId.From("x"), AgentId.From("y")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetPairInfo_ReturnsState_AfterExchange()
+    {
+        var tracker = CreateTracker(new AgentExchangeBudgetOptions { DailyTurnCap = 200 });
+        var a = AgentId.From("agent-a");
+        var b = AgentId.From("agent-b");
+
+        tracker.RecordExchangeComplete(a, b, 7);
+
+        var info = tracker.GetPairInfo(a, b);
+        info.ShouldNotBeNull();
+        info.DailyTurnsUsed.ShouldBe(7);
+        info.DailyTurnCap.ShouldBe(200);
+    }
+
+    [Fact]
+    public void GetAllPairInfo_ReturnsAllTracked()
+    {
+        var tracker = CreateTracker();
+        tracker.RecordExchangeComplete(AgentId.From("a"), AgentId.From("b"), 3);
+        tracker.RecordExchangeComplete(AgentId.From("a"), AgentId.From("c"), 5);
+
+        var all = tracker.GetAllPairInfo();
+        all.Count.ShouldBe(2);
+    }
+}
+
+internal sealed class TestTimeProvider : TimeProvider
+{
+    private DateTimeOffset _utcNow;
+
+    public TestTimeProvider(DateTimeOffset startTime)
+    {
+        _utcNow = startTime;
+    }
+
+    public override DateTimeOffset GetUtcNow() => _utcNow;
+
+    public void Advance(TimeSpan duration)
+    {
+        _utcNow = _utcNow.Add(duration);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `AgentExchangeBudgetTracker` — an in-memory per-pair budget enforcement system for agent-to-agent conversations.

## Guardrails

| Guard | Default | Effect |
|---|---|---|
| Daily turn cap | 200 per pair | Blocks exchanges after cap reached, resets UTC midnight |
| Loop detection window | 60s | Counts rapid re-engagements between same pair |
| Loop threshold | 3 | Triggers cooldown after N within-window checks |
| Cooldown duration | 300s (5 min) | Pair blocked from further exchanges |

## Configuration

```json
{
  "gateway": {
    "agentExchange": {
      "dailyTurnCap": 200,
      "loopDetectionWindowSeconds": 60,
      "loopThreshold": 3,
      "cooldownOnLoopDetectSeconds": 300
    }
  }
}
```

No configuration required — defaults are sensible for production use.

## Changes

- **New**: `AgentExchangeBudgetTracker` — singleton with thread-safe per-pair state tracking
- **New**: `AgentExchangeBudgetOptions` — configuration model
- **Modified**: `AgentExchangeService` — budget check before exchange, recording after completion (both local + cross-world paths)
- **Modified**: `GatewayServiceCollectionExtensions` — DI registration + config binding
- **New**: 10 tests covering daily caps, loop detection, cooldown expiry, independent pairs, diagnostics

## Design Decisions

- Budget tracker is **optional** (null parameter) — backward compatible
- State is **in-memory** — resets on restart (appropriate for rate limiting)
- `EnsureWithinBudget` throws `InvalidOperationException` — caught by exchange callers
- Both local and cross-world exchange paths enforce and record budgets
- `GetAllPairInfo()` exposed for future diagnostics REST endpoint

Closes #1248
Part of #1246 (Autonomous Agent Collaboration — Phase 1)
