### PR TITLE
feat(gateway): add active loop tracking to diagnostics for capacity monitoring

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/DiagnosticsController.cs
@@ -17,7 +17,8 @@ public sealed class DiagnosticsController(
     IThreadPoolMetrics? threadPoolMetrics = null,
     IOptions<ThreadPoolWatchdogOptions>? threadPoolOptions = null,
     IActivityTracker? activityTracker = null,
-    IOptions<LivenessWatchdogOptions>? livenessOptions = null) : ControllerBase
+    IOptions<LivenessWatchdogOptions>? livenessOptions = null,
+    IActiveLoopTracker? activeLoopTracker = null) : ControllerBase
 {
     private readonly ILogger<DiagnosticsController> _logger = logger;
     private readonly LogDiagnosticsRingBuffer? _logBuffer = logBuffer;
@@ -26,6 +27,7 @@ public sealed class DiagnosticsController(
     private readonly ThreadPoolWatchdogOptions? _threadPoolOptions = threadPoolOptions?.Value;
     private readonly IActivityTracker? _activityTracker = activityTracker;
     private readonly LivenessWatchdogOptions? _livenessOptions = livenessOptions?.Value;
+    private readonly IActiveLoopTracker? _activeLoopTracker = activeLoopTracker;
 
     /// <summary>
     /// Accepts an error report from any channel adapter and logs it at Error level.
@@ -217,6 +219,23 @@ public sealed class DiagnosticsController(
             WarningThresholdSeconds = (long)threshold.TotalSeconds
         });
     }
+
+    /// <summary>
+    /// Returns active agent loop metrics for capacity monitoring.
+    /// </summary>
+    [HttpGet("loops")]
+    public IActionResult GetActiveLoops()
+    {
+        if (_activeLoopTracker is null)
+            return NotFound("Active loop tracking not enabled.");
+
+        return Ok(new ActiveLoopSnapshotDto
+        {
+            ActiveCount = _activeLoopTracker.ActiveCount,
+            PeakCount = _activeLoopTracker.PeakCount,
+            TotalCompleted = _activeLoopTracker.TotalCompleted
+        });
+    }
 }
 
 /// <summary>
@@ -376,4 +395,19 @@ public sealed class ActivitySnapshotDto
 
     /// <summary>Configured warning threshold in seconds.</summary>
     public required long WarningThresholdSeconds { get; init; }
