### PR TITLE
feat(memory): add learning extraction pipeline with turn classification and knowledge routing

### DIFF
--- a/src/gateway/BotNexus.Memory/Learning/KnowledgeRouter.cs
+++ b/src/gateway/BotNexus.Memory/Learning/KnowledgeRouter.cs
@@ -1,0 +1,53 @@
+namespace BotNexus.Memory.Learning;
+
+/// <summary>
+/// Applies routing rules to determine which shared store (if any) an extracted
+/// piece of knowledge should be promoted to.
+/// </summary>
+public sealed class KnowledgeRouter
+{
+    private readonly IReadOnlyList<KnowledgeRoutingRule> _rules;
+
+    public KnowledgeRouter(IReadOnlyList<KnowledgeRoutingRule> rules)
+    {
+        _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+    }
+
+    /// <summary>
+    /// Determines the target shared store for a piece of extracted knowledge.
+    /// Returns null if no rule matches (knowledge stays in agent-private store).
+    /// </summary>
+    public string? Route(ExtractedKnowledge knowledge)
+    {
+        ArgumentNullException.ThrowIfNull(knowledge);
+
+        foreach (var rule in _rules)
+        {
+            if (rule.Category.HasValue && rule.Category.Value != knowledge.Category)
+                continue;
+
+            if (knowledge.Confidence < rule.MinConfidence)
+                continue;
+
+            return rule.TargetStore;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Routes multiple knowledge items and returns them with their resolved target stores.
+    /// Items that don't match any rule retain their original TargetStore (null = private).
+    /// </summary>
+    public IReadOnlyList<ExtractedKnowledge> RouteAll(IEnumerable<ExtractedKnowledge> items)
+    {
+        var results = new List<ExtractedKnowledge>();
+        foreach (var item in items)
+        {
+            var target = Route(item);
+            results.Add(target is not null ? item with { TargetStore = target } : item);
+        }
+
+        return results;
+    }
+}

--- a/src/gateway/BotNexus.Memory/Learning/LearningExtractionPipeline.cs
+++ b/src/gateway/BotNexus.Memory/Learning/LearningExtractionPipeline.cs
@@ -1,0 +1,101 @@
+using BotNexus.Memory.Models;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Memory.Learning;
+
+/// <summary>
+/// Extracts durable knowledge from indexed memory entries using the turn classifier
+/// and routes results to appropriate stores via routing rules.
+/// Integrates with the dreaming cron infrastructure for batch processing.
+/// </summary>
+public sealed class LearningExtractionPipeline
+{
+    private readonly IReadOnlyList<KnowledgeRoutingRule> _routingRules;
+    private readonly ILogger _logger;
+
+    public LearningExtractionPipeline(
+        IReadOnlyList<KnowledgeRoutingRule> routingRules,
+        ILogger logger)
+    {
+        _routingRules = routingRules ?? throw new ArgumentNullException(nameof(routingRules));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Processes memory entries from a session, classifying each turn pair and extracting
+    /// durable knowledge. Returns extracted items with routing decisions applied.
+    /// </summary>
+    /// <param name="entries">Memory entries to process (typically from a single session).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of extracted knowledge items with routing decisions.</returns>
+    public Task<IReadOnlyList<ExtractedKnowledge>> ExtractAsync(
+        IReadOnlyList<MemoryEntry> entries,
+        CancellationToken ct = default)
+    {
+        var extracted = new List<ExtractedKnowledge>();
+        var router = new KnowledgeRouter(_routingRules);
+
+        foreach (var entry in entries)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (entry.SourceType != "conversation")
+                continue;
+
+            // Parse user/assistant from the stored format "User: ...\nAssistant: ..."
+            if (!TryParseConversationEntry(entry.Content, out var userContent, out var assistantContent))
+                continue;
+
+            var classification = TurnClassifier.Classify(userContent, assistantContent);
+
+            if (!classification.IsDurable || classification.Category is null)
+                continue;
+
+            var knowledge = new ExtractedKnowledge
+            {
+                Content = assistantContent,
+                Category = classification.Category.Value,
+                Confidence = classification.Confidence,
+                SourceSessionId = entry.SessionId ?? string.Empty,
+                SourceTurnIndex = entry.TurnIndex ?? 0,
+                TargetStore = null,
+            };
+
+            extracted.Add(knowledge);
+        }
+
+        // Apply routing rules
+        var routed = router.RouteAll(extracted);
+
+        _logger.LogInformation(
+            "Learning extraction: {TotalEntries} entries processed, {DurableCount} durable items extracted, {RoutedCount} routed to shared stores.",
+            entries.Count,
+            routed.Count,
+            routed.Count(k => k.TargetStore is not null));
+
+        return Task.FromResult(routed);
+    }
+
+    /// <summary>
+    /// Parses the "User: ...\nAssistant: ..." format stored by MemoryIndexer.
+    /// </summary>
+    internal static bool TryParseConversationEntry(string content, out string userContent, out string assistantContent)
+    {
+        userContent = string.Empty;
+        assistantContent = string.Empty;
+
+        const string userPrefix = "User: ";
+        const string assistantPrefix = "\nAssistant: ";
+
+        if (!content.StartsWith(userPrefix, StringComparison.Ordinal))
+            return false;
+
+        var assistantIndex = content.IndexOf(assistantPrefix, StringComparison.Ordinal);
+        if (assistantIndex < 0)
+            return false;
+
+        userContent = content[userPrefix.Length..assistantIndex];
+        assistantContent = content[(assistantIndex + assistantPrefix.Length)..];
+        return true;
+    }
+}

--- a/src/gateway/BotNexus.Memory/Learning/LearningModels.cs
+++ b/src/gateway/BotNexus.Memory/Learning/LearningModels.cs
@@ -1,0 +1,52 @@
+using BotNexus.Memory.Models;
+
+namespace BotNexus.Memory.Learning;
+
+/// <summary>
+/// Categories for classifying durable knowledge extracted from conversations.
+/// </summary>
+public enum KnowledgeCategory
+{
+    Decision,
+    Pattern,
+    Fact,
+    Procedure,
+    Preference,
+}
+
+/// <summary>
+/// Result of classifying a conversation turn pair as transient or durable.
+/// </summary>
+public sealed record ClassificationResult(
+    bool IsDurable,
+    KnowledgeCategory? Category,
+    double Confidence);
+
+/// <summary>
+/// Extracted knowledge from a durable conversation turn.
+/// </summary>
+public sealed record ExtractedKnowledge
+{
+    public required string Content { get; init; }
+    public required KnowledgeCategory Category { get; init; }
+    public required double Confidence { get; init; }
+    public required string SourceSessionId { get; init; }
+    public required int SourceTurnIndex { get; init; }
+    public string? TargetStore { get; init; }
+}
+
+/// <summary>
+/// A routing rule that determines whether extracted knowledge should be promoted
+/// to a shared store based on category and confidence threshold.
+/// </summary>
+public sealed record KnowledgeRoutingRule
+{
+    /// <summary>Category to match. Null means match all categories.</summary>
+    public KnowledgeCategory? Category { get; init; }
+
+    /// <summary>Minimum confidence score required for promotion (0.0–1.0).</summary>
+    public double MinConfidence { get; init; } = 0.7;
+
+    /// <summary>Target shared store name to promote to.</summary>
+    public required string TargetStore { get; init; }
+}

--- a/src/gateway/BotNexus.Memory/Learning/TurnClassifier.cs
+++ b/src/gateway/BotNexus.Memory/Learning/TurnClassifier.cs
@@ -1,0 +1,113 @@
+using System.Text.RegularExpressions;
+
+namespace BotNexus.Memory.Learning;
+
+/// <summary>
+/// Heuristic classifier that determines whether a conversation turn pair
+/// contains durable (reusable) knowledge or is transient small-talk.
+/// Uses keyword detection, length thresholds, and structural patterns.
+/// </summary>
+public static class TurnClassifier
+{
+    private const int MinContentLengthForDurable = 100;
+    private const int StrongContentLengthThreshold = 300;
+
+    private static readonly (Regex Pattern, KnowledgeCategory Category, double Weight)[] CategoryPatterns =
+    [
+        // Decisions
+        (new Regex(@"\b(decided|decision|chose|choosing|went with|settled on|agreed|approved)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Decision, 0.4),
+        (new Regex(@"\b(we('ll| will| should)|going (to|with)|the plan is)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Decision, 0.3),
+
+        // Patterns
+        (new Regex(@"\b(pattern|convention|always|never|rule|standard|best practice|guideline)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Pattern, 0.4),
+        (new Regex(@"\b(whenever|every time|consistently|typical(ly)?)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Pattern, 0.3),
+
+        // Facts
+        (new Regex(@"\b(is located at|lives in|uses|version|configured|installed|runs on|deployed)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Fact, 0.3),
+        (new Regex(@"\b(the (path|url|endpoint|port|address) is|found at)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Fact, 0.4),
+
+        // Procedures
+        (new Regex(@"\b(step \d|first[,.]|then[,.]|finally[,.]|to do this|how to|instructions|workflow)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Procedure, 0.4),
+        (new Regex(@"\b(run|execute|invoke|call|use the command)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Procedure, 0.2),
+
+        // Preferences
+        (new Regex(@"\b(prefer|like|don't like|rather|favorite|avoid|instead of)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Preference, 0.4),
+        (new Regex(@"\b(style|format|tone|approach|way I)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), KnowledgeCategory.Preference, 0.3),
+    ];
+
+    private static readonly Regex TransientPatterns = new(
+        @"\b(hello|hi|hey|thanks|thank you|ok|okay|sure|got it|sounds good|no problem|bye|goodbye|good morning|good night)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex QuestionOnlyPattern = new(
+        @"^\s*\??\s*$|^[^.!]*\?\s*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Classifies a user+assistant turn pair as transient or durable.
+    /// </summary>
+    /// <param name="userContent">The user's message content.</param>
+    /// <param name="assistantContent">The assistant's response content.</param>
+    /// <returns>Classification result with durability, category, and confidence.</returns>
+    public static ClassificationResult Classify(string userContent, string assistantContent)
+    {
+        ArgumentNullException.ThrowIfNull(userContent);
+        ArgumentNullException.ThrowIfNull(assistantContent);
+
+        var combinedContent = $"{userContent}\n{assistantContent}";
+        var totalLength = combinedContent.Length;
+
+        // Short exchanges are almost always transient
+        if (totalLength < MinContentLengthForDurable)
+        {
+            return new ClassificationResult(false, null, 0.9);
+        }
+
+        // Pure greetings/acknowledgements are transient
+        if (IsTransientExchange(userContent, assistantContent))
+        {
+            return new ClassificationResult(false, null, 0.85);
+        }
+
+        // Score each category
+        var categoryScores = new Dictionary<KnowledgeCategory, double>();
+        foreach (var (pattern, category, weight) in CategoryPatterns)
+        {
+            var matches = pattern.Matches(combinedContent);
+            if (matches.Count > 0)
+            {
+                var score = Math.Min(1.0, matches.Count * weight);
+                if (!categoryScores.TryGetValue(category, out var existing) || score > existing)
+                {
+                    categoryScores[category] = score;
+                }
+            }
+        }
+
+        if (categoryScores.Count == 0)
+        {
+            // No category signals but content is long enough — might still be durable
+            if (totalLength >= StrongContentLengthThreshold)
+            {
+                return new ClassificationResult(true, null, 0.4);
+            }
+
+            return new ClassificationResult(false, null, 0.6);
+        }
+
+        // Pick highest-scoring category
+        var bestCategory = categoryScores.MaxBy(kvp => kvp.Value);
+        var confidence = Math.Min(0.95, bestCategory.Value + (totalLength >= StrongContentLengthThreshold ? 0.2 : 0.0));
+
+        return new ClassificationResult(true, bestCategory.Key, confidence);
+    }
+
+    private static bool IsTransientExchange(string userContent, string assistantContent)
+    {
+        // If both user and assistant messages are short greetings/acks
+        var userIsTransient = TransientPatterns.IsMatch(userContent) && userContent.Length < 50;
+        var assistantIsTransient = TransientPatterns.IsMatch(assistantContent) && assistantContent.Length < 80;
+
+        return userIsTransient && assistantIsTransient;
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/Learning/KnowledgeRouterTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Learning/KnowledgeRouterTests.cs
@@ -1,0 +1,139 @@
+using BotNexus.Memory.Learning;
+
+namespace BotNexus.Memory.Tests.Learning;
+
+public sealed class KnowledgeRouterTests
+{
+    [Fact]
+    public void Route_MatchingCategoryAndConfidence_ReturnsTargetStore()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = KnowledgeCategory.Decision, MinConfidence = 0.6, TargetStore = "platform-decisions" },
+        };
+        var router = new KnowledgeRouter(rules);
+
+        var knowledge = new ExtractedKnowledge
+        {
+            Content = "We decided X",
+            Category = KnowledgeCategory.Decision,
+            Confidence = 0.8,
+            SourceSessionId = "s1",
+            SourceTurnIndex = 0,
+        };
+
+        Assert.Equal("platform-decisions", router.Route(knowledge));
+    }
+
+    [Fact]
+    public void Route_ConfidenceBelowThreshold_ReturnsNull()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = KnowledgeCategory.Decision, MinConfidence = 0.9, TargetStore = "decisions" },
+        };
+        var router = new KnowledgeRouter(rules);
+
+        var knowledge = new ExtractedKnowledge
+        {
+            Content = "We decided X",
+            Category = KnowledgeCategory.Decision,
+            Confidence = 0.7,
+            SourceSessionId = "s1",
+            SourceTurnIndex = 0,
+        };
+
+        Assert.Null(router.Route(knowledge));
+    }
+
+    [Fact]
+    public void Route_WrongCategory_ReturnsNull()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = KnowledgeCategory.Decision, MinConfidence = 0.5, TargetStore = "decisions" },
+        };
+        var router = new KnowledgeRouter(rules);
+
+        var knowledge = new ExtractedKnowledge
+        {
+            Content = "The path is /usr/local",
+            Category = KnowledgeCategory.Fact,
+            Confidence = 0.8,
+            SourceSessionId = "s1",
+            SourceTurnIndex = 0,
+        };
+
+        Assert.Null(router.Route(knowledge));
+    }
+
+    [Fact]
+    public void Route_NullCategoryRule_MatchesAnyCategory()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = null, MinConfidence = 0.5, TargetStore = "catch-all" },
+        };
+        var router = new KnowledgeRouter(rules);
+
+        var knowledge = new ExtractedKnowledge
+        {
+            Content = "Something",
+            Category = KnowledgeCategory.Pattern,
+            Confidence = 0.7,
+            SourceSessionId = "s1",
+            SourceTurnIndex = 0,
+        };
+
+        Assert.Equal("catch-all", router.Route(knowledge));
+    }
+
+    [Fact]
+    public void Route_FirstMatchingRuleWins()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = KnowledgeCategory.Decision, MinConfidence = 0.5, TargetStore = "first" },
+            new() { Category = null, MinConfidence = 0.3, TargetStore = "second" },
+        };
+        var router = new KnowledgeRouter(rules);
+
+        var knowledge = new ExtractedKnowledge
+        {
+            Content = "Decided",
+            Category = KnowledgeCategory.Decision,
+            Confidence = 0.6,
+            SourceSessionId = "s1",
+            SourceTurnIndex = 0,
+        };
+
+        Assert.Equal("first", router.Route(knowledge));
+    }
+
+    [Fact]
+    public void RouteAll_AppliesRoutingToAllItems()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = KnowledgeCategory.Decision, MinConfidence = 0.5, TargetStore = "decisions" },
+        };
+        var router = new KnowledgeRouter(rules);
+
+        var items = new[]
+        {
+            new ExtractedKnowledge { Content = "A", Category = KnowledgeCategory.Decision, Confidence = 0.8, SourceSessionId = "s1", SourceTurnIndex = 0 },
+            new ExtractedKnowledge { Content = "B", Category = KnowledgeCategory.Fact, Confidence = 0.8, SourceSessionId = "s1", SourceTurnIndex = 1 },
+        };
+
+        var results = router.RouteAll(items);
+        Assert.Equal("decisions", results[0].TargetStore);
+        Assert.Null(results[1].TargetStore);
+    }
+
+    [Fact]
+    public void Route_NullKnowledge_ThrowsArgumentNullException()
+    {
+        var router = new KnowledgeRouter([]);
+        Assert.Throws<ArgumentNullException>(() => router.Route(null!));
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/Learning/LearningExtractionPipelineTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Learning/LearningExtractionPipelineTests.cs
@@ -1,0 +1,142 @@
+using BotNexus.Memory.Learning;
+using BotNexus.Memory.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Memory.Tests.Learning;
+
+public sealed class LearningExtractionPipelineTests
+{
+    private static LearningExtractionPipeline CreatePipeline(IReadOnlyList<KnowledgeRoutingRule>? rules = null)
+        => new(rules ?? [], NullLogger.Instance);
+
+    [Fact]
+    public async Task ExtractAsync_ConversationEntry_ExtractsDurableKnowledge()
+    {
+        var pipeline = CreatePipeline();
+        var entries = new List<MemoryEntry>
+        {
+            new()
+            {
+                Id = "1",
+                AgentId = "agent1",
+                SessionId = "session1",
+                TurnIndex = 0,
+                SourceType = "conversation",
+                Content = "User: Should we use PostgreSQL or SQLite?\nAssistant: We decided to go with SQLite because it requires no external dependencies and performs well for our use case.",
+                CreatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+
+        var results = await pipeline.ExtractAsync(entries);
+
+        Assert.Single(results);
+        Assert.Equal(KnowledgeCategory.Decision, results[0].Category);
+        Assert.Equal("session1", results[0].SourceSessionId);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TransientEntry_ReturnsEmpty()
+    {
+        var pipeline = CreatePipeline();
+        var entries = new List<MemoryEntry>
+        {
+            new()
+            {
+                Id = "1",
+                AgentId = "agent1",
+                SessionId = "session1",
+                TurnIndex = 0,
+                SourceType = "conversation",
+                Content = "User: hi\nAssistant: hello!",
+                CreatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+
+        var results = await pipeline.ExtractAsync(entries);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NonConversationEntry_Skipped()
+    {
+        var pipeline = CreatePipeline();
+        var entries = new List<MemoryEntry>
+        {
+            new()
+            {
+                Id = "1",
+                AgentId = "agent1",
+                SourceType = "dreaming",
+                Content = "Some consolidated note",
+                CreatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+
+        var results = await pipeline.ExtractAsync(entries);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WithRoutingRules_AppliesRouting()
+    {
+        var rules = new List<KnowledgeRoutingRule>
+        {
+            new() { Category = KnowledgeCategory.Decision, MinConfidence = 0.3, TargetStore = "platform-decisions" },
+        };
+        var pipeline = CreatePipeline(rules);
+
+        var entries = new List<MemoryEntry>
+        {
+            new()
+            {
+                Id = "1",
+                AgentId = "agent1",
+                SessionId = "s1",
+                TurnIndex = 0,
+                SourceType = "conversation",
+                Content = "User: What database should we use?\nAssistant: We decided to use SQLite for the store because it is lightweight and requires no setup.",
+                CreatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+
+        var results = await pipeline.ExtractAsync(entries);
+
+        Assert.Single(results);
+        Assert.Equal("platform-decisions", results[0].TargetStore);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MalformedContent_Skipped()
+    {
+        var pipeline = CreatePipeline();
+        var entries = new List<MemoryEntry>
+        {
+            new()
+            {
+                Id = "1",
+                AgentId = "agent1",
+                SourceType = "conversation",
+                Content = "This is not in the expected format at all",
+                CreatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+
+        var results = await pipeline.ExtractAsync(entries);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void TryParseConversationEntry_ValidFormat_ReturnsTrueAndParts()
+    {
+        var content = "User: Hello world\nAssistant: Hi there";
+        Assert.True(LearningExtractionPipeline.TryParseConversationEntry(content, out var user, out var assistant));
+        Assert.Equal("Hello world", user);
+        Assert.Equal("Hi there", assistant);
+    }
+
+    [Fact]
+    public void TryParseConversationEntry_InvalidFormat_ReturnsFalse()
+    {
+        Assert.False(LearningExtractionPipeline.TryParseConversationEntry("random text", out _, out _));
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/Learning/TurnClassifierTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Learning/TurnClassifierTests.cs
@@ -1,0 +1,107 @@
+using BotNexus.Memory.Learning;
+
+namespace BotNexus.Memory.Tests.Learning;
+
+public sealed class TurnClassifierTests
+{
+    [Fact]
+    public void Classify_ShortGreeting_ReturnsTransient()
+    {
+        var result = TurnClassifier.Classify("hi", "hello! how can I help?");
+        Assert.False(result.IsDurable);
+        Assert.Null(result.Category);
+    }
+
+    [Fact]
+    public void Classify_ShortExchange_ReturnsTransient()
+    {
+        var result = TurnClassifier.Classify("ok", "got it");
+        Assert.False(result.IsDurable);
+        Assert.Null(result.Category);
+    }
+
+    [Fact]
+    public void Classify_DecisionContent_ReturnsDurableDecision()
+    {
+        var user = "Should we use PostgreSQL or SQLite for the session store?";
+        var assistant = "We decided to go with SQLite for the session store because it requires no external dependencies and performs well for single-node deployments. This decision means we trade off horizontal scaling.";
+
+        var result = TurnClassifier.Classify(user, assistant);
+
+        Assert.True(result.IsDurable);
+        Assert.Equal(KnowledgeCategory.Decision, result.Category);
+        Assert.True(result.Confidence > 0.3);
+    }
+
+    [Fact]
+    public void Classify_PatternContent_ReturnsDurablePattern()
+    {
+        var user = "What's the convention for branch names?";
+        var assistant = "The standard convention is to always use feat/<slug> or fix/<slug> for branch naming. We never put issue numbers in branch names. This pattern applies consistently across all repos.";
+
+        var result = TurnClassifier.Classify(user, assistant);
+
+        Assert.True(result.IsDurable);
+        Assert.Equal(KnowledgeCategory.Pattern, result.Category);
+    }
+
+    [Fact]
+    public void Classify_FactContent_ReturnsDurableFact()
+    {
+        var user = "Where is the BotNexus config file?";
+        var assistant = "The config file is located at ~/.botnexus/config.json. This is the only platform config file. Agent descriptors live at ~/.botnexus/agents/{id}.json and workspaces at ~/.botnexus/agents/{id}/workspace/.";
+
+        var result = TurnClassifier.Classify(user, assistant);
+
+        Assert.True(result.IsDurable);
+        Assert.Equal(KnowledgeCategory.Fact, result.Category);
+    }
+
+    [Fact]
+    public void Classify_ProcedureContent_ReturnsDurableProcedure()
+    {
+        var user = "How do I deploy a new version?";
+        var assistant = "To do this, first run the build script. Then execute dotnet publish to create the artifacts. Finally, use the deploy command to push to production. Step 1 generates the binaries, step 2 packages them.";
+
+        var result = TurnClassifier.Classify(user, assistant);
+
+        Assert.True(result.IsDurable);
+        Assert.Equal(KnowledgeCategory.Procedure, result.Category);
+    }
+
+    [Fact]
+    public void Classify_PreferenceContent_ReturnsDurablePreference()
+    {
+        var user = "How should status updates look?";
+        var assistant = "I prefer bullet points over paragraphs for status updates. I'd rather have terse, direct communication instead of verbose explanations. Avoid long-winded summaries.";
+
+        var result = TurnClassifier.Classify(user, assistant);
+
+        Assert.True(result.IsDurable);
+        Assert.Equal(KnowledgeCategory.Preference, result.Category);
+    }
+
+    [Fact]
+    public void Classify_LongContentNoKeywords_ReturnsDurableWithLowConfidence()
+    {
+        var user = "Tell me about the architecture of the system and how all the pieces connect together in detail.";
+        var assistant = new string('x', 250); // Long but no keywords
+
+        var result = TurnClassifier.Classify(user, assistant);
+
+        Assert.True(result.IsDurable);
+        Assert.True(result.Confidence <= 0.5);
+    }
+
+    [Fact]
+    public void Classify_NullUserContent_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => TurnClassifier.Classify(null!, "response"));
+    }
+
+    [Fact]
+    public void Classify_NullAssistantContent_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => TurnClassifier.Classify("question", null!));
+    }
+}


### PR DESCRIPTION
Closes #1204

## Changes
- Add TurnClassifier with keyword/length heuristics to classify conversation turns as transient or durable
- Add KnowledgeCategory enum: Decision, Pattern, Fact, Procedure, Preference
- Add KnowledgeRouter with configurable routing rules for shared store promotion
- Add LearningExtractionPipeline that processes indexed memory entries and applies classification + routing
- 24 new tests (10 classifier, 7 router, 7 pipeline)

## Merge Notes
Self-contained in src/gateway/BotNexus.Memory/Learning/ — no overlap with any open PR. Safe to merge in any order.