### PR TITLE
fix(tools): validate apiProvider against registered providers in agent creation and update

### DIFF
--- a/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
+++ b/src/gateway/BotNexus.Gateway/Isolation/InProcessIsolationStrategy.cs
@@ -29,6 +29,7 @@ using BotNexus.Gateway.Sessions;
 using BotNexus.Gateway.Tools;
 using BotNexus.Agent.Providers.Core;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
 using BotNexus.Gateway.Contracts.Memory;
 using BotNexus.Memory;
 using BotNexus.Memory.Tools;
@@ -324,18 +325,19 @@ public sealed class InProcessIsolationStrategy : IIsolationStrategy
         var changeNotifiers = _serviceProvider.GetServices<IAgentChangeNotifier>();
         if (agentRegistry is not null && configurationWriter is not null && botNexusHome is not null)
         {
+            var apiProviderRegistry = _serviceProvider.GetService<ApiProviderRegistry>();
             var includeCreateAgent = effectiveToolIds.Count == 0
                 || effectiveToolIds.Contains("create_agent", StringComparer.OrdinalIgnoreCase);
             if (includeCreateAgent)
             {
                 var platformConfigOptions = _serviceProvider.GetService<IOptions<PlatformConfig>>();
-                tools.Add(new CreateAgentTool(agentRegistry, configurationWriter, changeNotifiers, botNexusHome, platformConfigOptions));
+                tools.Add(new CreateAgentTool(agentRegistry, configurationWriter, changeNotifiers, botNexusHome, platformConfigOptions, apiProviderRegistry));
             }
 
             var includeUpdateAgent = effectiveToolIds.Count == 0
                 || effectiveToolIds.Contains("update_agent", StringComparer.OrdinalIgnoreCase);
             if (includeUpdateAgent)
-                tools.Add(new UpdateAgentTool(agentRegistry, configurationWriter, changeNotifiers));
+                tools.Add(new UpdateAgentTool(agentRegistry, configurationWriter, changeNotifiers, apiProviderRegistry));
         }
 
         var includeCanvas = effectiveToolIds.Count == 0

--- a/src/gateway/BotNexus.Gateway/Tools/CreateAgentTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/CreateAgentTool.cs
@@ -8,6 +8,7 @@ using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
 using Microsoft.Extensions.Options;
 
 namespace BotNexus.Gateway.Tools;
