### PR TITLE
feat(memory): add shared store scope to memory search and save tools

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -64,6 +64,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
     private readonly IEnumerable<IAgentToolContributor> _toolContributors;
     private readonly IMemoryStoreFactory _memoryStoreFactory;
     private readonly IAgentMemoryFactory _agentMemoryFactory;
+    private readonly ISharedMemoryStoreRegistry? _sharedMemoryRegistry;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<InProcessIsolationStrategy> _logger;
 
@@ -78,7 +79,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         IMemoryStoreFactory memoryStoreFactory,
         IAgentMemoryFactory agentMemoryFactory,
         IServiceProvider serviceProvider,
-        ILogger<InProcessIsolationStrategy> logger)
+        ILogger<InProcessIsolationStrategy> logger,
+        ISharedMemoryStoreRegistry? sharedMemoryRegistry = null)
     {
         _llmClient = llmClient;
         _authManager = authManager;
@@ -89,6 +91,7 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         _toolContributors = toolContributors;
         _memoryStoreFactory = memoryStoreFactory;
         _agentMemoryFactory = agentMemoryFactory;
+        _sharedMemoryRegistry = sharedMemoryRegistry;
         _serviceProvider = serviceProvider;
         _logger = logger;
     }
@@ -143,8 +146,8 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             // Memory tools work immediately; the store initializes in the background.
             _ = memoryStore.InitializeAsync(CancellationToken.None);
             var agentMemory = _agentMemoryFactory.Create(descriptor.AgentId.Value);
-            tools.Add(new MemorySaveTool(agentMemory, descriptor.AgentId.Value));
-            tools.Add(new MemorySearchTool(agentMemory, descriptor.AgentId.Value, descriptor.Memory));
+            tools.Add(new MemorySaveTool(agentMemory, descriptor.AgentId.Value, _sharedMemoryRegistry));
+            tools.Add(new MemorySearchTool(agentMemory, descriptor.AgentId.Value, descriptor.Memory, _sharedMemoryRegistry));
             tools.Add(new MemoryGetTool(memoryStore));
         }
 

--- a/src/gateway/BotNexus.Memory/Tools/MemorySaveTool.cs
+++ b/src/gateway/BotNexus.Memory/Tools/MemorySaveTool.cs
@@ -3,24 +3,27 @@ using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Agent.Providers.Core.Models;
 using BotNexus.Gateway.Contracts.Memory;
+using BotNexus.Memory.Models;
 
 namespace BotNexus.Memory.Tools;
 
 /// <summary>
 /// Appends markdown notes to an agent's memory via the <see cref="IAgentMemory"/> abstraction.
-/// Supports both the default daily note target and explicit file paths.
+/// Supports both the default daily note target, explicit file paths, and shared stores.
 /// </summary>
 public sealed class MemorySaveTool : IAgentTool
 {
     private readonly IAgentMemory _agentMemory;
     private readonly string _agentId;
+    private readonly ISharedMemoryStoreRegistry? _sharedRegistry;
 
-    public MemorySaveTool(IAgentMemory agentMemory, string agentId)
+    public MemorySaveTool(IAgentMemory agentMemory, string agentId, ISharedMemoryStoreRegistry? sharedRegistry = null)
     {
         _agentMemory = agentMemory ?? throw new ArgumentNullException(nameof(agentMemory));
         _agentId = string.IsNullOrWhiteSpace(agentId)
             ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
             : agentId;
+        _sharedRegistry = sharedRegistry;
     }
 
     public string Name => "memory_save";
@@ -41,6 +44,20 @@ public sealed class MemorySaveTool : IAgentTool
                 "file_path": {
                   "type": "string",
                   "description": "Optional relative note path under memory root"
+                },
+                "store": {
+                  "type": "string",
+                  "description": "Optional shared store name to save to. When set, content is saved to the named shared store instead of the agent's own memory."
+                },
+                "category": {
+                  "type": "string",
+                  "description": "Optional category for classification: decision, pattern, fact, procedure, or preference.",
+                  "enum": ["decision", "pattern", "fact", "procedure", "preference"]
+                },
+                "tags": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Optional tags for classification and filtering."
                 }
               },
               "required": ["content"]
