### PR TITLE
feat(prompts): expose session identity in the agent runtime line

### DIFF
--- a/src/gateway/BotNexus.Gateway.Prompts/PromptRuntimeInfo.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/PromptRuntimeInfo.cs
@@ -45,4 +45,15 @@ public sealed record PromptRuntimeInfo
     /// Gets or sets the capabilities.
     /// </summary>
     public IReadOnlyList<string>? Capabilities { get; init; }
+    /// <summary>
+    /// Gets the agent's own session id for the active run, so the agent can reference
+    /// and target itself at runtime (for example for self-diagnosis or session-scoped tooling).
+    /// </summary>
+    public string? SessionId { get; init; }
+    /// <summary>
+    /// Gets the agent's own session key (channel-scoped routing identifier) for the active run.
+    /// Emitted separately from <see cref="SessionId"/> because the two identify the session at
+    /// different layers (persistence id vs channel routing key).
+    /// </summary>
+    public string? SessionKey { get; init; }
 }

--- a/src/gateway/BotNexus.Gateway.Prompts/RuntimeLineFormatter.cs
+++ b/src/gateway/BotNexus.Gateway.Prompts/RuntimeLineFormatter.cs
@@ -16,6 +16,8 @@ public static class RuntimeLineFormatter
         var parts = new List<string>
         {
             !string.IsNullOrWhiteSpace(runtime?.AgentId) ? $"agent={runtime!.AgentId}" : string.Empty,
+            !string.IsNullOrWhiteSpace(runtime?.SessionId) ? $"session={runtime!.SessionId}" : string.Empty,
+            !string.IsNullOrWhiteSpace(runtime?.SessionKey) ? $"session_key={runtime!.SessionKey}" : string.Empty,
             !string.IsNullOrWhiteSpace(runtime?.Host) ? $"host={runtime!.Host}" : string.Empty,
             !string.IsNullOrWhiteSpace(runtime?.Os)
                 ? $"os={runtime!.Os}{(!string.IsNullOrWhiteSpace(runtime.Arch) ? $" ({runtime.Arch})" : string.Empty)}"

--- a/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/SystemPromptBuilder.cs
@@ -23,6 +23,8 @@ public sealed record RuntimeInfo
     public string? Shell { get; init; }
     public string? Channel { get; init; }
     public IReadOnlyList<string>? Capabilities { get; init; }
+    public string? SessionId { get; init; }
+    public string? SessionKey { get; init; }
 }
 
 public sealed record ConversationContext(string ConversationId, string Title, string? Purpose, string? Instructions = null);
@@ -343,7 +345,9 @@ public static class SystemPromptBuilder
             DefaultModel = runtime.DefaultModel,
             Shell = runtime.Shell,
             Channel = runtime.Channel,
-            Capabilities = runtime.Capabilities
+            Capabilities = runtime.Capabilities,
+            SessionId = runtime.SessionId,
+            SessionKey = runtime.SessionKey
         });
     }
 

--- a/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
+++ b/src/gateway/BotNexus.Gateway/Agents/WorkspaceContextBuilder.cs
@@ -147,7 +147,8 @@ public sealed class WorkspaceContextBuilder : IContextBuilder
                 Os = Environment.OSVersion.ToString(),
                 Provider = descriptor.ApiProvider,
                 Model = descriptor.ModelId,
-                Channel = "signalr"
+                Channel = "signalr",
+                SessionId = executionContext?.SessionId.Value
             },
             HeartbeatPrompt = descriptor.Heartbeat?.Enabled == true
                 ? descriptor.Heartbeat.Prompt ?? "Read HEARTBEAT.md if it exists and execute any pending tasks. If nothing needs attention, reply HEARTBEAT_OK."

