### PR TITLE
feat(skills): add SHA-256 trust catalog verification for skill script integrity

### DIFF
--- a/src/extensions/BotNexus.Extensions.Skills/Security/SkillTrustVerifier.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/Security/SkillTrustVerifier.cs
@@ -1,0 +1,223 @@
+using System.IO.Abstractions;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Extensions.Skills.Security;
+
+/// <summary>
+/// Trust verification mode for skill scripts.
+/// </summary>
+public enum SkillTrustMode
+{
+    /// <summary>No trust verification — all skills are allowed (legacy behavior).</summary>
+    Disabled,
+
+    /// <summary>Log a warning when trust verification fails, but allow execution.</summary>
+    Warn,
+
+    /// <summary>Block execution of skills that fail trust verification.</summary>
+    Enforce,
+}
+
+/// <summary>
+/// A trust catalog entry representing the expected SHA-256 hash of a skill file.
+/// </summary>
+public sealed record TrustCatalogEntry
+{
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    [JsonPropertyName("sha256")]
+    public required string Sha256 { get; init; }
+
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>
+/// The trust catalog file format: a manifest of expected file hashes for a skill.
+/// Stored as trust.json in the skill root directory.
+/// </summary>
+public sealed record TrustCatalog
+{
+    [JsonPropertyName("version")]
+    public int Version { get; init; } = 1;
+
+    [JsonPropertyName("generatedAt")]
+    public DateTimeOffset GeneratedAt { get; init; }
+
+    [JsonPropertyName("entries")]
+    public IReadOnlyList<TrustCatalogEntry> Entries { get; init; } = [];
+}
+
+/// <summary>
+/// Result of verifying a skill against its trust catalog.
+/// </summary>
+public sealed record TrustVerificationResult(
+    bool Trusted,
+    IReadOnlyList<string> Violations);
+
+/// <summary>
+/// Verifies skill script integrity using SHA-256 hash catalogs.
+/// Skills with a trust.json catalog are verified; skills without one are
+/// treated according to the configured trust mode.
+/// </summary>
+public static class SkillTrustVerifier
+{
+    public const string CatalogFileName = "trust.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    /// <summary>
+    /// Verifies a skill directory against its trust catalog.
+    /// Returns a result indicating whether the skill is trusted.
+    /// </summary>
+    /// <param name="skillDir">Absolute path to the skill directory.</param>
+    /// <param name="fileSystem">File system abstraction.</param>
+    /// <returns>Verification result with any violations found.</returns>
+    public static TrustVerificationResult Verify(string skillDir, IFileSystem? fileSystem = null)
+    {
+        var fs = fileSystem ?? new FileSystem();
+        var catalogPath = fs.Path.Combine(skillDir, CatalogFileName);
+
+        if (!fs.File.Exists(catalogPath))
+        {
+            // No catalog = no verification possible — caller decides based on trust mode
+            return new TrustVerificationResult(false, ["No trust catalog found"]);
+        }
+
+        TrustCatalog? catalog;
+        try
+        {
+            var json = fs.File.ReadAllText(catalogPath);
+            catalog = JsonSerializer.Deserialize<TrustCatalog>(json, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            return new TrustVerificationResult(false, [$"Failed to parse trust catalog: {ex.Message}"]);
+        }
+
+        if (catalog is null || catalog.Entries.Count == 0)
+        {
+            return new TrustVerificationResult(false, ["Trust catalog is empty or invalid"]);
+        }
+
+        var violations = new List<string>();
+
+        foreach (var entry in catalog.Entries)
+        {
+            var filePath = fs.Path.Combine(skillDir, entry.Path.Replace('/', fs.Path.DirectorySeparatorChar));
+
+            if (!fs.File.Exists(filePath))
+            {
+                violations.Add($"Missing file: {entry.Path}");
+                continue;
+            }
+
+            var fileBytes = fs.File.ReadAllBytes(filePath);
+            var actualHash = ComputeSha256(fileBytes);
+
+            if (!string.Equals(actualHash, entry.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                violations.Add($"Hash mismatch: {entry.Path} (expected {entry.Sha256[..12]}..., got {actualHash[..12]}...)");
+            }
+        }
+
+        return new TrustVerificationResult(violations.Count == 0, violations);
+    }
+
+    /// <summary>
+    /// Generates a trust catalog for a skill directory by hashing all scannable files.
+    /// </summary>
+    /// <param name="skillDir">Absolute path to the skill directory.</param>
+    /// <param name="fileSystem">File system abstraction.</param>
+    /// <returns>A new trust catalog covering all script files in the skill.</returns>
+    public static TrustCatalog GenerateCatalog(string skillDir, IFileSystem? fileSystem = null)
+    {
+        var fs = fileSystem ?? new FileSystem();
+        var entries = new List<TrustCatalogEntry>();
+        var now = DateTimeOffset.UtcNow;
+
+        if (!fs.Directory.Exists(skillDir))
+            return new TrustCatalog { GeneratedAt = now, Entries = entries };
+
+        var files = CollectTrustableFiles(skillDir, fs);
+
+        foreach (var file in files)
+        {
+            var relativePath = fs.Path.GetRelativePath(skillDir, file)
+                .Replace(fs.Path.DirectorySeparatorChar, '/');
+
+            var fileBytes = fs.File.ReadAllBytes(file);
+            var hash = ComputeSha256(fileBytes);
+
+            entries.Add(new TrustCatalogEntry
+            {
+                Path = relativePath,
+                Sha256 = hash,
+                UpdatedAt = now,
+            });
+        }
+
+        return new TrustCatalog { GeneratedAt = now, Entries = entries };
+    }
+
+    /// <summary>
+    /// Writes a trust catalog to the skill directory as trust.json.
+    /// </summary>
+    public static void WriteCatalog(string skillDir, TrustCatalog catalog, IFileSystem? fileSystem = null)
+    {
+        var fs = fileSystem ?? new FileSystem();
+        var catalogPath = fs.Path.Combine(skillDir, CatalogFileName);
+        var json = JsonSerializer.Serialize(catalog, JsonOptions);
+        fs.File.WriteAllText(catalogPath, json);
+    }
+
+    internal static string ComputeSha256(byte[] data)
+    {
+        var hash = SHA256.HashData(data);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static List<string> CollectTrustableFiles(string dirPath, IFileSystem fs)
+    {
+        var files = new List<string>();
+        var stack = new Stack<string>();
+        stack.Push(dirPath);
+
+        while (stack.Count > 0)
+        {
+            var currentDir = stack.Pop();
+            try
+            {
+                foreach (var entry in fs.Directory.EnumerateFileSystemEntries(currentDir))
+                {
+                    var name = fs.Path.GetFileName(entry);
+                    if (name.StartsWith('.') || string.Equals(name, "node_modules", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (fs.Directory.Exists(entry))
+                    {
+                        stack.Push(entry);
+                    }
+                    else if (fs.File.Exists(entry) && SkillSecurityScanner.IsScannable(entry))
+                    {
+                        files.Add(entry);
+                    }
+                }
+            }
+            catch
+            {
+                // Skip inaccessible directories
+            }
+        }
+
+        files.Sort(StringComparer.OrdinalIgnoreCase);
+        return files;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Skills/SkillDiscovery.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillDiscovery.cs
@@ -28,14 +28,15 @@ public static class SkillDiscovery
         string? agentSkillsDir,
         string? workspaceSkillsDir,
         IFileSystem? fileSystem = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        SkillTrustMode trustMode = SkillTrustMode.Disabled)
     {
         var fs = fileSystem ?? new FileSystem();
         var skills = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
 
-        ScanDirectory(skills, globalSkillsDir, SkillSource.Global, fs, logger);
-        ScanDirectory(skills, agentSkillsDir, SkillSource.Agent, fs, logger);
-        ScanDirectory(skills, workspaceSkillsDir, SkillSource.Workspace, fs, logger);
+        ScanDirectory(skills, globalSkillsDir, SkillSource.Global, fs, logger, trustMode);
+        ScanDirectory(skills, agentSkillsDir, SkillSource.Agent, fs, logger, trustMode);
+        ScanDirectory(skills, workspaceSkillsDir, SkillSource.Workspace, fs, logger, trustMode);
 
         return skills.Values.ToList();
     }
@@ -45,7 +46,8 @@ public static class SkillDiscovery
         string? directory,
         SkillSource source,
         IFileSystem fileSystem,
-        ILogger? logger)
+        ILogger? logger,
+        SkillTrustMode trustMode)
     {
         if (string.IsNullOrWhiteSpace(directory) || !fileSystem.Directory.Exists(directory))
             return;
@@ -87,6 +89,28 @@ public static class SkillDiscovery
                         "Skill at '{SkillDir}' skipped: security scan found {CriticalCount} critical finding(s).",
                         skillDir, scanSummary.Critical);
                     continue;
+                }
+
+                // Trust verification: check script integrity against catalog
+                if (trustMode != SkillTrustMode.Disabled)
+                {
+                    var trustResult = SkillTrustVerifier.Verify(skillDir, fileSystem);
+                    if (!trustResult.Trusted)
+                    {
+                        var violations = string.Join("; ", trustResult.Violations);
+                        if (trustMode == SkillTrustMode.Enforce)
+                        {
+                            logger?.LogWarning(
+                                "Skill at '{SkillDir}' skipped: trust verification failed ({Violations}).",
+                                skillDir, violations);
+                            continue;
+                        }
+
+                        // Warn mode: log but allow
+                        logger?.LogWarning(
+                            "Skill at '{SkillDir}' has trust violations ({Violations}) — loading anyway (trust mode: warn).",
+                            skillDir, violations);
+                    }
                 }
 
                 skills[skill.Name] = skill;

--- a/src/extensions/BotNexus.Extensions.Skills/SkillsConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Skills/SkillsConfig.cs
@@ -1,3 +1,5 @@
+using BotNexus.Extensions.Skills.Security;
+
 namespace BotNexus.Extensions.Skills;
 
 /// <summary>
@@ -22,6 +24,12 @@ public sealed class SkillsConfig
 
     /// <summary>Maximum total characters of skill content in the prompt.</summary>
     public int MaxSkillContentChars { get; set; } = 100_000;
+
+    /// <summary>
+    /// Trust verification mode for skill scripts.
+    /// Disabled = no verification (default), Warn = log warning, Enforce = block untrusted.
+    /// </summary>
+    public SkillTrustMode TrustMode { get; set; } = SkillTrustMode.Disabled;
 
     // ── SkillManagerTool gates ──────────────────────────────────────────────
 

--- a/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillTrustVerifierTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Skills.Tests/SkillTrustVerifierTests.cs
@@ -1,0 +1,173 @@
+using BotNexus.Extensions.Skills.Security;
+using System.IO.Abstractions.TestingHelpers;
+using System.Text;
+
+namespace BotNexus.Extensions.Skills.Tests;
+
+public sealed class SkillTrustVerifierTests
+{
+    private const string SkillDir = "/skills/test-skill";
+
+    [Fact]
+    public void Verify_NoCatalog_ReturnsUntrusted()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillDir);
+
+        var result = SkillTrustVerifier.Verify(SkillDir, fs);
+
+        Assert.False(result.Trusted);
+        Assert.Contains("No trust catalog found", result.Violations);
+    }
+
+    [Fact]
+    public void Verify_ValidCatalog_AllHashesMatch_ReturnsTrusted()
+    {
+        var fs = new MockFileSystem();
+        var scriptContent = "Write-Output 'hello'"u8.ToArray();
+        var hash = SkillTrustVerifier.ComputeSha256(scriptContent);
+
+        fs.AddFile($"{SkillDir}/scripts/run.ps1", new MockFileData(scriptContent));
+        fs.AddFile($"{SkillDir}/trust.json", new MockFileData($$"""
+        {
+            "version": 1,
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "entries": [
+                { "path": "scripts/run.ps1", "sha256": "{{hash}}", "updatedAt": "2026-01-01T00:00:00Z" }
+            ]
+        }
+        """));
+
+        var result = SkillTrustVerifier.Verify(SkillDir, fs);
+
+        Assert.True(result.Trusted);
+        Assert.Empty(result.Violations);
+    }
+
+    [Fact]
+    public void Verify_HashMismatch_ReturnsUntrustedWithViolation()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{SkillDir}/scripts/run.ps1", new MockFileData("modified content"));
+        fs.AddFile($"{SkillDir}/trust.json", new MockFileData("""
+        {
+            "version": 1,
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "entries": [
+                { "path": "scripts/run.ps1", "sha256": "0000000000000000000000000000000000000000000000000000000000000000", "updatedAt": "2026-01-01T00:00:00Z" }
+            ]
+        }
+        """));
+
+        var result = SkillTrustVerifier.Verify(SkillDir, fs);
+
+        Assert.False(result.Trusted);
+        Assert.Single(result.Violations);
+        Assert.Contains("Hash mismatch", result.Violations[0]);
+    }
+
+    [Fact]
+    public void Verify_MissingFile_ReturnsUntrustedWithViolation()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillDir);
+        fs.AddFile($"{SkillDir}/trust.json", new MockFileData("""
+        {
+            "version": 1,
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "entries": [
+                { "path": "scripts/missing.ps1", "sha256": "abc123", "updatedAt": "2026-01-01T00:00:00Z" }
+            ]
+        }
+        """));
+
+        var result = SkillTrustVerifier.Verify(SkillDir, fs);
+
+        Assert.False(result.Trusted);
+        Assert.Contains("Missing file", result.Violations[0]);
+    }
+
+    [Fact]
+    public void Verify_InvalidCatalogJson_ReturnsUntrusted()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{SkillDir}/trust.json", new MockFileData("not valid json {{{"));
+
+        var result = SkillTrustVerifier.Verify(SkillDir, fs);
+
+        Assert.False(result.Trusted);
+        Assert.Contains("Failed to parse", result.Violations[0]);
+    }
+
+    [Fact]
+    public void GenerateCatalog_CreatesEntriesForScannableFiles()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{SkillDir}/scripts/run.ps1", new MockFileData("param() Write-Output 1"));
+        fs.AddFile($"{SkillDir}/scripts/helper.py", new MockFileData("print('hi')"));
+        fs.AddFile($"{SkillDir}/SKILL.md", new MockFileData("# Skill")); // .md not scannable
+
+        var catalog = SkillTrustVerifier.GenerateCatalog(SkillDir, fs);
+
+        Assert.Equal(2, catalog.Entries.Count);
+        Assert.Contains(catalog.Entries, e => e.Path == "scripts/run.ps1");
+        Assert.Contains(catalog.Entries, e => e.Path == "scripts/helper.py");
+        Assert.All(catalog.Entries, e => Assert.Equal(64, e.Sha256.Length)); // SHA-256 hex length
+    }
+
+    [Fact]
+    public void GenerateCatalog_EmptyDir_ReturnsEmptyCatalog()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillDir);
+
+        var catalog = SkillTrustVerifier.GenerateCatalog(SkillDir, fs);
+
+        Assert.Empty(catalog.Entries);
+    }
+
+    [Fact]
+    public void WriteCatalog_CreatesJsonFile()
+    {
+        var fs = new MockFileSystem();
+        fs.AddDirectory(SkillDir);
+
+        var catalog = new TrustCatalog
+        {
+            GeneratedAt = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+            Entries = [new TrustCatalogEntry { Path = "scripts/run.ps1", Sha256 = "abc", UpdatedAt = DateTimeOffset.Parse("2026-01-01T00:00:00Z") }],
+        };
+
+        SkillTrustVerifier.WriteCatalog(SkillDir, catalog, fs);
+
+        Assert.True(fs.File.Exists($"{SkillDir}/trust.json"));
+        var content = fs.File.ReadAllText($"{SkillDir}/trust.json");
+        Assert.Contains("abc", content);
+    }
+
+    [Fact]
+    public void ComputeSha256_ProducesCorrectHash()
+    {
+        // Known SHA-256 for empty byte array
+        var hash = SkillTrustVerifier.ComputeSha256([]);
+        Assert.Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash);
+    }
+
+    [Fact]
+    public void Verify_EmptyCatalogEntries_ReturnsUntrusted()
+    {
+        var fs = new MockFileSystem();
+        fs.AddFile($"{SkillDir}/trust.json", new MockFileData("""
+        {
+            "version": 1,
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "entries": []
+        }
+        """));
+
+        var result = SkillTrustVerifier.Verify(SkillDir, fs);
+
+        Assert.False(result.Trusted);
+        Assert.Contains("empty or invalid", result.Violations[0]);
+    }
+}


### PR DESCRIPTION
Closes #1236

## Changes
- Add \SkillTrustVerifier\ with SHA-256 hash catalog verification for skill scripts
- Add \SkillTrustMode\ enum (Disabled/Warn/Enforce) to \SkillsConfig\
- Integrate trust verification into \SkillDiscovery.ScanDirectory\ (after security scan)
- Add \GenerateCatalog\ and \WriteCatalog\ helpers for trust catalog management
- Trust catalog is \	rust.json\ in skill root — lists path + SHA-256 for each script
- Enforce mode blocks untrusted skills; Warn mode logs and allows; Disabled (default) skips
- 10 new tests covering all verification scenarios

## Merge Notes
Touches Skills extension only (\src/extensions/BotNexus.Extensions.Skills/\). No overlap with any open PR. Safe to merge in any order.