### PR TITLE
fix(gateway): add input length validation on conversation title, purpose, and instructions

### DIFF
--- a/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
+++ b/src/gateway/BotNexus.Gateway.Api/Controllers/ConversationsController.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BotNexus.Domain.Primitives;
 using BotNexus.Domain.World;
+using BotNexus.Gateway.Conversations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using BotNexus.Gateway.Abstractions.Agents;
@@ -165,6 +166,13 @@ public sealed class ConversationsController : ControllerBase
         if (string.IsNullOrWhiteSpace(request.AgentId))
             return BadRequest(new { error = "agentId is required." });
 
+        if (ConversationInputValidator.ValidateTitle(request.Title) is { } titleError)
+            return BadRequest(new { error = titleError });
+        if (ConversationInputValidator.ValidatePurpose(request.Purpose) is { } purposeError)
+            return BadRequest(new { error = purposeError });
+        if (ConversationInputValidator.ValidateInstructions(request.Instructions) is { } instructionsError)
+            return BadRequest(new { error = instructionsError });
+
         var conversation = new Conversation
         {
             ConversationId = ConversationId.Create(),
@@ -205,11 +213,15 @@ public sealed class ConversationsController : ControllerBase
         if (request.Title is null && request.Purpose is null && request.Instructions is null)
             return BadRequest(new { error = "title or purpose is required." });
 
-        if (request.Title is not null && string.IsNullOrWhiteSpace(request.Title))
-            return BadRequest(new { error = "title must not be empty." });
-
-        if (request.Title is { Length: > 500 })
-            return BadRequest(new { error = "title must be 500 characters or fewer." });
+        if (request.Title is not null)
+        {
+            if (ConversationInputValidator.ValidateTitle(request.Title, required: true) is { } titleError)
+                return BadRequest(new { error = titleError });
+        }
+        if (ConversationInputValidator.ValidatePurpose(request.Purpose) is { } purposeError)
+            return BadRequest(new { error = purposeError });
+        if (ConversationInputValidator.ValidateInstructions(request.Instructions) is { } instructionsError)
+            return BadRequest(new { error = instructionsError });
 
         var conversation = await _conversations.GetAsync(ConversationId.From(conversationId), cancellationToken);
         if (conversation is null)

--- a/src/gateway/BotNexus.Gateway.Conversations/ConversationInputValidator.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/ConversationInputValidator.cs
@@ -1,0 +1,68 @@
+namespace BotNexus.Gateway.Conversations;
+
+/// <summary>
+/// Validates conversation input fields (title, purpose, instructions) against length constraints.
+/// Shared by both the REST controller and the agent tool to enforce consistent limits.
+/// </summary>
+public static class ConversationInputValidator
+{
+    /// <summary>Maximum allowed length for conversation title after trimming.</summary>
+    public const int MaxTitleLength = 200;
+
+    /// <summary>Maximum allowed length for conversation purpose after trimming.</summary>
+    public const int MaxPurposeLength = 1_000;
+
+    /// <summary>Maximum allowed length for conversation instructions after trimming.</summary>
+    public const int MaxInstructionsLength = 10_000;
+
+    /// <summary>
+    /// Validates a title value. Returns null if valid, or an error message if invalid.
+    /// </summary>
+    /// <param name="title">The title to validate (may be null).</param>
+    /// <param name="required">Whether the title is required (non-empty after trim).</param>
+    /// <returns>Error message or null if valid.</returns>
+    public static string? ValidateTitle(string? title, bool required = false)
+    {
+        if (title is null)
+            return required ? "title is required." : null;
+
+        var trimmed = title.Trim();
+        if (required && trimmed.Length == 0)
+            return "title must not be empty.";
+
+        if (trimmed.Length > MaxTitleLength)
+            return $"title must be {MaxTitleLength} characters or fewer (was {trimmed.Length}).";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a purpose value. Returns null if valid, or an error message if invalid.
+    /// </summary>
+    public static string? ValidatePurpose(string? purpose)
+    {
+        if (purpose is null)
+            return null;
+
+        var trimmed = purpose.Trim();
+        if (trimmed.Length > MaxPurposeLength)
+            return $"purpose must be {MaxPurposeLength} characters or fewer (was {trimmed.Length}).";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates an instructions value. Returns null if valid, or an error message if invalid.
+    /// </summary>
+    public static string? ValidateInstructions(string? instructions)
+    {
+        if (instructions is null)
+            return null;
+
+        var trimmed = instructions.Trim();
+        if (trimmed.Length > MaxInstructionsLength)
+            return $"instructions must be {MaxInstructionsLength} characters or fewer (was {trimmed.Length}).";
+
+        return null;
+    }
+}

--- a/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/ConversationTool.cs
@@ -7,6 +7,7 @@ using BotNexus.Domain.World;
 using BotNexus.Gateway.Abstractions.Conversations;
 using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Conversations;
 using BotNexus.Gateway.Dispatching;
 
 namespace BotNexus.Gateway.Tools;
@@ -196,6 +197,8 @@ public sealed class ConversationTool(
             ?? throw new ArgumentException("Missing required argument: title or displayName.");
         if (string.IsNullOrWhiteSpace(title))
             throw new ArgumentException("title must not be empty.");
+        if (ConversationInputValidator.ValidateTitle(title) is { } titleValidationError)
+            throw new ArgumentException(titleValidationError);
 
         var conversation = await ResolveConversationAsync(arguments, ct).ConfigureAwait(false);
         EnsureCanAccess(conversation.AgentId);
@@ -210,6 +213,8 @@ public sealed class ConversationTool(
     {
         var purpose = ReadString(arguments, "purpose")
             ?? throw new ArgumentException("Missing required argument: purpose.");
+        if (ConversationInputValidator.ValidatePurpose(purpose) is { } purposeValidationError)
+            throw new ArgumentException(purposeValidationError);
 
         var conversation = await ResolveConversationAsync(arguments, ct).ConfigureAwait(false);
         EnsureCanAccess(conversation.AgentId);
@@ -241,6 +246,10 @@ public sealed class ConversationTool(
 
         var title = ReadString(arguments, "displayName") ?? ReadString(arguments, "title");
         var purpose = ReadString(arguments, "purpose");
+        if (ConversationInputValidator.ValidateTitle(title) is { } newTitleError)
+            throw new ArgumentException(newTitleError);
+        if (ConversationInputValidator.ValidatePurpose(purpose) is { } newPurposeError)
+            throw new ArgumentException(newPurposeError);
         var message = ReadString(arguments, "message");
         var now = DateTimeOffset.UtcNow;
         var conversation = new Conversation
@@ -313,6 +322,8 @@ public sealed class ConversationTool(
         var conversation = await ResolveConversationAsync(arguments, ct).ConfigureAwait(false);
         EnsureCanAccess(conversation.AgentId);
         var instructions = ReadString(arguments, "instructions");
+        if (ConversationInputValidator.ValidateInstructions(instructions) is { } instructionsValidationError)
+            throw new ArgumentException(instructionsValidationError);
         if (arguments.ContainsKey("instructions"))
         {
             conversation.Instructions = string.IsNullOrWhiteSpace(instructions) ? null : instructions.Trim();

--- a/tests/gateway/BotNexus.Gateway.Tests/Conversations/ConversationInputValidatorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Conversations/ConversationInputValidatorTests.cs
@@ -1,0 +1,97 @@
+using BotNexus.Gateway.Conversations;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests.Conversations;
+
+public sealed class ConversationInputValidatorTests
+{
+    [Fact]
+    public void ValidateTitle_Null_NotRequired_ReturnsNull()
+    {
+        Assert.Null(ConversationInputValidator.ValidateTitle(null, required: false));
+    }
+
+    [Fact]
+    public void ValidateTitle_Null_Required_ReturnsError()
+    {
+        var error = ConversationInputValidator.ValidateTitle(null, required: true);
+        Assert.NotNull(error);
+        Assert.Contains("required", error);
+    }
+
+    [Fact]
+    public void ValidateTitle_Empty_Required_ReturnsError()
+    {
+        var error = ConversationInputValidator.ValidateTitle("   ", required: true);
+        Assert.NotNull(error);
+        Assert.Contains("empty", error);
+    }
+
+    [Fact]
+    public void ValidateTitle_ExceedsMaxLength_ReturnsError()
+    {
+        var longTitle = new string('x', 201);
+        var error = ConversationInputValidator.ValidateTitle(longTitle);
+        Assert.NotNull(error);
+        Assert.Contains("200", error);
+    }
+
+    [Fact]
+    public void ValidateTitle_AtMaxLength_ReturnsNull()
+    {
+        var title = new string('x', 200);
+        Assert.Null(ConversationInputValidator.ValidateTitle(title));
+    }
+
+    [Fact]
+    public void ValidateTitle_TrimsWhitespaceBeforeValidation()
+    {
+        // 200 chars + spaces = over raw length, but trimmed is exactly 200
+        var title = "  " + new string('x', 200) + "  ";
+        Assert.Null(ConversationInputValidator.ValidateTitle(title));
+    }
+
+    [Fact]
+    public void ValidatePurpose_Null_ReturnsNull()
+    {
+        Assert.Null(ConversationInputValidator.ValidatePurpose(null));
+    }
+
+    [Fact]
+    public void ValidatePurpose_ExceedsMaxLength_ReturnsError()
+    {
+        var longPurpose = new string('y', 1001);
+        var error = ConversationInputValidator.ValidatePurpose(longPurpose);
+        Assert.NotNull(error);
+        Assert.Contains("1000", error);
+    }
+
+    [Fact]
+    public void ValidatePurpose_AtMaxLength_ReturnsNull()
+    {
+        var purpose = new string('y', 1000);
+        Assert.Null(ConversationInputValidator.ValidatePurpose(purpose));
+    }
+
+    [Fact]
+    public void ValidateInstructions_Null_ReturnsNull()
+    {
+        Assert.Null(ConversationInputValidator.ValidateInstructions(null));
+    }
+
+    [Fact]
+    public void ValidateInstructions_ExceedsMaxLength_ReturnsError()
+    {
+        var longInstructions = new string('z', 10_001);
+        var error = ConversationInputValidator.ValidateInstructions(longInstructions);
+        Assert.NotNull(error);
+        Assert.Contains("10000", error);
+    }
+
+    [Fact]
+    public void ValidateInstructions_AtMaxLength_ReturnsNull()
+    {
+        var instructions = new string('z', 10_000);
+        Assert.Null(ConversationInputValidator.ValidateInstructions(instructions));
+    }
+}


### PR DESCRIPTION
Closes #1313

## Changes
- Added \ConversationInputValidator\ static class in Gateway.Conversations with constants and validation methods
- Title: max 200 characters (trimmed)
- Purpose: max 1,000 characters (trimmed)
- Instructions: max 10,000 characters (trimmed)
- Wired validation into ConversationsController (Create, Patch)
- Wired validation into ConversationTool (set_title, set_purpose, set/instructions, new)
- Returns 400 / ArgumentException on violation with clear error message
- 12 unit tests for the validator

## Merge Notes
Safe to merge in any order with all other open PRs. Only touches ConversationsController.cs, ConversationTool.cs, and adds new files.