### PR TITLE
feat(prompts): wrap system prompt sections in XML tags and consolidate tool enforcement

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/IPromptSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/IPromptSection.cs
@@ -18,6 +18,13 @@ public interface IPromptSection
     string? SectionId => null;
 
     /// <summary>
+    /// Gets the optional XML tag name used to wrap this section's output in the assembled prompt.
+    /// When non-null, the pipeline wraps the section output in &lt;tag&gt;...&lt;/tag&gt;.
+    /// Null means no wrapping (content emitted raw — used for user workspace files).
+    /// </summary>
+    string? XmlTag => null;
+
+    /// <summary>
     /// Determines whether this section should be included given the current prompt context.
     /// </summary>
     bool ShouldInclude(PromptContext context);

--- a/src/gateway/BotNexus.Gateway.Prompts/LambdaPromptSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/LambdaPromptSection.cs
@@ -2,7 +2,8 @@ namespace BotNexus.Gateway.Prompts;
 
 /// <summary>
 /// A prompt section backed by a delegate that lazily builds its content lines.
-/// Supports an optional <see cref="SectionId"/> for override resolution.
+/// Supports an optional <see cref="SectionId"/> for override resolution and
+/// an optional <see cref="XmlTag"/> for XML wrapping in the assembled prompt.
 /// </summary>
 public sealed class LambdaPromptSection : IPromptSection
 {
@@ -16,17 +17,20 @@ public sealed class LambdaPromptSection : IPromptSection
     /// <param name="buildFunc">Delegate that produces the prompt lines.</param>
     /// <param name="sectionId">Optional stable identifier for override resolution.</param>
     /// <param name="shouldIncludeFunc">Optional predicate controlling inclusion. Defaults to always included.</param>
+    /// <param name="xmlTag">Optional XML tag name for wrapping this section's output.</param>
     public LambdaPromptSection(
         int order,
         Func<PromptContext, IReadOnlyList<string>> buildFunc,
         string? sectionId = null,
-        Func<PromptContext, bool>? shouldIncludeFunc = null)
+        Func<PromptContext, bool>? shouldIncludeFunc = null,
+        string? xmlTag = null)
     {
         ArgumentNullException.ThrowIfNull(buildFunc);
         Order = order;
         _buildFunc = buildFunc;
         SectionId = sectionId;
         _shouldIncludeFunc = shouldIncludeFunc;
+        XmlTag = xmlTag;
     }
 
     /// <inheritdoc/>
@@ -34,6 +38,9 @@ public sealed class LambdaPromptSection : IPromptSection
 
     /// <inheritdoc/>
     public string? SectionId { get; }
+
+    /// <inheritdoc/>
+    public string? XmlTag { get; }
 
     /// <inheritdoc/>
     public bool ShouldInclude(PromptContext context) =>

--- a/src/gateway/BotNexus.Gateway.Prompts/ModelGuidanceSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ModelGuidanceSection.cs
@@ -14,6 +14,11 @@ public static class ModelGuidanceSection
     public const string Id = "model-guidance";
 
     /// <summary>
+    /// The XML tag name for this section in the assembled prompt.
+    /// </summary>
+    public const string Tag = "model_guidance";
+
+    /// <summary>
     /// The ordering position for this section within the prompt pipeline.
     /// Placed late (135) so model-specific instructions come after all content sections.
     /// </summary>
