### PR TITLE
feat(search): add Microsoft AI Search provider (api.microsoft.ai)

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/Search/MicrosoftAiSearchProvider.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/Search/MicrosoftAiSearchProvider.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using System.Text.Json;
+
+namespace BotNexus.Extensions.WebTools.Search;
+
+/// <summary>
+/// Microsoft AI Search provider (api.microsoft.ai/v3/search/web).
+/// Returns rich markdown-formatted results with configurable content length.
+/// </summary>
+internal sealed class MicrosoftAiSearchProvider : ISearchProvider
+{
+    private const string ApiEndpoint = "https://api.microsoft.ai/v3/search/web";
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+
+    public MicrosoftAiSearchProvider(HttpClient httpClient, string apiKey)
+    {
+        _httpClient = httpClient;
+        _apiKey = apiKey;
+    }
+
+    public async Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
+    {
+        var payload = new
+        {
+            query,
+            maxResults,
+            language = "en",
+            region = "US",
+            contentFormat = "markdown",
+            maxLength = 10000
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, ApiEndpoint);
+        request.Headers.Add("x-apikey", _apiKey);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var responseJson = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(responseJson);
+
+        var results = new List<SearchResult>();
+
+        // The API may return results in a "results" array or "webPages" structure.
+        // Try common response shapes.
+        if (doc.RootElement.TryGetProperty("results", out var resultsArray) &&
+            resultsArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var result in resultsArray.EnumerateArray())
+            {
+                var title = result.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+                var url = result.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+                var snippet = result.TryGetProperty("content", out var c) ? c.GetString() ?? ""
+                    : result.TryGetProperty("snippet", out var s) ? s.GetString() ?? "" : "";
+
+                if (!string.IsNullOrWhiteSpace(url))
+                    results.Add(new SearchResult(title, url, snippet));
+            }
+        }
+        else if (doc.RootElement.TryGetProperty("webPages", out var webPages) &&
+                 webPages.TryGetProperty("value", out var values) &&
+                 values.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var result in values.EnumerateArray())
+            {
+                var title = result.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+                var url = result.TryGetProperty("url", out var u) ? u.GetString() ?? "" : "";
+                var snippet = result.TryGetProperty("snippet", out var s) ? s.GetString() ?? "" : "";
+
+                if (!string.IsNullOrWhiteSpace(url))
+                    results.Add(new SearchResult(title, url, snippet));
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
@@ -126,7 +126,7 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
         if (provider is null)
         {
             return TextResult(
-                $"Unknown search provider: '{_config.Provider}'. Supported: brave, tavily, bing, copilot.");
+                $"Unknown search provider: '{_config.Provider}'. Supported: brave, tavily, bing, microsoft, copilot.");
         }
 
         try
@@ -186,6 +186,7 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
                 "brave" when !string.IsNullOrWhiteSpace(apiKey) => new BraveSearchProvider(_httpClient, apiKey),
                 "tavily" when !string.IsNullOrWhiteSpace(apiKey) => new TavilySearchProvider(_httpClient, apiKey),
                 "bing" when !string.IsNullOrWhiteSpace(apiKey) => new BingSearchProvider(_httpClient, apiKey),
+                "microsoft" or "microsoft-ai" when !string.IsNullOrWhiteSpace(apiKey) => new MicrosoftAiSearchProvider(_httpClient, apiKey),
                 "copilot" when _copilotApiKeyResolver is not null =>
                     new CopilotMcpSearchProvider(_copilotApiKeyResolver, _httpClient, _copilotApiEndpoint,
                         _loggerFactory?.CreateLogger<CopilotMcpSearchProvider>()),

--- a/src/extensions/BotNexus.Extensions.WebTools/WebToolsConfig.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebToolsConfig.cs
@@ -21,7 +21,7 @@ public sealed class WebToolsConfig
 /// </summary>
 public sealed class WebSearchConfig
 {
-    /// <summary>Search provider: "brave", "tavily", "bing", or "copilot". Default: "brave".</summary>
+    /// <summary>Search provider: "brave", "tavily", "bing", "microsoft", or "copilot". Default: "brave".</summary>
     [JsonPropertyName("provider")]
     public string Provider { get; set; } = "brave";
 


### PR DESCRIPTION
Adds `microsoft` (alias `microsoft-ai`) as a new web search provider option.

## Changes
- New `MicrosoftAiSearchProvider` implementing `ISearchProvider`
- POST to `https://api.microsoft.ai/v3/search/web` with markdown content format
- Wired into `WebSearchTool.CreateProvider` switch expression
- Config doc updated to list `microsoft` as supported provider

## Configuration
```json
{
  "botnexus-web": {
    "search": {
      "provider": "microsoft",
      "apiKey": "${env:MICROSOFT_AI_SEARCH_KEY}"
    }
  }
}
```

## Secrets
API key stored at `~/.botnexus/secrets/microsoft-ai-search.key` — reference via env var `MICROSOFT_AI_SEARCH_KEY`.

Closes: N/A (new feature request from Jon)