### PR TITLE
refactor(persistence): extract shared world-id and citizen logic for conversation stores

### DIFF
--- a/src/gateway/BotNexus.Gateway.Conversations/BotNexus.Gateway.Conversations.csproj
+++ b/src/gateway/BotNexus.Gateway.Conversations/BotNexus.Gateway.Conversations.csproj
@@ -16,4 +16,9 @@
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Exposes internal helpers (e.g. ConversationStoreShared) to the store test project. -->
+    <InternalsVisibleTo Include="BotNexus.Gateway.Conversations.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/gateway/BotNexus.Gateway.Conversations/ConversationStoreShared.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/ConversationStoreShared.cs
@@ -1,0 +1,65 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Configuration;
+using BotNexus.Gateway.Abstractions.Models;
+
+namespace BotNexus.Gateway.Conversations;
+
+/// <summary>
+/// World-id stamping/back-fill and citizen-matching logic shared by every
+/// <see cref="BotNexus.Gateway.Abstractions.Conversations.IConversationStore"/> implementation.
+/// <para>
+/// These routines were previously copy-pasted byte-for-byte across <see cref="SqliteConversationStore"/>,
+/// <see cref="FileConversationStore"/> and <see cref="InMemoryConversationStore"/> with source comments
+/// noting they were "kept identical so the three stores behave the same way" — a standing invitation for
+/// silent drift in world/citizen scoping semantics (#1383, Finding 3). Hoisting them into one place makes
+/// the equivalence structural rather than a manual discipline; the store parity tests guard the behaviour.
+/// </para>
+/// </summary>
+internal static class ConversationStoreShared
+{
+    /// <summary>
+    /// Stamps the current world id onto a conversation being persisted (Create/Save). Only fills an
+    /// empty <see cref="Conversation.WorldId"/> — explicit non-empty values are preserved so cross-world
+    /// relays can hold the source world's id even when this gateway is the receiver. No-op when no world
+    /// context is wired (e.g. test setups using the parameterless ctor).
+    /// </summary>
+    public static void StampWorldId(Conversation conversation, IWorldContext? worldContext)
+    {
+        if (string.IsNullOrEmpty(conversation.WorldId) && worldContext is not null)
+            conversation.WorldId = worldContext.CurrentWorldId;
+    }
+
+    /// <summary>
+    /// Read-time projection: legacy rows/sidecars persisted before #613 carry an empty world id. This
+    /// projects them as belonging to the current world on the way out without rewriting the stored value —
+    /// the next save round-trip durably persists it via <see cref="StampWorldId"/>. Treating backfill as
+    /// projection-only keeps the read path single-pass and avoids touching the backing store on every read.
+    /// </summary>
+    public static Conversation? BackfillWorldId(Conversation? conversation, IWorldContext? worldContext)
+    {
+        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && worldContext is not null)
+            conversation.WorldId = worldContext.CurrentWorldId;
+        return conversation;
+    }
+
+    /// <summary>
+    /// Determines whether a conversation belongs to the given citizen for <c>ListForCitizen</c> scoping:
+    /// the citizen is the initiator, owns the conversation (agent-species only), or is a participant.
+    /// </summary>
+    public static bool MatchesCitizen(Conversation conversation, CitizenId citizen)
+    {
+        if (conversation.Initiator is { IsValid: true } init && init == citizen)
+            return true;
+
+        // Owner-match: only agent-species citizens own conversations.
+        if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
+            return true;
+
+        // Participant-match (P9-F): the conversation includes this citizen in its participant set.
+        if (conversation.Participants.Any(p => p.CitizenId == citizen))
+            return true;
+
+        return false;
+    }
+}

--- a/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/FileConversationStore.cs
@@ -101,21 +101,9 @@ public sealed class FileConversationStore : IConversationStore
         finally { _lock.Release(); }
     }
 
+    // Citizen scoping is shared across all three conversation stores — see ConversationStoreShared (#1383).
     private static bool MatchesCitizen(Conversation conversation, CitizenId citizen)