@@ -27,7 +32,6 @@ public static class ModelGuidanceSection
 
     private static readonly string[] ClaudeGuidance =
     [
-        "## Model Guidance (Claude)",
         "Prefer the edit tool over write for modifying existing files — it preserves context and is more precise.",
         "When editing, use the smallest possible oldText/newText to target changes precisely.",
         "You have extended thinking capabilities — use them for complex reasoning before acting."
@@ -35,7 +39,6 @@ public static class ModelGuidanceSection
 
     private static readonly string[] GptGuidance =
     [
-        "## Model Guidance (GPT)",
         "Never answer from memory when a tool can verify the answer — always check the source.",
         "When asked about file contents, always read the file rather than guessing from context.",
         "Be explicit about uncertainty — say when you are unsure rather than confabulating."
@@ -43,7 +46,6 @@ public static class ModelGuidanceSection
 
     private static readonly string[] GeminiGuidance =
     [
-        "## Model Guidance (Gemini)",
         "Always use absolute paths in file operations — relative paths may resolve incorrectly.",
         "When referencing files, use the full path from the workspace root.",
         "Verify tool output carefully before proceeding — do not assume success without checking."
@@ -54,7 +56,7 @@ public static class ModelGuidanceSection
     /// The section is only included when a recognized model family is detected.
     /// </summary>
     public static LambdaPromptSection Create() =>
-        new(SectionOrder, BuildLines, sectionId: Id, shouldIncludeFunc: ShouldInclude);
+        new(SectionOrder, BuildLines, sectionId: Id, shouldIncludeFunc: ShouldInclude, xmlTag: Tag);
 
     private static bool ShouldInclude(PromptContext context)
     {

--- a/src/gateway/BotNexus.Gateway.Prompts/PromptPipeline.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/PromptPipeline.cs
@@ -1,7 +1,8 @@
 namespace BotNexus.Gateway.Prompts;
 
 /// <summary>
-/// Represents prompt pipeline.
+/// Assembles system prompt content from ordered sections and contributors,
+/// optionally wrapping each block in XML tags for improved model attention.
 /// </summary>
 public sealed class PromptPipeline
 {
@@ -9,10 +10,8 @@ public sealed class PromptPipeline
     private readonly List<IPromptContributor> _contributors = [];
 
     /// <summary>
-    /// Executes add.
+    /// Adds a prompt section to the pipeline.
     /// </summary>
-    /// <param name="section">The section.</param>
-    /// <returns>The add result.</returns>
     public PromptPipeline Add(IPromptSection section)
     {
         ArgumentNullException.ThrowIfNull(section);
@@ -21,10 +20,8 @@ public sealed class PromptPipeline
     }
 
     /// <summary>
-    /// Executes add contributors.
+    /// Adds prompt contributors to the pipeline.
     /// </summary>
-    /// <param name="contributors">The contributors.</param>
-    /// <returns>The add contributors result.</returns>
     public PromptPipeline AddContributors(IEnumerable<IPromptContributor> contributors)
     {
         ArgumentNullException.ThrowIfNull(contributors);
@@ -33,29 +30,26 @@ public sealed class PromptPipeline
     }
 
     /// <summary>
-    /// Executes build.
+    /// Builds the complete system prompt string from all sections and contributors.
     /// </summary>
-    /// <param name="context">The context.</param>
-    /// <returns>The build result.</returns>
     public string Build(PromptContext context)
     {
         return string.Join("\n", BuildLines(context));
     }
 
     /// <summary>
-    /// Executes build lines.
+    /// Builds the ordered list of prompt lines from all sections and contributors,
+    /// wrapping each block in XML tags when the section specifies an <see cref="IPromptSection.XmlTag"/>.
     /// </summary>
-    /// <param name="context">The context.</param>
-    /// <returns>The build lines result.</returns>
     public IReadOnlyList<string> BuildLines(PromptContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var blocks = new List<(int Order, int TieBreaker, IReadOnlyList<string> Lines)>();
+        var blocks = new List<(int Order, int TieBreaker, string? XmlTag, IReadOnlyList<string> Lines)>();
         var sectionIndex = 0;
         foreach (var section in _sections.Where(section => section.ShouldInclude(context)).OrderBy(section => section.Order))
         {
-            blocks.Add((section.Order, sectionIndex++, section.Build(context)));
+            blocks.Add((section.Order, sectionIndex++, section.XmlTag, section.Build(context)));
         }
 
         foreach (var contributor in _contributors.Where(contributor => contributor.Target is null && contributor.ShouldInclude(context)))
@@ -68,13 +62,29 @@ public sealed class PromptPipeline
             }
 
             lines.AddRange(contribution.Lines);
-            blocks.Add((contribution.Order ?? contributor.Priority, sectionIndex++, lines));
+            blocks.Add((contribution.Order ?? contributor.Priority, sectionIndex++, null, lines));
         }
 
-        return blocks
-            .OrderBy(static item => item.Order)
-            .ThenBy(static item => item.TieBreaker)
-            .SelectMany(static item => item.Lines)
-            .ToList();
+        var result = new List<string>();
+        foreach (var block in blocks.OrderBy(static item => item.Order).ThenBy(static item => item.TieBreaker))
+        {
+            if (block.Lines.Count == 0)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(block.XmlTag))
+            {
+                result.Add($"<{block.XmlTag}>");
+                result.AddRange(block.Lines);
+                result.Add($"</{block.XmlTag}>");
+            }
+            else
+            {
+                result.AddRange(block.Lines);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/gateway/BotNexus.Gateway.Prompts/ShellEfficiencySection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ShellEfficiencySection.cs
@@ -13,6 +13,11 @@ public static class ShellEfficiencySection
     public const string Id = "shell-efficiency";
 
     /// <summary>
+    /// The XML tag name for this section in the assembled prompt.
+    /// </summary>
+    public const string Tag = "shell";
+
+    /// <summary>
     /// The ordering position for this section within the prompt pipeline.
     /// Placed after tool-enforcement (32) to build on established tool-call behavior.
     /// </summary>
@@ -20,7 +25,6 @@ public static class ShellEfficiencySection
 
     private static readonly string[] Lines =
     [
-        "## Shell Efficiency",
         "Prefer writing a temporary script file and executing it over chaining many individual shell commands.",
         "Combine related operations into a single shell invocation where possible.",
         "Avoid repeated read-modify-write cycles — batch edits into one tool call.",
@@ -33,5 +37,5 @@ public static class ShellEfficiencySection
     /// Creates a <see cref="LambdaPromptSection"/> for shell-efficiency guidance.
     /// </summary>
     public static LambdaPromptSection Create() =>
-        new(SectionOrder, static _ => Lines, sectionId: Id);
+        new(SectionOrder, static _ => Lines, sectionId: Id, xmlTag: Tag);
 }

--- a/src/gateway/BotNexus.Gateway.Prompts/SkillsGuidanceSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/SkillsGuidanceSection.cs
@@ -13,6 +13,11 @@ public static class SkillsGuidanceSection
     public const string Id = "skills-guidance";
 
     /// <summary>
+    /// The XML tag name for this section in the assembled prompt.
+    /// </summary>
+    public const string Tag = "skills";
+
+    /// <summary>
     /// The ordering position for this section within the prompt pipeline.
     /// Placed later in the pipeline (55) after content/tool sections to serve as
     /// behavioral guidance once the agent knows what tools and skills are available.
@@ -21,7 +26,6 @@ public static class SkillsGuidanceSection
 
     private static readonly string[] Lines =
     [
-        "## Skills",
         "Before starting domain-specific work, check available skills with `skills list` and load relevant ones.",
         "Skills contain reusable procedures, references, and templates — always load before improvising.",
         "When you discover a repeatable multi-step procedure, create a skill to capture it for future use.",
@@ -34,7 +38,7 @@ public static class SkillsGuidanceSection
     /// The section is only included when the agent has skill-related tools available.
     /// </summary>
     public static LambdaPromptSection Create() =>
-        new(SectionOrder, static _ => Lines, sectionId: Id, shouldIncludeFunc: HasSkillTools);
+        new(SectionOrder, static _ => Lines, sectionId: Id, shouldIncludeFunc: HasSkillTools, xmlTag: Tag);
 
     private static bool HasSkillTools(PromptContext context) =>
         context.AvailableTools.Contains("skills") || context.AvailableTools.Contains("skill_manage");

--- a/src/gateway/BotNexus.Gateway.Prompts/ToolEnforcementSection.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/ToolEnforcementSection.cs
@@ -1,8 +1,9 @@
 namespace BotNexus.Gateway.Prompts;
 
 /// <summary>
-/// Provides the built-in tool-enforcement prompt section that instructs the model
-/// to execute tools immediately rather than describing what it would do.
+/// Provides the unified tool-use prompt section that combines execution bias,
+/// tool enforcement, and tool call style guidance into a single cohesive block.
+/// Wrapped in &lt;tool_use&gt; XML tags for improved model attention.
 /// </summary>
 public static class ToolEnforcementSection
 {
@@ -12,24 +13,35 @@ public static class ToolEnforcementSection
     public const string Id = "tool-enforcement";
 
     /// <summary>
-    /// The ordering position for this section within the prompt pipeline.
-    /// Placed early (after safety at ~20) to establish tool behavior before content sections.
+    /// The XML tag name for this section in the assembled prompt.
     /// </summary>
-    public const int SectionOrder = 32;
+    public const string Tag = "tool_use";
+
+    /// <summary>
+    /// The ordering position for this section within the prompt pipeline.
+    /// Placed early to establish tool behavior before content sections.
+    /// </summary>
+    public const int SectionOrder = 30;
 
     private static readonly string[] Lines =
     [
-        "## Tool Enforcement",
-        "When a task requires a tool call, execute the tool immediately.",
-        "Do not describe what you would do — do it.",
-        "Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.",
+        "You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it.",
+        "When you say you will perform an action, you MUST immediately make the corresponding tool call in the same response.",
+        "Never end your turn with a promise of future action — execute it now.",
+        "Keep working until the task is actually complete. Do not stop with a summary of what you plan to do next time.",
+        "Every response should either (a) contain tool calls that make progress, or (b) deliver a final result to the user.",
+        "Responses that only describe intentions without acting are not acceptable.",
         "If multiple independent tool calls are needed, batch them in a single response.",
-        "Never simulate or fabricate tool output — always call the real tool."
+        "Never simulate or fabricate tool output — always call the real tool.",
+        "Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.",
+        "Default: do not narrate routine, low-risk tool calls (just call the tool).",
+        "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions, or when the user explicitly asks.",
+        "Keep narration brief and value-dense; avoid repeating obvious steps."
     ];
 
     /// <summary>
-    /// Creates a <see cref="LambdaPromptSection"/> for tool-enforcement guidance.
+    /// Creates a <see cref="LambdaPromptSection"/> for the unified tool-use guidance.
     /// </summary>
     public static LambdaPromptSection Create() =>
-        new(SectionOrder, static _ => Lines, sectionId: Id);
+        new(SectionOrder, static _ => Lines, sectionId: Id, xmlTag: Tag);
 }

--- a/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
@@ -112,20 +112,19 @@ public static class SystemPromptBuilder
         };
 
         var pipeline = new PromptPipeline()
-            .Add(new LambdaPromptSection(10, BuildToolingSection))
-            .Add(new LambdaPromptSection(20, BuildToolCallStyleSection))
-            .Add(new LambdaPromptSection(30, static context => buildOverridablePromptSection(null, buildExecutionBiasSection(GetGatewayData(context).IsMinimal))))
+            .Add(new LambdaPromptSection(10, BuildToolingSection, xmlTag: "tooling"))
             .Add(ToolEnforcementSection.Create())
             .Add(ShellEfficiencySection.Create())
-            .Add(new LambdaPromptSection(40, BuildSafetyAndCliSection))
+            .Add(new LambdaPromptSection(40, BuildSafetySection, xmlTag: "safety"))
+            .Add(new LambdaPromptSection(42, BuildCliSection, xmlTag: "cli"))
             .Add(SkillsGuidanceSection.Create())
             .Add(new LambdaPromptSection(60, static context => buildMemorySection(
                 GetGatewayData(context).IsMinimal,
                 GetGatewayData(context).Parameters.MemoryPromptInjection,
-                GetGatewayData(context).NormalizedTools)))
+                GetGatewayData(context).NormalizedTools), xmlTag: "memory"))
             .Add(new LambdaPromptSection(70, BuildSelfUpdateSection, static context => GetGatewayData(context).HasGateway && !GetGatewayData(context).IsMinimal))
             .Add(new LambdaPromptSection(80, BuildModelAliasesSection))
-            .Add(new LambdaPromptSection(90, BuildWorkspaceSection))
+            .Add(new LambdaPromptSection(90, BuildWorkspaceSection, xmlTag: "workspace"))
             .Add(new LambdaPromptSection(100, static context => buildDocsSection(GetGatewayData(context).Parameters.DocsPath, GetGatewayData(context).IsMinimal, GetGatewayData(context).ReadToolName)))
             .Add(new LambdaPromptSection(110, static context => buildUserIdentitySection(GetGatewayData(context).Parameters.OwnerIdentity, GetGatewayData(context).IsMinimal)))
             .Add(new LambdaPromptSection(120, static context => buildTimeSection(GetGatewayData(context).Parameters.UserTimezone)))
@@ -134,11 +133,11 @@ public static class SystemPromptBuilder
             .Add(new LambdaPromptSection(130, static _ => ["## Workspace Files (injected)", "These user-editable files are loaded by BotNexus and included below in Project Context.", string.Empty]))
             .Add(ModelGuidanceSection.Create())
             .Add(new LambdaPromptSection(140, static context => buildReplyTagsSection(GetGatewayData(context).IsMinimal), static _ => IncludeReplyTagsSectionByDefault))
-            .Add(new LambdaPromptSection(150, static context => buildMessagingSection(GetGatewayData(context).IsMinimal, GetGatewayData(context).NormalizedTools, GetGatewayData(context).RuntimeChannel, GetGatewayData(context).InlineButtonsEnabled)))
+            .Add(new LambdaPromptSection(150, static context => buildMessagingSection(GetGatewayData(context).IsMinimal, GetGatewayData(context).NormalizedTools, GetGatewayData(context).RuntimeChannel, GetGatewayData(context).InlineButtonsEnabled), xmlTag: "messaging"))
             .Add(new LambdaPromptSection(160, static context => buildVoiceSection(GetGatewayData(context).IsMinimal, GetGatewayData(context).Parameters.TtsHint)))
             .Add(new LambdaPromptSection(170, BuildReasoningSection, static context => GetGatewayData(context).Parameters.ReasoningTagHint))
             .Add(new LambdaPromptSection(180, static context => buildProjectContextSection(GetGatewayData(context).StableContextFiles, "# Project Context", dynamic: false)))
-            .Add(new LambdaPromptSection(190, BuildSilentRepliesSection, static context => !GetGatewayData(context).IsMinimal))
+            .Add(new LambdaPromptSection(190, BuildSilentRepliesSection, static context => !GetGatewayData(context).IsMinimal, xmlTag: "silent_replies"))
             .Add(new LambdaPromptSection(200, static _ => [SystemPromptCacheBoundary]))
             .Add(new LambdaPromptSection(210, static context => buildProjectContextSection(
                 GetGatewayData(context).DynamicContextFiles,
@@ -146,7 +145,7 @@ public static class SystemPromptBuilder
                 dynamic: true)))
             .Add(new LambdaPromptSection(220, BuildExtraSystemPromptSection))
             .Add(new LambdaPromptSection(230, BuildHeartbeatSection, static context => !GetGatewayData(context).IsMinimal))
-            .Add(new LambdaPromptSection(240, BuildRuntimeSection));
+            .Add(new LambdaPromptSection(240, BuildRuntimeSection, xmlTag: "runtime"));
 
         var lines = pipeline.BuildLines(promptContext);
         return string.Join("\n", lines.Where(static line => !string.IsNullOrEmpty(line)));
@@ -209,7 +208,6 @@ public static class SystemPromptBuilder
         {
             return
             [
-                "## Memory",
                 "Memory context is a snapshot loaded at session start and does not auto-refresh during this turn.",
                 BuildMemoryWriteGuidance(availableTools),
                 "Durable memory writes become available in future sessions after persistence.",
@@ -219,7 +217,6 @@ public static class SystemPromptBuilder
 
         return
         [
-            "## Memory",
             "Memory context in this prompt is frozen at session start; do not assume memory files changed unless a new session starts.",
             BuildMemoryWriteGuidance(availableTools),
             "Use `MEMORY.md` as long-lived consolidated context and `memory/YYYY-MM-DD.md` as append-only daily notes.",
@@ -274,7 +271,6 @@ public static class SystemPromptBuilder
 
         var lines = new List<string>
         {
-            "## Messaging",
             "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
             "- Cross-session messaging → use sessions_send(sessionKey, message)",
             "- Sub-agent orchestration → use subagents(action=list|steer|kill)",
@@ -334,22 +330,6 @@ public static class SystemPromptBuilder
         ];
     }
 
-    public static IReadOnlyList<string> buildExecutionBiasSection(bool isMinimal)
-    {
-        if (isMinimal)
-            return [];
-
-        return
-        [
-            "## Execution Bias",
-            "If the user asks you to do the work, start doing it in the same turn.",
-            "Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.",
-            "Commentary-only turns are incomplete when tools are available and the next action is clear.",
-            "If the work will take multiple steps or a while to finish, send one short progress update before or while acting.",
-            ""
-        ];
-    }
-
     public static string buildRuntimeLine(RuntimeInfo? runtime)
     {
         return RuntimeLineFormatter.BuildRuntimeLine(runtime is null ? null : new PromptRuntimeInfo
@@ -389,7 +369,6 @@ public static class SystemPromptBuilder
         {
             "You are a personal assistant running inside BotNexus.",
             string.Empty,
-            "## Tooling",
             "Structured tool definitions are the source of truth for tool names, descriptions, and parameters.",
             "Tool names are case-sensitive. Call tools exactly as listed in the structured tool definitions.",
             "If a tool is present in the structured tool definitions, it is available unless a later tool call reports a policy/runtime restriction.",
@@ -422,47 +401,34 @@ public static class SystemPromptBuilder
         lines.Add("If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.");
         lines.Add("Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).");
         lines.Add(string.Empty);
+        lines.Add(buildExecApprovalPromptGuidance(data.RuntimeChannel, data.InlineButtonsEnabled));
+        lines.Add("Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.");
+        lines.Add("Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.");
+        lines.Add("When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.");
         return lines;
     }
 
-    private static IReadOnlyList<string> BuildToolCallStyleSection(PromptContext context)
-    {
-        var data = GetGatewayData(context);
-        return buildOverridablePromptSection(
-            null,
-            [
-                "## Tool Call Style",
-                "Default: do not narrate routine, low-risk tool calls (just call the tool).",
-                "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
-                "Keep narration brief and value-dense; avoid repeating obvious steps.",
-                "Use plain human language for narration unless in a technical context.",
-                "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
-                buildExecApprovalPromptGuidance(data.RuntimeChannel, data.InlineButtonsEnabled),
-                "Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.",
-                "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
-                "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.",
-                ""
-            ]);
-    }
-
-    private static IReadOnlyList<string> BuildSafetyAndCliSection(PromptContext _)
+    private static IReadOnlyList<string> BuildSafetySection(PromptContext _)
     {
         return
         [
-            "## Safety",
             "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
             "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)",
-            "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.",
-            "",
-            "## BotNexus CLI Quick Reference",
+            "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested."
+        ];
+    }
+
+    private static IReadOnlyList<string> BuildCliSection(PromptContext _)
+    {
+        return
+        [
             "BotNexus is controlled via subcommands. Do not invent commands.",
             "To manage the Gateway daemon service (start/stop/restart):",
             "- botnexus gateway status",
             "- botnexus gateway start",
             "- botnexus gateway stop",
             "- botnexus gateway restart",
-            "If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output.",
-            ""
+            "If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output."
         ];
     }
 
@@ -507,7 +473,6 @@ public static class SystemPromptBuilder
         if (!string.IsNullOrWhiteSpace(data.Parameters.UserTimezone))
             lines.Add("If you need the current date, time, or day of week, run session_status (📊 session_status).");
 
-        lines.Add("## Workspace");
         lines.Add($"Your working directory is: {data.Parameters.WorkspaceDir}");
         lines.Add("Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.");
         lines.AddRange((data.Parameters.WorkspaceNotes ?? []).Select(NormalizeStructuredPromptSection).Where(static line => !string.IsNullOrWhiteSpace(line)));
@@ -521,7 +486,6 @@ public static class SystemPromptBuilder
     private static IReadOnlyList<string> BuildSilentRepliesSection(PromptContext _)
         =>
         [
-            "## Silent Replies",
             $"Use {SilentReplyToken} ONLY when no user-visible reply is required.",
             "",
             "⚠️ Rules:",
@@ -580,7 +544,6 @@ public static class SystemPromptBuilder
         var data = GetGatewayData(context);
         return
         [
-            "## Runtime",
             buildRuntimeLine(data.Parameters.Runtime),
             $"Reasoning: {(data.Parameters.ReasoningLevel ?? "off")} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled."
         ];
@@ -634,9 +597,12 @@ public static class SystemPromptBuilder
     private sealed class LambdaPromptSection(
         int order,
         Func<PromptContext, IReadOnlyList<string>> build,
-        Func<PromptContext, bool>? shouldInclude = null) : IPromptSection
+        Func<PromptContext, bool>? shouldInclude = null,
+        string? xmlTag = null) : IPromptSection
     {
         public int Order => order;
+
+        public string? XmlTag => xmlTag;
 
         public bool ShouldInclude(PromptContext context) => shouldInclude?.Invoke(context) ?? true;
 

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/LambdaPromptSectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/LambdaPromptSectionTests.cs
@@ -88,7 +88,7 @@ public sealed class ToolEnforcementSectionTests
     {
         var section = ToolEnforcementSection.Create();
 
-        section.Order.ShouldBe(32);
+        section.Order.ShouldBe(30);
     }
 
     [Fact]
@@ -116,10 +116,9 @@ public sealed class ToolEnforcementSectionTests
         var lines = section.Build(DefaultContext);
 
         lines.Count.ShouldBeGreaterThan(1);
-        lines[0].ShouldBe("## Tool Enforcement");
-        lines.ShouldContain(l => l.Contains("execute the tool immediately"));
-        lines.ShouldContain(l => l.Contains("Do not describe"));
+        lines[0].ShouldContain("MUST use your tools");
         lines.ShouldContain(l => l.Contains("Never simulate"));
+        lines.ShouldContain(l => l.Contains("Do not ask for confirmation"));
     }
 
     [Fact]
@@ -140,7 +139,7 @@ public sealed class ToolEnforcementSectionTests
 
         var lines = pipeline.BuildLines(DefaultContext);
 
-        var enforcementIdx = lines.ToList().FindIndex(l => l.Contains("Tool Enforcement"));
+        var enforcementIdx = lines.ToList().FindIndex(l => l.Contains("MUST use your tools"));
         var toolsIdx = lines.ToList().FindIndex(l => l.Contains("Tools content"));
         var safetyIdx = lines.ToList().FindIndex(l => l.Contains("Safety content"));
 

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/ModelGuidanceSectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/ModelGuidanceSectionTests.cs
@@ -118,8 +118,7 @@ public sealed class ModelGuidanceSectionTests
         var lines = section.Build(ContextWithClaude);
 
         lines.ShouldNotBeEmpty();
-        lines[0].ShouldContain("Claude");
-        lines.ShouldContain(l => l.Contains("edit tool", StringComparison.OrdinalIgnoreCase));
+        lines[0].ShouldContain("edit tool", Case.Insensitive);
     }
 
     [Fact]
@@ -130,7 +129,7 @@ public sealed class ModelGuidanceSectionTests
         var lines = section.Build(ContextWithGpt);
 
         lines.ShouldNotBeEmpty();
-        lines[0].ShouldContain("GPT");
+        lines[0].ShouldContain("memory", Case.Insensitive);
         lines.ShouldContain(l => l.Contains("memory", StringComparison.OrdinalIgnoreCase));
     }
 
@@ -142,7 +141,7 @@ public sealed class ModelGuidanceSectionTests
         var lines = section.Build(ContextWithGemini);
 
         lines.ShouldNotBeEmpty();
-        lines[0].ShouldContain("Gemini");
+        lines[0].ShouldContain("absolute paths", Case.Insensitive);
         lines.ShouldContain(l => l.Contains("absolute path", StringComparison.OrdinalIgnoreCase));
     }
 

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/ShellEfficiencySectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/ShellEfficiencySectionTests.cs
@@ -63,13 +63,21 @@ public sealed class ShellEfficiencySectionTests
     }
 
     [Fact]
-    public void Build_StartsWithMarkdownHeader()
+    public void Build_StartsWithScriptGuidance()
     {
         var section = ShellEfficiencySection.Create();
 
         var lines = section.Build(DefaultContext);
 
-        lines[0].ShouldBe("## Shell Efficiency");
+        lines[0].ShouldContain("script", Case.Insensitive);
+    }
+
+    [Fact]
+    public void Create_HasXmlTag()
+    {
+        var section = ShellEfficiencySection.Create();
+
+        section.XmlTag.ShouldBe("shell");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/SkillsGuidanceSectionTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/SkillsGuidanceSectionTests.cs
@@ -105,13 +105,21 @@ public sealed class SkillsGuidanceSectionTests
     }
 
     [Fact]
-    public void Build_StartsWithMarkdownHeader()
+    public void Build_StartsWithLoadGuidance()
     {
         var section = SkillsGuidanceSection.Create();
 
         var lines = section.Build(ContextWithSkillTools);
 
-        lines[0].ShouldBe("## Skills");
+        lines[0].ShouldContain("skills", Case.Insensitive);
+    }
+
+    [Fact]
+    public void Create_HasXmlTag()
+    {
+        var section = SkillsGuidanceSection.Create();
+
+        section.XmlTag.ShouldBe("skills");
     }
 
     [Fact]

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/PromptSectionWiringTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/PromptSectionWiringTests.cs
@@ -26,8 +26,9 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt();
 
-        prompt.ShouldContain("## Tool Enforcement");
-        prompt.ShouldContain("execute the tool immediately");
+        prompt.ShouldContain("<tool_use>");
+        prompt.ShouldContain("</tool_use>");
+        prompt.ShouldContain("MUST use your tools");
     }
 
     [Fact]
@@ -35,7 +36,8 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt();
 
-        prompt.ShouldContain("## Shell Efficiency");
+        prompt.ShouldContain("<shell>");
+        prompt.ShouldContain("</shell>");
         prompt.ShouldContain("temporary script file");
     }
 
