### PR TITLE
fix(tools): reject multi-statement SQL in platform_debug raw_sql action

### DIFF
--- a/src/extensions/BotNexus.Extensions.DebugTool/DebugTool.cs
+++ b/src/extensions/BotNexus.Extensions.DebugTool/DebugTool.cs
@@ -357,8 +357,16 @@ public sealed class DebugTool : IAgentTool
         if (string.IsNullOrWhiteSpace(sql))
             return TextResult("Error: 'sql' is required for raw_sql.");
 
-        if (!IsSelectOnly(sql))
+        if (!StartsWithReadKeyword(sql))
             return TextResult("Error: Only SELECT statements are permitted. The query must start with SELECT (after optional whitespace/comments).");
+
+        // Reject multiple statements. SQLite executes every statement in a batched command,
+        // so a payload such as "SELECT 1; PRAGMA database_list" would pass the keyword check
+        // yet still run the trailing statement — defeating the agent-scoping guards even under
+        // the read-only connection.
+        if (!IsSingleStatement(sql))
+            return TextResult("Error: Only a single statement is permitted. " +
+                "Multiple statements separated by ';' are not allowed.");
 
         var (_, limit) = GetPagination(args);
 
@@ -479,7 +487,24 @@ public sealed class DebugTool : IAgentTool
         return (offset, limit);
     }
 
-    internal static bool IsSelectOnly(string sql)
+    /// <summary>
+    /// Returns <see langword="true"/> only when <paramref name="sql"/> is a single read-only
+    /// statement: it must begin with an allowed read keyword (SELECT/WITH/EXPLAIN/PRAGMA) and
+    /// contain no statement separator beyond a single optional trailing semicolon.
+    /// <para>
+    /// A naive leading-keyword check is insufficient: SQLite executes every statement in a batch,
+    /// so a payload such as <c>SELECT 1; DELETE FROM t</c> would pass a prefix check yet still run
+    /// the trailing write. This combined gate guards both concerns.
+    /// </para>
+    /// </summary>
+    internal static bool IsSelectOnly(string sql) =>
+        StartsWithReadKeyword(sql) && IsSingleStatement(sql);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the first significant keyword (after leading whitespace
+    /// and line/block comments) is one of the permitted read-only keywords.
+    /// </summary>
+    internal static bool StartsWithReadKeyword(string sql)
     {
         // Strip leading whitespace and line comments, then check first keyword
         var trimmed = sql.AsSpan().TrimStart();
@@ -507,6 +532,41 @@ public sealed class DebugTool : IAgentTool
             || trimmed.StartsWith("WITH", StringComparison.OrdinalIgnoreCase)
             || trimmed.StartsWith("EXPLAIN", StringComparison.OrdinalIgnoreCase)
             || trimmed.StartsWith("PRAGMA", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="sql"/> contains a single statement,
+    /// allowing a single optional trailing semicolon. Semicolons inside single-quoted string
+    /// literals are not treated as separators (SQLite escapes an embedded quote by doubling it,
+    /// which this scan handles naturally because the closing quote toggles the literal state
+    /// open again on the very next character).
+    /// </summary>
+    internal static bool IsSingleStatement(string? sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql)) return false;
+
+        bool inLiteral = false;
+        for (int i = 0; i < sql.Length; i++)
+        {
+            char c = sql[i];
+            if (c == '\'')
+            {
+                inLiteral = !inLiteral;
+                continue;
+            }
+            if (inLiteral || c != ';') continue;
+
+            // Found a statement separator outside a literal. Everything after it must be
+            // whitespace for this to remain a single statement with a trailing semicolon.
+            for (int j = i + 1; j < sql.Length; j++)
+            {
+                if (!char.IsWhiteSpace(sql[j])) return false;
+            }
+            return true;
+        }
+
+        // No semicolon outside a literal — single statement.
+        return true;
     }
 
     private static AgentToolResult TextResult(string text) =>

--- a/tests/extensions/BotNexus.Extensions.DebugTool.Tests/DebugToolTests.cs
+++ b/tests/extensions/BotNexus.Extensions.DebugTool.Tests/DebugToolTests.cs
@@ -556,6 +556,43 @@ public sealed class DebugToolTests : IDisposable
         Assert.Contains("Only SELECT statements are permitted", TextOf(result));
     }
 
