### PR TITLE
feat(extensions): add per-agent store scoping for QMD knowledge base

### DIFF
--- a/src/extensions/BotNexus.Extensions.Qmd/InMemoryQmdBackend.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/InMemoryQmdBackend.cs
@@ -20,6 +20,20 @@ public sealed class InMemoryQmdBackend : IQmdBackend
     /// <summary>Records calls to <see cref="EmbedAsync"/> for test assertions.</summary>
     public ConcurrentBag<string?> EmbedCalls { get; } = [];
 
+    /// <summary>Replaces all stores with the given set.</summary>
+    public void SetStores(IEnumerable<QmdStoreInfo> stores)
+    {
+        Stores.Clear();
+        foreach (var store in stores) Stores.Add(store);
+    }
+
+    /// <summary>Replaces all documents with the given set.</summary>
+    public void SetDocuments(IEnumerable<QmdDocument> documents)
+    {
+        Documents.Clear();
+        foreach (var doc in documents) Documents.Add(doc);
+    }
+
     /// <inheritdoc />
     public Task<QmdSearchResult[]> SearchAsync(string query, string? store, QmdSearchMode mode, int limit, CancellationToken ct = default)
     {

--- a/src/extensions/BotNexus.Extensions.Qmd/KnowledgeGetTool.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/KnowledgeGetTool.cs
@@ -8,7 +8,7 @@ namespace BotNexus.Extensions.Qmd;
 /// <summary>
 /// Agent-facing tool for retrieving a specific document from the knowledge base by ID or path.
 /// </summary>
-public sealed class KnowledgeGetTool(IQmdBackend backend) : IAgentTool
+public sealed class KnowledgeGetTool(IQmdBackend backend, QmdConfig config) : IAgentTool
 {
     private const int MaxContentChars = 50_000;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -75,6 +75,10 @@ public sealed class KnowledgeGetTool(IQmdBackend backend) : IAgentTool
         if (document is null)
             return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
                 $"Document not found: '{id}'")]);
+
+        if (!string.IsNullOrWhiteSpace(document.Store) && !config.IsStoreAllowed(document.Store))
+            return new AgentToolResult([new AgentToolContent(AgentToolContentType.Text,
+                $"Error: Access denied. Store '{document.Store}' is not in your allowed stores.")]);
 
         var content = document.Content;
         var truncated = false;

--- a/src/extensions/BotNexus.Extensions.Qmd/KnowledgeSearchTool.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/KnowledgeSearchTool.cs
@@ -71,6 +71,10 @@ public sealed class KnowledgeSearchTool(IQmdBackend backend, QmdConfig config) :
             return TextResult("Error: The 'query' parameter is required.");
 
         var store = GetString(arguments, "store");
+
+        if (!string.IsNullOrWhiteSpace(store) && !config.IsStoreAllowed(store))
+            return TextResult($"Error: Access denied. Store '{store}' is not in your allowed stores.");
+
         var modeStr = GetString(arguments, "mode") ?? config.DefaultSearchMode;
         var limit = GetInt(arguments, "limit") ?? config.MaxResults;
 

--- a/src/extensions/BotNexus.Extensions.Qmd/KnowledgeStoresTool.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/KnowledgeStoresTool.cs
@@ -60,6 +60,12 @@ public sealed class KnowledgeStoresTool(IQmdBackend backend, QmdConfig config) :
                 $"Failed to retrieve knowledge stores: {ex.Message}")]);
         }
 
+        // Filter to allowed stores only
+        if (config.AllowedStores is { Count: > 0 })
+        {
+            stores = stores.Where(s => config.IsStoreAllowed(s.Name)).ToArray();
+        }
+
         // Enrich with descriptions from config
         var configDescriptions = config.Stores
             .Where(s => !string.IsNullOrWhiteSpace(s.Description))

--- a/src/extensions/BotNexus.Extensions.Qmd/QmdConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdConfig.cs
@@ -25,6 +25,23 @@ public sealed class QmdConfig
 
     /// <summary>Configured knowledge stores to index and search.</summary>
     public List<QmdStoreConfig> Stores { get; set; } = [];
+
+    /// <summary>
+    /// When set, restricts this agent to only see the listed store names.
+    /// Null or empty means the agent can see ALL configured stores.
+    /// </summary>
+    public List<string>? AllowedStores { get; set; }
+
+    /// <summary>
+    /// Returns true if the given store name is accessible to this agent.
+    /// When <see cref="AllowedStores"/> is null or empty, all stores are accessible.
+    /// </summary>
+    public bool IsStoreAllowed(string storeName)
+    {
+        if (AllowedStores is null || AllowedStores.Count == 0)
+            return true;
+        return AllowedStores.Contains(storeName, StringComparer.OrdinalIgnoreCase);
+    }
 }
 
 /// <summary>

