### PR TITLE
fix(telegram): add secure webhook receiver with secret-token validation

### DIFF
--- a/docs/user-guide/channels/telegram.md
+++ b/docs/user-guide/channels/telegram.md
@@ -56,7 +56,8 @@ DM your bot and it will respond via the configured agent.
       "streamingBufferMs": 500,
       "maxMessageLength": 4000,
       "processEditedMessages": false,
-      "webhookUrl": "string (optional)"
+      "webhookUrl": "string (optional)",
+      "webhookSecretToken": "string (optional)"
     }
   }
 }
@@ -73,6 +74,7 @@ DM your bot and it will respond via the configured agent.
 | `maxMessageLength` | int | `4000` | Characters before splitting long responses. |
 | `processEditedMessages` | bool | `false` | When `true`, edited messages are processed as new messages. |
 | `webhookUrl` | string | `null` | Set to enable webhook mode instead of polling (requires a public HTTPS URL). |
+| `webhookSecretToken` | string | `null` | Secret used to authenticate inbound webhook requests. When omitted in webhook mode, a strong token is generated automatically. Only used when `webhookUrl` is set. |
 
 ### Multiple bots
 
@@ -137,6 +139,7 @@ In a **group**, `chat.id` is the group's ID (a large negative number) and `from.
 | `from.id` in `allowedUserIds` | Inbound message is from an allowed sender |
 | `from` is non-null | Messages with no sender (channel posts) are rejected |
 | Edited messages | Ignored by default (`processEditedMessages: false`) |
+| Webhook secret token | In webhook mode, the `X-Telegram-Bot-Api-Secret-Token` header is validated (constant-time) before any update is processed; mismatches return HTTP 403 |
 
 ### Protecting your bot token
 
@@ -168,8 +171,39 @@ If the SignalR portal is also connected, messages from Telegram appear there too
 | Works behind NAT/VPN | Yes | Only with reverse proxy |
 | Latency | ~0.5s | ~0ms |
 | Setup complexity | None | Requires ingress config |
+| Inbound authentication | Bot token (held by gateway) | Secret token header (per request) |
 
 Long polling is the right default for self-hosted or home-lab setups. Set `webhookUrl` only if you already have a stable public HTTPS endpoint.
