### PR TITLE
feat(extensions): enforce configurable row limit on DataStore query action

### DIFF
--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreConfig.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreConfig.cs
@@ -18,4 +18,12 @@ public sealed class DataStoreConfig
     /// </summary>
     [JsonPropertyName("maxSizeBytes")]
     public long MaxSizeBytes { get; init; } = 50 * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum number of rows returned by a single query action.
+    /// Queries that would return more rows are truncated with a warning.
+    /// Default: 1000.
+    /// </summary>
+    [JsonPropertyName("maxQueryRows")]
+    public int MaxQueryRows { get; init; } = 1000;
 }

--- a/src/extensions/BotNexus.Extensions.DataStore/DataStoreToolContributor.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/DataStoreToolContributor.cs
@@ -23,7 +23,7 @@ public sealed class DataStoreToolContributor : IAgentToolContributor
             return Task.FromResult(new AgentToolContribution(Array.Empty<IAgentTool>()));
 
         var storePath = Path.Combine(context.WorkspacePath, ".store", "agent-data.db");
-        var backend   = new SqliteDataStoreBackend(storePath, config.MaxSizeBytes);
+        var backend   = new SqliteDataStoreBackend(storePath, config.MaxSizeBytes, config.MaxQueryRows);
         IReadOnlyList<IAgentTool> tools = [new DataStoreTool(backend)];
 
         return Task.FromResult(new AgentToolContribution(tools, [backend]));

--- a/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
+++ b/src/extensions/BotNexus.Extensions.DataStore/SqliteDataStoreBackend.cs
@@ -12,13 +12,15 @@ internal sealed class SqliteDataStoreBackend : IDataStoreBackend
 {
     private readonly string _dbPath;
     private readonly long _maxSizeBytes;
+    private readonly int _maxQueryRows;
     private SqliteConnection? _connection;
     private readonly SemaphoreSlim _lock = new(1, 1);
 
-    public SqliteDataStoreBackend(string dbPath, long maxSizeBytes)
+    public SqliteDataStoreBackend(string dbPath, long maxSizeBytes, int maxQueryRows = 1000)
     {
         _dbPath = dbPath;
         _maxSizeBytes = maxSizeBytes;
+        _maxQueryRows = maxQueryRows > 0 ? maxQueryRows : 1000;
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -96,8 +98,15 @@ internal sealed class SqliteDataStoreBackend : IDataStoreBackend
                 using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
 
                 var results = new List<Dictionary<string, object?>>();
+                var truncated = false;
                 while (await reader.ReadAsync(ct).ConfigureAwait(false))
                 {
+                    if (results.Count >= _maxQueryRows)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
                     var row = new Dictionary<string, object?>();
                     for (int i = 0; i < reader.FieldCount; i++)
                         row[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i);
@@ -105,6 +114,8 @@ internal sealed class SqliteDataStoreBackend : IDataStoreBackend
                 }
 
                 var payload = JsonSerializer.Serialize(results);
+                if (truncated)
+                    payload += $"\n(results truncated to {_maxQueryRows} rows; use LIMIT/OFFSET for pagination)";
                 return DataStoreResult.Ok(payload, results.Count);
             }
             finally { _lock.Release(); }

--- a/tests/extensions/BotNexus.Extensions.DataStore.Tests/SqliteDataStoreBackendTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DataStore.Tests/SqliteDataStoreBackendTests.cs
@@ -392,4 +392,70 @@ public sealed class SqliteDataStoreBackendTests : IDisposable
         result.Success.ShouldBeFalse();
         (result.Error ?? string.Empty).ShouldContain("Count failed");
     }
+
+    // ── Query row limit ───────────────────────────────────────────────────────
+
+    private SqliteDataStoreBackend CreateBackendWithQueryLimit(int maxQueryRows)
+    {
+        _backend?.Dispose();
+        var dbPath = Path.Combine(_dbDir, ".store", "agent-data.db");
+        _backend = new SqliteDataStoreBackend(dbPath, 50 * 1024 * 1024, maxQueryRows);
+        return _backend;
+    }
+
+    [Fact]
+    public async Task Query_UnderLimit_ReturnsAllRows()
+    {
+        var backend = CreateBackendWithQueryLimit(10);
+        var rows = Enumerable.Range(1, 5).Select(i => new { id = i, name = $"user{i}" });
+        await backend.IngestAsync("items", System.Text.Json.JsonSerializer.Serialize(rows));
+
+        var result = await backend.QueryAsync("SELECT * FROM items");
+
+        result.Success.ShouldBeTrue();
+        result.RowCount.ShouldBe(5);
+        result.Payload!.ShouldNotContain("truncated");
+    }
+
+    [Fact]
+    public async Task Query_ExceedsLimit_TruncatesWithWarning()
+    {
+        var backend = CreateBackendWithQueryLimit(3);
+        var rows = Enumerable.Range(1, 10).Select(i => new { id = i, name = $"user{i}" });
+        await backend.IngestAsync("items", System.Text.Json.JsonSerializer.Serialize(rows));
+
+        var result = await backend.QueryAsync("SELECT * FROM items");
+
+        result.Success.ShouldBeTrue();
+        result.RowCount.ShouldBe(3);
+        result.Payload!.ShouldContain("truncated to 3 rows");
+    }
+
+    [Fact]
+    public async Task Query_ExactlyAtLimit_DoesNotTruncate()
+    {
+        var backend = CreateBackendWithQueryLimit(5);
+        var rows = Enumerable.Range(1, 5).Select(i => new { id = i, name = $"user{i}" });
+        await backend.IngestAsync("items", System.Text.Json.JsonSerializer.Serialize(rows));
+
+        var result = await backend.QueryAsync("SELECT * FROM items");
+
+        result.Success.ShouldBeTrue();
+        result.RowCount.ShouldBe(5);
+        result.Payload!.ShouldNotContain("truncated");
+    }
+
+    [Fact]
+    public async Task Query_WithExplicitLimit_RespectsUserLimit()
+    {
+        var backend = CreateBackendWithQueryLimit(3);
+        var rows = Enumerable.Range(1, 10).Select(i => new { id = i, name = $"user{i}" });
+        await backend.IngestAsync("items", System.Text.Json.JsonSerializer.Serialize(rows));
+
+        var result = await backend.QueryAsync("SELECT * FROM items LIMIT 2");
+
+        result.Success.ShouldBeTrue();
+        result.RowCount.ShouldBe(2);
+        result.Payload!.ShouldNotContain("truncated");
+    }
 }


### PR DESCRIPTION
Closes #1288

## Changes
- Add \MaxQueryRows\ to \DataStoreConfig\ (default: 1000)
- \SqliteDataStoreBackend.QueryAsync()\ stops reading after \maxQueryRows\ rows
- Truncation warning appended when results are capped
- Queries with explicit LIMIT that return fewer rows than the cap are unaffected
- 4 new tests covering: under limit, over limit with truncation, exactly at limit, explicit LIMIT respected

## Merge Notes
Self-contained in DataStore extension. No overlap with any open PR. Merge in any order.