### PR TITLE
feat(sessions): add tool result trimming with age+size hybrid strategy

### DIFF
--- a/src/gateway/BotNexus.Gateway.Sessions/ToolResultTrimmer.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/ToolResultTrimmer.cs
@@ -1,0 +1,131 @@
+// ToolResultTrimmer.cs
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// Replaces large, stale tool results with compact tombstones to reclaim token budget.
+/// Uses an age+size hybrid strategy: tool results exceeding
+/// <see cref="ToolResultTrimmingOptions.MinContentLengthChars"/> that are older than the
+/// configured turn threshold are replaced with a tombstone containing metadata and a short preview.
+/// </summary>
+/// <remarks>
+/// Tombstone format:
+/// <code>
+/// [tool result trimmed — {toolName}, {originalLength} chars, produced {age} turns ago]
+/// {preview}…
+/// </code>
+/// This class is stateless and produces a new list; it never mutates the input entries.
+/// </remarks>
+public sealed class ToolResultTrimmer
+{
+    /// <summary>Marker prefix for tombstone detection.</summary>
+    public const string TombstoneMarker = "[tool result trimmed";
+
+    private readonly ToolResultTrimmingOptions _options;
+
+    /// <summary>Creates a new trimmer with the given options.</summary>
+    public ToolResultTrimmer(ToolResultTrimmingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
+    }
+
+    /// <summary>
+    /// Applies trimming to the live context entries. Tool results that exceed the size
+    /// threshold and are older than the configured turn threshold are replaced with tombstones.
+    /// </summary>
+    /// <param name="entries">The live context entries (output of <see cref="SessionContextProjector.ProjectForLiveContext"/>).</param>
+    /// <returns>A new list with eligible tool results replaced by tombstones. Returns the same list reference if no trimming occurred.</returns>
+    public IReadOnlyList<SessionEntry> Trim(IReadOnlyList<SessionEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        if (!_options.Enabled || entries.Count == 0)
+            return entries;
+
+        // Count user turns from the end to determine age of each entry.
+        int currentTurnAge = 0;
+        var turnAges = new int[entries.Count];
+
+        // Walk backward — every user message increments the turn counter.
+        for (int i = entries.Count - 1; i >= 0; i--)
+        {
+            if (entries[i].Role.Equals(MessageRole.User) && !entries[i].IsHistory)
+                currentTurnAge++;
+            turnAges[i] = currentTurnAge;
+        }
+
+        List<SessionEntry>? result = null;
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+
+            if (ShouldTrim(entry, turnAges[i]))
+            {
+                result ??= new List<SessionEntry>(entries.Count);
+                // Copy everything before this that we haven't added yet
+                if (result.Count == 0)
+                {
+                    for (int j = 0; j < i; j++)
+                        result.Add(entries[j]);
+                }
+
+                result.Add(CreateTombstone(entry, turnAges[i]));
+            }
+            else if (result is not null)
+            {
+                result.Add(entry);
+            }
+        }
+
+        return result ?? entries;
+    }
+
+    /// <summary>
+    /// Determines whether a given entry is already a tombstone (previously trimmed).
+    /// </summary>
+    public static bool IsTombstone(SessionEntry entry) =>
+        entry.Role.Equals(MessageRole.Tool)
+        && entry.Content.StartsWith(TombstoneMarker, StringComparison.Ordinal);
+
+    private bool ShouldTrim(SessionEntry entry, int turnAge)
+    {
+        // Only trim tool result entries (not tool-start entries which have ToolArgs).
+        if (!entry.Role.Equals(MessageRole.Tool))
+            return false;
+
+        // Don't trim tool-start entries (they have ToolArgs set).
+        if (entry.ToolArgs is not null)
+            return false;
+
+        // Already a tombstone — skip.
+        if (IsTombstone(entry))
+            return false;
+
+        // Too short to bother trimming.
+        if (entry.Content.Length < _options.MinContentLengthChars)
+            return false;
+
+        // Determine the age threshold for this tool.
+        int threshold = _options.AgeTurnsThreshold;
+        if (entry.ToolName is not null && _options.ToolThresholds.TryGetValue(entry.ToolName, out var custom))
+            threshold = custom;
+
+        return turnAge >= threshold;
+    }
+
+    private SessionEntry CreateTombstone(SessionEntry original, int turnAge)
+    {
+        var preview = original.Content.Length > _options.TombstonePreviewChars
+            ? original.Content[.._options.TombstonePreviewChars]
+            : original.Content;
+
+        var toolName = original.ToolName ?? "unknown";
+        var tombstoneContent = $"{TombstoneMarker} — {toolName}, {original.Content.Length} chars, produced {turnAge} turns ago]\n{preview}…";
+
+        return original with { Content = tombstoneContent };
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Sessions/ToolResultTrimmingOptions.cs
+++ b/src/gateway/BotNexus.Gateway.Sessions/ToolResultTrimmingOptions.cs
@@ -1,0 +1,52 @@
+// ToolResultTrimmingOptions.cs
+using System.Text.Json.Serialization;
+
+namespace BotNexus.Gateway.Sessions;
+
+/// <summary>
+/// Configuration for the tool result trimming pipeline. Controls when and how
+/// large tool results are replaced with compact tombstones to reclaim token budget.
+/// </summary>
+public sealed class ToolResultTrimmingOptions
+{
+    /// <summary>Section name in configuration.</summary>
+    public const string SectionName = "toolResultTrimming";
+
+    /// <summary>
+    /// Whether tool result trimming is enabled. Default: true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Minimum content length (chars) for a tool result to be a trimming candidate.
+    /// Results shorter than this are never trimmed. Default: 500.
+    /// </summary>
+    public int MinContentLengthChars { get; set; } = 500;
+
+    /// <summary>
+    /// Number of turns after which a large tool result becomes eligible for trimming.
+    /// A "turn" is one user→assistant exchange. Default: 3.
+    /// </summary>
+    public int AgeTurnsThreshold { get; set; } = 3;
+
+    /// <summary>
+    /// Maximum number of leading characters preserved in the tombstone preview.
+    /// Default: 200.
+    /// </summary>
+    public int TombstonePreviewChars { get; set; } = 200;
+
+    /// <summary>
+    /// Per-tool overrides for <see cref="AgeTurnsThreshold"/>.
+    /// Key is the tool name (case-insensitive), value is the turn threshold.
+    /// </summary>
+    public Dictionary<string, int> ToolThresholds { get; set; } = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["shell"] = 2,
+        ["exec"] = 2,
+        ["web_fetch"] = 2,
+        ["read"] = 3,
+        ["grep"] = 3,
+        ["glob"] = 3,
+        ["memory_search"] = 5
+    };
+}

