### PR TITLE
fix(tools): bound process output tail to a configurable ceiling

### DIFF
--- a/docs/extensions/process-tool.md
+++ b/docs/extensions/process-tool.md
@@ -25,7 +25,7 @@ The Process Tool enables agents to manage background processes that were started
 | `action` | string | Yes | Action to perform: `status`, `output`, `input`, `kill`, or `list`. |
 | `pid` | integer | Conditional | Process ID. Required for `status`, `output`, `input`, and `kill`. |
 | `content` | string | Conditional | Content to send to stdin (for `input` action). |
-| `tail` | integer | No | Number of lines from end of output (for `output` action). Default: 50. |
+| `tail` | integer | No | Number of lines from end of output (for `output` action). Default: 50. Values above the configured ceiling (`MaxTail`, default 10,000) are clamped; `tail <= 0` still returns the full captured buffer. |
 | `timeout` | integer | No | For `status` action: wait up to N ms for the process to produce output. Default: 0 (no wait). |
 
 ## Actions
@@ -53,6 +53,11 @@ Terminates a running process and its entire process tree.
 ## Configuration
 
 The Process Tool is enabled by default alongside the Exec Tool. No additional configuration is required.
+
+Captured output is bounded two ways:
+
+- The per-process output buffer is a circular buffer capped at 100 KB.
+- The `output` action's `tail` parameter is clamped to a configurable ceiling, `MaxTail` (default **10,000** lines), so a single read cannot request an unbounded number of trailing lines. A non-positive `tail` keeps its documented meaning of "return the full buffer".
 
 ## Usage Examples
 

