### PR TITLE
feat(tools): add per-call count parameter to WebSearchTool

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
@@ -71,6 +71,10 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
                 "query": {
                   "type": "string",
                   "description": "Search query."
+                },
+                "count": {
+                  "type": "integer",
+                  "description": "Maximum number of results to return. Clamped to [1, configured max]. Default: configured max."
                 }
               },
               "required": ["query"]
@@ -88,9 +92,12 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
         if (string.IsNullOrWhiteSpace(query))
             throw new ArgumentException("query is required.");
 
+        var count = ReadInt(args: arguments, key: "count");
+
         IReadOnlyDictionary<string, object?> prepared = new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["query"] = query,
+            ["count"] = count,
         };
 
         return Task.FromResult(prepared);
@@ -131,7 +138,13 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
 
         try
         {
-            var results = await provider.SearchAsync(query, _config.MaxResults, cancellationToken)
+            var effectiveCount = _config.MaxResults;
+            if (arguments.TryGetValue("count", out var countVal) && countVal is int requestedCount && requestedCount > 0)
+            {
+                effectiveCount = Math.Min(requestedCount, _config.MaxResults);
+            }
+
+            var results = await provider.SearchAsync(query, effectiveCount, cancellationToken)
                 .ConfigureAwait(false);
             _logger.LogInformation("WebSearch completed: provider={Provider} query={Query} resultCount={Count}", providerName, query, results.Count);
 
@@ -229,6 +242,19 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
             JsonElement { ValueKind: JsonValueKind.String } el => el.GetString(),
             JsonElement el => el.ToString(),
             _ => value.ToString()
+        };
+    }
+
+    private static int? ReadInt(IReadOnlyDictionary<string, object?> args, string key)
+    {
+        if (!args.TryGetValue(key, out var value) || value is null) return null;
+        return value switch
+        {
+            int i => i,
+            long l => (int)l,
+            JsonElement { ValueKind: JsonValueKind.Number } el => el.GetInt32(),
+            string s when int.TryParse(s, out var parsed) => parsed,
+            _ => null
         };
     }
 

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebSearchToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebSearchToolTests.cs
@@ -209,6 +209,64 @@ public class WebSearchToolTests
         provider.CallCount.ShouldBe(20);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WithCountParameter_LimitsResultsToRequestedCount()
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 10 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["query"] = "test", ["count"] = 3 });
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCountExceedingMax_ClampsToConfiguredMax()
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 5 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["query"] = "test", ["count"] = 50 });
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCountOmitted_UsesConfiguredMax()
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 7 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["query"] = "test" });
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(7);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task ExecuteAsync_WithCountBelowOne_UsesConfiguredMax(int count)
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 5 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(new Dictionary<string, object?> { ["query"] = "test", ["count"] = count });
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(5);
+    }
+
     private static ISearchProvider? GetProvider(WebSearchTool tool)
     {
         var field = typeof(WebSearchTool).GetField("_provider", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -245,6 +303,17 @@ public class WebSearchToolTests
             Interlocked.Increment(ref _callCount);
             await Task.Delay(delay, ct);
             return [new SearchResult("Title", "https://example.com", query)];
+        }
+    }
+
+    private sealed class CapturingSearchProvider : ISearchProvider
+    {
+        public int LastMaxResults { get; private set; }
+
+        public Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
+        {
+            LastMaxResults = maxResults;
+            return Task.FromResult<IReadOnlyList<SearchResult>>([new SearchResult("R", "https://example.com", "S")]);
         }
     }
 }


### PR DESCRIPTION
Closes #1300

## Changes
- Added optional \count\ parameter to WebSearchTool schema
- When provided, clamps to [1, MaxResults] from config (config acts as ceiling)
- When omitted, uses MaxResults from config (backward compatible)
- Added \ReadInt\ helper for parsing integer arguments
- 4 new tests covering: count provided, count exceeds max, count omitted, count below 1

## Merge Notes
Safe to merge in any order — only touches WebSearchTool.cs and its test file. No overlap with PR #1295 (WebFetchTool).