### PR TITLE
fix(gateway): separate config and data directories to support read-only mounts

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Program.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Program.cs
@@ -36,7 +36,7 @@ const string GatewayCorsPolicy = "GatewayCorsPolicy";
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .WriteTo.File(
-        Path.Combine(BotNexusHome.ResolveHomePath(), "logs", "botnexus-bootstrap-.log"),
+        Path.Combine(BotNexusHome.ResolveDataPath() ?? BotNexusHome.ResolveHomePath(), "logs", "botnexus-bootstrap-.log"),
         rollingInterval: RollingInterval.Day)
     .CreateBootstrapLogger();
 
@@ -58,7 +58,7 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}",
         restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Warning)
     .WriteTo.File(
-        Path.Combine(BotNexusHome.ResolveHomePath(), "logs", "botnexus-.log"),
+        Path.Combine(BotNexusHome.ResolveDataPath() ?? BotNexusHome.ResolveHomePath(), "logs", "botnexus-.log"),
         rollingInterval: RollingInterval.Hour,
         retainedFileCountLimit: 168),
     preserveStaticLogger: true);

--- a/src/gateway/BotNexus.Gateway/Configuration/BotNexusHome.cs
+++ b/src/gateway/BotNexus.Gateway/Configuration/BotNexusHome.cs
@@ -5,9 +5,10 @@ namespace BotNexus.Gateway.Configuration;
 public sealed class BotNexusHome
 {
     public const string HomeOverrideEnvVar = "BOTNEXUS_HOME";
+    public const string DataDirOverrideEnvVar = "BOTNEXUS_DATA_DIR";
     private const string HomeDirectoryName = ".botnexus";
 
-    private static readonly string[] RequiredDirectories =
+    private static readonly string[] DataDirectories =
     [
         "extensions",
         "tokens",
@@ -35,20 +36,31 @@ public sealed class BotNexusHome
 
     private readonly IFileSystem _fileSystem;
 
-    public BotNexusHome(IFileSystem fileSystem, string? homePath = null)
+    public BotNexusHome(IFileSystem fileSystem, string? homePath = null, string? dataPath = null)
     {
         _fileSystem = fileSystem;
         RootPath = ResolveHomePath(homePath);
+        DataPath = ResolveDataPath(dataPath) ?? RootPath;
     }
 
     public BotNexusHome(string? homePath = null)
-        : this(new FileSystem(), homePath)
+        : this(new FileSystem(), homePath, dataPath: null)
     {
     }
 
+    /// <summary>
+    /// Configuration root path. May be read-only in containerized deployments.
+    /// Contains config.json and agent descriptor files.
+    /// </summary>
     public string RootPath { get; }
 
-    public string AgentsPath => Path.Combine(RootPath, "agents");
+    /// <summary>
+    /// Writable data directory for runtime state (sessions, logs, tokens, extensions, agents, backups).
+    /// Defaults to <see cref="RootPath"/> when BOTNEXUS_DATA_DIR is not set.
+    /// </summary>
+    public string DataPath { get; }
+
+    public string AgentsPath => Path.Combine(DataPath, "agents");
 
     public static string ResolveHomePath(string? homePath = null)
     {
@@ -72,11 +84,36 @@ public sealed class BotNexusHome
         return Path.GetFullPath(Path.Combine(userProfile, HomeDirectoryName));
     }
 
+    /// <summary>
+    /// Resolves the data directory path from explicit parameter or BOTNEXUS_DATA_DIR environment variable.
+    /// Returns null when no override is configured (caller falls back to RootPath).
+    /// </summary>
+    public static string? ResolveDataPath(string? dataPath = null)
+    {
+        if (!string.IsNullOrWhiteSpace(dataPath))
+            return Path.GetFullPath(dataPath);
+
+        var dataOverride = Environment.GetEnvironmentVariable(DataDirOverrideEnvVar);
+        if (!string.IsNullOrWhiteSpace(dataOverride))
+            return Path.GetFullPath(dataOverride);
+
+        return null;
+    }
+
     public void Initialize()
     {
-        _fileSystem.Directory.CreateDirectory(RootPath);
-        foreach (var directory in RequiredDirectories)
-            _fileSystem.Directory.CreateDirectory(Path.Combine(RootPath, directory));
+        // Create data directory structure (always writable)
+        _fileSystem.Directory.CreateDirectory(DataPath);
+        foreach (var directory in DataDirectories)
+            _fileSystem.Directory.CreateDirectory(Path.Combine(DataPath, directory));
+
+        // Only create RootPath if it is separate from DataPath and doesn't already exist.
+        // When RootPath is mounted read-only (e.g. Docker :ro), it already exists and we skip creation.
+        if (!string.Equals(RootPath, DataPath, StringComparison.OrdinalIgnoreCase)
+            && !_fileSystem.Directory.Exists(RootPath))
+        {
+            _fileSystem.Directory.CreateDirectory(RootPath);
+        }
     }
 
     public string GetAgentDirectory(string agentName)

--- a/tests/gateway/BotNexus.Gateway.Tests/BotNexusHomeTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/BotNexusHomeTests.cs
@@ -6,6 +6,7 @@ namespace BotNexus.Gateway.Tests;
 public sealed class BotNexusHomeTests
 {
     private static readonly string HomePath = Path.Combine(Path.GetTempPath(), "botnexus-home");
+    private static readonly string DataDirPath = Path.Combine(Path.GetTempPath(), "botnexus-data");
 
     [Fact]
     public void Initialize_CreatesRequiredDirectoriesIncludingAgents()
@@ -87,6 +88,77 @@ public sealed class BotNexusHomeTests
 
         agentsContent.ShouldContain("memory/YYYY-MM-DD.md");
         agentsContent.ShouldContain("MEMORY.md");
+    }
+
+    [Fact]
+    public void Initialize_WithSeparateDataDir_CreatesDirectoriesInDataPath()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath, DataDirPath);
+
+        home.Initialize();
+
+        fs.Directory.Exists(Path.Combine(DataDirPath, "extensions")).ShouldBeTrue();
+        fs.Directory.Exists(Path.Combine(DataDirPath, "tokens")).ShouldBeTrue();
+        fs.Directory.Exists(Path.Combine(DataDirPath, "sessions")).ShouldBeTrue();
+        fs.Directory.Exists(Path.Combine(DataDirPath, "logs")).ShouldBeTrue();
+        fs.Directory.Exists(Path.Combine(DataDirPath, "agents")).ShouldBeTrue();
+        fs.Directory.Exists(Path.Combine(DataDirPath, "backups")).ShouldBeTrue();
+        // RootPath directories should NOT be created
+        fs.Directory.Exists(Path.Combine(HomePath, "extensions")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Initialize_WithSeparateDataDir_DoesNotCreateRootPathWhenItExists()
+    {
+        var fs = new MockFileSystem();
+        // Pre-create root to simulate read-only mount
+        fs.Directory.CreateDirectory(HomePath);
+        var home = new BotNexusHome(fs, HomePath, DataDirPath);
+
+        home.Initialize();
+
+        // Should not throw and should not try to create subdirs in RootPath
+        fs.Directory.Exists(DataDirPath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DataPath_DefaultsToRootPath_WhenNoOverrideSet()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath, dataPath: null);
+
+        home.DataPath.ShouldBe(home.RootPath);
+    }
+
+    [Fact]
+    public void DataPath_UsesOverride_WhenProvided()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath, DataDirPath);
+
+        home.DataPath.ShouldBe(Path.GetFullPath(DataDirPath));
+    }
+
+    [Fact]
+    public void AgentsPath_UsesDataPath_WhenSeparateDataDir()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath, DataDirPath);
+
+        home.AgentsPath.ShouldBe(Path.Combine(Path.GetFullPath(DataDirPath), "agents"));
+    }
+
+    [Fact]
+    public void GetAgentDirectory_WithSeparateDataDir_CreatesAgentInDataPath()
+    {
+        var fs = new MockFileSystem();
+        var home = new BotNexusHome(fs, HomePath, DataDirPath);
+
+        var path = home.GetAgentDirectory("test-agent");
+
+        path.ShouldStartWith(Path.GetFullPath(DataDirPath));
+        fs.Directory.Exists(Path.Combine(path, "workspace")).ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1272

## Changes

Introduces BOTNEXUS_DATA_DIR environment variable to specify a separate writable data directory for runtime state (sessions, logs, tokens, extensions, agents, backups). When set, BotNexusHome.Initialize() creates directories only in the data path, leaving RootPath untouched for read-only Docker volume mounts.

- Added DataPath property to BotNexusHome (defaults to RootPath when BOTNEXUS_DATA_DIR is unset)
- AgentsPath now resolves under DataPath
- Initialize() skips RootPath creation when it already exists and is separate from DataPath
- Program.cs log paths updated to prefer DataPath for bootstrap and runtime logs
- 6 new tests covering data dir separation, defaults, and agent directory creation

## Merge Notes

Independent of all open PRs. Safe to merge in any order.