--- a/tests/gateway/BotNexus.Gateway.Sessions.Tests/ToolResultTrimmerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Sessions.Tests/ToolResultTrimmerTests.cs
@@ -1,0 +1,314 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Sessions;
+
+namespace BotNexus.Gateway.Sessions.Tests;
+
+public class ToolResultTrimmerTests
+{
+    private static ToolResultTrimmingOptions DefaultOptions() => new();
+
+    private static SessionEntry UserEntry(string content = "hello") =>
+        new() { Role = MessageRole.User, Content = content };
+
+    private static SessionEntry AssistantEntry(string content = "response") =>
+        new() { Role = MessageRole.Assistant, Content = content };
+
+    private static SessionEntry ToolResult(string content, string? toolName = "read", string? toolCallId = null) =>
+        new()
+        {
+            Role = MessageRole.Tool,
+            Content = content,
+            ToolName = toolName,
+            ToolCallId = toolCallId ?? Guid.NewGuid().ToString()
+        };
+
+    private static SessionEntry ToolStart(string toolName = "read") =>
+        new()
+        {
+            Role = MessageRole.Tool,
+            Content = "",
+            ToolName = toolName,
+            ToolArgs = """{"path":"test.txt"}""",
+            ToolCallId = Guid.NewGuid().ToString()
+        };
+
+    private static string LargeContent(int chars = 1000) => new('x', chars);
+
+    [Fact]
+    public void Trim_WhenDisabled_ReturnsOriginalList()
+    {
+        var options = new ToolResultTrimmingOptions { Enabled = false };
+        var trimmer = new ToolResultTrimmer(options);
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), AssistantEntry(), ToolResult(LargeContent()),
+            UserEntry(), AssistantEntry(), UserEntry(), AssistantEntry(), UserEntry()
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result);
+    }
+
+    [Fact]
+    public void Trim_EmptyList_ReturnsSameReference()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var entries = Array.Empty<SessionEntry>();
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result);
+    }
+
+    [Fact]
+    public void Trim_SmallToolResult_NeverTrimmed()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        // Content under 500 chars
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult("short result", "shell"),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 4 turns later
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result);
+    }
+
+    [Fact]
+    public void Trim_LargeToolResult_UnderAgeThreshold_NotTrimmed()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        // Only 1 turn old, default threshold is 3
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(LargeContent(), "read"),
+            UserEntry() // 1 turn later
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result);
+    }
+
+    [Fact]
+    public void Trim_LargeToolResult_ExceedsAgeThreshold_Trimmed()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var largeContent = LargeContent(1000);
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(largeContent, "read"),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 3 turns later — equals threshold
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.NotSame(entries, result);
+        Assert.Equal(entries.Count, result.Count);
+
+        // The tool result should be a tombstone
+        var trimmed = result[1];
+        Assert.StartsWith(ToolResultTrimmer.TombstoneMarker, trimmed.Content);
+        Assert.Contains("read", trimmed.Content);
+        Assert.Contains("1000 chars", trimmed.Content);
+        Assert.Contains("3 turns ago", trimmed.Content);
+    }
+
+    [Fact]
+    public void Trim_ShellTool_UsesCustomThreshold_Of2()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(LargeContent(), "shell"),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 2 turns — shell threshold
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.NotSame(entries, result);
+        Assert.StartsWith(ToolResultTrimmer.TombstoneMarker, result[1].Content);
+    }
+
+    [Fact]
+    public void Trim_MemorySearchTool_HigherThreshold()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        // 4 turns — under memory_search threshold of 5
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(LargeContent(), "memory_search"),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 4 turns
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result); // Not trimmed — threshold is 5
+    }
+
+    [Fact]
+    public void Trim_MemorySearchTool_AtThreshold_Trimmed()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(LargeContent(), "memory_search"),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 5 turns
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.NotSame(entries, result);
+        Assert.StartsWith(ToolResultTrimmer.TombstoneMarker, result[1].Content);
+    }
+
+    [Fact]
+    public void Trim_TombstonePreview_ContainsFirstNChars()
+    {
+        var options = new ToolResultTrimmingOptions { TombstonePreviewChars = 50 };
+        var trimmer = new ToolResultTrimmer(options);
+        var content = "ABCDEFGHIJ" + new string('Z', 990); // 1000 chars, starts with known prefix
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(content, "read"),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 3 turns
+        };
+
+        var result = trimmer.Trim(entries);
+
+        var tombstone = result[1].Content;
+        Assert.Contains("ABCDEFGHIJ", tombstone);
+        // Should NOT contain the full 1000 chars
+        Assert.True(tombstone.Length < content.Length);
+    }
+
+    [Fact]
+    public void Trim_ToolStartEntry_NeverTrimmed()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolStart("read"),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // 3 turns
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result); // ToolStart entries have ToolArgs, should be skipped
+    }
+
+    [Fact]
+    public void Trim_AlreadyTombstone_NotRetrimmed()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var tombstoneContent = $"{ToolResultTrimmer.TombstoneMarker} — read, 5000 chars, produced 4 turns ago]\npreview…";
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(),
+            new() { Role = MessageRole.Tool, Content = tombstoneContent, ToolName = "read" },
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry() // well past threshold
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.Same(entries, result);
+    }
+
+    [Fact]
+    public void Trim_PreservesOtherEntryProperties()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var callId = "call_123";
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(), ToolResult(LargeContent(), "read", callId),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry()
+        };
+
+        var result = trimmer.Trim(entries);
+
+        var trimmed = result[1];
+        Assert.Equal(MessageRole.Tool, trimmed.Role);
+        Assert.Equal("read", trimmed.ToolName);
+        Assert.Equal(callId, trimmed.ToolCallId);
+    }
+
+    [Fact]
+    public void Trim_MultipleToolResults_OnlyTrimsEligible()
+    {
+        var trimmer = new ToolResultTrimmer(DefaultOptions());
+        var entries = new List<SessionEntry>
+        {
+            UserEntry(),
+            ToolResult(LargeContent(), "shell"),  // will be 4 turns old → trimmed (shell threshold=2)
+            ToolResult("tiny", "grep"),            // too small → not trimmed
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry(), AssistantEntry(),
+            UserEntry()
+        };
+
+        var result = trimmer.Trim(entries);
+
+        Assert.NotSame(entries, result);
+        Assert.StartsWith(ToolResultTrimmer.TombstoneMarker, result[1].Content);
+        Assert.Equal("tiny", result[2].Content); // Preserved
+    }
+
+    [Fact]
+    public void IsTombstone_DetectsMarker()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.Tool,
+            Content = $"{ToolResultTrimmer.TombstoneMarker} — read, 500 chars, produced 3 turns ago]\npreview…"
+        };
+
+        Assert.True(ToolResultTrimmer.IsTombstone(entry));
+    }
+
+    [Fact]
+    public void IsTombstone_FalseForNormalToolResult()
+    {
+        var entry = ToolResult("normal output");
+
+        Assert.False(ToolResultTrimmer.IsTombstone(entry));
+    }
+
+    [Fact]
+    public void IsTombstone_FalseForNonToolEntry()
+    {
+        var entry = new SessionEntry
+        {
+            Role = MessageRole.Assistant,
+            Content = $"{ToolResultTrimmer.TombstoneMarker} fake"
+        };
+
+        Assert.False(ToolResultTrimmer.IsTombstone(entry));
+    }
+}


### PR DESCRIPTION
Closes #1212

## Changes
- **ToolResultTrimmingOptions**: Configuration schema with per-tool thresholds, global defaults, tombstone preview size
- **ToolResultTrimmer**: Age+size hybrid trimming — replaces large tool results with compact tombstones after N turns
- Tombstones preserve: tool name, original size, age, and first N chars as preview
- Tool-specific thresholds: shell/exec (2 turns), read/grep/glob (3), memory_search (5)
- Never trims: results under 500 chars, tool-start entries, already-tombstoned entries
- 15 new tests covering all edge cases

## Merge Notes
Self-contained in BotNexus.Gateway.Sessions — no overlap with any open PR. Safe to merge in any order.