@@ -44,7 +46,8 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt(tools: ["read", "skills", "skill_manage"]);
 
-        prompt.ShouldContain("## Skills");
+        prompt.ShouldContain("<skills>");
+        prompt.ShouldContain("</skills>");
         prompt.ShouldContain("check available skills");
     }
 
@@ -61,7 +64,8 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt(model: "claude-sonnet-4-20250514");
 
-        prompt.ShouldContain("## Model Guidance (Claude)");
+        prompt.ShouldContain("<model_guidance>");
+        prompt.ShouldContain("</model_guidance>");
         prompt.ShouldContain("edit tool over write");
     }
 
@@ -70,7 +74,7 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt(model: "gpt-4.1");
 
-        prompt.ShouldContain("## Model Guidance (GPT)");
+        prompt.ShouldContain("<model_guidance>");
         prompt.ShouldContain("Never answer from memory");
     }
 
@@ -79,7 +83,7 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt(model: "gemini-2.5-pro");
 
-        prompt.ShouldContain("## Model Guidance (Gemini)");
+        prompt.ShouldContain("<model_guidance>");
         prompt.ShouldContain("absolute paths");
     }
 
@@ -88,7 +92,7 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt(model: "some-unknown-model-v1");
 
-        prompt.ShouldNotContain("## Model Guidance");
+        prompt.ShouldNotContain("<model_guidance>");
     }
 
     [Fact]