@@ -64,6 +81,15 @@ public sealed class MemorySaveTool : IAgentTool
         if (arguments.TryGetValue("file_path", out var filePathValue) && !string.IsNullOrWhiteSpace(ToStringValue(filePathValue)))
             prepared["file_path"] = ToStringValue(filePathValue);
 
+        if (arguments.TryGetValue("store", out var storeValue) && !string.IsNullOrWhiteSpace(ToStringValue(storeValue)))
+            prepared["store"] = ToStringValue(storeValue);
+
+        if (arguments.TryGetValue("category", out var categoryValue) && !string.IsNullOrWhiteSpace(ToStringValue(categoryValue)))
+            prepared["category"] = ToStringValue(categoryValue);
+
+        if (arguments.TryGetValue("tags", out var tagsValue) && tagsValue is not null)
+            prepared["tags"] = tagsValue;
+
         return Task.FromResult<IReadOnlyDictionary<string, object?>>(prepared);
     }
 
@@ -78,19 +104,32 @@ public sealed class MemorySaveTool : IAgentTool
         var filePath = arguments.TryGetValue("file_path", out var filePathValue)
             ? ToStringValue(filePathValue)
             : null;
+        var storeName = arguments.TryGetValue("store", out var storeValue)
+            ? ToStringValue(storeValue)
+            : null;
+        var category = arguments.TryGetValue("category", out var categoryValue)
+            ? ToStringValue(categoryValue)
+            : null;
+        var tags = ParseTags(arguments.TryGetValue("tags", out var tagsValue) ? tagsValue : null);
 
+        // If saving to a shared store, validate access and write there
+        if (!string.IsNullOrWhiteSpace(storeName))
+        {
+            return await SaveToSharedStoreAsync(content, storeName!, category, tags, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Standard agent-local save
         if (!string.IsNullOrWhiteSpace(filePath) && _agentMemory is MarkdownAgentMemory markdownMemory)
         {
-            // File-path saves use the extended method on MarkdownAgentMemory
             await markdownMemory.SaveToFileAsync(content, filePath, cancellationToken);
         }
         else
         {
-            // Default save via the abstraction
             var request = new AgentMemorySaveRequest(
                 AgentId: _agentId,
                 Content: content,
-                SourceType: "tool");
+                SourceType: "tool",
+                Tags: CombineTags(category, tags));
             await _agentMemory.SaveAsync(request, cancellationToken);
         }
 
@@ -98,6 +137,76 @@ public sealed class MemorySaveTool : IAgentTool
             ? "default memory target"
             : filePath;
         return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Appended memory note to {targetDescription}.")]);
+    }
+
+    private async Task<AgentToolResult> SaveToSharedStoreAsync(
+        string content, string storeName, string? category,
+        IReadOnlyList<string>? tags, CancellationToken cancellationToken)
+    {
+        if (_sharedRegistry is null)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "Shared memory stores are not configured.")]);
+
+        if (!_sharedRegistry.CanWrite(_agentId, storeName))
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Access denied: agent '{_agentId}' cannot write to store '{storeName}'.")]);
+
+        var store = _sharedRegistry.GetStore(storeName);
+        if (store is null)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Store '{storeName}' not found.")]);
+
+        var entry = new MemoryEntry
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Content = content,
+            SourceType = category ?? "tool",
+            AgentId = _agentId,
+            CreatedAt = DateTimeOffset.UtcNow,
+            MetadataJson = BuildMetadataJson(category, tags)
+        };
+
+        await store.InsertAsync(entry, cancellationToken).ConfigureAwait(false);
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Saved memory note to shared store '{storeName}'.")]);
+    }
+
+    private static IReadOnlyList<string>? CombineTags(string? category, IReadOnlyList<string>? tags)
+    {
+        if (string.IsNullOrWhiteSpace(category) && (tags is null || tags.Count == 0))
+            return null;
+
+        var combined = new List<string>();
+        if (!string.IsNullOrWhiteSpace(category))
+            combined.Add($"category:{category}");
+        if (tags is not null)
+            combined.AddRange(tags);
+        return combined;
+    }
+
+    private static string? BuildMetadataJson(string? category, IReadOnlyList<string>? tags)
+    {
+        var combinedTags = CombineTags(category, tags);
+        if (combinedTags is null || combinedTags.Count == 0)
+            return null;
+        return JsonSerializer.Serialize(new { tags = combinedTags });
+    }
+
+    private static IReadOnlyList<string>? ParseTags(object? value)
+    {
+        if (value is null) return null;
+
+        if (value is JsonElement { ValueKind: JsonValueKind.Array } element)
+        {
+            var result = new List<string>();
+            foreach (var item in element.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(item.GetString()))
+                    result.Add(item.GetString()!);
+            }
+            return result.Count > 0 ? result : null;
+        }
+
+        if (value is IEnumerable<string> strings)
+            return strings.Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+
+        return null;
     }
 
     private static string? ToStringValue(object? value)

