### PR TITLE
refactor(memory): delegate session indexing to IAgentMemory.OnSessionCompleteAsync()

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySessionEvent.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Memory/AgentMemorySessionEvent.cs
@@ -9,9 +9,24 @@ namespace BotNexus.Gateway.Contracts.Memory;
 /// <param name="ConversationId">The conversation the session belonged to, if any.</param>
 /// <param name="EndedAt">When the session ended.</param>
 /// <param name="TurnCount">Total number of turns in the session.</param>
+/// <param name="History">The session history entries for indexing. May be empty if not available.</param>
 public sealed record AgentMemorySessionEvent(
     string AgentId,
     string SessionId,
     string? ConversationId = null,
     DateTimeOffset? EndedAt = null,
-    int TurnCount = 0);
+    int TurnCount = 0,
+    IReadOnlyList<AgentMemorySessionTurn>? History = null);
+
+/// <summary>
+/// A single turn entry from a completed session, carrying the minimal data needed for memory indexing.
+/// </summary>
+/// <param name="Index">Position in the session history.</param>
+/// <param name="Role">The message role (user, assistant, tool, system).</param>
+/// <param name="Content">The text content of the turn.</param>
+/// <param name="Timestamp">When this turn was produced.</param>
+public sealed record AgentMemorySessionTurn(
+    int Index,
+    string Role,
+    string? Content,
+    DateTimeOffset Timestamp);

--- a/src/gateway/BotNexus.Memory/MarkdownAgentMemory.cs
+++ b/src/gateway/BotNexus.Memory/MarkdownAgentMemory.cs
@@ -99,10 +99,62 @@ public sealed class MarkdownAgentMemory : IAgentMemory
     }
 
     /// <inheritdoc />