@@ -96,7 +100,7 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt(model: null);
 
-        prompt.ShouldNotContain("## Model Guidance");
+        prompt.ShouldNotContain("<model_guidance>");
     }
 
     [Fact]
@@ -104,8 +108,8 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt();
 
-        var toolEnforcementIdx = prompt.IndexOf("## Tool Enforcement", StringComparison.Ordinal);
-        var safetyIdx = prompt.IndexOf("## Safety", StringComparison.Ordinal);
+        var toolEnforcementIdx = prompt.IndexOf("<tool_use>", StringComparison.Ordinal);
+        var safetyIdx = prompt.IndexOf("<safety>", StringComparison.Ordinal);
 
         toolEnforcementIdx.ShouldBeGreaterThan(-1);
         safetyIdx.ShouldBeGreaterThan(-1);
@@ -117,8 +121,8 @@ public sealed class PromptSectionWiringTests
     {
         var prompt = BuildFullPrompt();
 
-        var shellIdx = prompt.IndexOf("## Shell Efficiency", StringComparison.Ordinal);
-        var safetyIdx = prompt.IndexOf("## Safety", StringComparison.Ordinal);
+        var shellIdx = prompt.IndexOf("<shell>", StringComparison.Ordinal);
+        var safetyIdx = prompt.IndexOf("<safety>", StringComparison.Ordinal);
 
         shellIdx.ShouldBeGreaterThan(-1);
         safetyIdx.ShouldBeGreaterThan(-1);
@@ -131,7 +135,7 @@ public sealed class PromptSectionWiringTests
         var prompt = BuildFullPrompt(model: "claude-sonnet-4-20250514");
 
         var workspaceIdx = prompt.IndexOf("## Workspace Files (injected)", StringComparison.Ordinal);
-        var modelIdx = prompt.IndexOf("## Model Guidance (Claude)", StringComparison.Ordinal);
+        var modelIdx = prompt.IndexOf("<model_guidance>", StringComparison.Ordinal);
 
         workspaceIdx.ShouldBeGreaterThan(-1);
         modelIdx.ShouldBeGreaterThan(-1);

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-full.prompt.txt
@@ -1,5 +1,5 @@
-﻿You are a personal assistant running inside BotNexus.
-## Tooling
+﻿<tooling>
+You are a personal assistant running inside BotNexus.
 Structured tool definitions are the source of truth for tool names, descriptions, and parameters.
 Tool names are case-sensitive. Call tools exactly as listed in the structured tool definitions.
 If a tool is present in the structured tool definitions, it is available unless a later tool call reports a policy/runtime restriction.
@@ -14,39 +14,39 @@ When you use `update_plan`, keep exactly one step `in_progress` until the work i
 After calling `update_plan`, continue the work and do not repeat the full plan unless the user asks.
 If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.
 Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).
