### PR TITLE
feat(agent): add RunMetrics to AgentEndEvent for token and turn tracking

### DIFF
--- a/src/agent/BotNexus.Agent.Core/Agent.cs
+++ b/src/agent/BotNexus.Agent.Core/Agent.cs
@@ -479,7 +479,7 @@ public sealed class Agent
             try
             {
                 await HandleEventAsync(
-                        new AgentEndEvent([abortedMessage], DateTimeOffset.UtcNow),
+                        new AgentEndEvent([abortedMessage], null, DateTimeOffset.UtcNow),
                         CancellationToken.None)
                     .ConfigureAwait(false);
             }
@@ -509,7 +509,7 @@ public sealed class Agent
             try
             {
                 await HandleEventAsync(
-                        new AgentEndEvent([failureMessage], DateTimeOffset.UtcNow),
+                        new AgentEndEvent([failureMessage], null, DateTimeOffset.UtcNow),
                         CancellationToken.None)
                     .ConfigureAwait(false);
             }

--- a/src/agent/BotNexus.Agent.Core/Loop/AgentLoopRunner.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/AgentLoopRunner.cs
@@ -42,6 +42,7 @@ public static class AgentLoopRunner
         var runStartIndex = context.Messages.Count;
         var timeline = context.Messages.ToList();
         var newMessages = new List<AgentMessage>(prompts.Count);
+        var metrics = new RunMetricsAccumulator(DateTimeOffset.UtcNow);
 
         await emit(new AgentStartEvent(DateTimeOffset.UtcNow)).ConfigureAwait(false);
         await emit(new TurnStartEvent(DateTimeOffset.UtcNow)).ConfigureAwait(false);
@@ -59,6 +60,7 @@ public static class AgentLoopRunner
                 newMessages,
                 config,
                 emit,
+                metrics,
                 cancellationToken,
                 runStartIndex,
                 firstTurn: true)
@@ -106,10 +108,11 @@ public static class AgentLoopRunner
 
         var runStartIndex = context.Messages.Count;
         var newMessages = new List<AgentMessage>();
+        var metrics = new RunMetricsAccumulator(DateTimeOffset.UtcNow);
         await emit(new AgentStartEvent(DateTimeOffset.UtcNow)).ConfigureAwait(false);
         await emit(new TurnStartEvent(DateTimeOffset.UtcNow)).ConfigureAwait(false);
 
-        await RunLoopAsync(context, newMessages, config, emit, cancellationToken, runStartIndex, firstTurn: true)
+        await RunLoopAsync(context, newMessages, config, emit, metrics, cancellationToken, runStartIndex, firstTurn: true)
             .ConfigureAwait(false);
 
         return newMessages;
@@ -120,6 +123,7 @@ public static class AgentLoopRunner
         List<AgentMessage> newMessages,
         AgentLoopConfig config,
         Func<AgentEvent, Task> emit,
+        RunMetricsAccumulator metrics,
         CancellationToken cancellationToken,
         int runStartIndex,
         bool firstTurn)
@@ -187,8 +191,11 @@ public static class AgentLoopRunner
 
                 if (assistantMessage.FinishReason is StopReason.Error or StopReason.Aborted)
                 {
+                    metrics.IncrementTurns();
+                    metrics.AddTokens(assistantMessage.Usage?.InputTokens, assistantMessage.Usage?.OutputTokens);
                     await emit(new TurnEndEvent(assistantMessage, [], DateTimeOffset.UtcNow)).ConfigureAwait(false);
-                    await emit(new AgentEndEvent(messages.Skip(runStartIndex).ToList(), DateTimeOffset.UtcNow)).ConfigureAwait(false);
+                    var endTime = DateTimeOffset.UtcNow;
+                    await emit(new AgentEndEvent(messages.Skip(runStartIndex).ToList(), metrics.ToMetrics(endTime), endTime)).ConfigureAwait(false);
                     return;
                 }
 
@@ -214,6 +221,10 @@ public static class AgentLoopRunner
                     newMessages.Add(toolResult);
                 }
 