-    public Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default)
+    public async Task OnSessionCompleteAsync(AgentMemorySessionEvent sessionEvent, CancellationToken ct = default)
     {
-        // The markdown provider has no session-level bookkeeping — file writes are immediate.
-        return Task.CompletedTask;
+        ct.ThrowIfCancellationRequested();
+        if (sessionEvent.History is null || sessionEvent.History.Count == 0)
+            return;
+
+        await _memoryStore.InitializeAsync(ct).ConfigureAwait(false);
+
+        var existing = await _memoryStore.GetBySessionAsync(sessionEvent.SessionId, int.MaxValue, ct).ConfigureAwait(false);
+        var indexedTurns = existing
+            .Where(entry => entry.TurnIndex.HasValue)
+            .Select(entry => entry.TurnIndex!.Value)
+            .ToHashSet();
+
+        AgentMemorySessionTurn? pendingUser = null;
+
+        foreach (var turn in sessionEvent.History)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (turn.Role.Equals("tool", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (turn.Role.Equals("user", StringComparison.OrdinalIgnoreCase))
+            {
+                pendingUser = turn;
+                continue;
+            }
+
+            if (pendingUser is null || !turn.Role.Equals("assistant", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!indexedTurns.Contains(pendingUser.Index))
+            {
+                var memory = new MemoryEntry
+                {
+                    Id = string.Empty,
+                    AgentId = sessionEvent.AgentId,
+                    SessionId = sessionEvent.SessionId,
+                    TurnIndex = pendingUser.Index,
+                    SourceType = "conversation",
+                    Content = $"User: {pendingUser.Content}\nAssistant: {turn.Content}",
+                    MetadataJson = null,
+                    Embedding = null,
+                    CreatedAt = turn.Timestamp,
+                    UpdatedAt = null,
+                    ExpiresAt = null,
+                    IsArchived = false
+                };
+
+                await _memoryStore.InsertAsync(memory, ct).ConfigureAwait(false);
+                indexedTurns.Add(pendingUser.Index);
+            }
+
+            pendingUser = null;
+        }
     }
 
     /// <inheritdoc />

--- a/src/gateway/BotNexus.Memory/MemoryIndexer.cs
+++ b/src/gateway/BotNexus.Memory/MemoryIndexer.cs
@@ -1,5 +1,6 @@
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Domain.Primitives;
 using BotNexus.Memory.Models;
 using Microsoft.Extensions.Hosting;
@@ -8,10 +9,12 @@ using Microsoft.Extensions.Logging;
 namespace BotNexus.Memory;
 
 public sealed class MemoryIndexer(
+    IAgentMemoryFactory agentMemoryFactory,
     IMemoryStoreFactory storeFactory,
     ISessionLifecycleEvents lifecycleEvents,
     ILogger<MemoryIndexer> logger) : IHostedService
 {
+    private readonly IAgentMemoryFactory _agentMemoryFactory = agentMemoryFactory;
     private readonly IMemoryStoreFactory _storeFactory = storeFactory;
     private readonly ISessionLifecycleEvents _lifecycleEvents = lifecycleEvents;
     private readonly ILogger<MemoryIndexer> _logger = logger;
@@ -61,15 +64,51 @@ public sealed class MemoryIndexer(
     private async Task IndexSessionAsync(SessionLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
     {
         var session = lifecycleEvent.Session!;
-        var store = _storeFactory.Create(lifecycleEvent.AgentId);
-        await store.InitializeAsync(cancellationToken).ConfigureAwait(false);
+        var agentId = lifecycleEvent.AgentId;
+        var sessionId = lifecycleEvent.SessionId;
 
-        await IndexSessionCoreAsync(session, AgentId.From(lifecycleEvent.AgentId), SessionId.From(lifecycleEvent.SessionId), store, cancellationToken).ConfigureAwait(false);
+        var sessionEvent = BuildSessionEvent(session, agentId, sessionId);
+
+        try
+        {
+            var agentMemory = _agentMemoryFactory.Create(agentId);
+            await agentMemory.OnSessionCompleteAsync(sessionEvent, cancellationToken).ConfigureAwait(false);
+        }
+        catch (NotSupportedException)
+        {
+            // Provider not registered — fall back to direct store indexing
+            var store = _storeFactory.Create(agentId);
+            await store.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            await IndexSessionCoreAsync(session, AgentId.From(agentId), SessionId.From(sessionId), store, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Builds an <see cref="AgentMemorySessionEvent"/> from a gateway session, including history turns.
+    /// </summary>
+    internal static AgentMemorySessionEvent BuildSessionEvent(GatewaySession session, string agentId, string sessionId)
+    {
+        var history = session.GetHistorySnapshot();
+        var turns = new List<AgentMemorySessionTurn>(history.Count);
+        for (var i = 0; i < history.Count; i++)
+        {
+            var entry = history[i];
+            turns.Add(new AgentMemorySessionTurn(i, entry.Role.Value, entry.Content, entry.Timestamp));
+        }
+
+        return new AgentMemorySessionEvent(
+            AgentId: agentId,
+            SessionId: sessionId,
+            ConversationId: null,
+            EndedAt: DateTimeOffset.UtcNow,
+            TurnCount: history.Count,
+            History: turns);
     }
 
     /// <summary>
     /// Core indexing logic that extracts user/assistant turn pairs from a session and inserts
     /// any turns not already indexed into the memory store.
+    /// Preserved as internal fallback for when IAgentMemory is unavailable.
     /// </summary>
     /// <returns>The number of new turns indexed.</returns>
     internal static async Task<int> IndexSessionCoreAsync(
@@ -139,16 +178,11 @@ public sealed class MemoryIndexer(
 
     /// <summary>
     /// Backfills memory entries from all existing sessions in the session store.
-    /// Can be called standalone without the hosted service running.
+    /// Routes through IAgentMemory when available, falling back to direct store access.
     /// </summary>
-    /// <param name="sessionStore">The session store to read sessions from.</param>
-    /// <param name="storeFactory">Factory to create per-agent memory stores.</param>
-    /// <param name="logger">Logger for progress reporting.</param>
-    /// <param name="agentFilter">Optional agent ID to limit backfill to a single agent.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A summary of sessions processed and turns indexed.</returns>
     public static async Task<BackfillResult> BackfillAsync(
         ISessionStore sessionStore,
+        IAgentMemoryFactory agentMemoryFactory,
         IMemoryStoreFactory storeFactory,
         ILogger logger,
         AgentId? agentFilter = null,
@@ -169,19 +203,22 @@ public sealed class MemoryIndexer(
 
             try
             {
-                var store = storeFactory.Create(agentId.Value);
-                await store.InitializeAsync(ct).ConfigureAwait(false);
+                var sessionEvent = BuildSessionEvent(session, agentId.Value, sessionId.Value);
 
-                var turnsIndexed = await IndexSessionCoreAsync(session, agentId, sessionId, store, ct).ConfigureAwait(false);
-                sessionsProcessed++;
-                totalTurns += turnsIndexed;
-
-                if (turnsIndexed > 0)
+                try
                 {
-                    logger.LogInformation(
-                        "Indexed {TurnsIndexed} turn(s) from session '{SessionId}' (agent: {AgentId}).",
-                        turnsIndexed, sessionId, agentId);
+                    var agentMemory = agentMemoryFactory.Create(agentId.Value);
+                    await agentMemory.OnSessionCompleteAsync(sessionEvent, ct).ConfigureAwait(false);
                 }
+                catch (NotSupportedException)
+                {
+                    var store = storeFactory.Create(agentId.Value);
+                    await store.InitializeAsync(ct).ConfigureAwait(false);
+                    await IndexSessionCoreAsync(session, agentId, sessionId, store, ct).ConfigureAwait(false);
+                }
+
+                sessionsProcessed++;
+                totalTurns += sessionEvent.TurnCount;
             }
             catch (OperationCanceledException)
             {
@@ -198,6 +235,28 @@ public sealed class MemoryIndexer(
             sessionsProcessed, totalTurns);
 
         return new BackfillResult(sessionsProcessed, totalTurns);
+    }
+
+    /// <summary>
+    /// Legacy overload for backward compatibility.
+    /// </summary>
+    public static Task<BackfillResult> BackfillAsync(
+        ISessionStore sessionStore,
+        IMemoryStoreFactory storeFactory,
+        ILogger logger,
+        AgentId? agentFilter = null,
+        CancellationToken ct = default)
+    {
+        // Create a throwing factory to force fallback path
+        return BackfillAsync(sessionStore, new ThrowingAgentMemoryFactory(), storeFactory, logger, agentFilter, ct);
+    }
+
+    private sealed class ThrowingAgentMemoryFactory : IAgentMemoryFactory
+    {
+        public IAgentMemory Create(string agentId, string? providerName = null)
+            => throw new NotSupportedException();
+
+        public IReadOnlyList<string> GetRegisteredProviders() => [];
     }
 }
 

--- a/tests/gateway/BotNexus.Memory.Tests/MemoryIndexerAdditionalTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/MemoryIndexerAdditionalTests.cs
@@ -7,6 +7,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BotNexus.Memory.Tests;
 
+internal sealed class ThrowingMemoryFactory : BotNexus.Gateway.Contracts.Memory.IAgentMemoryFactory
+{
+    public BotNexus.Gateway.Contracts.Memory.IAgentMemory Create(string agentId, string? providerName = null) => throw new NotSupportedException();
+    public IReadOnlyList<string> GetRegisteredProviders() => [];
+}
+
 public sealed class MemoryIndexerAdditionalTests
 {
     [Fact]
@@ -14,7 +20,7 @@ public sealed class MemoryIndexerAdditionalTests
     {
         var lifecycle = new TestLifecycleEvents();
         var store = new RecordingMemoryStore();
-        var indexer = new MemoryIndexer(new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -34,7 +40,7 @@ public sealed class MemoryIndexerAdditionalTests
     {
         var lifecycle = new TestLifecycleEvents();
         var store = new RecordingMemoryStore();
-        var indexer = new MemoryIndexer(new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -60,7 +66,7 @@ public sealed class MemoryIndexerAdditionalTests
     {
         var lifecycle = new TestLifecycleEvents();
         var store = new RecordingMemoryStore();
-        var indexer = new MemoryIndexer(new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -93,7 +99,7 @@ public sealed class MemoryIndexerAdditionalTests
     {
         var lifecycle = new TestLifecycleEvents();
         var store = new RecordingMemoryStore();
-        var indexer = new MemoryIndexer(new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -124,7 +130,7 @@ public sealed class MemoryIndexerAdditionalTests
     {
         var lifecycle = new TestLifecycleEvents();
         var store = new RecordingMemoryStore { ThrowOnFirstInsert = true };
-        var indexer = new MemoryIndexer(new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -158,7 +164,7 @@ public sealed class MemoryIndexerAdditionalTests
     {
         var lifecycle = new TestLifecycleEvents();
         var store = new RecordingMemoryStore();
-        var indexer = new MemoryIndexer(new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), new TestFactory(store), lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
         await indexer.StopAsync(CancellationToken.None);
 

--- a/tests/gateway/BotNexus.Memory.Tests/MemoryIndexerDelegationTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/MemoryIndexerDelegationTests.cs
@@ -1,0 +1,193 @@
+using BotNexus.Gateway.Contracts.Memory;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Domain.Primitives;
+using BotNexus.Memory.Models;
+using System.IO.Abstractions.TestingHelpers;
+using BotNexus.Gateway.Abstractions.Agents;
+
+namespace BotNexus.Memory.Tests;
+
+public sealed class MemoryIndexerDelegationTests
+{
+    [Fact]
+    public void BuildSessionEvent_MapsHistoryToTurns()
+    {
+        var session = new GatewaySession { SessionId = SessionId.From("session-1"), AgentId = AgentId.From("test-agent") };
+        session.AddEntry(new SessionEntry { Role = MessageRole.User, Content = "Hello", Timestamp = DateTimeOffset.UtcNow });
+        session.AddEntry(new SessionEntry { Role = MessageRole.Assistant, Content = "Hi there", Timestamp = DateTimeOffset.UtcNow });
+
+        var result = MemoryIndexer.BuildSessionEvent(session, "test-agent", "session-1");
+
+        result.AgentId.ShouldBe("test-agent");
+        result.SessionId.ShouldBe("session-1");
+        result.History.ShouldNotBeNull();
+        result.History!.Count.ShouldBe(2);
+        result.History[0].Role.ShouldBe("user");
+        result.History[0].Content.ShouldBe("Hello");
+        result.History[1].Role.ShouldBe("assistant");
+        result.History[1].Content.ShouldBe("Hi there");
+    }
+
+    [Fact]
+    public async Task MarkdownAgentMemory_OnSessionComplete_IndexesTurnPairs()
+    {
+        var store = new InMemoryMemoryStore();
+        var fileSystem = new MockFileSystem();
+        var workspaceManager = new StubWorkspaceManager("/workspace");
+        var memory = new MarkdownAgentMemory("test-agent", workspaceManager, store, fileSystem);
+
+        var history = new List<AgentMemorySessionTurn>
+        {
+            new(0, "user", "What is 2+2?", DateTimeOffset.UtcNow),
+            new(1, "assistant", "4", DateTimeOffset.UtcNow),
+            new(2, "user", "Thanks", DateTimeOffset.UtcNow),
+            new(3, "assistant", "You're welcome", DateTimeOffset.UtcNow)
+        };
+
+        var sessionEvent = new AgentMemorySessionEvent(
+            "test-agent", "session-1", TurnCount: 4, History: history);
+
+        await memory.OnSessionCompleteAsync(sessionEvent);
+
+        var indexed = await store.GetBySessionAsync("session-1", 100);
+        indexed.Count.ShouldBe(2);
+        indexed[0].Content.ShouldContain("What is 2+2?");
+        indexed[0].Content.ShouldContain("4");
+        indexed[1].Content.ShouldContain("Thanks");
+        indexed[1].Content.ShouldContain("You're welcome");
+    }
+
+    [Fact]
+    public async Task MarkdownAgentMemory_OnSessionComplete_SkipsToolMessages()
+    {
+        var store = new InMemoryMemoryStore();
+        var fileSystem = new MockFileSystem();
+        var workspaceManager = new StubWorkspaceManager("/workspace");
+        var memory = new MarkdownAgentMemory("test-agent", workspaceManager, store, fileSystem);
+
+        var history = new List<AgentMemorySessionTurn>
+        {
+            new(0, "user", "Read file.txt", DateTimeOffset.UtcNow),
+            new(1, "tool", "file contents here", DateTimeOffset.UtcNow),
+            new(2, "assistant", "Here is the file content", DateTimeOffset.UtcNow)
+        };
+
+        var sessionEvent = new AgentMemorySessionEvent(
+            "test-agent", "session-2", TurnCount: 3, History: history);
+
+        await memory.OnSessionCompleteAsync(sessionEvent);
+
+        var indexed = await store.GetBySessionAsync("session-2", 100);
+        indexed.Count.ShouldBe(1);
+        indexed[0].Content.ShouldContain("Read file.txt");
+        indexed[0].Content.ShouldContain("Here is the file content");
+        indexed[0].Content.ShouldNotContain("file contents here");
+    }
+
+    [Fact]
+    public async Task MarkdownAgentMemory_OnSessionComplete_DeduplicatesExistingTurns()
+    {
+        var store = new InMemoryMemoryStore();
+        var fileSystem = new MockFileSystem();
+        var workspaceManager = new StubWorkspaceManager("/workspace");
+        var memory = new MarkdownAgentMemory("test-agent", workspaceManager, store, fileSystem);
+
+        // Pre-index turn 0
+        await store.InsertAsync(new MemoryEntry
+        {
+            Id = "existing",
+            AgentId = "test-agent",
+            SessionId = "session-3",
+            TurnIndex = 0,
+            SourceType = "conversation",
+            Content = "User: Hello\nAssistant: Hi",
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+
+        var history = new List<AgentMemorySessionTurn>
+        {
+            new(0, "user", "Hello", DateTimeOffset.UtcNow),
+            new(1, "assistant", "Hi", DateTimeOffset.UtcNow),
+            new(2, "user", "Second question", DateTimeOffset.UtcNow),
+            new(3, "assistant", "Second answer", DateTimeOffset.UtcNow)
+        };
+
+        var sessionEvent = new AgentMemorySessionEvent(
+            "test-agent", "session-3", TurnCount: 4, History: history);
+
+        await memory.OnSessionCompleteAsync(sessionEvent);
+
+        var indexed = await store.GetBySessionAsync("session-3", 100);
+        // Should have 2: the pre-existing one + the new turn pair (not a duplicate of turn 0)
+        indexed.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task MarkdownAgentMemory_OnSessionComplete_WithNullHistory_DoesNothing()
+    {
+        var store = new InMemoryMemoryStore();
+        var fileSystem = new MockFileSystem();
+        var workspaceManager = new StubWorkspaceManager("/workspace");
+        var memory = new MarkdownAgentMemory("test-agent", workspaceManager, store, fileSystem);
+
+        var sessionEvent = new AgentMemorySessionEvent("test-agent", "session-4", TurnCount: 0);
+
+        await memory.OnSessionCompleteAsync(sessionEvent);
+
+        var indexed = await store.GetBySessionAsync("session-4", 100);
+        indexed.Count.ShouldBe(0);
+    }
+
+    private sealed class StubWorkspaceManager : IAgentWorkspaceManager
+    {
+        private readonly string _path;
+        public StubWorkspaceManager(string path) => _path = path;
+        public string GetWorkspacePath(string agentName) => _path;
+        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
+            => Task.FromResult(new AgentWorkspace(agentName, Soul: "", Identity: "", User: "", Memory: ""));
+        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, string? memoryPathOverride, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class InMemoryMemoryStore : IMemoryStore
+    {
+        private readonly List<MemoryEntry> _entries = [];
+        private int _nextId = 1;
+
+        public Task InitializeAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<MemoryEntry> InsertAsync(MemoryEntry entry, CancellationToken ct = default)
+        {
+            entry = entry with { Id = (_nextId++).ToString() };
+            _entries.Add(entry);
+            return Task.FromResult(entry);
+        }
+
+        public Task<IReadOnlyList<MemoryEntry>> GetBySessionAsync(string sessionId, int limit, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<MemoryEntry>>(_entries.Where(e => e.SessionId == sessionId).Take(limit).ToList());
+
+        public Task<MemoryEntry?> GetByIdAsync(string id, CancellationToken ct = default)
+            => Task.FromResult(_entries.FirstOrDefault(e => e.Id == id));
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(string query, int topK, MemorySearchFilter? filter = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<MemoryEntry>>(_entries.Take(topK).ToList());
+
+        public Task<MemoryStoreStats> GetStatsAsync(CancellationToken ct = default)
+            => Task.FromResult(new MemoryStoreStats(_entries.Count, 0, null));
+
+        public Task DeleteAsync(string id, CancellationToken ct = default)
+        {
+            _entries.RemoveAll(e => e.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken ct = default)
+        {
+            _entries.Clear();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/MemoryIndexerTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/MemoryIndexerTests.cs
@@ -15,7 +15,7 @@ public sealed class MemoryIndexerTests
         var lifecycle = new TestSessionLifecycleEvents();
         var store = new FakeMemoryStore();
         var factory = new FakeMemoryStoreFactory(store);
-        var indexer = new MemoryIndexer(factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -49,7 +49,7 @@ public sealed class MemoryIndexerTests
         var lifecycle = new TestSessionLifecycleEvents();
         var store = new FakeMemoryStore();
         var factory = new FakeMemoryStoreFactory(store);
-        var indexer = new MemoryIndexer(factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -80,7 +80,7 @@ public sealed class MemoryIndexerTests
         var lifecycle = new TestSessionLifecycleEvents();
         var store = new FakeMemoryStore();
         var factory = new FakeMemoryStoreFactory(store);
-        var indexer = new MemoryIndexer(factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try
@@ -110,7 +110,7 @@ public sealed class MemoryIndexerTests
         var lifecycle = new TestSessionLifecycleEvents();
         var store = new FakeMemoryStore();
         var factory = new FakeMemoryStoreFactory(store);
-        var indexer = new MemoryIndexer(factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
+        var indexer = new MemoryIndexer(new ThrowingMemoryFactory(), factory, lifecycle, NullLogger<MemoryIndexer>.Instance);
         await indexer.StartAsync(CancellationToken.None);
 
         try


### PR DESCRIPTION
Closes #1265

## Changes
- Extended `AgentMemorySessionEvent` with `History` property (`IReadOnlyList<AgentMemorySessionTurn>?`)
- Added `AgentMemorySessionTurn` DTO (Index, Role, Content, Timestamp)
- Moved turn-pair extraction and indexing logic into `MarkdownAgentMemory.OnSessionCompleteAsync()`
- `MemoryIndexer` now creates `AgentMemorySessionEvent` via `BuildSessionEvent()` and delegates to `IAgentMemory`
- Falls back to direct `IMemoryStore` indexing when factory throws `NotSupportedException`
- Preserved legacy `BackfillAsync` overload for CLI backward compatibility
- 5 new tests for the delegation path (BuildSessionEvent mapping, indexing, tool skipping, deduplication, null history)
- All existing 10 MemoryIndexer tests pass unchanged via `ThrowingMemoryFactory` (forces fallback path)

## Merge Notes
Touches `BotNexus.Gateway.Contracts/Memory/AgentMemorySessionEvent.cs`, `BotNexus.Memory/MemoryIndexer.cs`, `BotNexus.Memory/MarkdownAgentMemory.cs`, and test files. No overlap with any open PR.