-## Tool Call Style
-Default: do not narrate routine, low-risk tool calls (just call the tool).
-Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.
-Keep narration brief and value-dense; avoid repeating obvious steps.
-Use plain human language for narration unless in a technical context.
-When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.
 When exec returns approval-pending on this channel, rely on native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.
 Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.
 Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.
 When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.
-## Execution Bias
-If the user asks you to do the work, start doing it in the same turn.
-Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.
-Commentary-only turns are incomplete when tools are available and the next action is clear.
-If the work will take multiple steps or a while to finish, send one short progress update before or while acting.
-## Tool Enforcement
-When a task requires a tool call, execute the tool immediately.
-Do not describe what you would do — do it.
-Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+</tooling>
+<tool_use>
+You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it.
+When you say you will perform an action, you MUST immediately make the corresponding tool call in the same response.
+Never end your turn with a promise of future action — execute it now.
+Keep working until the task is actually complete. Do not stop with a summary of what you plan to do next time.
+Every response should either (a) contain tool calls that make progress, or (b) deliver a final result to the user.
+Responses that only describe intentions without acting are not acceptable.
 If multiple independent tool calls are needed, batch them in a single response.
 Never simulate or fabricate tool output — always call the real tool.
-## Shell Efficiency
+Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+Default: do not narrate routine, low-risk tool calls (just call the tool).
+Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions, or when the user explicitly asks.
+Keep narration brief and value-dense; avoid repeating obvious steps.
+</tool_use>
+<shell>
 Prefer writing a temporary script file and executing it over chaining many individual shell commands.
 Combine related operations into a single shell invocation where possible.
 Avoid repeated read-modify-write cycles — batch edits into one tool call.
 Never use backtick line continuations in shell commands — they break across platforms.
 Use single quotes for strings containing special characters ($, @, |, ;).
 For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it.