--- a/src/extensions/BotNexus.Extensions.ProcessTool/ProcessTool.cs
+++ b/src/extensions/BotNexus.Extensions.ProcessTool/ProcessTool.cs
@@ -13,12 +13,16 @@ namespace BotNexus.Extensions.ProcessTool;
 public sealed class ProcessTool : IAgentTool
 {
     private readonly ProcessManager _manager;
+    private readonly ProcessToolOptions _options;
 
-    public ProcessTool() : this(ProcessManager.Instance) { }
+    public ProcessTool() : this(ProcessManager.Instance, ProcessToolOptions.Default) { }
 
-    internal ProcessTool(ProcessManager manager)
+    internal ProcessTool(ProcessManager manager) : this(manager, ProcessToolOptions.Default) { }
+
+    internal ProcessTool(ProcessManager manager, ProcessToolOptions options)
     {
         _manager = manager;
+        _options = options ?? ProcessToolOptions.Default;
     }
 
     public string Name => "process";
@@ -46,7 +50,7 @@ public sealed class ProcessTool : IAgentTool
                 },
                 "tail": {
                   "type": "integer",
-                  "description": "Number of lines from end of output (for output action). Default: 50."
+                  "description": "Number of lines from end of output (for output action). Default: 50. Values above the configured ceiling are clamped."
                 },
                 "timeout": {
                   "type": "integer",
@@ -143,7 +147,10 @@ public sealed class ProcessTool : IAgentTool
         if (process is null)
             return TextResult($"No tracked process with PID {pid}.");
 
-        var tail = ReadInt(arguments, "tail") ?? 50;
+        // Preserve the "tail <= 0 means full output" convention; only bound the upper end so a
+        // huge positive value cannot request more than the configured ceiling of trailing lines.
+        var requestedTail = ReadInt(arguments, "tail") ?? 50;
+        var tail = requestedTail > _options.MaxTail ? _options.MaxTail : requestedTail;
         var output = process.GetOutput(tail);
 
         return TextResult(string.IsNullOrEmpty(output)
@@ -215,14 +222,28 @@ public sealed class ProcessTool : IAgentTool
         if (!args.TryGetValue(key, out var value) || value is null) return null;
         return value switch
         {
-            JsonElement { ValueKind: JsonValueKind.Number } el => el.GetInt32(),
+            JsonElement { ValueKind: JsonValueKind.Number } el => ReadJsonNumber(el),
             JsonElement el when int.TryParse(el.ToString(), out var n) => n,
             int n => n,
-            long l => (int)l,
+            long l => ClampLong(l),
             _ when int.TryParse(value.ToString(), out var n) => n,
             _ => null
         };
     }
+
+    // Tolerate out-of-range JSON numbers (e.g. tail: 99999999999) instead of throwing from
+    // GetInt32(); the caller clamps the value, so saturating to int bounds is the safe behaviour.
+    private static int? ReadJsonNumber(JsonElement element)
+    {
+        if (element.TryGetInt32(out var i)) return i;
+        if (element.TryGetInt64(out var l)) return ClampLong(l);
+        if (element.TryGetDouble(out var d))
+            return (int)Math.Clamp(d, int.MinValue, (double)int.MaxValue);
+        return null;
+    }
+
+    private static int ClampLong(long value)
+        => (int)Math.Clamp(value, int.MinValue, int.MaxValue);
 
     private static AgentToolResult TextResult(string text)
         => new([new AgentToolContent(AgentToolContentType.Text, text)]);

--- a/src/extensions/BotNexus.Extensions.ProcessTool/ProcessToolOptions.cs
+++ b/src/extensions/BotNexus.Extensions.ProcessTool/ProcessToolOptions.cs
@@ -1,0 +1,18 @@
+namespace BotNexus.Extensions.ProcessTool;
+
+/// <summary>
+/// Configuration for <see cref="ProcessTool"/>. Currently bounds the <c>output</c> action's
+/// <c>tail</c> parameter so an agent (or a poisoned cron prompt) cannot pull the entire captured
+/// ring buffer into a single tool result with an absurd line count.
+/// </summary>
+public sealed class ProcessToolOptions
+{
+    /// <summary>
+    /// Maximum number of trailing lines the <c>output</c> action may return. Caller-supplied
+    /// <c>tail</c> values above this ceiling are clamped. Defaults to 10,000 lines.
+    /// </summary>
+    public int MaxTail { get; set; } = 10_000;
+
+    /// <summary>Shared default instance used when no options are injected.</summary>
+    public static ProcessToolOptions Default { get; } = new();
+}

--- a/tests/extensions/BotNexus.Extensions.ProcessTool.Tests/ProcessToolTailCeilingTests.cs
+++ b/tests/extensions/BotNexus.Extensions.ProcessTool.Tests/ProcessToolTailCeilingTests.cs
@@ -1,0 +1,156 @@
+using System.Diagnostics;
+using System.Text.Json;
+using BotNexus.Agent.Core.Types;
+using BotNexus.Extensions.ProcessTool;
+
+namespace BotNexus.Extensions.ProcessTool.Tests;
+
+/// <summary>
+/// Verifies that <see cref="ProcessTool"/>'s <c>output</c> action clamps the caller-supplied
+/// <c>tail</c> to a configured ceiling, and tolerates out-of-range JSON numbers instead of
+/// throwing. Without the clamp, an agent could request an enormous tail and pull the entire
+/// captured ring buffer into one tool result.
+/// </summary>
+public sealed class ProcessToolTailCeilingTests : IDisposable
+{
+    private readonly ProcessManager _manager = new();
+    private readonly List<ManagedProcess> _spawned = [];
+
+    public void Dispose()
+    {
+        _manager.Clear();
+        foreach (var p in _spawned)
+            p.Dispose();
+    }
+
+    [Fact]
+    public async Task Output_TailAboveCeiling_IsClampedToMaxTail()
+    {
+        var tool = new ProcessTool(_manager, new ProcessToolOptions { MaxTail = 3 });
+        var managed = SpawnFiveLineProcess();
+        managed.WaitForExit(5_000);
+        await WaitForOutputAsync(tool, managed.Pid, "line5");
+
+        // Request 1000 lines but MaxTail is 3 -> only the last few lines should come back,
+        // and the earliest lines must be excluded by the ceiling.
+        var result = await tool.ExecuteAsync("c1", Args("output", pid: managed.Pid, tail: 1000));
+        var text = ResultText(result);
+
+        text.ShouldContain("line5");
+        text.ShouldContain("line4");
+        text.ShouldNotContain("line1");
+        text.ShouldNotContain("line2");
+    }
+
+    [Fact]
+    public async Task Output_OutOfRangeTailNumber_DoesNotThrowAndIsClamped()
+    {
+        var tool = new ProcessTool(_manager, new ProcessToolOptions { MaxTail = 3 });
+        var managed = SpawnFiveLineProcess();
+        managed.WaitForExit(5_000);
+        await WaitForOutputAsync(tool, managed.Pid, "line5");
+
+        // A JSON number larger than int.MaxValue would throw from GetInt32(); it must be tolerated
+        // and then bounded by MaxTail (3) so line1/line2 are excluded.
+        var args = ParseArgs($$"""{ "action": "output", "pid": {{managed.Pid}}, "tail": 99999999999 }""");
+        var result = await tool.ExecuteAsync("c2", args);
+        var text = ResultText(result);
+
+        text.ShouldContain("line5");
+        text.ShouldNotContain("line1");
+    }
+
+    [Fact]
+    public async Task Output_NonPositiveTail_StillReturnsFullOutput()
+    {
+        // Preserve the documented convention: tail <= 0 means "return full output". The ceiling
+        // bounds only the upper end, so a non-positive sentinel must be unaffected.
+        var tool = new ProcessTool(_manager, new ProcessToolOptions { MaxTail = 3 });
+        var managed = SpawnFiveLineProcess();
+        managed.WaitForExit(5_000);
+        await WaitForOutputAsync(tool, managed.Pid, "line5");
+
+        var result = await tool.ExecuteAsync("c3", Args("output", pid: managed.Pid, tail: 0));
+        var text = ResultText(result);
+
+        text.ShouldContain("line1");
+        text.ShouldContain("line5");
+    }
+
+    [Fact]
+    public async Task Output_TailBelowCeiling_IsHonoured()
+    {
+        // A positive tail under the ceiling passes through unchanged.
+        var tool = new ProcessTool(_manager, new ProcessToolOptions { MaxTail = 100 });
+        var managed = SpawnFiveLineProcess();
+        managed.WaitForExit(5_000);
+        await WaitForOutputAsync(tool, managed.Pid, "line5");
+
+        var result = await tool.ExecuteAsync("c4", Args("output", pid: managed.Pid, tail: 2));
+        var text = ResultText(result);
+
+        text.ShouldContain("line5");
+        text.ShouldNotContain("line1");
+    }
+
+    [Fact]
+    public void Default_MaxTail_IsTenThousand()
+        => ProcessToolOptions.Default.MaxTail.ShouldBe(10_000);
+
+    // ───────────── helpers ─────────────
+
+    private ManagedProcess SpawnFiveLineProcess()
+    {
+        var (file, args) = OperatingSystem.IsWindows()
+            ? ("cmd.exe", "/c echo line1 & echo line2 & echo line3 & echo line4 & echo line5")
+            : ("/bin/bash", "-lc \"echo line1; echo line2; echo line3; echo line4; echo line5\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = file,
+            Arguments = args,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        var process = Process.Start(psi)!;
+        var managed = new ManagedProcess(process, "five-line", DateTimeOffset.UtcNow);
+        _spawned.Add(managed);
+        _manager.Register(process.Id, managed);
+        return managed;
+    }
+
+    private static async Task WaitForOutputAsync(ProcessTool tool, int pid, string expected)
+    {
+        var timeoutAt = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < timeoutAt)
+        {
+            var result = await tool.ExecuteAsync("wait", Args("output", pid: pid, tail: 100));
+            if (ResultText(result).Contains(expected, StringComparison.Ordinal))
+                return;
+            await Task.Delay(100);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, object?> Args(string action, int? pid = null, int? tail = null)
+    {
+        var dict = new Dictionary<string, object?> { ["action"] = action };
+        if (pid is not null) dict["pid"] = pid;
+        if (tail is not null) dict["tail"] = tail;
+        return dict;
+    }
+
+    private static IReadOnlyDictionary<string, object?> ParseArgs(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var dict = new Dictionary<string, object?>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            dict[prop.Name] = prop.Value.Clone();
+        return dict;
+    }
+
+    private static string ResultText(AgentToolResult result)
+        => string.Join("", result.Content.Select(c => c.Value));
+}


### PR DESCRIPTION
Closes #1352

## Changes
The process tool's \output\ action read \	ail\ with **no upper bound** and passed it straight to \GetOutput\, and \ReadInt\ threw from \GetInt32()\ on JSON numbers larger than \int\ (same fragility class as #1338). A huge \	ail\ could pull the entire captured ring buffer into a single tool result.

- Added \ProcessToolOptions\ with \MaxTail\ (default **10,000** lines) and an internal \ProcessTool(ProcessManager, ProcessToolOptions)\ constructor seam for testing.
- \HandleOutput\ caps a **positive** \	ail\ at \MaxTail\ while **preserving the documented \	ail <= 0\ means "return full output" convention** (only the upper end is bounded; the buffer itself is already capped at 100 KB).
- \ReadInt\ now tolerates out-of-range JSON numbers by saturating to \int\ bounds (\TryGetInt32\ → \TryGetInt64\ → \TryGetDouble\) instead of throwing.
- Schema \description\ for \	ail\ advertises the ceiling and the \<= 0\ behaviour.
- Docs: \docs/extensions/process-tool.md\ parameter table + Configuration section updated.

## Tests
New \ProcessToolTailCeilingTests\ (4 cases): over-ceiling clamp excludes earliest lines, out-of-range JSON number tolerated + clamped, non-positive \	ail\ still returns full output, positive \	ail\ below ceiling honoured. The pre-existing \Output_WithNonPositiveTail_ReturnsFullOutput\ contract test still passes (an earlier blanket \Math.Clamp(..., 1, ...)\ broke it — caught by the full test run and corrected).

\	est-impacted.ps1\: Architecture 178, ProcessTool 58, Scenarios 29 — all green. Full solution build clean.

## Merge Notes
Self-contained to \BotNexus.Extensions.ProcessTool\. Zero file overlap with any open PR. Safe to merge in any order.