### PR TITLE
fix(tools): tolerate non-integer and out-of-range count in web search

### DIFF
--- a/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
+++ b/src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs
@@ -251,8 +251,10 @@ public sealed class WebSearchTool : IAgentTool, IDisposable, IAsyncDisposable
         return value switch
         {
             int i => i,
-            long l => (int)l,
-            JsonElement { ValueKind: JsonValueKind.Number } el => el.GetInt32(),
+            long l when l is >= int.MinValue and <= int.MaxValue => (int)l,
+            // Tolerate fractional or out-of-range JSON numbers and non-numeric strings:
+            // return null so callers fall back to the configured default instead of throwing.
+            JsonElement { ValueKind: JsonValueKind.Number } el when el.TryGetInt32(out var n) => n,
             string s when int.TryParse(s, out var parsed) => parsed,
             _ => null
         };

--- a/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebSearchToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.WebTools.Tests/WebSearchToolTests.cs
@@ -267,6 +267,74 @@ public class WebSearchToolTests
         capturing.LastMaxResults.ShouldBe(5);
     }
 
+    [Fact]
+    public async Task PrepareArgumentsAsync_WithFractionalJsonCount_DoesNotThrowAndFallsBackToMax()
+    {
+        // The agent loop delivers tool arguments as JsonElement. A fractional number
+        // previously caused GetInt32() to throw FormatException out of PrepareArgumentsAsync.
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 6 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(JsonArgs("""{ "query": "test", "count": 3.5 }"""));
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(6);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WithOutOfRangeJsonCount_DoesNotThrowAndFallsBackToMax()
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 4 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        // 99999999999 exceeds Int32.MaxValue.
+        var args = await tool.PrepareArgumentsAsync(JsonArgs("""{ "query": "test", "count": 99999999999 }"""));
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WithNonNumericStringCount_DoesNotThrowAndFallsBackToMax()
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 8 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(JsonArgs("""{ "query": "test", "count": "lots" }"""));
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(8);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WithIntegerJsonCount_ClampsToRequestedValue()
+    {
+        using var tool = new WebSearchTool(
+            new WebSearchConfig { Provider = "brave", ApiKey = "token", MaxResults = 10 });
+        var capturing = new CapturingSearchProvider();
+        SetProvider(tool, capturing);
+
+        var args = await tool.PrepareArgumentsAsync(JsonArgs("""{ "query": "test", "count": 2 }"""));
+        await tool.ExecuteAsync("call-1", args);
+
+        capturing.LastMaxResults.ShouldBe(2);
+    }
+
+    private static Dictionary<string, object?> JsonArgs(string json)
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            dict[prop.Name] = prop.Value.Clone();
+        return dict;
+    }
+
     private static ISearchProvider? GetProvider(WebSearchTool tool)
     {
         var field = typeof(WebSearchTool).GetField("_provider", BindingFlags.Instance | BindingFlags.NonPublic);


### PR DESCRIPTION
Closes #1338

## Problem
`WebSearchTool.ReadInt` parsed the optional `count` argument with `JsonElement.GetInt32()` for any JSON number. A fractional (`3.5`) or out-of-range (`99999999999`) value threw `FormatException` / `InvalidOperationException` from `PrepareArgumentsAsync` — **before** `ExecuteAsync`'s try/catch — turning a recoverable bad-input situation into a hard tool-preparation failure. Inconsistent with the rest of the tool, which returns friendly errors for invalid input.

## Changes
- `ReadInt` now uses `TryGetInt32` for JSON numbers and range-checks `long` values, returning `null` when the value is not a valid `Int32`.
- A `null` result flows into the existing `count` clamping logic (`requestedCount > 0` guard + `Math.Min(requestedCount, MaxResults)`), so malformed counts fall back to the configured `MaxResults` default instead of throwing.
- Valid integer counts behave exactly as before.

## Tests
- New: fractional JSON count (fallback, no throw), out-of-range JSON count (fallback, no throw), non-numeric string count (fallback), integer JSON count (clamped).
- Existing count tests (clamp to max, below-one fallback, omitted default) unchanged.
- WebTools impacted tests: 120 pass. Architecture 178, Scenarios 29 pass. Full solution build clean.

## Merge Notes
Touches only `src/extensions/BotNexus.Extensions.WebTools/WebSearchTool.cs` (+ its test). No overlap with PR #1332 (`WebFetchTool.cs` in the same project, different file). Fully independent — merge in any order.