### PR TITLE
feat(cron): add agent-converse action for scheduled inter-agent conversations

### DIFF
--- a/src/gateway/BotNexus.Cron/Actions/AgentConverseCronAction.cs
+++ b/src/gateway/BotNexus.Cron/Actions/AgentConverseCronAction.cs
@@ -1,0 +1,96 @@
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Cron.Actions;
+
+/// <summary>
+/// Executes a cron job by initiating an agent-to-agent conversation via <see cref="IAgentExchangeService"/>.
+/// Action type: "agent-converse".
+/// </summary>
+/// <remarks>
+/// Configuration is read from <see cref="CronJob.Metadata"/>:
+/// <list type="bullet">
+///   <item><c>targetAgentId</c> (required): the agent to converse with.</item>
+///   <item><c>message</c> (optional, falls back to <see cref="CronJob.Message"/>): opening message.</item>
+///   <item><c>objective</c> (optional): conversation objective.</item>
+///   <item><c>maxTurns</c> (optional, default 5): maximum conversation turns.</item>
+/// </list>
+/// Budget limits from <c>AgentExchangeBudgetTracker</c> apply identically to interactive exchanges.
+/// </remarks>
+public sealed class AgentConverseCronAction : ICronAction
+{
+    /// <summary>Default maximum turns if not specified in job metadata.</summary>
+    internal const int DefaultMaxTurns = 5;
+
+    /// <inheritdoc/>
+    public string ActionType => "agent-converse";
+
+    /// <inheritdoc/>
+    public async Task ExecuteAsync(CronExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var initiatorAgentId = context.Job.AgentId
+            ?? throw new InvalidOperationException(
+                $"Cron job '{context.Job.Id}' has action type 'agent-converse' but AgentId is null.");
+
+        var targetAgentId = ResolveMetadataString(context.Job, "targetAgentId")
+            ?? throw new InvalidOperationException(
+                $"Cron job '{context.Job.Id}' requires 'targetAgentId' in metadata for agent-converse actions.");
+
+        var message = ResolveMetadataString(context.Job, "message") ?? context.Job.Message;
+        if (string.IsNullOrWhiteSpace(message))
+            throw new InvalidOperationException(
+                $"Cron job '{context.Job.Id}' requires a message (in metadata or job Message) for agent-converse actions.");
+
+        var objective = ResolveMetadataString(context.Job, "objective");
+        var maxTurns = ResolveMetadataInt(context.Job, "maxTurns", DefaultMaxTurns);
+
+        var exchangeService = context.Services.GetService<IAgentExchangeService>()
+            ?? throw new InvalidOperationException("IAgentExchangeService is not registered.");
+
+        var logger = context.Services.GetService<ILogger<AgentConverseCronAction>>();
+
+        logger?.LogInformation(
+            "AgentConverseCronAction: job '{JobId}' initiating conversation from '{Initiator}' to '{Target}' (maxTurns={MaxTurns}).",
+            context.Job.Id, initiatorAgentId.Value, targetAgentId, maxTurns);
+
+        var request = new AgentExchangeRequest
+        {
+            InitiatorId = initiatorAgentId,
+            TargetId = AgentId.From(targetAgentId),
+            Message = message,
+            Objective = objective,
+            MaxTurns = maxTurns,
+            CallChain = [initiatorAgentId]
+        };
+
+        var result = await exchangeService.ConverseAsync(request, cancellationToken).ConfigureAwait(false);
+
+        logger?.LogInformation(
+            "AgentConverseCronAction: job '{JobId}' completed. Status={Status}, Turns={Turns}.",
+            context.Job.Id, result.Status, result.Turns);
+    }
+
+    private static string? ResolveMetadataString(CronJob job, string key)
+    {
+        if (job.Metadata is null) return null;
+        if (!job.Metadata.TryGetValue(key, out var value)) return null;
+        return value switch
+        {
+            string s => s,
+            System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String } el => el.GetString(),
+            _ => value?.ToString()
+        };
+    }
+
+    private static int ResolveMetadataInt(CronJob job, string key, int defaultValue)
+    {
+        var raw = ResolveMetadataString(job, key);
+        if (raw is null) return defaultValue;
+        return int.TryParse(raw, out var parsed) ? parsed : defaultValue;
+    }
+}

