### PR TITLE
feat(cli): add conversation management subcommands for list, inspect, and archive

### DIFF
--- a/src/gateway/BotNexus.Cli/CliApp.cs
+++ b/src/gateway/BotNexus.Cli/CliApp.cs
@@ -106,6 +106,7 @@ internal static class CliApp
             .AddSingleton<CronCommands>()
             .AddSingleton<SatelliteCommand>()
             .AddSingleton<DebugCommand>()
+            .AddSingleton<ConversationCommands>()
             .BuildServiceProvider();
     }
 
@@ -134,6 +135,7 @@ internal static class CliApp
         root.AddCommand(serviceProvider.GetRequiredService<CronCommands>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<SatelliteCommand>().Build(verboseOption, targetOption));
         root.AddCommand(serviceProvider.GetRequiredService<DebugCommand>().Build(verboseOption, targetOption));
+        root.AddCommand(serviceProvider.GetRequiredService<ConversationCommands>().Build(verboseOption, targetOption));
 
         return root;
     }

--- a/src/gateway/BotNexus.Cli/Commands/ConversationCommands.cs
+++ b/src/gateway/BotNexus.Cli/Commands/ConversationCommands.cs
@@ -1,0 +1,240 @@
+using System.CommandLine;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Configuration;
+using Spectre.Console;
+
+namespace BotNexus.Cli.Commands;
+
+/// <summary>
+/// CLI subcommand group for conversation management via the gateway REST API.
+/// Provides list, inspect, and archive operations against a running gateway instance.
+/// </summary>
+internal sealed class ConversationCommands
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public Command Build(Option<bool> verboseOption, Option<string?> targetOption)
+    {
+        var command = new Command("conversation", "Manage conversations via the gateway REST API.");
+
+        var formatOption = new Option<string>("--format", () => "table", "Output format: table or json.");
+        var urlOption = new Option<string>("--url", () => "http://localhost:5005", "Gateway base URL.");
+        command.AddOption(formatOption);
+        command.AddOption(urlOption);
+
+        // ── list ──
+        var agentOption = new Option<string?>("--agent", "Filter by agent ID.");
+        var listCommand = new Command("list", "List active conversations.")
+        {
+            agentOption
+        };
+        listCommand.SetHandler(async context =>
+        {
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            var agent = context.ParseResult.GetValueForOption(agentOption);
+            context.ExitCode = await ExecuteListAsync(url, agent, format, CancellationToken.None);
+        });
+
+        // ── inspect ──
+        var idArgument = new Argument<string>("id", "Conversation ID to inspect.");
+        var inspectCommand = new Command("inspect", "Show conversation metadata, participants, and bindings.")
+        {
+            idArgument
+        };
+        inspectCommand.SetHandler(async context =>
+        {
+            var format = context.ParseResult.GetValueForOption(formatOption) ?? "table";
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            var id = context.ParseResult.GetValueForArgument(idArgument);
+            context.ExitCode = await ExecuteInspectAsync(url, id, format, CancellationToken.None);
+        });
+
+        // ── archive ──
+        var archiveIdArgument = new Argument<string>("id", "Conversation ID to archive.");
+        var archiveCommand = new Command("archive", "Archive a conversation.")
+        {
+            archiveIdArgument
+        };
+        archiveCommand.SetHandler(async context =>
+        {
+            var url = context.ParseResult.GetValueForOption(urlOption) ?? "http://localhost:5005";
+            var id = context.ParseResult.GetValueForArgument(archiveIdArgument);
+            context.ExitCode = await ExecuteArchiveAsync(url, id, CancellationToken.None);
+        });
+
+        command.AddCommand(listCommand);
+        command.AddCommand(inspectCommand);
+        command.AddCommand(archiveCommand);
+
+        return command;
+    }
+
+    internal static async Task<int> ExecuteListAsync(string baseUrl, string? agentId, string format, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var query = agentId != null ? $"?agentId={Uri.EscapeDataString(agentId)}" : "";
+            var conversations = await client.GetFromJsonAsync<JsonElement>($"/api/conversations{query}", ct);
+
+            if (format == "json")
+            {
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(conversations, JsonOptions));
+            }
+            else
+            {
+                var table = new Table()
+                    .AddColumn("ID")
+                    .AddColumn("Agent")
+                    .AddColumn("Title")
+                    .AddColumn("Updated");
+
+                if (conversations.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var c in conversations.EnumerateArray())
+                    {
+                        var id = c.TryGetProperty("conversationId", out var cid) ? cid.GetString() ?? "" : "";
+                        var agent = c.TryGetProperty("agentId", out var aid) ? aid.GetString() ?? "" : "";
+                        var title = c.TryGetProperty("title", out var t) ? t.GetString() ?? "(untitled)" : "(untitled)";
+                        var updated = c.TryGetProperty("lastUpdatedUtc", out var u) ? u.GetString() ?? "" : "";
+                        table.AddRow(
+                            Markup.Escape(TruncateId(id)),
+                            Markup.Escape(agent),
+                            Markup.Escape(Truncate(title, 40)),
+                            Markup.Escape(updated));
+                    }
+                }
+
+                AnsiConsole.Write(table);
+            }
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    internal static async Task<int> ExecuteInspectAsync(string baseUrl, string conversationId, string format, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var response = await client.GetAsync($"/api/conversations/{Uri.EscapeDataString(conversationId)}", ct);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine("[yellow]Conversation '{0}' not found.[/]", Markup.Escape(conversationId));
+                return 1;
+            }
+            response.EnsureSuccessStatusCode();
+            var conversation = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+
+            if (format == "json")
+            {
+                AnsiConsole.WriteLine(JsonSerializer.Serialize(conversation, JsonOptions));
+            }
+            else
+            {
+                AnsiConsole.Write(new Rule("[bold blue]Conversation[/]") { Justification = Justify.Left });
+
+                if (conversation.TryGetProperty("conversationId", out var cid))
+                    AnsiConsole.MarkupLine("[dim]ID:[/]      {0}", Markup.Escape(cid.GetString() ?? ""));
+                if (conversation.TryGetProperty("agentId", out var aid))
+                    AnsiConsole.MarkupLine("[dim]Agent:[/]   {0}", Markup.Escape(aid.GetString() ?? ""));
+                if (conversation.TryGetProperty("title", out var title))
+                    AnsiConsole.MarkupLine("[dim]Title:[/]   {0}", Markup.Escape(title.GetString() ?? ""));
+                if (conversation.TryGetProperty("status", out var status))
+                    AnsiConsole.MarkupLine("[dim]Status:[/]  {0}", Markup.Escape(status.GetString() ?? ""));
+                if (conversation.TryGetProperty("createdUtc", out var created))
+                    AnsiConsole.MarkupLine("[dim]Created:[/] {0}", Markup.Escape(created.GetString() ?? ""));
+                if (conversation.TryGetProperty("lastUpdatedUtc", out var updated))
+                    AnsiConsole.MarkupLine("[dim]Updated:[/] {0}", Markup.Escape(updated.GetString() ?? ""));
+
+                if (conversation.TryGetProperty("participants", out var participants) && participants.ValueKind == JsonValueKind.Array)
+                {
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine("[dim]Participants:[/] {0}", participants.GetArrayLength());
+                    foreach (var p in participants.EnumerateArray())
+                    {
+                        var citizenId = p.TryGetProperty("citizenId", out var pid) ? pid.GetString() ?? "" : "";
+                        AnsiConsole.MarkupLine("  - {0}", Markup.Escape(citizenId));
+                    }
+                }
+
+                if (conversation.TryGetProperty("bindings", out var bindings) && bindings.ValueKind == JsonValueKind.Array)
+                {
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine("[dim]Bindings:[/] {0}", bindings.GetArrayLength());
+                }
+            }
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    internal static async Task<int> ExecuteArchiveAsync(string baseUrl, string conversationId, CancellationToken ct)
+    {
+        using var client = CreateClient(baseUrl);
+        try
+        {
+            var response = await client.DeleteAsync(
+                $"/api/conversations/{Uri.EscapeDataString(conversationId)}",
+                ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                AnsiConsole.MarkupLine("[yellow]Conversation '{0}' not found.[/]", Markup.Escape(conversationId));
+                return 1;
+            }
+
+            response.EnsureSuccessStatusCode();
+            AnsiConsole.MarkupLine("[green]Conversation '{0}' archived.[/]", Markup.Escape(conversationId));
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            AnsiConsole.MarkupLine("[red]Cannot reach gateway at {0}:[/] {1}", Markup.Escape(baseUrl), Markup.Escape(ex.Message));
+            return 1;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine("[red]Request to gateway timed out.[/]");
+            return 1;
+        }
+    }
+
+    private static HttpClient CreateClient(string baseUrl)
+    {
+        return new HttpClient
+        {
+            BaseAddress = new Uri(baseUrl.TrimEnd('/')),
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+    }
+
+    private static string TruncateId(string id)
+        => id.Length > 12 ? id[..12] + "..." : id;
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length > maxLength ? value[..maxLength] + "..." : value;
+}

