### PR TITLE
fix(tools): respect exchange access policy in ListAgentsTool CanConverse field

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -316,7 +316,10 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
             var includeListAgents = effectiveToolIds.Count == 0
                 || effectiveToolIds.Contains("list_agents", StringComparer.OrdinalIgnoreCase);
             if (includeListAgents)
-                tools.Add(new ListAgentsTool(agentRegistry, descriptor.AgentId));
+            {
+                var exchangeOptions = _serviceProvider.GetService<IOptions<AgentExchangeOptions>>()?.Value;
+                tools.Add(new ListAgentsTool(agentRegistry, descriptor.AgentId, exchangeOptions));
+            }
         }
 
         var configurationWriter = _serviceProvider.GetService<IAgentConfigurationWriter>();

--- a/src/gateway/BotNexus.Gateway/Tools/ListAgentsTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ListAgentsTool.cs
@@ -5,16 +5,20 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
 using BotNexus.Agent.Providers.Core.Models;
 
 namespace BotNexus.Gateway.Tools;
 
 /// <summary>
 /// Tool that lets agents discover other registered agents and their capabilities.
+/// Respects <see cref="AgentExchangeOptions.AccessPolicy"/> when computing the
+/// <c>canConverse</c> field — when the policy is "open", all agents can converse.
 /// </summary>
 public sealed class ListAgentsTool(
     IAgentRegistry agentRegistry,
-    AgentId callerAgentId) : IAgentTool
+    AgentId callerAgentId,
+    AgentExchangeOptions? exchangeOptions = null) : IAgentTool
 {
     public string Name => "list_agents";
     public string Label => "List Agents";
@@ -61,6 +65,7 @@ public sealed class ListAgentsTool(
         var callerDescriptor = agentRegistry.Get(callerAgentId);
         var subAgentIds = callerDescriptor?.SubAgentIds ?? [];
         var subAgentRoles = callerDescriptor?.SubAgentRoles ?? [];
+        var isOpenPolicy = exchangeOptions?.IsOpen ?? true;
 
         var agents = agentRegistry.GetAll()
             .Where(d => MatchesFilter(d, filter))
@@ -71,7 +76,8 @@ public sealed class ListAgentsTool(
                 Description: d.Description,
                 Emoji: d.Emoji,
                 Capabilities: ResolveCapabilities(d),
-                CanConverse: subAgentIds.Contains(d.AgentId.Value, StringComparer.OrdinalIgnoreCase)
+                CanConverse: isOpenPolicy
+                    || subAgentIds.Contains(d.AgentId.Value, StringComparer.OrdinalIgnoreCase)
                     || IsRoleGranted(subAgentRoles, d)))
             .OrderBy(e => e.AgentId, StringComparer.OrdinalIgnoreCase)
             .ToList();

--- a/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentRolesTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Agents/SubAgentRolesTests.cs
@@ -257,7 +257,8 @@ public sealed class SubAgentRolesTests
         registry.Setup(r => r.GetAll()).Returns([callerDescriptor, specialistAgent, notGranted]);
         registry.Setup(r => r.Get(callerDescriptor.AgentId)).Returns(callerDescriptor);
 
-        var tool = new ListAgentsTool(registry.Object, callerDescriptor.AgentId);
+        var whitelistPolicy = new AgentExchangeOptions { AccessPolicy = "whitelist" };
+        var tool = new ListAgentsTool(registry.Object, callerDescriptor.AgentId, whitelistPolicy);
         var result = await tool.ExecuteAsync("tc", new Dictionary<string, object?>());
 
         var entries = JsonSerializer.Deserialize<JsonElement>(result.Content[0].Value);

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/ListAgentsToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/ListAgentsToolTests.cs
@@ -3,6 +3,7 @@ using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Tools;
 using Moq;
 
@@ -117,6 +118,62 @@ public sealed class ListAgentsToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_OpenPolicy_AllAgentsCanConverse()
+    {
+        var registry = MakeRegistry(MakeAgent("specialist"), MakeAgent("other"));
+        registry.Setup(r => r.Get(AgentId.From("caller"))).Returns((AgentDescriptor?)null);
+
+        var options = new AgentExchangeOptions { AccessPolicy = "open" };
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"), options);
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list.ShouldAllBe(e => e.GetProperty("canConverse").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhitelistPolicy_OnlyWhitelistedCanConverse()
+    {
+        var callerDescriptor = new AgentDescriptor
+        {
+            AgentId = AgentId.From("caller"),
+            DisplayName = "Caller",
+            ModelId = "m",
+            ApiProvider = "p",
+            SubAgentIds = ["specialist"]
+        };
+        var specialist = MakeAgent("specialist");
+        var other = MakeAgent("other");
+
+        var registry = MakeRegistry(specialist, other);
+        registry.Setup(r => r.Get(AgentId.From("caller"))).Returns(callerDescriptor);
+
+        var options = new AgentExchangeOptions { AccessPolicy = "whitelist" };
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"), options);
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        var specialistEntry = list.First(e => e.GetProperty("agentId").GetString() == "specialist");
+        var otherEntry = list.First(e => e.GetProperty("agentId").GetString() == "other");
+
+        specialistEntry.GetProperty("canConverse").GetBoolean().ShouldBeTrue();
+        otherEntry.GetProperty("canConverse").GetBoolean().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullOptions_DefaultsToOpen()
+    {
+        var registry = MakeRegistry(MakeAgent("target"));
+        registry.Setup(r => r.Get(AgentId.From("caller"))).Returns((AgentDescriptor?)null);
+
+        var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"), exchangeOptions: null);
+        var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
+
+        var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
+        list[0].GetProperty("canConverse").GetBoolean().ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_CallerHasSubAgentId_CanConverseIsTrue()
     {
         var callerDescriptor = new AgentDescriptor
@@ -133,15 +190,12 @@ public sealed class ListAgentsToolTests
         var registry = MakeRegistry(specialist, other);
         registry.Setup(r => r.Get(AgentId.From("caller"))).Returns(callerDescriptor);
 
+        // Default null options → open policy → all canConverse
         var tool = new ListAgentsTool(registry.Object, AgentId.From("caller"));
         var result = await tool.ExecuteAsync("t1", new Dictionary<string, object?>());
 
         var list = JsonSerializer.Deserialize<List<JsonElement>>(result.Content[0].Value)!;
-        var specialistEntry = list.First(e => e.GetProperty("agentId").GetString() == "specialist");
-        var otherEntry = list.First(e => e.GetProperty("agentId").GetString() == "other");
-
-        specialistEntry.GetProperty("canConverse").GetBoolean().ShouldBeTrue();
-        otherEntry.GetProperty("canConverse").GetBoolean().ShouldBeFalse();
+        list.ShouldAllBe(e => e.GetProperty("canConverse").GetBoolean());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1292

## Changes
- ListAgentsTool now accepts optional AgentExchangeOptions parameter
- When access policy is "open" (default), all agents show canConverse: true
- When access policy is "whitelist", existing SubAgentIds/SubAgentRoles logic applies
- InProcessIsolationStrategy passes resolved options from DI
- 3 new tests for open policy, whitelist policy, and null options (defaults to open)
- Existing SubAgentRolesTests updated to explicitly use whitelist policy

## Merge Notes
Safe to merge in any order with existing PRs — only touches ListAgentsTool.cs, InProcessIsolationStrategy.cs (one line), and test files.
