### PR TITLE
feat(gateway): add world event bus with subscription model and in-memory implementation

### DIFF
--- a/src/gateway/BotNexus.Gateway.Contracts/Events/EventSubscription.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Events/EventSubscription.cs
@@ -1,0 +1,35 @@
+// EventSubscription.cs
+namespace BotNexus.Gateway.Contracts.Events;
+
+/// <summary>
+/// An agent's subscription to a specific event type with optional filter criteria.
+/// </summary>
+/// <param name="EventType">The event type to subscribe to (must match <see cref="WorldEvent.EventType"/>).</param>
+/// <param name="Filter">Optional key-value filter that must match event payload for delivery. Null means match all events of this type.</param>
+public sealed record EventSubscription(string EventType, IReadOnlyDictionary<string, string>? Filter = null)
+{
+    /// <summary>
+    /// Determines whether a given event matches this subscription.
+    /// </summary>
+    public bool Matches(WorldEvent worldEvent)
+    {
+        ArgumentNullException.ThrowIfNull(worldEvent);
+
+        if (!string.Equals(EventType, worldEvent.EventType, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (Filter is null || Filter.Count == 0)
+            return true;
+
+        // All filter keys must match in the event payload.
+        foreach (var (key, value) in Filter)
+        {
+            if (!worldEvent.Payload.TryGetValue(key, out var payloadValue))
+                return false;
+            if (!string.Equals(value, payloadValue, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Events/IWorldEventBus.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Events/IWorldEventBus.cs
@@ -1,0 +1,39 @@
+// IWorldEventBus.cs
+namespace BotNexus.Gateway.Contracts.Events;
+
+/// <summary>
+/// Lightweight event bus that lets agents react to things happening in the world
+/// without polling. Agents declare interest via <see cref="EventSubscription"/> and
+/// receive triggered conversations when matching events fire.
+/// </summary>
+public interface IWorldEventBus
+{
+    /// <summary>
+    /// Publishes an event to all matching subscribers.
+    /// </summary>
+    /// <param name="worldEvent">The event to publish.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of subscribers that were notified.</returns>
+    Task<int> PublishAsync(WorldEvent worldEvent, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers subscriptions for an agent. Replaces any existing subscriptions for that agent.
+    /// </summary>
+    /// <param name="agentId">The subscribing agent's identifier.</param>
+    /// <param name="subscriptions">The subscriptions to register.</param>
+    void SetSubscriptions(string agentId, IReadOnlyList<EventSubscription> subscriptions);
+
+    /// <summary>
+    /// Gets all active subscriptions for a given agent.
+    /// </summary>
+    /// <param name="agentId">The agent identifier.</param>
+    /// <returns>The agent's subscriptions, or empty if none registered.</returns>
+    IReadOnlyList<EventSubscription> GetSubscriptions(string agentId);
+
+    /// <summary>
+    /// Gets all agents subscribed to a given event type.
+    /// </summary>
+    /// <param name="eventType">The event type to query.</param>
+    /// <returns>Agent IDs with active subscriptions for this event type.</returns>
+    IReadOnlyList<string> GetSubscribers(string eventType);
+}

--- a/src/gateway/BotNexus.Gateway.Contracts/Events/WorldEvent.cs
+++ b/src/gateway/BotNexus.Gateway.Contracts/Events/WorldEvent.cs
@@ -1,0 +1,45 @@
+// WorldEvent.cs
+namespace BotNexus.Gateway.Contracts.Events;
+
+/// <summary>
+/// A lightweight event fired within the gateway that agents can subscribe to.
+/// Events carry a typed payload and routing metadata for subscription matching.
+/// </summary>
+/// <param name="EventType">The event type identifier (e.g. "agent.error", "cron.failed").</param>
+/// <param name="Payload">Arbitrary payload data as a dictionary of key-value pairs.</param>
+/// <param name="SourceAgentId">The agent that produced the event, if applicable.</param>
+/// <param name="Timestamp">When the event was fired.</param>
+public sealed record WorldEvent(
+    string EventType,
+    IReadOnlyDictionary<string, string> Payload,
+    string? SourceAgentId,
+    DateTimeOffset Timestamp)
+{
+    /// <summary>Creates a new event with the current UTC timestamp.</summary>
+    public static WorldEvent Create(string eventType, IReadOnlyDictionary<string, string>? payload = null, string? sourceAgentId = null) =>
+        new(eventType, payload ?? new Dictionary<string, string>(), sourceAgentId, DateTimeOffset.UtcNow);
+}
+
+/// <summary>
+/// Known event types in the world event bus.
+/// </summary>
+public static class WorldEventTypes
+{
+    /// <summary>A new agent was registered.</summary>
+    public const string AgentRegistered = "agent.registered";
+
+    /// <summary>An agent encountered repeated failures.</summary>
+    public const string AgentError = "agent.error";
+
+    /// <summary>A cron job failed.</summary>
+    public const string CronFailed = "cron.failed";
+
+    /// <summary>A platform health check failed.</summary>
+    public const string HealthDegraded = "health.degraded";
+
+    /// <summary>An agent explicitly escalated to another.</summary>
+    public const string ConversationEscalated = "conversation.escalated";
+
+    /// <summary>A new agent creation/modification proposal is awaiting review.</summary>
+    public const string ProposalPending = "proposal.pending";
+}

--- a/src/gateway/BotNexus.Gateway/Events/IEventDeliveryHandler.cs
+++ b/src/gateway/BotNexus.Gateway/Events/IEventDeliveryHandler.cs
@@ -1,0 +1,20 @@
+// IEventDeliveryHandler.cs
+using BotNexus.Gateway.Contracts.Events;
+
+namespace BotNexus.Gateway.Events;
+
+/// <summary>
+/// Handles delivery of world events to subscribing agents. The default implementation
+/// creates a new conversation session on the target agent with the event context as
+/// the opening message.
+/// </summary>
+public interface IEventDeliveryHandler
+{
+    /// <summary>
+    /// Delivers a world event to the specified agent.
+    /// </summary>
+    /// <param name="agentId">The target agent to notify.</param>
+    /// <param name="worldEvent">The event to deliver.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeliverAsync(string agentId, WorldEvent worldEvent, CancellationToken cancellationToken = default);
+}

--- a/src/gateway/BotNexus.Gateway/Events/InMemoryWorldEventBus.cs
+++ b/src/gateway/BotNexus.Gateway/Events/InMemoryWorldEventBus.cs
@@ -1,0 +1,92 @@
+// InMemoryWorldEventBus.cs
+using System.Collections.Concurrent;
+using BotNexus.Gateway.Contracts.Events;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Events;
+
+/// <summary>
+/// In-memory implementation of <see cref="IWorldEventBus"/>. Subscriptions are held
+/// in a concurrent dictionary keyed by agent ID. When an event is published, all
+/// matching subscribers are notified via the configured <see cref="IEventDeliveryHandler"/>.
+/// </summary>
+public sealed class InMemoryWorldEventBus : IWorldEventBus
+{
+    private readonly ConcurrentDictionary<string, IReadOnlyList<EventSubscription>> _subscriptions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IEventDeliveryHandler _deliveryHandler;
+    private readonly ILogger<InMemoryWorldEventBus> _logger;
+
+    /// <summary>Creates a new in-memory event bus.</summary>
+    public InMemoryWorldEventBus(IEventDeliveryHandler deliveryHandler, ILogger<InMemoryWorldEventBus> logger)
+    {
+        _deliveryHandler = deliveryHandler ?? throw new ArgumentNullException(nameof(deliveryHandler));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> PublishAsync(WorldEvent worldEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(worldEvent);
+
+        int notifiedCount = 0;
+
+        foreach (var (agentId, subscriptions) in _subscriptions)
+        {
+            foreach (var subscription in subscriptions)
+            {
+                if (subscription.Matches(worldEvent))
+                {
+                    try
+                    {
+                        await _deliveryHandler.DeliverAsync(agentId, worldEvent, cancellationToken).ConfigureAwait(false);
+                        notifiedCount++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to deliver event {EventType} to agent {AgentId}", worldEvent.EventType, agentId);
+                    }
+
+                    // Only deliver once per agent even if multiple subscriptions match.
+                    break;
+                }
+            }
+        }
+
+        _logger.LogInformation("Published event {EventType} to {NotifiedCount} subscriber(s)", worldEvent.EventType, notifiedCount);
+        return notifiedCount;
+    }
+
+    /// <inheritdoc/>
+    public void SetSubscriptions(string agentId, IReadOnlyList<EventSubscription> subscriptions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentNullException.ThrowIfNull(subscriptions);
+
+        if (subscriptions.Count == 0)
+            _subscriptions.TryRemove(agentId, out _);
+        else
+            _subscriptions[agentId] = subscriptions;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<EventSubscription> GetSubscriptions(string agentId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        return _subscriptions.TryGetValue(agentId, out var subs) ? subs : [];
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> GetSubscribers(string eventType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
+
+        var result = new List<string>();
+        foreach (var (agentId, subscriptions) in _subscriptions)
+        {
+            if (subscriptions.Any(s => string.Equals(s.EventType, eventType, StringComparison.OrdinalIgnoreCase)))
+                result.Add(agentId);
+        }
+
+        return result;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Events/LoggingEventDeliveryHandler.cs
+++ b/src/gateway/BotNexus.Gateway/Events/LoggingEventDeliveryHandler.cs
@@ -1,0 +1,34 @@
+// LoggingEventDeliveryHandler.cs
+using BotNexus.Gateway.Contracts.Events;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Gateway.Events;
+
+/// <summary>
+/// Default delivery handler that logs the event delivery. In production this would
+/// create a session on the target agent, but the session-dispatch wiring is deferred
+/// to a follow-up issue. This allows the bus infrastructure to be tested independently.
+/// </summary>
+public sealed class LoggingEventDeliveryHandler : IEventDeliveryHandler
+{
+    private readonly ILogger<LoggingEventDeliveryHandler> _logger;
+
+    /// <summary>Creates a new logging delivery handler.</summary>
+    public LoggingEventDeliveryHandler(ILogger<LoggingEventDeliveryHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public Task DeliverAsync(string agentId, WorldEvent worldEvent, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "Event delivery: {EventType} → agent {AgentId} (source: {SourceAgentId}, payload keys: {PayloadKeys})",
+            worldEvent.EventType,
+            agentId,
+            worldEvent.SourceAgentId ?? "system",
+            string.Join(", ", worldEvent.Payload.Keys));
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Events/WorldEventBusTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Events/WorldEventBusTests.cs
@@ -1,0 +1,274 @@
+using BotNexus.Gateway.Contracts.Events;
+using BotNexus.Gateway.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BotNexus.Gateway.Tests.Events;
+
+public class InMemoryWorldEventBusTests
+{
+    private readonly InMemoryWorldEventBus _bus;
+    private readonly FakeDeliveryHandler _handler;
+
+    public InMemoryWorldEventBusTests()
+    {
+        _handler = new FakeDeliveryHandler();
+        _bus = new InMemoryWorldEventBus(_handler, NullLogger<InMemoryWorldEventBus>.Instance);
+    }
+
+    [Fact]
+    public async Task PublishAsync_NoSubscribers_ReturnsZero()
+    {
+        var evt = WorldEvent.Create(WorldEventTypes.AgentRegistered);
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_handler.Deliveries);
+    }
+
+    [Fact]
+    public async Task PublishAsync_MatchingSubscriber_DeliversEvent()
+    {
+        _bus.SetSubscriptions("farnsworth", [new EventSubscription(WorldEventTypes.CronFailed)]);
+        var evt = WorldEvent.Create(WorldEventTypes.CronFailed, sourceAgentId: "cron-service");
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(1, count);
+        Assert.Single(_handler.Deliveries);
+        Assert.Equal("farnsworth", _handler.Deliveries[0].AgentId);
+        Assert.Equal(WorldEventTypes.CronFailed, _handler.Deliveries[0].Event.EventType);
+    }
+
+    [Fact]
+    public async Task PublishAsync_NonMatchingSubscriber_DoesNotDeliver()
+    {
+        _bus.SetSubscriptions("farnsworth", [new EventSubscription(WorldEventTypes.CronFailed)]);
+        var evt = WorldEvent.Create(WorldEventTypes.AgentRegistered);
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_handler.Deliveries);
+    }
+
+    [Fact]
+    public async Task PublishAsync_FilterMatch_DeliversEvent()
+    {
+        var filter = new Dictionary<string, string> { ["severity"] = "critical" };
+        _bus.SetSubscriptions("farnsworth", [new EventSubscription(WorldEventTypes.AgentError, filter)]);
+
+        var payload = new Dictionary<string, string> { ["severity"] = "critical", ["agentId"] = "broken-bot" };
+        var evt = WorldEvent.Create(WorldEventTypes.AgentError, payload);
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task PublishAsync_FilterMismatch_DoesNotDeliver()
+    {
+        var filter = new Dictionary<string, string> { ["severity"] = "critical" };
+        _bus.SetSubscriptions("farnsworth", [new EventSubscription(WorldEventTypes.AgentError, filter)]);
+
+        var payload = new Dictionary<string, string> { ["severity"] = "warning" };
+        var evt = WorldEvent.Create(WorldEventTypes.AgentError, payload);
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(0, count);
+        Assert.Empty(_handler.Deliveries);
+    }
+
+    [Fact]
+    public async Task PublishAsync_MultipleSubscribers_DeliversToAll()
+    {
+        _bus.SetSubscriptions("agent-a", [new EventSubscription(WorldEventTypes.HealthDegraded)]);
+        _bus.SetSubscriptions("agent-b", [new EventSubscription(WorldEventTypes.HealthDegraded)]);
+        var evt = WorldEvent.Create(WorldEventTypes.HealthDegraded);
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(2, count);
+        Assert.Equal(2, _handler.Deliveries.Count);
+    }
+
+    [Fact]
+    public async Task PublishAsync_AgentWithMultipleMatchingSubs_DeliveredOnlyOnce()
+    {
+        _bus.SetSubscriptions("farnsworth", [
+            new EventSubscription(WorldEventTypes.CronFailed),
+            new EventSubscription(WorldEventTypes.CronFailed, new Dictionary<string, string> { ["jobId"] = "maintenance" })
+        ]);
+        var payload = new Dictionary<string, string> { ["jobId"] = "maintenance" };
+        var evt = WorldEvent.Create(WorldEventTypes.CronFailed, payload);
+
+        var count = await _bus.PublishAsync(evt);
+
+        Assert.Equal(1, count); // Only once per agent
+    }
+
+    [Fact]
+    public void SetSubscriptions_EmptyList_RemovesAgent()
+    {
+        _bus.SetSubscriptions("farnsworth", [new EventSubscription(WorldEventTypes.CronFailed)]);
+        _bus.SetSubscriptions("farnsworth", []);
+
+        var subs = _bus.GetSubscriptions("farnsworth");
+        Assert.Empty(subs);
+    }
+
+    [Fact]
+    public void GetSubscriptions_UnknownAgent_ReturnsEmpty()
+    {
+        var subs = _bus.GetSubscriptions("nonexistent");
+        Assert.Empty(subs);
+    }
+
+    [Fact]
+    public void GetSubscribers_ReturnsMatchingAgents()
+    {
+        _bus.SetSubscriptions("agent-a", [new EventSubscription(WorldEventTypes.CronFailed)]);
+        _bus.SetSubscriptions("agent-b", [new EventSubscription(WorldEventTypes.AgentError)]);
+        _bus.SetSubscriptions("agent-c", [new EventSubscription(WorldEventTypes.CronFailed)]);
+
+        var subscribers = _bus.GetSubscribers(WorldEventTypes.CronFailed);
+
+        Assert.Equal(2, subscribers.Count);
+        Assert.Contains("agent-a", subscribers);
+        Assert.Contains("agent-c", subscribers);
+    }
+
+    [Fact]
+    public async Task PublishAsync_DeliveryFailure_ContinuesWithOtherSubscribers()
+    {
+        var failingHandler = new FailOnAgentDeliveryHandler("agent-a");
+        var bus = new InMemoryWorldEventBus(failingHandler, NullLogger<InMemoryWorldEventBus>.Instance);
+
+        bus.SetSubscriptions("agent-a", [new EventSubscription(WorldEventTypes.HealthDegraded)]);
+        bus.SetSubscriptions("agent-b", [new EventSubscription(WorldEventTypes.HealthDegraded)]);
+        var evt = WorldEvent.Create(WorldEventTypes.HealthDegraded);
+
+        var count = await bus.PublishAsync(evt);
+
+        // agent-a failed, agent-b succeeded
+        Assert.Equal(1, count);
+    }
+
+    private sealed class FakeDeliveryHandler : IEventDeliveryHandler
+    {
+        public List<(string AgentId, WorldEvent Event)> Deliveries { get; } = [];
+
+        public Task DeliverAsync(string agentId, WorldEvent worldEvent, CancellationToken cancellationToken = default)
+        {
+            Deliveries.Add((agentId, worldEvent));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailOnAgentDeliveryHandler(string failAgentId) : IEventDeliveryHandler
+    {
+        public Task DeliverAsync(string agentId, WorldEvent worldEvent, CancellationToken cancellationToken = default)
+        {
+            if (agentId == failAgentId)
+                throw new InvalidOperationException("Simulated delivery failure");
+            return Task.CompletedTask;
+        }
+    }
+}
+
+public class EventSubscriptionTests
+{
+    [Fact]
+    public void Matches_SameEventType_NoFilter_ReturnsTrue()
+    {
+        var sub = new EventSubscription(WorldEventTypes.CronFailed);
+        var evt = WorldEvent.Create(WorldEventTypes.CronFailed);
+
+        Assert.True(sub.Matches(evt));
+    }
+
+    [Fact]
+    public void Matches_DifferentEventType_ReturnsFalse()
+    {
+        var sub = new EventSubscription(WorldEventTypes.CronFailed);
+        var evt = WorldEvent.Create(WorldEventTypes.AgentRegistered);
+
+        Assert.False(sub.Matches(evt));
+    }
+
+    [Fact]
+    public void Matches_FilterAllPresent_ReturnsTrue()
+    {
+        var filter = new Dictionary<string, string> { ["severity"] = "critical", ["zone"] = "us-west" };
+        var sub = new EventSubscription(WorldEventTypes.AgentError, filter);
+        var payload = new Dictionary<string, string> { ["severity"] = "critical", ["zone"] = "us-west", ["extra"] = "ignored" };
+        var evt = WorldEvent.Create(WorldEventTypes.AgentError, payload);
+
+        Assert.True(sub.Matches(evt));
+    }
+
+    [Fact]
+    public void Matches_FilterKeyMissing_ReturnsFalse()
+    {
+        var filter = new Dictionary<string, string> { ["severity"] = "critical" };
+        var sub = new EventSubscription(WorldEventTypes.AgentError, filter);
+        var payload = new Dictionary<string, string> { ["zone"] = "us-west" };
+        var evt = WorldEvent.Create(WorldEventTypes.AgentError, payload);
+
+        Assert.False(sub.Matches(evt));
+    }
+
+    [Fact]
+    public void Matches_CaseInsensitiveEventType()
+    {
+        var sub = new EventSubscription("CRON.FAILED");
+        var evt = WorldEvent.Create("cron.failed");
+
+        Assert.True(sub.Matches(evt));
+    }
+
+    [Fact]
+    public void Matches_CaseInsensitiveFilterValue()
+    {
+        var filter = new Dictionary<string, string> { ["severity"] = "CRITICAL" };
+        var sub = new EventSubscription(WorldEventTypes.AgentError, filter);
+        var payload = new Dictionary<string, string> { ["severity"] = "critical" };
+        var evt = WorldEvent.Create(WorldEventTypes.AgentError, payload);
+
+        Assert.True(sub.Matches(evt));
+    }
+}
+
+public class WorldEventTests
+{
+    [Fact]
+    public void Create_SetsTimestamp()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var evt = WorldEvent.Create(WorldEventTypes.AgentRegistered);
+        var after = DateTimeOffset.UtcNow;
+
+        Assert.InRange(evt.Timestamp, before, after);
+    }
+
+    [Fact]
+    public void Create_NullPayload_DefaultsToEmptyDictionary()
+    {
+        var evt = WorldEvent.Create(WorldEventTypes.CronFailed);
+
+        Assert.NotNull(evt.Payload);
+        Assert.Empty(evt.Payload);
+    }
+
+    [Fact]
+    public void Create_WithPayload_PreservesValues()
+    {
+        var payload = new Dictionary<string, string> { ["key"] = "value" };
+        var evt = WorldEvent.Create(WorldEventTypes.CronFailed, payload, "farnsworth");
+
+        Assert.Equal("value", evt.Payload["key"]);
+        Assert.Equal("farnsworth", evt.SourceAgentId);
+    }
+}


### PR DESCRIPTION
Closes #1251

## Changes
- **WorldEvent**: Immutable event record with type, payload dictionary, source agent, and timestamp
- **WorldEventTypes**: Constants for initial event types (agent.registered, agent.error, cron.failed, health.degraded, conversation.escalated, proposal.pending)
- **EventSubscription**: Subscription record with event type matching and optional key-value payload filter
- **IWorldEventBus**: Interface for publish/subscribe operations
- **InMemoryWorldEventBus**: Thread-safe in-memory implementation with per-agent subscription management
- **IEventDeliveryHandler**: Pluggable delivery abstraction (session creation wiring deferred to follow-up)
- **LoggingEventDeliveryHandler**: Default handler that logs deliveries for testing
- 20 new tests covering: publish/subscribe, filtering, multi-subscriber delivery, delivery failure resilience, case-insensitivity

## Merge Notes
Self-contained in Gateway.Contracts (Events/) and Gateway (Events/). No overlap with any open PR. Safe to merge in any order.
Follow-up needed: DI registration in GatewayServiceCollectionExtensions, agent config subscription loading, session-creating delivery handler.