### PR TITLE
feat(extensions): add knowledge_stores and knowledge_get tools to QMD extension

### DIFF
--- a/src/extensions/BotNexus.Extensions.Qmd/KnowledgeGetTool.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/KnowledgeGetTool.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Agent-facing tool for retrieving a specific document from the knowledge base by ID or path.
+/// </summary>
+public sealed class KnowledgeGetTool(IQmdBackend backend) : IAgentTool
+{
+    private const int MaxContentChars = 50_000;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public string Name => "knowledge_get";
+
+    /// <inheritdoc />
+    public string Label => "Knowledge Get";
+
+    /// <inheritdoc />
+    public Tool Definition => new(
+        Name,
+        "Retrieve a specific document from the knowledge base by ID or path.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Document ID (#abc123 format) or path (store/path/to/file.md)."
+                }
+              },
+              "required": ["id"]
+            }
+            """).RootElement.Clone());
+
+    /// <inheritdoc />
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!arguments.TryGetValue("id", out var idValue) || string.IsNullOrWhiteSpace(ToStringValue(idValue)))
+            throw new ArgumentException("Missing required argument: id.");
+
+        return Task.FromResult<IReadOnlyDictionary<string, object?>>(
+            new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) { ["id"] = ToStringValue(idValue)! });
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var id = ToStringValue(arguments["id"]) ?? string.Empty;
+
+        QmdDocument? document;
+        try
+        {
+            document = await backend.GetDocumentAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                $"Failed to retrieve document: {ex.Message}")]);
+        }
+
+        if (document is null)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                $"Document not found: '{id}'")]);
+
+        var content = document.Content;
+        var truncated = false;
+        if (content.Length > MaxContentChars)
+        {
+            content = content[..MaxContentChars];
+            truncated = true;
+        }
+
+        var output = new
+        {
+            document.Id,
+            document.Store,
+            document.Path,
+            document.Title,
+            Content = content + (truncated ? "\n\n[truncated — document exceeds 50K characters]" : string.Empty)
+        };
+
+        var json = JsonSerializer.Serialize(output, JsonOptions);
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, json)]);
+    }
+
+    private static string? ToStringValue(object? value)
+        => value switch
+        {
+            null => null,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            JsonElement element => element.ToString(),
+            _ => value.ToString()
+        };
+}

--- a/src/extensions/BotNexus.Extensions.Qmd/KnowledgeStoresTool.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/KnowledgeStoresTool.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using BotNexus.Agent.Core.Tools;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Extensions.Qmd;
+
+/// <summary>
+/// Agent-facing tool for listing available knowledge stores with metadata.
+/// </summary>
+public sealed class KnowledgeStoresTool(IQmdBackend backend, QmdConfig config) : IAgentTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public string Name => "knowledge_stores";
+
+    /// <inheritdoc />
+    public string Label => "Knowledge Stores";
+
+    /// <inheritdoc />
+    public Tool Definition => new(
+        Name,
+        "List available knowledge stores with descriptions, document counts, and health status.",
+        JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": false
+            }
+            """).RootElement.Clone());
+
+    /// <inheritdoc />
+    public Task<IReadOnlyDictionary<string, object?>> PrepareArgumentsAsync(
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyDictionary<string, object?>>(
+            new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc />
+    public async Task<AgentToolResult> ExecuteAsync(
+        string toolCallId,
+        IReadOnlyDictionary<string, object?> arguments,
+        CancellationToken cancellationToken = default,
+        AgentToolUpdateCallback? onUpdate = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        QmdStoreInfo[] stores;
+        try
+        {
+            stores = await backend.GetStoresAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                $"Failed to retrieve knowledge stores: {ex.Message}")]);
+        }
+
+        // Enrich with descriptions from config
+        var configDescriptions = config.Stores
+            .Where(s => !string.IsNullOrWhiteSpace(s.Description))
+            .ToDictionary(s => s.Name, s => s.Description!, StringComparer.OrdinalIgnoreCase);
+
+        var output = stores.Select(s => new
+        {
+            s.Name,
+            Description = configDescriptions.TryGetValue(s.Name, out var desc) ? desc : s.Description,
+            s.DocumentCount,
+            LastUpdated = s.LastUpdated?.ToString("O"),
+            s.Healthy
+        }).ToArray();
+
+        if (output.Length == 0)
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                "No knowledge stores are configured or available.")]);
+
+        var json = JsonSerializer.Serialize(output, JsonOptions);
+        var hint = "\n\nUse knowledge_search with store='<name>' to search a specific store, or omit store to search all.";
+        return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text, json + hint)]);
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Qmd/QmdToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdToolContributor.cs
@@ -26,7 +26,7 @@ public sealed class QmdToolContributor(ILoggerFactory? loggerFactory = null) : I
 
         var logger = loggerFactory?.CreateLogger<QmdCliBackend>();
         var backend = new QmdCliBackend(config.QmdPath, TimeSpan.FromSeconds(30), logger);