-## Safety
+</shell>
+<safety>
 You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.
 Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)
 Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.
-## BotNexus CLI Quick Reference
+</safety>
+<cli>
 BotNexus is controlled via subcommands. Do not invent commands.
 To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway status
@@ -54,12 +54,14 @@ To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway stop
 - botnexus gateway restart
 If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output.
-## Memory
+</cli>
+<memory>
 Memory context in this prompt is frozen at session start; do not assume memory files changed unless a new session starts.
 Use the runtime's memory-write capability for durable memory writes when available.
 Use `MEMORY.md` as long-lived consolidated context and `memory/YYYY-MM-DD.md` as append-only daily notes.
 Do not rewrite prior memory notes in-place during normal turns; append durable updates instead.
 Durable memory writes appear in subsequent sessions after persistence and prompt rebuild.
+</memory>
 ## BotNexus Self-Update
 Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.
 Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.
@@ -70,12 +72,13 @@ After restart, BotNexus pings the last active session automatically.
 Prefer aliases when specifying model overrides; full provider/model is also accepted.
 - fast => gpt-5-mini
 - smart => gpt-5
+<workspace>
 If you need the current date, time, or day of week, run session_status (📊 session_status).
-## Workspace
 Your working directory is: <workspace>
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 Note one
 Note two
+</workspace>
 ## Documentation
 BotNexus docs: <docs-path>
 Mirror: https://docs.botnexus.ai
