### PR TITLE
fix(portal): tolerate non-integer delay seconds in tool-call description renderer

### DIFF
--- a/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ToolDescriptionFormatter.cs
+++ b/src/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient/Components/ToolDescriptionFormatter.cs
@@ -179,8 +179,11 @@ public static class ToolDescriptionFormatter
     private static string FormatDelay(JsonElement? args)
     {
         if (args is null) return "Delay";
-        if (args.Value.TryGetProperty("seconds", out var sec) && sec.ValueKind == JsonValueKind.Number)
-            return $"Delay {sec.GetInt32()}s";
+        if (args.Value.TryGetProperty("seconds", out var sec) && sec.ValueKind == JsonValueKind.Number
+            && sec.TryGetInt32(out var seconds))
+        {
+            return $"Delay {seconds}s";
+        }
         return "Delay";
     }
 

--- a/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ToolDescriptionFormatterTests.cs
+++ b/tests/extensions/BotNexus.Extensions.Channels.SignalR.BlazorClient.Tests/ToolDescriptionFormatterTests.cs
@@ -215,6 +215,30 @@ public sealed class ToolDescriptionFormatterTests
     }
 
     [Fact]
+    public void Delay_WithFractionalSeconds_FallsBackWithoutThrowing()
+    {
+        // GetInt32() throws FormatException on a fractional JSON number; that is not a
+        // JsonException, so the formatter's parse guard would not catch it. It must degrade.
+        var result = ToolDescriptionFormatter.FormatDescription("delay", """{"seconds": 1.5}""");
+        Assert.Equal("⏳ Delay", result);
+    }
+
+    [Fact]
+    public void Delay_WithOutOfRangeSeconds_FallsBackWithoutThrowing()
+    {
+        // 9999999999 is a valid JSON number but out of Int32 range; GetInt32() would throw.
+        var result = ToolDescriptionFormatter.FormatDescription("delay", """{"seconds": 9999999999}""");
+        Assert.Equal("⏳ Delay", result);
+    }
+
+    [Fact]
+    public void Delay_WithNonNumberSeconds_FallsBack()
+    {
+        var result = ToolDescriptionFormatter.FormatDescription("delay", """{"seconds": "soon"}""");
+        Assert.Equal("⏳ Delay", result);
+    }
+
+    [Fact]
     public void GetDatetime_ShowsDescription()
     {
         var result = ToolDescriptionFormatter.FormatDescription("get_datetime", """{}""");


### PR DESCRIPTION
Closes #1411

## Changes
`ToolDescriptionFormatter.FormatDelay` (the SignalR Blazor chat-panel tool-call renderer) called `JsonElement.GetInt32()` directly on the `seconds` argument. `GetInt32()` throws `FormatException` on a fractional JSON number and `InvalidOperationException`/`OverflowException` on an out-of-`Int32`-range number — none of which are `JsonException`, so the formatter's parse guard (`try { JsonDocument.Parse } catch (JsonException)`) does **not** catch them. A `delay` tool call with `{"seconds": 1.5}` or `{"seconds": 9999999999}` would crash the tool-description render.

Fix: use `TryGetInt32` and fall back to the plain `"Delay"` label when the value is not a valid `Int32` — the same tolerant pattern already adopted for the `GetInt32()`-before-validation class (#1338, #1362, #1363).

This is display-only — `DelayTool` already clamps the executed value — so it is a low-severity crash on the in-flight render of a malformed `delay` argument.

## Tests
Added 3 cases to `ToolDescriptionFormatterTests` (the existing in-slnx project):
- `Delay_WithFractionalSeconds_FallsBackWithoutThrowing`
- `Delay_WithOutOfRangeSeconds_FallsBackWithoutThrowing`
- `Delay_WithNonNumberSeconds_FallsBack`

The first two fail against the old code (they throw). `BlazorClient.Tests` 540/540, Architecture 178, Scenarios 29, Gateway 2868 — all green. Full solution build clean (0 warnings, 0 errors).

## Merge Notes
Touches only `ToolDescriptionFormatter.cs` (+ its test file) in `BotNexus.Extensions.Channels.SignalR.BlazorClient`. No file overlap with any other open PR — safe to merge in any order.