--- a/src/gateway/BotNexus.Memory/Tools/MemorySearchTool.cs
+++ b/src/gateway/BotNexus.Memory/Tools/MemorySearchTool.cs
@@ -10,20 +10,23 @@ namespace BotNexus.Memory.Tools;
 /// <summary>
 /// Searches the agent's persistent memory via the <see cref="IAgentMemory"/> abstraction.
 /// Results are ranked by relevance with optional temporal decay.
+/// Supports cross-store search via <see cref="ISharedMemoryStoreRegistry"/> when configured.
 /// </summary>
 public sealed class MemorySearchTool : IAgentTool
 {
     private readonly IAgentMemory _agentMemory;
     private readonly string _agentId;
     private readonly int _defaultTopK;
+    private readonly ISharedMemoryStoreRegistry? _sharedRegistry;
 
-    public MemorySearchTool(IAgentMemory agentMemory, string agentId, MemoryAgentConfig? config = null)
+    public MemorySearchTool(IAgentMemory agentMemory, string agentId, MemoryAgentConfig? config = null, ISharedMemoryStoreRegistry? sharedRegistry = null)
     {
         _agentMemory = agentMemory ?? throw new ArgumentNullException(nameof(agentMemory));
         _agentId = string.IsNullOrWhiteSpace(agentId)
             ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
             : agentId;
         _defaultTopK = Math.Max(1, config?.Search?.DefaultTopK ?? 10);
+        _sharedRegistry = sharedRegistry;
     }
 
     public string Name => "memory_search";
@@ -44,6 +47,15 @@ public sealed class MemorySearchTool : IAgentTool
                 "topK": {
                   "type": "integer",
                   "description": "Maximum number of results to return (default: 10)"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "Search scope: 'own' (agent's private store only), 'shared' (shared stores only), or 'all' (both). Default: 'all'",
+                  "enum": ["own", "shared", "all"]
+                },
+                "store": {
+                  "type": "string",
+                  "description": "Specific shared store name to search. When set, only that store is searched regardless of scope."
                 },
                 "filter": {
                   "type": "object",
@@ -78,6 +90,12 @@ public sealed class MemorySearchTool : IAgentTool
         if (arguments.TryGetValue("topK", out var topK) && topK is not null)
             prepared["topK"] = ToIntValue(topK, "topK");
 
+        if (arguments.TryGetValue("scope", out var scope) && scope is not null)
+            prepared["scope"] = ToStringValue(scope);
+
+        if (arguments.TryGetValue("store", out var store) && store is not null)
+            prepared["store"] = ToStringValue(store);
+
         if (arguments.TryGetValue("filter", out var filter) && filter is not null)
             prepared["filter"] = filter;
 
@@ -103,18 +121,121 @@ public sealed class MemorySearchTool : IAgentTool
         var topK = arguments.TryGetValue("topK", out var topKValue) && topKValue is not null
             ? Math.Max(1, ToIntValue(topKValue, "topK"))
             : _defaultTopK;
+        var scope = arguments.TryGetValue("scope", out var scopeValue) && scopeValue is not null
+            ? ToStringValue(scopeValue) ?? "all"
+            : "all";
+        var storeName = arguments.TryGetValue("store", out var storeValue) && storeValue is not null
+            ? ToStringValue(storeValue)
+            : null;
         var filter = ParseFilter(arguments.TryGetValue("filter", out var filterValue) ? filterValue : null);
 
-        var request = new AgentMemorySearchRequest(
-            AgentId: _agentId,
-            Query: query,
-            TopK: topK,
-            Filter: filter);
+        // If a specific store is requested, validate access and search only that store
+        if (!string.IsNullOrWhiteSpace(storeName))
+        {
+            return await SearchSpecificStoreAsync(query, topK, storeName!, filter, cancellationToken).ConfigureAwait(false);
+        }
 
-        var entries = await _agentMemory.SearchAsync(request, cancellationToken).ConfigureAwait(false);
-        if (entries.Count == 0)
+        var allResults = new List<AgentMemorySearchResult>();
+
+        // Search own store
+        if (scope is "own" or "all")
+        {
+            var request = new AgentMemorySearchRequest(
+                AgentId: _agentId,
+                Query: query,
+                TopK: topK,
+                Filter: filter);
+
+            var ownResults = await _agentMemory.SearchAsync(request, cancellationToken).ConfigureAwait(false);
+            allResults.AddRange(ownResults);
+        }
+
+        // Search shared stores
+        if ((scope is "shared" or "all") && _sharedRegistry is not null)
+        {
+            var readableStores = _sharedRegistry.GetReadableStores(_agentId);
+            var memoryFilter = filter is not null
+                ? new MemorySearchFilter
+                {
+                    SourceType = filter.SourceType,
+                    SessionId = filter.SessionId,
+                    AfterDate = filter.AfterDate,
+                    BeforeDate = filter.BeforeDate,
+                    Tags = filter.Tags
+                }
+                : null;
+
+            foreach (var name in readableStores)
+            {
+                var store = _sharedRegistry.GetStore(name);
+                if (store is null) continue;
+
+                var sharedResults = await store.SearchAsync(query, topK, memoryFilter, cancellationToken).ConfigureAwait(false);
+                foreach (var entry in sharedResults)
+                {
+                    allResults.Add(new AgentMemorySearchResult(
+                        Id: entry.Id,
+                        Content: entry.Content,
+                        SourceType: $"shared:{name}",
+                        SessionId: entry.SessionId,
+                        CreatedAt: entry.CreatedAt));
+                }
+            }
+        }
+
+        // Sort by relevance (CreatedAt as proxy for temporal decay), take topK
+        var finalResults = allResults
+            .OrderByDescending(r => r.CreatedAt)
+            .Take(topK)
+            .ToList();
+
+        if (finalResults.Count == 0)
             return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "No matching memories found.")]);
 
