### PR TITLE
feat(sessions): add delete action to SessionTool for expired and sealed sessions

### DIFF
--- a/src/gateway/BotNexus.Gateway/Tools/SessionTool.cs
+++ b/src/gateway/BotNexus.Gateway/Tools/SessionTool.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using BotNexus.Agent.Core.Tools;
 using BotNexus.Agent.Core.Types;
 using BotNexus.Domain.Primitives;
+using BotNexus.Gateway.Abstractions.Models;
 using BotNexus.Gateway.Abstractions.Sessions;
 using BotNexus.Agent.Providers.Core.Models;
 
@@ -29,7 +30,7 @@ public sealed class SessionTool(
               "properties": {
                 "action": {
                   "type": "string",
-                  "enum": ["list", "get", "search", "history"],
+                  "enum": ["list", "get", "search", "history", "delete"],
                   "description": "Action to perform."
                 },
                 "sessionId": {
@@ -66,7 +67,8 @@ public sealed class SessionTool(
         if (!action.Equals("list", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("get", StringComparison.OrdinalIgnoreCase) &&
             !action.Equals("search", StringComparison.OrdinalIgnoreCase) &&
-            !action.Equals("history", StringComparison.OrdinalIgnoreCase))
+            !action.Equals("history", StringComparison.OrdinalIgnoreCase) &&
+            !action.Equals("delete", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException($"Unsupported session action '{action}'.");
 
         return Task.FromResult(arguments);
@@ -85,6 +87,7 @@ public sealed class SessionTool(
             "get" => await GetAsync(arguments, cancellationToken),
             "search" => await SearchAsync(arguments, cancellationToken),
             "history" => await HistoryAsync(arguments, cancellationToken),
+            "delete" => await DeleteAsync(arguments, cancellationToken),
             _ => throw new InvalidOperationException($"Unsupported session action '{action}'.")
         };
     }
@@ -212,6 +215,33 @@ public sealed class SessionTool(
         };
 
         return TextResult(JsonSerializer.Serialize(result, JsonOptions));
+    }
+
+    private async Task<AgentToolResult> DeleteAsync(IReadOnlyDictionary<string, object?> arguments, CancellationToken ct)
+    {
+        var sessionId = ReadString(arguments, "sessionId")
+            ?? throw new ArgumentException("Missing required argument: sessionId.");
+
+        var session = await sessionStore.GetAsync(SessionId.From(sessionId), ct)
+            ?? throw new KeyNotFoundException($"Session '{sessionId}' not found.");
+
+        EnsureCanAccess(session.AgentId);
+
+        if (session.Status is SessionStatus.Active or SessionStatus.Suspended)
+            throw new InvalidOperationException(
+                $"Cannot delete session '{sessionId}' with status '{session.Status}'. Only expired or sealed sessions can be deleted.");
+
+        await sessionStore.DeleteAsync(SessionId.From(sessionId), ct);
+
+        var confirmation = new
+        {
+            status = "deleted",
+            session.SessionId,
+            session.AgentId,
+            session.CreatedAt
+        };
+
+        return TextResult(JsonSerializer.Serialize(confirmation, JsonOptions));
     }
 
     private void EnsureCanAccess(AgentId targetAgentId)

--- a/tests/gateway/BotNexus.Gateway.Tests/SessionToolDeleteTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/SessionToolDeleteTests.cs
@@ -1,0 +1,131 @@
+using BotNexus.Domain.Primitives;
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Abstractions.Sessions;
+using BotNexus.Gateway.Tools;
+using Moq;
+
+namespace BotNexus.Gateway.Tests;
+
+public sealed class SessionToolDeleteTests
+{
+    [Fact]
+    public async Task Delete_SealedSession_Succeeds()
+    {
+        var store = new Mock<ISessionStore>();
+        var session = CreateSession("s1", "agent-a", SessionStatus.Sealed);
+        store.Setup(s => s.GetAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        store.Setup(s => s.DeleteAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("delete", sessionId: "s1"));
+        var text = ReadText(result);
+
+        text.ShouldContain("s1");
+        text.ShouldContain("deleted");
+        store.Verify(s => s.DeleteAsync(SessionId.From("s1"), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_ExpiredSession_Succeeds()
+    {
+        var store = new Mock<ISessionStore>();
+        var session = CreateSession("s1", "agent-a", SessionStatus.Expired);
+        store.Setup(s => s.GetAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        store.Setup(s => s.DeleteAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        var result = await tool.ExecuteAsync("call-1", Args("delete", sessionId: "s1"));
+        var text = ReadText(result);
+
+        text.ShouldContain("deleted");
+    }
+
+    [Fact]
+    public async Task Delete_ActiveSession_Throws()
+    {
+        var store = new Mock<ISessionStore>();
+        var session = CreateSession("s1", "agent-a", SessionStatus.Active);
+        store.Setup(s => s.GetAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("delete", sessionId: "s1"));
+
+        await act.ShouldThrowAsync<InvalidOperationException>();
+        store.Verify(s => s.DeleteAsync(It.IsAny<SessionId>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_SuspendedSession_Throws()
+    {
+        var store = new Mock<ISessionStore>();
+        var session = CreateSession("s1", "agent-a", SessionStatus.Suspended);
+        store.Setup(s => s.GetAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("delete", sessionId: "s1"));
+
+        await act.ShouldThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Delete_NonexistentSession_Throws()
+    {
+        var store = new Mock<ISessionStore>();
+        store.Setup(s => s.GetAsync(SessionId.From("missing"), It.IsAny<CancellationToken>())).ReturnsAsync((GatewaySession?)null);
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("delete", sessionId: "missing"));
+
+        await act.ShouldThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Delete_OtherAgentSession_DeniedForOwnAccess()
+    {
+        var store = new Mock<ISessionStore>();
+        var session = CreateSession("s1", "agent-b", SessionStatus.Sealed);
+        store.Setup(s => s.GetAsync(SessionId.From("s1"), It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("delete", sessionId: "s1"));
+
+        await act.ShouldThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task Delete_MissingSessionId_Throws()
+    {
+        var store = new Mock<ISessionStore>();
+        var tool = new SessionTool(store.Object, AgentId.From("agent-a"));
+
+        Func<Task> act = () => tool.ExecuteAsync("call-1", Args("delete"));
+
+        await act.ShouldThrowAsync<ArgumentException>();
+    }
+
+    private static GatewaySession CreateSession(string sessionId, string agentId, SessionStatus status = SessionStatus.Active)
+    {
+        var session = new GatewaySession
+        {
+            SessionId = SessionId.From(sessionId),
+            AgentId = AgentId.From(agentId),
+            ChannelType = ChannelKey.From("Web Chat"),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-30),
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        session.Status = status;
+        return session;
+    }
+
+    private static Dictionary<string, object?> Args(string action, string? sessionId = null)
+    {
+        var args = new Dictionary<string, object?> { ["action"] = action };
+        if (sessionId is not null) args["sessionId"] = sessionId;
+        return args;
+    }
+
+    private static string ReadText(AgentToolResult result)
+        => result.Content.Single(c => c.Type == AgentToolContentType.Text).Value;
+}


### PR DESCRIPTION
Closes #1326

## Changes
- Added \delete\ action to SessionTool schema and implementation
- Delete is gated by session status: only \Expired\ or \Sealed\ sessions can be deleted
- Active and Suspended sessions are rejected with \InvalidOperationException\
- Access control enforced via existing \EnsureCanAccess\ (Own/Allowlist/All)
- Returns confirmation JSON with session metadata on success
- 7 new tests covering: sealed/expired success, active/suspended rejection, not-found, unauthorized, missing sessionId

## Merge Notes
No file overlap with any open PR. Safe to merge in any order.