### PR TITLE
feat(tools): return response metadata in WebFetchTool output

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/WebFetchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebFetchTool.cs
@@ -16,6 +16,11 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
     private readonly HttpClient _httpClient;
     private readonly bool _ownsHttpClient;
 
+    private static readonly JsonSerializerOptions MetadataJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
     public WebFetchTool(WebFetchConfig config, HttpClient? httpClient = null)
     {
         _config = config;
@@ -150,21 +155,47 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
         try
         {
             var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
+            var statusCode = (int)response.StatusCode;
+            var contentType = response.Content.Headers.ContentType?.ToString();
 
             if (!response.IsSuccessStatusCode)
             {
+                var errorMetadata = new Dictionary<string, object?>
+                {
+                    ["url"] = finalUrl,
+                    ["status"] = statusCode,
+                    ["content_type"] = contentType
+                };
+                var errorJson = JsonSerializer.Serialize(errorMetadata, MetadataJsonOptions);
                 return TextResult(
-                    $"HTTP {(int)response.StatusCode} {response.ReasonPhrase} when fetching {url}");
+                    $"{errorJson}\n\nHTTP {statusCode} {response.ReasonPhrase} when fetching {url}");
             }
 
             var html = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             var content = raw ? html : HtmlToText.Convert(html);
 
+            var totalLength = content.Length;
+            var endIndex = Math.Min(startIndex + maxLength, totalLength);
+            var hasMore = endIndex < totalLength;
+
+            var metadata = new Dictionary<string, object?>
+            {
+                ["url"] = finalUrl,
+                ["status"] = statusCode,
+                ["content_type"] = contentType,
+                ["total_length"] = totalLength,
+                ["start_index"] = startIndex,
+                ["end_index"] = endIndex,
+                ["has_more"] = hasMore
+            };
+            var metadataJson = JsonSerializer.Serialize(metadata, MetadataJsonOptions);
+
             // Apply pagination
             if (startIndex >= content.Length)
             {
-                return TextResult("[No content at this offset]");
+                return TextResult($"{metadataJson}\n\n[No content at this offset]");
             }
 
             var remaining = content.Length - startIndex;
@@ -177,7 +208,7 @@ public sealed class WebFetchTool : IAgentTool, IDisposable
                 output += $"\n\n[Content truncated. Use start_index={nextIndex} to continue reading.]";
             }
 
-            return TextResult(output);
+            return TextResult($"{metadataJson}\n\n{output}");
         }
         catch (HttpRequestException ex)
         {

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebFetchToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebFetchToolTests.cs
@@ -32,7 +32,7 @@ public class WebFetchToolTests
 
         var result = await tool.ExecuteAsync("call-1", args);
 
-        result.Content[0].Value.ShouldStartWith("abcdefghij");
+        result.Content[0].Value.ShouldContain("abcdefghij");
         result.Content[0].Value.ShouldContain("Content truncated");
     }
 
@@ -51,7 +51,7 @@ public class WebFetchToolTests
 
         var result = await tool.ExecuteAsync("call-1", args);
 
-        result.Content[0].Value.ShouldBe(html);
+        result.Content[0].Value.ShouldContain(html);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class WebFetchToolTests
 
         var result = await tool.ExecuteAsync("call-1", args);
 
-        result.Content[0].Value.ShouldBe("Hello [Link](https://example.com)");
+        result.Content[0].Value.ShouldContain("Hello [Link](https://example.com)");
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class WebFetchToolTests
 
         var result = await tool.ExecuteAsync("call-1", args);
 
-        result.Content[0].Value.ShouldStartWith("56789A");
+        result.Content[0].Value.ShouldContain("56789A");
     }
 
     [Theory]
@@ -310,7 +310,7 @@ public class WebFetchToolTests
 
         var result = await tool.ExecuteAsync("call-1", args);
 
-        result.Content[0].Value.Length.ShouldBeLessThan(650);
+        result.Content[0].Value.Length.ShouldBeLessThan(750);
         result.Content[0].Value.ShouldContain("Content truncated");
     }
 
@@ -328,7 +328,57 @@ public class WebFetchToolTests
 
         var result = await tool.ExecuteAsync("call-1", args);
 
-        result.Content[0].Value.ShouldBe("[No content at this offset]");
+        result.Content[0].Value.ShouldContain("[No content at this offset]");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsMetadataWithFinalUrlAndContentType()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.EnqueueResponse(System.Net.HttpStatusCode.OK, "<html><body>test</body></html>", "text/html");
+        using var tool = CreateTool(handler);
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["url"] = "https://example.com/page" });
+
+        var result = await tool.ExecuteAsync("call-1", args);
+
+        var output = result.Content[0].Value;
+        output.ShouldContain("\"url\":");
+        output.ShouldContain("\"status\":200");
+        output.ShouldContain("\"content_type\":\"text/html");
+        output.ShouldContain("\"total_length\":");
+        output.ShouldContain("\"has_more\":false");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTruncation_HasMoreIsTrue()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.EnqueueResponse(System.Net.HttpStatusCode.OK, "<html><body>abcdefghijklmnopqrstuvwxyz</body></html>", "text/html");
+        using var tool = CreateTool(handler);
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+        {
+            ["url"] = "https://example.com",
+            ["max_length"] = 5
+        });
+
+        var result = await tool.ExecuteAsync("call-1", args);
+
+        result.Content[0].Value.ShouldContain("\"has_more\":true");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ErrorResponse_IncludesMetadata()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.EnqueueResponse(System.Net.HttpStatusCode.NotFound, "not found", "text/plain");
+        using var tool = CreateTool(handler);
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["url"] = "https://example.com/missing" });
+
+        var result = await tool.ExecuteAsync("call-1", args);
+
+        var output = result.Content[0].Value;
+        output.ShouldContain("\"status\":404");
+        output.ShouldContain("HTTP 404");
     }
 
     private static WebFetchTool CreateTool(MockHttpMessageHandler handler)


### PR DESCRIPTION
Closes #1293

## Changes
- WebFetchTool now prepends a JSON metadata block before content in all responses
- Metadata includes: final URL (after redirects), HTTP status, content-type, total content length, start/end index, has_more flag
- Error responses (4xx/5xx) also include metadata for visibility
- 3 new tests for metadata output, truncation flag, and error metadata
- Existing tests updated to use `ShouldContain` instead of exact match

## Merge Notes
Safe to merge in any order — only touches WebFetchTool.cs and its test file. No overlap with any open PR.