+                metrics.IncrementTurns();
+                metrics.AddTokens(assistantMessage.Usage?.InputTokens, assistantMessage.Usage?.OutputTokens);
+                metrics.AddToolCalls(toolResults.Count);
+
                 await emit(new TurnEndEvent(assistantMessage, toolResults, DateTimeOffset.UtcNow))
                     .ConfigureAwait(false);
 
@@ -231,7 +242,8 @@ public static class AgentLoopRunner
             break;
         }
 
-        await emit(new AgentEndEvent(messages.Skip(runStartIndex).ToList(), DateTimeOffset.UtcNow)).ConfigureAwait(false);
+        var endTime2 = DateTimeOffset.UtcNow;
+        await emit(new AgentEndEvent(messages.Skip(runStartIndex).ToList(), metrics.ToMetrics(endTime2), endTime2)).ConfigureAwait(false);
     }
 
     private static async Task<SimpleStreamOptions> BuildStreamOptionsAsync(

--- a/src/agent/BotNexus.Agent.Core/Loop/RunMetricsAccumulator.cs
+++ b/src/agent/BotNexus.Agent.Core/Loop/RunMetricsAccumulator.cs
@@ -1,0 +1,36 @@
+namespace BotNexus.Agent.Core.Loop;
+
+/// <summary>
+/// Mutable accumulator for run metrics during an agent loop execution.
+/// Thread-safe is not required — only accessed from the single-threaded loop.
+/// </summary>
+internal sealed class RunMetricsAccumulator
+{
+    private readonly DateTimeOffset _startTime;
+    private long _inputTokens;
+    private long _outputTokens;
+    private int _turnCount;
+    private int _toolCallCount;
+
+    public RunMetricsAccumulator(DateTimeOffset startTime)
+    {
+        _startTime = startTime;
+    }
+
+    public void AddTokens(int? inputTokens, int? outputTokens)
+    {
+        _inputTokens += inputTokens ?? 0;
+        _outputTokens += outputTokens ?? 0;
+    }
+
+    public void IncrementTurns() => _turnCount++;
+
+    public void AddToolCalls(int count) => _toolCallCount += count;
+
+    public Types.RunMetrics ToMetrics(DateTimeOffset endTime) => new(
+        _inputTokens,
+        _outputTokens,
+        _turnCount,
+        _toolCallCount,
+        endTime - _startTime);
+}

--- a/src/agent/BotNexus.Agent.Core/Types/AgentEvent.cs
+++ b/src/agent/BotNexus.Agent.Core/Types/AgentEvent.cs
@@ -37,7 +37,7 @@ public sealed record AgentStartEvent(DateTimeOffset Timestamp) : AgentEvent(Agen
 /// Emitted after all turns and tool executions complete, or after an error/abort.
 /// </para>
 /// </remarks>
-public sealed record AgentEndEvent(IReadOnlyList<AgentMessage> Messages, DateTimeOffset Timestamp)
+public sealed record AgentEndEvent(IReadOnlyList<AgentMessage> Messages, RunMetrics? Metrics, DateTimeOffset Timestamp)
     : AgentEvent(AgentEventType.AgentEnd, Timestamp);
 
 /// <summary>

--- a/src/agent/BotNexus.Agent.Core/Types/RunMetrics.cs
+++ b/src/agent/BotNexus.Agent.Core/Types/RunMetrics.cs
@@ -1,0 +1,17 @@
+namespace BotNexus.Agent.Core.Types;
+
+/// <summary>
+/// Aggregate metrics for a completed agent run.
+/// Accumulated across all turns during a single <see cref="AgentLoopRunner"/> execution.
+/// </summary>
+/// <param name="InputTokens">Total input tokens reported by the provider across all turns.</param>
+/// <param name="OutputTokens">Total output tokens reported by the provider across all turns.</param>
+/// <param name="TurnCount">Number of turns (LLM invocations) in this run.</param>
+/// <param name="ToolCallCount">Number of tool executions completed in this run.</param>
+/// <param name="Duration">Wall-clock duration from run start to end.</param>
+public sealed record RunMetrics(
+    long InputTokens,
+    long OutputTokens,
+    int TurnCount,
+    int ToolCallCount,
+    TimeSpan Duration);

--- a/tests/agent/BotNexus.Agent.Core.Tests/Loop/RunMetricsTests.cs
+++ b/tests/agent/BotNexus.Agent.Core.Tests/Loop/RunMetricsTests.cs
@@ -1,0 +1,172 @@
+using BotNexus.Agent.Core.Configuration;
+using BotNexus.Agent.Core.Loop;
+using BotNexus.Agent.Core.Tests.TestUtils;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Agent.Providers.Core.Models;
+
+namespace BotNexus.Agent.Core.Tests.Loop;
+
+using AgentUserMessage = BotNexus.Agent.Core.Types.UserMessage;
+
+public class RunMetricsTests
+{
+    [Fact]
+    public async Task RunAsync_SingleTurn_ReportsCorrectMetrics()
+    {
+        using var provider = RegisterProvider(TestStreamFactory.CreateTextResponse("hello"));
+        var config = TestHelpers.CreateTestConfig();
+        var context = TestHelpers.CreateEmptyContext();
+
+        AgentEndEvent? endEvent = null;
+        Task Emit(AgentEvent evt)
+        {
+            if (evt is AgentEndEvent end) endEvent = end;
+            return Task.CompletedTask;
+        }
+
+        await AgentLoopRunner.RunAsync([new AgentUserMessage("hi")], context, config, Emit, CancellationToken.None);
+
+        endEvent.ShouldNotBeNull();
+        endEvent.Metrics.ShouldNotBeNull();
+        endEvent.Metrics.TurnCount.ShouldBe(1);
+        endEvent.Metrics.InputTokens.ShouldBe(10);
+        endEvent.Metrics.OutputTokens.ShouldBe(5);
+        endEvent.Metrics.ToolCallCount.ShouldBe(0);
+        endEvent.Metrics.Duration.ShouldBeGreaterThan(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task RunAsync_MultiTurnWithToolCalls_AccumulatesMetrics()
+    {
+        var callCount = 0;
+        using var provider = RegisterProvider(() =>
+        {
+            if (Interlocked.Increment(ref callCount) == 1)
+            {
+                return TestStreamFactory.CreateToolCallResponse(
+                    ("call-1", "calculate", new Dictionary<string, object?> { ["expression"] = "1+1" }),
+                    ("call-2", "calculate", new Dictionary<string, object?> { ["expression"] = "2+2" }));
+            }
+
+            return TestStreamFactory.CreateTextResponse("done");
+        });
+
+        var tool = new CalculateTool();
+        var config = TestHelpers.CreateTestConfig();
+        var context = new AgentContext(null, [], [tool]);
+
+        AgentEndEvent? endEvent = null;
+        Task Emit(AgentEvent evt)
+        {
+            if (evt is AgentEndEvent end) endEvent = end;
+            return Task.CompletedTask;
+        }
+
+        await AgentLoopRunner.RunAsync([new AgentUserMessage("calc")], context, config, Emit, CancellationToken.None);
+
+        endEvent.ShouldNotBeNull();
+        endEvent.Metrics.ShouldNotBeNull();
+        endEvent.Metrics.TurnCount.ShouldBe(2);
+        endEvent.Metrics.InputTokens.ShouldBe(20); // 10 per turn × 2
+        endEvent.Metrics.OutputTokens.ShouldBe(10); // 5 per turn × 2
+        endEvent.Metrics.ToolCallCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task RunAsync_ErrorResponse_StillReportsMetrics()
+    {
+        using var provider = RegisterProvider(TestStreamFactory.CreateErrorResponse("something broke"));
+        var config = TestHelpers.CreateTestConfig();
+        var context = TestHelpers.CreateEmptyContext();
+
+        AgentEndEvent? endEvent = null;
+        Task Emit(AgentEvent evt)
+        {
+            if (evt is AgentEndEvent end) endEvent = end;
+            return Task.CompletedTask;
+        }
+
+        await AgentLoopRunner.RunAsync([new AgentUserMessage("hi")], context, config, Emit, CancellationToken.None);
+
+        endEvent.ShouldNotBeNull();
+        endEvent.Metrics.ShouldNotBeNull();
+        endEvent.Metrics.TurnCount.ShouldBe(1);
+        endEvent.Metrics.ToolCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_NullUsage_TreatsAsZeroTokens()
+    {
+        // Create a stream with no usage info
+        var stream = new BotNexus.Agent.Providers.Core.Streaming.LlmStream();
+        var message = new AssistantMessage(
+            Content: [new TextContent("no usage")],
+            Api: "test-api",
+            Provider: "test-provider",
+            ModelId: "test-model",
+            Usage: null!,
+            StopReason: StopReason.Stop,
+            ErrorMessage: null,
+            ResponseId: "r1",
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        stream.Push(new BotNexus.Agent.Providers.Core.Streaming.StartEvent(message));
+        stream.Push(new BotNexus.Agent.Providers.Core.Streaming.TextStartEvent(0, message));
+        stream.Push(new BotNexus.Agent.Providers.Core.Streaming.TextDeltaEvent(0, "no usage", message));
+        stream.Push(new BotNexus.Agent.Providers.Core.Streaming.TextEndEvent(0, "no usage", message));
+        stream.Push(new BotNexus.Agent.Providers.Core.Streaming.DoneEvent(StopReason.Stop, message));
+        stream.End(message);
+
+        using var provider = RegisterProvider(stream);
+        var config = TestHelpers.CreateTestConfig();
+        var context = TestHelpers.CreateEmptyContext();
+
+        AgentEndEvent? endEvent = null;
+        Task Emit(AgentEvent evt)
+        {
+            if (evt is AgentEndEvent end) endEvent = end;
+            return Task.CompletedTask;
+        }
+
+        await AgentLoopRunner.RunAsync([new AgentUserMessage("hi")], context, config, Emit, CancellationToken.None);
+
+        endEvent.ShouldNotBeNull();
+        endEvent.Metrics.ShouldNotBeNull();
+        endEvent.Metrics.InputTokens.ShouldBe(0);
+        endEvent.Metrics.OutputTokens.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ContinueAsync_ReportsMetrics()
+    {
+        using var provider = RegisterProvider(TestStreamFactory.CreateTextResponse("continued"));
+        var config = TestHelpers.CreateTestConfig();
+        var context = new AgentContext(null, [new AgentUserMessage("start")], []);
+
+        AgentEndEvent? endEvent = null;
+        Task Emit(AgentEvent evt)
+        {
+            if (evt is AgentEndEvent end) endEvent = end;
+            return Task.CompletedTask;
+        }
+
+        await AgentLoopRunner.ContinueAsync(context, config, Emit, CancellationToken.None);
+
+        endEvent.ShouldNotBeNull();
+        endEvent.Metrics.ShouldNotBeNull();
+        endEvent.Metrics.TurnCount.ShouldBe(1);
+        endEvent.Metrics.InputTokens.ShouldBe(10);
+        endEvent.Metrics.OutputTokens.ShouldBe(5);
+    }
+
+    private static IDisposable RegisterProvider(BotNexus.Agent.Providers.Core.Streaming.LlmStream stream)
+    {
+        var provider = new TestApiProvider("test-api", simpleStreamFactory: (_, _, _) => stream);
+        return TestHelpers.RegisterProvider(provider);
+    }
+
+    private static IDisposable RegisterProvider(Func<BotNexus.Agent.Providers.Core.Streaming.LlmStream> factory)
+    {
+        var provider = new TestApiProvider("test-api", simpleStreamFactory: (_, _, _) => factory());
+        return TestHelpers.RegisterProvider(provider);
+    }
+}


### PR DESCRIPTION
Closes #1304

## Changes
- Added \RunMetrics\ record to \Agent.Core.Types\ (InputTokens, OutputTokens, TurnCount, ToolCallCount, Duration)
- Extended \AgentEndEvent\ with nullable \Metrics\ property
- Added \RunMetricsAccumulator\ internal class to \Agent.Core.Loop\
- \AgentLoopRunner\ accumulates metrics during RunAsync/ContinueAsync and passes them to AgentEndEvent
- Null token values from providers that don't report usage are treated as 0
- 5 new tests covering single-turn, multi-turn with tools, error responses, null usage, and ContinueAsync

## Merge Notes
Touches only Agent.Core (Types + Loop). No overlap with any open PR. Safe to merge in any order.