--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -20,7 +20,8 @@
     <Compile Include="Prompts\CronOptionsPromptTemplateResolver.cs" />
     <Compile Include="Prompts\PromptTemplateRenderer.cs" />
     <Compile Include="Actions\CommandCronAction.cs" />
-    <Compile Include="Actions\MemoryDreamingCronAction.cs" />
+    <Compile Include="Actions\AgentConverseCronAction.cs" />
+     <Compile Include="Actions\MemoryDreamingCronAction.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="Actions\HeartbeatAction.cs" />
     <Compile Include="Actions\TimeZoneHelper.cs" />

--- a/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Cron/Extensions/CronServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class CronServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, WebhookAction>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, CommandCronAction>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, MemoryDreamingCronAction>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ICronAction, AgentConverseCronAction>());
         services.TryAddSingleton<IPromptTemplateResolver, CronOptionsPromptTemplateResolver>();
         services.AddOptions<CronRunRetentionOptions>();
         services.AddSingleton<IHostedService, CronRunRetentionHostedService>();

--- a/tests/gateway/BotNexus.Cron.Tests/Actions/AgentConverseCronActionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/Actions/AgentConverseCronActionTests.cs
@@ -1,0 +1,168 @@
+using BotNexus.Cron;
+using BotNexus.Cron.Actions;
+using BotNexus.Domain.AgentExchange;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BotNexus.Cron.Tests.Actions;
+
+public sealed class AgentConverseCronActionTests
+{
+    private readonly AgentConverseCronAction _action = new();
+
+    [Fact]
+    public void ActionType_ReturnsAgentConverse()
+    {
+        _action.ActionType.ShouldBe("agent-converse");
+    }
+
+    [Fact]
+    public async Task Execute_WithValidConfig_CallsConverseAsync()
+    {
+        var mockExchange = new Mock<IAgentExchangeService>();
+        mockExchange.Setup(x => x.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentExchangeResult { SessionId = SessionId.From("s1"), ConversationId = ConversationId.From("c1"), Status = "completed", Turns = 1, FinalResponse = "Done" });
+
+        var services = new ServiceCollection()
+            .AddSingleton(mockExchange.Object)
+            .AddSingleton<ILogger<AgentConverseCronAction>>(new Mock<ILogger<AgentConverseCronAction>>().Object)
+            .BuildServiceProvider();
+
+        var job = CreateJob("test-agent", metadata: new Dictionary<string, object?>
+        {
+            ["targetAgentId"] = "target-agent",
+            ["message"] = "Hello!",
+            ["objective"] = "Daily sync",
+            ["maxTurns"] = "3"
+        });
+
+        var context = CreateContext(job, services);
+        await _action.ExecuteAsync(context);
+
+        mockExchange.Verify(x => x.ConverseAsync(
+            It.Is<AgentExchangeRequest>(r =>
+                r.InitiatorId == AgentId.From("test-agent") &&
+                r.TargetId == AgentId.From("target-agent") &&
+                r.Message == "Hello!" &&
+                r.Objective == "Daily sync" &&
+                r.MaxTurns == 3),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_FallsBackToJobMessage_WhenMetadataMessageMissing()
+    {
+        var mockExchange = new Mock<IAgentExchangeService>();
+        mockExchange.Setup(x => x.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentExchangeResult { SessionId = SessionId.From("s1"), ConversationId = ConversationId.From("c1"), Status = "completed", Turns = 1, FinalResponse = "Done" });
+
+        var services = new ServiceCollection()
+            .AddSingleton(mockExchange.Object)
+            .BuildServiceProvider();
+
+        var job = CreateJob("initiator", message: "Fallback message", metadata: new Dictionary<string, object?>
+        {
+            ["targetAgentId"] = "target"
+        });
+
+        var context = CreateContext(job, services);
+        await _action.ExecuteAsync(context);
+
+        mockExchange.Verify(x => x.ConverseAsync(
+            It.Is<AgentExchangeRequest>(r => r.Message == "Fallback message"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_UsesDefaultMaxTurns_WhenNotSpecified()
+    {
+        var mockExchange = new Mock<IAgentExchangeService>();
+        mockExchange.Setup(x => x.ConverseAsync(It.IsAny<AgentExchangeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentExchangeResult { SessionId = SessionId.From("s1"), ConversationId = ConversationId.From("c1"), Status = "completed", Turns = 1, FinalResponse = "Done" });
+
+        var services = new ServiceCollection()
+            .AddSingleton(mockExchange.Object)
+            .BuildServiceProvider();
+
+        var job = CreateJob("initiator", message: "Hi", metadata: new Dictionary<string, object?>
+        {
+            ["targetAgentId"] = "target"
+        });
+
+        var context = CreateContext(job, services);
+        await _action.ExecuteAsync(context);
+
+        mockExchange.Verify(x => x.ConverseAsync(
+            It.Is<AgentExchangeRequest>(r => r.MaxTurns == AgentConverseCronAction.DefaultMaxTurns),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_ThrowsWhenAgentIdMissing()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var job = CreateJob(null, metadata: new Dictionary<string, object?> { ["targetAgentId"] = "t" });
+        var context = CreateContext(job, services);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => _action.ExecuteAsync(context));
+    }
+
+    [Fact]
+    public async Task Execute_ThrowsWhenTargetAgentIdMissing()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var job = CreateJob("initiator", message: "Hi", metadata: new Dictionary<string, object?>());
+        var context = CreateContext(job, services);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => _action.ExecuteAsync(context));
+    }
+
+    [Fact]
+    public async Task Execute_ThrowsWhenNoMessageAvailable()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var job = CreateJob("initiator", metadata: new Dictionary<string, object?> { ["targetAgentId"] = "t" });
+        var context = CreateContext(job, services);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => _action.ExecuteAsync(context));
+    }
+
+    [Fact]
+    public async Task Execute_ThrowsWhenExchangeServiceNotRegistered()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var job = CreateJob("initiator", message: "Hi", metadata: new Dictionary<string, object?>
+        {
+            ["targetAgentId"] = "target"
+        });
+        var context = CreateContext(job, services);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => _action.ExecuteAsync(context));
+    }
+
+    private static CronJob CreateJob(string? agentId, string? message = null, Dictionary<string, object?>? metadata = null)
+        => new()
+        {
+            Id = JobId.From("test-job-1"),
+            Name = "Test Converse Job",
+            AgentId = agentId is null ? null : AgentId.From(agentId),
+            Schedule = "0 9 * * 1-5",
+            ActionType = "agent-converse",
+            Message = message,
+            Metadata = metadata
+        };
+
+    private static CronExecutionContext CreateContext(CronJob job, IServiceProvider services)
+        => new()
+        {
+            Job = job,
+            RunId = RunId.From("run-1"),
+            TriggeredAt = DateTimeOffset.UtcNow,
+            TriggerType = CronTriggerType.Manual,
+            Services = services
+        };
+}


### PR DESCRIPTION
Closes #1249

## Changes
- New AgentConverseCronAction (action type: gent-converse) that initiates agent-to-agent conversations via IAgentExchangeService.ConverseAsync
- Configuration via job metadata: 	argetAgentId (required), message (optional, falls back to job Message), objective (optional), maxTurns (optional, default 5)
- Budget limits enforced (same as interactive exchanges)
- Registered in DI via CronServiceCollectionExtensions
- 7 unit tests covering happy path, fallback, defaults, and error cases

## Merge Notes
Touches only BotNexus.Cron project (action + DI registration + csproj). No overlap with any open PR.