--- a/tests/gateway/BotNexus.Cli.Tests/ConversationCommandsTests.cs
+++ b/tests/gateway/BotNexus.Cli.Tests/ConversationCommandsTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using BotNexus.Cli.Commands;
+
+namespace BotNexus.Cli.Tests;
+
+public sealed class ConversationCommandsTests : IDisposable
+{
+    private readonly MockHttpServer _server;
+
+    public ConversationCommandsTests()
+    {
+        _server = new MockHttpServer();
+    }
+
+    public void Dispose() => _server.Dispose();
+
+    [Fact]
+    public async Task List_ReturnsZero_WithValidResponse()
+    {
+        _server.SetResponse("/api/conversations", HttpStatusCode.OK,
+            """[{"conversationId":"c_abc123","agentId":"farnsworth","title":"Test","lastUpdatedUtc":"2026-06-12T00:00:00Z"}]""");
+
+        var result = await ConversationCommands.ExecuteListAsync(_server.BaseUrl, null, "json", CancellationToken.None);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task List_ReturnsZero_WithAgentFilter()
+    {
+        _server.SetResponse("/api/conversations", HttpStatusCode.OK, "[]");
+
+        var result = await ConversationCommands.ExecuteListAsync(_server.BaseUrl, "farnsworth", "table", CancellationToken.None);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task List_ReturnsOne_WhenGatewayUnreachable()
+    {
+        var result = await ConversationCommands.ExecuteListAsync("http://localhost:1", null, "table", CancellationToken.None);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Inspect_ReturnsZero_WithValidConversation()
+    {
+        _server.SetResponse("/api/conversations/c_abc123", HttpStatusCode.OK,
+            """{"conversationId":"c_abc123","agentId":"farnsworth","title":"Test","status":"active","createdUtc":"2026-06-12T00:00:00Z","lastUpdatedUtc":"2026-06-12T00:00:00Z","participants":[{"citizenId":"farnsworth"}],"bindings":[]}""");
+
+        var result = await ConversationCommands.ExecuteInspectAsync(_server.BaseUrl, "c_abc123", "json", CancellationToken.None);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Inspect_ReturnsOne_WhenNotFound()
+    {
+        _server.SetResponse("/api/conversations/c_missing", HttpStatusCode.NotFound, "");
+
+        var result = await ConversationCommands.ExecuteInspectAsync(_server.BaseUrl, "c_missing", "table", CancellationToken.None);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Inspect_ReturnsOne_WhenGatewayUnreachable()
+    {
+        var result = await ConversationCommands.ExecuteInspectAsync("http://localhost:1", "c_abc", "table", CancellationToken.None);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Archive_ReturnsZero_WhenSuccessful()
+    {
+        _server.SetResponse("/api/conversations/c_abc123", HttpStatusCode.NoContent, "");
+
+        var result = await ConversationCommands.ExecuteArchiveAsync(_server.BaseUrl, "c_abc123", CancellationToken.None);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task Archive_ReturnsOne_WhenNotFound()
+    {
+        _server.SetResponse("/api/conversations/c_missing", HttpStatusCode.NotFound, "");
+
+        var result = await ConversationCommands.ExecuteArchiveAsync(_server.BaseUrl, "c_missing", CancellationToken.None);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task Archive_ReturnsOne_WhenGatewayUnreachable()
+    {
+        var result = await ConversationCommands.ExecuteArchiveAsync("http://localhost:1", "c_abc", CancellationToken.None);
+
+        Assert.Equal(1, result);
+    }
+}


### PR DESCRIPTION
Closes #1308

## Changes
- Add ConversationCommands class with list, inspect, and rchive subcommands
- All commands connect to the gateway REST API (like debug gateway)
- --format table|json and --url options for flexibility
- Graceful error handling for unreachable gateway and not-found conversations
- 9 new tests using MockHttpServer

## Merge Notes
Only touches BotNexus.Cli and BotNexus.Cli.Tests — safe to merge in any order with all other open PRs.