### PR TITLE
fix(tools): clamp grep limit to a configurable ceiling

### DIFF
--- a/src/gateway/BotNexus.Tools/GrepTool.cs
+++ b/src/gateway/BotNexus.Tools/GrepTool.cs
@@ -17,6 +17,14 @@ namespace BotNexus.Tools;
 public sealed class GrepTool : IAgentTool
 {
     private const int DefaultLimit = 100;
+
+    /// <summary>
+    /// Upper bound for the agent-supplied <c>limit</c>/<c>max_results</c> argument. The result list is
+    /// pre-allocated with this value, so an unbounded <c>limit</c> would let a single call request a
+    /// multi-billion-element list and throw <see cref="OutOfMemoryException"/> before any output-size
+    /// protection runs. Clamping at read time keeps the allocation bounded. Matches GlobTool's fixed cap.
+    /// </summary>
+    private const int MaxLimit = 1000;
     private const int MaxOutputBytes = 50 * 1024;
     private const int MaxLineLength = 500;
     private const int BinaryProbeBytes = 4096;
@@ -150,7 +158,7 @@ public sealed class GrepTool : IAgentTool
                 throw new ArgumentOutOfRangeException(nameof(arguments), "limit must be greater than 0.");
             }
 
-            prepared["limit"] = limit;
+            prepared["limit"] = Math.Min(limit, MaxLimit);
         }
         else if (arguments.TryGetValue("max_results", out var maxResultsObj) && maxResultsObj is not null)
         {
@@ -160,7 +168,7 @@ public sealed class GrepTool : IAgentTool
                 throw new ArgumentOutOfRangeException(nameof(arguments), "max_results must be greater than 0.");
             }
 
-            prepared["limit"] = maxResults;
+            prepared["limit"] = Math.Min(maxResults, MaxLimit);
         }
 
         return Task.FromResult<IReadOnlyDictionary<string, object?>>(prepared);
@@ -193,6 +201,11 @@ public sealed class GrepTool : IAgentTool
         var maxResults = arguments.TryGetValue("limit", out var maxObj) && maxObj is int parsedMax
             ? parsedMax
             : DefaultLimit;
+
+        // Defence-in-depth: PrepareArgumentsAsync already clamps to [1, MaxLimit], but a direct caller
+        // could pass an out-of-range value straight to ExecuteAsync. Clamp again before pre-allocating
+        // the result list so capacity can never exceed MaxLimit (avoids OutOfMemoryException).
+        maxResults = Math.Clamp(maxResults, 1, MaxLimit);
         var include = arguments.TryGetValue("glob", out var includeObj) ? includeObj?.ToString() : null;
 
         var rawPath = arguments.TryGetValue("path", out var pathObj) && pathObj is not null

