### PR TITLE
fix(portal): include cron-assigned conversations in scheduled sidebar group

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/CronApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Core/Services/CronApiClient.cs
@@ -153,4 +153,5 @@ public sealed class CronJobDto
     public DateTimeOffset? NextRunAt { get; set; }
     public string? LastRunStatus { get; set; }
     public string? LastRunError { get; set; }
+    public string? ConversationId { get; set; }
 }

--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Layout/MainLayout.razor
@@ -10,6 +10,7 @@
 @inject IUpdateStatusService UpdateStatus
 @inject IJSRuntime JS
 @inject IPortalPreferencesService Prefs
+@inject CronApiClient CronApi
 @implements IDisposable
 @implements IAsyncDisposable
 
@@ -308,6 +309,7 @@
 
 @code {
     private bool _cronGroupCollapsed = true;
+    private HashSet<string> _cronConversationIds = new(StringComparer.OrdinalIgnoreCase);
     private const string CronCollapsedKey = "botnexus-cron-collapsed";
 
     private record Announcement(string Id, string Text, string Type = "info");
@@ -352,6 +354,7 @@
                 await Interaction.RefreshConversationsAsync(activeAgentId);
 
             await LoadSidebarAgentsAsync();
+            await LoadCronConversationIdsAsync();
             StateHasChanged();
         }
     }
@@ -503,9 +506,10 @@
         return true;
     }
 
-    private static bool IsCronConversation(ConversationState c) =>
+    private bool IsCronConversation(ConversationState c) =>
         c.ConversationId.StartsWith("cronconv:", StringComparison.OrdinalIgnoreCase) ||
-        (c.IsVirtualSession && string.Equals(c.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase));
+        (c.IsVirtualSession && string.Equals(c.VirtualSessionKind, "cron", StringComparison.OrdinalIgnoreCase)) ||
+        _cronConversationIds.Contains(c.ConversationId);
 
     private static bool IsPinnedConversation(ConversationState c) => c.IsPinned;
 
@@ -731,6 +735,19 @@
                 .ToList();
         }
         catch { _sidebarAgents = []; }
+    }
+
+    private async Task LoadCronConversationIdsAsync()
+    {
+        try
+        {
+            var (jobs, _) = await CronApi.ListAsync();
+            _cronConversationIds = jobs
+                .Where(j => !string.IsNullOrEmpty(j.ConversationId))
+                .Select(j => j.ConversationId!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+        catch { _cronConversationIds = new(StringComparer.OrdinalIgnoreCase); }
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationGroupingTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ConversationGroupingTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using System.Net;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.AspNetCore.Components;
@@ -43,6 +44,7 @@ public sealed class ConversationGroupingTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -198,5 +200,81 @@ public sealed class ConversationGroupingTests : IDisposable
 
         // Cron should NOT be in the normal conversations group
         Assert.DoesNotContain("Cron Job", convsGroup.TextContent);
+    }
+
+    [Fact]
+    public async Task ConversationAssignedToCronJob_RenderedInScheduledGroup()
+    {
+        // Arrange: set up a mock HTTP handler that returns cron jobs with a conversationId
+        var handler = new MockCronHttpHandler();
+        handler.SetCronResponse("[{\"id\":\"job-1\",\"name\":\"Daily Digest\",\"schedule\":\"0 8 * * *\",\"enabled\":true,\"conversationId\":\"conv:assigned-to-cron\"}]");
+        using var ctx = new BunitContext();
+        var httpWithMock = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var restClient = Substitute.For<IGatewayRestClient>();
+        restClient.ApiBaseUrl.Returns("");
+        var store = new ClientStateStore();
+        ctx.Services.AddSingleton<IClientStateStore>(store);
+        ctx.Services.AddSingleton(Substitute.For<IAgentInteractionService>());
+        var portalLoad = Substitute.For<IPortalLoadService>();
+        portalLoad.IsReady.Returns(false);
+        portalLoad.IsLoading.Returns(true);
+        portalLoad.LoadError.Returns((string?)null);
+        ctx.Services.AddSingleton(portalLoad);
+        ctx.Services.AddSingleton(new GatewayHubConnection());
+        ctx.Services.AddSingleton(new GatewayInfoService(httpWithMock, restClient));
+        ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
+        var mockPrefs = Substitute.For<IPortalPreferencesService>();
+        mockPrefs.Current.Returns(new PortalPreferences());
+        ctx.Services.AddSingleton(mockPrefs);
+        ctx.Services.AddSingleton(restClient);
+        ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
+        ctx.Services.AddSingleton(httpWithMock);
+        ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        ctx.Services.AddSingleton(new CronApiClient(httpWithMock));
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        store.SeedAgents([new AgentSummary("a-1", "Alpha")]);
+        store.SeedConversations("a-1", [
+            new ConversationSummaryDto("conv:assigned-to-cron", "a-1", "Digest Conv", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new ConversationSummaryDto("conv:normal", "a-1", "Normal Conv", false, "Active", null, 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+        ]);
+        store.ActiveAgentId = "a-1";
+
+        var cut = ctx.Render<MainLayout>(p => p
+            .Add(c => c.Body, (RenderFragment)(_ => { })));
+
+        // Wait for async OnAfterRenderAsync to complete
+        await Task.Delay(100);
+        cut.Render();
+
+        // Expand the cron group
+        cut.Find("[data-testid='cron-group-toggle']").Click();
+
+        // The assigned conversation should be in the scheduled group
+        var scheduledGroup = cut.Find("[data-testid='conversation-group-scheduled']");
+        Assert.Contains("Digest Conv", scheduledGroup.TextContent);
+
+        // The normal conversation should NOT be in the scheduled group
+        Assert.DoesNotContain("Normal Conv", scheduledGroup.TextContent);
+    }
+
+    private sealed class MockCronHttpHandler : HttpMessageHandler
+    {
+        private string _cronJson = "[]";
+
+        public void SetCronResponse(string json) => _cronJson = json;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? "";
+            if (path.Contains("/api/cron", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_cronJson, System.Text.Encoding.UTF8, "application/json")
+                });
+            }
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+        }
     }
 }

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/DataTestIdAttributeTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/DataTestIdAttributeTests.cs
@@ -45,6 +45,7 @@ public sealed class DataTestIdAttributeTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/DebugModeTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/DebugModeTests.cs
@@ -38,6 +38,7 @@ public sealed class DebugModeTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/MainLayoutTests.cs
@@ -43,6 +43,7 @@ public sealed class MainLayoutTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ProbeRound2ComponentTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using Bunit.TestDoubles;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Components;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
@@ -29,8 +29,10 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         var restClient = Substitute.For<IGatewayRestClient>();
         _ctx.Services.AddSingleton(restClient);
         _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
