### PR TITLE
fix(config): add JsonConverter for TitlingConfig to handle legacy string format

### DIFF
--- a/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/PlatformConfig.cs
@@ -632,6 +632,7 @@ public sealed class AuxiliaryConfig
     /// <c>AuxiliarySchemaContributor</c> as a nested object (<c>{ model, timeoutSeconds }</c>);
     /// this property must remain an object so the bound config matches the on-disk shape.
     /// </summary>
+    [System.Text.Json.Serialization.JsonConverter(typeof(TitlingConfigJsonConverter))]
     public TitlingConfig? Titling { get; set; }
 
     /// <summary>

--- a/src/gateway/BotNexus.Gateway/Configuration/TitlingConfigJsonConverter.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/TitlingConfigJsonConverter.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Gateway.Configuration;
+
+/// <summary>
+/// Handles backward compatibility for the titling config field.
+/// Previously <c>gateway.auxiliary.titling</c> was a plain string (model name).
+/// Now it is a <see cref="TitlingConfig"/> object. This converter accepts both forms.
+/// </summary>
+internal sealed class TitlingConfigJsonConverter : JsonConverter<TitlingConfig?>
+{
+    public override TitlingConfig? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var model = reader.GetString();
+            return string.IsNullOrWhiteSpace(model) ? null : new TitlingConfig { Model = model };
+        }
+
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            var doc = JsonDocument.ParseValue(ref reader);
+            var root = doc.RootElement;
+
+            var config = new TitlingConfig();
+            if (root.TryGetProperty("model", out var modelEl) || root.TryGetProperty("Model", out modelEl))
+                config.Model = modelEl.GetString();
+            if (root.TryGetProperty("timeoutSeconds", out var timeoutEl) || root.TryGetProperty("TimeoutSeconds", out timeoutEl))
+                config.TimeoutSeconds = timeoutEl.GetInt32();
+
+            return config;
+        }
+
+        throw new JsonException($"Unexpected token type '{reader.TokenType}' when reading TitlingConfig.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TitlingConfig? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStartObject();
+        if (value.Model is not null)
+        {
+            writer.WriteString("model", value.Model);
+        }
+        writer.WriteNumber("timeoutSeconds", value.TimeoutSeconds);
+        writer.WriteEndObject();
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Configuration/TitlingConfigMigrationTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Configuration/TitlingConfigMigrationTests.cs
@@ -1,0 +1,118 @@
+using BotNexus.Gateway.Configuration;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Configuration;
+
+public sealed class TitlingConfigMigrationTests
+{
+    [Fact]
+    public void Load_WithStringTitling_MigratesToObject()
+    {
+        var json = """
+        {
+            "version": 1,
+            "gateway": {
+                "auxiliary": {
+                    "titling": "gpt-4o-mini"
+                }
+            }
+        }
+        """;
+
+        var config = LoadFromJson(json);
+
+        Assert.NotNull(config.Gateway?.Auxiliary?.Titling);
+        Assert.Equal("gpt-4o-mini", config.Gateway!.Auxiliary!.Titling!.Model);
+        Assert.Equal(30, config.Gateway.Auxiliary.Titling.TimeoutSeconds);
+    }
+
+    [Fact]
+    public void Load_WithObjectTitling_PreservesConfig()
+    {
+        var json = """
+        {
+            "version": 1,
+            "gateway": {
+                "auxiliary": {
+                    "titling": { "model": "claude-haiku-3-5", "timeoutSeconds": 15 }
+                }
+            }
+        }
+        """;
+
+        var config = LoadFromJson(json);
+
+        Assert.NotNull(config.Gateway?.Auxiliary?.Titling);
+        Assert.Equal("claude-haiku-3-5", config.Gateway!.Auxiliary!.Titling!.Model);
+        Assert.Equal(15, config.Gateway.Auxiliary.Titling.TimeoutSeconds);
+    }
+
+    [Fact]
+    public void Load_WithNullTitling_ReturnsNull()
+    {
+        var json = """
+        {
+            "version": 1,
+            "gateway": {
+                "auxiliary": {
+                    "titling": null
+                }
+            }
+        }
+        """;
+
+        var config = LoadFromJson(json);
+
+        Assert.Null(config.Gateway?.Auxiliary?.Titling);
+    }
+
+    [Fact]
+    public void Load_WithEmptyStringTitling_ReturnsNull()
+    {
+        var json = """
+        {
+            "version": 1,
+            "gateway": {
+                "auxiliary": {
+                    "titling": ""
+                }
+            }
+        }
+        """;
+
+        var config = LoadFromJson(json);
+
+        Assert.Null(config.Gateway?.Auxiliary?.Titling);
+    }
+
+    [Fact]
+    public void Load_WithNoTitling_ReturnsNullTitling()
+    {
+        var json = """
+        {
+            "version": 1,
+            "gateway": {
+                "auxiliary": {}
+            }
+        }
+        """;
+
+        var config = LoadFromJson(json);
+
+        Assert.Null(config.Gateway?.Auxiliary?.Titling);
+    }
+
+    private static PlatformConfig LoadFromJson(string json)
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, json);
+            return PlatformConfigLoader.Load(tempFile);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1273

## Changes
- Added `TitlingConfigJsonConverter` that accepts both string (`"gpt-4o-mini"`) and object (`{ "model": "...", "timeoutSeconds": 30 }`) forms
- Applied `[JsonConverter]` attribute to `AuxiliaryConfig.Titling` property
- 5 new tests covering string, object, null, empty string, and absent scenarios

## Merge Notes
Independent of all other open PRs. Safe to merge in any order.
