### PR TITLE
feat(tools): add status filter to ConversationTool list action

### DIFF
--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -67,6 +67,10 @@ public sealed class ConversationTool(
                 "message": {
                   "type": "string",
                   "description": "Optional initial user message to seed the new conversation."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Filter by conversation status for list action: 'active' or 'archived'. Omit to return all."
                 }
               },
               "required": ["action"]
@@ -228,7 +232,22 @@ public sealed class ConversationTool(
         EnsureCanAccess(targetAgentId);
 
         var conversations = await conversationStore.ListAsync(targetAgentId, ct).ConfigureAwait(false);
-        var result = conversations.Select(ToToolResponse);
+
+        var statusFilter = ReadString(arguments, "status");
+        IEnumerable<Conversation> filtered = conversations;
+        if (!string.IsNullOrWhiteSpace(statusFilter))
+        {
+            if (Enum.TryParse<ConversationStatus>(statusFilter, ignoreCase: true, out var parsedStatus))
+            {
+                filtered = conversations.Where(c => c.Status == parsedStatus);
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid status filter '{statusFilter}'. Valid values: active, archived.");
+            }
+        }
+
+        var result = filtered.Select(ToToolResponse);
         return TextResult(JsonSerializer.Serialize(result, JsonOptions));
     }
 

--- a/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/ConversationToolTests.cs
@@ -369,6 +369,70 @@ public sealed class ConversationToolTests
         document.RootElement.GetProperty("sessionId").GetString().ShouldBe(session.SessionId.Value);
     }
 
+    // --- List status filter tests (#1301) ---
+
+    [Fact]
+    public async Task List_WithActiveStatusFilter_ReturnsOnlyActiveConversations()
+    {
+        var store = new InMemoryConversationStore();
+        await store.CreateAsync(CreateConversation("agent-a", "Active Chat", null));
+        var archived = await store.CreateAsync(CreateConversation("agent-a", "Old Chat", null));
+        archived.Status = ConversationStatus.Archived;
+        await store.SaveAsync(archived, default);
+
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.Own);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list", ["status"] = "active" });
+        var text = ReadText(result);
+
+        text.ShouldContain("Active Chat");
+        text.ShouldNotContain("Old Chat");
+    }
+
+    [Fact]
+    public async Task List_WithArchivedStatusFilter_ReturnsOnlyArchivedConversations()
+    {
+        var store = new InMemoryConversationStore();
+        await store.CreateAsync(CreateConversation("agent-a", "Active Chat", null));
+        var archived = await store.CreateAsync(CreateConversation("agent-a", "Old Chat", null));
+        archived.Status = ConversationStatus.Archived;
+        await store.SaveAsync(archived, default);
+
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.Own);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list", ["status"] = "archived" });
+        var text = ReadText(result);
+
+        text.ShouldNotContain("Active Chat");
+        text.ShouldContain("Old Chat");
+    }
+
+    [Fact]
+    public async Task List_WithNoStatusFilter_ReturnsAllConversations()
+    {
+        var store = new InMemoryConversationStore();
+        await store.CreateAsync(CreateConversation("agent-a", "Active Chat", null));
+        var archived = await store.CreateAsync(CreateConversation("agent-a", "Old Chat", null));
+        archived.Status = ConversationStatus.Archived;
+        await store.SaveAsync(archived, default);
+
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.Own);
+        var result = await tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list" });
+        var text = ReadText(result);
+
+        text.ShouldContain("Active Chat");
+        text.ShouldContain("Old Chat");
+    }
+
+    [Fact]
+    public async Task List_WithInvalidStatusFilter_ThrowsArgumentException()
+    {
+        var store = new InMemoryConversationStore();
+        var tool = new ConversationTool(store, AgentId.From("agent-a"), accessLevel: ConversationAccessLevel.Own);
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", new Dictionary<string, object?> { ["action"] = "list", ["status"] = "invalid" });
+
+        (await act.ShouldThrowAsync<ArgumentException>()).Message.ShouldContain("Invalid status filter");
+    }
+
     private static Conversation CreateConversation(string agentId, string title, string? purpose)
         => new()
         {


### PR DESCRIPTION
Closes #1301

## Changes
- Added optional \status\ parameter to ConversationTool schema
- \list\ action filters by status when provided (\ctive\ or \rchived\)
- Omitting status returns all conversations (backward compatible)
- Invalid status values throw ArgumentException with clear message
- 4 new tests covering all filter scenarios

## Merge Notes
Safe to merge in any order — only touches ConversationTool.cs and its test file. No overlap with any open PR.