--- a/src/extensions/BotNexus.Extensions.Qmd/QmdToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Qmd/QmdToolContributor.cs
@@ -26,7 +26,7 @@ public sealed class QmdToolContributor(ILoggerFactory? loggerFactory = null) : I
 
         var logger = loggerFactory?.CreateLogger<QmdCliBackend>();
         var backend = new QmdCliBackend(config.QmdPath, TimeSpan.FromSeconds(30), logger);
-        IReadOnlyList<IAgentTool> tools = [new KnowledgeSearchTool(backend, config), new KnowledgeStoresTool(backend, config), new KnowledgeGetTool(backend)];
+        IReadOnlyList<IAgentTool> tools = [new KnowledgeSearchTool(backend, config), new KnowledgeStoresTool(backend, config), new KnowledgeGetTool(backend, config)];
 
         return Task.FromResult(new AgentToolContribution(tools, [backend]));
     }

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/KnowledgeStoresAndGetToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/KnowledgeStoresAndGetToolTests.cs
@@ -80,7 +80,7 @@ public sealed class KnowledgeGetToolTests
         var backend = new InMemoryQmdBackend();
         backend.Documents.Add(new QmdDocument("doc1", "vault", "/vault/test.md", "Test Doc", "# Hello\nContent here"));
 
-        var tool = new KnowledgeGetTool(backend);
+        var tool = new KnowledgeGetTool(backend, new QmdConfig());
         var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "doc1" });
 
         var text = result.Content[0].Value;
@@ -93,7 +93,7 @@ public sealed class KnowledgeGetToolTests
     public async Task Execute_NotFound_ReturnsMessage()
     {
         var backend = new InMemoryQmdBackend();
-        var tool = new KnowledgeGetTool(backend);
+        var tool = new KnowledgeGetTool(backend, new QmdConfig());
         var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "nonexistent" });
 
         result.Content[0].Value.ShouldContain("Document not found");
@@ -106,7 +106,7 @@ public sealed class KnowledgeGetToolTests
         var backend = new InMemoryQmdBackend();
         backend.Documents.Add(new QmdDocument("big", "vault", "/vault/big.md", "Big", largeContent));
 
-        var tool = new KnowledgeGetTool(backend);
+        var tool = new KnowledgeGetTool(backend, new QmdConfig());
         var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "big" });
 
         var text = result.Content[0].Value;
@@ -118,7 +118,7 @@ public sealed class KnowledgeGetToolTests
     public async Task Execute_BackendFailure_ReturnsErrorMessage()
     {
         var backend = new FailingQmdBackend();
-        var tool = new KnowledgeGetTool(backend);
+        var tool = new KnowledgeGetTool(backend, new QmdConfig());
         var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?> { ["id"] = "doc1" });
 
         result.Content[0].Value.ShouldContain("Failed to retrieve");
@@ -128,7 +128,7 @@ public sealed class KnowledgeGetToolTests
     public async Task PrepareArguments_MissingId_Throws()
     {
         var backend = new InMemoryQmdBackend();
-        var tool = new KnowledgeGetTool(backend);
+        var tool = new KnowledgeGetTool(backend, new QmdConfig());
 
         var act = () => tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["id"] = "   " });
         await act.ShouldThrowAsync<ArgumentException>();

