### PR TITLE
fix(memory): clamp memory_get limit and memory_search topK to configured ceilings

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -191,6 +191,8 @@ Agents are defined in the `agents` section, keyed by agent ID.
 | `memory.path` | string | `memory` | Memory root directory relative to agent workspace. Daily notes (`YYYY-MM-DD.md`) are written here |
 | `memory.indexing` | string | `auto` | Memory indexing mode |
 | `memory.search.defaultTopK` | int | `10` | Default number of search results |
+| `memory.search.maxTopK` | int | `100` | Upper bound for the `memory_search` `topK` argument. Caller-supplied values above this are clamped (floored at `defaultTopK`) to bound the search fan-out and tool-result size |
+| `memory.search.maxLimit` | int | `100` | Upper bound for the `memory_get` session-listing `limit` argument. Caller-supplied values above this are clamped |
 | `soul.enabled` | bool | `false` | Enable soul session (persistent agent identity) |
 | `soul.idleTimeoutMinutes` | int | `30` | Idle timeout for soul sessions |
 | `sessionAccess.level` | string | `own` | Session access: `own`, `allowlist`, or `all` |

--- a/src/domain/BotNexus.Domain/Gateway/Models/MemoryAgentConfig.cs
+++ b/src/domain/BotNexus.Domain/Gateway/Models/MemoryAgentConfig.cs
@@ -42,6 +42,20 @@ public sealed class MemorySearchAgentConfig
     public int DefaultTopK { get; set; } = 10;
 
     /// <summary>
+    /// Gets or sets the maximum number of results an agent-supplied <c>topK</c> can request.
+    /// Caller-provided values above this ceiling are clamped so a single search cannot fan out
+    /// over the entire store; protects against runaway embedding fetches and oversized tool results.
+    /// </summary>
+    public int MaxTopK { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the maximum number of entries a <c>memory_get</c> session listing can return.
+    /// Caller-provided <c>limit</c> values above this ceiling are clamped to bound the fetch and
+    /// the resulting serialized payload.
+    /// </summary>
+    public int MaxLimit { get; set; } = 100;
+
+    /// <summary>
     /// Gets or sets the temporal decay.
     /// </summary>
     public TemporalDecayAgentConfig? TemporalDecay { get; set; }

--- a/src/gateway/BotNexus.Memory/Tools/MemoryGetTool.cs
+++ b/src/gateway/BotNexus.Memory/Tools/MemoryGetTool.cs
@@ -8,11 +8,16 @@ namespace BotNexus.Memory.Tools;
 
 public sealed class MemoryGetTool : IAgentTool
 {
-    private readonly IMemoryStore _memoryStore;
+    /// <summary>Default ceiling for the session listing <c>limit</c> when none is configured.</summary>
+    public const int DefaultMaxLimit = 100;
 
-    public MemoryGetTool(IMemoryStore memoryStore)
+    private readonly IMemoryStore _memoryStore;
+    private readonly int _maxLimit;
+
+    public MemoryGetTool(IMemoryStore memoryStore, int maxLimit = DefaultMaxLimit)
     {
         _memoryStore = memoryStore;
+        _maxLimit = Math.Max(1, maxLimit);
     }
 
     public string Name => "memory_get";
@@ -36,7 +41,7 @@ public sealed class MemoryGetTool : IAgentTool
                 },
                 "limit": {
                   "type": "integer",
-                  "description": "Max entries when listing by session (default: 20)"
+                  "description": "Max entries when listing by session (default: 20). Values above the configured ceiling are clamped."
                 }
               }
             }
@@ -91,7 +96,7 @@ public sealed class MemoryGetTool : IAgentTool
 
         var sessionId = ToStringValue(arguments["sessionId"])!;
         var limit = arguments.TryGetValue("limit", out var limitValue) && limitValue is not null
-            ? Math.Max(1, ToIntValue(limitValue, "limit"))
+            ? Math.Clamp(ToIntValue(limitValue, "limit"), 1, _maxLimit)
             : 20;
 
         var entries = await _memoryStore.GetBySessionAsync(sessionId, limit, cancellationToken).ConfigureAwait(false);