--- a/tests/gateway/BotNexus.Gateway.Tests/Tools/GrepToolLimitCeilingTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Tools/GrepToolLimitCeilingTests.cs
@@ -1,0 +1,131 @@
+using BotNexus.Tools;
+
+namespace BotNexus.Gateway.Tests.Tools;
+
+/// <summary>
+/// Covers the upper-bound clamp on GrepTool's <c>limit</c>/<c>max_results</c> argument. Without a ceiling,
+/// the agent-supplied value flows into <c>new List&lt;string&gt;(capacity: maxResults)</c> and a multi-billion
+/// value throws <see cref="OutOfMemoryException"/>/<see cref="ArgumentOutOfRangeException"/> before any
+/// output-size protection runs. See issue #1358.
+/// </summary>
+public sealed class GrepToolLimitCeilingTests : IDisposable
+{
+    private const int MaxLimit = 1000;
+
+    private readonly string _tempDirectory =
+        Path.Combine(Path.GetTempPath(), $"botnexus-grep-limit-{Guid.NewGuid():N}");
+    private readonly GrepTool _tool;
+
+    public GrepToolLimitCeilingTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        _tool = new GrepTool(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenLimitExceedsCeiling_ClampsToMaxLimit()
+    {
+        var prepared = await _tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+        {
+            ["pattern"] = "x",
+            ["limit"] = MaxLimit + 5_000
+        });
+
+        prepared["limit"].ShouldBe(MaxLimit);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenMaxResultsAliasExceedsCeiling_ClampsToMaxLimit()
+    {
+        var prepared = await _tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+        {
+            ["pattern"] = "x",
+            ["max_results"] = int.MaxValue
+        });
+
+        prepared["limit"].ShouldBe(MaxLimit);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenLimitWithinCeiling_PreservesValue()
+    {
+        var prepared = await _tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+        {
+            ["pattern"] = "x",
+            ["limit"] = 250
+        });
+
+        prepared["limit"].ShouldBe(250);
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenLimitIsZero_StillRejects()
+    {
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await _tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+            {
+                ["pattern"] = "x",
+                ["limit"] = 0
+            }));
+    }
+
+    [Fact]
+    public async Task PrepareArgumentsAsync_WhenLimitIsNegative_StillRejects()
+    {
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await _tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+            {
+                ["pattern"] = "x",
+                ["limit"] = -1
+            }));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLimitIsEnormous_DoesNotThrowAndReturnsBoundedResults()
+    {
+        // A single file with a handful of matches; an unbounded limit previously pre-allocated a
+        // List<string> with int.MaxValue capacity and threw before reaching this point.
+        await File.WriteAllTextAsync(
+            Path.Combine(_tempDirectory, "sample.txt"),
+            "match\nmatch\nmatch");
+
+        // Execute receives the already-prepared (clamped) limit, but pass the raw enormous value to
+        // ExecuteAsync directly to exercise the defence-in-depth clamp on the allocation path.
+        var result = await _tool.ExecuteAsync("test-call", new Dictionary<string, object?>
+        {
+            ["pattern"] = "match",
+            ["limit"] = int.MaxValue
+        });
+
+        result.Content.ShouldNotBeEmpty();
+        result.Content[0].Value.ShouldContain("sample.txt:1: match");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLimitWithinCeiling_TruncatesAtRequestedLimit()
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_tempDirectory, "many.txt"),
+            "match\nmatch\nmatch\nmatch");
+
+        var prepared = await _tool.PrepareArgumentsAsync(new Dictionary<string, object?>
+        {
+            ["pattern"] = "match",
+            ["limit"] = 2
+        });
+
+        var result = await _tool.ExecuteAsync("test-call", prepared);
+
+        var lines = result.Content[0].Value.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        lines.Count(line => line.StartsWith("many.txt:", StringComparison.Ordinal)).ShouldBe(2);
+        result.Content[0].Value.ShouldContain("[warning] Results truncated at 2 matches.");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1358

## Changes
`GrepTool` pre-allocated its result list with the agent-supplied, unbounded `limit`:

```csharp
var maxResults = ... ? parsedMax : DefaultLimit;   // DefaultLimit = 100
var matches = new List<string>(capacity: maxResults);   // agent-controlled capacity
```

`PrepareArgumentsAsync` only enforced `limit > 0` (no ceiling), so `limit: 2000000000` threw
`OutOfMemoryException`/`ArgumentOutOfRangeException` from the `List<T>` constructor **before** any
of the existing output protections (`MaxOutputBytes`, the `matchCount >= maxResults` break) ran.

- Added `GrepTool.MaxLimit = 1000` (matches `GlobTool.MaxResults`).
- `PrepareArgumentsAsync`: clamp `limit` and the `max_results` alias to `[1, MaxLimit]` via `Math.Min`,
  keeping the existing `<= 0` rejection (lower-bound errors still throw; upper bound clamps, mirroring
  #1353/#1354/#1355).
- `ExecuteAsync`: re-clamp `maxResults` with `Math.Clamp(maxResults, 1, MaxLimit)` before the
  `new List<string>(capacity: …)` allocation as defence-in-depth (a direct caller cannot over-allocate).

This is the remaining uncapped numeric input in `BotNexus.Tools`, completing the unbounded-input
hardening series (#1338/#1339, #1341/#1342, #1344/#1346, #1348/#1349, #1351/#1353, #1352/#1354,
#1350/#1355).

## Tests
New `GrepToolLimitCeilingTests` (7 tests) in the in-slnx `BotNexus.Gateway.Tests` project (the existing
`GrepToolTests` live in `BotNexus.CodingAgent.Tests`, which is orphaned from the slnx and does not run in
CI — see #1356/#1357):
- `limit`/`max_results` above the ceiling clamp to `MaxLimit`
- `limit` within the ceiling is preserved
- `limit <= 0` and negative still rejected
- `limit: int.MaxValue` no longer throws and returns bounded results
- existing truncation behaviour (default 100, byte cap, warnings) unchanged

Verification: full solution build clean (0 warnings); `test-impacted.ps1` green — Architecture 178,
Scenarios 29, Gateway.Tests 2875 (incl. the 7 new), Cli 282, Mcp 186, Conversations 192.

## Merge Notes
Touches only `src/gateway/BotNexus.Tools/GrepTool.cs` and a new test file in `BotNexus.Gateway.Tests` —
no overlap with any open PR. Merge in any order. Same change class as the other unbounded-input PRs;
independent of all of them.
