### PR TITLE
feat(gateway): expose agent exchange budget diagnostics via REST endpoint

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ExchangesController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ExchangesController.cs
@@ -1,0 +1,74 @@
+using BotNexus.Gateway.Agents;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BotNexus.Gateway.Api.Controllers;
+
+/// <summary>
+/// REST endpoint for agent exchange budget diagnostics.
+/// Surfaces inter-agent communication budget state for operators.
+/// </summary>
+[ApiController]
+[Route("api/exchanges")]
+public sealed class ExchangesController(
+    AgentExchangeBudgetTracker? budgetTracker = null) : ControllerBase
+{
+    /// <summary>
+    /// Returns budget state for all tracked agent pairs, optionally filtered by initiator or target.
+    /// </summary>
+    [HttpGet("budget")]
+    public IActionResult GetBudget([FromQuery] string? initiator = null, [FromQuery] string? target = null)
+    {
+        if (budgetTracker is null)
+            return Ok(new ExchangeBudgetResponse([], 0, DateTimeOffset.UtcNow));
+
+        var allPairs = budgetTracker.GetAllPairInfo();
+        var now = DateTimeOffset.UtcNow;
+
+        var entries = new List<ExchangeBudgetEntry>();
+        foreach (var (key, info) in allPairs)
+        {
+            var parts = key.Split(':');
+            if (parts.Length != 2) continue;
+
+            var pairInitiator = parts[0];
+            var pairTarget = parts[1];
+
+            if (initiator is not null && !string.Equals(pairInitiator, initiator, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (target is not null && !string.Equals(pairTarget, target, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var cooldownActive = info.CooldownUntil.HasValue && info.CooldownUntil.Value > now;
+            var cooldownRemainingSeconds = cooldownActive
+                ? (int)Math.Ceiling((info.CooldownUntil!.Value - now).TotalSeconds)
+                : 0;
+
+            entries.Add(new ExchangeBudgetEntry(
+                Initiator: pairInitiator,
+                Target: pairTarget,
+                DailyTurnsUsed: info.DailyTurnsUsed,
+                DailyTurnCap: info.DailyTurnCap,
+                CooldownActive: cooldownActive,
+                CooldownRemainingSeconds: cooldownRemainingSeconds,
+                LoopCounter: info.LoopCounter,
+                LastInteraction: info.LastExchangeEnd));
+        }
+
+        return Ok(new ExchangeBudgetResponse(entries, entries.Count, now));
+    }
+}
+
+internal sealed record ExchangeBudgetResponse(
+    IReadOnlyList<ExchangeBudgetEntry> Pairs,
+    int TotalPairs,
+    DateTimeOffset Timestamp);
+
+internal sealed record ExchangeBudgetEntry(
+    string Initiator,
+    string Target,
+    int DailyTurnsUsed,
+    int DailyTurnCap,
+    bool CooldownActive,
+    int CooldownRemainingSeconds,
+    int LoopCounter,
+    DateTimeOffset? LastInteraction);

--- a/tests/gateway/BotNexus.Gateway.Tests/Controllers/ExchangesControllerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Controllers/ExchangesControllerTests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Agents;
+using BotNexus.Gateway.Api.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BotNexus.Gateway.Tests.Controllers;
+
+public sealed class ExchangesControllerTests
+{
+    private static AgentExchangeBudgetTracker CreateTracker()
+    {
+        var options = Options.Create(new AgentExchangeBudgetOptions());
+        var logger = NullLogger<AgentExchangeBudgetTracker>.Instance;
+        return new AgentExchangeBudgetTracker(options, logger);
+    }
+
+    [Fact]
+    public void GetBudget_NullTracker_ReturnsEmptyResponse()
+    {
+        var controller = new ExchangesController(null);
+        var result = controller.GetBudget() as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var json = JsonSerializer.Serialize(result.Value);
+        json.ShouldContain("\"totalPairs\":0");
+        json.ShouldContain("\"pairs\":[]");
+    }
+
+    [Fact]
+    public void GetBudget_WithExchanges_ReturnsPairInfo()
+    {
+        var tracker = CreateTracker();
+        tracker.RecordExchangeComplete(AgentId.From("alpha"), AgentId.From("beta"), 5);
+
+        var controller = new ExchangesController(tracker);
+        var result = controller.GetBudget() as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var json = JsonSerializer.Serialize(result.Value, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        json.ShouldContain("\"initiator\":\"alpha\"");
+        json.ShouldContain("\"target\":\"beta\"");
+        json.ShouldContain("\"dailyTurnsUsed\":5");
+        json.ShouldContain("\"totalPairs\":1");
+    }
+
+    [Fact]
+    public void GetBudget_FilterByInitiator_FiltersCorrectly()
+    {
+        var tracker = CreateTracker();
+        tracker.RecordExchangeComplete(AgentId.From("alpha"), AgentId.From("beta"), 3);
+        tracker.RecordExchangeComplete(AgentId.From("gamma"), AgentId.From("beta"), 2);
+
+        var controller = new ExchangesController(tracker);
+        var result = controller.GetBudget(initiator: "alpha") as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var json = JsonSerializer.Serialize(result.Value, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        json.ShouldContain("\"totalPairs\":1");
+        json.ShouldContain("\"initiator\":\"alpha\"");
+        json.ShouldNotContain("\"initiator\":\"gamma\"");
+    }
+
+    [Fact]
+    public void GetBudget_FilterByTarget_FiltersCorrectly()
+    {
+        var tracker = CreateTracker();
+        tracker.RecordExchangeComplete(AgentId.From("alpha"), AgentId.From("beta"), 3);
+        tracker.RecordExchangeComplete(AgentId.From("alpha"), AgentId.From("delta"), 2);
+
+        var controller = new ExchangesController(tracker);
+        var result = controller.GetBudget(target: "delta") as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var json = JsonSerializer.Serialize(result.Value, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        json.ShouldContain("\"totalPairs\":1");
+        json.ShouldContain("\"target\":\"delta\"");
+        json.ShouldNotContain("\"target\":\"beta\"");
+    }
+
+    [Fact]
+    public void GetBudget_CooldownActive_ReportsCorrectly()
+    {
+        var tracker = CreateTracker();
+
+        // Trigger cooldown by hitting loop threshold
+        var options = new AgentExchangeBudgetOptions();
+        for (int i = 0; i < options.LoopThreshold; i++)
+        {
+            try
+            {
+                tracker.EnsureWithinBudget(AgentId.From("looper"), AgentId.From("target"));
+                tracker.RecordExchangeComplete(AgentId.From("looper"), AgentId.From("target"), 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected on final iteration when loop is detected
+            }
+        }
+
+        var controller = new ExchangesController(tracker);
+        var result = controller.GetBudget() as OkObjectResult;
+
+        result.ShouldNotBeNull();
+        var json = JsonSerializer.Serialize(result.Value, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        json.ShouldContain("cooldownRemainingSeconds");
+    }
+}


### PR DESCRIPTION
Closes #1297

## Changes
- New \ExchangesController\ with \GET /api/exchanges/budget\ endpoint
- Returns all tracked agent pairs with budget state: daily turns used/cap, cooldown state, loop counter, last interaction
- Optional \?initiator=\ and \?target=\ query params for filtering
- Graceful handling when \AgentExchangeBudgetTracker\ is not registered (returns empty)
- 5 new tests covering: null tracker, pair info, initiator filter, target filter, cooldown detection

## Merge Notes
Independent of all open PRs. Only adds new files (ExchangesController.cs + test). No overlap with any existing PR.