### PR TITLE
feat(cli): add debug gateway subcommand for live gateway diagnostics

### DIFF
--- a/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugCommand.cs
@@ -2,20 +2,23 @@ using System.CommandLine;
 namespace BotNexus.Cli.Commands;
 /// <summary>
 /// Top-level <c>botnexus debug</c> command that groups diagnostic subcommands
-/// for offline platform inspection. All debug subcommands operate directly on
-/// local files (SQLite databases, log files) without requiring a running gateway.
+/// for platform inspection. Most subcommands operate directly on local files
+/// (SQLite databases, log files) without requiring a running gateway.
+/// The <c>gateway</c> subcommand connects to a live gateway instance via REST API.
 /// </summary>
 internal sealed class DebugCommand
 {
     private readonly DebugCronCommand _cron = new();
     private readonly DebugDbCommand _db = new();
+    private readonly DebugGatewayCommand _gateway = new();
     private readonly DebugLogsCommand _logs = new();
     private readonly DebugSessionsCommand _sessions = new();
     public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
     {
-        var command = new Command("debug", "Platform diagnostics - inspect sessions, logs, and databases offline.");
+        var command = new Command("debug", "Platform diagnostics - inspect sessions, logs, databases, and live gateway state.");
         command.AddCommand(_cron.Build(targetOption));
         command.AddCommand(_db.Build(targetOption));
+        command.AddCommand(_gateway.Build(targetOption));
         command.AddCommand(_logs.Build(targetOption));
         command.AddCommand(_sessions.Build(targetOption));
         return command;

--- a/src/gateway/BotNexus.Cli/Commands/DebugGatewayCommand.cs
+++ b/src/gateway/BotNexus.Cli/Commands/DebugGatewayCommand.cs
@@ -1,0 +1,275 @@
+using System.CommandLine;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// CLI subcommand for inspecting a live gateway instance via its REST API.
+/// Unlike other debug subcommands that work offline against local files,
+/// this requires a running gateway and makes HTTP requests to its endpoints.
+/// </summary>
+internal sealed class DebugGatewayCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public Command Build(Option<string?> targetOption)
+    {
+        var command = new Command("gateway", "Inspect live gateway state via REST API (requires running gateway).");
+        var formatOption = new Option<string>("--format", () => "table", "Output format: table or json.");
+        var urlOption = new Option<string>("--url", () => "http://localhost:5005", "Gateway base URL.");
+        command.AddOption(formatOption);
+        command.AddOption(urlOption);
+
+        // ── status ──
+        var statusCommand = new Command("status", "Show gateway uptime, version, and session count.");
+        statusCommand.SetHandler(async context =>
+        {
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            context.ExitCode = await ExecuteStatusAsync(url, format, context.GetCancellationToken());
+        });
+
+        // ── sessions ──
+        var agentOption = new Option<string?>("--agent", "Filter by agent ID.");
+        var limitOption = new Option<int>("--limit", () => 20, "Maximum sessions to return.");
+        var sessionsCommand = new Command("sessions", "List active sessions from the gateway.")
+        {
+            agentOption, limitOption
+        };
+        sessionsCommand.SetHandler(async context =>
+        {
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            var agent = context.ParseResult.GetValueForOption(agentOption);
+            var limit = context.ParseResult.GetValueForOption(limitOption);
+            context.ExitCode = await ExecuteSessionsAsync(url, agent, limit, format, context.GetCancellationToken());
+        });
+
+        // ── providers ──
+        var providersCommand = new Command("providers", "List registered providers and model counts.");
+        providersCommand.SetHandler(async context =>
+        {
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            context.ExitCode = await ExecuteProvidersAsync(url, format, context.GetCancellationToken());
+        });
+
+        // ── config ──
+        var sectionOption = new Option<string?>("--section", "Filter to a specific config section.");
+        var configCommand = new Command("config", "Dump resolved gateway configuration (secrets redacted).")
+        {
+            sectionOption
+        };
+        configCommand.SetHandler(async context =>
+        {
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            var section = context.ParseResult.GetValueForOption(sectionOption);
+            context.ExitCode = await ExecuteConfigAsync(url, section, format, context.GetCancellationToken());
+        });
+
+        command.AddCommand(statusCommand);
+        command.AddCommand(sessionsCommand);
+        command.AddCommand(providersCommand);
+        command.AddCommand(configCommand);
+
+        return command;
+    }
+
+    internal static async Task<int> ExecuteStatusAsync(string baseUrl, string format, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var health = await client.GetAsync("/health", ct);
+            if (!health.IsSuccessStatusCode)
+            {
+                AnsiConsole.MarkupLine("[red]Gateway is not healthy.[/] Status: {0}", health.StatusCode);
+                return 1;
+            }
+
+            var diagnostics = await client.GetFromJsonAsync<JsonElement>("/api/diagnostics/threadpool", ct);
+            var activity = await client.GetFromJsonAsync<JsonElement>("/api/diagnostics/activity", ct);
+
+            if (format == "json")
+            {
+                var result = new { health = "healthy", diagnostics, activity };
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+            }
+            else
+            {
+                AnsiConsole.Write(new Rule("[bold blue]Gateway Status[/]") { Justification = Justify.Left });
+                AnsiConsole.MarkupLine("[green]● Healthy[/]");
+                AnsiConsole.WriteLine();
+
+                if (diagnostics.TryGetProperty("pendingWorkItems", out var pending))
+                    AnsiConsole.MarkupLine("[dim]ThreadPool pending:[/] {0}", pending);
+                if (diagnostics.TryGetProperty("workerThreads", out var workers))
+                    AnsiConsole.MarkupLine("[dim]Worker threads:[/]    {0}", workers);
+                if (activity.TryGetProperty("lastActivityUtc", out var lastAct))
+                    AnsiConsole.MarkupLine("[dim]Last activity:[/]    {0}", lastAct);
+                if (activity.TryGetProperty("inactivitySeconds", out var inactivity))
+                    AnsiConsole.MarkupLine("[dim]Inactivity:[/]       {0}s", inactivity);
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    internal static async Task<int> ExecuteSessionsAsync(string baseUrl, string? agentId, int limit, string format, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var query = agentId != null ? $"?agentId={Uri.EscapeDataString(agentId)}" : "";
+            var sessions = await client.GetFromJsonAsync<JsonElement>($"/api/sessions/stats{query}", ct);
+
+            if (format == "json")
+            {
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(sessions, JsonOptions));
+            }
+            else
+            {
+                AnsiConsole.Write(new Rule("[bold blue]Session Statistics[/]") { Justification = Justify.Left });
+                if (sessions.TryGetProperty("totalSessions", out var total))
+                    AnsiConsole.MarkupLine("[dim]Total sessions:[/]  {0}", total);
+                if (sessions.TryGetProperty("activeSessions", out var active))
+                    AnsiConsole.MarkupLine("[dim]Active sessions:[/] {0}", active);
+                if (sessions.TryGetProperty("agentBreakdown", out var breakdown) && breakdown.ValueKind == JsonValueKind.Object)
+                {
+                    AnsiConsole.WriteLine();
+                    var table = new Table().AddColumn("Agent").AddColumn("Count");
+                    foreach (var prop in breakdown.EnumerateObject())
+                        table.AddRow(prop.Name, prop.Value.ToString());
+                    AnsiConsole.Write(table);
+                }
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    internal static async Task<int> ExecuteProvidersAsync(string baseUrl, string format, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var providers = await client.GetFromJsonAsync<JsonElement>("/api/providers", ct);
+            var models = await client.GetFromJsonAsync<JsonElement>("/api/models", ct);
+
+            if (format == "json")
+            {
+                var result = new { providers, models };
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+            }
+            else
+            {
+                AnsiConsole.Write(new Rule("[bold blue]Providers[/]") { Justification = Justify.Left });
+                var table = new Table().AddColumn("Provider").AddColumn("Models");
+
+                if (providers.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var p in providers.EnumerateArray())
+                    {
+                        var name = p.TryGetProperty("name", out var n) ? n.GetString() ?? "?" : "?";
+                        var modelCount = 0;
+                        if (models.ValueKind == JsonValueKind.Array)
+                        {
+                            modelCount = models.EnumerateArray()
+                                .Count(m => m.TryGetProperty("provider", out var mp) &&
+                                            string.Equals(mp.GetString(), name, StringComparison.OrdinalIgnoreCase));
+                        }
+                        table.AddRow(Markup.Escape(name), modelCount.ToString());
+                    }
+                }
+
+                AnsiConsole.Write(table);
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    internal static async Task<int> ExecuteConfigAsync(string baseUrl, string? section, string format, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var config = await client.GetFromJsonAsync<JsonElement>("/api/config", ct);
+
+            if (section != null && config.TryGetProperty(section, out var sectionValue))
+                config = sectionValue;
+            else if (section != null)
+            {
+                AnsiConsole.MarkupLine("[yellow]Section '{0}' not found in configuration.[/]", Markup.Escape(section));
+                return 1;
+            }
+
+            if (format == "json")
+            {
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(config, JsonOptions));
+            }
+            else
+            {
+                AnsiConsole.Write(new Rule("[bold blue]Configuration[/]") { Justification = Justify.Left });
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(config, JsonOptions));
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    private static HttpClient CreateClient(string baseUrl)
+    {
+        return new HttpClient
+        {
+            BaseAddress = new Uri(baseUrl.TrimEnd('/')),
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+    }
+}

--- a/tests/gateway/BotNexus.Cli.Tests/DebugGatewayCommandTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/DebugGatewayCommandTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BotNexus.Cli.Commands;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class DebugGatewayCommandTests : IDisposable
+{
+    private readonly MockHttpServer _server;
+
+    public DebugGatewayCommandTests()
+    {
+        _server = new MockHttpServer();
+    }
+
+    public void Dispose() => _server.Dispose();
+
+    [Fact]
+    public async Task Status_ReturnsZero_WhenGatewayHealthy()
+    {
+        _server.SetResponse("/health", HttpStatusCode.OK, "{}");
+        _server.SetResponse("/api/diagnostics/threadpool", HttpStatusCode.OK,
+            """{"pendingWorkItems":0,"workerThreads":8,"completionPortThreads":2,"healthy":true}""");
+        _server.SetResponse("/api/diagnostics/activity", HttpStatusCode.OK,
+            """{"lastActivityUtc":"2026-06-11T12:00:00Z","inactivitySeconds":5,"healthy":true}""");
+
+        var result = await DebugGatewayCommand.ExecuteStatusAsync(_server.BaseUrl, "json", CancellationToken.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Status_ReturnsOne_WhenGatewayUnhealthy()
+    {
+        _server.SetResponse("/health", HttpStatusCode.ServiceUnavailable, "");
+
+        var result = await DebugGatewayCommand.ExecuteStatusAsync(_server.BaseUrl, "table", CancellationToken.None);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Status_ReturnsOne_WhenGatewayUnreachable()
+    {
+        var result = await DebugGatewayCommand.ExecuteStatusAsync("http://localhost:1", "table", CancellationToken.None);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Sessions_ReturnsZero_WithValidResponse()
+    {
+        _server.SetResponse("/api/sessions/stats", HttpStatusCode.OK,
+            """{"totalSessions":10,"activeSessions":3,"agentBreakdown":{"farnsworth":5,"nova":5}}""");
+
+        var result = await DebugGatewayCommand.ExecuteSessionsAsync(_server.BaseUrl, null, 20, "json", CancellationToken.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Sessions_ReturnsOne_WhenUnreachable()
+    {
+        var result = await DebugGatewayCommand.ExecuteSessionsAsync("http://localhost:1", null, 20, "table", CancellationToken.None);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Providers_ReturnsZero_WithValidResponse()
+    {
+        _server.SetResponse("/api/providers", HttpStatusCode.OK,
+            """[{"name":"copilot","providerId":"copilot","id":"copilot"}]""");
+        _server.SetResponse("/api/models", HttpStatusCode.OK,
+            """[{"id":"claude-sonnet-4-20250514","provider":"copilot"}]""");
+
+        var result = await DebugGatewayCommand.ExecuteProvidersAsync(_server.BaseUrl, "json", CancellationToken.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Providers_ReturnsOne_WhenUnreachable()
+    {
+        var result = await DebugGatewayCommand.ExecuteProvidersAsync("http://localhost:1", "table", CancellationToken.None);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Config_ReturnsZero_WithValidResponse()
+    {
+        _server.SetResponse("/api/config", HttpStatusCode.OK,
+            """{"gateway":{"port":5005},"agents":{}}""");
+
+        var result = await DebugGatewayCommand.ExecuteConfigAsync(_server.BaseUrl, null, "json", CancellationToken.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Config_ReturnsOne_WhenSectionNotFound()
+    {
+        _server.SetResponse("/api/config", HttpStatusCode.OK,
+            """{"gateway":{"port":5005}}""");
+
+        var result = await DebugGatewayCommand.ExecuteConfigAsync(_server.BaseUrl, "nonexistent", "table", CancellationToken.None);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Config_FiltersBySection()
+    {
+        _server.SetResponse("/api/config", HttpStatusCode.OK,
+            """{"gateway":{"port":5005},"agents":{"farnsworth":{}}}""");
+
+        var result = await DebugGatewayCommand.ExecuteConfigAsync(_server.BaseUrl, "gateway", "json", CancellationToken.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Config_ReturnsOne_WhenUnreachable()
+    {
+        var result = await DebugGatewayCommand.ExecuteConfigAsync("http://localhost:1", null, "json", CancellationToken.None);
+        Assert.Equal(1, result);
+    }
+}
+
+/// <summary>
+/// Minimal HTTP server for testing gateway client commands without a real gateway.
+/// </summary>
+internal sealed class MockHttpServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly Dictionary<string, (HttpStatusCode status, string body)> _responses = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _listenTask;
+
+    public string BaseUrl { get; }
+
+    public MockHttpServer()
+    {
+        var port = FindFreePort();
+        BaseUrl = $"http://localhost:{port}";
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"http://localhost:{port}/");
+        _listener.Start();
+        _listenTask = Task.Run(ListenLoop);
+    }
+
+    public void SetResponse(string path, HttpStatusCode status, string body)
+    {
+        _responses[path] = (status, body);
+    }
+
+    private async Task ListenLoop()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            try
+            {
+                var context = await _listener.GetContextAsync();
+                var path = context.Request.Url?.AbsolutePath ?? "/";
+
+                // Strip query string for matching
+                if (_responses.TryGetValue(path, out var response))
+                {
+                    context.Response.StatusCode = (int)response.status;
+                    context.Response.ContentType = "application/json";
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(response.body);
+                    await context.Response.OutputStream.WriteAsync(bytes);
+                }
+                else
+                {
+                    context.Response.StatusCode = 404;
+                }
+                context.Response.Close();
+            }
+            catch (ObjectDisposedException) { break; }
+            catch (HttpListenerException) { break; }
+        }
+    }
+
+    private static int FindFreePort()
+    {
+        using var socket = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        socket.Start();
+        var port = ((System.Net.IPEndPoint)socket.LocalEndpoint).Port;
+        socket.Stop();
+        return port;
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        _listener.Close();
+        try { _listenTask.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        _cts.Dispose();
+    }
+}


### PR DESCRIPTION
Closes #1262

## Changes
- Add \DebugGatewayCommand\ with 4 subcommands: status, sessions, providers, config
- All subcommands connect to a live gateway via REST API (unlike other offline debug commands)
- \--url\ option for custom gateway address (default http://localhost:5005)
- \--format table|json\ on all subcommands
- Graceful error handling when gateway is unreachable or unhealthy
- 11 tests using a lightweight mock HTTP server

## Merge Notes
Touches only CLI project (BotNexus.Cli + BotNexus.Cli.Tests). Modifies DebugCommand.cs (adds gateway subcommand registration). No overlap with any current open PR.