+}
+
+/// <summary>
+/// Active agent loop metrics for capacity monitoring.
+/// </summary>
+public sealed class ActiveLoopSnapshotDto
+{
+    /// <summary>Current number of active agent loops.</summary>
+    public required int ActiveCount { get; init; }
+
+    /// <summary>Peak concurrent loop count since startup.</summary>
+    public required int PeakCount { get; init; }
+
+    /// <summary>Total number of completed loops since startup.</summary>
+    public required long TotalCompleted { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway/Diagnostics/ActiveLoopTracker.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/ActiveLoopTracker.cs
@@ -1,0 +1,40 @@
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Lock-free implementation of <see cref="IActiveLoopTracker"/> using <see cref="Interlocked"/>.
+/// </summary>
+public sealed class ActiveLoopTracker : IActiveLoopTracker
+{
+    private int _activeCount;
+    private int _peakCount;
+    private long _totalCompleted;
+
+    /// <inheritdoc />
+    public int ActiveCount => Volatile.Read(ref _activeCount);
+
+    /// <inheritdoc />
+    public int PeakCount => Volatile.Read(ref _peakCount);
+
+    /// <inheritdoc />
+    public long TotalCompleted => Interlocked.Read(ref _totalCompleted);
+
+    /// <inheritdoc />
+    public void TrackStart()
+    {
+        var current = Interlocked.Increment(ref _activeCount);
+        // Update peak using compare-and-swap loop
+        int peak;
+        while (current > (peak = Volatile.Read(ref _peakCount)))
+        {
+            if (Interlocked.CompareExchange(ref _peakCount, current, peak) == peak)
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    public void TrackEnd()
+    {
+        Interlocked.Decrement(ref _activeCount);
+        Interlocked.Increment(ref _totalCompleted);
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Diagnostics/IActiveLoopTracker.cs
+++ b/src/gateway/BotNexus.Gateway/Diagnostics/IActiveLoopTracker.cs
@@ -1,0 +1,32 @@
+namespace BotNexus.Gateway.Diagnostics;
+
+/// <summary>
+/// Tracks the number of concurrently active agent loops for capacity monitoring.
+/// </summary>
+public interface IActiveLoopTracker
+{
+    /// <summary>
+    /// Current number of active agent loops.
+    /// </summary>
+    int ActiveCount { get; }
+
+    /// <summary>
+    /// Peak concurrent loop count since startup.
+    /// </summary>
+    int PeakCount { get; }
+
+    /// <summary>
+    /// Total number of completed loops since startup.
+    /// </summary>
+    long TotalCompleted { get; }
+
+    /// <summary>
+    /// Records that an agent loop has started.
+    /// </summary>
+    void TrackStart();
+
+    /// <summary>
+    /// Records that an agent loop has ended.
+    /// </summary>
+    void TrackEnd();
+}

--- a/src/gateway/BotNexus.Gateway/Extensions/DiagnosticsServiceCollectionExtensions.cs
+++ b/src/gateway/BotNexus.Gateway/Extensions/DiagnosticsServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class DiagnosticsServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddDiagnosticsHardening(this IServiceCollection services)
     {
+        services.AddSingleton<IActiveLoopTracker, ActiveLoopTracker>();
         services.AddSingleton<IThreadPoolMetrics, SystemThreadPoolMetrics>();
         services.Configure<ThreadPoolWatchdogOptions>(_ => { });
         services.AddHostedService<ThreadPoolWatchdogService>();

--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -64,6 +64,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
     private readonly IOptions<PlatformConfig>? _platformConfig;
     private readonly ConversationAutoTitleService? _autoTitleService;
     private readonly IActivityTracker? _activityTracker;
+    private readonly IActiveLoopTracker? _activeLoopTracker;
 
     public GatewayHost(
         IAgentSupervisor supervisor,
@@ -87,7 +88,8 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         IOptions<PlatformConfig>? platformConfig = null,
         LlmClient? llmClient = null,
         IConversationChangeNotifier? conversationChangeNotifier = null,
-        IActivityTracker? activityTracker = null)
+        IActivityTracker? activityTracker = null,
+        IActiveLoopTracker? activeLoopTracker = null)
     {
         _supervisor = supervisor;
         _router = router;
@@ -107,6 +109,7 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
         _conversationStore = conversationStore;
         _platformConfig = platformConfig;
         _activityTracker = activityTracker;
+        _activeLoopTracker = activeLoopTracker;
         // Wire up the auto-title service when the required dependencies are present.
         if (llmClient is not null && conversationStore is not null)
         {
@@ -565,6 +568,9 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                     }
 
                     var userMessage = BuildUserMessage(message, processedParts ?? originalParts, agentDescriptor);
+                    _activeLoopTracker?.TrackStart();
+                    try
+                    {
                     await StreamingSessionHelper.ProcessAndSaveAsync(
                         handle.StreamAsync(userMessage, cancellationToken),
                         session,
@@ -632,12 +638,26 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
                             }),
                         _sessionLifecycleEvents,
                         cancellationToken);
+                    }
+                    finally
+                    {
+                        _activeLoopTracker?.TrackEnd();
+                    }
                     sessionSaved = true;
                 }
                 else
                 {
                     var userMessage = BuildUserMessage(message, processedParts ?? originalParts, agentDescriptor);
-                    var response = await handle.PromptAsync(userMessage, cancellationToken);
+                    _activeLoopTracker?.TrackStart();
+                    AgentResponse response;
+                    try
+                    {
+                        response = await handle.PromptAsync(userMessage, cancellationToken);
+                    }
+                    finally
+                    {
+                        _activeLoopTracker?.TrackEnd();
+                    }
                     if (IsHeartbeatAck(response.Content))
                     {
                         _logger.LogDebug("Heartbeat ack from agent '{AgentId}' session '{SessionId}'", agentId, sessionId);

--- a/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/ActiveLoopTrackerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Diagnostics/ActiveLoopTrackerTests.cs
@@ -1,0 +1,90 @@
+using BotNexus.Gateway.Diagnostics;
+
+namespace BotNexus.Gateway.Tests.Diagnostics;
+
+public class ActiveLoopTrackerTests
+{
+    [Fact]
+    public void InitialState_AllZeros()
+    {
+        var tracker = new ActiveLoopTracker();
+
+        tracker.ActiveCount.ShouldBe(0);
+        tracker.PeakCount.ShouldBe(0);
+        tracker.TotalCompleted.ShouldBe(0);
+    }
+
+    [Fact]
+    public void TrackStart_IncrementsActiveCount()
+    {
+        var tracker = new ActiveLoopTracker();
+
+        tracker.TrackStart();
+
+        tracker.ActiveCount.ShouldBe(1);
+        tracker.PeakCount.ShouldBe(1);
+        tracker.TotalCompleted.ShouldBe(0);
+    }
+
+    [Fact]
+    public void TrackEnd_DecrementsActiveCount_IncrementsTotalCompleted()
+    {
+        var tracker = new ActiveLoopTracker();
+        tracker.TrackStart();
+
+        tracker.TrackEnd();
+
+        tracker.ActiveCount.ShouldBe(0);
+        tracker.PeakCount.ShouldBe(1);
+        tracker.TotalCompleted.ShouldBe(1);
+    }
+
+    [Fact]
+    public void PeakCount_TracksHighWaterMark()
+    {
+        var tracker = new ActiveLoopTracker();
+
+        tracker.TrackStart();
+        tracker.TrackStart();
+        tracker.TrackStart();
+        tracker.TrackEnd();
+        tracker.TrackEnd();
+
+        tracker.ActiveCount.ShouldBe(1);
+        tracker.PeakCount.ShouldBe(3);
+        tracker.TotalCompleted.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ConcurrentAccess_MaintainsConsistency()
+    {
+        var tracker = new ActiveLoopTracker();
+        const int iterations = 1000;
+
+        Parallel.For(0, iterations, _ =>
+        {
+            tracker.TrackStart();
+            Thread.SpinWait(10);
+            tracker.TrackEnd();
+        });
+
+        tracker.ActiveCount.ShouldBe(0);
+        tracker.TotalCompleted.ShouldBe(iterations);
+        tracker.PeakCount.ShouldBeGreaterThan(0);
+        tracker.PeakCount.ShouldBeLessThanOrEqualTo(iterations);
+    }
+
+    [Fact]
+    public void PeakCount_DoesNotDecrease_AfterTrackEnd()
+    {
+        var tracker = new ActiveLoopTracker();
+
+        tracker.TrackStart();
+        tracker.TrackStart();
+        var peakAfterTwo = tracker.PeakCount;
+        tracker.TrackEnd();
+        tracker.TrackEnd();
+
+        tracker.PeakCount.ShouldBe(peakAfterTwo);
+    }
+}


### PR DESCRIPTION
Closes #1305

## Changes
- Added \IActiveLoopTracker\ interface and \ActiveLoopTracker\ implementation (lock-free via Interlocked)
- Registered as singleton via \DiagnosticsServiceCollectionExtensions.AddDiagnosticsHardening()\
- Added \GET /api/diagnostics/loops\ endpoint returning ActiveCount, PeakCount, TotalCompleted
- Wired TrackStart/TrackEnd into GatewayHost streaming and non-streaming execution paths
- 6 new tests covering initial state, increment/decrement, peak tracking, concurrent access

## Merge Notes
Touches Gateway.Diagnostics (new files), DiagnosticsServiceCollectionExtensions, DiagnosticsController, and GatewayHost.
No overlap with any open PR. Safe to merge in any order.