-    {
-        if (conversation.Initiator is { IsValid: true } init && init == citizen)
-            return true;
-
-        if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
-            return true;
-
-        // Participant-match (P9-F): the conversation includes this citizen in its
-        // participant set persisted in the JSON sidecar.
-        if (conversation.Participants.Any(p => p.CitizenId == citizen))
-            return true;
-
-        return false;
-    }
+        => ConversationStoreShared.MatchesCitizen(conversation, citizen);
 
     public async Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
     {
@@ -362,27 +350,14 @@ public sealed class FileConversationStore : IConversationStore
     private string GetPath(AgentId agentId, ConversationId conversationId)
         => Path.Combine(_rootPath, agentId.Value, $"{conversationId.Value}.json");
 
-    // Stamps the current world id onto a conversation being persisted (Create/Save). Only
-    // fills an empty WorldId — explicit non-empty values are preserved so cross-world relays
-    // can hold the source world's id even when this gateway is the receiver. No-op when no
-    // world context is wired (e.g. test setups using the parameterless ctor).
+    // World-id stamping/back-fill is shared across all three conversation stores — see
+    // ConversationStoreShared (#1383). These forwarders thread this store's world context
+    // into the shared logic while keeping the existing call-site signatures unchanged.
     private void StampWorldId(Conversation conversation)
-    {
-        if (string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
-            conversation.WorldId = _worldContext.CurrentWorldId;
-    }
+        => ConversationStoreShared.StampWorldId(conversation, _worldContext);
 
-    // Read-time projection: legacy JSON sidecars persisted before #613 deserialise with an
-    // empty WorldId. This projects them to the current world on the way out. The file on
-    // disk is not rewritten — the next SaveAsync round-trip will durably persist via
-    // StampWorldId. Treating backfill as projection-only keeps the read path single-pass
-    // and avoids touching disk on every Get/List.
     private Conversation? BackfillWorldId(Conversation? conversation)
-    {
-        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
-            conversation.WorldId = _worldContext.CurrentWorldId;
-        return conversation;
-    }
+        => ConversationStoreShared.BackfillWorldId(conversation, _worldContext);
 
     private static ConversationSummary ToSummary(Conversation c) =>
         new(

--- a/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/InMemoryConversationStore.cs
@@ -63,22 +63,9 @@ public sealed class InMemoryConversationStore : IConversationStore
         return Task.FromResult(results);
     }
 
+    // Citizen scoping is shared across all three conversation stores — see ConversationStoreShared (#1383).
     private static bool MatchesCitizen(Conversation conversation, CitizenId citizen)
-    {
-        if (conversation.Initiator is { IsValid: true } init && init == citizen)
-            return true;
-
-        // Owner-match: only agent-species citizens own conversations.
-        if (citizen.Kind == CitizenKind.Agent && citizen.AsAgent is { } agent && conversation.AgentId == agent)
-            return true;
-
-        // Participant-match (P9-F): the conversation includes this citizen in its
-        // participant set.
-        if (conversation.Participants.Any(p => p.CitizenId == citizen))
-            return true;
-
-        return false;
-    }
+        => ConversationStoreShared.MatchesCitizen(conversation, citizen);
 
     public Task<Conversation> CreateAsync(Conversation conversation, CancellationToken ct = default)
     {
@@ -210,27 +197,14 @@ public sealed class InMemoryConversationStore : IConversationStore
         return Task.FromResult(summaries);
     }
 
-    // Stamps the current world id onto a conversation being persisted (Create/Save). Only
-    // fills an empty WorldId — explicit non-empty values are preserved so cross-world relays
-    // can hold the source world's id even when this gateway is the receiver. No-op when no
-    // world context is wired (e.g. test setups using the parameterless ctor).
+    // World-id stamping/back-fill is shared across all three conversation stores — see
+    // ConversationStoreShared (#1383). These forwarders thread this store's world context
+    // into the shared logic while keeping the existing call-site signatures unchanged.
     private void StampWorldId(Conversation conversation)
-    {
-        if (string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
-            conversation.WorldId = _worldContext.CurrentWorldId;
-    }
+        => ConversationStoreShared.StampWorldId(conversation, _worldContext);
 
-    // Read-time projection: any conversation stored before the world context was wired
-    // (e.g. via the parameterless ctor) carries an empty WorldId. This projects it to the
-    // current world on the way out. The in-memory dictionary itself is not mutated to
-    // "repair" the value — kept identical to the Sqlite/File semantics so the three stores
-    // behave the same way under tests and under the lazy upgrade path.
     private Conversation? BackfillWorldId(Conversation? conversation)
-    {
-        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
-            conversation.WorldId = _worldContext.CurrentWorldId;
-        return conversation;
-    }
+        => ConversationStoreShared.BackfillWorldId(conversation, _worldContext);
 
     private static ConversationSummary ToSummary(Conversation c) =>
         new(

--- a/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
+++ b/src/gateway/BotNexus.Gateway.Conversations/SqliteConversationStore.cs
@@ -60,28 +60,15 @@ public sealed class SqliteConversationStore : IConversationStore
         _worldContext = worldContext;
     }
 
-    // Stamps the current world id onto a conversation being persisted (Create/Save). Only
-    // fills an empty WorldId — explicit non-empty values are preserved so cross-world relays
-    // can hold the source world's id even when this gateway is the receiver. No-op when no
-    // world context is wired (e.g. test setups using the parameterless ctor).
+    // World-id stamping/back-fill is shared across all three conversation stores — see
+    // ConversationStoreShared (#1383). These forwarders thread this store's world context
+    // into the shared logic while keeping the existing call-site signatures unchanged.
+    // (Sqlite scopes ListForCitizen with a SQL predicate rather than the shared MatchesCitizen.)
     private void StampWorldId(Conversation conversation)
-    {
-        if (string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
-            conversation.WorldId = _worldContext.CurrentWorldId;
-    }
+        => ConversationStoreShared.StampWorldId(conversation, _worldContext);
 
-    // Read-time projection: legacy rows persisted before #613 carry empty WorldId from the
-    // schema default. This projects them as belonging to the current world on the way out.
-    // The disk row itself is not rewritten — the next SaveAsync (or any in-place mutation
-    // that round-trips through SaveConversationAsync) will durably persist via StampWorldId.
-    // Treating backfill as projection-only avoids touching disk on every read and keeps
-    // ArchiveAsync's lighter "status-only" persistence path simple.
     private Conversation? BackfillWorldId(Conversation? conversation)
-    {
-        if (conversation is not null && string.IsNullOrEmpty(conversation.WorldId) && _worldContext is not null)
-            conversation.WorldId = _worldContext.CurrentWorldId;
-        return conversation;
-    }
+        => ConversationStoreShared.BackfillWorldId(conversation, _worldContext);
 
     /// <inheritdoc />
     public async Task<Conversation?> GetAsync(ConversationId conversationId, CancellationToken ct = default)

--- a/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreSharedTests.cs
+++ b/tests/gateway/BotNexus.Gateway.Conversations.Tests/ConversationStoreSharedTests.cs
@@ -1,0 +1,144 @@
+using BotNexus.Domain.Primitives;
+using BotNexus.Domain.World;
+using BotNexus.Gateway.Abstractions.Models;
+using BotNexus.Gateway.Conversations;
+
+namespace BotNexus.Gateway.Conversations.Tests;
+
+/// <summary>
+/// Direct unit coverage for <see cref="ConversationStoreShared"/> — the world-id stamping/back-fill
+/// and citizen-matching logic hoisted out of the three conversation stores (#1383, Finding 3). Before
+/// the extraction these routines were copy-pasted byte-for-byte across the stores with no test guarding
+/// the shared logic itself; the store contract tests exercised it only indirectly. These tests pin the
+/// behaviour at the single shared source so any future change is caught here.
+/// </summary>
+public sealed class ConversationStoreSharedTests
+{
+    private static Conversation NewConversation()
+        => new()
+        {
+            ConversationId = ConversationId.Create(),
+            AgentId = AgentId.From("agent-a"),
+            Title = "t",
+            Status = ConversationStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+    // ── StampWorldId ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void StampWorldId_FillsEmpty_FromWorldContext()
+    {
+        var conv = NewConversation();
+        conv.WorldId.ShouldBe(string.Empty);
+
+        ConversationStoreShared.StampWorldId(conv, new FakeWorldContext("world-x"));
+
+        conv.WorldId.ShouldBe("world-x");
+    }
+
+    [Fact]
+    public void StampWorldId_PreservesExplicitNonEmptyValue()
+    {
+        var conv = NewConversation();
+        conv.WorldId = "world-y"; // e.g. a cross-world relay receiver holding the source world id.
+
+        ConversationStoreShared.StampWorldId(conv, new FakeWorldContext("world-x"));
+
+        conv.WorldId.ShouldBe("world-y", customMessage: "Stamp must only fill an EMPTY WorldId.");
+    }
+
+    [Fact]
+    public void StampWorldId_NoOp_WhenWorldContextNull()
+    {
+        var conv = NewConversation();
+
+        ConversationStoreShared.StampWorldId(conv, worldContext: null);
+
+        conv.WorldId.ShouldBe(string.Empty, customMessage: "No world context wired (parameterless-ctor case) is a no-op.");
+    }
+
+    // ── BackfillWorldId ──────────────────────────────────────────────────
+
+    [Fact]
+    public void BackfillWorldId_ProjectsEmpty_ToCurrentWorld()
+    {
+        var conv = NewConversation();
+
+        var result = ConversationStoreShared.BackfillWorldId(conv, new FakeWorldContext("world-x"));
+
+        result.ShouldBeSameAs(conv);
+        result!.WorldId.ShouldBe("world-x");
+    }
+
+    [Fact]
+    public void BackfillWorldId_PreservesExplicitValue()
+    {
+        var conv = NewConversation();
+        conv.WorldId = "world-y";
+
+        var result = ConversationStoreShared.BackfillWorldId(conv, new FakeWorldContext("world-x"));
+
+        result!.WorldId.ShouldBe("world-y");
+    }
+
+    [Fact]
+    public void BackfillWorldId_ReturnsNull_ForNullInput()
+    {
+        var result = ConversationStoreShared.BackfillWorldId(conversation: null, new FakeWorldContext("world-x"));
+
+        result.ShouldBeNull();
+    }
+
+    // ── MatchesCitizen ───────────────────────────────────────────────────
+
+    [Fact]
+    public void MatchesCitizen_True_WhenCitizenIsInitiator()
+    {
+        var user = CitizenId.Of(UserId.From("user-1"));
+        var conv = NewConversation();
+        conv.Initiator = user;
+
+        ConversationStoreShared.MatchesCitizen(conv, user).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MatchesCitizen_True_WhenAgentCitizenOwnsConversation()
+    {
+        var conv = NewConversation(); // AgentId = agent-a
+        var owner = CitizenId.Of(AgentId.From("agent-a"));
+
+        ConversationStoreShared.MatchesCitizen(conv, owner).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MatchesCitizen_True_WhenCitizenIsParticipant()
+    {
+        var participant = CitizenId.Of(AgentId.From("agent-peer"));
+        var conv = NewConversation();
+        conv.Participants.Add(new SessionParticipant { CitizenId = participant });
+
+        ConversationStoreShared.MatchesCitizen(conv, participant).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MatchesCitizen_False_WhenUnrelated()
+    {
+        var conv = NewConversation(); // owner agent-a, no initiator, no participants
+        var stranger = CitizenId.Of(AgentId.From("agent-z"));
+
+        ConversationStoreShared.MatchesCitizen(conv, stranger).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MatchesCitizen_OwnerMatch_OnlyForAgentSpeciesNotUser()
+    {
+        // A user citizen whose value happens to equal the owning agent id must NOT owner-match —
+        // owner-match is agent-species only. (Guards the CitizenKind.Agent gate in the shared logic.)
+        var conv = NewConversation(); // owner agent-a
+        var userNamedLikeAgent = CitizenId.Of(UserId.From("agent-a"));
+
+        ConversationStoreShared.MatchesCitizen(conv, userNamedLikeAgent).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Closes #1383 (Finding 3)

## Changes
Implements **Finding 3** of #1383 — hoists the world-id and citizen-matching logic that was copy-pasted **byte-for-byte** across the three `IConversationStore` implementations into one `ConversationStoreShared` static helper. The source comments literally said these were *"kept identical so the three stores behave the same way"* — a standing invitation for silent drift in world/citizen scoping semantics.

- New internal `ConversationStoreShared` with `StampWorldId(conversation, worldContext)`, `BackfillWorldId(conversation?, worldContext)` (used by all three stores) and `MatchesCitizen(conversation, citizen)` (used by File + InMemory).
- `SqliteConversationStore`, `FileConversationStore` and `InMemoryConversationStore` now delegate via thin forwarders that thread their own `IWorldContext` in, keeping every existing call-site signature unchanged. (Sqlite scopes `ListForCitizen` with a SQL predicate, so it shares only the world-id pair.)
- `InternalsVisibleTo` added for the store test project so the helper can be unit-tested directly.

**Scope note:** I deliberately left `ToSummary` **out** of this extraction. It is *not* byte-identical — `InMemoryConversationStore.ToSummary` populates `ConversationSummary.Participants` while `File` and `Sqlite` omit it. Unifying it would change observable listing output (a behaviour change, not a refactor), so I filed it separately rather than fold it in silently. See the new issue linked below.

## Tests
- New `ConversationStoreSharedTests` (11 tests) covering `StampWorldId` (fill-empty / preserve-explicit / null-context no-op), `BackfillWorldId` (projection / preserve / null passthrough), and `MatchesCitizen` (initiator / agent-owner / participant / unrelated / user-not-owner-match) — direct coverage the shared logic previously lacked.
- All existing world-id, parity, contract, participants and citizen store tests pass unchanged. `test-impacted.ps1` green: Conversations.Tests 211, Architecture 180, Scenarios 29. Full `--warnaserror` solution build clean.

## Merge Notes
Touches only the three conversation stores + a new helper/test + the Conversations csproj — no file overlap with any open PR. Behaviour-preserving (parity tests guard the equivalence). Safe to merge in any order. Findings 1/2/4/5 of #1383 (god-class split, `EnsureColumn` dedup, `SqliteExecutor`, save write-amplification) remain as separate follow-ups.