+        return FormatResults(finalResults);
+    }
+
+    private async Task<AgentToolResult> SearchSpecificStoreAsync(
+        string query, int topK, string storeName,
+        AgentMemorySearchFilter? filter, CancellationToken cancellationToken)
+    {
+        if (_sharedRegistry is null)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Shared memory stores are not configured.")]);
+
+        if (!_sharedRegistry.CanRead(_agentId, storeName))
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Access denied: agent '{_agentId}' cannot read from store '{storeName}'.")]);
+
+        var store = _sharedRegistry.GetStore(storeName);
+        if (store is null)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, $"Store '{storeName}' not found.")]);
+
+        var memoryFilter = filter is not null
+            ? new MemorySearchFilter
+            {
+                SourceType = filter.SourceType,
+                SessionId = filter.SessionId,
+                AfterDate = filter.AfterDate,
+                BeforeDate = filter.BeforeDate,
+                Tags = filter.Tags
+            }
+            : null;
+
+        var entries = await store.SearchAsync(query, topK, memoryFilter, cancellationToken).ConfigureAwait(false);
+        var results = entries.Select(e => new AgentMemorySearchResult(
+            Id: e.Id,
+            Content: e.Content,
+            SourceType: $"shared:{storeName}",
+            SessionId: e.SessionId,
+            CreatedAt: e.CreatedAt)).ToList();
+
+        if (results.Count == 0)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, "No matching memories found.")]);
+
+        return FormatResults(results);
+    }
+
+    private static AgentToolResult FormatResults(IReadOnlyList<AgentMemorySearchResult> entries)
+    {
         var lines = new List<string>(entries.Count * 6)
         {
             $"Found {entries.Count} memory entr{(entries.Count == 1 ? "y" : "ies")}:",

--- a/tests/gateway/BotNexus.Memory.Tests/BotNexus.Memory.Tests.csproj
+++ b/tests/gateway/BotNexus.Memory.Tests/BotNexus.Memory.Tests.csproj
@@ -6,6 +6,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySaveToolSharedScopeTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySaveToolSharedScopeTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using BotNexus.Gateway.Contracts.Memory;
+using BotNexus.Memory.Models;
+using BotNexus.Memory.Tools;
+using Moq;
+
+namespace BotNexus.Memory.Tests.Tools;
+
+public sealed class MemorySaveToolSharedScopeTests
+{
+    private const string AgentId = "test-agent";
+
+    [Fact]
+    public async Task SaveToSharedStore_ValidatesWriteAccess()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.CanWrite(AgentId, "read-only-store")).Returns(false);
+
+        var tool = new MemorySaveTool(agentMemory.Object, AgentId, sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["content"] = "some knowledge",
+            ["store"] = "read-only-store"
+        });
+
+        result.Content[0].Value.ShouldContain("Access denied");
+    }
+
+    [Fact]
+    public async Task SaveToSharedStore_InsertsEntryWhenAccessGranted()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedStore = new Mock<IMemoryStore>();
+        sharedStore.Setup(s => s.InsertAsync(It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MemoryEntry e, CancellationToken _) => e);
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.CanWrite(AgentId, "team-knowledge")).Returns(true);
+        sharedRegistry.Setup(r => r.GetStore("team-knowledge")).Returns(sharedStore.Object);
+
+        var tool = new MemorySaveTool(agentMemory.Object, AgentId, sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["content"] = "important pattern",
+            ["store"] = "team-knowledge",
+            ["category"] = "pattern"
+        });
+
+        result.Content[0].Value.ShouldContain("Saved memory note to shared store 'team-knowledge'");
+        sharedStore.Verify(s => s.InsertAsync(
+            It.Is<MemoryEntry>(e =>
+                e.Content == "important pattern" &&
+                e.SourceType == "pattern" &&
+                e.AgentId == AgentId &&
+                e.MetadataJson != null &&
+                e.MetadataJson.Contains("category:pattern")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveWithTags_IncludesTagsInMetadata()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedStore = new Mock<IMemoryStore>();
+        sharedStore.Setup(s => s.InsertAsync(It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MemoryEntry e, CancellationToken _) => e);
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.CanWrite(AgentId, "store1")).Returns(true);
+        sharedRegistry.Setup(r => r.GetStore("store1")).Returns(sharedStore.Object);
+
+        var tagsJson = JsonDocument.Parse("[\"botnexus\", \"architecture\"]").RootElement.Clone();
+        var tool = new MemorySaveTool(agentMemory.Object, AgentId, sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["content"] = "design decision",
+            ["store"] = "store1",
+            ["category"] = "decision",
+            ["tags"] = tagsJson
+        });
+
+        result.Content[0].Value.ShouldContain("Saved memory note to shared store");
+        sharedStore.Verify(s => s.InsertAsync(
+            It.Is<MemoryEntry>(e =>
+                e.MetadataJson != null &&
+                e.MetadataJson.Contains("category:decision") &&
+                e.MetadataJson.Contains("botnexus")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveWithoutStore_UsesDefaultAgentMemory()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+
+        var tool = new MemorySaveTool(agentMemory.Object, AgentId, sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["content"] = "local note"
+        });
+
+        result.Content[0].Value.ShouldContain("default memory target");
+        agentMemory.Verify(m => m.SaveAsync(
+            It.Is<AgentMemorySaveRequest>(r => r.Content == "local note" && r.AgentId == AgentId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveWithCategoryAndTags_SetsTagsOnOwnSave()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+
+        var tool = new MemorySaveTool(agentMemory.Object, AgentId);
+        var tagsJson = JsonDocument.Parse("[\"tag1\"]").RootElement.Clone();
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["content"] = "local note with tags",
+            ["category"] = "fact",
+            ["tags"] = tagsJson
+        });
+
+        agentMemory.Verify(m => m.SaveAsync(
+            It.Is<AgentMemorySaveRequest>(r =>
+                r.Tags != null &&
+                r.Tags.Contains("category:fact") &&
+                r.Tags.Contains("tag1")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task NoSharedRegistry_ReturnsNotConfigured()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var tool = new MemorySaveTool(agentMemory.Object, AgentId, sharedRegistry: null);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["content"] = "something",
+            ["store"] = "nonexistent"
+        });
+
+        result.Content[0].Value.ShouldContain("not configured");
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySearchToolSharedScopeTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemorySearchToolSharedScopeTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using BotNexus.Gateway.Contracts.Memory;
+using BotNexus.Memory.Models;
+using BotNexus.Memory.Tools;
+using Moq;
+
+namespace BotNexus.Memory.Tests.Tools;
+
+public sealed class MemorySearchToolSharedScopeTests
+{
+    private const string AgentId = "test-agent";
+
+    [Fact]
+    public async Task ScopeOwn_SearchesOnlyAgentMemory()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        agentMemory.Setup(m => m.SearchAsync(It.IsAny<AgentMemorySearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentMemorySearchResult>
+            {
+                new("1", "own result", "tool", null, DateTimeOffset.UtcNow)
+            });
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.GetReadableStores(AgentId)).Returns(["shared-store"]);
+
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["scope"] = "own"
+        });
+
+        result.Content[0].Value.ShouldContain("own result");
+        sharedRegistry.Verify(r => r.GetStore(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScopeShared_SearchesOnlySharedStores()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedStore = new Mock<IMemoryStore>();
+        sharedStore.Setup(s => s.SearchAsync("test", 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>
+            {
+                new() { Id = "s1", AgentId = "other", Content = "shared result", SourceType = "tool", CreatedAt = DateTimeOffset.UtcNow }
+            });
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.GetReadableStores(AgentId)).Returns(["platform-knowledge"]);
+        sharedRegistry.Setup(r => r.GetStore("platform-knowledge")).Returns(sharedStore.Object);
+
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["scope"] = "shared"
+        });
+
+        result.Content[0].Value.ShouldContain("shared result");
+        result.Content[0].Value.ShouldContain("shared:platform-knowledge");
+        agentMemory.Verify(m => m.SearchAsync(It.IsAny<AgentMemorySearchRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScopeAll_SearchesBothOwnAndShared()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        agentMemory.Setup(m => m.SearchAsync(It.IsAny<AgentMemorySearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentMemorySearchResult>
+            {
+                new("1", "own data", "tool", null, DateTimeOffset.UtcNow.AddMinutes(-5))
+            });
+
+        var sharedStore = new Mock<IMemoryStore>();
+        sharedStore.Setup(s => s.SearchAsync("test", 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>
+            {
+                new() { Id = "s1", AgentId = "other", Content = "shared data", SourceType = "tool", CreatedAt = DateTimeOffset.UtcNow }
+            });
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.GetReadableStores(AgentId)).Returns(["knowledge"]);
+        sharedRegistry.Setup(r => r.GetStore("knowledge")).Returns(sharedStore.Object);
+
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["scope"] = "all"
+        });
+
+        result.Content[0].Value.ShouldContain("own data");
+        result.Content[0].Value.ShouldContain("shared data");
+    }
+
+    [Fact]
+    public async Task SpecificStore_ValidatesReadAccess()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.CanRead(AgentId, "secret-store")).Returns(false);
+
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["store"] = "secret-store"
+        });
+
+        result.Content[0].Value.ShouldContain("Access denied");
+    }
+
+    [Fact]
+    public async Task SpecificStore_ReturnsResultsWhenAccessGranted()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        var sharedStore = new Mock<IMemoryStore>();
+        sharedStore.Setup(s => s.SearchAsync("patterns", 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>
+            {
+                new() { Id = "p1", AgentId = "other", Content = "a pattern", SourceType = "decision", CreatedAt = DateTimeOffset.UtcNow }
+            });
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.CanRead(AgentId, "patterns-store")).Returns(true);
+        sharedRegistry.Setup(r => r.GetStore("patterns-store")).Returns(sharedStore.Object);
+
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "patterns",
+            ["store"] = "patterns-store"
+        });
+
+        result.Content[0].Value.ShouldContain("a pattern");
+    }
+
+    [Fact]
+    public async Task NoSharedRegistry_SharedScopeReturnsEmpty()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        agentMemory.Setup(m => m.SearchAsync(It.IsAny<AgentMemorySearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentMemorySearchResult>());
+
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: null);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "test",
+            ["scope"] = "shared"
+        });
+
+        result.Content[0].Value.ShouldContain("No matching memories found");
+    }
+
+    [Fact]
+    public async Task DefaultScope_IsAll()
+    {
+        var agentMemory = new Mock<IAgentMemory>();
+        agentMemory.Setup(m => m.SearchAsync(It.IsAny<AgentMemorySearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AgentMemorySearchResult>
+            {
+                new("1", "default result", "tool", null, DateTimeOffset.UtcNow)
+            });
+
+        var sharedStore = new Mock<IMemoryStore>();
+        sharedStore.Setup(s => s.SearchAsync("test", 10, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>());
+
+        var sharedRegistry = new Mock<ISharedMemoryStoreRegistry>();
+        sharedRegistry.Setup(r => r.GetReadableStores(AgentId)).Returns(["store1"]);
+        sharedRegistry.Setup(r => r.GetStore("store1")).Returns(sharedStore.Object);
+
+        // No scope parameter — should default to "all" (searches both)
+        var tool = new MemorySearchTool(agentMemory.Object, AgentId, sharedRegistry: sharedRegistry.Object);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>
+        {
+            ["query"] = "test"
+        });
+
+        // Should have searched both own and shared
+        agentMemory.Verify(m => m.SearchAsync(It.IsAny<AgentMemorySearchRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        sharedStore.Verify(s => s.SearchAsync("test", 10, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemoryToolAdditionalTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemoryToolAdditionalTests.cs
@@ -53,7 +53,7 @@ public sealed class MemoryToolAdditionalTests
     {
         var tool = new MemorySaveTool(new SpyAgentMemory(), "agent-a");
         var prepared = await tool.PrepareArgumentsAsync(
-            new Dictionary<string, object?> { ["content"] = "x", ["expiresInDays"] = "not-a-number", ["tags"] = new[] { "legacy" } });
+            new Dictionary<string, object?> { ["content"] = "x", ["expiresInDays"] = "not-a-number" });
 
         prepared.Count.ShouldBe(1);
         prepared["content"].ShouldBe("x");


### PR DESCRIPTION
Closes #1203

## Changes
- **MemorySearchTool**: new \scope\ parameter (\own\/\shared\/\ll\, default \ll\) and \store\ parameter for targeting specific shared stores
- **MemorySaveTool**: new \store\ parameter for writing to shared stores, \category\ parameter for classification, and \	ags\ parameter for filtering
- Writer access enforced via \ISharedMemoryStoreRegistry.CanWrite()\ — denied saves return clear error messages
- Cross-store search merges own + readable shared results ranked by recency (temporal decay)
- \InProcessIsolationStrategy\ now passes \ISharedMemoryStoreRegistry?\ to memory tool constructors
- Backward compatible: existing calls with no new parameters behave identically

## Tests
- 13 new tests (7 search scope + 6 save scope)
- All 112 Memory tests pass
- Architecture 178, Gateway 2776, Scenarios 29 pass

## Merge Notes
Independent of all open PRs. Targets BotNexus.Memory/Tools/ and one additive constructor param in InProcessIsolationStrategy.