+    [Theory]
+    [InlineData("SELECT 1; PRAGMA database_list")]
+    [InlineData("SELECT * FROM conversations; SELECT * FROM sessions")]
+    [InlineData("SELECT id FROM conversations; DELETE FROM conversations")]
+    [InlineData("PRAGMA table_info('conversations'); SELECT 1")]
+    public async Task RawSql_RejectsMultipleStatements(string sql)
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql", ("sql", sql)));
+        Assert.True(IsError(result));
+        Assert.Contains("single statement", TextOf(result), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RawSql_AllowsSingleStatementWithTrailingSemicolon()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "SELECT id FROM conversations;")));
+        Assert.False(IsError(result));
+        Assert.Contains("conv-1", TextOf(result));
+    }
+
+    [Fact]
+    public async Task RawSql_AllowsSemicolonInsideStringLiteral()
+    {
+        var config = new DebugToolConfig { AllowRawSql = true };
+        var tool = CreateTool(config);
+        // The ';' here is inside a quoted literal and must not be treated as a separator.
+        var result = await tool.ExecuteAsync("tc1", Args("raw_sql",
+            ("sql", "SELECT 'a;b' AS v")));
+        Assert.False(IsError(result));
+        Assert.Contains("a;b", TextOf(result));
+    }
+
     // ── Pagination ────────────────────────────────────────────────────────────
 
     [Fact]
@@ -598,11 +635,17 @@ public sealed class DebugToolTests : IDisposable
     [InlineData("PRAGMA table_info('t')", true)]
     [InlineData("-- comment\nSELECT 1", true)]
     [InlineData("/* block */\nSELECT 1", true)]
+    [InlineData("SELECT 1;", true)]
+    [InlineData("SELECT 1;   ", true)]
+    [InlineData("SELECT 'a;b' AS v", true)]
     [InlineData("INSERT INTO t VALUES (1)", false)]
     [InlineData("UPDATE t SET x = 1", false)]
     [InlineData("DELETE FROM t", false)]
     [InlineData("DROP TABLE t", false)]
     [InlineData("CREATE TABLE t (id INT)", false)]
+    [InlineData("SELECT 1; SELECT 2", false)]
+    [InlineData("SELECT 1; DELETE FROM t", false)]
+    [InlineData("PRAGMA foo; SELECT 1", false)]
     [InlineData("", false)]
     public void IsSelectOnly_CorrectlyClassifiesStatements(string sql, bool expected)
     {


### PR DESCRIPTION
Closes #1337

## Problem
The `platform_debug` tool's `raw_sql` action validated SQL with `IsSelectOnly`, which only checked the **first keyword**. A batched payload such as `SELECT 1; PRAGMA database_list` passed the check, and `Microsoft.Data.Sqlite` executes **every** statement in a batched command. Even under the read-only connection (which blocks writes), this defeats the single-statement contract and the agent-scoping intent (a scoped leading query can be followed by an unscoped one). This is the same vulnerability class fixed for DataStore in #1329 / PR #1331; `DebugTool` was not covered by that fix (different extension/file).

## Changes
- Split the `raw_sql` guard into two checks with distinct messages:
  - `StartsWithReadKeyword` — unchanged: first keyword must be `SELECT`/`WITH`/`EXPLAIN`/`PRAGMA` (after whitespace and line/block comments).
  - `IsSingleStatement` — new literal-aware scan that rejects any `;` separator found **outside** a single-quoted string literal when followed by more non-whitespace SQL, while allowing one optional trailing `;`.
- `IsSelectOnly` is retained as the combined gate (keyword AND single-statement) so its existing classification contract holds.
- Mirrors `DataStoreTool.IsSingleSelectStatement` from PR #1331 for consistency.

## Tests
- New `raw_sql` cases: multi-statement rejection (`SELECT;PRAGMA`, `SELECT;SELECT`, `SELECT;DELETE`, `PRAGMA;SELECT`), single statement with trailing `;` (allowed), `;` inside a string literal (allowed).
- `IsSelectOnly` theory extended: trailing semicolon (true), embedded-literal semicolon (true), two statements (false), SELECT+DELETE (false), PRAGMA+SELECT (false).
- DebugTool.Tests: 78 pass. Architecture 178, Scenarios 29 pass. Full solution build clean.

## Merge Notes
Touches only `src/extensions/BotNexus.Extensions.DebugTool/DebugTool.cs` (+ its test). Zero overlap with any open PR (DataStore's analogous fix is in a different extension). Fully independent — merge in any order.