### PR TITLE
fix(gateway): make IConversationChangeNotifier optional to prevent DI crash in minimal configs

### DIFF
--- a/src/gateway/BotNexus.Gateway/Conversations/ConversationRetentionHostedService.cs
+++ b/src/gateway/BotNexus.Gateway/Conversations/ConversationRetentionHostedService.cs
@@ -21,13 +21,13 @@ namespace BotNexus.Gateway.Conversations;
 /// </summary>
 public sealed class ConversationRetentionHostedService(
     IConversationStore conversationStore,
-    IConversationChangeNotifier changeNotifier,
+    IConversationChangeNotifier? changeNotifier,
     IAgentRegistry agentRegistry,
     IOptions<ConversationRetentionOptions> optionsAccessor,
     ILogger<ConversationRetentionHostedService> logger) : BackgroundService
 {
     private readonly IConversationStore _conversationStore = conversationStore;
-    private readonly IConversationChangeNotifier _changeNotifier = changeNotifier;
+    private readonly IConversationChangeNotifier? _changeNotifier = changeNotifier;
     private readonly IAgentRegistry _agentRegistry = agentRegistry;
     private readonly ILogger<ConversationRetentionHostedService> _logger = logger;
 
@@ -150,6 +150,9 @@ public sealed class ConversationRetentionHostedService(
 
     private async Task NotifyBestEffortAsync(Conversation conv, CancellationToken cancellationToken)
     {
+        if (_changeNotifier is null)
+            return;
+
         try
         {
             await _changeNotifier.NotifyConversationChangedAsync(

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationRetentionHostedServiceTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationRetentionHostedServiceTests.cs
@@ -170,6 +170,29 @@ public sealed class ConversationRetentionHostedServiceTests
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    // ── Null notifier (not registered) ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task RunRetentionOnceAsync_WhenNotifierIsNull_ArchivesWithoutThrowing()
+    {
+        var store = new InMemoryConversationStore();
+        var registry = new DefaultAgentRegistry(NullLogger<DefaultAgentRegistry>.Instance);
+        await store.CreateAsync(CreateConversation("c-1", "a-1", inactiveDays: 31));
+        var options = new ConversationRetentionOptions { AutoArchiveEnabled = true, AutoArchiveAfterDays = 30 };
+
+        var svc = new ConversationRetentionHostedService(
+            store,
+            null,
+            registry,
+            Options.Create(options),
+            NullLogger<ConversationRetentionHostedService>.Instance);
+        var archived = await svc.RunRetentionOnceAsync();
+
+        archived.ShouldBe(1);
+        var conv = await store.GetAsync(ConversationId.From("c-1"));
+        conv!.Status.ShouldBe(ConversationStatus.Archived);
+    }
+
     // ── SignalR push fires on archive ─────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #1282

## Changes
- Made \IConversationChangeNotifier\ parameter nullable in \ConversationRetentionHostedService\ constructor
- Added null guard in \NotifyBestEffortAsync\ — skips notification silently when no notifier is registered
- Added test verifying archive works correctly with null notifier

## Root Cause
\ConversationRetentionHostedService\ is registered unconditionally, but \IConversationChangeNotifier\ is only registered by the SignalR channel extension. In Docker or minimal configs without SignalR, the hosted service crashes on startup.

## Merge Notes
Safe to merge in any order with other open PRs — only touches \ConversationRetentionHostedService.cs\ and its test file.