-        IReadOnlyList<IAgentTool> tools = [new KnowledgeSearchTool(backend, config)];
+        IReadOnlyList<IAgentTool> tools = [new KnowledgeSearchTool(backend, config), new KnowledgeStoresTool(backend, config), new KnowledgeGetTool(backend)];
 
         return Task.FromResult(new AgentToolContribution(tools, [backend]));
     }

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/KnowledgeStoresAndGetToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/KnowledgeStoresAndGetToolTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public sealed class KnowledgeStoresToolTests
+{
+    [Fact]
+    public async Task Execute_ReturnsStoreListWithDescriptions()
+    {
+        var backend = new InMemoryQmdBackend();
+        backend.Stores.Add(new QmdStoreInfo("vault", "/docs/vault", null, 42, DateTimeOffset.UtcNow, true));
+        backend.Stores.Add(new QmdStoreInfo("work", "/docs/work", null, 10, null, true));
+
+        var config = new QmdConfig
+        {
+            Stores =
+            [
+                new QmdStoreConfig { Name = "vault", Path = "/docs/vault", Description = "Personal knowledge vault" },
+                new QmdStoreConfig { Name = "work", Path = "/docs/work", Description = "Work documents" }
+            ]
+        };
+
+        var tool = new KnowledgeStoresTool(backend, config);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>());
+
+        var text = result.Content[0].Value;
+        text.ShouldContain("vault");
+        text.ShouldContain("Personal knowledge vault");
+        text.ShouldContain("42");
+        text.ShouldContain("work");
+        text.ShouldContain("Work documents");
+        text.ShouldContain("knowledge_search");
+    }
+
+    [Fact]
+    public async Task Execute_EmptyStores_ReturnsMessage()
+    {
+        var backend = new InMemoryQmdBackend();
+        var tool = new KnowledgeStoresTool(backend, new QmdConfig());
+
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>());
+
+        result.Content[0].Value.ShouldContain("No knowledge stores");
+    }
+
+    [Fact]
+    public async Task Execute_BackendFailure_ReturnsErrorMessage()
+    {
+        var backend = new FailingQmdBackend();
+        var tool = new KnowledgeStoresTool(backend, new QmdConfig());
+
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>());
+
+        result.Content[0].Value.ShouldContain("Failed to retrieve");
+    }
+
+    [Fact]
+    public async Task Execute_ConfigDescriptionOverridesBackend()
+    {
+        var backend = new InMemoryQmdBackend();
+        backend.Stores.Add(new QmdStoreInfo("notes", "/notes", "Backend description", 5, null, true));
+
+        var config = new QmdConfig
+        {
+            Stores = [new QmdStoreConfig { Name = "notes", Path = "/notes", Description = "Config description" }]
+        };
+
+        var tool = new KnowledgeStoresTool(backend, config);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>());
+
+        result.Content[0].Value.ShouldContain("Config description");
+    }
+}
+
+public sealed class KnowledgeGetToolTests
+{
+    [Fact]
+    public async Task Execute_ReturnsDocument()
+    {
+        var backend = new InMemoryQmdBackend();
+        backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/test.md", "Test Doc", "# Hello\nContent here"));
+
+        var tool = new KnowledgeGetTool(backend);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "doc1" });
+
+        var text = result.Content[0].Value;
+        text.ShouldContain("Test Doc");
+        text.ShouldContain("# Hello");
+        text.ShouldContain("Content here");
+    }
+
+    [Fact]
+    public async Task Execute_NotFound_ReturnsMessage()
+    {
+        var backend = new InMemoryQmdBackend();
+        var tool = new KnowledgeGetTool(backend);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "nonexistent" });
+
+        result.Content[0].Value.ShouldContain("Document not found");
+    }
+
+    [Fact]
+    public async Task Execute_LargeContent_Truncates()
+    {
+        var largeContent = new string('x', 60_000);
+        var backend = new InMemoryQmdBackend();
+        backend.Documents.Add(new QmdDocument("big", "vault", "/vault/big.md", "Big", largeContent));
+
+        var tool = new KnowledgeGetTool(backend);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "big" });
+
+        var text = result.Content[0].Value;
+        text.ShouldContain("[truncated");
+        text.Length.ShouldBeLessThan(55_000); // 50K content + JSON overhead + marker
+    }
+
+    [Fact]
+    public async Task Execute_BackendFailure_ReturnsErrorMessage()
+    {
+        var backend = new FailingQmdBackend();
+        var tool = new KnowledgeGetTool(backend);
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "doc1" });
+
+        result.Content[0].Value.ShouldContain("Failed to retrieve");
+    }
+
+    [Fact]
+    public async Task PrepareArguments_MissingId_Throws()
+    {
+        var backend = new InMemoryQmdBackend();
+        var tool = new KnowledgeGetTool(backend);
+
+        var act = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["id"] = "   " });
+        await act.ShouldThrowAsync<ArgumentException>();
+    }
+}
+
+/// <summary>Test helper that always throws on backend calls.</summary>
+internal sealed class FailingQmdBackend : IQmdBackend
+{
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public Task<QmdSearchResult[]> SearchAsync(string query, string? store, QmdSearchMode mode, int limit, CancellationToken ct) => throw new InvalidOperationException("Backend unavailable");
+    public Task<QmdDocument?> GetDocumentAsync(string id, CancellationToken ct) => throw new InvalidOperationException("Backend unavailable");
+    public Task<QmdStoreInfo[]> GetStoresAsync(CancellationToken ct) => throw new InvalidOperationException("Backend unavailable");
+    public Task UpdateIndexAsync(string? store, CancellationToken ct) => throw new InvalidOperationException("Backend unavailable");
+    public Task EmbedAsync(string? store, CancellationToken ct) => throw new InvalidOperationException("Backend unavailable");
+}


### PR DESCRIPTION
Closes #1174

## Changes
- **KnowledgeStoresTool**: lists available knowledge stores with descriptions enriched from config, document counts, health status, and a usage hint
- **KnowledgeGetTool**: retrieves a specific document by ID with 50K character truncation and clear not-found messaging
- Both tools handle backend failures gracefully (return error messages, not exceptions)
- **QmdToolContributor**: now registers all three QMD tools (search, stores, get)

## Tests
- 9 new tests: store listing, empty stores, config override, document retrieval, not found, truncation, backend failure, argument validation
- All 54 QMD extension tests pass
- Architecture 178 pass

## Merge Notes
Independent of all open PRs. Only touches BotNexus.Extensions.Qmd/ files. Safe to merge in any order.