### PR TITLE
fix(gateway): skip fan-out for non-deliverable channel types like cron

### DIFF
--- a/src/gateway/BotNexus.Gateway/GatewayHost.cs
+++ b/src/gateway/BotNexus.Gateway/GatewayHost.cs
@@ -1241,6 +1241,17 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
             {
                 try
                 {
+                    // Cron sessions create conversation bindings with channel type "cron" which
+                    // has no registered adapter (by design). Skip silently to avoid log noise.
+                    if (IsNonDeliverableChannel(binding.ChannelType))
+                    {
+                        _logger.LogDebug(
+                            "Fan-out: skipping non-deliverable channel type '{ChannelType}' (binding {BindingId}).",
+                            binding.ChannelType,
+                            binding.BindingId);
+                        continue;
+                    }
+
                     var adapter = ResolveChannelAdapter(binding.ChannelType, binding.AdapterId);
                     if (adapter is null)
                     {
@@ -1293,6 +1304,19 @@ public sealed class GatewayHost : BackgroundService, IChannelDispatcher, IInboun
             _logger.LogWarning(ex, "Fan-out resolution failed for session {SessionId}. Continuing.", typedSessionId.Value);
         }
     }
+
+    /// <summary>
+    /// Channel types that are not deliverable (no adapter exists by design).
+    /// Fan-out skips these silently at DEBUG level instead of logging a WARNING.
+    /// </summary>
+    internal static readonly HashSet<string> NonDeliverableChannels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "cron",
+        "exchange"
+    };
+
+    internal static bool IsNonDeliverableChannel(ChannelKey channelType) =>
+        NonDeliverableChannels.Contains(channelType.Value);
 
     private IChannelAdapter? ResolveChannelAdapter(ChannelKey channelType, string? adapterId = null)
     {

--- a/tests/gateway/BotNexus.Gateway.Tests/GatewayHostNonDeliverableChannelTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/GatewayHostNonDeliverableChannelTests.cs
@@ -1,0 +1,34 @@
+using BotNexus.Domain.Primitives;
+using Xunit;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class GatewayHostNonDeliverableChannelTests
+{
+    [Theory]
+    [InlineData("cron", true)]
+    [InlineData("Cron", true)]
+    [InlineData("CRON", true)]
+    [InlineData("exchange", true)]
+    [InlineData("Exchange", true)]
+    [InlineData("signalr", false)]
+    [InlineData("telegram", false)]
+    [InlineData("signal", false)]
+    public void IsNonDeliverableChannel_ClassifiesCorrectly(string channelType, bool expected)
+    {
+        var key = ChannelKey.From(channelType);
+        Assert.Equal(expected, GatewayHost.IsNonDeliverableChannel(key));
+    }
+
+    [Fact]
+    public void NonDeliverableChannels_ContainsCron()
+    {
+        Assert.Contains("cron", GatewayHost.NonDeliverableChannels);
+    }
+
+    [Fact]
+    public void NonDeliverableChannels_ContainsExchange()
+    {
+        Assert.Contains("exchange", GatewayHost.NonDeliverableChannels);
+    }
+}


### PR DESCRIPTION
Closes #1319

## Changes
- Add `NonDeliverableChannels` set ("cron", "exchange") to GatewayHost
- Skip fan-out delivery attempt for these channel types (log at DEBUG instead of WARNING)
- Eliminates ~192 noisy WARNING log entries per day from cron-originated sessions

## Merge Notes
Independent of all other open PRs. Safe to merge in any order.
