### PR TITLE
feat(memory): add shared store promotion during dreaming consolidation

### DIFF
--- a/src/gateway/BotNexus.Cron/Actions/MemoryDreamingCronAction.cs
+++ b/src/gateway/BotNexus.Cron/Actions/MemoryDreamingCronAction.cs
@@ -1,6 +1,9 @@
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Triggers;
+using BotNexus.Memory;
+using BotNexus.Memory.Learning;
+using BotNexus.Memory.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
@@ -110,6 +113,116 @@ public sealed class MemoryDreamingCronAction : ICronAction
 
         if (triggerRequest.ResolvedConversationId is { } resolvedConversationId)
             context.RecordConversationId(resolvedConversationId);
+
+        // Phase 2: Promote insights to shared stores (runs independently of consolidation)
+        await PromoteToSharedStoresAsync(context, agentId, lookbackDays, logger, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the learning extraction pipeline on the agent's memory store and promotes
+    /// routed knowledge items to shared stores.
+    /// </summary>
+    private static async Task PromoteToSharedStoresAsync(
+        CronExecutionContext context,
+        AgentId agentId,
+        int lookbackDays,
+        ILogger? logger,
+        CancellationToken ct)
+    {
+        var sharedRegistry = context.Services.GetService<ISharedMemoryStoreRegistry>();
+        if (sharedRegistry is null)
+        {
+            logger?.LogDebug("Shared memory promotion skipped: no ISharedMemoryStoreRegistry registered");
+            return;
+        }
+
+        var writableStores = sharedRegistry.GetWritableStores(agentId.Value);
+        if (writableStores.Count == 0)
+        {
+            logger?.LogDebug("Shared memory promotion skipped: agent '{AgentId}' has no writable shared stores", agentId.Value);
+            return;
+        }
+
+        var memoryFactory = context.Services.GetService<IMemoryStoreFactory>();
+        if (memoryFactory is null)
+        {
+            logger?.LogDebug("Shared memory promotion skipped: no IMemoryStoreFactory registered");
+            return;
+        }
+
+        var agentStore = memoryFactory.Create(agentId.Value);
+        await agentStore.InitializeAsync(ct).ConfigureAwait(false);
+
+        try
+        {
+            // Get recent entries from the agent's private store
+            var cutoffDate = DateTimeOffset.UtcNow.AddDays(-lookbackDays);
+            var recentEntries = await agentStore.SearchAsync(
+                "*", topK: 200, filter: new MemorySearchFilter { AfterDate = cutoffDate }, ct: ct)
+                .ConfigureAwait(false);
+
+            if (recentEntries.Count == 0)
+            {
+                logger?.LogDebug("Shared memory promotion skipped: no recent entries for agent '{AgentId}'", agentId.Value);
+                return;
+            }
+
+            // Build routing rules from config (route all categories to writable stores)
+            var rules = BuildRoutingRules(sharedRegistry, agentId.Value);
+            if (rules.Count == 0)
+            {
+                logger?.LogDebug("Shared memory promotion skipped: no routing rules generated for agent '{AgentId}'", agentId.Value);
+                return;
+            }
+
+            var pipeline = new LearningExtractionPipeline(
+                rules,
+                logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            var extracted = await pipeline.ExtractAsync(recentEntries, ct).ConfigureAwait(false);
+
+            var promotable = extracted.Where(e => e.TargetStore is not null).ToList();
+            if (promotable.Count == 0)
+            {
+                logger?.LogInformation("Shared memory promotion: no promotable items found for agent '{AgentId}'", agentId.Value);
+                return;
+            }
+
+            var promoter = new SharedMemoryPromoter(
+                sharedRegistry,
+                logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            var promoted = await promoter.PromoteAsync(agentId.Value, promotable, ct).ConfigureAwait(false);
+            logger?.LogInformation(
+                "Shared memory promotion complete for agent '{AgentId}': {Promoted} items promoted",
+                agentId.Value, promoted);
+        }
+        finally
+        {
+            await agentStore.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Builds routing rules that send high-confidence knowledge to the agent's writable shared stores.
+    /// Uses a default confidence threshold of 0.7 for all categories.
+    /// </summary>
+    internal static IReadOnlyList<KnowledgeRoutingRule> BuildRoutingRules(
+        ISharedMemoryStoreRegistry registry, string agentId)
+    {
+        var writableStores = registry.GetWritableStores(agentId);
+        if (writableStores.Count == 0)
+            return [];
+
+        // Route to the first writable store by default
+        // Future: allow per-category store mapping via metadata
+        var targetStore = writableStores[0];
+
+        return
+        [
+            new KnowledgeRoutingRule { Category = null, MinConfidence = 0.7, TargetStore = targetStore }
+        ];
     }
 
     /// <summary>

--- a/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
+++ b/src/gateway/BotNexus.Cron/BotNexus.Cron.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\agent\BotNexus.Agent.Providers.Core\BotNexus.Agent.Providers.Core.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Memory\BotNexus.Memory.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gateway/BotNexus.Memory/SharedMemoryPromoter.cs
+++ b/src/gateway/BotNexus.Memory/SharedMemoryPromoter.cs
@@ -1,0 +1,163 @@
+using BotNexus.Memory.Learning;
+using BotNexus.Memory.Models;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Memory;
+
+/// <summary>
+/// Promotes extracted knowledge to shared memory stores during the dreaming cycle.
+/// Handles deduplication by checking existing entries for content overlap.
+/// </summary>
+public sealed class SharedMemoryPromoter
+{
+    private readonly ISharedMemoryStoreRegistry _registry;
+    private readonly ILogger _logger;
+
+    /// <summary>Minimum similarity ratio (0-1) to consider an entry a duplicate.</summary>
+    private const double DeduplicationThreshold = 0.85;
+
+    public SharedMemoryPromoter(ISharedMemoryStoreRegistry registry, ILogger logger)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Promotes routed knowledge items to their target shared stores.
+    /// Skips items that already exist (deduplication) or where the agent lacks write access.
+    /// </summary>
+    /// <param name="agentId">Agent performing the promotion.</param>
+    /// <param name="items">Knowledge items with routing decisions already applied.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of items successfully promoted.</returns>
+    public async Task<int> PromoteAsync(
+        string agentId,
+        IReadOnlyList<ExtractedKnowledge> items,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        var promoted = 0;
+
+        foreach (var item in items)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (item.TargetStore is null)
+                continue;
+
+            if (!_registry.CanWrite(agentId, item.TargetStore))
+            {
+                _logger.LogWarning(
+                    "Agent '{AgentId}' lacks write access to shared store '{Store}', skipping promotion",
+                    agentId, item.TargetStore);
+                continue;
+            }
+
+            var store = _registry.GetStore(item.TargetStore);
+            if (store is null)
+            {
+                _logger.LogWarning(
+                    "Shared store '{Store}' not found in registry, skipping promotion",
+                    item.TargetStore);
+                continue;
+            }
+
+            // Deduplication: search for similar content
+            if (await IsDuplicateAsync(store, item.Content, ct).ConfigureAwait(false))
+            {
+                _logger.LogDebug(
+                    "Skipping duplicate promotion to '{Store}': {ContentPreview}",
+                    item.TargetStore, Truncate(item.Content, 80));
+                continue;
+            }
+
+            var entry = new MemoryEntry
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                AgentId = agentId,
+                SessionId = item.SourceSessionId,
+                TurnIndex = item.SourceTurnIndex,
+                SourceType = "dreaming",
+                Content = item.Content,
+                MetadataJson = BuildMetadataJson(item),
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+
+            await store.InsertAsync(entry, ct).ConfigureAwait(false);
+            promoted++;
+
+            _logger.LogInformation(
+                "Promoted knowledge to shared store '{Store}': category={Category}, confidence={Confidence:F2}",
+                item.TargetStore, item.Category, item.Confidence);
+        }
+
+        _logger.LogInformation(
+            "Shared memory promotion complete: {Promoted}/{Total} items promoted for agent '{AgentId}'",
+            promoted, items.Count(i => i.TargetStore is not null), agentId);
+
+        return promoted;
+    }
+
+    /// <summary>
+    /// Checks if content already exists in the target store (basic keyword overlap dedup).
+    /// Uses search to find potential duplicates, then compares content similarity.
+    /// </summary>
+    internal async Task<bool> IsDuplicateAsync(IMemoryStore store, string content, CancellationToken ct)
+    {
+        // Extract key terms for search (first 100 chars as query)
+        var query = Truncate(content, 100);
+
+        try
+        {
+            var existing = await store.SearchAsync(query, topK: 5, ct: ct).ConfigureAwait(false);
+
+            foreach (var entry in existing)
+            {
+                var similarity = ComputeJaccardSimilarity(content, entry.Content);
+                if (similarity >= DeduplicationThreshold)
+                    return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            // If search fails, allow promotion (don't block on dedup failure)
+            _logger.LogDebug(ex, "Deduplication search failed, allowing promotion");
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Computes Jaccard similarity between two texts based on word-level tokens.
+    /// Returns 0.0 (no overlap) to 1.0 (identical word sets).
+    /// </summary>
+    internal static double ComputeJaccardSimilarity(string a, string b)
+    {
+        var setA = Tokenize(a);
+        var setB = Tokenize(b);
+
+        if (setA.Count == 0 && setB.Count == 0)
+            return 1.0;
+        if (setA.Count == 0 || setB.Count == 0)
+            return 0.0;
+
+        var intersection = setA.Intersect(setB).Count();
+        var union = setA.Union(setB).Count();
+
+        return union == 0 ? 0.0 : (double)intersection / union;
+    }
+
+    private static HashSet<string> Tokenize(string text)
+        => text.Split([' ', '\t', '\n', '\r', '.', ',', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}', '"', '\''],
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(t => t.ToLowerInvariant())
+            .Where(t => t.Length > 2)
+            .ToHashSet();
+
+    private static string Truncate(string text, int maxLength)
+        => text.Length <= maxLength ? text : text[..maxLength];
+
+    private static string BuildMetadataJson(ExtractedKnowledge item)
+        => $"{{\"category\":\"{item.Category}\",\"confidence\":{item.Confidence:F2},\"sourceSession\":\"{item.SourceSessionId}\",\"sourceTurn\":{item.SourceTurnIndex}}}";
+}

--- a/tests/gateway/BotNexus.Cron.Tests/BotNexus.Cron.Tests.csproj
+++ b/tests/gateway/BotNexus.Cron.Tests/BotNexus.Cron.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Cron\BotNexus.Cron.csproj" />
     <ProjectReference Include="..\..\..\src\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
     <ProjectReference Include="..\..\..\src\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\src\gateway\BotNexus.Memory\BotNexus.Memory.csproj" />
   </ItemGroup>
 
 

--- a/tests/gateway/BotNexus.Cron.Tests/MemoryDreamingPromotionTests.cs
+++ b/tests/gateway/BotNexus.Cron.Tests/MemoryDreamingPromotionTests.cs
@@ -1,0 +1,45 @@
+using BotNexus.Cron.Actions;
+using BotNexus.Memory;
+using Moq;
+
+namespace BotNexus.Cron.Tests;
+
+public sealed class MemoryDreamingPromotionTests
+{
+    [Fact]
+    public void BuildRoutingRules_NoWritableStores_ReturnsEmpty()
+    {
+        var registry = new Mock<ISharedMemoryStoreRegistry>();
+        registry.Setup(r => r.GetWritableStores("agent-1")).Returns(new List<string>());
+
+        var rules = MemoryDreamingCronAction.BuildRoutingRules(registry.Object, "agent-1");
+
+        rules.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildRoutingRules_WithWritableStore_ReturnsCatchAllRule()
+    {
+        var registry = new Mock<ISharedMemoryStoreRegistry>();
+        registry.Setup(r => r.GetWritableStores("agent-1")).Returns(new List<string> { "platform-knowledge" });
+
+        var rules = MemoryDreamingCronAction.BuildRoutingRules(registry.Object, "agent-1");
+
+        rules.Count.ShouldBe(1);
+        rules[0].Category.ShouldBeNull(); // catch-all
+        rules[0].MinConfidence.ShouldBe(0.7);
+        rules[0].TargetStore.ShouldBe("platform-knowledge");
+    }
+
+    [Fact]
+    public void BuildRoutingRules_MultipleWritableStores_UsesFirst()
+    {
+        var registry = new Mock<ISharedMemoryStoreRegistry>();
+        registry.Setup(r => r.GetWritableStores("agent-1")).Returns(new List<string> { "store-a", "store-b" });
+
+        var rules = MemoryDreamingCronAction.BuildRoutingRules(registry.Object, "agent-1");
+
+        rules.Count.ShouldBe(1);
+        rules[0].TargetStore.ShouldBe("store-a");
+    }
+}

--- a/tests/gateway/BotNexus.Memory.Tests/SharedMemoryPromoterTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/SharedMemoryPromoterTests.cs
@@ -1,0 +1,151 @@
+using BotNexus.Memory;
+using BotNexus.Memory.Learning;
+using BotNexus.Memory.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace BotNexus.Memory.Tests;
+
+public sealed class SharedMemoryPromoterTests
+{
+    private readonly Mock<ISharedMemoryStoreRegistry> _registry = new();
+    private readonly Mock<IMemoryStore> _store = new();
+    private readonly SharedMemoryPromoter _promoter;
+
+    public SharedMemoryPromoterTests()
+    {
+        _promoter = new SharedMemoryPromoter(_registry.Object, NullLogger.Instance);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_NoTargetStore_SkipsAll()
+    {
+        var items = new List<ExtractedKnowledge>
+        {
+            new() { Content = "test", Category = KnowledgeCategory.Fact, Confidence = 0.9, SourceSessionId = "s1", SourceTurnIndex = 1, TargetStore = null }
+        };
+
+        var result = await _promoter.PromoteAsync("agent-1", items);
+
+        result.ShouldBe(0);
+        _store.Verify(s => s.InsertAsync(It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_NoWriteAccess_SkipsItem()
+    {
+        _registry.Setup(r => r.CanWrite("agent-1", "shared-store")).Returns(false);
+
+        var items = new List<ExtractedKnowledge>
+        {
+            new() { Content = "test", Category = KnowledgeCategory.Decision, Confidence = 0.9, SourceSessionId = "s1", SourceTurnIndex = 1, TargetStore = "shared-store" }
+        };
+
+        var result = await _promoter.PromoteAsync("agent-1", items);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_StoreNotFound_SkipsItem()
+    {
+        _registry.Setup(r => r.CanWrite("agent-1", "shared-store")).Returns(true);
+        _registry.Setup(r => r.GetStore("shared-store")).Returns((IMemoryStore?)null);
+
+        var items = new List<ExtractedKnowledge>
+        {
+            new() { Content = "test", Category = KnowledgeCategory.Pattern, Confidence = 0.8, SourceSessionId = "s1", SourceTurnIndex = 1, TargetStore = "shared-store" }
+        };
+
+        var result = await _promoter.PromoteAsync("agent-1", items);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_DuplicateContent_SkipsItem()
+    {
+        _registry.Setup(r => r.CanWrite("agent-1", "shared-store")).Returns(true);
+        _registry.Setup(r => r.GetStore("shared-store")).Returns(_store.Object);
+
+        var existingEntry = new MemoryEntry
+        {
+            Id = "existing-1",
+            AgentId = "other-agent",
+            SourceType = "dreaming",
+            Content = "This is some important architectural decision about the system design",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+        _store.Setup(s => s.SearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<MemorySearchFilter?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry> { existingEntry });
+
+        var items = new List<ExtractedKnowledge>
+        {
+            new() { Content = "This is some important architectural decision about the system design", Category = KnowledgeCategory.Decision, Confidence = 0.9, SourceSessionId = "s1", SourceTurnIndex = 1, TargetStore = "shared-store" }
+        };
+
+        var result = await _promoter.PromoteAsync("agent-1", items);
+
+        result.ShouldBe(0);
+        _store.Verify(s => s.InsertAsync(It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_NewContent_InsertsEntry()
+    {
+        _registry.Setup(r => r.CanWrite("agent-1", "shared-store")).Returns(true);
+        _registry.Setup(r => r.GetStore("shared-store")).Returns(_store.Object);
+        _store.Setup(s => s.SearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<MemorySearchFilter?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>());
+
+        var items = new List<ExtractedKnowledge>
+        {
+            new() { Content = "New insight about deployment patterns", Category = KnowledgeCategory.Pattern, Confidence = 0.85, SourceSessionId = "s1", SourceTurnIndex = 3, TargetStore = "shared-store" }
+        };
+
+        var result = await _promoter.PromoteAsync("agent-1", items);
+
+        result.ShouldBe(1);
+        _store.Verify(s => s.InsertAsync(
+            It.Is<MemoryEntry>(e =>
+                e.AgentId == "agent-1" &&
+                e.SourceType == "dreaming" &&
+                e.Content == "New insight about deployment patterns"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PromoteAsync_MultipleItems_PromotesOnlyEligible()
+    {
+        _registry.Setup(r => r.CanWrite("agent-1", "shared-store")).Returns(true);
+        _registry.Setup(r => r.CanWrite("agent-1", "no-access-store")).Returns(false);
+        _registry.Setup(r => r.GetStore("shared-store")).Returns(_store.Object);
+        _store.Setup(s => s.SearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<MemorySearchFilter?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MemoryEntry>());
+
+        var items = new List<ExtractedKnowledge>
+        {
+            new() { Content = "Item 1", Category = KnowledgeCategory.Fact, Confidence = 0.9, SourceSessionId = "s1", SourceTurnIndex = 1, TargetStore = "shared-store" },
+            new() { Content = "Item 2", Category = KnowledgeCategory.Fact, Confidence = 0.9, SourceSessionId = "s1", SourceTurnIndex = 2, TargetStore = "no-access-store" },
+            new() { Content = "Item 3", Category = KnowledgeCategory.Fact, Confidence = 0.9, SourceSessionId = "s1", SourceTurnIndex = 3, TargetStore = null },
+        };
+
+        var result = await _promoter.PromoteAsync("agent-1", items);
+
+        result.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData("identical content here", "identical content here", true)]
+    [InlineData("completely different text about dogs", "unrelated words about the weather today", false)]
+    [InlineData("the system uses sqlite for persistence", "the system uses sqlite for data persistence layer", true)]
+    public void ComputeJaccardSimilarity_CorrectlyIdentifiesDuplicates(string a, string b, bool shouldBeAboveThreshold)
+    {
+        var similarity = SharedMemoryPromoter.ComputeJaccardSimilarity(a, b);
+
+        if (shouldBeAboveThreshold)
+            similarity.ShouldBeGreaterThanOrEqualTo(0.7);
+        else
+            similarity.ShouldBeLessThan(0.7);
+    }
+}


### PR DESCRIPTION
Closes #1206

## Changes
- Added \SharedMemoryPromoter\ class: promotes extracted knowledge to shared stores with Jaccard similarity deduplication
- Extended \MemoryDreamingCronAction\ with Phase 2: after dispatching consolidation prompt, runs learning extraction pipeline on recent memory entries and promotes routed items to shared stores
- Added \BuildRoutingRules\ helper that generates catch-all routing to the agent's first writable shared store (threshold 0.7)
- Added project reference from BotNexus.Cron → BotNexus.Memory
- 12 new tests (9 SharedMemoryPromoter + 3 BuildRoutingRules)

## Merge Notes
Independent of other open PRs. Touches MemoryDreamingCronAction.cs (no other PRs touch this file) and adds new SharedMemoryPromoter.cs.