--- a/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdStoreScopingTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Qmd.Tests/QmdStoreScopingTests.cs
@@ -1,0 +1,168 @@
+using BotNexus.Agent.Core.Types;
+
+namespace BotNexus.Extensions.Qmd.Tests;
+
+public sealed class QmdStoreScopingTests
+{
+    private readonly InMemoryQmdBackend _backend = new();
+
+    private static string GetText(AgentToolResult result) =>
+        result.Content[0].Value;
+
+    // --- QmdConfig.IsStoreAllowed ---
+
+    [Fact]
+    public void IsStoreAllowed_NullAllowedStores_ReturnsTrue()
+    {
+        var config = new QmdConfig { AllowedStores = null };
+        Assert.True(config.IsStoreAllowed("any-store"));
+    }
+
+    [Fact]
+    public void IsStoreAllowed_EmptyAllowedStores_ReturnsTrue()
+    {
+        var config = new QmdConfig { AllowedStores = [] };
+        Assert.True(config.IsStoreAllowed("any-store"));
+    }
+
+    [Fact]
+    public void IsStoreAllowed_StoreInList_ReturnsTrue()
+    {
+        var config = new QmdConfig { AllowedStores = ["projects", "resources"] };
+        Assert.True(config.IsStoreAllowed("projects"));
+    }
+
+    [Fact]
+    public void IsStoreAllowed_StoreNotInList_ReturnsFalse()
+    {
+        var config = new QmdConfig { AllowedStores = ["projects", "resources"] };
+        Assert.False(config.IsStoreAllowed("secrets"));
+    }
+
+    [Fact]
+    public void IsStoreAllowed_CaseInsensitive()
+    {
+        var config = new QmdConfig { AllowedStores = ["Projects"] };
+        Assert.True(config.IsStoreAllowed("projects"));
+    }
+
+    // --- KnowledgeSearchTool access control ---
+
+    [Fact]
+    public async Task Search_DeniedStore_ReturnsAccessDenied()
+    {
+        var config = new QmdConfig { AllowedStores = ["projects"] };
+        var tool = new KnowledgeSearchTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1",
+            new Dictionary<string, object?> { ["query"] = "test", ["store"] = "secrets" });
+
+        var text = GetText(result);
+        Assert.Contains("Access denied", text);
+        Assert.Contains("secrets", text);
+    }
+
+    [Fact]
+    public async Task Search_AllowedStore_Succeeds()
+    {
+        var config = new QmdConfig { AllowedStores = ["projects"] };
+        var tool = new KnowledgeSearchTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1",
+            new Dictionary<string, object?> { ["query"] = "test", ["store"] = "projects" });
+
+        var text = GetText(result);
+        Assert.DoesNotContain("Access denied", text);
+    }
+
+    [Fact]
+    public async Task Search_NoStoreSpecified_NoRestriction()
+    {
+        var config = new QmdConfig { AllowedStores = ["projects"] };
+        var tool = new KnowledgeSearchTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1",
+            new Dictionary<string, object?> { ["query"] = "test" });
+
+        var text = GetText(result);
+        Assert.DoesNotContain("Access denied", text);
+    }
+
+    // --- KnowledgeStoresTool filtering ---
+
+    [Fact]
+    public async Task Stores_WithAllowedStores_FiltersOutput()
+    {
+        _backend.SetStores([
+            new QmdStoreInfo("projects", "/p", null, 5, null, true),
+            new QmdStoreInfo("secrets", "/s", null, 3, null, true),
+            new QmdStoreInfo("resources", "/r", null, 8, null, true)
+        ]);
+
+        var config = new QmdConfig { AllowedStores = ["projects", "resources"] };
+        var tool = new KnowledgeStoresTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>());
+
+        var text = GetText(result);
+        Assert.Contains("projects", text);
+        Assert.Contains("resources", text);
+        Assert.DoesNotContain("secrets", text);
+    }
+
+    [Fact]
+    public async Task Stores_NoAllowedStores_ShowsAll()
+    {
+        _backend.SetStores([
+            new QmdStoreInfo("projects", "/p", null, 5, null, true),
+            new QmdStoreInfo("secrets", "/s", null, 3, null, true)
+        ]);
+
+        var config = new QmdConfig { AllowedStores = null };
+        var tool = new KnowledgeStoresTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1", new Dictionary<string, object?>());
+
+        var text = GetText(result);
+        Assert.Contains("projects", text);
+        Assert.Contains("secrets", text);
+    }
+
+    // --- KnowledgeGetTool access control ---
+
+    [Fact]
+    public async Task Get_DeniedStore_ReturnsAccessDenied()
+    {
+        _backend.SetDocuments([
+            new QmdDocument("#abc", "secrets", "secrets/file.md", "Secret", "content")
+        ]);
+
+        var config = new QmdConfig { AllowedStores = ["projects"] };
+        var tool = new KnowledgeGetTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1",
+            new Dictionary<string, object?> { ["id"] = "#abc" });
+
+        var text = GetText(result);
+        Assert.Contains("Access denied", text);
+        Assert.Contains("secrets", text);
+    }
+
+    [Fact]
+    public async Task Get_AllowedStore_Succeeds()
+    {
+        _backend.SetDocuments([
+            new QmdDocument("#abc", "projects", "projects/file.md", "Project", "content")
+        ]);
+
+        var config = new QmdConfig { AllowedStores = ["projects"] };
+        var tool = new KnowledgeGetTool(_backend, config);
+
+        var result = await tool.ExecuteAsync("tc1",
+            new Dictionary<string, object?> { ["id"] = "#abc" });
+
+        var text = GetText(result);
+        Assert.DoesNotContain("Access denied", text);
+        Assert.Contains("content", text);
+    }
+}


### PR DESCRIPTION
Closes #1176

## Changes
- Added `AllowedStores` property to `QmdConfig` with case-insensitive matching
- `KnowledgeSearchTool`: rejects search to non-allowed stores with clear access denied error
- `KnowledgeStoresTool`: filters output to only show allowed stores
- `KnowledgeGetTool`: validates store on retrieved documents, returns access denied (not 'not found')
- Added `SetStores`/`SetDocuments` helpers to `InMemoryQmdBackend`
- 12 new tests covering config validation, tool enforcement, and filtering

## Merge Notes
Independent of all other open PRs. Part of #1171 QMD extension chain (3/5).