--- a/src/gateway/BotNexus.Memory/Tools/MemorySearchTool.cs
+++ b/src/gateway/BotNexus.Memory/Tools/MemorySearchTool.cs
@@ -17,6 +17,7 @@ public sealed class MemorySearchTool : IAgentTool
     private readonly IAgentMemory _agentMemory;
     private readonly string _agentId;
     private readonly int _defaultTopK;
+    private readonly int _maxTopK;
     private readonly ISharedMemoryStoreRegistry? _sharedRegistry;
 
     public MemorySearchTool(IAgentMemory agentMemory, string agentId, MemoryAgentConfig? config = null, ISharedMemoryStoreRegistry? sharedRegistry = null)
@@ -26,6 +27,7 @@ public sealed class MemorySearchTool : IAgentTool
             ? throw new ArgumentException("Agent ID is required.", nameof(agentId))
             : agentId;
         _defaultTopK = Math.Max(1, config?.Search?.DefaultTopK ?? 10);
+        _maxTopK = Math.Max(_defaultTopK, config?.Search?.MaxTopK ?? 100);
         _sharedRegistry = sharedRegistry;
     }
 
@@ -46,7 +48,7 @@ public sealed class MemorySearchTool : IAgentTool
                 },
                 "topK": {
                   "type": "integer",
-                  "description": "Maximum number of results to return (default: 10)"
+                  "description": "Maximum number of results to return (default: 10). Values above the configured ceiling are clamped."
                 },
                 "scope": {
                   "type": "string",
@@ -119,7 +121,7 @@ public sealed class MemorySearchTool : IAgentTool
 
         var query = ToStringValue(arguments["query"]) ?? string.Empty;
         var topK = arguments.TryGetValue("topK", out var topKValue) && topKValue is not null
-            ? Math.Max(1, ToIntValue(topKValue, "topK"))
+            ? Math.Clamp(ToIntValue(topKValue, "topK"), 1, _maxTopK)
             : _defaultTopK;
         var scope = arguments.TryGetValue("scope", out var scopeValue) && scopeValue is not null
             ? ToStringValue(scopeValue) ?? "all"

--- a/tests/gateway/BotNexus.Memory.Tests/Tools/MemoryToolCeilingTests.cs
+++ b/tests/gateway/BotNexus.Memory.Tests/Tools/MemoryToolCeilingTests.cs
@@ -1,0 +1,176 @@
+using BotNexus.Agent.Core.Types;
+using BotNexus.Gateway.Abstractions.Agents;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Memory.Tests.TestInfrastructure;
+using BotNexus.Memory.Tools;
+using System.IO.Abstractions;
+
+namespace BotNexus.Memory.Tests.Tools;
+
+/// <summary>
+/// Verifies that <see cref="MemoryGetTool"/> and <see cref="MemorySearchTool"/> clamp the
+/// caller-supplied <c>limit</c> / <c>topK</c> to a configured upper bound. Without a ceiling an
+/// agent (or a poisoned cron prompt) could request an enormous value and drive an unbounded
+/// fetch plus serialization of the entire store into a single tool result.
+/// </summary>
+public sealed class MemoryToolCeilingTests
+{
+    // -------------------- MemoryGetTool.limit --------------------
+
+    [Fact]
+    public async Task MemoryGet_LimitAboveCeiling_IsClampedToMaxLimit()
+    {
+        await using var context = await MemoryStoreTestContext.CreateAsync();
+        // Insert more entries than the (deliberately tiny) ceiling so the clamp is observable.
+        for (var i = 0; i < 5; i++)
+        {
+            await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry(
+                $"entry-{i}", "agent-a", $"content-{i}", sessionId: "session-1",
+                createdAt: DateTimeOffset.UtcNow.AddSeconds(i)));
+        }
+
+        var tool = new MemoryGetTool(context.Store, maxLimit: 2);
+
+        var result = await tool.ExecuteAsync(
+            "call-1",
+            new Dictionary<string, object?> { ["sessionId"] = "session-1", ["limit"] = 1000 });
+
+        // Clamped to 2 entries despite requesting 1000.
+        GetText(result).ShouldContain("Session 'session-1' memories (2):");
+    }
+
+    [Fact]
+    public async Task MemoryGet_LimitWithinCeiling_IsHonoured()
+    {
+        await using var context = await MemoryStoreTestContext.CreateAsync();
+        for (var i = 0; i < 5; i++)
+        {
+            await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry(
+                $"entry-{i}", "agent-a", $"content-{i}", sessionId: "session-1",
+                createdAt: DateTimeOffset.UtcNow.AddSeconds(i)));
+        }
+
+        var tool = new MemoryGetTool(context.Store, maxLimit: 100);
+
+        var result = await tool.ExecuteAsync(
+            "call-2",
+            new Dictionary<string, object?> { ["sessionId"] = "session-1", ["limit"] = 3 });
+
+        GetText(result).ShouldContain("Session 'session-1' memories (3):");
+    }
+
+    [Fact]
+    public async Task MemoryGet_LimitBelowOne_IsClampedToOne()
+    {
+        await using var context = await MemoryStoreTestContext.CreateAsync();
+        for (var i = 0; i < 3; i++)
+        {
+            await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry(
+                $"entry-{i}", "agent-a", $"content-{i}", sessionId: "session-1",
+                createdAt: DateTimeOffset.UtcNow.AddSeconds(i)));
+        }
+
+        var tool = new MemoryGetTool(context.Store, maxLimit: 100);
+
+        var result = await tool.ExecuteAsync(
+            "call-3",
+            new Dictionary<string, object?> { ["sessionId"] = "session-1", ["limit"] = 0 });
+
+        GetText(result).ShouldContain("Session 'session-1' memories (1):");
+    }
+
+    [Fact]
+    public void MemoryGet_DefaultMaxLimit_IsOneHundred()
+        => MemoryGetTool.DefaultMaxLimit.ShouldBe(100);
+
+    // -------------------- MemorySearchTool.topK --------------------
+
+    [Fact]
+    public async Task MemorySearch_TopKAboveCeiling_IsClampedToMaxTopK()
+    {
+        await using var context = await MemoryStoreTestContext.CreateAsync();
+        // Insert more matching entries than the tiny MaxTopK so the clamp limits the result set.
+        for (var i = 0; i < 6; i++)
+        {
+            await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry(
+                $"entry-{i}", "agent-a", "searchablememorytext",
+                createdAt: DateTimeOffset.UtcNow.AddSeconds(i)));
+        }
+
+        var config = new MemoryAgentConfig { Search = new MemorySearchAgentConfig { DefaultTopK = 1, MaxTopK = 2 } };
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a", config);
+
+        var result = await tool.ExecuteAsync(
+            "call-4",
+            new Dictionary<string, object?> { ["query"] = "searchablememorytext", ["topK"] = 1000 });
+
+        // Clamped to 2 results despite requesting 1000.
+        GetText(result).ShouldContain("Found 2 memory entries:");
+    }
+
+    [Fact]
+    public async Task MemorySearch_TopKWithinCeiling_IsHonoured()
+    {
+        await using var context = await MemoryStoreTestContext.CreateAsync();
+        for (var i = 0; i < 6; i++)
+        {
+            await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry(
+                $"entry-{i}", "agent-a", "searchablememorytext",
+                createdAt: DateTimeOffset.UtcNow.AddSeconds(i)));
+        }
+
+        var config = new MemoryAgentConfig { Search = new MemorySearchAgentConfig { MaxTopK = 100 } };
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a", config);
+
+        var result = await tool.ExecuteAsync(
+            "call-5",
+            new Dictionary<string, object?> { ["query"] = "searchablememorytext", ["topK"] = 3 });
+
+        GetText(result).ShouldContain("Found 3 memory entries:");
+    }
+
+    [Fact]
+    public async Task MemorySearch_MaxTopKNeverBelowDefaultTopK()
+    {
+        // A misconfigured MaxTopK lower than DefaultTopK must not throttle the default below itself.
+        await using var context = await MemoryStoreTestContext.CreateAsync();
+        for (var i = 0; i < 8; i++)
+        {
+            await context.Store.InsertAsync(MemoryStoreTestContext.CreateEntry(
+                $"entry-{i}", "agent-a", "searchablememorytext",
+                createdAt: DateTimeOffset.UtcNow.AddSeconds(i)));
+        }
+
+        // DefaultTopK 5 but MaxTopK misconfigured to 1 -> effective ceiling floors at DefaultTopK (5).
+        var config = new MemoryAgentConfig
+        {
+            Search = new MemorySearchAgentConfig { DefaultTopK = 5, MaxTopK = 1 }
+        };
+        var agentMemory = CreateAgentMemory(context);
+        var tool = new MemorySearchTool(agentMemory, "agent-a", config);
+
+        var result = await tool.ExecuteAsync(
+            "call-6",
+            new Dictionary<string, object?> { ["query"] = "searchablememorytext", ["topK"] = 1000 });
+
+        GetText(result).ShouldContain("Found 5 memory entries:");
+    }
+
+    private static MarkdownAgentMemory CreateAgentMemory(MemoryStoreTestContext context)
+        => new("agent-a", new StubWorkspaceManager(), context.Store, new FileSystem());
+
+    private static string GetText(AgentToolResult result)
+        => result.Content.Single(content => content.Type == AgentToolContentType.Text).Value;
+
+    private sealed class StubWorkspaceManager : IAgentWorkspaceManager
+    {
+        public Task<AgentWorkspace> LoadWorkspaceAsync(string agentName, CancellationToken ct = default)
+            => Task.FromResult(new AgentWorkspace(agentName, Soul: "", Identity: "", User: "", Memory: ""));
+        public Task SaveMemoryAsync(string agentName, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SaveMemoryAsync(string agentName, string? filePath, string content, string? memoryPathOverride, CancellationToken ct = default) => Task.CompletedTask;
+        public string GetWorkspacePath(string agentName) => $@"C:\agents\{agentName}\workspace";
+    }
+}