@@ -90,11 +93,12 @@ Owner: Jon
 Time zone: Pacific/Auckland
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.
-## Model Guidance (GPT)
+<model_guidance>
 Never answer from memory when a tool can verify the answer — always check the source.
 When asked about file contents, always read the file rather than guessing from context.
 Be explicit about uncertainty — say when you are unsure rather than confabulating.
-## Messaging
+</model_guidance>
+<messaging>
 - Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)
 - Cross-session messaging → use sessions_send(sessionKey, message)
 - Sub-agent orchestration → use subagents(action=list|steer|kill)
@@ -106,6 +110,7 @@ Be explicit about uncertainty — say when you are unsure rather than confabulat
 - If multiple channels are configured, pass `channel` (discord|signal|slack|telegram|webchat).
 - If you use `message` (`action=send`) to deliver your user-visible reply, respond with ONLY: NO_REPLY (avoid duplicate replies).
 - Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`.
+</messaging>
 ## Voice (TTS)
 Speak naturally.
 ## Reasoning Format
@@ -119,7 +124,7 @@ Agent instructions
 Persona guidance
 ## README.md
 Repo overview
-## Silent Replies
+<silent_replies>
 Use NO_REPLY ONLY when no user-visible reply is required.
 ⚠️ Rules:
 - Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.
@@ -130,6 +135,7 @@ Use NO_REPLY ONLY when no user-visible reply is required.
 ❌ Wrong: "Here's help... NO_REPLY"
 ❌ Wrong: "NO_REPLY"
 ✅ Right: NO_REPLY
+</silent_replies>
 
 <!-- BOTNEXUS_CACHE_BOUNDARY -->
 
@@ -147,6 +153,7 @@ If you receive a heartbeat poll (a user message matching the heartbeat prompt ab
 HEARTBEAT_OK
 BotNexus treats a leading/trailing "HEARTBEAT_OK" as a heartbeat ack (and may discard it).
 If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.
-## Runtime
+<runtime>
 Runtime: agent=agent-a | host=host-a | os=Windows (x64) | provider=openai | model=gpt-5 | default_model=gpt-5-mini | shell=pwsh | channel=telegram | capabilities=inlinebuttons,reactions
 Reasoning: medium (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.
+</runtime>

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-minimal.prompt.txt
@@ -1,5 +1,5 @@
-﻿You are a personal assistant running inside BotNexus.
-## Tooling
+﻿<tooling>
+You are a personal assistant running inside BotNexus.
 Structured tool definitions are the source of truth for tool names, descriptions, and parameters.
 Tool names are case-sensitive. Call tools exactly as listed in the structured tool definitions.
 If a tool is present in the structured tool definitions, it is available unless a later tool call reports a policy/runtime restriction.
@@ -8,34 +8,39 @@ For long waits, avoid rapid poll loops: use exec with enough yieldMs or process(
 For long-running work that starts now, start it once and rely on automatic completion wake when it is enabled and the command emits output or fails; otherwise use process to confirm completion, and use it for logs, status, input, or intervention.
 If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.
 Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).
-## Tool Call Style
-Default: do not narrate routine, low-risk tool calls (just call the tool).
-Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.
-Keep narration brief and value-dense; avoid repeating obvious steps.
-Use plain human language for narration unless in a technical context.
-When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.
 When exec returns approval-pending, include the concrete /approve command from tool output as plain chat text for the user, and do not ask for a different or rotated code.
 Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.
 Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.
 When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.
-## Tool Enforcement
-When a task requires a tool call, execute the tool immediately.
-Do not describe what you would do — do it.
-Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+</tooling>
+<tool_use>
+You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it.
+When you say you will perform an action, you MUST immediately make the corresponding tool call in the same response.
+Never end your turn with a promise of future action — execute it now.
+Keep working until the task is actually complete. Do not stop with a summary of what you plan to do next time.
+Every response should either (a) contain tool calls that make progress, or (b) deliver a final result to the user.
+Responses that only describe intentions without acting are not acceptable.
 If multiple independent tool calls are needed, batch them in a single response.
 Never simulate or fabricate tool output — always call the real tool.
-## Shell Efficiency
+Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+Default: do not narrate routine, low-risk tool calls (just call the tool).
+Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions, or when the user explicitly asks.
+Keep narration brief and value-dense; avoid repeating obvious steps.
+</tool_use>
+<shell>
 Prefer writing a temporary script file and executing it over chaining many individual shell commands.
 Combine related operations into a single shell invocation where possible.
 Avoid repeated read-modify-write cycles — batch edits into one tool call.
 Never use backtick line continuations in shell commands — they break across platforms.
 Use single quotes for strings containing special characters ($, @, |, ;).
 For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it.
-## Safety
+</shell>
+<safety>
 You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.
 Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)
 Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.
-## BotNexus CLI Quick Reference
+</safety>
+<cli>
 BotNexus is controlled via subcommands. Do not invent commands.
 To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway status
@@ -43,19 +48,22 @@ To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway stop
 - botnexus gateway restart
 If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output.
+</cli>
+<workspace>
 If you need the current date, time, or day of week, run session_status (📊 session_status).
-## Workspace
 Your working directory is: <workspace>
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
 Minimal note
+</workspace>
 ## Current Date & Time
 Time zone: UTC
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.
-## Model Guidance (GPT)
+<model_guidance>
 Never answer from memory when a tool can verify the answer — always check the source.
 When asked about file contents, always read the file rather than guessing from context.
 Be explicit about uncertainty — say when you are unsure rather than confabulating.
+</model_guidance>
 ## Reasoning Format
 ALL internal reasoning MUST be inside <think>...</think>. Do not output any analysis outside <think>. Format every reply as <think>...</think> then <final>...</final>, with no other text. Only the final user-visible reply may appear inside <final>. Only text inside <final> is shown to the user; everything else is discarded and never seen by the user. Example: <think>Short internal reasoning.</think> <final>Hey there! What would you like to do next?</final>
 # Project Context
@@ -71,6 +79,7 @@ The following frequently-changing project context files are kept below the cache
 Heartbeat context
 ## Subagent Context
 Sub-agent context
-## Runtime
+<runtime>
 Runtime: agent=agent-a | host=host-a | os=Windows (x64) | provider=openai | model=gpt-5 | shell=pwsh | channel=signalr | capabilities=reactions
 Reasoning: off (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.
+</runtime>

--- a/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
+++ b/tests/gateway/BotNexus.Gateway.Tests/Snapshots/gateway-no-tools.prompt.txt
@@ -1,5 +1,5 @@
-﻿You are a personal assistant running inside BotNexus.
-## Tooling
+﻿<tooling>
+You are a personal assistant running inside BotNexus.
 Structured tool definitions are the source of truth for tool names, descriptions, and parameters.
 Tool names are case-sensitive. Call tools exactly as listed in the structured tool definitions.
 If a tool is present in the structured tool definitions, it is available unless a later tool call reports a policy/runtime restriction.
@@ -10,39 +10,39 @@ For long-running work that starts now, start it once and rely on automatic compl
 Do not emulate scheduling with sleep loops, timeout loops, or repeated polling.
 If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.
 Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).
-## Tool Call Style
-Default: do not narrate routine, low-risk tool calls (just call the tool).
-Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.
-Keep narration brief and value-dense; avoid repeating obvious steps.
-Use plain human language for narration unless in a technical context.
-When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.
 When exec returns approval-pending, include the concrete /approve command from tool output as plain chat text for the user, and do not ask for a different or rotated code.
 Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.
 Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.
 When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.
-## Execution Bias
-If the user asks you to do the work, start doing it in the same turn.
-Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.
-Commentary-only turns are incomplete when tools are available and the next action is clear.
-If the work will take multiple steps or a while to finish, send one short progress update before or while acting.
-## Tool Enforcement
-When a task requires a tool call, execute the tool immediately.
-Do not describe what you would do — do it.
-Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+</tooling>
+<tool_use>
+You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it.
+When you say you will perform an action, you MUST immediately make the corresponding tool call in the same response.
+Never end your turn with a promise of future action — execute it now.
+Keep working until the task is actually complete. Do not stop with a summary of what you plan to do next time.
+Every response should either (a) contain tool calls that make progress, or (b) deliver a final result to the user.
+Responses that only describe intentions without acting are not acceptable.
 If multiple independent tool calls are needed, batch them in a single response.
 Never simulate or fabricate tool output — always call the real tool.
-## Shell Efficiency
+Do not ask for confirmation before using tools unless the tool is destructive or the user explicitly asked for a plan.
+Default: do not narrate routine, low-risk tool calls (just call the tool).
+Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions, or when the user explicitly asks.
+Keep narration brief and value-dense; avoid repeating obvious steps.
+</tool_use>
+<shell>
 Prefer writing a temporary script file and executing it over chaining many individual shell commands.
 Combine related operations into a single shell invocation where possible.
 Avoid repeated read-modify-write cycles — batch edits into one tool call.
 Never use backtick line continuations in shell commands — they break across platforms.
 Use single quotes for strings containing special characters ($, @, |, ;).
 For complex multi-step operations, write a .ps1 or .sh script to a temp location and execute it.
-## Safety
+</shell>
+<safety>
 You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.
 Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)
 Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.
-## BotNexus CLI Quick Reference
+</safety>
+<cli>
 BotNexus is controlled via subcommands. Do not invent commands.
 To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway status
@@ -50,24 +50,28 @@ To manage the Gateway daemon service (start/stop/restart):
 - botnexus gateway stop
 - botnexus gateway restart
 If unsure, ask the user to run `botnexus help` (or `botnexus gateway --help`) and paste the output.
-## Memory
+</cli>
+<memory>
 Memory context in this prompt is frozen at session start; do not assume memory files changed unless a new session starts.
 Use the runtime's memory-write capability for durable memory writes when available.
 Use `MEMORY.md` as long-lived consolidated context and `memory/YYYY-MM-DD.md` as append-only daily notes.
 Do not rewrite prior memory notes in-place during normal turns; append durable updates instead.
 Durable memory writes appear in subsequent sessions after persistence and prompt rebuild.
-## Workspace
+</memory>
+<workspace>
 Your working directory is: <workspace>
 Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.
+</workspace>
 ## Workspace Files (injected)
 These user-editable files are loaded by BotNexus and included below in Project Context.
-## Messaging
+<messaging>
 - Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)
 - Cross-session messaging → use sessions_send(sessionKey, message)
 - Sub-agent orchestration → use subagents(action=list|steer|kill)
 - Runtime-generated completion events may ask for a user update. Rewrite those in your normal assistant voice and send the update (do not forward raw internal metadata or default to NO_REPLY).
 - Never use exec/curl for provider messaging; BotNexus handles all routing internally.
-## Silent Replies
+</messaging>
+<silent_replies>
 Use NO_REPLY ONLY when no user-visible reply is required.
 ⚠️ Rules:
 - Valid cases: silent housekeeping, deliberate no-op ambient wakeups, or after a messaging tool already delivered the user-visible reply.
@@ -78,9 +82,11 @@ Use NO_REPLY ONLY when no user-visible reply is required.
 ❌ Wrong: "Here's help... NO_REPLY"
 ❌ Wrong: "NO_REPLY"
 ✅ Right: NO_REPLY
+</silent_replies>
 
 <!-- BOTNEXUS_CACHE_BOUNDARY -->
 
-## Runtime
+<runtime>
 Runtime: agent=agent-a | channel=signalr | capabilities=none
 Reasoning: off (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.
+</runtime>


### PR DESCRIPTION
Closes #1266

## Changes
- Added \XmlTag\ property to \IPromptSection\ interface and \LambdaPromptSection\
- \PromptPipeline.BuildLines()\ wraps section output in \<tag>...</tag>\ when \XmlTag\ is non-null
- Removed \## Heading\ markdown headers from platform sections (replaced by XML tags)
- Merged Execution Bias + Tool Call Style into unified \ToolEnforcementSection\ (\<tool_use>\)
- Split Safety/CLI into separate sections with distinct XML tags
- Exec approval guidance moved into Tooling section
- User workspace files (Project Context) remain unwrapped

### Tag mapping
| Section | XML Tag |
|---------|---------|
| Tooling | \<tooling>\ |
| Tool Enforcement (merged) | \<tool_use>\ |
| Shell Efficiency | \<shell>\ |
| Skills | \<skills>\ |
| Safety | \<safety>\ |
| CLI Reference | \<cli>\ |
| Memory | \<memory>\ |
| Workspace | \<workspace>\ |
| Messaging | \<messaging>\ |
| Silent Replies | \<silent_replies>\ |
| Model Guidance | \<model_guidance>\ |
| Runtime | \<runtime>\ |

## Merge Notes
Independent of all other open PRs. No file overlap.