+
+### Webhook mode
+
+When `webhookUrl` is set, the adapter:
+
+1. Registers the URL with Telegram via `setWebhook`, including a **secret token**.
+2. Exposes a receiver endpoint at **`POST /telegram/webhook/{botName}`** (the `{botName}` segment is the key under `bots`, or `default` for a single-bot config).
+3. Validates the `X-Telegram-Bot-Api-Secret-Token` header on every inbound request (constant-time comparison) and rejects mismatches with HTTP 403 before any message is processed.
+
+Point `webhookUrl` at the public address of that receiver, e.g.:
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "botToken": "YOUR_BOT_TOKEN",
+      "agentId": "my-agent",
+      "allowedChatIds": [1234567890],
+      "allowedUserIds": [1234567890],
+      "webhookUrl": "https://your-host.example.com/telegram/webhook/default"
+    }
+  }
+}
+```
+
+The `webhookSecretToken` is optional — when omitted the adapter generates a cryptographically strong one at startup, so webhook mode is never unauthenticated. Set it explicitly only if you need a stable, known value (e.g. to coordinate with an external reverse proxy). Multi-bot configs append the bot name to the path: `/telegram/webhook/<botName>`.
+
+::: warning Webhook mode requires a public HTTPS endpoint
+The receiver must be reachable by Telegram over HTTPS with a valid certificate. The secret token authenticates that inbound requests genuinely came from Telegram; it does **not** replace the allow-lists, which are still enforced after the secret check exactly as in polling mode.
+:::
 
 ---
 

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/BotNexus.Extensions.Channels.Telegram.csproj
@@ -3,6 +3,10 @@
     <RootNamespace>BotNexus.Extensions.Channels.Telegram</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Required for the inbound webhook receiver (WebApplication, minimal-API endpoint mapping). -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <InternalsVisibleTo Include="BotNexus.Gateway.Tests" />
   </ItemGroup>
   <ItemGroup>
@@ -10,12 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\domain\BotNexus.Domain\BotNexus.Domain.csproj" />
+    <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Abstractions\BotNexus.Gateway.Abstractions.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Contracts\BotNexus.Gateway.Contracts.csproj" />
     <ProjectReference Include="..\..\gateway\BotNexus.Gateway.Channels\BotNexus.Gateway.Channels.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 </Project>

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotApiClient.cs
@@ -114,12 +114,21 @@ public sealed class TelegramBotApiClient(
     }
 
     /// <summary>
-    /// Registers a webhook URL with Telegram.
+    /// Registers a webhook URL with Telegram, including the secret token Telegram will echo back
+    /// in the <c>X-Telegram-Bot-Api-Secret-Token</c> header on every update POST.
     /// </summary>
-    public Task SetWebhookAsync(string url, CancellationToken cancellationToken = default)
+    /// <param name="url">Public HTTPS endpoint Telegram delivers updates to.</param>
+    /// <param name="secretToken">
+    /// 1–256 character token (<c>A-Z</c>, <c>a-z</c>, <c>0-9</c>, <c>_</c>, <c>-</c>) used to
+    /// authenticate inbound requests. When null/empty no secret is registered (not recommended).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task SetWebhookAsync(string url, string? secretToken, CancellationToken cancellationToken = default)
         => PostForResultAsync<bool>(
             "setWebhook",
-            new { url },
+            string.IsNullOrEmpty(secretToken)
+                ? new { url, allowed_updates = AllowedUpdateTypes }
+                : (object)new { url, secret_token = secretToken, allowed_updates = AllowedUpdateTypes },
             cancellationToken,
             allowMarkdownFallback: false);
 

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramBotConfig.cs
@@ -23,6 +23,21 @@ public sealed class TelegramBotConfig
     public string? WebhookUrl { get; set; }
 
     /// <summary>
+    /// Gets or sets the secret token used to authenticate inbound webhook requests.
+    /// </summary>
+    /// <remarks>
+    /// When webhook mode is active, this value is registered with Telegram via
+    /// <c>setWebhook</c>'s <c>secret_token</c> parameter; Telegram then echoes it back in the
+    /// <c>X-Telegram-Bot-Api-Secret-Token</c> header on every update POST. The receiver rejects
+    /// any request whose header does not match (constant-time comparison), which is the only thing
+    /// preventing an attacker who learns the public webhook URL from injecting forged updates.
+    /// When left null/empty the adapter generates a cryptographically strong token at startup, so
+    /// webhook mode is never silently unauthenticated. Allowed characters per the Bot API:
+    /// <c>A-Z</c>, <c>a-z</c>, <c>0-9</c>, <c>_</c> and <c>-</c>, length 1–256.
+    /// </remarks>
+    public string? WebhookSecretToken { get; set; }
+
+    /// <summary>
     /// Gets the allow-list of Telegram chat IDs that can interact with this bot.
     /// An empty list allows all chats.
     /// </summary>

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramChannelAdapter.cs
@@ -90,9 +90,9 @@ public sealed class TelegramChannelAdapter(
         {
             if (!string.IsNullOrWhiteSpace(runtime.Config.WebhookUrl))
             {
-                await runtime.ApiClient.SetWebhookAsync(runtime.Config.WebhookUrl, cancellationToken);
+                await runtime.ApiClient.SetWebhookAsync(runtime.Config.WebhookUrl, runtime.WebhookSecret, cancellationToken);
                 _logger.LogInformation(
-                    "{DisplayName} bot '{BotName}' configured webhook mode at {WebhookUrl}",
+                    "{DisplayName} bot '{BotName}' configured webhook mode at {WebhookUrl} (secret-token authentication enabled)",
                     DisplayName,
                     runtime.BotName,
                     runtime.Config.WebhookUrl);
@@ -407,6 +407,75 @@ public sealed class TelegramChannelAdapter(
         }, cancellationToken);
     }
 
+    /// <summary>
+    /// Result of attempting to handle an inbound Telegram webhook update.
+    /// Lets the HTTP receiver map outcomes to status codes without leaking detail to callers.
+    /// </summary>
+    public enum WebhookHandleResult
+    {
+        /// <summary>The update was accepted and dispatched (or intentionally ignored as non-actionable).</summary>
+        Accepted,
+
+        /// <summary>The supplied secret token did not match the bot's registered secret. Map to 403.</summary>
+        SecretMismatch,
+
+        /// <summary>No bot with the supplied name is configured, or it is not in webhook mode. Map to 404.</summary>
+        UnknownBot,
+    }
+
+    /// <summary>
+    /// Handles a single inbound Telegram update delivered to the webhook receiver for
+    /// <paramref name="botName"/>. The supplied secret token is validated in constant time against
+    /// the secret registered with Telegram before the update is routed through the same allow-list
+    /// and dispatch path used by long polling.
+    /// </summary>
+    /// <param name="botName">Logical bot name from the webhook route.</param>
+    /// <param name="update">The deserialized Telegram update.</param>
+    /// <param name="providedSecret">Raw <c>X-Telegram-Bot-Api-Secret-Token</c> header value (may be null).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An outcome the receiver maps to an HTTP status code.</returns>
+    public async Task<WebhookHandleResult> HandleWebhookUpdateAsync(
+        string botName,
+        TelegramUpdate update,
+        string? providedSecret,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureBotsInitialized();
+
+        if (string.IsNullOrWhiteSpace(botName) || !_bots.TryGetValue(botName, out var runtime))
+            return WebhookHandleResult.UnknownBot;
+
+        // Webhook delivery is only meaningful for bots configured in webhook mode. A bot in polling
+        // mode has no registered secret; treating it as unknown avoids an unauthenticated code path.
+        if (string.IsNullOrWhiteSpace(runtime.Config.WebhookUrl))
+            return WebhookHandleResult.UnknownBot;
+
+        if (!TelegramWebhookSecret.Matches(runtime.WebhookSecret, providedSecret))
+        {
+            _logger.LogWarning(
+                "{DisplayName} bot '{BotName}' rejected webhook update with invalid secret token",
+                DisplayName,
+                runtime.BotName);
+            return WebhookHandleResult.SecretMismatch;
+        }
+
+        await HandleUpdateAsync(runtime, update, cancellationToken);
+        return WebhookHandleResult.Accepted;
+    }
+
+    /// <summary>
+    /// Returns the logical names of all configured bots running in webhook mode.
+    /// Used by the HTTP receiver to map a route per webhook bot.
+    /// </summary>
+    public IReadOnlyCollection<string> GetWebhookBotNames()
+    {
+        EnsureBotsInitialized();
+        return _bots.Values
+            .Where(r => !string.IsNullOrWhiteSpace(r.Config.WebhookUrl))
+            .Select(r => r.BotName)
+            .ToArray();
+    }
+
     private async Task FlushStreamingStateAsync(BotRuntime runtime, StreamingState state, bool force, CancellationToken cancellationToken)
     {
         if (state.Buffer.Length == 0)
@@ -471,7 +540,27 @@ public sealed class TelegramChannelAdapter(
                 config.BotToken,
                 NullLogger<TelegramBotApiClient>.Instance);
 
-            _bots.TryAdd(botName, new BotRuntime(botName, config, client));
+            // Resolve the webhook secret once, only for bots in webhook mode. A configured secret is
+            // used when syntactically valid; otherwise a cryptographically strong one is generated so
+            // webhook mode is never registered without authentication. Polling bots get no secret.
+            var webhookSecret = string.Empty;
+            if (!string.IsNullOrWhiteSpace(config.WebhookUrl))
+            {
+                webhookSecret = TelegramWebhookSecret.IsValid(config.WebhookSecretToken)
+                    ? config.WebhookSecretToken!
+                    : TelegramWebhookSecret.Generate();
+
+                if (!TelegramWebhookSecret.IsValid(config.WebhookSecretToken)
+                    && !string.IsNullOrEmpty(config.WebhookSecretToken))
+                {
+                    _logger.LogWarning(
+                        "{DisplayName} bot '{BotName}' configured webhookSecretToken is invalid (allowed: A-Z a-z 0-9 _ -, length 1-256); generated a replacement",
+                        DisplayName,
+                        botName);
+                }
+            }
+
+            _bots.TryAdd(botName, new BotRuntime(botName, config, client, webhookSecret));
         }
     }
 
@@ -640,11 +729,18 @@ public sealed class TelegramChannelAdapter(
         }
     }
 
-    private sealed class BotRuntime(string botName, TelegramBotConfig config, TelegramBotApiClient apiClient)
+    private sealed class BotRuntime(string botName, TelegramBotConfig config, TelegramBotApiClient apiClient, string webhookSecret)
     {
         public string BotName { get; } = botName;
         public TelegramBotConfig Config { get; } = config;
         public TelegramBotApiClient ApiClient { get; } = apiClient;
+
+        /// <summary>
+        /// Secret token registered with Telegram for this bot's webhook, validated against the
+        /// <c>X-Telegram-Bot-Api-Secret-Token</c> header on each inbound update. Empty for polling bots.
+        /// </summary>
+        public string WebhookSecret { get; } = webhookSecret;
+
         public ConcurrentDictionary<string, StreamingState> StreamingStates { get; } = new(StringComparer.Ordinal);
         public ConcurrentDictionary<long, DateTimeOffset> LastErrorReplyUtcByChat { get; } = new();
         public CancellationTokenSource? PollingCancellation { get; set; }

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramGatewayOptions.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramGatewayOptions.cs
@@ -39,6 +39,13 @@ public sealed class TelegramGatewayOptions
     public string? WebhookUrl { get; set; }
 
     /// <summary>
+    /// Secret token authenticating inbound webhook requests for a single-bot deployment.
+    /// Ignored when <see cref="Bots"/> is non-empty. When null/empty the adapter generates a
+    /// cryptographically strong token at startup so webhook mode is never unauthenticated.
+    /// </summary>
+    public string? WebhookSecretToken { get; set; }
+
+    /// <summary>
     /// Allow-list of chat IDs for a single-bot deployment.
     /// Ignored when <see cref="Bots"/> is non-empty.
     /// An empty list allows all chats.
@@ -111,6 +118,7 @@ public sealed class TelegramGatewayOptions
             BotToken = BotToken,
             AgentId = AgentId,
             WebhookUrl = WebhookUrl,
+            WebhookSecretToken = WebhookSecretToken,
             PollingTimeoutSeconds = PollingTimeoutSeconds,
             StreamingBufferMs = StreamingBufferMs,
             MaxMessageLength = MaxMessageLength,

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramWebhookEndpointContributor.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramWebhookEndpointContributor.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace BotNexus.Extensions.Channels.Telegram;
+
+/// <summary>
+/// Maps the inbound Telegram webhook receiver endpoint.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Telegram delivers updates by POSTing JSON to a public HTTPS URL registered via <c>setWebhook</c>.
+/// This contributor exposes <c>POST /telegram/webhook/{botName}</c> and is the counterpart to the
+/// adapter's <c>setWebhook</c> registration: without it, webhook mode registers a URL Telegram posts
+/// to but nothing receives the updates.
+/// </para>
+/// <para>
+/// <b>Authentication.</b> The only thing standing between this public endpoint and forged-update
+/// injection is the <c>X-Telegram-Bot-Api-Secret-Token</c> header, which Telegram echoes back from
+/// the secret registered with <c>setWebhook</c>. Every request is validated against the bot's
+/// registered secret in constant time before any update is dispatched; a mismatch returns 403 and
+/// the update is dropped. After the secret check, the update flows through the exact same allow-list
+/// (<c>allowedChatIds</c>/<c>allowedUserIds</c>) and dispatch path as long polling, so webhook mode
+/// is no less restricted than polling.
+/// </para>
+/// </remarks>
+public sealed class TelegramWebhookEndpointContributor : IEndpointContributor
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public void MapEndpoints(WebApplication app)
+    {
+        app.MapPost("/telegram/webhook/{botName}", HandleAsync)
+            .WithName("TelegramWebhook")
+            .ExcludeFromDescription();
+    }
+
+    private static async Task<IResult> HandleAsync(
+        string botName,
+        HttpRequest request,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var logger = services.GetService<ILogger<TelegramWebhookEndpointContributor>>();
+
+        // The Telegram adapter is registered as a singleton IChannelAdapter; resolving the
+        // collection and selecting by channel type yields the same instance the gateway started,
+        // so dispatched updates reuse the running adapter's allow-list and routing pipeline.
+        var adapter = services.GetServices<IChannelAdapter>()
+            .OfType<TelegramChannelAdapter>()
+            .FirstOrDefault();
+
+        if (adapter is null)
+        {
+            // Telegram channel not loaded — nothing to receive for. 404 keeps the endpoint quiet.
+            return Results.NotFound();
+        }
+
+        var providedSecret = request.Headers["X-Telegram-Bot-Api-Secret-Token"].ToString();
+
+        TelegramUpdate? update;
+        try
+        {
+            update = await JsonSerializer.DeserializeAsync<TelegramUpdate>(request.Body, JsonOptions, cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            // Malformed body. Do not echo content back. 400 tells a misbehaving caller; Telegram
+            // itself never sends malformed JSON, so this is almost always a probe.
+            logger?.LogWarning(ex, "Telegram webhook for bot '{BotName}' received a malformed body", botName);
+            return Results.BadRequest();
+        }
+
+        if (update is null)
+            return Results.BadRequest();
+
+        var result = await adapter.HandleWebhookUpdateAsync(botName, update, providedSecret, cancellationToken);
+        return result switch
+        {
+            TelegramChannelAdapter.WebhookHandleResult.Accepted => Results.Ok(),
+            TelegramChannelAdapter.WebhookHandleResult.SecretMismatch => Results.StatusCode(StatusCodes.Status403Forbidden),
+            TelegramChannelAdapter.WebhookHandleResult.UnknownBot => Results.NotFound(),
+            _ => Results.Ok(),
+        };
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramWebhookSecret.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/TelegramWebhookSecret.cs
@@ -1,0 +1,89 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BotNexus.Extensions.Channels.Telegram;
+
+/// <summary>
+/// Generation and constant-time validation of the Telegram webhook secret token.
+/// </summary>
+/// <remarks>
+/// Telegram's <c>setWebhook</c> accepts an optional <c>secret_token</c> which Telegram then sends
+/// back in the <c>X-Telegram-Bot-Api-Secret-Token</c> header on every update POST. Validating that
+/// header is the sole mechanism that authenticates inbound webhook traffic: without it, anyone who
+/// discovers the public webhook URL can POST forged updates straight into the agent pipeline. The
+/// allowed character set is restricted by the Bot API to <c>A-Z</c>, <c>a-z</c>, <c>0-9</c>,
+/// <c>_</c> and <c>-</c>, with a length of 1–256 characters.
+/// </remarks>
+internal static class TelegramWebhookSecret
+{
+    // 32 bytes of entropy → 43 url-safe base64 characters, comfortably within the 1–256 limit and
+    // far beyond brute-force reach. All emitted characters are in the Bot API's allowed set.
+    private const int EntropyBytes = 32;
+
+    /// <summary>
+    /// Characters permitted by the Telegram Bot API for the webhook <c>secret_token</c>.
+    /// </summary>
+    private static bool IsAllowedChar(char c)
+        => (c >= 'A' && c <= 'Z')
+           || (c >= 'a' && c <= 'z')
+           || (c >= '0' && c <= '9')
+           || c == '_'
+           || c == '-';
+
+    /// <summary>
+    /// Generates a cryptographically strong, URL-safe secret token within the Bot API's allowed
+    /// character set and length bounds.
+    /// </summary>
+    public static string Generate()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(EntropyBytes);
+        // URL-safe base64 (RFC 4648 §5): replace '+'/'/' with '-'/'_', strip '=' padding.
+        // Every resulting character is in the Bot API's allowed set.
+        return System.Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="value"/> is a syntactically valid
+    /// Telegram webhook secret token (non-empty, ≤256 chars, allowed character set only).
+    /// </summary>
+    public static bool IsValid(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length > 256)
+            return false;
+
+        foreach (var c in value)
+        {
+            if (!IsAllowedChar(c))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Compares an expected secret against the value supplied in an inbound request header in
+    /// constant time, so a mismatch reveals nothing about how many leading characters matched.
+    /// </summary>
+    /// <param name="expected">The secret registered with Telegram for this bot. Never null/empty in practice.</param>
+    /// <param name="provided">The raw <c>X-Telegram-Bot-Api-Secret-Token</c> header value, or null when absent.</param>
+    /// <returns><see langword="true"/> only when both are present and byte-for-byte equal.</returns>
+    /// <remarks>
+    /// Both inputs are SHA-256 hashed before comparison so the fixed-length digest comparison can
+    /// never short-circuit on a length difference — the comparison time is independent of both the
+    /// length and the content of <paramref name="provided"/>.
+    /// </remarks>
+    public static bool Matches(string? expected, string? provided)
+    {
+        if (string.IsNullOrEmpty(expected) || string.IsNullOrEmpty(provided))
+            return false;
+
+        Span<byte> expectedHash = stackalloc byte[32];
+        Span<byte> providedHash = stackalloc byte[32];
+        SHA256.HashData(Encoding.UTF8.GetBytes(expected), expectedHash);
+        SHA256.HashData(Encoding.UTF8.GetBytes(provided), providedHash);
+        return CryptographicOperations.FixedTimeEquals(expectedHash, providedHash);
+    }
+}

--- a/src/extensions/BotNexus.Extensions.Channels.Telegram/botnexus-extension.json
+++ b/src/extensions/BotNexus.Extensions.Channels.Telegram/botnexus-extension.json
@@ -1,8 +1,8 @@
 {
   "id": "botnexus-telegram",
   "name": "Telegram Channel",
-  "description": "Telegram Bot API channel adapter - long polling, DMs and group topics",
-  "version": "1.0.0",
+  "description": "Telegram Bot API channel adapter - long polling or secure webhook, DMs and group topics",
+  "version": "1.1.0",
   "entryAssembly": "BotNexus.Extensions.Channels.Telegram.dll",
   "extensionTypes": ["channel"],
   "enabled": true,
@@ -27,6 +27,13 @@
       "required": false,
       "sensitive": false,
       "description": "Webhook URL for webhook mode. When absent, the adapter uses long polling."
+    },
+    {
+      "id": "webhookSecretToken",
+      "type": "string",
+      "required": false,
+      "sensitive": true,
+      "description": "Secret token authenticating inbound webhook requests (validated against the X-Telegram-Bot-Api-Secret-Token header). When absent in webhook mode, a cryptographically strong token is generated automatically."
     },
     {
       "id": "pollingTimeoutSeconds",

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramWebhookEndpointContributorTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramWebhookEndpointContributorTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using BotNexus.Extensions.Channels.Telegram;
+using BotNexus.Gateway.Abstractions.Channels;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+/// <summary>
+/// HTTP-level tests for <see cref="TelegramWebhookEndpointContributor"/>, hosting only the
+/// webhook endpoint in an in-memory <see cref="TestServer"/> and asserting status-code mapping
+/// for valid, invalid, missing-secret, unknown-bot, and malformed-body requests.
+/// </summary>
+public sealed class TelegramWebhookEndpointContributorTests
+{
+    private const string ValidUpdateJson =
+        "{\"update_id\":1,\"message\":{\"message_id\":1,\"chat\":{\"id\":42},\"from\":{\"id\":7},\"text\":\"hello\"}}";
+
+    [Fact]
+    public async Task Post_WithValidSecret_Returns200()
+    {
+        var (host, secret) = await StartHostAsync();
+        await using var _ = host;
+        using var client = host.GetTestClient();
+
+        using var response = await PostAsync(client, "default", secret, ValidUpdateJson);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Post_WithWrongSecret_Returns403()
+    {
+        var (host, _) = await StartHostAsync();
+        await using var __ = host;
+        using var client = host.GetTestClient();
+
+        using var response = await PostAsync(client, "default", "wrong-secret", ValidUpdateJson);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Post_WithoutSecretHeader_Returns403()
+    {
+        var (host, _) = await StartHostAsync();
+        await using var __ = host;
+        using var client = host.GetTestClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/telegram/webhook/default")
+        {
+            Content = new StringContent(ValidUpdateJson, Encoding.UTF8, "application/json")
+        };
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Post_ForUnknownBot_Returns404()
+    {
+        var (host, secret) = await StartHostAsync();
+        await using var _ = host;
+        using var client = host.GetTestClient();
+
+        using var response = await PostAsync(client, "nonexistent", secret, ValidUpdateJson);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Post_WithMalformedBody_Returns400()
+    {
+        var (host, secret) = await StartHostAsync();
+        await using var _ = host;
+        using var client = host.GetTestClient();
+
+        using var response = await PostAsync(client, "default", secret, "{ this is not valid json");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    // ── Host setup ────────────────────────────────────────────────────────────
+
+    private static async Task<(WebApplication Host, string Secret)> StartHostAsync()
+    {
+        // Capture the secret the adapter registers with Telegram during StartAsync.
+        string? capturedSecret = null;
+        var handler = new SetWebhookCapturingHandler(s => capturedSecret = s);
+
+        var options = new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            WebhookUrl = "https://example.com/telegram/webhook/default",
+            AllowedChatIds = { 42 },
+            AllowedUserIds = { 7 }
+        };
+
+        var adapter = new TelegramChannelAdapter(
+            NullLogger<TelegramChannelAdapter>.Instance,
+            Options.Create(options),
+            new SingleClientFactory(new HttpClient(handler)));
+
+        // Start the adapter so it registers the webhook (and its secret) and is ready to dispatch.
+        await adapter.StartAsync(new Mock<IChannelDispatcher>().Object, CancellationToken.None);
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<IChannelAdapter>(adapter);
+        builder.Services.AddRouting();
+
+        var app = builder.Build();
+        new TelegramWebhookEndpointContributor().MapEndpoints(app);
+        await app.StartAsync();
+
+        var secret = capturedSecret ?? throw new InvalidOperationException("setWebhook did not capture a secret token.");
+        return (app, secret);
+    }
+
+    private static Task<HttpResponseMessage> PostAsync(HttpClient client, string botName, string secret, string json)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/telegram/webhook/{botName}")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Add("X-Telegram-Bot-Api-Secret-Token", secret);
+        return client.SendAsync(request);
+    }
+
+    private sealed class SingleClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private sealed class SetWebhookCapturingHandler(Action<string?> onSecret) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var method = request.RequestUri?.Segments.LastOrDefault()?.Trim('/') ?? string.Empty;
+            var body = request.Content is null ? "{}" : await request.Content.ReadAsStringAsync(cancellationToken);
+            if (method == "setWebhook")
+            {
+                using var json = JsonDocument.Parse(body);
+                onSecret(json.RootElement.TryGetProperty("secret_token", out var el) && el.ValueKind == JsonValueKind.String
+                    ? el.GetString()
+                    : null);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true,\"result\":true}", Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramWebhookHandlerTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramWebhookHandlerTests.cs
@@ -1,0 +1,299 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using BotNexus.Domain.Primitives;
+using BotNexus.Extensions.Channels.Telegram;
+using BotNexus.Gateway.Abstractions.Channels;
+using BotNexus.Gateway.Abstractions.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+/// <summary>
+/// Tests for the inbound Telegram webhook handling path on <see cref="TelegramChannelAdapter"/>:
+/// secret-token registration via <c>setWebhook</c>, constant-time secret validation, allow-list
+/// reuse, and dispatch routing identical to long polling.
+/// </summary>
+public sealed class TelegramWebhookHandlerTests
+{
+    [Fact]
+    public async Task StartAsync_WebhookMode_RegistersSecretTokenWithTelegram()
+    {
+        var (adapter, getSecret) = await StartWebhookAdapterAsync(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            WebhookUrl = "https://example.com/telegram/webhook/default"
+        });
+
+        // setWebhook must have carried a non-empty secret_token so the receiver can authenticate.
+        getSecret().ShouldNotBeNullOrWhiteSpace();
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_WebhookMode_UsesConfiguredSecretWhenValid()
+    {
+        const string configured = "my-configured-secret_123";
+        var (adapter, getSecret) = await StartWebhookAdapterAsync(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            WebhookUrl = "https://example.com/telegram/webhook/default",
+            WebhookSecretToken = configured
+        });
+
+        getSecret().ShouldBe(configured);
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_WebhookMode_GeneratesSecretWhenConfiguredOneIsInvalid()
+    {
+        var (adapter, getSecret) = await StartWebhookAdapterAsync(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            WebhookUrl = "https://example.com/telegram/webhook/default",
+            WebhookSecretToken = "invalid secret with spaces"
+        });
+
+        var actual = getSecret();
+        actual.ShouldNotBeNullOrWhiteSpace();
+        actual.ShouldNotBe("invalid secret with spaces");
+        TelegramWebhookSecret.IsValid(actual).ShouldBeTrue();
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HandleWebhookUpdate_WithValidSecret_DispatchesThroughNormalPipeline()
+    {
+        var dispatcher = new Mock<IChannelDispatcher>();
+        var (adapter, getSecret) = await StartWebhookAdapterAsync(
+            new TelegramGatewayOptions
+            {
+                BotToken = "token",
+                WebhookUrl = "https://example.com/telegram/webhook/default",
+                AllowedChatIds = { 42 },
+                AllowedUserIds = { 7 }
+            },
+            dispatcher);
+
+        var result = await adapter.HandleWebhookUpdateAsync(
+            "default",
+            BuildUpdate(chatId: 42, userId: 7, text: "hello"),
+            getSecret(),
+            CancellationToken.None);
+
+        result.ShouldBe(TelegramChannelAdapter.WebhookHandleResult.Accepted);
+        dispatcher.Invocations
+            .Where(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync))
+            .Select(i => (InboundMessage)i.Arguments[0])
+            .ShouldContain(m => m.ChannelAddress == ChannelAddress.From("42") && m.Content == "hello");
+
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HandleWebhookUpdate_WithWrongSecret_RejectsAndDoesNotDispatch()
+    {
+        var dispatcher = new Mock<IChannelDispatcher>();
+        var (adapter, _) = await StartWebhookAdapterAsync(
+            new TelegramGatewayOptions
+            {
+                BotToken = "token",
+                WebhookUrl = "https://example.com/telegram/webhook/default"
+            },
+            dispatcher);
+
+        var result = await adapter.HandleWebhookUpdateAsync(
+            "default",
+            BuildUpdate(chatId: 42, userId: 7, text: "hello"),
+            providedSecret: "totally-wrong-secret",
+            CancellationToken.None);
+
+        result.ShouldBe(TelegramChannelAdapter.WebhookHandleResult.SecretMismatch);
+        dispatcher.Invocations
+            .ShouldNotContain(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync));
+
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HandleWebhookUpdate_WithMissingSecret_RejectsAndDoesNotDispatch()
+    {
+        var dispatcher = new Mock<IChannelDispatcher>();
+        var (adapter, _) = await StartWebhookAdapterAsync(
+            new TelegramGatewayOptions
+            {
+                BotToken = "token",
+                WebhookUrl = "https://example.com/telegram/webhook/default"
+            },
+            dispatcher);
+
+        var result = await adapter.HandleWebhookUpdateAsync(
+            "default",
+            BuildUpdate(chatId: 42, userId: 7, text: "hello"),
+            providedSecret: null,
+            CancellationToken.None);
+
+        result.ShouldBe(TelegramChannelAdapter.WebhookHandleResult.SecretMismatch);
+        dispatcher.Invocations
+            .ShouldNotContain(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync));
+
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HandleWebhookUpdate_EnforcesChatAllowList_EvenWithValidSecret()
+    {
+        var dispatcher = new Mock<IChannelDispatcher>();
+        var (adapter, getSecret) = await StartWebhookAdapterAsync(
+            new TelegramGatewayOptions
+            {
+                BotToken = "token",
+                WebhookUrl = "https://example.com/telegram/webhook/default",
+                AllowedChatIds = { 42 }
+            },
+            dispatcher);
+
+        // Correct secret but a chat that is not on the allow-list — must be dropped silently.
+        var result = await adapter.HandleWebhookUpdateAsync(
+            "default",
+            BuildUpdate(chatId: 9999, userId: 7, text: "intruder"),
+            getSecret(),
+            CancellationToken.None);
+
+        result.ShouldBe(TelegramChannelAdapter.WebhookHandleResult.Accepted); // accepted = not a secret failure
+        dispatcher.Invocations
+            .ShouldNotContain(i => i.Method.Name == nameof(IChannelDispatcher.DispatchAsync));
+
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HandleWebhookUpdate_ForUnknownBot_ReturnsUnknownBot()
+    {
+        var (adapter, _) = await StartWebhookAdapterAsync(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            WebhookUrl = "https://example.com/telegram/webhook/default"
+        });
+
+        var result = await adapter.HandleWebhookUpdateAsync(
+            "nonexistent-bot",
+            BuildUpdate(chatId: 42, userId: 7, text: "hello"),
+            providedSecret: "anything",
+            CancellationToken.None);
+
+        result.ShouldBe(TelegramChannelAdapter.WebhookHandleResult.UnknownBot);
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task HandleWebhookUpdate_ForPollingModeBot_ReturnsUnknownBot()
+    {
+        // Polling-mode bot has no registered secret; webhook delivery to it must be treated as
+        // unknown rather than opening an unauthenticated dispatch path.
+        var handler = new RecordingHandler();
+        var adapter = CreateAdapter(new TelegramGatewayOptions
+        {
+            BotToken = "token",
+            PollingTimeoutSeconds = 1
+        }, handler);
+
+        var dispatcher = new Mock<IChannelDispatcher>();
+        await adapter.StartAsync(dispatcher.Object, CancellationToken.None);
+
+        var result = await adapter.HandleWebhookUpdateAsync(
+            "default",
+            BuildUpdate(chatId: 42, userId: 7, text: "hello"),
+            providedSecret: "anything",
+            CancellationToken.None);
+
+        result.ShouldBe(TelegramChannelAdapter.WebhookHandleResult.UnknownBot);
+        await adapter.StopAsync(CancellationToken.None);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static TelegramUpdate BuildUpdate(long chatId, long userId, string text)
+        => new()
+        {
+            UpdateId = 1,
+            Message = new TelegramMessage
+            {
+                MessageId = 1,
+                Chat = new TelegramChat { Id = chatId },
+                From = new TelegramUser { Id = userId },
+                Text = text
+            }
+        };
+
+    /// <summary>
+    /// Starts an adapter in webhook mode and returns it plus an accessor for the secret_token that
+    /// was sent to Telegram's setWebhook (captured from the request body).
+    /// </summary>
+    private static async Task<(TelegramChannelAdapter Adapter, Func<string?> GetSecret)> StartWebhookAdapterAsync(
+        TelegramGatewayOptions options,
+        Mock<IChannelDispatcher>? dispatcher = null)
+    {
+        string? capturedSecret = null;
+        var handler = new RecordingHandler(request =>
+        {
+            // setWebhook is the only call this adapter makes at startup in webhook mode.
+        }, onSetWebhookSecret: s => capturedSecret = s);
+
+        var adapter = CreateAdapter(options, handler);
+        await adapter.StartAsync((dispatcher ?? new Mock<IChannelDispatcher>()).Object, CancellationToken.None);
+        return (adapter, () => capturedSecret);
+    }
+
+    private static TelegramChannelAdapter CreateAdapter(TelegramGatewayOptions options, HttpMessageHandler handler)
+    {
+        var factory = new SingleClientFactory(new HttpClient(handler));
+        return new TelegramChannelAdapter(
+            NullLogger<TelegramChannelAdapter>.Instance,
+            Options.Create(options),
+            factory);
+    }
+
+    private sealed class SingleClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    /// <summary>
+    /// Stub handler that returns <c>{"ok":true,"result":true}</c> for every Bot API call and
+    /// extracts the <c>secret_token</c> from any <c>setWebhook</c> request.
+    /// </summary>
+    private sealed class RecordingHandler(
+        Action<HttpRequestMessage>? onRequest = null,
+        Action<string?>? onSetWebhookSecret = null) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            onRequest?.Invoke(request);
+            var method = request.RequestUri?.Segments.LastOrDefault()?.Trim('/') ?? string.Empty;
+            var body = request.Content is null ? "{}" : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            if (method == "setWebhook")
+            {
+                using var json = JsonDocument.Parse(body);
+                var secret = json.RootElement.TryGetProperty("secret_token", out var el) && el.ValueKind == JsonValueKind.String
+                    ? el.GetString()
+                    : null;
+                onSetWebhookSecret?.Invoke(secret);
+            }
+
+            var payload = method switch
+            {
+                "getUpdates" => "{\"ok\":true,\"result\":[]}",
+                _ => "{\"ok\":true,\"result\":true}"
+            };
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramWebhookSecretTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Tests/Channels/TelegramWebhookSecretTests.cs
@@ -1,0 +1,85 @@
+using BotNexus.Extensions.Channels.Telegram;
+
+namespace BotNexus.Gateway.Tests.Channels;
+
+/// <summary>
+/// Unit tests for <see cref="TelegramWebhookSecret"/> — the generation and constant-time
+/// validation of the Telegram webhook secret token that authenticates inbound webhook traffic.
+/// </summary>
+public sealed class TelegramWebhookSecretTests
+{
+    [Fact]
+    public void Generate_ProducesTokenWithinBotApiCharsetAndLength()
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            var token = TelegramWebhookSecret.Generate();
+
+            token.Length.ShouldBeInRange(1, 256);
+            token.ShouldAllBe(c =>
+                (c >= 'A' && c <= 'Z') ||
+                (c >= 'a' && c <= 'z') ||
+                (c >= '0' && c <= '9') ||
+                c == '_' ||
+                c == '-');
+        }
+    }
+
+    [Fact]
+    public void Generate_ProducesDistinctTokens()
+    {
+        var tokens = Enumerable.Range(0, 100).Select(_ => TelegramWebhookSecret.Generate()).ToHashSet();
+
+        // 32 bytes of entropy per token — collisions across 100 draws are astronomically unlikely.
+        tokens.Count.ShouldBe(100);
+    }
+
+    [Theory]
+    [InlineData("abcDEF123_-", true)]
+    [InlineData("a", true)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("has spaces", false)]
+    [InlineData("has.dot", false)]
+    [InlineData("has/slash", false)]
+    [InlineData("has+plus", false)]
+    public void IsValid_EnforcesBotApiCharset(string? value, bool expected)
+        => TelegramWebhookSecret.IsValid(value).ShouldBe(expected);
+
+    [Fact]
+    public void IsValid_RejectsTokenLongerThan256()
+    {
+        var tooLong = new string('a', 257);
+        TelegramWebhookSecret.IsValid(tooLong).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_AcceptsTokenOfExactly256()
+    {
+        var maxLength = new string('a', 256);
+        TelegramWebhookSecret.IsValid(maxLength).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Matches_ReturnsTrue_ForIdenticalSecrets()
+    {
+        var secret = TelegramWebhookSecret.Generate();
+        TelegramWebhookSecret.Matches(secret, secret).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("expected-secret", "different-secret")]
+    [InlineData("expected-secret", "expected-secre")]   // one char short
+    [InlineData("expected-secret", "expected-secretX")] // one char long
+    [InlineData("expected-secret", "EXPECTED-SECRET")]  // case differs
+    public void Matches_ReturnsFalse_ForMismatchedSecrets(string expected, string provided)
+        => TelegramWebhookSecret.Matches(expected, provided).ShouldBeFalse();
+
+    [Theory]
+    [InlineData(null, "anything")]
+    [InlineData("", "anything")]
+    [InlineData("expected", null)]
+    [InlineData("expected", "")]
+    public void Matches_ReturnsFalse_WhenEitherSideMissing(string? expected, string? provided)
+        => TelegramWebhookSecret.Matches(expected, provided).ShouldBeFalse();
+}


### PR DESCRIPTION
## Summary

Makes the Telegram channel's **webhook mode** functional and secure. Previously `setWebhook` registered a URL with Telegram, but there was **no receiver endpoint** anywhere in the gateway and **no secret token** — so webhook mode could not receive updates, and if it could, anyone who learned the public URL could POST forged updates straight into the agent pipeline.

The long-polling path (the current default, fully working) is **unchanged**.

## What this adds

- **Receiver endpoint** `POST /telegram/webhook/{botName}` via `TelegramWebhookEndpointContributor : IEndpointContributor` — auto-discovered by the extension loader exactly like the SignalR `/hub/gateway` contributor. `{botName}` is the key under `bots` (or `default` for a single-bot config).
- **Secret-token authentication.** The adapter registers a `secret_token` with `setWebhook`; Telegram echoes it in the `X-Telegram-Bot-Api-Secret-Token` header on every update. The receiver validates it in **constant time** (SHA-256 + `CryptographicOperations.FixedTimeEquals`) and returns **403** on mismatch *before any dispatch*.
- **Secure by default.** When no `webhookSecretToken` is configured, the adapter generates a cryptographically strong, URL-safe token (32 bytes of entropy, Bot-API charset) at startup, so webhook mode is never silently unauthenticated. A valid configured token is honoured; an invalid one is replaced with a warning.
- **Same restrictions as polling.** Validated updates flow through the exact same `allowedChatIds`/`allowedUserIds` allow-lists and dispatch path as long polling. Polling-mode bots have no secret and reject webhook delivery as `UnknownBot` (no unauthenticated code path).

## Status-code mapping

| Outcome | Status |
|---|---|
| Valid secret, accepted/ignored | 200 |
| Secret missing or mismatched | 403 |
| Unknown / non-webhook bot | 404 |
| Malformed body | 400 |

## Tests

35 new tests (all green), zero regression in the 144 existing Telegram tests:
- `TelegramWebhookSecretTests` — generation charset/length/uniqueness + constant-time compare (match, mismatch, length-diff, null).
- `TelegramWebhookHandlerTests` — `setWebhook` carries the secret, configured-vs-generated resolution, secret enforcement, allow-list reuse, unknown/polling-bot handling.
- `TelegramWebhookEndpointContributorTests` — in-memory `TestServer` asserting 200/403/404/400 over real HTTP.

`scripts/repo/test-impacted.ps1` green (Gateway.Tests 2903/1-skip/0-fail, Architecture 178, Scenarios 29). Full `--warnaserror` solution build clean.

## Docs

- `docs/user-guide/channels/telegram.md`: new "Webhook mode" section (receiver path, secret token, allow-list interaction), `webhookSecretToken` in the config reference + example, and a validated-checks row.
- `botnexus-extension.json`: `webhookSecretToken` config field (sensitive), version 1.0.0 -> 1.1.0.

## Notes

- Adds `FrameworkReference Microsoft.AspNetCore.App` to the extension (needed for the minimal-API receiver — same as the SignalR channel extension) and drops three now-redundant `Microsoft.Extensions.*` package refs the framework supplies.
- This is the first of a planned set; follow-ups will cover getting the extension reliably online (the "missing assembly" deployment issue) and optional Bot API 10.1 Rich Messages.