-        _ctx.Services.AddSingleton(new HttpClient());
+        var http = new HttpClient();
+        _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         _ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
         var _mockPrefs = Substitute.For<IPortalPreferencesService>(); _mockPrefs.Current.Returns(new PortalPreferences()); _ctx.Services.AddSingleton(_mockPrefs);
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -183,6 +185,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
         ctx.Services.AddSingleton(http);
         ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        ctx.Services.AddSingleton(new CronApiClient(http));
         ctx.Services.AddSingleton(Substitute.For<IUpdateStatusService>());
         var mockPrefs2 = Substitute.For<IPortalPreferencesService>(); mockPrefs2.Current.Returns(new PortalPreferences()); ctx.Services.AddSingleton(mockPrefs2);
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -223,6 +226,7 @@ public sealed class ProbeRound2ComponentTests : IDisposable
         _ctx.Services.AddSingleton(hub);
         _ctx.Services.AddSingleton(gatewayInfo);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
 
         _store.SeedAgents([new AgentSummary("a-1", "Agent One")]);
         _store.SeedConversations("a-1", []);

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionDebugPanelWiringTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/SessionDebugPanelWiringTests.cs
@@ -41,6 +41,7 @@ public sealed class SessionDebugPanelWiringTests : IDisposable
         _ctx.Services.AddSingleton(Substitute.For<IChannelErrorReporter>());
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/UpdateBadgeTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Layout;
 using BotNexus.Extensions.Channels.SignalR.BlazorClient.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +44,7 @@ public sealed class UpdateBadgeTests : IDisposable
         _ctx.Services.AddSingleton(http);
         _ctx.Services.AddSingleton(_updateSvc);
         _ctx.Services.AddSingleton(new ExtensionFeatureService(restClient));
+        _ctx.Services.AddSingleton(new CronApiClient(http));
         var _mockPrefs = Substitute.For<IPortalPreferencesService>(); _mockPrefs.Current.Returns(new PortalPreferences()); _ctx.Services.AddSingleton(_mockPrefs);
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
     }


### PR DESCRIPTION
Closes #1268

## Changes
- Added \ConversationId\ property to \CronJobDto\ (client-side DTO)
- Injected \CronApiClient\ in MainLayout and load cron conversation IDs on first render
- Extended \IsCronConversation\ to cross-reference conversations assigned to cron jobs via their \conversationId\ field
- Updated all test classes that render MainLayout to register \CronApiClient\ in DI
- Added integration test with mock HTTP handler verifying cron-assigned conversations appear in the scheduled group

## Merge Notes
Safe to merge independently. No file overlap with other open PRs.