### PR TITLE
refactor(gateway): delegate daily memory loading to IAgentMemory.GetPromptContextAsync()

### DIFF
--- a/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
@@ -4,6 +4,7 @@ using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Hooks;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Contracts.Memory;
 using System.IO.Abstractions;
 
 namespace BotNexus.Gateway.Agents;
@@ -24,6 +25,7 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
     private readonly IHookDispatcher? _hookDispatcher;
     private readonly IConversationStore? _conversationStore;
     private readonly ISessionStore? _sessionStore;
+    private readonly IAgentMemoryFactory? _agentMemoryFactory;
     private readonly string? _homePath;
 
     public WorkspaceContextBuilder(IAgentWorkspaceManager workspaceManager, IFileSystem fileSystem)
@@ -82,6 +84,24 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
         _homePath = botNexusHome.RootPath;
     }
 
+    public WorkspaceContextBuilder(
+        IAgentWorkspaceManager workspaceManager,
+        IFileSystem fileSystem,
+        BotNexusHome botNexusHome,
+        IConversationStore conversationStore,
+        ISessionStore sessionStore,
+        IAgentMemoryFactory agentMemoryFactory,
+        IHookDispatcher? hookDispatcher = null)
+    {
+        _workspaceManager = workspaceManager;
+        _fileSystem = fileSystem;
+        _homePath = botNexusHome.RootPath;
+        _conversationStore = conversationStore;
+        _sessionStore = sessionStore;
+        _agentMemoryFactory = agentMemoryFactory;
+        _hookDispatcher = hookDispatcher;
+    }
+
     public async Task<string> BuildSystemPromptAsync(
         AgentDescriptor descriptor,
         AgentExecutionContext? executionContext,
@@ -110,7 +130,7 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
         {
             if (!IsMemoryPromptInjectionNone(memoryPromptInjection))
             {
-                var recentMemoryFiles = await LoadRecentDailyMemoryFilesAsync(_fileSystem, workspacePath, descriptor.Memory?.Path, cancellationToken);
+                var recentMemoryFiles = await LoadDailyMemoryAsync(descriptor, workspacePath, cancellationToken);
                 contextFiles.AddRange(recentMemoryFiles);
             }
         }
@@ -261,6 +281,55 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
 
     private static bool IsMemoryPromptInjectionNone(string promptInjection) =>
         promptInjection.Equals(MemoryPromptInjectionNone, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Loads daily memory context, delegating to IAgentMemory when available,
+    /// falling back to direct file I/O for backward compatibility.
+    /// </summary>
+    private async Task<IReadOnlyList<ContextFile>> LoadDailyMemoryAsync(
+        AgentDescriptor descriptor,
+        string workspacePath,
+        CancellationToken cancellationToken)
+    {
+        if (_agentMemoryFactory is not null)
+        {
+            try
+            {
+                var agentMemory = _agentMemoryFactory.Create(descriptor.AgentId.Value);
+                var request = new AgentMemoryPromptRequest(descriptor.AgentId.Value);
+                var context = await agentMemory.GetPromptContextAsync(request, cancellationToken).ConfigureAwait(false);
+                return MapMemoryContextToFiles(context, descriptor.Memory?.Path);
+            }
+            catch (NotSupportedException)
+            {
+                // Provider not registered — fall through to file-based loading
+            }
+        }
+
+        return await LoadRecentDailyMemoryFilesAsync(_fileSystem, workspacePath, descriptor.Memory?.Path, cancellationToken);
+    }
+
+    /// <summary>
+    /// Maps an <see cref="AgentMemoryContext"/> to context files compatible with the prompt pipeline.
+    /// </summary>
+    private static IReadOnlyList<ContextFile> MapMemoryContextToFiles(AgentMemoryContext context, string? memoryPathOverride)
+    {
+        var memoryDir = string.IsNullOrWhiteSpace(memoryPathOverride) ? "memory" : memoryPathOverride.Trim().Replace('\\', '/');
+        if (memoryDir.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            memoryDir = Path.GetDirectoryName(memoryDir)?.Replace('\\', '/') ?? "memory";
+
+        List<ContextFile> result = [];
+        foreach (var note in context.DailyNotes)
+        {
+            if (!string.IsNullOrWhiteSpace(note.Content))
+            {
+                var relativePath = $"{memoryDir}/{note.Date:yyyy-MM-dd}.md";
+                result.Add(new ContextFile(relativePath, note.Content.Trim()));
+            }
+        }
+
+        return result;
+    }
 
     private static async Task<IReadOnlyList<ContextFile>> LoadRecentDailyMemoryFilesAsync(
         IFileSystem fileSystem,

--- a/tests/gateway/BotNexus.Gateway.Tests/WorkspaceContextBuilderTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/WorkspaceContextBuilderTests.cs
@@ -1,7 +1,11 @@
-﻿using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Conversations;
+using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Contracts.Memory;
+using NSubstitute;
 using System.IO.Abstractions.TestingHelpers;
 
 namespace BotNexus.Gateway.Tests;
@@ -437,5 +441,210 @@ public sealed class WorkspaceContextBuilderTests
         var property = typeof(MemoryAgentConfig).GetProperty("PromptInjection");
         property.ShouldNotBeNull("MemoryAgentConfig.PromptInjection should exist for memory prompt-injection behavior.");
         property!.SetValue(config, mode);
+    }
+
+    [Fact]
+    public async Task BuildSystemPromptAsync_WithAgentMemoryFactory_DelegatesToGetPromptContextAsync()
+    {
+        var workspacePath = CreateWorkspace(("AGENTS.md", "AGENTS"));
+        try
+        {
+            var manager = new StubWorkspaceManager(workspacePath);
+            var homePath = Path.Combine(Path.GetTempPath(), "botnexus-home-" + Guid.NewGuid().ToString("N"));
+            _fileSystem.Directory.CreateDirectory(homePath);
+            var home = new BotNexusHome(_fileSystem, homePath);
+
+            var memoryContext = new AgentMemoryContext(
+                null,
+                [new AgentMemoryDailyNote(DateOnly.FromDateTime(DateTime.Now), "Daily note from IAgentMemory")],
+                50);
+            var mockFactory = new StubAgentMemoryFactory(memoryContext);
+            var builder = new WorkspaceContextBuilder(
+                manager, _fileSystem, home,
+                Substitute.For<IConversationStore>(), Substitute.For<ISessionStore>(),
+                mockFactory);
+
+            var result = await builder.BuildSystemPromptAsync(new AgentDescriptor
+            {
+                AgentId = BotNexus.Domain.Primitives.AgentId.From("test-agent"),
+                DisplayName = "Test",
+                ModelId = "test-model",
+                ApiProvider = "test-provider"
+            });
+
+            result.ShouldContain("Daily note from IAgentMemory");
+        }
+        finally
+        {
+            _fileSystem.Directory.Delete(Path.GetDirectoryName(workspacePath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task BuildSystemPromptAsync_WhenMemoryFactoryThrowsNotSupported_FallsBackToFileLoading()
+    {
+        var today = DateTime.Now.Date;
+        var todayFileName = $"memory/{today:yyyy-MM-dd}.md";
+        var workspacePath = CreateWorkspace(
+            ("AGENTS.md", "AGENTS"),
+            (todayFileName, "File-based daily note"));
+        try
+        {
+            var manager = new StubWorkspaceManager(workspacePath);
+            var homePath = Path.Combine(Path.GetTempPath(), "botnexus-home-" + Guid.NewGuid().ToString("N"));
+            _fileSystem.Directory.CreateDirectory(homePath);
+            var home = new BotNexusHome(_fileSystem, homePath);
+
+            var mockFactory = new StubAgentMemoryFactory(throwNotSupported: true);
+            var builder = new WorkspaceContextBuilder(
+                manager, _fileSystem, home,
+                Substitute.For<IConversationStore>(), Substitute.For<ISessionStore>(),
+                mockFactory);
+
+            var result = await builder.BuildSystemPromptAsync(new AgentDescriptor
+            {
+                AgentId = BotNexus.Domain.Primitives.AgentId.From("test-agent"),
+                DisplayName = "Test",
+                ModelId = "test-model",
+                ApiProvider = "test-provider"
+            });
+
+            result.ShouldContain("File-based daily note");
+        }
+        finally
+        {
+            _fileSystem.Directory.Delete(Path.GetDirectoryName(workspacePath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task BuildSystemPromptAsync_WithMemoryFactoryAndPromptInjectionNone_SkipsMemoryLoading()
+    {
+        var workspacePath = CreateWorkspace(("AGENTS.md", "AGENTS"));
+        try
+        {
+            var manager = new StubWorkspaceManager(workspacePath);
+            var homePath = Path.Combine(Path.GetTempPath(), "botnexus-home-" + Guid.NewGuid().ToString("N"));
+            _fileSystem.Directory.CreateDirectory(homePath);
+            var home = new BotNexusHome(_fileSystem, homePath);
+
+            var memoryContext = new AgentMemoryContext(
+                null,
+                [new AgentMemoryDailyNote(DateOnly.FromDateTime(DateTime.Now), "Should not appear")],
+                50);
+            var mockFactory = new StubAgentMemoryFactory(memoryContext);
+            var builder = new WorkspaceContextBuilder(
+                manager, _fileSystem, home,
+                Substitute.For<IConversationStore>(), Substitute.For<ISessionStore>(),
+                mockFactory);
+
+            var memory = new MemoryAgentConfig();
+            SetPromptInjection(memory, "none");
+            var result = await builder.BuildSystemPromptAsync(new AgentDescriptor
+            {
+                AgentId = BotNexus.Domain.Primitives.AgentId.From("test-agent"),
+                DisplayName = "Test",
+                ModelId = "test-model",
+                ApiProvider = "test-provider",
+                Memory = memory
+            });
+
+            result.ShouldNotContain("Should not appear");
+        }
+        finally
+        {
+            _fileSystem.Directory.Delete(Path.GetDirectoryName(workspacePath)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task BuildSystemPromptAsync_WithMemoryFactory_MapsMultipleDailyNotesInOrder()
+    {
+        var workspacePath = CreateWorkspace(("AGENTS.md", "AGENTS"));
+        try
+        {
+            var manager = new StubWorkspaceManager(workspacePath);
+            var homePath = Path.Combine(Path.GetTempPath(), "botnexus-home-" + Guid.NewGuid().ToString("N"));
+            _fileSystem.Directory.CreateDirectory(homePath);
+            var home = new BotNexusHome(_fileSystem, homePath);
+
+            var today = DateOnly.FromDateTime(DateTime.Now);
+            var yesterday = today.AddDays(-1);
+            var memoryContext = new AgentMemoryContext(
+                null,
+                [
+                    new AgentMemoryDailyNote(today, "Today note"),
+                    new AgentMemoryDailyNote(yesterday, "Yesterday note")
+                ],
+                100);
+            var mockFactory = new StubAgentMemoryFactory(memoryContext);
+            var builder = new WorkspaceContextBuilder(
+                manager, _fileSystem, home,
+                Substitute.For<IConversationStore>(), Substitute.For<ISessionStore>(),
+                mockFactory);
+
+            var result = await builder.BuildSystemPromptAsync(new AgentDescriptor
+            {
+                AgentId = BotNexus.Domain.Primitives.AgentId.From("test-agent"),
+                DisplayName = "Test",
+                ModelId = "test-model",
+                ApiProvider = "test-provider"
+            });
+
+            result.ShouldContain("Today note");
+            result.ShouldContain("Yesterday note");
+        }
+        finally
+        {
+            _fileSystem.Directory.Delete(Path.GetDirectoryName(workspacePath)!, recursive: true);
+        }
+    }
+
+    private sealed class StubAgentMemoryFactory : IAgentMemoryFactory
+    {
+        private readonly AgentMemoryContext? _context;
+        private readonly bool _throwNotSupported;
+
+        public StubAgentMemoryFactory(AgentMemoryContext? context = null, bool throwNotSupported = false)
+        {
+            _context = context;
+            _throwNotSupported = throwNotSupported;
+        }
+
+        public IAgentMemory Create(string agentId, string? providerName = null)
+        {
+            if (_throwNotSupported)
+                throw new NotSupportedException("Provider not registered");
+            return new StubAgentMemory(_context ?? AgentMemoryContext.Empty);
+        }
+
+        public IReadOnlyList<string> GetRegisteredProviders() => ["markdown"];
+    }
+
+    private sealed class StubAgentMemory : IAgentMemory
+    {
+        private readonly AgentMemoryContext _context;
+
+        public StubAgentMemory(AgentMemoryContext context) => _context = context;
+
+        public Task<AgentMemoryContext> GetPromptContextAsync(
+            AgentMemoryPromptRequest request, CancellationToken ct = default)
+            => Task.FromResult(_context);
+
+        public Task SaveAsync(AgentMemorySaveRequest request, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<AgentMemorySearchResult>> SearchAsync(
+            AgentMemorySearchRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentMemorySearchResult>>([]);
+
+        public Task<AgentMemorySearchResult?> GetAsync(string entryId, CancellationToken ct = default)
+            => Task.FromResult<AgentMemorySearchResult?>(null);
+
+        public Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task ConsolidateAsync(AgentMemoryConsolidateRequest request, CancellationToken ct = default)
+            => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Closes #1264

## Changes
- Added `IAgentMemoryFactory` as an optional dependency to `WorkspaceContextBuilder`
- New constructor overload (6-param) that DI selects when `IAgentMemoryFactory` is registered
- `LoadDailyMemoryAsync()` delegates to `IAgentMemory.GetPromptContextAsync()` when factory is available
- Falls back to direct file I/O on `NotSupportedException` (provider not registered)
- `MapMemoryContextToFiles()` converts `AgentMemoryContext.DailyNotes` to `ContextFile` entries
- 4 new tests covering: delegation, fallback, prompt-injection-none skip, multi-note mapping
- All 10 existing tests pass unchanged (use constructors without memory factory)

## Merge Notes
Touches only `WorkspaceContextBuilder.cs` and its test file. No overlap with any open PR. Safe to merge in any order.