@@ -20,7 +21,8 @@ public sealed class CreateAgentTool(
     IAgentConfigurationWriter configurationWriter,
     IEnumerable<IAgentChangeNotifier> changeNotifiers,
     BotNexusHome botNexusHome,
-    IOptions<PlatformConfig>? platformConfigOptions = null) : IAgentTool
+    IOptions<PlatformConfig>? platformConfigOptions = null,
+    ApiProviderRegistry? apiProviderRegistry = null) : IAgentTool
 {
     private static readonly Regex IdPattern = new(@"^[a-z0-9][a-z0-9-]*[a-z0-9]$", RegexOptions.Compiled);
 
@@ -108,6 +110,9 @@ public sealed class CreateAgentTool(
 
         if (string.IsNullOrWhiteSpace(apiProvider))
             return Error("Parameter 'apiProvider' is required.");
+
+        if (apiProviderRegistry is not null && apiProviderRegistry.Get(apiProvider) is null)
+            return Error($"Unknown API provider '{apiProvider}'. Available providers: {string.Join(", ", apiProviderRegistry.GetAll().Select(p => p.Api))}.");
 
         var agentId = AgentId.From(id);
         if (agentRegistry.Contains(agentId))

--- a/src/gateway/BotNexus.Gateway/Tools/UpdateAgentTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/UpdateAgentTool.cs
@@ -6,6 +6,7 @@ using BotNexus.Domain.Primitives;
 using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
 
 namespace BotNexus.Gateway.Tools;
 
@@ -15,7 +16,8 @@ namespace BotNexus.Gateway.Tools;
 public sealed class UpdateAgentTool(
     IAgentRegistry agentRegistry,
     IAgentConfigurationWriter configurationWriter,
-    IEnumerable<IAgentChangeNotifier> changeNotifiers) : IAgentTool
+    IEnumerable<IAgentChangeNotifier> changeNotifiers,
+    ApiProviderRegistry? apiProviderRegistry = null) : IAgentTool
 {
     public string Name => "update_agent";
     public string Label => "Update Agent";
@@ -100,7 +102,11 @@ public sealed class UpdateAgentTool(
         if (arguments.ContainsKey("modelId") && ReadString(arguments, "modelId") is { } mid)
             updated = updated with { ModelId = mid };
         if (arguments.ContainsKey("apiProvider") && ReadString(arguments, "apiProvider") is { } ap)
+        {
+            if (apiProviderRegistry is not null && apiProviderRegistry.Get(ap) is null)
+                return Error($"Unknown API provider '{ap}'. Available providers: {string.Join(", ", apiProviderRegistry.GetAll().Select(p => p.Api))}.");
             updated = updated with { ApiProvider = ap };
+        }
         if (arguments.ContainsKey("systemPrompt"))
             updated = updated with { SystemPrompt = ReadString(arguments, "systemPrompt") };
         if (arguments.ContainsKey("toolIds"))

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/AgentManagementToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/AgentManagementToolTests.cs
@@ -5,6 +5,10 @@ using BotNexus.Gateway.Abstractions.Agents;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Configuration;
 using BotNexus.Gateway.Tools;
+using BotNexus.Agent.Providers.Core.Models;
+using BotNexus.Agent.Providers.Core.Registry;
+using BotNexus.Agent.Providers.Core;
+using BotNexus.Agent.Providers.Core.Streaming;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -395,5 +399,102 @@ public sealed class AgentManagementToolTests
         savedDescriptor!.Memory.ShouldNotBeNull();
         savedDescriptor.Memory!.Enabled.ShouldBeTrue();
         savedDescriptor.Memory.Indexing.ShouldBe("auto");
+    }
+
+    // --- Provider Validation Tests ---
+
+    [Fact]
+    public async Task CreateAgent_UnknownProvider_ReturnsError()
+    {
+        var (registry, writer, home, notifier) = MakeDeps();
+        var providerRegistry = new ApiProviderRegistry();
+        providerRegistry.Register(new FakeProvider("anthropic"));
+        providerRegistry.Register(new FakeProvider("copilot"));
+        var tool = new CreateAgentTool(registry.Object, writer.Object, [notifier.Object], home, null, providerRegistry);
+
+        var result = await tool.ExecuteAsync("t1", Args(
+            ("id", "bad-provider"),
+            ("displayName", "Bad"),
+            ("modelId", "model"),
+            ("apiProvider", "nonexistent")));
+
+        result.Content[0].Value.ShouldContain("error");
+        result.Content[0].Value.ShouldContain("Unknown API provider");
+        result.Content[0].Value.ShouldContain("nonexistent");
+        registry.Verify(r => r.Register(It.IsAny<AgentDescriptor>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAgent_ValidProvider_Succeeds()
+    {
+        var (registry, writer, home, notifier) = MakeDeps();
+        var providerRegistry = new ApiProviderRegistry();
+        providerRegistry.Register(new FakeProvider("anthropic"));
+        var tool = new CreateAgentTool(registry.Object, writer.Object, [notifier.Object], home, null, providerRegistry);
+
+        var result = await tool.ExecuteAsync("t1", Args(
+            ("id", "valid-provider"),
+            ("displayName", "Good"),
+            ("modelId", "model"),
+            ("apiProvider", "anthropic")));
+
+        result.Content[0].Value.ShouldNotContain("error");
+        result.Content[0].Value.ShouldContain("created");
+    }
+
+    [Fact]
+    public async Task CreateAgent_NoProviderRegistry_SkipsValidation()
+    {
+        var (registry, writer, home, notifier) = MakeDeps();
+        var tool = new CreateAgentTool(registry.Object, writer.Object, [notifier.Object], home, null, null);
+
+        var result = await tool.ExecuteAsync("t1", Args(
+            ("id", "no-registry"),
+            ("displayName", "No Registry"),
+            ("modelId", "model"),
+            ("apiProvider", "anything-goes")));
+
+        result.Content[0].Value.ShouldNotContain("error");
+    }
+
+    [Fact]
+    public async Task UpdateAgent_UnknownProvider_ReturnsError()
+    {
+        var (registry, writer, _, notifier) = MakeDeps(agentExists: true, existingId: "update-test");
+        registry.Setup(r => r.Update(It.IsAny<AgentId>(), It.IsAny<AgentDescriptor>())).Returns(true);
+        var providerRegistry = new ApiProviderRegistry();
+        providerRegistry.Register(new FakeProvider("anthropic"));
+        var tool = new UpdateAgentTool(registry.Object, writer.Object, [notifier.Object], providerRegistry);
+
+        var result = await tool.ExecuteAsync("t1", Args(
+            ("id", "update-test"),
+            ("apiProvider", "bad-provider")));
+
+        result.Content[0].Value.ShouldContain("error");
+        result.Content[0].Value.ShouldContain("Unknown API provider");
+        registry.Verify(r => r.Update(It.IsAny<AgentId>(), It.IsAny<AgentDescriptor>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAgent_ValidProvider_Succeeds()
+    {
+        var (registry, writer, _, notifier) = MakeDeps(agentExists: true, existingId: "update-valid");
+        registry.Setup(r => r.Update(It.IsAny<AgentId>(), It.IsAny<AgentDescriptor>())).Returns(true);
+        var providerRegistry = new ApiProviderRegistry();
+        providerRegistry.Register(new FakeProvider("copilot"));
+        var tool = new UpdateAgentTool(registry.Object, writer.Object, [notifier.Object], providerRegistry);
+
+        var result = await tool.ExecuteAsync("t1", Args(
+            ("id", "update-valid"),
+            ("apiProvider", "copilot")));
+
+        result.Content[0].Value.ShouldNotContain("error");
+    }
+
+    private sealed class FakeProvider(string api) : IApiProvider
+    {
+        public string Api => api;
+        public LlmStream Stream(LlmModel model, Context context, StreamOptions? options = null) => throw new NotImplementedException();
+        public LlmStream StreamSimple(LlmModel model, Context context, SimpleStreamOptions? options = null) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Closes #1296

## Changes
- Added ApiProviderRegistry as an optional parameter to both CreateAgentTool and UpdateAgentTool
- When registry is available, validates that the provided piProvider key exists before creating/updating
- Returns clear error message listing available providers on validation failure
- Gracefully skips validation when registry is not injected (backward compatible)
- Updated InProcessIsolationStrategy to resolve and pass ApiProviderRegistry to both tools
- Added 5 new tests covering: unknown provider rejection, valid provider success, null registry skip, update tool validation

## Merge Notes
Independent of all open PRs. Only touches CreateAgentTool.cs, UpdateAgentTool.cs, InProcessIsolationStrategy.cs, and AgentManagementToolTests.cs — none of which are modified by other PRs.