### PR DESCRIPTION
Closes #1351

## Changes
\memory_get.limit\ and \memory_search.topK\ previously applied only a lower floor (\Math.Max(1, ...)\) with **no upper bound**. An agent (or a poisoned cron prompt) could pass \	opK: 1_000_000\ and drive an unbounded vector/embedding fetch plus serialization of the entire store into a single tool result.

- Added \MaxTopK\ (default **100**) and \MaxLimit\ (default **100**) to \MemorySearchAgentConfig\.
- \MemorySearchTool\: clamps \	opK\ to \[1, MaxTopK]\; the effective ceiling is floored at \DefaultTopK\ so a misconfigured \MaxTopK\ below the default cannot throttle the default itself.
- \MemoryGetTool\: clamps \limit\ to \[1, MaxLimit]\ via an **optional** \maxLimit\ constructor parameter (default \DefaultMaxLimit = 100\) so the production registration call site is unchanged — **no edit to \InProcessIsolationStrategy.cs\** (which is locked by open PR #1342).
- Schema \description\s for both \	opK\ and \limit\ now advertise that over-ceiling values are clamped.
- Docs: \memory.search.maxTopK\ / \memory.search.maxLimit\ rows added to \docs/user-guide/configuration.md\.

Mirrors the existing \KnowledgeSearchTool\ clamp pattern and the runaway-resource hardening already applied in #1339 / #1342 / #1346.

## Tests
New \MemoryToolCeilingTests\ (7 cases): over-ceiling clamp + within-ceiling honoured for both tools, below-one clamp, default ceiling constant, and the \MaxTopK >= DefaultTopK\ floor.

\	est-impacted.ps1\: Architecture 178, Memory 157, Gateway 2868, Scenarios 29 — all green. Full solution build clean.

## Merge Notes
Independent of every open PR. Deliberately avoids \InProcessIsolationStrategy.cs\ (locked by #1342) by wiring the \MemoryGetTool\ ceiling through an optional constructor default. \MemorySearchTool\ reads the ceiling from the \MemoryAgentConfig\ it already receives. Safe to merge in any order.