--- a/tests/gateway/BotNexus.Gateway.Prompts.Tests/RuntimeLineFormatterTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Prompts.Tests/RuntimeLineFormatterTests.cs
@@ -1,0 +1,126 @@
+using BotNexus.Gateway.Prompts;
+
+namespace BotNexus.Gateway.Prompts.Tests;
+
+public sealed class RuntimeLineFormatterTests
+{
+    [Fact]
+    public void BuildRuntimeLine_WithSessionId_EmitsSessionField()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            SessionId = "979279bc3ead433696aa0ce91bfecb90"
+        });
+
+        line.ShouldContain("session=979279bc3ead433696aa0ce91bfecb90");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_WithoutSessionId_OmitsSessionField()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth"
+        });
+
+        line.ShouldNotContain("session=");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_WithWhitespaceSessionId_OmitsSessionField()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            SessionId = "   "
+        });
+
+        line.ShouldNotContain("session=");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_WithSessionKey_EmitsSessionKeyField()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            SessionKey = "signalr:farnsworth:conv-123"
+        });
+
+        line.ShouldContain("session_key=signalr:farnsworth:conv-123");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_WithoutSessionKey_OmitsSessionKeyField()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            SessionId = "abc"
+        });
+
+        line.ShouldNotContain("session_key=");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_EmitsSessionAfterAgent()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            Host = "host-1",
+            SessionId = "sess-1"
+        });
+
+        // session should appear, and the agent field should precede it for readability.
+        var agentIndex = line.IndexOf("agent=", System.StringComparison.Ordinal);
+        var sessionIndex = line.IndexOf("session=", System.StringComparison.Ordinal);
+        agentIndex.ShouldBeGreaterThanOrEqualTo(0);
+        sessionIndex.ShouldBeGreaterThan(agentIndex);
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_WithBothSessionFields_EmitsBoth()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            SessionId = "sess-1",
+            SessionKey = "signalr:farnsworth:conv-9"
+        });
+
+        line.ShouldContain("session=sess-1");
+        line.ShouldContain("session_key=signalr:farnsworth:conv-9");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_NullRuntime_DoesNotThrowAndOmitsSession()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(null);
+
+        line.ShouldStartWith("Runtime:");
+        line.ShouldNotContain("session=");
+    }
+
+    [Fact]
+    public void BuildRuntimeLine_PreservesExistingFields_WithSessionAdded()
+    {
+        var line = RuntimeLineFormatter.BuildRuntimeLine(new PromptRuntimeInfo
+        {
+            AgentId = "farnsworth",
+            Host = "CPC-jobul",
+            Provider = "github-copilot",
+            Model = "claude-opus-4.8",
+            Channel = "signalr",
+            SessionId = "sess-42"
+        });
+
+        line.ShouldContain("agent=farnsworth");
+        line.ShouldContain("host=CPC-jobul");
+        line.ShouldContain("provider=github-copilot");
+        line.ShouldContain("model=claude-opus-4.8");
+        line.ShouldContain("channel=signalr");
+        line.ShouldContain("session=sess-42");
+    }
+}


### PR DESCRIPTION
Closes #1372

## Changes
Threads the agent's own session identity into the system-prompt runtime line so an agent can reference and target itself at runtime.

- `PromptRuntimeInfo` (Gateway.Prompts): add `SessionId` and `SessionKey` (both optional) with XML docs explaining the persistence-id vs channel-routing-key distinction.
- `RuntimeLineFormatter.BuildRuntimeLine`: emit `session=<id>` and `session_key=<key>` immediately after `agent=`, only when present (null/whitespace omitted), preserving all existing fields and the null-runtime path.
- `RuntimeInfo` (SystemPromptBuilder) + `buildRuntimeLine` mapping: carry the two new fields through.
- `WorkspaceContextBuilder`: populate `SessionId` from `executionContext?.SessionId.Value` (the active run's session). `SessionKey` is left null here because `AgentExecutionContext` carries no session key — the field stays available for callers that do have one.

Directly addresses the recurring "which session am I / how do I target myself" friction (e.g. `sessions_send`, self-diagnosis, autonomous maintenance runs).

## Tests
- New `RuntimeLineFormatterTests` (9 tests, in the in-slnx `BotNexus.Gateway.Prompts.Tests` project → runs in CI): emits/omits `session=` and `session_key=` on present/null/whitespace, field ordering (session after agent), both-present, null-runtime safety, and existing-fields-preserved.
- `BotNexus.Gateway.Prompts.Tests` 111 passing (was 102). `BotNexus.Gateway.Tests` 2868 passing (SystemPromptBuilder/WorkspaceContextBuilder consumers unaffected). Architecture 178, Scenarios 29. Full-solution build: 0 warnings, 0 errors.

## Merge Notes
Independent and safe to merge in any order. Touches only `RuntimeLineFormatter.cs`, `PromptRuntimeInfo.cs`, `SystemPromptBuilder.cs`, and `WorkspaceContextBuilder.cs` — none of which overlap with any other open PR. Purely additive (new optional fields + a conditional output segment); no behavioural change when the session fields are absent.